### PR TITLE
Add timer and stopwatch web app

### DIFF
--- a/apps/timer_stopwatch/index.html
+++ b/apps/timer_stopwatch/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Timer & Stopwatch</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      margin-top: 50px;
+      background: #f0f0f0;
+    }
+    .display {
+      font-size: 4rem;
+      font-family: 'Courier New', monospace;
+      margin: 20px 0;
+    }
+    button {
+      margin: 5px;
+      padding: 10px 20px;
+      font-size: 1rem;
+    }
+    input {
+      width: 60px;
+      text-align: center;
+      font-size: 1rem;
+      padding: 5px;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+      margin-top: 10px;
+      width: 100%;
+      max-width: 300px;
+    }
+    li {
+      background: #fff;
+      margin: 2px 0;
+      padding: 5px 10px;
+      border-radius: 4px;
+      font-family: 'Courier New', monospace;
+    }
+  </style>
+</head>
+<body>
+  <div>
+    <button id="modeTimer">Timer</button>
+    <button id="modeStopwatch">Stopwatch</button>
+  </div>
+
+  <div id="timerControls">
+    <div>
+      <input type="number" id="minutes" min="0" value="0" /> :
+      <input type="number" id="seconds" min="0" max="59" value="30" />
+    </div>
+    <div class="display" id="timerDisplay">00:30</div>
+    <div>
+      <button id="startTimer">Start</button>
+      <button id="stopTimer">Stop</button>
+      <button id="resetTimer">Reset</button>
+    </div>
+  </div>
+
+  <div id="stopwatchControls" style="display:none;">
+    <div class="display" id="stopwatchDisplay">00:00</div>
+    <div>
+      <button id="startWatch">Start</button>
+      <button id="stopWatch">Stop</button>
+      <button id="resetWatch">Reset</button>
+      <button id="lapWatch">Lap</button>
+    </div>
+    <ul id="laps"></ul>
+  </div>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -1,0 +1,131 @@
+let mode = 'timer';
+let timerInterval = null;
+let timerRemaining = 30;
+let stopwatchInterval = null;
+let stopwatchElapsed = 0;
+let lapNumber = 1;
+
+const timerDisplay = document.getElementById('timerDisplay');
+const stopwatchDisplay = document.getElementById('stopwatchDisplay');
+const timerControls = document.getElementById('timerControls');
+const stopwatchControls = document.getElementById('stopwatchControls');
+const minutesInput = document.getElementById('minutes');
+const secondsInput = document.getElementById('seconds');
+const lapsList = document.getElementById('laps');
+
+function formatTime(seconds) {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+function switchMode(newMode) {
+  mode = newMode;
+  if (mode === 'timer') {
+    timerControls.style.display = 'block';
+    stopwatchControls.style.display = 'none';
+  } else {
+    timerControls.style.display = 'none';
+    stopwatchControls.style.display = 'block';
+  }
+}
+
+document.getElementById('modeTimer').addEventListener('click', () => switchMode('timer'));
+document.getElementById('modeStopwatch').addEventListener('click', () => switchMode('stopwatch'));
+
+function updateTimerDisplay() {
+  timerDisplay.textContent = formatTime(timerRemaining);
+}
+
+function startTimer() {
+  if (timerInterval) return;
+  const mins = parseInt(minutesInput.value, 10) || 0;
+  const secs = parseInt(secondsInput.value, 10) || 0;
+  timerRemaining = mins * 60 + secs;
+  updateTimerDisplay();
+  timerInterval = setInterval(() => {
+    timerRemaining--;
+    updateTimerDisplay();
+    if (timerRemaining <= 0) {
+      clearInterval(timerInterval);
+      timerInterval = null;
+      playSound();
+    }
+  }, 1000);
+}
+
+function stopTimer() {
+  clearInterval(timerInterval);
+  timerInterval = null;
+}
+
+function resetTimer() {
+  stopTimer();
+  const mins = parseInt(minutesInput.value, 10) || 0;
+  const secs = parseInt(secondsInput.value, 10) || 0;
+  timerRemaining = mins * 60 + secs;
+  updateTimerDisplay();
+}
+
+function updateStopwatchDisplay() {
+  stopwatchDisplay.textContent = formatTime(stopwatchElapsed);
+}
+
+function startWatch() {
+  if (stopwatchInterval) return;
+  stopwatchInterval = setInterval(() => {
+    stopwatchElapsed++;
+    updateStopwatchDisplay();
+  }, 1000);
+}
+
+function stopWatch() {
+  clearInterval(stopwatchInterval);
+  stopwatchInterval = null;
+}
+
+function resetWatch() {
+  stopWatch();
+  stopwatchElapsed = 0;
+  lapNumber = 1;
+  updateStopwatchDisplay();
+  lapsList.innerHTML = '';
+}
+
+function lapWatch() {
+  const li = document.createElement('li');
+  li.textContent = `Lap ${lapNumber++}: ${formatTime(stopwatchElapsed)}`;
+  lapsList.appendChild(li);
+}
+
+function playSound() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const oscillator = ctx.createOscillator();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(440, ctx.currentTime);
+    oscillator.connect(ctx.destination);
+    oscillator.start();
+    setTimeout(() => {
+      oscillator.stop();
+      ctx.close();
+    }, 500);
+  } catch (e) {
+    console.error('AudioContext not supported', e);
+  }
+}
+
+document.getElementById('startTimer').addEventListener('click', startTimer);
+document.getElementById('stopTimer').addEventListener('click', stopTimer);
+document.getElementById('resetTimer').addEventListener('click', resetTimer);
+
+document.getElementById('startWatch').addEventListener('click', startWatch);
+document.getElementById('stopWatch').addEventListener('click', stopWatch);
+document.getElementById('resetWatch').addEventListener('click', resetWatch);
+document.getElementById('lapWatch').addEventListener('click', lapWatch);
+
+// Initialize displays
+updateTimerDisplay();
+updateStopwatchDisplay();


### PR DESCRIPTION
## Summary
- add standalone timer/stopwatch app with mode toggle
- implement countdown timer with audio alert
- add stopwatch with lap recording and large digit display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a776ea7efc8328aa67ffdb68623225