### PR TITLE
refactor: migrate core components to hooks

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -33,6 +33,7 @@ export class SideBarApp extends Component {
         return (
             <div
                 tabIndex="0"
+                ref={this.props.innerRef}
                 onClick={this.openApp}
                 onMouseEnter={() => {
                     this.setState({ showTitle: true });

--- a/components/context menus/default.js
+++ b/components/context menus/default.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
-function DefaultMenu(props) {
+function DefaultMenu(props, ref) {
     return (
-        <div id="default-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
+        <div ref={ref} id="default-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
 
             <Devider />
             <a rel="noreferrer noopener" href="https://www.linkedin.com/in/unnippillil/" target="_blank" className="w-full block cursor-default py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
@@ -30,4 +30,4 @@ function Devider() {
     );
 }
 
-export default DefaultMenu
+export default forwardRef(DefaultMenu)

--- a/components/context menus/desktop-menu.js
+++ b/components/context menus/desktop-menu.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, forwardRef } from 'react'
 
-function DesktopMenu(props) {
+function DesktopMenu(props, ref) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
 
@@ -43,7 +43,7 @@ function DesktopMenu(props) {
     }
 
     return (
-        <div id="desktop-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
+        <div ref={ref} id="desktop-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
             <div onClick={props.addNewFolder} className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
                 <span className="ml-5">New Folder</span>
             </div>
@@ -86,4 +86,4 @@ function Devider() {
 }
 
 
-export default DesktopMenu
+export default forwardRef(DesktopMenu)

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,545 +1,503 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
 import BackgroundImage from '../util components/background-image';
 import SideBar from './side_bar';
 import apps from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
-import AllApplications from '../screen/all-applications'
+import AllApplications from '../screen/all-applications';
 import DesktopMenu from '../context menus/desktop-menu';
 import DefaultMenu from '../context menus/default';
-import $ from 'jquery';
 import ReactGA from 'react-ga4';
 
-export class Desktop extends Component {
-    constructor() {
-        super();
-        this.app_stack = [];
-        this.initFavourite = {};
-        this.allWindowClosed = false;
-        this.state = {
-            focused_windows: {},
-            closed_windows: {},
-            allAppsView: false,
-            overlapped_windows: {},
-            disabled_apps: {},
-            favourite_apps: {},
-            hideSideBar: false,
-            minimized_windows: {},
-            desktop_apps: [],
-            context_menus: {
-                desktop: false,
-                default: false,
-            },
-            showNameBar: false,
-        }
+export const Desktop = forwardRef((props, ref) => {
+  const appStack = useRef([]);
+  const initFavourite = useRef({});
+  const windowRefs = useRef({});
+  const sidebarRefs = useRef({});
+  const desktopMenuRef = useRef(null);
+  const defaultMenuRef = useRef(null);
+  const folderInputRef = useRef(null);
+
+  const [focusedWindows, setFocusedWindows] = useState({});
+  const [closedWindows, setClosedWindows] = useState({});
+  const [allAppsView, setAllAppsView] = useState(false);
+  const [overlappedWindows, setOverlappedWindows] = useState({});
+  const [disabledApps, setDisabledApps] = useState({});
+  const [favouriteApps, setFavouriteApps] = useState({});
+  const [hideSideBar, setHideSideBar] = useState(false);
+  const [minimizedWindows, setMinimizedWindows] = useState({});
+  const [desktopApps, setDesktopApps] = useState([]);
+  const [contextMenus, setContextMenus] = useState({ desktop: false, default: false });
+  const [showNameBar, setShowNameBar] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    openApp
+  }));
+
+  useEffect(() => {
+    ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+    fetchAppsData();
+    checkForNewFolders();
+    document.addEventListener('contextmenu', checkContextMenu);
+    document.addEventListener('click', hideAllContextMenu);
+    return () => {
+      document.removeEventListener('contextmenu', checkContextMenu);
+      document.removeEventListener('click', hideAllContextMenu);
+    };
+  }, []);
+
+  const checkForNewFolders = () => {
+    var new_folders = localStorage.getItem('new_folders');
+    if (new_folders === null && new_folders !== undefined) {
+      localStorage.setItem("new_folders", JSON.stringify([]));
     }
-
-    componentDidMount() {
-        // google analytics
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
-
-        this.fetchAppsData();
-        this.setContextListeners();
-        this.setEventListeners();
-        this.checkForNewFolders();
-    }
-
-    componentWillUnmount() {
-        this.removeContextListeners();
-    }
-
-    checkForNewFolders = () => {
-        var new_folders = localStorage.getItem('new_folders');
-        if (new_folders === null && new_folders !== undefined) {
-            localStorage.setItem("new_folders", JSON.stringify([]));
-        }
-        else {
-            new_folders = JSON.parse(new_folders);
-            new_folders.forEach(folder => {
-                apps.push({
-                    id: `new-folder-${folder.id}`,
-                    title: folder.name,
-                    icon: './themes/Yaru/system/folder.png',
-                    disabled: true,
-                    favourite: false,
-                    desktop_shortcut: true,
-                    screen: () => { },
-                });
-            });
-            this.updateAppsData();
-        }
-    }
-
-    setEventListeners = () => {
-        document.getElementById("open-settings").addEventListener("click", () => {
-            this.openApp("settings");
-        });
-    }
-
-    setContextListeners = () => {
-        document.addEventListener('contextmenu', this.checkContextMenu);
-        // on click, anywhere, hide all menus
-        document.addEventListener('click', this.hideAllContextMenu);
-    }
-
-    removeContextListeners = () => {
-        document.removeEventListener("contextmenu", this.checkContextMenu);
-        document.removeEventListener("click", this.hideAllContextMenu);
-    }
-
-    checkContextMenu = (e) => {
-        e.preventDefault();
-        this.hideAllContextMenu();
-        switch (e.target.dataset.context) {
-            case "desktop-area":
-                ReactGA.event({
-                    category: `Context Menu`,
-                    action: `Opened Desktop Context Menu`
-                });
-                this.showContextMenu(e, "desktop");
-                break;
-            default:
-                ReactGA.event({
-                    category: `Context Menu`,
-                    action: `Opened Default Context Menu`
-                });
-                this.showContextMenu(e, "default");
-        }
-    }
-
-    showContextMenu = (e, menuName /* context menu name */) => {
-        let { posx, posy } = this.getMenuPosition(e);
-        let contextMenu = document.getElementById(`${menuName}-menu`);
-
-        if (posx + $(contextMenu).width() > window.innerWidth) posx -= $(contextMenu).width();
-        if (posy + $(contextMenu).height() > window.innerHeight) posy -= $(contextMenu).height();
-
-        posx = posx.toString() + "px";
-        posy = posy.toString() + "px";
-
-        contextMenu.style.left = posx;
-        contextMenu.style.top = posy;
-
-        this.setState({ context_menus: { ...this.state.context_menus, [menuName]: true } });
-    }
-
-    hideAllContextMenu = () => {
-        let menus = this.state.context_menus;
-        Object.keys(menus).forEach(key => {
-            menus[key] = false;
-        });
-        this.setState({ context_menus: menus });
-    }
-
-    getMenuPosition = (e) => {
-        var posx = 0;
-        var posy = 0;
-
-        if (!e) e = window.event;
-
-        if (e.pageX || e.pageY) {
-            posx = e.pageX;
-            posy = e.pageY;
-        } else if (e.clientX || e.clientY) {
-            posx = e.clientX + document.body.scrollLeft +
-                document.documentElement.scrollLeft;
-            posy = e.clientY + document.body.scrollTop +
-                document.documentElement.scrollTop;
-        }
-        return {
-            posx, posy
-        }
-    }
-
-    fetchAppsData = () => {
-        let focused_windows = {}, closed_windows = {}, disabled_apps = {}, favourite_apps = {}, overlapped_windows = {}, minimized_windows = {};
-        let desktop_apps = [];
-        apps.forEach((app) => {
-            focused_windows = {
-                ...focused_windows,
-                [app.id]: false,
-            };
-            closed_windows = {
-                ...closed_windows,
-                [app.id]: true,
-            };
-            disabled_apps = {
-                ...disabled_apps,
-                [app.id]: app.disabled,
-            };
-            favourite_apps = {
-                ...favourite_apps,
-                [app.id]: app.favourite,
-            };
-            overlapped_windows = {
-                ...overlapped_windows,
-                [app.id]: false,
-            };
-            minimized_windows = {
-                ...minimized_windows,
-                [app.id]: false,
-            }
-            if (app.desktop_shortcut) desktop_apps.push(app.id);
-        });
-        this.setState({
-            focused_windows,
-            closed_windows,
-            disabled_apps,
-            favourite_apps,
-            overlapped_windows,
-            minimized_windows,
-            desktop_apps
-        });
-        this.initFavourite = { ...favourite_apps };
-    }
-
-    updateAppsData = () => {
-        let focused_windows = {}, closed_windows = {}, favourite_apps = {}, minimized_windows = {}, disabled_apps = {};
-        let desktop_apps = [];
-        apps.forEach((app) => {
-            focused_windows = {
-                ...focused_windows,
-                [app.id]: ((this.state.focused_windows[app.id] !== undefined || this.state.focused_windows[app.id] !== null) ? this.state.focused_windows[app.id] : false),
-            };
-            minimized_windows = {
-                ...minimized_windows,
-                [app.id]: ((this.state.minimized_windows[app.id] !== undefined || this.state.minimized_windows[app.id] !== null) ? this.state.minimized_windows[app.id] : false)
-            };
-            disabled_apps = {
-                ...disabled_apps,
-                [app.id]: app.disabled
-            };
-            closed_windows = {
-                ...closed_windows,
-                [app.id]: ((this.state.closed_windows[app.id] !== undefined || this.state.closed_windows[app.id] !== null) ? this.state.closed_windows[app.id] : true)
-            };
-            favourite_apps = {
-                ...favourite_apps,
-                [app.id]: app.favourite
-            }
-            if (app.desktop_shortcut) desktop_apps.push(app.id);
-        });
-        this.setState({
-            focused_windows,
-            closed_windows,
-            disabled_apps,
-            minimized_windows,
-            favourite_apps,
-            desktop_apps
-        });
-        this.initFavourite = { ...favourite_apps };
-    }
-
-    renderDesktopApps = () => {
-        if (Object.keys(this.state.closed_windows).length === 0) return;
-        let appsJsx = [];
-        apps.forEach((app, index) => {
-            if (this.state.desktop_apps.includes(app.id)) {
-
-                const props = {
-                    name: app.title,
-                    id: app.id,
-                    icon: app.icon,
-                    openApp: this.openApp
-                }
-
-                appsJsx.push(
-                    <UbuntuApp key={index} {...props} />
-                );
-            }
-        });
-        return appsJsx;
-    }
-
-    renderWindows = () => {
-        let windowsJsx = [];
-        apps.forEach((app, index) => {
-            if (this.state.closed_windows[app.id] === false) {
-
-                const props = {
-                    title: app.title,
-                    id: app.id,
-                    screen: app.screen,
-                    addFolder: this.addToDesktop,
-                    closed: this.closeApp,
-                    openApp: this.openApp,
-                    focus: this.focus,
-                    isFocused: this.state.focused_windows[app.id],
-                    hideSideBar: this.hideSideBar,
-                    hasMinimised: this.hasMinimised,
-                    minimized: this.state.minimized_windows[app.id],
-                    changeBackgroundImage: this.props.changeBackgroundImage,
-                    bg_image_name: this.props.bg_image_name,
-                }
-
-                windowsJsx.push(
-                    <Window key={index} {...props} />
-                )
-            }
-        });
-        return windowsJsx;
-    }
-
-    hideSideBar = (objId, hide) => {
-        if (hide === this.state.hideSideBar) return;
-
-        if (objId === null) {
-            if (hide === false) {
-                this.setState({ hideSideBar: false });
-            }
-            else {
-                for (const key in this.state.overlapped_windows) {
-                    if (this.state.overlapped_windows[key]) {
-                        this.setState({ hideSideBar: true });
-                        return;
-                    }  // if any window is overlapped then hide the SideBar
-                }
-            }
-            return;
-        }
-
-        if (hide === false) {
-            for (const key in this.state.overlapped_windows) {
-                if (this.state.overlapped_windows[key] && key !== objId) return; // if any window is overlapped then don't show the SideBar
-            }
-        }
-
-        let overlapped_windows = this.state.overlapped_windows;
-        overlapped_windows[objId] = hide;
-        this.setState({ hideSideBar: hide, overlapped_windows });
-    }
-
-    hasMinimised = (objId) => {
-        let minimized_windows = this.state.minimized_windows;
-        var focused_windows = this.state.focused_windows;
-
-        // remove focus and minimise this window
-        minimized_windows[objId] = true;
-        focused_windows[objId] = false;
-        this.setState({ minimized_windows, focused_windows });
-
-        this.hideSideBar(null, false);
-
-        this.giveFocusToLastApp();
-    }
-
-    giveFocusToLastApp = () => {
-        // if there is atleast one app opened, give it focus
-        if (!this.checkAllMinimised()) {
-            for (const index in this.app_stack) {
-                if (!this.state.minimized_windows[this.app_stack[index]]) {
-                    this.focus(this.app_stack[index]);
-                    break;
-                }
-            }
-        }
-    }
-
-    checkAllMinimised = () => {
-        let result = true;
-        for (const key in this.state.minimized_windows) {
-            if (!this.state.closed_windows[key]) { // if app is opened
-                result = result & this.state.minimized_windows[key];
-            }
-        }
-        return result;
-    }
-
-    openApp = (objId) => {
-
-        // google analytics
-        ReactGA.event({
-            category: `Open App`,
-            action: `Opened ${objId} window`
-        });
-
-        // if the app is disabled
-        if (this.state.disabled_apps[objId]) return;
-
-        if (this.state.minimized_windows[objId]) {
-            // focus this app's window
-            this.focus(objId);
-
-            // set window's last position
-            var r = document.querySelector("#" + objId);
-            r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
-
-            // tell childs that his app has been not minimised
-            let minimized_windows = this.state.minimized_windows;
-            minimized_windows[objId] = false;
-            this.setState({ minimized_windows: minimized_windows });
-            return;
-        }
-
-        //if app is already opened
-        if (this.app_stack.includes(objId)) this.focus(objId);
-        else {
-            let closed_windows = this.state.closed_windows;
-            let favourite_apps = this.state.favourite_apps;
-            var frequentApps = localStorage.getItem('frequentApps') ? JSON.parse(localStorage.getItem('frequentApps')) : [];
-            var currentApp = frequentApps.find(app => app.id === objId);
-            if (currentApp) {
-                frequentApps.forEach((app) => {
-                    if (app.id === currentApp.id) {
-                        app.frequency += 1; // increase the frequency if app is found 
-                    }
-                });
-            } else {
-                frequentApps.push({ id: objId, frequency: 1 }); // new app opened
-            }
-
-            frequentApps.sort((a, b) => {
-                if (a.frequency < b.frequency) {
-                    return 1;
-                }
-                if (a.frequency > b.frequency) {
-                    return -1;
-                }
-                return 0; // sort according to decreasing frequencies
-            });
-
-            localStorage.setItem("frequentApps", JSON.stringify(frequentApps));
-
-            setTimeout(() => {
-                favourite_apps[objId] = true; // adds opened app to sideBar
-                closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, this.focus(objId));
-                this.app_stack.push(objId);
-            }, 200);
-        }
-    }
-
-    closeApp = (objId) => {
-
-        // remove app from the app stack
-        this.app_stack.splice(this.app_stack.indexOf(objId), 1);
-
-        this.giveFocusToLastApp();
-
-        this.hideSideBar(null, false);
-
-        // close window
-        let closed_windows = this.state.closed_windows;
-        let favourite_apps = this.state.favourite_apps;
-
-        if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
-        closed_windows[objId] = true; // closes the app's window
-
-        this.setState({ closed_windows, favourite_apps });
-    }
-
-    focus = (objId) => {
-        // removes focus from all window and 
-        // gives focus to window with 'id = objId'
-        var focused_windows = this.state.focused_windows;
-        focused_windows[objId] = true;
-        for (let key in focused_windows) {
-            if (focused_windows.hasOwnProperty(key)) {
-                if (key !== objId) {
-                    focused_windows[key] = false;
-                }
-            }
-        }
-        this.setState({ focused_windows });
-    }
-
-    addNewFolder = () => {
-        this.setState({ showNameBar: true });
-    }
-
-    addToDesktop = (folder_name) => {
-        folder_name = folder_name.trim();
-        let folder_id = folder_name.replace(/\s+/g, '-').toLowerCase();
+    else {
+      new_folders = JSON.parse(new_folders);
+      new_folders.forEach(folder => {
         apps.push({
-            id: `new-folder-${folder_id}`,
-            title: folder_name,
-            icon: './themes/Yaru/system/folder.png',
-            disabled: true,
-            favourite: false,
-            desktop_shortcut: true,
-            screen: () => { },
+          id: `new-folder-${folder.id}`,
+          title: folder.name,
+          icon: './themes/Yaru/system/folder.png',
+          disabled: true,
+          favourite: false,
+          desktop_shortcut: true,
+          screen: () => { },
         });
-        // store in local storage
-        var new_folders = JSON.parse(localStorage.getItem('new_folders'));
-        new_folders.push({ id: `new-folder-${folder_id}`, name: folder_name });
-        localStorage.setItem("new_folders", JSON.stringify(new_folders));
-
-        this.setState({ showNameBar: false }, this.updateAppsData);
+      });
+      updateAppsData();
     }
+  };
 
-    showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }) }
+  const checkContextMenu = (e) => {
+    e.preventDefault();
+    hideAllContextMenu();
+    switch (e.target.dataset.context) {
+      case "desktop-area":
+        ReactGA.event({
+          category: `Context Menu`,
+          action: `Opened Desktop Context Menu`
+        });
+        showContextMenu(e, "desktop");
+        break;
+      default:
+        ReactGA.event({
+          category: `Context Menu`,
+          action: `Opened Default Context Menu`
+        });
+        showContextMenu(e, "default");
+    }
+  };
 
-    renderNameBar = () => {
-        let addFolder = () => {
-            let folder_name = document.getElementById("folder-name-input").value;
-            this.addToDesktop(folder_name);
+  const showContextMenu = (e, menuName) => {
+    let { posx, posy } = getMenuPosition(e);
+    let contextMenu = menuName === "desktop" ? desktopMenuRef.current : defaultMenuRef.current;
+
+    if (!contextMenu) return;
+
+    const { offsetWidth, offsetHeight } = contextMenu;
+    if (posx + offsetWidth > window.innerWidth) posx -= offsetWidth;
+    if (posy + offsetHeight > window.innerHeight) posy -= offsetHeight;
+
+    contextMenu.style.left = posx.toString() + "px";
+    contextMenu.style.top = posy.toString() + "px";
+
+    setContextMenus(prev => ({ ...prev, [menuName]: true }));
+  };
+
+  const hideAllContextMenu = () => {
+    setContextMenus(prev => {
+      const menus = { ...prev };
+      Object.keys(menus).forEach(key => {
+        menus[key] = false;
+      });
+      return menus;
+    });
+  };
+
+  const getMenuPosition = (e) => {
+    var posx = 0;
+    var posy = 0;
+
+    if (!e) e = window.event;
+
+    if (e.pageX || e.pageY) {
+      posx = e.pageX;
+      posy = e.pageY;
+    } else if (e.clientX || e.clientY) {
+      posx = e.clientX + document.body.scrollLeft +
+        document.documentElement.scrollLeft;
+      posy = e.clientY + document.body.scrollTop +
+        document.documentElement.scrollTop;
+    }
+    return {
+      posx, posy
+    }
+  };
+
+  const fetchAppsData = () => {
+    let focused_windows = {}, closed_windows = {}, disabled_apps = {}, favourite_apps = {}, overlapped_windows = {}, minimized_windows = {};
+    let desktop_apps = [];
+    apps.forEach((app) => {
+      focused_windows = {
+        ...focused_windows,
+        [app.id]: false,
+      };
+      closed_windows = {
+        ...closed_windows,
+        [app.id]: true,
+      };
+      disabled_apps = {
+        ...disabled_apps,
+        [app.id]: app.disabled,
+      };
+      favourite_apps = {
+        ...favourite_apps,
+        [app.id]: app.favourite,
+      };
+      overlapped_windows = {
+        ...overlapped_windows,
+        [app.id]: false,
+      };
+      minimized_windows = {
+        ...minimized_windows,
+        [app.id]: false,
+      }
+      if (app.desktop_shortcut) desktop_apps.push(app.id);
+    });
+    setFocusedWindows(focused_windows);
+    setClosedWindows(closed_windows);
+    setDisabledApps(disabled_apps);
+    setFavouriteApps(favourite_apps);
+    setOverlappedWindows(overlapped_windows);
+    setMinimizedWindows(minimized_windows);
+    setDesktopApps(desktop_apps);
+    initFavourite.current = { ...favourite_apps };
+  };
+
+  const updateAppsData = () => {
+    let focused_windows = {}, closed_windows = {}, favourite_apps = {}, minimized_windows = {}, disabled_apps = {};
+    let desktop_apps = [];
+    apps.forEach((app) => {
+      focused_windows = {
+        ...focused_windows,
+        [app.id]: ((focusedWindows[app.id] !== undefined || focusedWindows[app.id] !== null) ? focusedWindows[app.id] : false),
+      };
+      minimized_windows = {
+        ...minimized_windows,
+        [app.id]: ((minimizedWindows[app.id] !== undefined || minimizedWindows[app.id] !== null) ? minimizedWindows[app.id] : false)
+      };
+      disabled_apps = {
+        ...disabled_apps,
+        [app.id]: app.disabled
+      };
+      closed_windows = {
+        ...closed_windows,
+        [app.id]: ((closedWindows[app.id] !== undefined || closedWindows[app.id] !== null) ? closedWindows[app.id] : true)
+      };
+      favourite_apps = {
+        ...favourite_apps,
+        [app.id]: app.favourite
+      }
+      if (app.desktop_shortcut) desktop_apps.push(app.id);
+    });
+    setFocusedWindows(focused_windows);
+    setClosedWindows(closed_windows);
+    setDisabledApps(disabled_apps);
+    setMinimizedWindows(minimized_windows);
+    setFavouriteApps(favourite_apps);
+    setDesktopApps(desktop_apps);
+    initFavourite.current = { ...favourite_apps };
+  };
+
+  const renderDesktopApps = () => {
+    if (Object.keys(closedWindows).length === 0) return;
+    let appsJsx = [];
+    apps.forEach((app, index) => {
+      if (desktopApps.includes(app.id)) {
+
+        const propsApp = {
+          name: app.title,
+          id: app.id,
+          icon: app.icon,
+          openApp: openApp
         }
 
-        let removeCard = () => {
-            this.setState({ showNameBar: false });
-        }
-
-        return (
-            <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
-                <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
-                </div>
-                <div className="flex">
-                    <div onClick={addFolder} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Create</div>
-                    <div onClick={removeCard} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Cancel</div>
-                </div>
-            </div>
+        appsJsx.push(
+          <UbuntuApp key={index} {...propsApp} />
         );
-    }
+      }
+    });
+    return appsJsx;
+  };
 
-    render() {
-        return (
-            <div className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+  const renderWindows = () => {
+    let windowsJsx = [];
+    apps.forEach((app, index) => {
+      if (closedWindows[app.id] === false) {
 
-                {/* Window Area */}
-                <div className="absolute h-full w-full bg-transparent" data-context="desktop-area">
-                    {this.renderWindows()}
-                </div>
+        const propsWindow = {
+          title: app.title,
+          id: app.id,
+          screen: app.screen,
+          addFolder: addToDesktop,
+          closed: closeApp,
+          openApp: openApp,
+          focus: focus,
+          isFocused: focusedWindows[app.id],
+          hideSideBar: hideSideBarFn,
+          hasMinimised: hasMinimised,
+          minimized: minimizedWindows[app.id],
+          changeBackgroundImage: props.changeBackgroundImage,
+          bg_image_name: props.bg_image_name,
+          sidebarRefs: sidebarRefs
+        }
 
-                {/* Background Image */}
-                <BackgroundImage img={this.props.bg_image_name} />
-
-                {/* Ubuntu Side Menu Bar */}
-                <SideBar apps={apps}
-                    hide={this.state.hideSideBar}
-                    hideSideBar={this.hideSideBar}
-                    favourite_apps={this.state.favourite_apps}
-                    showAllApps={this.showAllApps}
-                    allAppsView={this.state.allAppsView}
-                    closed_windows={this.state.closed_windows}
-                    focused_windows={this.state.focused_windows}
-                    isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
-
-                {/* Desktop Apps */}
-                {this.renderDesktopApps()}
-
-                {/* Context Menus */}
-                <DesktopMenu active={this.state.context_menus.desktop} openApp={this.openApp} addNewFolder={this.addNewFolder} />
-                <DefaultMenu active={this.state.context_menus.default} />
-
-                {/* Folder Input Name Bar */}
-                {
-                    (this.state.showNameBar
-                        ? this.renderNameBar()
-                        : null
-                    )
-                }
-
-                { this.state.allAppsView ?
-                    <AllApplications apps={apps}
-                        recentApps={this.app_stack}
-                        openApp={this.openApp} /> : null}
-
-            </div>
+        windowsJsx.push(
+          <Window key={index} ref={el => windowRefs.current[app.id] = el} {...propsWindow} />
         )
-    }
-}
+      }
+    });
+    return windowsJsx;
+  };
 
-export default Desktop
+  const hideSideBarFn = (objId, hide) => {
+    if (hide === hideSideBar) return;
+
+    if (objId === null) {
+      if (hide === false) {
+        setHideSideBar(false);
+      }
+      else {
+        for (const key in overlappedWindows) {
+          if (overlappedWindows[key]) {
+            setHideSideBar(true);
+            return;
+          }
+        }
+      }
+      return;
+    }
+
+    if (hide === false) {
+      for (const key in overlappedWindows) {
+        if (overlappedWindows[key] && key !== objId) return;
+      }
+    }
+
+    setOverlappedWindows(prev => {
+      const ow = { ...prev, [objId]: hide };
+      return ow;
+    });
+    setHideSideBar(hide);
+  };
+
+  const hasMinimised = (objId) => {
+    setMinimizedWindows(prev => ({ ...prev, [objId]: true }));
+    setFocusedWindows(prev => ({ ...prev, [objId]: false }));
+    hideSideBarFn(null, false);
+    giveFocusToLastApp();
+  };
+
+  const giveFocusToLastApp = () => {
+    if (!checkAllMinimised()) {
+      for (const index in appStack.current) {
+        if (!minimizedWindows[appStack.current[index]]) {
+          focus(appStack.current[index]);
+          break;
+        }
+      }
+    }
+  };
+
+  const checkAllMinimised = () => {
+    let result = true;
+    for (const key in minimizedWindows) {
+      if (!closedWindows[key]) {
+        result = result & minimizedWindows[key];
+      }
+    }
+    return result;
+  };
+
+  const openApp = (objId) => {
+
+    ReactGA.event({
+      category: `Open App`,
+      action: `Opened ${objId} window`
+    });
+
+    if (disabledApps[objId]) return;
+
+    if (minimizedWindows[objId]) {
+      focus(objId);
+
+      var r = windowRefs.current[objId];
+      r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
+
+      setMinimizedWindows(prev => ({ ...prev, [objId]: false }));
+      return;
+    }
+
+    if (appStack.current.includes(objId)) focus(objId);
+    else {
+      let closed_windows = { ...closedWindows };
+      let favourite_apps = { ...favouriteApps };
+      var frequentApps = localStorage.getItem('frequentApps') ? JSON.parse(localStorage.getItem('frequentApps')) : [];
+      var currentApp = frequentApps.find(app => app.id === objId);
+      if (currentApp) {
+        frequentApps.forEach((app) => {
+          if (app.id === currentApp.id) {
+            app.frequency += 1;
+          }
+        });
+      } else {
+        frequentApps.push({ id: objId, frequency: 1 });
+      }
+
+      frequentApps.sort((a, b) => {
+        if (a.frequency < b.frequency) {
+          return 1;
+        }
+        if (a.frequency > b.frequency) {
+          return -1;
+        }
+        return 0;
+      });
+
+      localStorage.setItem("frequentApps", JSON.stringify(frequentApps));
+
+      setTimeout(() => {
+        favourite_apps[objId] = true;
+        closed_windows[objId] = false;
+        setClosedWindows(closed_windows);
+        setFavouriteApps(favourite_apps);
+        setAllAppsView(false);
+        focus(objId);
+        appStack.current.push(objId);
+      }, 200);
+    }
+  };
+
+  const closeApp = (objId) => {
+
+    appStack.current.splice(appStack.current.indexOf(objId), 1);
+
+    giveFocusToLastApp();
+
+    hideSideBarFn(null, false);
+
+    let closed_windows = { ...closedWindows };
+    let favourite_apps = { ...favouriteApps };
+
+    if (initFavourite.current[objId] === false) favourite_apps[objId] = false;
+    closed_windows[objId] = true;
+
+    setClosedWindows(closed_windows);
+    setFavouriteApps(favourite_apps);
+  };
+
+  const focus = (objId) => {
+    setFocusedWindows(prev => {
+      const newFocus = { ...prev };
+      Object.keys(newFocus).forEach(key => {
+        newFocus[key] = key === objId;
+      });
+      return newFocus;
+    });
+  };
+
+  const addNewFolder = () => {
+    setShowNameBar(true);
+  };
+
+  const addToDesktop = (folder_name) => {
+    folder_name = folder_name.trim();
+    let folder_id = folder_name.replace(/\s+/g, '-').toLowerCase();
+    apps.push({
+      id: `new-folder-${folder_id}`,
+      title: folder_name,
+      icon: './themes/Yaru/system/folder.png',
+      disabled: true,
+      favourite: false,
+      desktop_shortcut: true,
+      screen: () => { },
+    });
+    var new_folders = JSON.parse(localStorage.getItem('new_folders'));
+    new_folders.push({ id: `new-folder-${folder_id}`, name: folder_name });
+    localStorage.setItem("new_folders", JSON.stringify(new_folders));
+
+    setShowNameBar(false);
+    updateAppsData();
+  };
+
+  const showAllApps = () => { setAllAppsView(!allAppsView) }
+
+  const renderNameBar = () => {
+    let addFolder = () => {
+      let folder_name = folderInputRef.current.value;
+      addToDesktop(folder_name);
+    }
+
+    let removeCard = () => {
+      setShowNameBar(false);
+    }
+
+    return (
+      <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
+        <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
+          <span>New folder name</span>
+          <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" ref={folderInputRef} type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+        </div>
+        <div className="flex">
+          <div onClick={addFolder} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Create</div>
+          <div onClick={removeCard} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Cancel</div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+
+      <div className="absolute h-full w-full bg-transparent" data-context="desktop-area">
+        {renderWindows()}
+      </div>
+
+      <BackgroundImage img={props.bg_image_name} />
+
+      <SideBar apps={apps}
+        hide={hideSideBar}
+        hideSideBar={hideSideBarFn}
+        favourite_apps={favouriteApps}
+        showAllApps={showAllApps}
+        allAppsView={allAppsView}
+        closed_windows={closedWindows}
+        focused_windows={focusedWindows}
+        isMinimized={minimizedWindows}
+        openAppByAppId={openApp}
+        sidebarRefs={sidebarRefs}
+      />
+
+      {renderDesktopApps()}
+
+      <DesktopMenu ref={desktopMenuRef} active={contextMenus.desktop} openApp={openApp} addNewFolder={addNewFolder} />
+      <DefaultMenu ref={defaultMenuRef} active={contextMenus.default} />
+
+      {
+        (showNameBar
+          ? renderNameBar()
+          : null
+        )
+      }
+
+      {allAppsView ?
+        <AllApplications apps={apps}
+          recentApps={appStack.current}
+          openApp={openApp} /> : null}
+
+    </div>
+  )
+});
+
+export default Desktop;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -30,28 +30,28 @@ export default class Navbar extends Component {
 				>
 					<Clock />
 				</div>
-				<div
-					id="status-bar"
-					tabIndex="0"
-					onFocus={() => {
-						this.setState({ status_card: true });
-					}}
-					// removed onBlur from here
-					className={
-						'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-					}
-				>
-					<Status />
-					<StatusCard
-						shutDown={this.props.shutDown}
-						lockScreen={this.props.lockScreen}
-						visible={this.state.status_card}
-						toggleVisible={() => {
-							// this prop is used in statusCard component in handleClickOutside callback using react-onclickoutside
-							this.setState({ status_card: false });
-						}}
-					/>
-				</div>
+                                <div
+                                        id="status-bar"
+                                        ref={this.props.statusRef}
+                                        tabIndex="0"
+                                        onFocus={() => {
+                                                this.setState({ status_card: true });
+                                        }}
+                                        className={
+                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                        }
+                                >
+                                        <Status />
+                                        <StatusCard
+                                                shutDown={this.props.shutDown}
+                                                lockScreen={this.props.lockScreen}
+                                                visible={this.state.status_card}
+                                                openSettings={this.props.openSettings}
+                                                toggleVisible={() => {
+                                                        this.setState({ status_card: false });
+                                                }}
+                                        />
+                                </div>
 			</div>
 		);
 	}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -6,7 +6,18 @@ let renderApps = (props) => {
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={index} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={index}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                innerRef={el => props.sidebarRefs.current[app.id] = el}
+            />
         );
     });
     return sideBarAppsJsx;

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -1,127 +1,121 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 
-export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+export default function Ubuntu() {
+        const [screenLocked, setScreenLocked] = useState(false);
+        const [bgImageName, setBgImageName] = useState('wall-2');
+        const [bootingScreen, setBootingScreen] = useState(true);
+        const [shutDownScreen, setShutDownScreen] = useState(false);
+        const statusBarRef = useRef(null);
+        const desktopRef = useRef(null);
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        useEffect(() => {
+                getLocalData();
+        }, []);
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        const setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        setBootingScreen(false);
+                }, 2000);
+        };
 
-	getLocalData = () => {
-		// Get Previously selected Background Image
-		let bg_image_name = localStorage.getItem('bg-image');
-		if (bg_image_name !== null && bg_image_name !== undefined) {
-			this.setState({ bg_image_name });
-		}
+        const getLocalData = () => {
+                let bg_image_name = localStorage.getItem('bg-image');
+                if (bg_image_name !== null && bg_image_name !== undefined) {
+                        setBgImageName(bg_image_name);
+                }
 
-		let booting_screen = localStorage.getItem('booting_screen');
-		if (booting_screen !== null && booting_screen !== undefined) {
-			// user has visited site before
-			this.setState({ booting_screen: false });
-		} else {
-			// user is visiting site for the first time
-			localStorage.setItem('booting_screen', false);
-			this.setTimeOutBootScreen();
-		}
+                let booting_screen = localStorage.getItem('booting_screen');
+                if (booting_screen !== null && booting_screen !== undefined) {
+                        setBootingScreen(false);
+                } else {
+                        localStorage.setItem('booting_screen', false);
+                        setTimeOutBootScreen();
+                }
 
-		// get shutdown state
-		let shut_down = localStorage.getItem('shut-down');
-		if (shut_down !== null && shut_down !== undefined && shut_down === 'true') this.shutDown();
-		else {
-			// Get previous lock screen state
-			let screen_locked = localStorage.getItem('screen-locked');
-			if (screen_locked !== null && screen_locked !== undefined) {
-				this.setState({ screen_locked: screen_locked === 'true' ? true : false });
-			}
-		}
-	};
+                let shut_down = localStorage.getItem('shut-down');
+                if (shut_down !== null && shut_down !== undefined && shut_down === 'true') shutDown();
+                else {
+                        let screen_locked = localStorage.getItem('screen-locked');
+                        if (screen_locked !== null && screen_locked !== undefined) {
+                                setScreenLocked(screen_locked === 'true');
+                        }
+                }
+        };
 
-	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Set Screen to Locked`
-		});
+        const lockScreen = () => {
+                ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Set Screen to Locked`
+                });
 
