### PR TITLE
Anonymize contact form analytics event

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ const displayMyApp = (addFolder, openApp) => (
 ```
 
 Add the `displayMyApp` function to `apps.config.js` and reference it in the `apps` array to make the app available to the desktop.
+
+## Privacy
+
+The contact application records only non-PII metadata in Google Analytics.
+Submissions trigger an event with `{ category: "contact", action: "submit_success" }`, and the
+free-text fields (name, subject, message) are never sent to analytics.

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -50,18 +50,20 @@ export class Gedit extends Component {
             'message': message,
         }
 
-        emailjs.send(serviceID, templateID, templateParams).then(() => {
-            this.setState({ sending: false });
-            $("#close-gedit").trigger("click");
-        }).catch(() => {
-            this.setState({ sending: false });
-            $("#close-gedit").trigger("click");
-        })
+        emailjs.send(serviceID, templateID, templateParams)
+            .then(() => {
+                this.setState({ sending: false });
+                $("#close-gedit").trigger("click");
 
-        ReactGA.event({
-            category: "Send Message",
-            action: `${name}, ${subject}, ${message}`
-        });
+                ReactGA.event({
+                    category: "contact",
+                    action: "submit_success",
+                });
+            })
+            .catch(() => {
+                this.setState({ sending: false });
+                $("#close-gedit").trigger("click");
+            });
 
     }
 


### PR DESCRIPTION
## Summary
- avoid sending PII to Google Analytics by logging only `{category: "contact", action: "submit_success"}` on message send
- document that contact form analytics only records non-PII metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4cbf9160883288b7c6bf013ab6e2c