### PR TITLE
Add color picker app with swatch copy feature

### DIFF
--- a/apps/color_picker/index.html
+++ b/apps/color_picker/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Color Picker</title>
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      padding: 2rem;
+      background: #f4f4f4;
+    }
+    h1 {
+      margin-bottom: 1rem;
+    }
+    #color-input {
+      width: 80px;
+      height: 80px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      transition: transform 0.2s ease;
+    }
+    #color-input:hover {
+      transform: scale(1.05);
+    }
+    #swatches {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .swatch {
+      width: 40px;
+      height: 40px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .swatch:hover {
+      transform: scale(1.1);
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    }
+  </style>
+</head>
+<body>
+  <h1>Color Picker</h1>
+  <input type="color" id="color-input" />
+  <div id="swatches"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/color_picker/main.js
+++ b/apps/color_picker/main.js
@@ -1,0 +1,34 @@
+const colors = [];
+const input = document.getElementById('color-input');
+const swatches = document.getElementById('swatches');
+
+function addColor(color) {
+  if (!color) return;
+  const existingIndex = colors.indexOf(color);
+  if (existingIndex !== -1) {
+    colors.splice(existingIndex, 1);
+  }
+  colors.unshift(color);
+  if (colors.length > 10) {
+    colors.pop();
+  }
+  renderSwatches();
+}
+
+function renderSwatches() {
+  swatches.innerHTML = '';
+  colors.forEach((color) => {
+    const swatch = document.createElement('div');
+    swatch.className = 'swatch';
+    swatch.style.backgroundColor = color;
+    swatch.title = color;
+    swatch.addEventListener('click', () => {
+      navigator.clipboard.writeText(color);
+    });
+    swatches.appendChild(swatch);
+  });
+}
+
+input.addEventListener('input', (e) => {
+  addColor(e.target.value);
+});


### PR DESCRIPTION
## Summary
- Add standalone color picker mini-app under `apps/color_picker`
- Track selected colors and render recent swatches
- Copy hex value to clipboard when a swatch is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a776e8ade88328b8e29540fa8a569b