### PR TITLE
Add Notes app with localStorage persistence

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayGedit } from './components/apps/gedit';
 import { displayAboutAlex } from './components/apps/alex';
 import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
+import { displayNotes } from './components/apps/notes';
 
 const TerminalApp = dynamic(
   () =>
@@ -166,6 +167,16 @@ const apps = [
     desktop_shortcut: true,
     screen: displayGedit,
   },
+  {
+    id: 'notes',
+    title: 'Notes',
+    icon: 'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/notepad.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNotes,
+  },
+
 ];
 
 export default apps;

--- a/components/apps/notes.js
+++ b/components/apps/notes.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+const NotesApp = () => {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('notes');
+    if (saved !== null) {
+      setText(saved);
+    }
+  }, []);
+
+  const handleChange = (e) => {
+    const value = e.target.value;
+    setText(value);
+    localStorage.setItem('notes', value);
+  };
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white">
+      <textarea
+        className="w-full h-full bg-transparent resize-none outline-none p-2"
+        value={text}
+        onChange={handleChange}
+        spellCheck="false"
+      />
+    </div>
+  );
+};
+
+export default NotesApp;
+
+export const displayNotes = () => <NotesApp />;
+


### PR DESCRIPTION
## Summary
- add Notes app with textarea that saves to localStorage
- register Notes in apps config with remote icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76f9c66008328a925ac71371eadf7