-		document.getElementById('status-bar').blur();
-		setTimeout(() => {
-			this.setState({ screen_locked: true });
-		}, 100); // waiting for all windows to close (transition-duration)
-		localStorage.setItem('screen-locked', true);
-	};
+                statusBarRef.current?.blur();
+                setTimeout(() => {
+                        setScreenLocked(true);
+                }, 100);
+                localStorage.setItem('screen-locked', true);
+        };
 
-	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        const unLockScreen = useCallback(() => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-		window.removeEventListener('click', this.unLockScreen);
-		window.removeEventListener('keypress', this.unLockScreen);
+                window.removeEventListener('click', unLockScreen);
+                window.removeEventListener('keypress', unLockScreen);
 
-		this.setState({ screen_locked: false });
-		localStorage.setItem('screen-locked', false);
-	};
+                setScreenLocked(false);
+                localStorage.setItem('screen-locked', false);
+        }, []);
 
-	changeBackgroundImage = (img_name) => {
-		this.setState({ bg_image_name: img_name });
-		localStorage.setItem('bg-image', img_name);
-	};
+        const changeBackgroundImage = (img_name) => {
+                setBgImageName(img_name);
+                localStorage.setItem('bg-image', img_name);
+        };
 
-	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+        const shutDown = () => {
+                ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Switched off the Ubuntu`
-		});
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Switched off the Ubuntu`
+                });
 
