### PR TITLE
refactor forms to remove jquery

### DIFF
--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import $ from 'jquery';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
 
@@ -9,6 +8,11 @@ export class Gedit extends Component {
         super();
         this.state = {
             sending: false,
+            name: '',
+            subject: '',
+            message: '',
+            namePlaceholder: 'Your Email / Name :',
+            messagePlaceholder: 'Message',
         }
     }
 
@@ -16,10 +20,16 @@ export class Gedit extends Component {
         emailjs.init(process.env.NEXT_PUBLIC_USER_ID);
     }
 
+    handleChange = (e) => {
+        const { name, value } = e.target;
+        const newState = { [name]: value };
+        if (name === 'name') newState.namePlaceholder = 'Your Email / Name :';
+        if (name === 'message') newState.messagePlaceholder = 'Message';
+        this.setState(newState);
+    }
+
     sendMessage = async () => {
-        let name = $("#sender-name").val();
-        let subject = $("#sender-subject").val();
-        let message = $("#sender-message").val();
+        let { name, subject, message } = this.state;
 
         name = name.trim();
         subject = subject.trim();
@@ -28,14 +38,12 @@ export class Gedit extends Component {
         let error = false;
 
         if (name.length === 0) {
-            $("#sender-name").val('');
-            $("#sender-name").attr("placeholder", "Name must not be Empty!");
+            this.setState({ name: '', namePlaceholder: 'Name must not be Empty!' });
             error = true;
         }
 
         if (message.length === 0) {
-            $("#sender-message").val('');
-            $("#sender-message").attr("placeholder", "Message must not be Empty!");
+            this.setState({ message: '', messagePlaceholder: 'Message must not be Empty!' });
             error = true;
         }
         if (error) return;
@@ -51,11 +59,11 @@ export class Gedit extends Component {
         }
 
         emailjs.send(serviceID, templateID, templateParams).then(() => {
-            this.setState({ sending: false });
-            $("#close-gedit").trigger("click");
+            this.setState({ sending: false, name: '', subject: '', message: '' });
+            document.getElementById('close-gedit')?.click();
         }).catch(() => {
             this.setState({ sending: false });
-            $("#close-gedit").trigger("click");
+            document.getElementById('close-gedit')?.click();
         })
 
         ReactGA.event({
@@ -77,15 +85,15 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" className=" w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent" placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" name="name" value={this.state.name} onChange={this.handleChange} className=" w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent" placeholder={this.state.namePlaceholder} spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" name="subject" value={this.state.subject} onChange={this.handleChange} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" className=" w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent" placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <textarea id="sender-message" name="message" value={this.state.message} onChange={this.handleChange} className=" w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent" placeholder={this.state.messagePlaceholder} spellCheck="false" autoComplete="none" type="text" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                     </div>
                 </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import $ from 'jquery';
 
 export function Settings(props) {
     const wallpapers = {
@@ -14,7 +13,7 @@ export function Settings(props) {
     };
 
     let changeBackgroundImage = (e) => {
-        props.changeBackgroundImage($(e.target).data("path"));
+        props.changeBackgroundImage(e.currentTarget.dataset.path);
     }
 
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@emailjs/browser": "^3.10.0",
         "autoprefixer": "^10.4.13",
         "expr-eval": "^2.0.2",
-        "jquery": "^3.6.3",
         "next": "^13.1.2",
         "postcss": "^8.4.21",
         "prop-types": "^15.8.1",
@@ -4557,11 +4556,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
-      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@emailjs/browser": "^3.10.0",
     "autoprefixer": "^10.4.13",
     "expr-eval": "^2.0.2",
-    "jquery": "^3.6.3",
     "next": "^13.1.2",
     "postcss": "^8.4.21",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
## Summary
- refactor gedit app to use controlled inputs and native DOM interactions
- switch settings wallpaper chooser to native dataset access
- remove jquery from project dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4cbfbefac8328ae842509cb2410df