### PR TITLE
feat: lazy load external widgets

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -2,160 +2,146 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import ReactGA from 'react-ga4';
 
-import displaySpotify from './components/apps/spotify';
-import { displayVsCode } from './components/apps/vscode';
-=======
 import { displayX } from './components/apps/spotify';
-import displayVsCode from './components/apps/vscode';
+import { displayVsCode } from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/chrome';
 import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayAboutVivek } from './components/apps/vivek';
 import { displayTodoist } from './components/apps/todoist';
-// Dynamically loaded apps
-const TerminalApp = dynamic(() =>
-    import('./components/apps/terminal').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded Terminal' });
-        return mod.default;
-    }), {
-        ssr: false,
-        loading: () => (
-            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-                Loading Terminal...
-            </div>
-        ),
-    }
+
+const TerminalApp = dynamic(
+  () =>
+    import('./components/apps/terminal').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Terminal' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Terminal...
+      </div>
+    ),
+  }
 );
 
-const CalcApp = dynamic(() =>
-    import('./components/apps/calc').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded Calc' });
-        return mod.default;
-    }), {
-        ssr: false,
-        loading: () => (
-            <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-                Loading Calc...
-            </div>
-        ),
-    }
+const CalcApp = dynamic(
+  () =>
+    import('./components/apps/calc').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Calc' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Calc...
+      </div>
+    ),
+  }
 );
 
 const displayTerminal = (addFolder, openApp) => (
-    <TerminalApp addFolder={addFolder} openApp={openApp} />
+  <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
 
 const displayTerminalCalc = (addFolder, openApp) => (
-    <CalcApp addFolder={addFolder} openApp={openApp} />
+  <CalcApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
-    {
-        id: "chrome",
-        title: "Google Chrome",
-        icon: './themes/Yaru/apps/chrome.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: true,
-        screen: displayChrome,
-    },
-    {
-        id: "calc",
-        title: "Calc",
-        icon: './themes/Yaru/apps/calc.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displayTerminalCalc,
-    },
-    {
-        id: "about-alex",
-        title: "About Alex",
-        icon: './themes/Yaru/system/user-home.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: true,
-        screen: displayAboutVivek,
-    },
-    {
-        id: "vscode",
-        title: "Visual Studio Code",
-        icon: './themes/Yaru/apps/vscode.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displayVsCode,
-    },
-    {
-        id: "terminal",
-        title: "Terminal",
-        icon: './themes/Yaru/apps/bash.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displayTerminal,
-    },
-      {
-          id: "x",
-          title: "X",
-          icon: './themes/Yaru/apps/x.png',
-          disabled: false,
-          favourite: true,
-          desktop_shortcut: false,
-          screen: displaySpotify, // India Top 50 Playlist 😅
-      },
-      {
-          id: "todoist",
-          title: "Todoist",
-          icon: './themes/Yaru/apps/todoist.png',
-          disabled: false,
-          favourite: false,
-          desktop_shortcut: false,
-          screen: displayTodoist,
-      },
-      {
-          id: "settings",
-          title: "Settings",
-          icon: './themes/Yaru/apps/gnome-control-center.png',
-          disabled: false,
-=======
-    {
-        id: "spotify",
-        title: "X",
-        icon: './themes/Yaru/apps/x.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displayX, // India Top 50 Playlist 😅
-    },
-    {
-        id: "settings",
-        title: "Settings",
-        icon: './themes/Yaru/apps/gnome-control-center.png',
-        disabled: false,
-        favourite: true,
-        desktop_shortcut: false,
-        screen: displaySettings,
-    },
-    {
-        id: "trash",
-        title: "Trash",
-        icon: './themes/Yaru/system/user-trash-full.png',
-        disabled: false,
-        favourite: false,
-        desktop_shortcut: true,
-        screen: displayTrash,
-    },
-    {
-        id: "gedit",
-        title: "Contact Me",
-        icon: './themes/Yaru/apps/gedit.png',
-        disabled: false,
-        favourite: false,
-        desktop_shortcut: true,
-        screen: displayGedit,
-    },
-]
+  {
+    id: 'chrome',
+    title: 'Google Chrome',
+    icon: './themes/Yaru/apps/chrome.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: true,
+    screen: displayChrome,
+  },
+  {
+    id: 'calc',
+    title: 'Calc',
+    icon: './themes/Yaru/apps/calc.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayTerminalCalc,
+  },
+  {
+    id: 'about-alex',
+    title: 'About Alex',
+    icon: './themes/Yaru/system/user-home.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: true,
+    screen: displayAboutVivek,
+  },
+  {
+    id: 'vscode',
+    title: 'Visual Studio Code',
+    icon: './themes/Yaru/apps/vscode.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayVsCode,
+  },
+  {
+    id: 'terminal',
+    title: 'Terminal',
+    icon: './themes/Yaru/apps/bash.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayTerminal,
+  },
+  {
+    id: 'x',
+    title: 'X',
+    icon: './themes/Yaru/apps/x.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displayX,
+  },
+  {
+    id: 'todoist',
+    title: 'Todoist',
+    icon: './themes/Yaru/apps/todoist.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTodoist,
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    icon: './themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: true,
+    desktop_shortcut: false,
+    screen: displaySettings,
+  },
+  {
+    id: 'trash',
+    title: 'Trash',
+    icon: './themes/Yaru/system/user-trash-full.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: true,
+    screen: displayTrash,
+  },
+  {
+    id: 'gedit',
+    title: 'Contact Me',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: true,
+    screen: displayGedit,
+  },
+];
 
 export default apps;

--- a/components/LazyGitHubButton.js
+++ b/components/LazyGitHubButton.js
@@ -1,12 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
 
-const TwitterTimeline = dynamic(
-  () => import('react-twitter-embed').then((m) => m.TwitterTimelineEmbed),
-  { ssr: false }
-);
-
-export default function XApp() {
+const LazyGitHubButton = ({ user, repo }) => {
   const ref = useRef(null);
   const [visible, setVisible] = useState(false);
 
@@ -26,18 +20,21 @@ export default function XApp() {
   }, []);
 
   return (
-    <div ref={ref} className="h-full w-full bg-ub-cool-grey">
+    <div ref={ref} className="inline-block">
       {visible ? (
-        <TwitterTimeline
-          sourceType="profile"
-          screenName="AUnnippillil"
-          options={{ height: '1200%' }}
-        />
+        <iframe
+          src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
+          frameBorder="0"
+          scrolling="0"
+          width="150"
+          height="20"
+          title={`${repo}-star`}
+        ></iframe>
       ) : (
-        <div className="h-full w-full flex items-center justify-center text-white">Loading...</div>
+        <div className="h-5 w-24 bg-gray-200 animate-pulse rounded"></div>
       )}
     </div>
   );
-}
+};
 