-		document.getElementById('status-bar').blur();
-		this.setState({ shutDownScreen: true });
-		localStorage.setItem('shut-down', true);
-	};
+                statusBarRef.current?.blur();
+                setShutDownScreen(true);
+                localStorage.setItem('shut-down', true);
+        };
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        const turnOn = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-		this.setState({ shutDownScreen: false, booting_screen: true });
-		this.setTimeOutBootScreen();
-		localStorage.setItem('shut-down', false);
-	};
+                setShutDownScreen(false);
+                setBootingScreen(true);
+                setTimeOutBootScreen();
+                localStorage.setItem('shut-down', false);
+        };
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+        const openSettings = () => {
+                desktopRef.current?.openApp && desktopRef.current.openApp('settings');
+        };
+
+        return (
+                <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                        <LockScreen
+                                isLocked={screenLocked}
+                                bgImgName={bgImageName}
+                                unLockScreen={unLockScreen}
+                        />
+                        <BootingScreen
+                                visible={bootingScreen}
+                                isShutDown={shutDownScreen}
+                                turnOn={turnOn}
+                        />
+                        <Navbar lockScreen={lockScreen} shutDown={shutDown} statusRef={statusBarRef} openSettings={openSettings} />
+                        <Desktop ref={desktopRef} bg_image_name={bgImageName} changeBackgroundImage={changeBackgroundImage} />
+                </div>
+        );
 }

--- a/components/util components/status_card.js
+++ b/components/util components/status_card.js
@@ -120,10 +120,10 @@ export class StatusCard extends Component {
 				<div className="w-64 flex content-center justify-center">
 					<div className="w-2/4 border-black border-opacity-50 border-b my-2 border-solid" />
 				</div>
-				<div
-					id="open-settings"
-					className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
-				>
+                                <div
+                                        onClick={this.props.openSettings}
+                                        className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
+                                >
 					<div className="w-8">
 						<img width="16px" height="16px" src="./themes/Yaru/status/emblem-system-symbolic.svg" alt="ubuntu settings" />
 					</div>


### PR DESCRIPTION
## Summary
- refactor Ubuntu shell and support components to functional React components using hooks
- manage desktop windows and context menus with refs instead of DOM queries or jQuery
- expose window operations and settings launch through refs for cleaner interactions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7309b8e883288dea7c56ad3c4cb1