### PR TITLE
Use repository secrets for public env vars

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Installing Packages 
         run: yarn install
 
-      - name: Building 
+      - name: Building
         run: yarn build
         env:
-          NEXT_PUBLIC_TRACKING_ID: G-8FBXBFXC10
-          NEXT_PUBLIC_SERVICE_ID: service_qt4ryip
-          NEXT_PUBLIC_TEMPLATE_ID: template_2ni69n8
-          NEXT_PUBLIC_USER_ID: user_Do31sKneP4eYfn5n1nLTD
+          NEXT_PUBLIC_TRACKING_ID: ${{ secrets.NEXT_PUBLIC_TRACKING_ID }}
+          NEXT_PUBLIC_SERVICE_ID: ${{ secrets.NEXT_PUBLIC_SERVICE_ID }}
+          NEXT_PUBLIC_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_TEMPLATE_ID }}
+          NEXT_PUBLIC_USER_ID: ${{ secrets.NEXT_PUBLIC_USER_ID }}
 
       - name: Exporting Bundle File
         run: yarn export

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ Add the `displayMyApp` function to `apps.config.js` and reference it in the `app
 The contact application records only non-PII metadata in Google Analytics.
 Submissions trigger an event with `{ category: "contact", action: "submit_success" }`, and the
 free-text fields (name, subject, message) are never sent to analytics.
+
+## Required CI Secrets
+
+The GitHub Actions workflow relies on the following secrets configured in the repository settings:
+
+- `NEXT_PUBLIC_TRACKING_ID`
+- `NEXT_PUBLIC_SERVICE_ID`
+- `NEXT_PUBLIC_TEMPLATE_ID`
+- `NEXT_PUBLIC_USER_ID`
+
+These secrets provide the values for the corresponding environment variables during the build step.


### PR DESCRIPTION
## Summary
- reference public environment variables from repository secrets in the deploy workflow
- document required CI secrets for contributors

## Testing
- `npm test` *(fails: _image.default is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a5885af4708328a8dd1e554b34946b