### PR TITLE
feat: add space invaders game

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -61,6 +61,22 @@ const TicTacToeApp = dynamic(
   }
 );
 
+const SpaceInvadersApp = dynamic(
+  () =>
+    import('./components/apps/space-invaders').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Space Invaders' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Space Invaders...
+      </div>
+    ),
+  }
+);
+
 const displayTerminal = (addFolder, openApp) => (
   <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
@@ -71,6 +87,10 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displaySpaceInvaders = (addFolder, openApp) => (
+  <SpaceInvadersApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
@@ -104,6 +124,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTicTacToe,
+  },
+  {
+    id: 'space-invaders',
+    title: 'Space Invaders',
+    icon: './themes/Yaru/apps/space-invaders.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySpaceInvaders,
   },
   {
     id: 'about-alex',
@@ -197,4 +226,26 @@ const apps = [
   },
 ];
 
+const games = [
+  {
+    id: 'tictactoe',
+    title: 'Tic Tac Toe',
+    icon: './themes/Yaru/apps/tictactoe.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTicTacToe,
+  },
+  {
+    id: 'space-invaders',
+    title: 'Space Invaders',
+    icon: './themes/Yaru/apps/space-invaders.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySpaceInvaders,
+  },
+];
+
 export default apps;
+export { games };

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -1,0 +1,116 @@
+import React, { useRef, useEffect } from 'react';
+
+const SpaceInvaders = () => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    let animationFrameId;
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+
+    const player = { x: canvas.width / 2 - 20, y: canvas.height - 30, w: 40, h: 10, dx: 0 };
+    const bullets = [];
+    const aliens = [];
+    const rows = 4;
+    const cols = 8;
+    const alienW = 30;
+    const alienH = 20;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        aliens.push({ x: c * (alienW + 10) + 30, y: r * (alienH + 10) + 30, w: alienW, h: alienH });
+      }
+    }
+    let alienDx = 1;
+
+    const keyDown = (e) => {
+      if (e.key === 'ArrowLeft') player.dx = -5;
+      if (e.key === 'ArrowRight') player.dx = 5;
+      if (e.key === ' ') {
+        bullets.push({ x: player.x + player.w / 2 - 1, y: player.y, w: 2, h: 10, dy: -7 });
+      }
+    };
+
+    const keyUp = (e) => {
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') player.dx = 0;
+    };
+
+    const collision = (a, b) =>
+      a.x < b.x + b.w &&
+      a.x + a.w > b.x &&
+      a.y < b.y + b.h &&
+      a.h + a.y > b.y;
+
+    const update = () => {
+      player.x += player.dx;
+      if (player.x < 0) player.x = 0;
+      if (player.x + player.w > canvas.width) player.x = canvas.width - player.w;
+
+      bullets.forEach((b, i) => {
+        b.y += b.dy;
+        if (b.y + b.h < 0) bullets.splice(i, 1);
+      });
+
+      let shiftDown = false;
+      aliens.forEach((a) => {
+        a.x += alienDx;
+        if (a.x + a.w > canvas.width - 10 || a.x < 10) shiftDown = true;
+      });
+      if (shiftDown) {
+        alienDx *= -1;
+        aliens.forEach((a) => {
+          a.y += 20;
+        });
+      }
+
+      bullets.forEach((b, bi) => {
+        aliens.forEach((a, ai) => {
+          if (collision(b, a)) {
+            aliens.splice(ai, 1);
+            bullets.splice(bi, 1);
+          }
+        });
+      });
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0f0';
+      ctx.fillRect(player.x, player.y, player.w, player.h);
+
+      ctx.fillStyle = '#f00';
+      bullets.forEach((b) => ctx.fillRect(b.x, b.y, b.w, b.h));
+
+      ctx.fillStyle = '#0ff';
+      aliens.forEach((a) => ctx.fillRect(a.x, a.y, a.w, a.h));
+    };
+
+    const loop = () => {
+      update();
+      draw();
+      animationFrameId = requestAnimationFrame(loop);
+    };
+    loop();
+
+    window.addEventListener('keydown', keyDown);
+    window.addEventListener('keyup', keyUp);
+    window.addEventListener('resize', resize);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('keydown', keyDown);
+      window.removeEventListener('keyup', keyUp);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-full bg-black" />;
+};
+
+export default SpaceInvaders;
+

--- a/public/themes/Yaru/apps/space-invaders.svg
+++ b/public/themes/Yaru/apps/space-invaders.svg
@@ -1,0 +1,43 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <g fill="#4caf50">
+    <rect x="8" y="0" width="8" height="8"/>
+    <rect x="16" y="0" width="8" height="8"/>
+    <rect x="40" y="0" width="8" height="8"/>
+    <rect x="48" y="0" width="8" height="8"/>
+    <rect x="0" y="8" width="8" height="8"/>
+    <rect x="8" y="8" width="8" height="8"/>
+    <rect x="16" y="8" width="8" height="8"/>
+    <rect x="24" y="8" width="8" height="8"/>
+    <rect x="32" y="8" width="8" height="8"/>
+    <rect x="40" y="8" width="8" height="8"/>
+    <rect x="48" y="8" width="8" height="8"/>
+    <rect x="56" y="8" width="8" height="8"/>
+    <rect x="0" y="16" width="8" height="8"/>
+    <rect x="8" y="16" width="8" height="8"/>
+    <rect x="16" y="16" width="8" height="8"/>
+    <rect x="24" y="16" width="8" height="8"/>
+    <rect x="32" y="16" width="8" height="8"/>
+    <rect x="40" y="16" width="8" height="8"/>
+    <rect x="48" y="16" width="8" height="8"/>
+    <rect x="56" y="16" width="8" height="8"/>
+    <rect x="0" y="24" width="8" height="8"/>
+    <rect x="8" y="24" width="8" height="8"/>
+    <rect x="24" y="24" width="8" height="8"/>
+    <rect x="32" y="24" width="8" height="8"/>
+    <rect x="48" y="24" width="8" height="8"/>
+    <rect x="56" y="24" width="8" height="8"/>
+    <rect x="8" y="32" width="8" height="8"/>
+    <rect x="16" y="32" width="8" height="8"/>
+    <rect x="24" y="32" width="8" height="8"/>
+    <rect x="32" y="32" width="8" height="8"/>
+    <rect x="40" y="32" width="8" height="8"/>
+    <rect x="48" y="32" width="8" height="8"/>
+    <rect x="16" y="40" width="8" height="8"/>
+    <rect x="40" y="40" width="8" height="8"/>
+    <rect x="0" y="48" width="8" height="8"/>
+    <rect x="56" y="48" width="8" height="8"/>
+    <rect x="8" y="56" width="8" height="8"/>
+    <rect x="48" y="56" width="8" height="8"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add canvas-based Space Invaders game component
- load Space Invaders dynamically and register under apps and games
- include Space Invaders icon in theme assets
- switch Space Invaders icon to SVG

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7786747cc83289bbfbba69336d0f6