### PR TITLE
feat: track game launch frequency

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -28,6 +28,34 @@ export class AllApplications extends React.Component {
         })
     }
 
+    openApp = (objId) => {
+        let frequentApps = localStorage.getItem('frequentApps') ? JSON.parse(localStorage.getItem('frequentApps')) : [];
+        let currentApp = frequentApps.find(app => app.id === objId);
+        if (currentApp) {
+            frequentApps.forEach((app) => {
+                if (app.id === currentApp.id) {
+                    app.frequency += 1;
+                }
+            });
+        } else {
+            frequentApps.push({ id: objId, frequency: 1 });
+        }
+
+        frequentApps.sort((a, b) => {
+            if (a.frequency < b.frequency) {
+                return 1;
+            }
+            if (a.frequency > b.frequency) {
+                return -1;
+            }
+            return 0;
+        });
+
+        localStorage.setItem("frequentApps", JSON.stringify(frequentApps));
+
+        this.props.openApp(objId);
+    }
+
     renderApps = () => {
 
         let appsJsx = [];
@@ -51,7 +79,7 @@ export class AllApplications extends React.Component {
                 name: app.title,
                 id: app.id,
                 icon: app.icon,
-                openApp: this.props.openApp
+                openApp: this.openApp
             }
 
             appsJsx.push(


### PR DESCRIPTION
## Summary
- track game launch frequency by updating localStorage when apps are opened

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7756c29cc8328a734555ce1ba5155