### PR TITLE
Add quote generator app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayGedit } from './components/apps/gedit';
 import { displayAboutAlex } from './components/apps/alex';
 import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
+import { displayQuoteGenerator } from './components/apps/quote_generator';
 
 const TerminalApp = dynamic(
   () =>
@@ -104,6 +105,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTicTacToe,
+  },
+  {
+    id: 'quote-generator',
+    title: 'Quote Generator',
+    icon: './themes/Yaru/apps/quote.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayQuoteGenerator,
   },
   {
     id: 'about-alex',

--- a/components/apps/quote_generator.js
+++ b/components/apps/quote_generator.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+
+const quotes = [
+  "The only limit to our realization of tomorrow is our doubts of today.",
+  "In the middle of difficulty lies opportunity.",
+  "Life is 10% what happens to us and 90% how we react to it.",
+  "The purpose of our lives is to be happy.",
+];
+
+const QuoteGenerator = () => {
+  const [quote, setQuote] = useState('');
+  const [fade, setFade] = useState(true);
+
+  const getRandomQuote = () => quotes[Math.floor(Math.random() * quotes.length)];
+
+  const changeQuote = () => {
+    setFade(true);
+    setTimeout(() => {
+      setQuote(getRandomQuote());
+      setFade(false);
+    }, 300);
+  };
+
+  useEffect(() => {
+    changeQuote();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const copyQuote = () => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(quote);
+    }
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <p className={`text-center text-lg mb-4 transition-opacity duration-300 ${fade ? 'opacity-0' : 'opacity-100'}`}>{quote}</p>
+      <div className="flex space-x-2">
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={changeQuote}
+        >
+          New Quote
+        </button>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={copyQuote}
+        >
+          Copy Quote
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default QuoteGenerator;
+export const displayQuoteGenerator = () => <QuoteGenerator />;
+

--- a/public/themes/Yaru/apps/quote.svg
+++ b/public/themes/Yaru/apps/quote.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M20 24h10v16H16V36c0-7 5-12 10-12zm24 0h10v16H40V36c0-7 5-12 10-12z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add quote generator mini app with copy feature and fade transitions
- register quote generator in app configuration with icon

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a776f682548328b3fd92a0abda7f74