### PR TITLE
Add chess game application with basic AI

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -59,6 +59,22 @@ const TicTacToeApp = dynamic(
       </div>
     ),
   }
+  );
+
+const ChessApp = dynamic(
+  () =>
+    import('./components/apps/chess').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded Chess' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Chess...
+      </div>
+    ),
+  }
 );
 
 const displayTerminal = (addFolder, openApp) => (
@@ -72,6 +88,31 @@ const displayTerminalCalc = (addFolder, openApp) => (
 const displayTicTacToe = (addFolder, openApp) => (
   <TicTacToeApp addFolder={addFolder} openApp={openApp} />
 );
+
+const displayChess = (addFolder, openApp) => (
+  <ChessApp addFolder={addFolder} openApp={openApp} />
+);
+
+const games = [
+  {
+    id: 'tictactoe',
+    title: 'Tic Tac Toe',
+    icon: './themes/Yaru/apps/tictactoe.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTicTacToe,
+  },
+  {
+    id: 'chess',
+    title: 'Chess',
+    icon: './themes/Yaru/apps/chess.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayChess,
+  },
+];
 
 const apps = [
   {
@@ -96,15 +137,7 @@ const apps = [
     defaultWidth: 25,
     defaultHeight: 40,
   },
-  {
-    id: 'tictactoe',
-    title: 'Tic Tac Toe',
-    icon: './themes/Yaru/apps/tictactoe.svg',
-    disabled: false,
-    favourite: false,
-    desktop_shortcut: false,
-    screen: displayTicTacToe,
-  },
+  ...games,
   {
     id: 'about-alex',
     title: 'About Alex',
@@ -197,4 +230,5 @@ const apps = [
   },
 ];
 
+export { games };
 export default apps;

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import { Chess } from 'chess.js';
+
+const pieceUnicode = {
+  p: { w: '♙', b: '♟' },
+  r: { w: '♖', b: '♜' },
+  n: { w: '♘', b: '♞' },
+  b: { w: '♗', b: '♝' },
+  q: { w: '♕', b: '♛' },
+  k: { w: '♔', b: '♚' },
+};
+
+const ChessGame = () => {
+  const [game, setGame] = useState(new Chess());
+  const [board, setBoard] = useState(game.board());
+  const [selected, setSelected] = useState(null);
+  const [status, setStatus] = useState('Your move');
+
+  useEffect(() => {
+    setBoard(game.board());
+  }, [game]);
+
+  const reset = () => {
+    const newGame = new Chess();
+    setGame(newGame);
+    setSelected(null);
+    setStatus('Your move');
+  };
+
+  const makeAIMove = () => {
+    const moves = game.moves();
+    if (moves.length === 0) {
+      setStatus('Game over');
+      return;
+    }
+    const move = moves[Math.floor(Math.random() * moves.length)];
+    game.move(move);
+    setBoard(game.board());
+    if (game.game_over()) {
+      setStatus('Game over');
+    } else {
+      setStatus('Your move');
+    }
+  };
+
+  const handleSquareClick = (file, rank) => {
+    const square = 'abcdefgh'[file] + (8 - rank);
+    if (selected) {
+      const move = { from: selected, to: square, promotion: 'q' };
+      const result = game.move(move);
+      if (result) {
+        setBoard(game.board());
+        setSelected(null);
+        if (game.game_over()) {
+          setStatus('Game over');
+        } else {
+          setStatus('AI thinking...');
+          setTimeout(() => makeAIMove(), 300);
+        }
+      } else {
+        setSelected(square);
+      }
+    } else {
+      const piece = game.get(square);
+      if (piece && piece.color === game.turn()) {
+        setSelected(square);
+      }
+    }
+  };
+
+  const renderSquare = (piece, file, rank) => {
+    const squareName = 'abcdefgh'[file] + (8 - rank);
+    const isSelected = selected === squareName;
+    const squareColor = (file + rank) % 2 === 0 ? 'bg-gray-300' : 'bg-gray-700';
+    return (
+      <div
+        key={squareName}
+        onClick={() => handleSquareClick(file, rank)}
+        className={`w-10 h-10 md:w-12 md:h-12 flex items-center justify-center select-none ${squareColor} ${
+          isSelected ? 'ring-2 ring-yellow-400' : ''
+        }`}
+      >
+        {piece ? pieceUnicode[piece.type][piece.color] : ''}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <div className="grid grid-cols-8">
+        {board.map((row, rank) =>
+          row.map((piece, file) => renderSquare(piece, file, rank))
+        )}
+      </div>
+      <div className="mt-4">{status}</div>
+      <button
+        className="mt-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+        onClick={reset}
+      >
+        Reset
+      </button>
+    </div>
+  );
+};
+
+export default ChessGame;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "2.0.0",
       "dependencies": {
         "@emailjs/browser": "^3.10.0",
+        "@vercel/analytics": "^1.5.0",
         "autoprefixer": "^10.4.13",
+        "chess.js": "^1.0.0",
         "expr-eval": "^2.0.2",
         "next": "^13.1.2",
         "postcss": "^8.4.21",
@@ -2489,6 +2491,44 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3208,6 +3248,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.0.0.tgz",
+      "integrity": "sha512-zHaSRub6xkUXxvX9lqgovwRiBvbOmVCTh47rZ0I/HVyCiNc0T5bVLwzshL5X6JtrP+rN/CTmIxdpFr943eP97Q==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/chokidar": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@emailjs/browser": "^3.10.0",
     "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.13",
+    "chess.js": "^1.0.0",
     "expr-eval": "^2.0.2",
     "next": "^13.1.2",
     "postcss": "^8.4.21",

--- a/public/themes/Yaru/apps/chess.svg
+++ b/public/themes/Yaru/apps/chess.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <!-- Simple chess rook icon -->
+  <rect x="24" y="12" width="16" height="8" fill="#ffffff"/>
+  <rect x="20" y="20" width="24" height="12" fill="#ffffff"/>
+  <rect x="16" y="32" width="32" height="16" fill="#ffffff"/>
+  <rect x="12" y="48" width="40" height="8" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add chess game component with board state, move validation, and basic AI opponent
- register chess game via dynamic import and games array
- include chess icon and dependency
- use an SVG chess icon instead of PNG for compatibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a783ee9f4c832899a8921e188af96c