### PR TITLE
Add Snake game

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -61,6 +61,22 @@ const TicTacToeApp = dynamic(
   }
 );
 
+const SnakeApp = dynamic(
+  () =>
+    import('./components/apps/snake').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Snake' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Snake...
+      </div>
+    ),
+  }
+);
+
 const displayTerminal = (addFolder, openApp) => (
   <TerminalApp addFolder={addFolder} openApp={openApp} />
 );
@@ -71,6 +87,10 @@ const displayTerminalCalc = (addFolder, openApp) => (
 
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
+);
+
+const displaySnake = (addFolder, openApp) => (
+  <SnakeApp addFolder={addFolder} openApp={openApp} />
 );
 
 const apps = [
@@ -194,6 +214,21 @@ const apps = [
     favourite: false,
     desktop_shortcut: true,
     screen: displayGedit,
+  },
+];
+
+export const games = [
+  {
+    id: 'tictactoe',
+    title: 'Tic Tac Toe',
+    icon: './themes/Yaru/apps/tictactoe.svg',
+    screen: displayTicTacToe,
+  },
+  {
+    id: 'snake',
+    title: 'Snake',
+    icon: './themes/Yaru/apps/snake.svg',
+    screen: displaySnake,
   },
 ];
 

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,0 +1,102 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+const gridSize = 20;
+const createFood = () => ({
+  x: Math.floor(Math.random() * gridSize),
+  y: Math.floor(Math.random() * gridSize),
+});
+
+const Snake = () => {
+  const [snake, setSnake] = useState([{ x: 10, y: 10 }]);
+  const [food, setFood] = useState(createFood());
+  const [direction, setDirection] = useState({ x: 0, y: -1 });
+  const [gameOver, setGameOver] = useState(false);
+  const moveRef = useRef();
+
+  const moveSnake = useCallback(() => {
+    setSnake((prev) => {
+      const head = { x: prev[0].x + direction.x, y: prev[0].y + direction.y };
+      if (
+        head.x < 0 ||
+        head.x >= gridSize ||
+        head.y < 0 ||
+        head.y >= gridSize ||
+        prev.some((seg) => seg.x === head.x && seg.y === head.y)
+      ) {
+        setGameOver(true);
+        return prev;
+      }
+      const newSnake = [head, ...prev];
+      if (head.x === food.x && head.y === food.y) {
+        setFood(createFood());
+      } else {
+        newSnake.pop();
+      }
+      return newSnake;
+    });
+  }, [direction, food]);
+
+  useEffect(() => {
+    moveRef.current = setInterval(moveSnake, 150);
+    return () => clearInterval(moveRef.current);
+  }, [moveSnake]);
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'ArrowUp' && direction.y !== 1) setDirection({ x: 0, y: -1 });
+      if (e.key === 'ArrowDown' && direction.y !== -1) setDirection({ x: 0, y: 1 });
+      if (e.key === 'ArrowLeft' && direction.x !== 1) setDirection({ x: -1, y: 0 });
+      if (e.key === 'ArrowRight' && direction.x !== -1) setDirection({ x: 1, y: 0 });
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [direction]);
+
+  const reset = () => {
+    setSnake([{ x: 10, y: 10 }]);
+    setFood(createFood());
+    setDirection({ x: 0, y: -1 });
+    setGameOver(false);
+  };
+
+  const cells = [];
+  for (let y = 0; y < gridSize; y += 1) {
+    for (let x = 0; x < gridSize; x += 1) {
+      const isSnake = snake.some((s) => s.x === x && s.y === y);
+      const isFood = food.x === x && food.y === y;
+      cells.push(
+        <div
+          key={`${x}-${y}`}
+          className={`w-4 h-4 border border-gray-700 ${
+            isSnake ? 'bg-green-500' : isFood ? 'bg-red-500' : 'bg-ub-cool-grey'
+          }`}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(0, 1fr))` }}
+      >
+        {cells}
+      </div>
+      {gameOver && (
+        <div className="mt-2 flex items-center">
+          <span className="mr-2">Game Over</span>
+          <button
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={reset}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Snake;
+

--- a/public/themes/Yaru/apps/snake.svg
+++ b/public/themes/Yaru/apps/snake.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <path d="M8 40 Q16 24 24 40 T40 40 T56 24" stroke="#4caf50" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="56" cy="24" r="5" fill="#4caf50"/>
+  <circle cx="58" cy="22" r="1.5" fill="#2e3436"/>
+</svg>


### PR DESCRIPTION
## Summary
- implement classic Snake game with stateful snake, food, and controls
- dynamically import Snake and expose it via the games config
- add Snake icon to Yaru theme assets (svg)

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7756594ac8328878810063336a4fe