### PR TITLE
feat: add minesweeper game

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -61,6 +61,22 @@ const TicTacToeApp = dynamic(
   }
 );
 
+const MinesweeperApp = dynamic(
+  () =>
+    import('./components/apps/minesweeper').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Minesweeper' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Minesweeper...
+      </div>
+    ),
+  },
+);
+
 const displayTerminal = (addFolder, openApp) => (
   <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
@@ -71,6 +87,10 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displayMinesweeper = (addFolder, openApp) => (
+  <MinesweeperApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
@@ -105,6 +125,15 @@ const apps = [
     desktop_shortcut: false,
     screen: displayTicTacToe,
   },
+    {
+      id: 'minesweeper',
+      title: 'Minesweeper',
+      icon: './themes/Yaru/apps/minesweeper.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayMinesweeper,
+    },
   {
     id: 'about-alex',
     title: 'About Alex',

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+
+const BOARD_SIZE = 8;
+const MINES_COUNT = 10;
+
+const generateBoard = () => {
+  const board = Array.from({ length: BOARD_SIZE }, () =>
+    Array.from({ length: BOARD_SIZE }, () => ({
+      mine: false,
+      revealed: false,
+      flagged: false,
+      adjacent: 0,
+    })),
+  );
+
+  let placed = 0;
+  while (placed < MINES_COUNT) {
+    const x = Math.floor(Math.random() * BOARD_SIZE);
+    const y = Math.floor(Math.random() * BOARD_SIZE);
+    if (!board[x][y].mine) {
+      board[x][y].mine = true;
+      placed++;
+    }
+  }
+
+  const dirs = [-1, 0, 1];
+  for (let x = 0; x < BOARD_SIZE; x++) {
+    for (let y = 0; y < BOARD_SIZE; y++) {
+      if (board[x][y].mine) continue;
+      let count = 0;
+      dirs.forEach((dx) =>
+        dirs.forEach((dy) => {
+          if (dx === 0 && dy === 0) return;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (
+            nx >= 0 &&
+            nx < BOARD_SIZE &&
+            ny >= 0 &&
+            ny < BOARD_SIZE &&
+            board[nx][ny].mine
+          ) {
+            count++;
+          }
+        }),
+      );
+      board[x][y].adjacent = count;
+    }
+  }
+  return board;
+};
+
+const cloneBoard = (board) => board.map((row) => row.map((cell) => ({ ...cell })));
+
+const revealCell = (board, x, y) => {
+  const cell = board[x][y];
+  if (cell.revealed || cell.flagged) return false;
+  cell.revealed = true;
+  if (cell.mine) return true;
+  if (cell.adjacent === 0) {
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE) {
+          revealCell(board, nx, ny);
+        }
+      }
+    }
+  }
+  return false;
+};
+
+const checkWin = (board) =>
+  board.flat().every((cell) => cell.revealed || cell.mine);
+
+const Minesweeper = () => {
+  const [board, setBoard] = useState(generateBoard());
+  const [status, setStatus] = useState('playing');
+
+  const handleClick = (x, y) => {
+    if (status !== 'playing') return;
+    const newBoard = cloneBoard(board);
+    const hitMine = revealCell(newBoard, x, y);
+    setBoard(newBoard);
+    if (hitMine) {
+      setStatus('lost');
+    } else if (checkWin(newBoard)) {
+      setStatus('won');
+    }
+  };
+
+  const handleRightClick = (e, x, y) => {
+    e.preventDefault();
+    if (status !== 'playing') return;
+    const newBoard = cloneBoard(board);
+    const cell = newBoard[x][y];
+    if (cell.revealed) return;
+    cell.flagged = !cell.flagged;
+    setBoard(newBoard);
+  };
+
+  const reset = () => {
+    setBoard(generateBoard());
+    setStatus('playing');
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4 select-none">
+      <div className="grid grid-cols-8 gap-1" style={{ width: 'fit-content' }}>
+        {board.map((row, x) =>
+          row.map((cell, y) => {
+            let display = '';
+            if (cell.revealed) {
+              display = cell.mine ? '💣' : cell.adjacent || '';
+            } else if (cell.flagged) {
+              display = '🚩';
+            }
+            return (
+              <button
+                key={`${x}-${y}`}
+                onClick={() => handleClick(x, y)}
+                onContextMenu={(e) => handleRightClick(e, x, y)}
+                className={`h-8 w-8 flex items-center justify-center text-sm font-bold
+                ${cell.revealed ? 'bg-gray-400' : 'bg-gray-700 hover:bg-gray-600'}`}
+              >
+                {display}
+              </button>
+            );
+          }),
+        )}
+      </div>
+      <div className="mt-4 mb-2">
+        {status === 'playing'
+          ? 'Game in progress'
+          : status === 'won'
+          ? 'You win!'
+          : 'Boom! Game over'}
+      </div>
+      <button
+        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+        onClick={reset}
+      >
+        Reset
+      </button>
+    </div>
+  );
+};
+
+export default Minesweeper;

--- a/public/themes/Yaru/apps/minesweeper.svg
+++ b/public/themes/Yaru/apps/minesweeper.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <rect x="8" y="8" width="48" height="48" fill="#cccccc"/>
+  <line x1="24" y1="8" x2="24" y2="56" stroke="#ffffff" stroke-width="2"/>
+  <line x1="40" y1="8" x2="40" y2="56" stroke="#ffffff" stroke-width="2"/>
+  <line x1="8" y1="24" x2="56" y2="24" stroke="#ffffff" stroke-width="2"/>
+  <line x1="8" y1="40" x2="56" y2="40" stroke="#ffffff" stroke-width="2"/>
+  <circle cx="32" cy="32" r="6" fill="#d32f2f"/>
+  <circle cx="32" cy="32" r="3" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary
- add playable Minesweeper React component
- register Minesweeper app and icon in app configuration
- replace Minesweeper launcher icon with an SVG asset

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a775682e9083288d5a0990e137b73f