### PR TITLE
feat: gate analytics with consent

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
-import ReactGA from 'react-ga4';
+import { trackEvent } from './lib/analytics';
 
-import displaySpotify from './components/apps/spotify';
-import { displayVsCode } from './components/apps/vscode';
-=======
 import { displayX } from './components/apps/spotify';
 import displayVsCode from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
@@ -13,12 +10,15 @@ import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayAboutVivek } from './components/apps/vivek';
 import { displayTodoist } from './components/apps/todoist';
+
 // Dynamically loaded apps
-const TerminalApp = dynamic(() =>
-    import('./components/apps/terminal').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded Terminal' });
-        return mod.default;
-    }), {
+const TerminalApp = dynamic(
+    () =>
+        import('./components/apps/terminal').then(mod => {
+            trackEvent({ category: 'Application', action: 'Loaded Terminal' });
+            return mod.default;
+        }),
+    {
         ssr: false,
         loading: () => (
             <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
@@ -28,11 +28,13 @@ const TerminalApp = dynamic(() =>
     }
 );
 
-const CalcApp = dynamic(() =>
-    import('./components/apps/calc').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded Calc' });
-        return mod.default;
-    }), {
+const CalcApp = dynamic(
+    () =>
+        import('./components/apps/calc').then(mod => {
+            trackEvent({ category: 'Application', action: 'Loaded Calc' });
+            return mod.default;
+        }),
+    {
         ssr: false,
         loading: () => (
             <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
@@ -52,8 +54,8 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const apps = [
     {
-        id: "chrome",
-        title: "Google Chrome",
+        id: 'chrome',
+        title: 'Google Chrome',
         icon: './themes/Yaru/apps/chrome.png',
         disabled: false,
         favourite: true,
@@ -61,8 +63,8 @@ const apps = [
         screen: displayChrome,
     },
     {
-        id: "calc",
-        title: "Calc",
+        id: 'calc',
+        title: 'Calc',
         icon: './themes/Yaru/apps/calc.png',
         disabled: false,
         favourite: true,
@@ -70,8 +72,8 @@ const apps = [
         screen: displayTerminalCalc,
     },
     {
-        id: "about-alex",
-        title: "About Alex",
+        id: 'about-alex',
+        title: 'About Alex',
         icon: './themes/Yaru/system/user-home.png',
         disabled: false,
         favourite: true,
@@ -79,8 +81,8 @@ const apps = [
         screen: displayAboutVivek,
     },
     {
-        id: "vscode",
-        title: "Visual Studio Code",
+        id: 'vscode',
+        title: 'Visual Studio Code',
         icon: './themes/Yaru/apps/vscode.png',
         disabled: false,
         favourite: true,
@@ -88,41 +90,17 @@ const apps = [
         screen: displayVsCode,
     },
     {
-        id: "terminal",
-        title: "Terminal",
+        id: 'terminal',
+        title: 'Terminal',
         icon: './themes/Yaru/apps/bash.png',
         disabled: false,
         favourite: true,
         desktop_shortcut: false,
         screen: displayTerminal,
     },
-      {
-          id: "x",
-          title: "X",
-          icon: './themes/Yaru/apps/x.png',
-          disabled: false,
-          favourite: true,
-          desktop_shortcut: false,
-          screen: displaySpotify, // India Top 50 Playlist 😅
-      },
-      {
-          id: "todoist",
-          title: "Todoist",
-          icon: './themes/Yaru/apps/todoist.png',
-          disabled: false,
-          favourite: false,
-          desktop_shortcut: false,
-          screen: displayTodoist,
-      },
-      {
-          id: "settings",
-          title: "Settings",
-          icon: './themes/Yaru/apps/gnome-control-center.png',
-          disabled: false,
-=======
     {
-        id: "spotify",
-        title: "X",
+        id: 'spotify',
+        title: 'X',
         icon: './themes/Yaru/apps/x.png',
         disabled: false,
         favourite: true,
@@ -130,8 +108,17 @@ const apps = [
         screen: displayX, // India Top 50 Playlist 😅
     },
     {
-        id: "settings",
-        title: "Settings",
+        id: 'todoist',
+        title: 'Todoist',
+        icon: './themes/Yaru/apps/todoist.png',
+        disabled: false,
+        favourite: false,
+        desktop_shortcut: false,
+        screen: displayTodoist,
+    },
+    {
+        id: 'settings',
+        title: 'Settings',
         icon: './themes/Yaru/apps/gnome-control-center.png',
         disabled: false,
         favourite: true,
@@ -139,8 +126,8 @@ const apps = [
         screen: displaySettings,
     },
     {
-        id: "trash",
-        title: "Trash",
+        id: 'trash',
+        title: 'Trash',
         icon: './themes/Yaru/system/user-trash-full.png',
         disabled: false,
         favourite: false,
@@ -148,14 +135,15 @@ const apps = [
         screen: displayTrash,
     },
     {
-        id: "gedit",
-        title: "Contact Me",
+        id: 'gedit',
+        title: 'Contact Me',
         icon: './themes/Yaru/apps/gedit.png',
         disabled: false,
         favourite: false,
         desktop_shortcut: true,
         screen: displayGedit,
     },
-]
+];
 
 export default apps;
+

--- a/components/ConsentBanner.tsx
+++ b/components/ConsentBanner.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { setAnalyticsConsent, trackPageview } from '../lib/analytics';
+
+const STORAGE_KEY = 'ga-consent';
+
+export default function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    if (stored === 'granted') {
+      setAnalyticsConsent(true);
+      trackPageview(window.location.pathname);
+    } else if (stored !== 'denied') {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem(STORAGE_KEY, 'granted');
+    setAnalyticsConsent(true);
+    trackPageview(window.location.pathname);
+    setVisible(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem(STORAGE_KEY, 'denied');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-gray-800 text-white p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between z-50">
+      <p className="text-sm mb-2 sm:mb-0">We use cookies for analytics. Do you accept?</p>
+      <div className="flex space-x-2">
+        <button className="px-3 py-1 bg-blue-600 rounded" onClick={accept}>Accept</button>
+        <button className="px-3 py-1 bg-gray-600 rounded" onClick={decline}>Decline</button>
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { trackEvent } from '../../lib/analytics';
 import emailjs from '@emailjs/browser';
 
 export class Gedit extends Component {
@@ -58,7 +58,7 @@ export class Gedit extends Component {
             $("#close-gedit").trigger("click");
         })
 
-        ReactGA.event({
+        trackEvent({
             category: "Send Message",
             action: `${name}, ${subject}, ${message}`
         });

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -26,5 +26,3 @@ export default function XApp() {
 }
 
 export const displayX = () => <XApp />;
-
-=======

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { trackEvent } from '../../lib/analytics';
 
 export class Terminal extends Component {
     constructor() {
@@ -315,7 +315,7 @@ export class Terminal extends Component {
                 return;
             case "sudo":
 
-                ReactGA.event({
+                trackEvent({
                     category: "Sudo Access",
                     action: "lol",
                 });

--- a/components/apps/vivek.js
+++ b/components/apps/vivek.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReactGA from 'react-ga4';
+import { trackPageview } from '../../lib/analytics';
 
 export class AboutVivek extends Component {
 
@@ -38,7 +38,7 @@ export class AboutVivek extends Component {
         localStorage.setItem("about-section", screen);
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${screen}`, title: "Custom Title" });
+        trackPageview(`/${screen}`);
 
 
         this.setState({

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
-import ReactGA from 'react-ga4';
+import { trackPageview } from '../../lib/analytics';
 
 export class Window extends Component {
     constructor() {
@@ -27,14 +27,14 @@ export class Window extends Component {
         this.setDefaultWindowDimenstion();
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
+        trackPageview(`/${this.id}`);
 
         // on window resize, resize boundary
         window.addEventListener('resize', this.resizeBoundries);
     }
 
     componentWillUnmount() {
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        trackPageview("/desktop");
 
         window.removeEventListener('resize', this.resizeBoundries);
     }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,7 +8,7 @@ import AllApplications from '../screen/all-applications'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import $ from 'jquery';
-import ReactGA from 'react-ga4';
+import { trackPageview, trackEvent } from '../../lib/analytics';
 
 export class Desktop extends Component {
     constructor() {
@@ -36,7 +36,7 @@ export class Desktop extends Component {
 
     componentDidMount() {
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        trackPageview("/desktop");
 
         this.fetchAppsData();
         this.setContextListeners();
@@ -95,14 +95,14 @@ export class Desktop extends Component {
         this.hideAllContextMenu();
         switch (e.target.dataset.context) {
             case "desktop-area":
-                ReactGA.event({
+                trackEvent({
                     category: `Context Menu`,
                     action: `Opened Desktop Context Menu`
                 });
                 this.showContextMenu(e, "desktop");
                 break;
             default:
-                ReactGA.event({
+                trackEvent({
                     category: `Context Menu`,
                     action: `Opened Default Context Menu`
                 });
@@ -351,7 +351,7 @@ export class Desktop extends Component {
     openApp = (objId) => {
 
         // google analytics
-        ReactGA.event({
+        trackEvent({
             category: `Open App`,
             action: `Opened ${objId} window`
         });

--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -3,7 +3,7 @@ import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
-import ReactGA from 'react-ga4';
+import { trackPageview, trackEvent } from '../lib/analytics';
 
 interface UbuntuProps {}
 
@@ -64,8 +64,8 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   lockScreen = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/lock-screen', title: 'Lock Screen' });
-    ReactGA.event({
+    trackPageview('/lock-screen');
+    trackEvent({
       category: `Screen Change`,
       action: `Set Screen to Locked`,
     });
@@ -78,7 +78,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   unLockScreen = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/desktop', title: 'Custom Title' });
+    trackPageview('/desktop');
 
     window.removeEventListener('click', this.unLockScreen);
     window.removeEventListener('keypress', this.unLockScreen);
@@ -93,9 +93,9 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   shutDown = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/switch-off', title: 'Custom Title' });
+    trackPageview('/switch-off');
 
-    ReactGA.event({
+    trackEvent({
       category: `Screen Change`,
       action: `Switched off the Ubuntu`,
     });
@@ -106,7 +106,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   turnOn = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/desktop', title: 'Custom Title' });
+    trackPageview('/desktop');
 
     this.setState({ shutDownScreen: false, booting_screen: true });
     this.setTimeOutBootScreen();

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,28 @@
+import ReactGA from 'react-ga4';
+
+let initialized = false;
+let consentGranted = false;
+
+export const initAnalytics = (measurementId?: string) => {
+  if (measurementId && !initialized) {
+    ReactGA.initialize(measurementId);
+    initialized = true;
+  }
+};
+
+export const setAnalyticsConsent = (consent: boolean) => {
+  consentGranted = consent;
+};
+
+export const trackPageview = (page: string) => {
+  if (initialized && consentGranted) {
+    ReactGA.send({ hitType: 'pageview', page });
+  }
+};
+
+export const trackEvent = (options: Parameters<typeof ReactGA.event>[0]) => {
+  if (initialized && consentGranted) {
+    ReactGA.event(options);
+  }
+};
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,21 @@
 import type { AppProps } from 'next/app';
+import { useEffect } from 'react';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
+import { initAnalytics } from '../lib/analytics';
+import ConsentBanner from '../components/ConsentBanner';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  useEffect(() => {
+    initAnalytics(process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID);
+  }, []);
+
+  return (
+    <>
+      <Component {...pageProps} />
+      <ConsentBanner />
+    </>
+  );
 }
 
 export default MyApp;


### PR DESCRIPTION
## Summary
- initialize Google Analytics using NEXT_PUBLIC_GA_MEASUREMENT_ID
- add consent banner and event helper to only send analytics after consent
- replace direct react-ga4 imports with helper functions across components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4cbfc63208328855a9da16906b536