### PR TITLE
Lazy load X timeline

### DIFF
--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,13 +1,25 @@
 import React from 'react';
-import { TwitterTimelineEmbed } from 'react-twitter-embed';
+import dynamic from 'next/dynamic';
+
+const TwitterTimeline = dynamic(
+    () => import('react-twitter-embed').then(m => m.TwitterTimelineEmbed),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+                Loading...
+            </div>
+        ),
+    }
+);
 
 export default function x() {
     return (
         <div className="h-full w-full bg-ub-cool-grey">
-            <TwitterTimelineEmbed
+            <TwitterTimeline
                 sourceType="profile"
                 screenName="AUnnippillil"
-                options={{height: '1200%'}}
+                options={{ height: '1200%' }}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- Dynamically load the X (Twitter) timeline component to keep the initial bundle lean
- Add a simple loading state while the timeline component is fetched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44731ab0c8328aed27f929f608736