### PR TITLE
feat: add clipboard manager app

### DIFF
--- a/apps/clipboard_manager/index.html
+++ b/apps/clipboard_manager/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Clipboard Manager</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    button { margin-bottom: 1rem; }
+    li { cursor: pointer; margin: 0.25rem 0; }
+    li:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>Clipboard Manager</h1>
+  <button id="clear">Clear History</button>
+  <ul id="history"></ul>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -1,0 +1,48 @@
+/* eslint-env browser */
+const historyKey = 'clipboardHistory';
+let history = JSON.parse(localStorage.getItem(historyKey)) || [];
+
+const list = document.getElementById('history');
+const clearBtn = document.getElementById('clear');
+
+function render() {
+  list.innerHTML = '';
+  history.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    li.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(item);
+      } catch (err) {
+        console.error('Failed to copy text:', err);
+      }
+    });
+    list.appendChild(li);
+  });
+}
+
+function save() {
+  localStorage.setItem(historyKey, JSON.stringify(history));
+}
+
+clearBtn.addEventListener('click', () => {
+  history = [];
+  save();
+  render();
+});
+
+document.addEventListener('copy', async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text && (history.length === 0 || history[0] !== text)) {
+      history.unshift(text);
+      save();
+      render();
+    }
+  } catch (err) {
+    console.error('Clipboard read failed:', err);
+  }
+});
+
+// initial render
+render();


### PR DESCRIPTION
## Summary
- add standalone clipboard manager web app
- track copied text, show history, and restore items

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a776e7ac808328ba245f7c1bc85c28