### PR TITLE
Initialize Google Analytics tracking

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,16 @@
 import type { AppProps } from 'next/app';
+import { useEffect } from 'react';
+import ReactGA from 'react-ga4';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
+    if (trackingId) {
+      ReactGA.initialize(trackingId);
+    }
+  }, []);
   return <Component {...pageProps} />;
 }
 


### PR DESCRIPTION
## Summary
- initialize Google Analytics in custom App using NEXT_PUBLIC_TRACKING_ID

## Testing
- `npm test` (fails: TypeError: _image.default is not a constructor)

------
https://chatgpt.com/codex/tasks/task_e_68a5885a29d88328a6cbcab0dbf53256