### PR TITLE
Add security headers via Next.js configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,33 @@
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: "default-src 'self'; frame-ancestors 'none';"
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()'
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY'
+  }
+];
+
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders
+      }
+    ];
+  }
+};


### PR DESCRIPTION
## Summary
- configure global security headers via `next.config.js`

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `npm run build` *(fails: merge conflict marker in apps.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cbfe62988328a0b60dfff6031dc7