### PR TITLE
Refactor calculator to hooks and add tests

### DIFF
--- a/components/apps/calc.js
+++ b/components/apps/calc.js
@@ -1,256 +1,133 @@
-import React, { Component } from 'react'
-import $ from 'jquery';
-const Parser = require('expr-eval').Parser;
+import React, { useState, useEffect, useRef } from 'react';
+import { evaluateExpression, navigateHistory, HELP_TEXT } from './calcUtils.mjs';
 
-const parser = new Parser({
-    operators: {
-      // These default to true, but are included to be explicit
-      add: true,
-      concatenate: true,
-      conditional: true,
-      divide: true,
-      factorial: true,
-      multiply: true,
-      power: true,
-      remainder: true,
-      subtract: true,
-
-      // Disable and, or, not, <, ==, !=, etc.
-      logical: false,
-      comparison: false,
-
-      // Disable 'in' and = operators
-      'in': false,
-      assignment: true
-    }
-  });
-
-export class Calc extends Component {
-    constructor() {
-        super();
-        this.cursor = "";
-        this.terminal_rows = 2;
-        this.prev_commands = [];
-        this.commands_index = -1;
-        this.variables={}
-        this.state = {
-            terminal: [],
+const xss = (str) => {
+    if (!str) return '';
+    return str.split('').map(char => {
+        switch (char) {
+            case '&':
+                return '&amp';
+            case '<':
+                return '&lt';
+            case '>':
+                return '&gt';
+            case '"':
+                return '&quot';
+            case "'":
+                return '&#x27';
+            case '/':
+                return '&#x2F';
+            default:
+                return char;
         }
-    }
+    }).join('');
+};
 
-    componentDidMount() {
-        this.reStartTerminal();
-    }
+export default function Calc() {
+    const [rows, setRows] = useState([{ id: 0, command: '', result: '' }]);
+    const [currentInput, setCurrentInput] = useState('');
+    const [cursorVisible, setCursorVisible] = useState(true);
+    const history = useRef([]);
+    const historyIndex = useRef(-1);
+    const variables = useRef({});
+    const inputRef = useRef(null);
 
-    componentDidUpdate() {
-        clearInterval(this.cursor);
-        this.startCursor(this.terminal_rows - 2);
-    }
+    const currentRow = rows[rows.length - 1];
 
-    componentWillUnmount() {
-        clearInterval(this.cursor);
-    }
+    useEffect(() => {
+        inputRef.current?.focus();
+        const interval = setInterval(() => setCursorVisible(v => !v), 500);
+        return () => clearInterval(interval);
+    }, [currentRow.id]);
 
-    reStartTerminal = () => {
-        clearInterval(this.cursor);
-        $('#calculator-body').empty();
-        this.appendTerminalRow();
-    }
-
-    appendTerminalRow = () => {
-        let terminal = this.state.terminal;
-        terminal.push(this.terminalRow(this.terminal_rows));
-        this.setState({ terminal });
-        this.terminal_rows += 2;
-    }
-
-    terminalRow = (id) => {
-        return (
-
-            <React.Fragment key={id}>
-                <div className=" flex p-2 text-ubt-grey opacity-100 mt-1 float-left font-normal "></div>
-                <div className="flex w-full h-5">
-                        <div className=" flex text-ubt-green h-1 mr-2"> {'$'} </div>
-                    <div id="cmd" onClick={this.focusCursor} className=" bg-transparent relative flex-1 overflow-hidden">
-                        <span id={`show-calculator-${id}`} className=" float-left whitespace-pre pb-1 opacity-100 font-normal tracking-wider"></span>
-                        <div id={`cursor-${id}`} className=" float-left mt-1 w-1.5 h-3.5 bg-white"></div>
-                        <input id={`calculator-input-${id}`} data-row-id={id} onKeyDown={this.checkKey} onBlur={this.unFocusCursor} className=" absolute top-0 left-0 w-full opacity-0 outline-none bg-transparent" spellCheck={false} autoFocus={true} autoComplete="off" type="text" />
-                    </div>
-                </div>
-                <div id={`row-calculator-result-${id}`} className={"my-2 font-normal"}></div>
-            </React.Fragment>
-        );
-
-    }
-
-    focusCursor = (e) => {
-        clearInterval(this.cursor);
-        this.startCursor($(e.target).data("row-id"));
-    }
-
-    unFocusCursor = (e) => {
-        this.stopCursor($(e.target).data("row-id"));
-    }
-
-    startCursor = (id) => {
-        clearInterval(this.cursor);
-        $(`input#calculator-input-${id}`).trigger("focus");
-        // On input change, set current text in span
-        $(`input#calculator-input-${id}`).on("input", function () {
-            $(`#cmd span#show-calculator-${id}`).text($(this).val());
-        });
-        this.cursor = window.setInterval(function () {
-            if ($(`#cursor-${id}`).css('visibility') === 'visible') {
-                $(`#cursor-${id}`).css({ visibility: 'hidden' });
-            } else {
-                $(`#cursor-${id}`).css({ visibility: 'visible' });
-            }
-        }, 500);
-    }
-
-    stopCursor = (id) => {
-        clearInterval(this.cursor);
-        $(`#cursor-${id}`).css({ visibility: 'visible' });
-    }
-
-    removeCursor = (id) => {
-        this.stopCursor(id);
-        $(`#cursor-${id}`).css({ display: 'none' });
-    }
-
-    clearInput = (id) => {
-        $(`input#calculator-input-${id}`).trigger("blur");
-    }
-
-    checkKey = (e) => {
-        if (e.key === "Enter") {
-            let terminal_row_id = $(e.target).data("row-id");
-            let command = $(`input#calculator-input-${terminal_row_id}`).val().trim();
-            if (command.length !== 0) {
-                this.removeCursor(terminal_row_id);
-                this.handleCommands(command, terminal_row_id);
-            }
-            else return;
-            // push to history
-            this.prev_commands.push(command);
-            this.commands_index = this.prev_commands.length - 1;
-
-            this.clearInput(terminal_row_id);
-        }
-        else if (e.key === "ArrowUp") {
-            let prev_command;
-
-            if (this.commands_index <= -1) prev_command = "";
-            else prev_command = this.prev_commands[this.commands_index];
-
-            let terminal_row_id = $(e.target).data("row-id");
-
-            $(`input#calculator-input-${terminal_row_id}`).val(prev_command);
-            $(`#show-calculator-${terminal_row_id}`).text(prev_command);
-
-            this.commands_index--;
-        }
-        else if (e.key === "ArrowDown") {
-            let prev_command;
-
-            if (this.commands_index >= this.prev_commands.length) return;
-            if (this.commands_index <= -1) this.commands_index = 0;
-
-            if (this.commands_index === this.prev_commands.length) prev_command = "";
-            else prev_command = this.prev_commands[this.commands_index];
-
-            let terminal_row_id = $(e.target).data("row-id");
-
-            $(`input#calculator-input-${terminal_row_id}`).val(prev_command);
-            $(`#show-calculator-${terminal_row_id}`).text(prev_command);
-
-            this.commands_index++;
-        }
-    }
-
-    closeTerminal = () => {
-        $("#close-calc").trigger('click');
-    }
-
-    handleCommands = (command, rowId) => {
-        let words = command.split(' ').filter(Boolean);
-        let main = words[0];
-        // words.shift()
-        let result = "";
-        switch (main) {        
-            case "clear":
-                this.reStartTerminal();
-                return;
-            case "exit":
-                this.closeTerminal();
-                return;
-            case "help":                
-                result = "Available Commands: <br/>Operators:<br/> addition ( + ), subtraction ( - ),<br/>multiplication ( * ), division ( / ),<br/>modulo ( % )exponentiation. ( ^ )<br/><br/>Mathematical functions:<br/>abs[x] : Absolute value (magnitude) of x<br/>acos[x] : Arc cosine of x (in radians)<br/>acosh[x] : Hyperbolic arc cosine of x (in radians)<br/>asin[x] : Arc sine of x (in radians)<br/>asinh[x] : Hyperbolic arc sine of x (in radians)<br/>atan[x] : Arc tangent of x (in radians)<br/>atanh[x] : Hyperbolic arc tangent of x (in radians)<br/>cbrt[x] : Cube root of x<br/>ceil[x] : Ceiling of x — the smallest integer that’s >= x<br/>cos[x] : Cosine of x (x is in radians)<br/>cosh[x] : Hyperbolic cosine of x (x is in radians)<br/>exp[x] : e^x (exponential/antilogarithm function with base e)<br/>floor[x] : Floor of x — the largest integer that’s <= x<br/>ln[x] : Natural logarithm of x<br/>log[x] : Natural logarithm of x (synonym for ln, not base-10)<br/>log10[x] :	Base-10 logarithm of x<br/>log2[x] : Base-2 logarithm of x<br/>round[x] :	X, rounded to the nearest integer<br/>sign[x] : Sign of x (-1, 0, or 1 for negative, zero, or positive respectively)<br/>sin[x] : Sine of x (x is in radians)<br/>sinh[x] : Hyperbolic sine of x (x is in radians)<br/>sqrt[x] : Square root of x. Result is NaN (Not a Number) if x is negative.<br/>tan[x] : Tangent of x (x is in radians)<br/>tanh[x] : Hyperbolic tangent of x (x is in radians)<br/> <br/><br/>Pre-defined functions:<br/>random(n) : Get a random number in the range [0, n). If n is zero, or not provided, it defaults to 1.<br/>fac(n)	n! : (factorial of n: \"n * (n-1) * (n-2) * … * 2 * 1\") Deprecated. Use the ! operator instead.<br/>min(a,b,…) : Get the smallest (minimum) number in the list.<br/>max(a,b,…) : Get the largest (maximum) number in the list.<br/>hypot(a,b) : Hypotenuse, i.e. the square root of the sum of squares of its arguments.<br/>pyt(a, b) : Alias for hypot.<br/>pow(x, y) : Equivalent to x^y.<br/>roundTo(x, n) : Rounds x to n places after the decimal point.<br/><br/>Constants: <br/>E : The value of Math.E from your JavaScript runtime.<br/>PI : The value of Math.PI from your JavaScript runtime.<br/><br/>Variable assignments : <br/>declare variable and assign a value: x=1  declared variable can be used in further calculation x+2.<br/><br/>clear command for clearing calculator app.<br/><br/>exit command for exit from calculator app. ";
-                break;                
-            default: 
-                result = this.evaluteExp(command);                    
-        }
-        document.getElementById(`row-calculator-result-${rowId}`).innerHTML = result;
-        this.appendTerminalRow();
-    }
-    evaluteExp = (command) => {
-        let result = "";
-        let expr;
-            try{
-                expr=parser.parse(command)
-                try{
-                    result = parser.evaluate(command,this.variables)
-                    if(expr.tokens.length===2&&expr.tokens[2].type==="IOP2")
-                    this.variables[expr.variables()[0]]=result
+    const handleCommands = (command) => {
+        const words = command.split(' ').filter(Boolean);
+        const main = words[0];
+        switch (main) {
+            case 'exit':
+                if (typeof document !== 'undefined') {
+                    document.getElementById('close-calc')?.click();
                 }
-                catch (e) {
-                    result = e.message;
-                }
-            }
-            catch(e){
-                result="Invalid Expression"
-            }    
-        return result;
-    }
-    xss(str) {
-        if (!str) return;
-        return str.split('').map(char => {
-            switch (char) {
-                case '&':
-                    return '&amp';
-                case '<':
-                    return '&lt';
-                case '>':
-                    return '&gt';
-                case '"':
-                    return '&quot';
-                case "'":
-                    return '&#x27';
-                case '/':
-                    return '&#x2F';
-                default:
-                    return char;
-            }
-        }).join('');
-    }
-    
+                return '';
+            case 'help':
+                return HELP_TEXT;
+            default:
+                return evaluateExpression(command, variables.current);
+        }
+    };
 
-    render() {
-        return (
-            <div className="h-full w-full bg-ub-drk-abrgn text-ubt-grey opacity-100 p-1 float-left font-normal">
-                <div>C-style arbitary precision calculator (version 2.12.7.2)</div>
-                <div>Calc is open software.</div>
-                <div>[ type "exit" to exit, "clear" to clear, "help" for help.]</div>
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            const command = currentInput.trim();
+            if (command.length === 0) return;
+            history.current.push(command);
+            historyIndex.current = history.current.length - 1;
+            if (command === 'clear') {
+                setRows([{ id: 0, command: '', result: '' }]);
+                setCurrentInput('');
+                variables.current = {};
+                return;
+            }
+            const result = handleCommands(command);
+            setRows(prev => {
+                const newRows = [...prev];
+                newRows[newRows.length - 1] = { id: currentRow.id, command, result };
+                newRows.push({ id: currentRow.id + 2, command: '', result: '' });
+                return newRows;
+            });
+            setCurrentInput('');
+        } else if (e.key === 'ArrowUp') {
+            const res = navigateHistory(history.current, historyIndex.current, 'up');
+            historyIndex.current = res.index;
+            setCurrentInput(res.cmd);
+        } else if (e.key === 'ArrowDown') {
+            const res = navigateHistory(history.current, historyIndex.current, 'down');
+            if (res.cmd === null) return;
+            historyIndex.current = res.index;
+            setCurrentInput(res.cmd);
+        }
+    };
+
+    return (
+        <div className="h-full w-full bg-ub-drk-abrgn text-ubt-grey opacity-100 p-1 float-left font-normal">
+            <div>C-style arbitary precision calculator (version 2.12.7.2)</div>
+            <div>Calc is open software.</div>
+            <div>[ type "exit" to exit, "clear" to clear, "help" for help.]</div>
             <div className="text-white text-sm font-bold bg-ub-drk-abrgn" id="calculator-body">
-                {this.state.terminal}
+                {rows.map(row => (
+                    <React.Fragment key={row.id}>
+                        <div className=" flex p-2 text-ubt-grey opacity-100 mt-1 float-left font-normal "></div>
+                        <div className="flex w-full h-5">
+                            <div className=" flex text-ubt-green h-1 mr-2"> {'$'} </div>
+                            <div className=" bg-transparent relative flex-1 overflow-hidden" onClick={() => inputRef.current?.focus()}>
+                                <span className=" float-left whitespace-pre pb-1 opacity-100 font-normal tracking-wider">{row.id === currentRow.id ? xss(currentInput) : xss(row.command)}</span>
+                                {row.id === currentRow.id && (
+                                    <div className=" float-left mt-1 w-1.5 h-3.5 bg-white" style={{ visibility: cursorVisible ? 'visible' : 'hidden' }}></div>
+                                )}
+                                {row.id === currentRow.id && (
+                                    <input
+                                        ref={inputRef}
+                                        className=" absolute top-0 left-0 w-full opacity-0 outline-none bg-transparent"
+                                        spellCheck={false}
+                                        autoComplete="off"
+                                        type="text"
+                                        value={currentInput}
+                                        onChange={e => setCurrentInput(e.target.value)}
+                                        onKeyDown={handleKeyDown}
+                                    />
+                                )}
+                            </div>
+                        </div>
+                        {row.result !== '' && (
+                            <pre className="my-2 font-normal">{xss(String(row.result))}</pre>
+                        )}
+                    </React.Fragment>
+                ))}
             </div>
-            </div>
-        )
-    }
+        </div>
+    );
 }
 
-export default Calc
-
-export const displayTerminalCalc = (addFolder,openApp) => {
+export const displayTerminalCalc = (addFolder, openApp) => {
     return <Calc addFolder={addFolder} openApp={openApp}> </Calc>;
-}
+};

--- a/components/apps/calcUtils.mjs
+++ b/components/apps/calcUtils.mjs
@@ -1,0 +1,111 @@
+import { Parser } from 'expr-eval';
+
+const parser = new Parser({
+    operators: {
+        add: true,
+        concatenate: true,
+        conditional: true,
+        divide: true,
+        factorial: true,
+        multiply: true,
+        power: true,
+        remainder: true,
+        subtract: true,
+        logical: false,
+        comparison: false,
+        in: false,
+        assignment: true,
+    },
+});
+
+export function evaluateExpression(command, variables = {}) {
+    let result = "";
+    let expr;
+    try {
+        expr = parser.parse(command);
+        try {
+            result = parser.evaluate(command, variables);
+            if (expr.tokens.length === 2 && expr.tokens[2].type === "IOP2") {
+                variables[expr.variables()[0]] = result;
+            }
+        } catch (e) {
+            result = e.message;
+        }
+    } catch (e) {
+        result = "Invalid Expression";
+    }
+    return result;
+}
+
+export const HELP_TEXT = [
+"Available Commands:",
+"Operators:",
+" addition ( + ), subtraction ( - ),",
+"multiplication ( * ),",
+"division ( / ),",
+"modulo ( % )exponentiation. ( ^ )",
+"",
+"Mathematical functions:",
+"abs[x] : Absolute value (magnitude) of x",
+"acos[x] : Arc cosine of x (in radians)",
+"acosh[x] : Hyperbolic arc cosine of x (in radians)",
+"asin[x] : Arc sine of x (in radians)",
+"asinh[x] : Hyperbolic arc sine of x (in radians)",
+"atan[x] : Arc tangent of x (in radians)",
+"atanh[x] : Hyperbolic arc tangent of x (in radians)",
+"cbrt[x] : Cube root of x",
+"ceil[x] : Ceiling of x — the smallest integer that’s >= x",
+"cos[x] : Cosine of x (x is in radians)",
+"cosh[x] : Hyperbolic cosine of x (x is in radians)",
+"exp[x] : e^x (exponential/antilogarithm function with base e)",
+"floor[x] : Floor of x — the largest integer that’s <= x",
+"ln[x] : Natural logarithm of x",
+"log[x] : Natural logarithm of x (synonym for ln, not base-10)",
+"log10[x] :  Base-10 logarithm of x",
+"log2[x] : Base-2 logarithm of x",
+"round[x] :       X, rounded to the nearest integer",
+"sign[x] : Sign of x (-1, 0, or 1 for negative, zero, or positive respectively)",
+"sin[x] : Sine of x (x is in radians)",
+"sinh[x] : Hyperbolic sine of x (x is in radians)",
+"sqrt[x] : Square root of x. Result is NaN (Not a Number) if x is negative.",
+"tan[x] : Tangent of x (x is in radians)",
+"tanh[x] : Hyperbolic tangent of x (x is in radians)",
+"",
+"",
+"Pre-defined functions:",
+"random(n) : Get a random number in the range [0, n). If n is zero, or not provided, it defaults to 1.",
+"fac(n)        n! : (factorial of n: \"n * (n-1) * (n-2) * … *2 * 1\") Deprecated. Use the ! operator instead.",
+"min(a,b,…) : Get the smallest (minimum) number in the list.",
+"max(a,b,…) : Get the largest (maximum) number in the list.",
+"hypot(a,b) : Hypotenuse, i.e. the square root of the sum of squares of its arguments.",
+"pyt(a, b) : Alias for hypot.",
+"pow(x, y) : Equivalent to x^y.",
+"roundTo(x, n) : Rounds x to n places after the decimal point.",
+"",
+"Constants: ",
+"E : The value of Math.E from your JavaScript runtime.",
+"PI : The value of Math.PI from your JavaScript runtime.",
+"",
+"Variable assignments : ",
+"declare variable and assign a value: x=1  declared variable can be used in further calculation x+2.",
+"",
+"clear command for clearing calculator app.",
+"",
+"exit command for exit from calculator app."
+].join('\n');
+
+export function navigateHistory(history, index, direction) {
+    if (direction === "up") {
+        const cmd = index <= -1 ? "" : history[index] ?? "";
+        return { cmd, index: index - 1 };
+    }
+    if (direction === "down") {
+        if (index >= history.length) {
+            return { cmd: null, index };
+        }
+        if (index <= -1) index = 0;
+        const cmd = index === history.length ? "" : history[index] ?? "";
+        return { cmd, index: index + 1 };
+    }
+    return { cmd: null, index };
+}

--- a/components/apps/calcUtils.test.mjs
+++ b/components/apps/calcUtils.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateExpression, navigateHistory } from './calcUtils.mjs';
+
+test('evaluateExpression handles arithmetic and variables', () => {
+    const vars = {};
+    assert.equal(evaluateExpression('2+3', vars), 5);
+    assert.equal(evaluateExpression('x=3', vars), 3);
+    assert.equal(vars.x, 3);
+    assert.equal(evaluateExpression('x*2', vars), 6);
+});
+
+test('navigateHistory navigates command history', () => {
+    const history = ['a', 'b'];
+    let res = navigateHistory(history, history.length - 1, 'up');
+    assert.deepEqual(res, { cmd: 'b', index: 0 });
+    res = navigateHistory(history, res.index, 'up');
+    assert.deepEqual(res, { cmd: 'a', index: -1 });
+    res = navigateHistory(history, res.index, 'down');
+    assert.deepEqual(res, { cmd: 'a', index: 1 });
+    res = navigateHistory(history, res.index, 'down');
+    assert.deepEqual(res, { cmd: 'b', index: 2 });
+    res = navigateHistory(history, res.index, 'down');
+    assert.deepEqual(res, { cmd: null, index: 2 });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next export"
+    "export": "next export",
+    "test": "node --test"
   },
   "engines": {
     "node": ">=16.x"


### PR DESCRIPTION
## Summary
- rewrite calc app as functional component with hooks and state-driven cursor
- sanitize output and render results via JSX instead of innerHTML
- add utility helpers and unit tests for evaluation and command history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b730c98f88328be0a3d557797ae4e