### PR TITLE
feat: add screen recorder app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -61,6 +61,22 @@ const TicTacToeApp = dynamic(
   }
 );
 
+const RecorderApp = dynamic(
+  () =>
+    import('./components/apps/recorder').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Recorder' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Recorder...
+      </div>
+    ),
+  }
+);
+
 const displayTerminal = (addFolder, openApp) => (
   <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
@@ -71,6 +87,10 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displayRecorder = (addFolder, openApp) => (
+  <RecorderApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
@@ -104,6 +124,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTicTacToe,
+  },
+  {
+    id: 'recorder',
+    title: 'Recorder',
+    icon: './themes/Yaru/apps/recorder.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayRecorder,
   },
   {
     id: 'about-alex',

--- a/components/apps/recorder.js
+++ b/components/apps/recorder.js
@@ -1,0 +1,90 @@
+import React, { useRef, useState } from 'react';
+
+const RecorderApp = () => {
+  const [recording, setRecording] = useState(false);
+  const [videoURL, setVideoURL] = useState('');
+  const mediaRecorderRef = useRef(null);
+  const streamRef = useRef(null);
+  const chunksRef = useRef([]);
+  const videoRef = useRef(null);
+
+  const startRecording = async () => {
+    try {
+      const screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
+      const micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const tracks = [
+        ...screenStream.getVideoTracks(),
+        ...screenStream.getAudioTracks(),
+        ...micStream.getAudioTracks(),
+      ];
+      const stream = new MediaStream(tracks);
+      streamRef.current = stream;
+
+      const recorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+      recorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+        chunksRef.current = [];
+        const url = URL.createObjectURL(blob);
+        setVideoURL(url);
+        if (videoRef.current) {
+          videoRef.current.src = url;
+        }
+      };
+      recorder.start();
+      setRecording(true);
+    } catch (err) {
+      console.error('Error starting recording', err);
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop();
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+    }
+    setRecording(false);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 space-y-4">
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={startRecording}
+          disabled={recording}
+          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+        >
+          Start
+        </button>
+        <button
+          onClick={stopRecording}
+          disabled={!recording}
+          className="px-4 py-2 bg-red-600 rounded disabled:opacity-50"
+        >
+          Stop
+        </button>
+        {recording && <span className="h-3 w-3 rounded-full bg-red-500 animate-pulse"></span>}
+      </div>
+      {videoURL && (
+        <div className="flex flex-col space-y-2">
+          <video ref={videoRef} controls className="w-full h-64 bg-black" src={videoURL}></video>
+          <a href={videoURL} download="recording.webm" className="text-blue-300 underline">
+            Download
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecorderApp;
+
+export const displayRecorder = () => <RecorderApp />;
+

--- a/public/themes/Yaru/apps/recorder.svg
+++ b/public/themes/Yaru/apps/recorder.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <circle cx="32" cy="32" r="18" fill="#e53935"/>
+  <circle cx="32" cy="32" r="10" fill="#ff5252"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Recorder app with MediaRecorder-based screen and microphone capture
- enable preview, download, and recording status indicator
- register Recorder app and icon in configuration using SVG icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a776eddb2c8328baf13b3eedabfac5