### PR TITLE
Add calculator app with scientific toggle

### DIFF
--- a/apps/calculator/index.html
+++ b/apps/calculator/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calculator</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="calculator">
+    <div id="display" class="display"></div>
+    <button id="toggle-scientific" class="toggle">Scientific</button>
+    <div class="buttons">
+      <button class="btn" data-value="7">7</button>
+      <button class="btn" data-value="8">8</button>
+      <button class="btn" data-value="9">9</button>
+      <button class="btn" data-value="/">&divide;</button>
+      <button class="btn" data-value="4">4</button>
+      <button class="btn" data-value="5">5</button>
+      <button class="btn" data-value="6">6</button>
+      <button class="btn" data-value="*">&times;</button>
+      <button class="btn" data-value="1">1</button>
+      <button class="btn" data-value="2">2</button>
+      <button class="btn" data-value="3">3</button>
+      <button class="btn" data-value="-">&minus;</button>
+      <button class="btn" data-value="0">0</button>
+      <button class="btn" data-value=".">.</button>
+      <button class="btn" data-action="equals">=</button>
+      <button class="btn" data-value="+">+</button>
+      <button class="btn span-two" data-action="clear">C</button>
+    </div>
+    <div id="scientific" class="scientific hidden">
+      <button class="btn" data-value="sin(">sin</button>
+      <button class="btn" data-value="cos(">cos</button>
+      <button class="btn" data-value="tan(">tan</button>
+      <button class="btn" data-value="sqrt(">&#8730;</button>
+      <button class="btn" data-value="(">(</button>
+      <button class="btn" data-value=")">)</button>
+    </div>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/calculator/main.js
+++ b/apps/calculator/main.js
@@ -1,0 +1,35 @@
+const display = document.getElementById('display');
+const buttons = document.querySelectorAll('.btn');
+const toggle = document.getElementById('toggle-scientific');
+const scientific = document.getElementById('scientific');
+
+toggle.addEventListener('click', () => {
+  scientific.classList.toggle('hidden');
+});
+
+buttons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const action = btn.dataset.action;
+    const value = btn.dataset.value || btn.textContent;
+
+    if (action === 'clear') {
+      display.textContent = '';
+      return;
+    }
+
+    if (action === 'equals') {
+      display.textContent = evaluate(display.textContent);
+      return;
+    }
+
+    display.textContent += value;
+  });
+});
+
+function evaluate(expression) {
+  try {
+    return Function('with (Math) { return (' + expression + ') }')();
+  } catch (e) {
+    return 'Error';
+  }
+}

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,0 +1,66 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.calculator {
+  background: #ffffff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  width: 240px;
+}
+
+.display {
+  background: #eaeaea;
+  height: 40px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  text-align: right;
+  font-size: 1.2rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.toggle {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.buttons,
+.scientific {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.btn {
+  padding: 0.75rem;
+  background: #f0f0f0;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background: #e0e0e0;
+}
+
+.span-two {
+  grid-column: span 2;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add standalone calculator with grid layout for digits and operators
- hook up arithmetic logic and scientific toggle via event listeners
- apply minimalist styling for buttons and display

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a776e73cfc8328a4e626edf38abfef