### PR TITLE
Use in-window navigation for Chrome and link X app to profile

### DIFF
--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -4,10 +4,10 @@ import Image from 'next/image';
 export class Chrome extends Component {
     constructor() {
         super();
-        this.home_url = 'https://example.com';
+        this.home_url = 'https://www.google.com';
         this.state = {
-            url: 'https://example.com',
-            display_url: 'https://example.com',
+            url: 'https://www.google.com',
+            display_url: 'https://www.google.com',
         }
     }
 
@@ -42,10 +42,10 @@ export class Chrome extends Component {
             }
 
             const display_url = encodeURI(url);
-            window.open(display_url, '_blank');
-            this.setState({ url: this.home_url, display_url: this.home_url });
-            this.storeVisitedUrl(display_url, display_url);
-            document.getElementById("chrome-url-bar").blur();
+            this.setState({ url: display_url, display_url }, () => {
+                this.storeVisitedUrl(display_url, display_url);
+                document.getElementById("chrome-url-bar").blur();
+            });
         }
     }
 

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,43 +1,15 @@
-import React, { useEffect, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
-
-const TwitterTimeline = dynamic(
-  () => import('react-twitter-embed').then((m) => m.TwitterTimelineEmbed),
-  { ssr: false }
-);
+import React from 'react';
 
 export default function XApp() {
-  const ref = useRef(null);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          observer.disconnect();
-        }
-      });
-    });
-    if (ref.current) {
-      observer.observe(ref.current);
-    }
-    return () => observer.disconnect();
-  }, []);
-
   return (
-    <div ref={ref} className="h-full w-full bg-ub-cool-grey">
-      {visible ? (
-        <TwitterTimeline
-          sourceType="profile"
-          screenName="AUnnippillil"
-          options={{ height: '1200%' }}
-        />
-      ) : (
-        <div className="h-full w-full flex items-center justify-center text-white">Loading...</div>
-      )}
-    </div>
+    <iframe
+      src="https://twitter.com/AUnnippillil"
+      className="h-full w-full bg-ub-cool-grey"
+      title="AUnnippillil on X"
+      frameBorder="0"
+    />
   );
 }
 
 export const displayX = () => <XApp />;
+


### PR DESCRIPTION
## Summary
- Replace Chrome's pop-up navigation with an in-app iframe and use Google as the default homepage.
- Update the X application to display AUnnippillil's Twitter profile directly.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0b8ca148328ab26ad0be4453050