### PR TITLE
Rename Spotify app component and align IDs

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -2,7 +2,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import ReactGA from 'react-ga4';
 
-import displaySpotify from './components/apps/spotify';
+import { displayX } from './components/apps/spotify';
 import displayVsCode from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/chrome';
@@ -93,13 +93,13 @@ const apps = [
         screen: displayTerminal,
     },
     {
-        id: "x",
+        id: "spotify",
         title: "X",
         icon: './themes/Yaru/apps/x.png',
         disabled: false,
         favourite: true,
         desktop_shortcut: false,
-        screen: displaySpotify, // India Top 50 Playlist 😅
+        screen: displayX, // India Top 50 Playlist 😅
     },
     {
         id: "settings",

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TwitterTimelineEmbed } from 'react-twitter-embed';
 
-export default function x() {
+export default function XApp() {
     return (
         <div className="h-full w-full bg-ub-cool-grey">
             <TwitterTimelineEmbed
@@ -12,3 +12,6 @@ export default function x() {
         </div>
     );
 }
+
+export const displayX = () => <XApp />;
+

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -253,7 +253,7 @@ export class Terminal extends Component {
                 break;
             case "spotify":
                 if (words[0] === "." || words.length === 0) {
-                    this.props.openApp("spotify");
+                    this.props.openApp("spotify"); // launch Spotify app
                 } else {
                     result = "Command '" + main + "' not found, or not yet implemented.<br>Available Commands: [ cd, ls, pwd, echo, clear, exit, mkdir, code, spotify, chrome, about-alex, todoist, trash, settings, sendmsg ]";
                 }


### PR DESCRIPTION
## Summary
- rename Spotify component to `XApp`
- expose `displayX` helper and import in app config
- sync terminal command to open Spotify via matching ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4473383848328b31c71e62d08d689