### PR TITLE
refactor: use next/image for static assets

### DIFF
--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 
 export class Chrome extends Component {
     constructor() {
@@ -64,10 +65,24 @@ export class Chrome extends Component {
         return (
             <div className="w-full pt-0.5 pb-1 flex justify-start items-center text-white text-sm border-b border-gray-900">
                 <div onClick={this.refreshChrome} className=" ml-2 mr-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10">
-                    <img className="w-5" src="./themes/Yaru/status/chrome_refresh.svg" alt="Ubuntu Chrome Refresh" />
+                    <Image
+                        className="w-5"
+                        src="/themes/Yaru/status/chrome_refresh.svg"
+                        alt="Ubuntu Chrome Refresh"
+                        width={20}
+                        height={20}
+                        sizes="20px"
+                    />
                 </div>
                 <div onClick={this.goToHome} className=" mr-2 ml-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10">
-                    <img className="w-5" src="./themes/Yaru/status/chrome_home.svg" alt="Ubuntu Chrome Home" />
+                    <Image
+                        className="w-5"
+                        src="/themes/Yaru/status/chrome_home.svg"
+                        alt="Ubuntu Chrome Home"
+                        width={20}
+                        height={20}
+                        sizes="20px"
+                    />
                 </div>
                 <input onKeyDown={this.checkKey} onChange={this.handleDisplayUrl} value={this.state.display_url} id="chrome-url-bar" className="outline-none bg-ub-grey rounded-full pl-3 py-0.5 mr-3 w-5/6 text-gray-300 focus:text-white" type="url" spellCheck={false} autoComplete="off" />
             </div>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import $ from 'jquery';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
@@ -93,7 +94,15 @@ export class Gedit extends Component {
                     (this.state.sending
                         ?
                         <div className="flex justify-center items-center animate-pulse h-full w-full bg-gray-400 bg-opacity-30 absolute top-0 left-0">
-                            <img className={" w-8 absolute animate-spin"} src="./themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" />
+                            <Image
+                                className=" w-8 absolute animate-spin"
+                                src="/themes/Yaru/status/process-working-symbolic.svg"
+                                alt="Ubuntu Process Symbol"
+                                width={32}
+                                height={32}
+                                sizes="32px"
+                                priority
+                            />
                         </div>
                         : null
                     )

--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import $ from 'jquery';
 
 export class Trash extends Component {
@@ -7,32 +8,32 @@ export class Trash extends Component {
         this.trashItems = [
             {
                 name: "php",
-                icon: "./themes/filetypes/php.png"
+                icon: "/themes/filetypes/php.png"
             },
             {
                 name: "Angular.js",
-                icon: "./themes/filetypes/js.png"
+                icon: "/themes/filetypes/js.png"
             },
             {
                 name: "node_modules",
-                icon: "./themes/Yaru/system/folder.png"
+                icon: "/themes/Yaru/system/folder.png"
             },
 
             {
                 name: "abandoned project",
-                icon: "./themes/Yaru/system/folder.png"
+                icon: "/themes/Yaru/system/folder.png"
             },
             {
                 name: "INFR 4900U blockchain assignment AlexUnnippillil.zip",
-                icon: "./themes/filetypes/zip.png"
+                icon: "/themes/filetypes/zip.png"
             },
             {
                 name: "cryptography project final",
-                icon: "./themes/Yaru/system/folder.png"
+                icon: "/themes/Yaru/system/folder.png"
             },
             {
                 name: "project machine learning-final",
-                icon: "./themes/Yaru/system/folder.png"
+                icon: "/themes/Yaru/system/folder.png"
             },
 
         ];
@@ -64,7 +65,14 @@ export class Trash extends Component {
     emptyScreen = () => {
         return (
             <div className="flex-grow flex flex-col justify-center items-center">
-                <img className=" w-24" src="./themes/Yaru/status/user-trash-symbolic.svg" alt="Ubuntu Trash" />
+                <Image
+                    className=" w-24"
+                    src="/themes/Yaru/status/user-trash-symbolic.svg"
+                    alt="Ubuntu Trash"
+                    width={96}
+                    height={96}
+                    sizes="96px"
+                />
                 <span className="font-bold mt-4 text-xl px-1 text-gray-400">Trash is Empty</span>
             </div>
         );
@@ -78,7 +86,13 @@ export class Trash extends Component {
                         return (
                             <div key={index} tabIndex="1" onFocus={this.focusFile} onBlur={this.focusFile} className="flex flex-col items-center text-sm outline-none w-16 my-2 mx-4">
                                 <div className="w-16 h-16 flex items-center justify-center">
-                                    <img src={item.icon} alt="Ubuntu File Icons" />
+                                    <Image
+                                        src={item.icon}
+                                        alt="Ubuntu File Icons"
+                                        width={48}
+                                        height={48}
+                                        sizes="48px"
+                                    />
                                 </div>
                                 <span className="text-center rounded px-0.5">{item.name}</span>
                             </div>

--- a/components/apps/vivek.js
+++ b/components/apps/vivek.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import ReactGA from 'react-ga4';
 
 export class AboutVivek extends Component {
@@ -55,23 +56,58 @@ export class AboutVivek extends Component {
         return (
             <>
                 <div id="about" tabIndex="0" onFocus={this.changeScreen} className={(this.state.active_screen === "about" ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}>
-                    <img className=" w-3 md:w-4" alt="about Unnippillil" src="./themes/Yaru/status/about.svg" />
+                    <Image
+                        className=" w-3 md:w-4"
+                        alt="about Unnippillil"
+                        src="/themes/Yaru/status/about.svg"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
                     <span className=" ml-1 md:ml-2 text-gray-50 ">About Me</span>
                 </div>
                 <div id="education" tabIndex="0" onFocus={this.changeScreen} className={(this.state.active_screen === "education" ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}>
-                    <img className=" w-3 md:w-4" alt="Unnippillil' education" src="./themes/Yaru/status/education.svg" />
+                    <Image
+                        className=" w-3 md:w-4"
+                        alt="Unnippillil' education"
+                        src="/themes/Yaru/status/education.svg"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
                     <span className=" ml-1 md:ml-2 text-gray-50 ">Education</span>
                 </div>
                 <div id="skills" tabIndex="0" onFocus={this.changeScreen} className={(this.state.active_screen === "skills" ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}>
-                    <img className=" w-3 md:w-4" alt="Unnippillil' skills" src="./themes/Yaru/status/skills.svg" />
+                    <Image
+                        className=" w-3 md:w-4"
+                        alt="Unnippillil' skills"
+                        src="/themes/Yaru/status/skills.svg"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
                     <span className=" ml-1 md:ml-2 text-gray-50 ">Skills</span>
                 </div>
                 <div id="projects" tabIndex="0" onFocus={this.changeScreen} className={(this.state.active_screen === "projects" ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}>
-                    <img className=" w-3 md:w-4" alt="Unnippillil' projects" src="./themes/Yaru/status/projects.svg" />
+                    <Image
+                        className=" w-3 md:w-4"
+                        alt="Unnippillil' projects"
+                        src="/themes/Yaru/status/projects.svg"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
                     <span className=" ml-1 md:ml-2 text-gray-50 ">Projects</span>
                 </div>
                 <div id="resume" tabIndex="0" onFocus={this.changeScreen} className={(this.state.active_screen === "resume" ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}>
-                    <img className=" w-3 md:w-4" alt="Unnippillil's resume" src="./themes/Yaru/status/download.svg" />
+                    <Image
+                        className=" w-3 md:w-4"
+                        alt="Unnippillil's resume"
+                        src="/themes/Yaru/status/download.svg"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
                     <span className=" ml-1 md:ml-2 text-gray-50 ">Resume</span>
                 </div>
 
@@ -112,7 +148,15 @@ function About() {
     return (
         <>
             <div className="w-20 md:w-28 my-4 full">
-                <img className="w-full" src="./images/logos/bitmoji.png" alt="Alex Unnippillil Logo" />
+                <Image
+                    className="w-full"
+                    src="/images/logos/bitmoji.png"
+                    alt="Alex Unnippillil Logo"
+                    width={256}
+                    height={256}
+                    sizes="(max-width: 768px) 50vw, 25vw"
+                    priority
+                />
             </div>
             <div className=" mt-4 md:mt-8 text-lg md:text-2xl text-center px-1">
                 <div>My name is <span className="font-bold">Alex Unnippillil</span>, </div>
@@ -582,6 +626,6 @@ function Projects() {
 }
 function Resume() {
     return (
-        <iframe className="h-full w-full" src="./files/Alex-Unnippillil-Resume.pdf" title="Alex Unnippillil Resume" frameBorder="0"></iframe>
+        <iframe className="h-full w-full" src="/files/Alex-Unnippillil-Resume.pdf" title="Alex Unnippillil Resume" frameBorder="0"></iframe>
     )
 }

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Image from 'next/image';
 
 export class SideBarApp extends Component {
     constructor() {
@@ -43,8 +44,22 @@ export class SideBarApp extends Component {
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") + " w-auto p-2 outline-none relative transition hover:bg-white hover:bg-opacity-10 rounded m-1"}
                 id={"sidebar-" + this.props.id}
             >
-                <img width="28px" height="28px" className="w-7" src={this.props.icon} alt="Ubuntu App Icon" />
-                <img className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"} src={this.props.icon} alt="" />
+                <Image
+                    width={28}
+                    height={28}
+                    className="w-7"
+                    src={this.props.icon.replace('./', '/')}
+                    alt="Ubuntu App Icon"
+                    sizes="28px"
+                />
+                <Image
+                    width={28}
+                    height={28}
+                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
+                    src={this.props.icon.replace('./', '/')}
+                    alt=""
+                    sizes="28px"
+                />
                 {
                     (
                         this.props.isClose[this.id] === false

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import Image from 'next/image'
 
 export class UbuntuApp extends Component {
 
@@ -14,7 +15,14 @@ export class UbuntuApp extends Component {
                 onDoubleClick={this.openApp}
                 tabIndex={0}
             >
-                <img width="40px" height="40px" className="mb-1 w-10" src={this.props.icon} alt={"Kali " + this.props.name} />
+                <Image
+                    width={40}
+                    height={40}
+                    className="mb-1 w-10"
+                    src={this.props.icon.replace('./', '/')}
+                    alt={"Kali " + this.props.name}
+                    sizes="40px"
+                />
                 {this.props.name}
 
             </div>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
@@ -236,37 +237,49 @@ export function WindowEditButtons(props) {
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center">
             <span className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.minimize}>
-                <img
-                    src="./themes/Yaru/window/window-minimize-symbolic.svg"
+                <Image
+                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
                     alt="Kali window minimize"
                     className="h-5 w-5 inline"
+                    width={20}
+                    height={20}
+                    sizes="20px"
                 />
             </span>
             {
                 (props.isMaximised
                     ?
                     <span className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.maximize}>
-                        <img
-                            src="./themes/Yaru/window/window-restore-symbolic.svg"
+                        <Image
+                            src="/themes/Yaru/window/window-restore-symbolic.svg"
                             alt="Kali window restore"
                             className="h-5 w-5 inline"
+                            width={20}
+                            height={20}
+                            sizes="20px"
                         />
                     </span>
                     :
                     <span className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.maximize}>
-                        <img
-                            src="./themes/Yaru/window/window-maximize-symbolic.svg"
+                        <Image
+                            src="/themes/Yaru/window/window-maximize-symbolic.svg"
                             alt="Kali window maximize"
                             className="h-5 w-5 inline"
+                            width={20}
+                            height={20}
+                            sizes="20px"
                         />
                     </span>
                 )
             }
             <button tabIndex="-1" id={`close-${props.id}`} className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.close}>
-                <img
-                    src="./themes/Yaru/window/window-close-symbolic.svg"
+                <Image
+                    src="/themes/Yaru/window/window-close-symbolic.svg"
                     alt="Kali window close"
                     className="h-5 w-5 inline"
+                    width={20}
+                    height={20}
+                    sizes="20px"
                 />
             </button>
         </div>

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 
 export class AllApplications extends React.Component {
@@ -73,7 +74,14 @@ export class AllApplications extends React.Component {
             <div className={"absolute h-full top-7 w-full z-20 pl-12 justify-center md:pl-20 border-black border-opacity-60 bg-black bg-opacity-70"}>
                 <div className={"flex md:pr-20 pt-5 align-center justify-center"}>
                     <div className={"flex w-2/3 h-full items-center pl-2 pr-2 bg-white border-black border-width-2 rounded-xl overflow-hidden md:w-1/3 "}>
-                        <img className={"w-5 h-5"} alt="search icon" src={'./images/logos/search.png'} />
+                        <Image
+                            className={"w-5 h-5"}
+                            alt="search icon"
+                            src={'/images/logos/search.png'}
+                            width={20}
+                            height={20}
+                            sizes="20px"
+                        />
                         <input className={"w-3/4 p-1 bg-transparent focus:outline-none"}
                             placeholder="Type to Search "
                             value={this.state.query}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,16 +1,32 @@
 import React from 'react'
+import Image from 'next/image'
 
 function BootingScreen(props) {
 
     return (
         <div style={(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" })} className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
-            <img width="400px" height="400px" className="md:w-1/4 w-1/2" src="./themes/Yaru/status/cof_orange_hex.svg" alt="Ubuntu Logo" />
+            <Image
+                width={400}
+                height={400}
+                className="md:w-1/4 w-1/2"
+                src="/themes/Yaru/status/cof_orange_hex.svg"
+                alt="Ubuntu Logo"
+                sizes="(max-width: 768px) 50vw, 25vw"
+                priority
+            />
             <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
                 {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><img width="32px" height="32px" className="w-8" src="./themes/Yaru/status/power-button.svg" alt="Power Button" /></div>
-                    : <img width="40px" height="40px" className={" w-10 " + (props.visible ? " animate-spin " : "")} src="./themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" />)}
+                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
+                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
             </div>
-            <img width="200px" height="100px" className="md:w-1/5 w-1/2" src="./themes/Yaru/status/ubuntu_white_hex.svg" alt="Kali Linux Name" />
+            <Image
+                width={200}
+                height={100}
+                className="md:w-1/5 w-1/2"
+                src="/themes/Yaru/status/ubuntu_white_hex.svg"
+                alt="Kali Linux Name"
+                sizes="(max-width: 768px) 50vw, 20vw"
+            />
             <div className="text-white mb-4">
                 <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noreferrer noopener" target="_blank">linkedin</a>
                 <span className="font-bold mx-1">|</span>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
 
 let renderApps = (props) => {
@@ -58,7 +59,14 @@ export function AllApps(props) {
             onClick={props.showApps}
         >
             <div className="relative">
-                <img width="28px" height="28px" className="w-7" src="./themes/Yaru/system/view-app-grid-symbolic.svg" alt="Ubuntu view app" />
+                <Image
+                    width={28}
+                    height={28}
+                    className="w-7"
+                    src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+                    alt="Ubuntu view app"
+                    sizes="28px"
+                />
                 <div
                     className={
                         (title ? " visible " : " invisible ") +

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,31 +1,38 @@
 import React from "react";
+import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 
 export default function Status() {
   return (
     <div className="flex justify-center items-center">
       <span className="mx-1.5">
-        <img
-          width="16px" height="16px"
-          src="./themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+        <Image
+          width={16}
+          height={16}
+          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
           alt="ubuntu wifi"
           className="inline status-symbol w-4 h-4"
+          sizes="16px"
         />
       </span>
       <span className="mx-1.5">
-        <img
-          width="16px" height="16px"
-          src="./themes/Yaru/status/audio-volume-medium-symbolic.svg"
+        <Image
+          width={16}
+          height={16}
+          src="/themes/Yaru/status/audio-volume-medium-symbolic.svg"
           alt="ubuntu sound"
           className="inline status-symbol w-4 h-4"
+          sizes="16px"
         />
       </span>
       <span className="mx-1.5">
-        <img
-          width="16px" height="16px"
-          src="./themes/Yaru/status/battery-good-symbolic.svg"
+        <Image
+          width={16}
+          height={16}
+          src="/themes/Yaru/status/battery-good-symbolic.svg"
           alt="ubuntu battry"
           className="inline status-symbol w-4 h-4"
+          sizes="16px"
         />
       </span>
       <span className="mx-1">

--- a/components/util-components/status_card.js
+++ b/components/util-components/status_card.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import SmallArrow from './small_arrow';
 import onClickOutside from 'react-onclickoutside';
 
@@ -67,7 +68,13 @@ export class StatusCard extends Component {
 				<div className="absolute w-0 h-0 -top-1 right-6 top-arrow-up" />
 				<div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/audio-headphones-symbolic.svg" alt="ubuntu headphone" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/audio-headphones-symbolic.svg"
+                                                        alt="ubuntu headphone"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<Slider
 						onChange={this.handleSound}
@@ -78,7 +85,13 @@ export class StatusCard extends Component {
 				</div>
 				<div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/display-brightness-symbolic.svg" alt="ubuntu brightness" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/display-brightness-symbolic.svg"
+                                                        alt="ubuntu brightness"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<Slider
 						onChange={this.handleBrightness}
@@ -92,7 +105,13 @@ export class StatusCard extends Component {
 				</div>
 				<div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="ubuntu wifi" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+                                                        alt="ubuntu wifi"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between text-gray-400">
 						<span>TellMyWiFiLoveHer</span>
@@ -101,7 +120,13 @@ export class StatusCard extends Component {
 				</div>
 				<div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/bluetooth-symbolic.svg" alt="ubuntu bluetooth" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/bluetooth-symbolic.svg"
+                                                        alt="ubuntu bluetooth"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between text-gray-400">
 						<span>Off</span>
@@ -110,7 +135,13 @@ export class StatusCard extends Component {
 				</div>
 				<div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/battery-good-symbolic.svg" alt="ubuntu battery" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/battery-good-symbolic.svg"
+                                                        alt="ubuntu battery"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between text-gray-400">
 						<span>2:42 Remaining (77%)</span>
@@ -125,7 +156,13 @@ export class StatusCard extends Component {
 					className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
 				>
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/emblem-system-symbolic.svg" alt="ubuntu settings" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/emblem-system-symbolic.svg"
+                                                        alt="ubuntu settings"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between">
 						<span>Settings</span>
@@ -136,7 +173,13 @@ export class StatusCard extends Component {
 					className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
 				>
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/changes-prevent-symbolic.svg" alt="ubuntu lock" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/changes-prevent-symbolic.svg"
+                                                        alt="ubuntu lock"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between">
 						<span>Lock</span>
@@ -147,7 +190,13 @@ export class StatusCard extends Component {
 					className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
 				>
 					<div className="w-8">
-						<img width="16px" height="16px" src="./themes/Yaru/status/system-shutdown-symbolic.svg" alt="ubuntu power" />
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/system-shutdown-symbolic.svg"
+                                                        alt="ubuntu power"
+                                                        sizes="16px"
+                                                />
 					</div>
 					<div className="w-2/3 flex items-center justify-between">
 						<span>Power Off / Log Out</span>


### PR DESCRIPTION
## Summary
- replace legacy `<img>` elements with `next/image` in common components
- standardize asset paths to the `public` directory and add sizing and priority hints

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc00a5608328a79701492359a25e