### PR TITLE
Add Clock app prototype

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayGedit } from './components/apps/gedit';
 import { displayAboutAlex } from './components/apps/alex';
 import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
+import { displayClock } from './components/apps/clock';
 
 const TerminalApp = dynamic(
   () =>
@@ -75,6 +76,15 @@ const apps = [
     allowMaximize: false,
     defaultWidth: 25,
     defaultHeight: 40,
+  },
+  {
+    id: 'clock',
+    title: 'Clock',
+    icon: 'https://img.icons8.com/fluency/48/clock.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayClock,
   },
   {
     id: 'about-alex',

--- a/components/apps/clock.js
+++ b/components/apps/clock.js
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ClockApp() {
+  const [time, setTime] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white select-none">
+      <div className="text-6xl font-bold" data-testid="clock-time">{time.toLocaleTimeString()}</div>
+      <div className="text-xl mt-2" data-testid="clock-date">{time.toLocaleDateString()}</div>
+    </div>
+  );
+}
+
+export const displayClock = (addFolder, openApp) => {
+  return <ClockApp addFolder={addFolder} openApp={openApp} />;
+};


### PR DESCRIPTION
## Summary
- add a simple clock application that shows current time and date
- register clock app using external icon instead of bundled binary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76da49e68832896bd5dffb2fd460b