### PR TITLE
Add Calendar Peek app with notes

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -61,6 +61,22 @@ const TicTacToeApp = dynamic(
   }
 );
 
+const CalendarPeekApp = dynamic(
+  () =>
+    import('./components/apps/calendar_peek').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Calendar Peek' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Calendar...
+      </div>
+    ),
+  }
+);
+
 const displayTerminal = (addFolder, openApp) => (
   <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
@@ -71,6 +87,10 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displayCalendarPeek = (addFolder, openApp) => (
+  <CalendarPeekApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
@@ -104,6 +124,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTicTacToe,
+  },
+  {
+    id: 'calendar_peek',
+    title: 'Calendar Peek',
+    icon: './themes/Yaru/apps/calendar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCalendarPeek,
   },
   {
     id: 'about-alex',

--- a/components/apps/calendar_peek/index.js
+++ b/components/apps/calendar_peek/index.js
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+
+const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const CalendarPeek = () => {
+  const today = new Date();
+  const currentMonth = today.getMonth();
+  const currentYear = today.getFullYear();
+  const [notes, setNotes] = useState({});
+
+  // Load saved notes
+  useEffect(() => {
+    const stored = localStorage.getItem('calendar-peek-notes');
+    if (stored) {
+      try {
+        setNotes(JSON.parse(stored));
+      } catch {
+        setNotes({});
+      }
+    }
+  }, []);
+
+  // Persist notes
+  useEffect(() => {
+    localStorage.setItem('calendar-peek-notes', JSON.stringify(notes));
+  }, [notes]);
+
+  const firstDay = new Date(currentYear, currentMonth, 1).getDay();
+  const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+
+  const handleAddNote = (day) => {
+    const key = `${currentYear}-${currentMonth + 1}-${day}`; // month 1-based
+    const existing = notes[key] || '';
+    const note = prompt('Add note', existing);
+    if (note === null) return; // cancelled
+    setNotes((prev) => {
+      const next = { ...prev };
+      if (note.trim()) next[key] = note.trim();
+      else delete next[key];
+      return next;
+    });
+  };
+
+  const cells = [];
+  for (let i = 0; i < firstDay; i++) {
+    cells.push(<div key={`blank-${i}`} />);
+  }
+  for (let day = 1; day <= daysInMonth; day++) {
+    const key = `${currentYear}-${currentMonth + 1}-${day}`;
+    const note = notes[key];
+    const isToday =
+      day === today.getDate() &&
+      currentMonth === today.getMonth() &&
+      currentYear === today.getFullYear();
+    cells.push(
+      <div
+        key={day}
+        onClick={() => handleAddNote(day)}
+        title={note || ''}
+        className={[
+          'p-2',
+          'border',
+          'border-gray-700',
+          'cursor-pointer',
+          'hover:bg-gray-700',
+          'relative',
+          isToday ? 'bg-blue-600 text-white' : '',
+          !isToday && note ? 'bg-yellow-300 text-gray-900' : '',
+        ].join(' ')}
+      >
+        {day}
+      </div>
+    );
+  }
+
+  const monthLabel = new Date(currentYear, currentMonth).toLocaleString('default', {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4">
+      <div className="text-center mb-2 font-bold">{monthLabel}</div>
+      <div className="grid grid-cols-7 text-center mb-1">
+        {daysOfWeek.map((d) => (
+          <div key={d} className="font-semibold">
+            {d}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 flex-grow">
+        {cells}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarPeek;
+

--- a/public/themes/Yaru/apps/calendar.svg
+++ b/public/themes/Yaru/apps/calendar.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="8" width="56" height="52" rx="4" ry="4" fill="#ffffff" stroke="#2e3436" stroke-width="4"/>
+  <rect x="4" y="8" width="56" height="16" rx="4" ry="4" fill="#d32f2f"/>
+  <line x1="4" y1="24" x2="60" y2="24" stroke="#2e3436" stroke-width="2"/>
+  <line x1="16" y1="24" x2="16" y2="60" stroke="#2e3436" stroke-width="2"/>
+  <line x1="28" y1="24" x2="28" y2="60" stroke="#2e3436" stroke-width="2"/>
+  <line x1="40" y1="24" x2="40" y2="60" stroke="#2e3436" stroke-width="2"/>
+  <line x1="52" y1="24" x2="52" y2="60" stroke="#2e3436" stroke-width="2"/>
+  <line x1="4" y1="36" x2="60" y2="36" stroke="#2e3436" stroke-width="2"/>
+  <line x1="4" y1="48" x2="60" y2="48" stroke="#2e3436" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Calendar Peek app showing current month's grid and note tooltips
- wire Calendar Peek into desktop app configuration
- use SVG calendar icon instead of PNG

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a776f13e74832890685a06ebf92f14