### PR TITLE
feat: add Todoist app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -9,6 +9,7 @@ import { displayChrome } from './components/apps/chrome';
 import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayAboutVivek } from './components/apps/vivek';
+import { displayTodoist } from './components/apps/todoist';
 // Dynamically loaded apps
 const TerminalApp = dynamic(() =>
     import('./components/apps/terminal').then(mod => {
@@ -92,20 +93,29 @@ const apps = [
         desktop_shortcut: false,
         screen: displayTerminal,
     },
-    {
-        id: "x",
-        title: "X",
-        icon: './themes/Yaru/apps/x.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displaySpotify, // India Top 50 Playlist 😅
-    },
-    {
-        id: "settings",
-        title: "Settings",
-        icon: './themes/Yaru/apps/gnome-control-center.png',
-        disabled: false,
+      {
+          id: "x",
+          title: "X",
+          icon: './themes/Yaru/apps/x.png',
+          disabled: false,
+          favourite: true,
+          desktop_shortcut: false,
+          screen: displaySpotify, // India Top 50 Playlist 😅
+      },
+      {
+          id: "todoist",
+          title: "Todoist",
+          icon: './themes/Yaru/apps/todoist.png',
+          disabled: false,
+          favourite: false,
+          desktop_shortcut: false,
+          screen: displayTodoist,
+      },
+      {
+          id: "settings",
+          title: "Settings",
+          icon: './themes/Yaru/apps/gnome-control-center.png',
+          disabled: false,
         favourite: true,
         desktop_shortcut: false,
         screen: displaySettings,

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -267,7 +267,7 @@ export class Terminal extends Component {
                 break;
             case "todoist":
                 if (words[0] === "." || words.length === 0) {
-                    this.props.openApp("todo-ist");
+                    this.props.openApp("todoist");
                 } else {
                     result = "Command '" + main + "' not found, or not yet implemented.<br>Available Commands: [ cd, ls, pwd, echo, clear, exit, mkdir, code, spotify, chrome, about-alex, todoist, trash, settings, sendmsg ]";
                 }


### PR DESCRIPTION
## Summary
- add Todoist app definition and import
- wire terminal `todoist` command to open Todoist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44732ec8483289f92896dd30442a1