### PR TITLE
Lazy load heavy apps with dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
+## Adding New Apps
 
+Heavy applications should be loaded with [`next/dynamic`](https://nextjs.org/docs/advanced-features/dynamic-import) so that they do not bloat the initial bundle.
+
+```js
+import dynamic from 'next/dynamic';
+import ReactGA from 'react-ga4';
+
+const MyApp = dynamic(() =>
+    import('./components/apps/my-app').then(mod => {
+        ReactGA.event({ category: 'Application', action: 'Loaded My App' });
+        return mod.default;
+    }), {
+        ssr: false,
+        loading: () => (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+                Loading My App...
+            </div>
+        ),
+    }
+);
+
+const displayMyApp = (addFolder, openApp) => (
+    <MyApp addFolder={addFolder} openApp={openApp} />
+);
+```
+
+Add the `displayMyApp` function to `apps.config.js` and reference it in the `apps` array to make the app available to the desktop.

--- a/apps.config.js
+++ b/apps.config.js
@@ -1,12 +1,50 @@
+import React from 'react';
+import dynamic from 'next/dynamic';
+import ReactGA from 'react-ga4';
+
 import displaySpotify from './components/apps/spotify';
 import displayVsCode from './components/apps/vscode';
-import { displayTerminal } from './components/apps/terminal';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/chrome';
 import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayAboutVivek } from './components/apps/vivek';
-import { displayTerminalCalc } from './components/apps/calc';
+// Dynamically loaded apps
+const TerminalApp = dynamic(() =>
+    import('./components/apps/terminal').then(mod => {
+        ReactGA.event({ category: 'Application', action: 'Loaded Terminal' });
+        return mod.default;
+    }), {
+        ssr: false,
+        loading: () => (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+                Loading Terminal...
+            </div>
+        ),
+    }
+);
+
+const CalcApp = dynamic(() =>
+    import('./components/apps/calc').then(mod => {
+        ReactGA.event({ category: 'Application', action: 'Loaded Calc' });
+        return mod.default;
+    }), {
+        ssr: false,
+        loading: () => (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+                Loading Calc...
+            </div>
+        ),
+    }
+);
+
+const displayTerminal = (addFolder, openApp) => (
+    <TerminalApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displayTerminalCalc = (addFolder, openApp) => (
+    <CalcApp addFolder={addFolder} openApp={openApp} />
+);
 
 const apps = [
     {

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
-import { displayTerminal } from '../apps/terminal'
 
 export class Window extends Component {
     constructor() {
@@ -290,7 +289,7 @@ export class WindowMainScreen extends Component {
     render() {
         return (
             <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
-                {this.props.addFolder ? displayTerminal(this.props.addFolder, this.props.openApp) : this.props.screen()}
+                {this.props.screen(this.props.addFolder, this.props.openApp)}
             </div>
         )
     }


### PR DESCRIPTION
## Summary
- Lazily load Terminal and Calc apps using `next/dynamic` with Ubuntu-themed fallbacks
- Emit GA events when Terminal and Calc modules finish loading
- Simplify window screen rendering so apps receive optional parameters
- Document how to add apps with dynamic imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b731697988328bd7577ba3aa04ed0