### PR TITLE
Add keyboard control to TicTacToe game

### DIFF
--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -89,6 +89,13 @@ const TicTacToe = () => {
             key={idx}
             className="h-20 w-20 bg-gray-700 hover:bg-gray-600 text-4xl flex items-center justify-center"
             onClick={() => handleClick(idx)}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleClick(idx);
+              }
+            }}
           >
             {cell}
           </button>


### PR DESCRIPTION
## Summary
- allow keyboard activation of TicTacToe cells via Enter or Space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7756bba2883289a523cf6e802ed42