### PR TITLE
feat: centralize analytics setup and helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Google Analytics measurement ID
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { gaEvent } from '../../lib/analytics';
 import emailjs from '@emailjs/browser';
 
 export class Gedit extends Component {
@@ -58,7 +58,7 @@ export class Gedit extends Component {
             $("#close-gedit").trigger("click");
         })
 
-        ReactGA.event({
+        gaEvent({
             category: "Send Message",
             action: `${name}, ${subject}, ${message}`
         });

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { gaEvent } from '../../lib/analytics';
 
 export class Terminal extends Component {
     constructor() {
@@ -315,7 +315,7 @@ export class Terminal extends Component {
                 return;
             case "sudo":
 
-                ReactGA.event({
+                gaEvent({
                     category: "Sudo Access",
                     action: "lol",
                 });

--- a/components/apps/vivek.js
+++ b/components/apps/vivek.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReactGA from 'react-ga4';
+import { gaSend } from '../../lib/analytics';
 
 export class AboutVivek extends Component {
 
@@ -38,7 +38,7 @@ export class AboutVivek extends Component {
         localStorage.setItem("about-section", screen);
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${screen}`, title: "Custom Title" });
+        gaSend({ hitType: "pageview", page: `/${screen}`, title: "Custom Title" });
 
 
         this.setState({

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
-import ReactGA from 'react-ga4';
+import { gaSend } from '../../lib/analytics';
 import { displayTerminal } from '../apps/terminal'
 
 export class Window extends Component {
@@ -28,14 +28,14 @@ export class Window extends Component {
         this.setDefaultWindowDimenstion();
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
+        gaSend({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
 
         // on window resize, resize boundary
         window.addEventListener('resize', this.resizeBoundries);
     }
 
     componentWillUnmount() {
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        gaSend({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
         window.removeEventListener('resize', this.resizeBoundries);
     }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,7 +8,7 @@ import AllApplications from '../screen/all-applications'
 import DesktopMenu from '../context menus/desktop-menu';
 import DefaultMenu from '../context menus/default';
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { gaSend, gaEvent } from '../../lib/analytics';
 
 export class Desktop extends Component {
     constructor() {
@@ -36,7 +36,7 @@ export class Desktop extends Component {
 
     componentDidMount() {
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        gaSend({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
         this.fetchAppsData();
         this.setContextListeners();
@@ -92,14 +92,14 @@ export class Desktop extends Component {
         this.hideAllContextMenu();
         switch (e.target.dataset.context) {
             case "desktop-area":
-                ReactGA.event({
+                gaEvent({
                     category: `Context Menu`,
                     action: `Opened Desktop Context Menu`
                 });
                 this.showContextMenu(e, "desktop");
                 break;
             default:
-                ReactGA.event({
+                gaEvent({
                     category: `Context Menu`,
                     action: `Opened Default Context Menu`
                 });
@@ -348,7 +348,7 @@ export class Desktop extends Component {
     openApp = (objId) => {
 
         // google analytics
-        ReactGA.event({
+        gaEvent({
             category: `Open App`,
             action: `Opened ${objId} window`
         });

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -3,7 +3,7 @@ import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
-import ReactGA from 'react-ga4';
+import { gaSend, gaEvent } from '../lib/analytics';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -56,12 +56,12 @@ export default class Ubuntu extends Component {
 	};
 
 	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Set Screen to Locked`
-		});
+                // google analytics
+                gaSend({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+                gaEvent({
+                        category: `Screen Change`,
+                        action: `Set Screen to Locked`
+                });
 
 		document.getElementById('status-bar').blur();
 		setTimeout(() => {
@@ -71,7 +71,7 @@ export default class Ubuntu extends Component {
 	};
 
 	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+                gaSend({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		window.removeEventListener('click', this.unLockScreen);
 		window.removeEventListener('keypress', this.unLockScreen);
@@ -86,12 +86,12 @@ export default class Ubuntu extends Component {
 	};
 
 	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+                gaSend({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Switched off the Ubuntu`
-		});
+                gaEvent({
+                        category: `Screen Change`,
+                        action: `Switched off the Ubuntu`
+                });
 
 		document.getElementById('status-bar').blur();
 		this.setState({ shutDownScreen: true });
@@ -99,7 +99,7 @@ export default class Ubuntu extends Component {
 	};
 
 	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+                gaSend({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		this.setState({ shutDownScreen: false, booting_screen: true });
 		this.setTimeOutBootScreen();

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,14 @@
+import ReactGA from 'react-ga4';
+
+export const gaSend = (options = {}) => {
+  ReactGA.send(options);
+};
+
+export const gaEvent = (options = {}) => {
+  ReactGA.event(options);
+};
+
+export default {
+  gaSend,
+  gaEvent,
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,13 @@
+import { useEffect } from 'react'
+import ReactGA from 'react-ga4'
 import 'tailwindcss/tailwind.css'
 import '../styles/index.css'
 
 function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    ReactGA.initialize(process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID)
+  }, [])
+
   return <Component {...pageProps} />
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,5 @@
 import Ubuntu from "../components/ubuntu";
-import ReactGA from 'react-ga4';
 import Meta from "../components/SEO/Meta";
-
-const TRACKING_ID = process.env.GA_MEASUREMENT_ID;
 
 function App() {
   return (


### PR DESCRIPTION
## Summary
- initialize Google Analytics in `_app.js` using `NEXT_PUBLIC_GA_MEASUREMENT_ID`
- remove unused GA setup from `index.js`
- add reusable analytics helper and refactor components to use it

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b730f0b0c8328993af36a33910401