-export const displayX = () => <XApp />;
+export default LazyGitHubButton;

--- a/components/apps/vivek.js
+++ b/components/apps/vivek.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ReactGA from 'react-ga4';
+import LazyGitHubButton from '../LazyGitHubButton';
 
 export class AboutVivek extends Component {
 
@@ -548,7 +549,7 @@ function Projects() {
                                 <div className="flex flex-wrap justify-between items-center">
                                     <div className='flex justify-center items-center'>
                                         <div className=" text-base md:text-lg mr-2">{project.name.toLowerCase()}</div>
-                                        <iframe src={`https://ghbtns.com/github-btn.html?user=alex-unnippillil&repo=${projectName}&type=star&count=true`} frameBorder="0" scrolling="0" width="150" height="20" title={project.name.toLowerCase()+"-star"}></iframe>
+                                        <LazyGitHubButton user="alex-unnippillil" repo={projectName} />
                                     </div>
                                     <div className="text-gray-300 font-light text-sm">{project.date}</div>
                                 </div>


### PR DESCRIPTION
## Summary
- load Twitter timeline only when the app enters the viewport
- replace heavy GitHub star iframes with a lazy-loaded component
- clean up app configuration to remove leftover merge markers

## Testing
- `npm test`
- `npm run build`
- `CHROME_PATH=$(which chromium-browser) npx -y lighthouse http://localhost:3001 --quiet --chrome-flags="--headless --no-sandbox" --output=json --output-path=./lighthouse-after.json` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc0360dc8328aaf02588895c947e