### PR TITLE
Sandbox iframe apps and restrict frame sources

### DIFF
--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -78,7 +78,8 @@ export class Chrome extends Component {
         return (
             <div className="h-full w-full flex flex-col bg-ub-cool-grey">
                 {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
+                {/* Sandbox allows forms, scripts, same-origin, and popups for browsing */}
+                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url" sandbox="allow-forms allow-scripts allow-same-origin allow-popups"></iframe>
             </div>
         )
     }

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -2,8 +2,11 @@ import React from 'react'
 
 export default function Todoist() {
     return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
-        // just to bypass the headers 🙃
+        <>
+            {/* Allows forms and scripts for Todoist project interface */}
+            <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full" sandbox="allow-forms allow-scripts allow-same-origin"></iframe>
+            {/* just to bypass the headers 🙃 */}
+        </>
     )
 }
 

--- a/components/apps/vivek.js
+++ b/components/apps/vivek.js
@@ -548,7 +548,8 @@ function Projects() {
                                 <div className="flex flex-wrap justify-between items-center">
                                     <div className='flex justify-center items-center'>
                                         <div className=" text-base md:text-lg mr-2">{project.name.toLowerCase()}</div>
-                                        <iframe src={`https://ghbtns.com/github-btn.html?user=alex-unnippillil&repo=${projectName}&type=star&count=true`} frameBorder="0" scrolling="0" width="150" height="20" title={project.name.toLowerCase()+"-star"}></iframe>
+                                        {/* GitHub star button only requires scripts */}
+                                        <iframe src={`https://ghbtns.com/github-btn.html?user=alex-unnippillil&repo=${projectName}&type=star&count=true`} frameBorder="0" scrolling="0" width="150" height="20" title={project.name.toLowerCase()+"-star"} sandbox="allow-scripts"></iframe>
                                     </div>
                                     <div className="text-gray-300 font-light text-sm">{project.date}</div>
                                 </div>
@@ -582,6 +583,7 @@ function Projects() {
 }
 function Resume() {
     return (
-        <iframe className="h-full w-full" src="./files/Alex-Unnippillil-Resume.pdf" title="Alex Unnippillil Resume" frameBorder="0"></iframe>
+        {/* Static PDF; no extra permissions needed */}
+        <iframe className="h-full w-full" src="./files/Alex-Unnippillil-Resume.pdf" title="Alex Unnippillil Resume" frameBorder="0" sandbox=""></iframe>
     )
 }

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -2,9 +2,12 @@ import React from 'react'
 
 export default function VsCode() {
     return (
-        <iframe src="https://github1s.com/Alex-Unnippillil/kali-linux-portfolio" frameBorder="0" title="VsCode" className="h-full w-full bg-ub-cool-grey"></iframe>
-        // this is not my work, but it's amazing!
-        // Here is the link to the original repo: https://github.com/conwnet/github1s
+        <>
+            {/* Only scripts and same-origin needed for GitHub1s */}
+            <iframe src="https://github1s.com/Alex-Unnippillil/kali-linux-portfolio" frameBorder="0" title="VsCode" className="h-full w-full bg-ub-cool-grey" sandbox="allow-scripts allow-same-origin"></iframe>
+            {/* this is not my work, but it's amazing! */}
+            {/* Here is the link to the original repo: https://github.com/conwnet/github1s */}
+        </>
     )
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,18 @@
+const securityHeaders = [
+    {
+        key: 'Content-Security-Policy',
+        value: "frame-src 'self' https://www.google.com https://todoist.com https://github1s.com https://ghbtns.com;",
+    },
+];
+
+module.exports = {
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: securityHeaders,
+            },
+        ];
+    },
+};
+


### PR DESCRIPTION
## Summary
- add sandbox restrictions and documentation to embedded app iframes
- enforce CSP frame-src header for approved domains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4cbfabefc8328a26e26d476430274