### PR TITLE
feat: redesign calculator with functional UI

### DIFF
--- a/__tests__/calc.test.ts
+++ b/__tests__/calc.test.ts
@@ -1,26 +1,16 @@
-import { Calc } from "../components/apps/calc";
+import { evaluateExpression } from '../components/apps/calc';
 
-describe("Calc output sanitization", () => {
-  test("renders expressions and errors as plain text", () => {
-    const calc = new Calc({});
-    // stub appendTerminalRow to avoid React state updates
-    // @ts-ignore
-    calc.appendTerminalRow = jest.fn();
+describe('Calc output sanitization', () => {
+  test('renders expressions and errors as plain text', () => {
+    const resultEl = document.createElement('div');
 
-    const resultEl = document.createElement("div");
-    resultEl.id = "row-calculator-result-1";
-    document.body.appendChild(resultEl);
-
-    // expression producing HTML-like string
-    // @ts-ignore
-    calc.handleCommands('"<img src=x>"', 1);
+    resultEl.textContent = evaluateExpression('"<img src=x>"');
     expect(resultEl.textContent).toBe('<img src=x>');
     expect(resultEl.innerHTML).toBe('&lt;img src=x&gt;');
 
-    // invalid expression results in error text
-    // @ts-ignore
-    calc.handleCommands('2 < 3', 1);
+    resultEl.textContent = evaluateExpression('2 < 3');
     expect(resultEl.textContent).toBe('Invalid Expression');
     expect(resultEl.innerHTML).toBe('Invalid Expression');
   });
 });
+

--- a/__tests__/calc.test.tsx
+++ b/__tests__/calc.test.tsx
@@ -4,20 +4,21 @@ import Calc from '../components/apps/calc';
 
 describe('Calc component', () => {
   it('evaluates expressions correctly', () => {
-    const { container } = render(<Calc />);
-    const input = container.querySelector('#calculator-input-2') as HTMLInputElement;
-    fireEvent.input(input, { target: { value: '1+1' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    const result = container.querySelector('#row-calculator-result-2');
-    expect(result?.textContent).toBe('2');
+    const { getByText, getByTestId } = render(<Calc />);
+    fireEvent.click(getByText('1'));
+    fireEvent.click(getByText('+'));
+    fireEvent.click(getByText('1'));
+    fireEvent.click(getByText('='));
+    expect(getByTestId('calc-display').textContent).toBe('2');
   });
 
   it('handles invalid expressions', () => {
-    const { container } = render(<Calc />);
-    const input = container.querySelector('#calculator-input-2') as HTMLInputElement;
-    fireEvent.input(input, { target: { value: '2++' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    const result = container.querySelector('#row-calculator-result-2');
-    expect(result?.textContent).toBe('Invalid Expression');
+    const { getByText, getByTestId } = render(<Calc />);
+    fireEvent.click(getByText('2'));
+    fireEvent.click(getByText('+'));
+    fireEvent.click(getByText('+'));
+    fireEvent.click(getByText('='));
+    expect(getByTestId('calc-display').textContent).toBe('Invalid Expression');
   });
 });
+

--- a/components/apps/calc.js
+++ b/components/apps/calc.js
@@ -1,202 +1,85 @@
-import React, { Component, createRef } from 'react';
+import React, { useState } from 'react';
 const Parser = require('expr-eval').Parser;
 
+// configure parser similar to previous implementation
 const parser = new Parser({
-    operators: {
-      // These default to true, but are included to be explicit
-      add: true,
-      concatenate: true,
-      conditional: true,
-      divide: true,
-      factorial: true,
-      multiply: true,
-      power: true,
-      remainder: true,
-      subtract: true,
+  operators: {
+    add: true,
+    concatenate: true,
+    conditional: true,
+    divide: true,
+    factorial: true,
+    multiply: true,
+    power: true,
+    remainder: true,
+    subtract: true,
 
-      // Disable and, or, not, <, ==, !=, etc.
-      logical: false,
-      comparison: false,
+    logical: false,
+    comparison: false,
+    'in': false,
+    assignment: true,
+  },
+});
 
-      // Disable 'in' and = operators
-      'in': false,
-      assignment: true
+export const evaluateExpression = (expression) => {
+  let result = '';
+  try {
+    result = parser.evaluate(expression);
+  } catch (e) {
+    result = 'Invalid Expression';
+  }
+  return String(result);
+};
+
+const Calc = () => {
+  const [display, setDisplay] = useState('');
+
+  const handleClick = (value) => {
+    if (value === 'C') {
+      setDisplay('');
+    } else if (value === '=') {
+      setDisplay(evaluateExpression(display));
+    } else {
+      setDisplay((prev) => prev + value);
     }
-  });
+  };
 
-export class Calc extends Component {
-    constructor() {
-        super();
-        this.inputRef = createRef();
-        this.variables = {};
-        this.state = {
-            lines: [],
-            currentInput: '',
-            history: [],
-            historyIndex: -1,
-        };
-    }
+  const buttons = [
+    '7', '8', '9', '/',
+    '4', '5', '6', '*',
+    '1', '2', '3', '-',
+    '0', '.', '=', '+',
+    'C',
+  ];
 
-    componentDidMount() {
-        this.inputRef.current?.focus();
-    }
+  return (
+    <div className="max-w-xs mx-auto p-4 bg-gray-800 text-white rounded-lg shadow-lg">
+      <div
+        data-testid="calc-display"
+        className="mb-4 h-10 bg-black text-right px-2 py-1 rounded"
+      >
+        {display}
+      </div>
+      <div className="grid grid-cols-4 gap-2">
+        {buttons.map((btn, idx) => (
+          <button
+            key={idx}
+            className={`bg-gray-700 hover:bg-gray-600 p-2 rounded text-xl ${
+              btn === 'C' ? 'col-span-4' : ''
+            }`}
+            onClick={() => handleClick(btn)}
+          >
+            {btn}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
 
-    handleInputChange = (e) => {
-        this.setState({ currentInput: e.target.value });
-    }
+export default Calc;
 
-    appendTerminalRow = () => {
-        // React handles terminal rows via state; this is a no-op for compatibility.
-    }
+export const displayTerminalCalc = (addFolder, openApp) => {
+  return <Calc addFolder={addFolder} openApp={openApp} />;
+};
 
-    handleKeyDown = (e) => {
-        const { history, historyIndex } = this.state;
-        if (e.key === 'Enter') {
-            const command = this.state.currentInput.trim();
-            if (command.length === 0) return;
-            const rowId = this.state.lines.length + 2;
-            this.handleCommands(command, rowId);
-        } else if (e.key === 'ArrowUp') {
-            if (history.length === 0) return;
-            const newIndex = historyIndex <= 0 ? history.length - 1 : historyIndex - 1;
-            this.setState({ currentInput: history[newIndex], historyIndex: newIndex });
-            e.preventDefault();
-        } else if (e.key === 'ArrowDown') {
-            if (history.length === 0) return;
-            if (historyIndex === -1 || historyIndex >= history.length - 1) {
-                this.setState({ currentInput: '', historyIndex: -1 });
-            } else {
-                const newIndex = historyIndex + 1;
-                this.setState({ currentInput: history[newIndex], historyIndex: newIndex });
-            }
-            e.preventDefault();
-        }
-    }
-
-    handleCommands = (command, rowId) => {
-        let result = '';
-        switch (command) {
-            case 'clear':
-                this.setState({ lines: [], currentInput: '', history: [], historyIndex: -1 });
-                return;
-            case 'exit':
-                this.closeTerminal();
-                return;
-            case 'help':
-                result = `Available Commands: <br/>Operators:<br/> addition ( + ), subtraction ( - ),<br/>multiplication ( * ), division ( / ),<br/>modulo ( % )exponentiation. ( ^ )<br/><br/>Mathematical functions:<br/>abs[x] : Absolute value (magnitude) of x<br/>acos[x] : Arc cosine of x (in radians)<br/>acosh[x] : Hyperbolic arc cosine of x (in radians)<br/>asin[x] : Arc sine of x (in radians)<br/>asinh[x] : Hyperbolic arc sine of x (in radians)<br/>atan[x] : Arc tangent of x (in radians)<br/>atanh[x] : Hyperbolic arc tangent of x (in radians)<br/>cbrt[x] : Cube root of x<br/>ceil[x] : Ceiling of x — the smallest integer that’s >= x<br/>cos[x] : Cosine of x (x is in radians)<br/>cosh[x] : Hyperbolic cosine of x (x is in radians)<br/>exp[x] : e^x (exponential/antilogarithm function with base e)<br/>floor[x] : Floor of x — the largest integer that’s <= x<br/>ln[x] : Natural logarithm of x<br/>log[x] : Natural logarithm of x (synonym for ln, not base-10)<br/>log10[x] :  Base-10 logarithm of x<br/>log2[x] : Base-2 logarithm of x<br/>round[x] :       X, rounded to the nearest integer<br/>sign[x] : Sign of x (-1, 0, or 1 for negative, zero, or positive respectively)<br/>sin[x] : Sine of x (x is in radians)<br/>sinh[x] : Hyperbolic sine of x (x is in radians)<br/>sqrt[x] : Square root of x. Result is NaN (Not a Number) if x is negative.<br/>tan[x] : Tangent of x (x is in radians)<br/>tanh[x] : Hyperbolic tangent of x (x is in radians)<br/> <br/><br/>Pre-defined functions:<br/>random(n) : Get a random number in the range [0, n). If n is zero, or not provided, it defaults to 1.<br/>fac(n)        n! : (factorial of n: \"n * (n-1) * (n-2) * … *2 * 1\") Deprecated. Use the ! operator instead.<br/>min(a,b,…) : Get the smallest (minimum) number in the list.<br/>max(a,b,…) : Get the largest (maximum) number in the list.<br/>hypot(a,b) : Hypotenuse, i.e. the square root of the sum of squares of its arguments.<br/>pyt(a, b) : Alias for hypot.<br/>pow(x, y) : Equivalent to x^y.<br/>roundTo(x, n) : Rounds x to n places after the decimal point.<br/><br/>Constants: <br/>E : The value of Math.E from your JavaScript runtime.<br/>PI : The value of Math.PI from your JavaScript runtime.<br/><br/>Variable assignments : <br/>declare variable and assign a value: x=1  declared variable can be used in further calculation x+2.<br/><br/>clear command for clearing calculator app.<br/><br/>exit command for exit from calculator app. `;
-                break;
-            default:
-                result = this.evaluateExp(command);
-        }
-
-        const resultEl = document.getElementById(`row-calculator-result-${rowId}`);
-        if (resultEl) {
-            resultEl.textContent = String(result);
-        }
-        this.appendTerminalRow();
-        this.setState(prev => ({
-            lines: [...prev.lines, { id: rowId, command, result: this.xss(String(result)) }],
-            currentInput: '',
-            history: [...prev.history, command],
-            historyIndex: -1,
-        }), () => {
-            this.inputRef.current?.focus();
-        });
-    }
-
-    closeTerminal = () => {
-        document.getElementById('close-calc')?.click();
-
-      
-    }
-
-    evaluateExp = (command) => {
-        let result = '';
-        let expr;
-        try{
-            expr = parser.parse(command);
-            try{
-                result = parser.evaluate(command,this.variables);
-                if(expr.tokens.length > 2 && expr.tokens[expr.tokens.length - 1].type === "IOP2")
-                    this.variables[expr.variables()[0]] = result;
-            }
-            catch (e) {
-                result = e.message;
-            }
-        }
-        catch(e){
-            result = "Invalid Expression";
-        }
-        return result;
-    }
-
-    xss(str) {
-        if (!str) return '';
-        return str.split('').map(char => {
-            switch (char) {
-                case '&':
-                    return '&amp';
-                case '<':
-                    return '&lt';
-                case '>':
-                    return '&gt';
-                case '"':
-                    return '&quot';
-                case "'":
-                    return '&#x27';
-                case '/':
-                    return '&#x2F';
-                default:
-                    return char;
-            }
-        }).join('');
-    }
-
-
-    render() {
-        return (
-            <div className="h-full w-full bg-ub-drk-abrgn text-ubt-grey opacity-100 p-1 float-left font-normal">
-                <div>C-style arbitary precision calculator (version 2.12.7.2)</div>
-                <div>Calc is open software.</div>
-                 <div>[ type &quot;exit&quot; to exit, &quot;clear&quot; to clear, &quot;help&quot; for help.]</div>
-            <div className="text-white text-sm font-bold bg-ub-drk-abrgn" id="calculator-body">
-                {this.state.lines.map(line => (
-                    <React.Fragment key={line.id}>
-                        <div className=" flex p-2 text-ubt-grey opacity-100 mt-1 float-left font-normal "></div>
-                        <div className="flex w-full h-5">
-                                <div className=" flex text-ubt-green h-1 mr-2"> {'$'} </div>
-                            <div className="bg-transparent flex-1 overflow-hidden">
-                                <span className=" float-left whitespace-pre pb-1 opacity-100 font-normal tracking-wider">{line.command}</span>
-                            </div>
-                        </div>
-                        <div id={`row-calculator-result-${line.id}`} className="my-2 font-normal" dangerouslySetInnerHTML={{ __html: line.result }}></div>
-                    </React.Fragment>
-                ))}
-                <div className=" flex p-2 text-ubt-grey opacity-100 mt-1 float-left font-normal "></div>
-                <div className="flex w-full h-5">
-                        <div className=" flex text-ubt-green h-1 mr-2"> {'$'} </div>
-                    <div className="bg-transparent flex-1 overflow-hidden">
-                        <input
-                            id={`calculator-input-${this.state.lines.length + 2}`}
-                            ref={this.inputRef}
-                            value={this.state.currentInput}
-                            onChange={this.handleInputChange}
-                            onKeyDown={this.handleKeyDown}
-                            className=" absolute top-0 left-0 w-full outline-none bg-transparent"
-                            spellCheck={false}
-                            autoComplete="off"
-                            type="text"
-                        />
-                    </div>
-                </div>
-            </div>
-            </div>
-        )
-    }
-}
-
-export default Calc
-
-export const displayTerminalCalc = (addFolder,openApp) => {
-    return <Calc addFolder={addFolder} openApp={openApp}> </Calc>;
-}


### PR DESCRIPTION
## Summary
- replace terminal-like calculator with button-based UI using React and Tailwind
- expose `evaluateExpression` helper and update tests for new workflow
- ensure expression handling remains safe and reports invalid input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6c36bd2b483288509e88a22aa2d29