### PR TITLE
Fix YouTube sorting freeze after category switch

### DIFF
--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -75,6 +75,22 @@ describe('YouTubeApp', () => {
     expect(screen.queryByText('React Tutorial')).not.toBeInTheDocument();
   });
 
+  it('allows sorting after switching categories', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeApp initialVideos={mockVideos} />);
+
+    // Filter to a category with multiple videos then change sort order
+    await user.click(screen.getByRole('button', { name: 'Dev' }));
+    const getTitles = () =>
+      screen.getAllByRole('link').map((a) => a.textContent);
+
+    // Initial order should be newest first
+    expect(getTitles()).toEqual(['React Tutorial', 'Advanced React']);
+
+    await user.selectOptions(screen.getByLabelText(/sort by/i), 'title');
+    expect(getTitles()).toEqual(['Advanced React', 'React Tutorial']);
+  });
+
   it('sort options reorder videos', async () => {
     const user = userEvent.setup();
     render(<YouTubeApp initialVideos={mockVideos} />);

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -147,12 +147,18 @@ export default function YouTubeApp({ initialVideos = [] }) {
   );
 
   const handleSortChange = useCallback(
-    (e) => startTransition(() => setSortBy(e.target.value)),
+    (e) => {
+      const { value } = e.target;
+      startTransition(() => setSortBy(value));
+    },
     [startTransition]
   );
 
   const handleSearchChange = useCallback(
-    (e) => startTransition(() => setSearch(e.target.value)),
+    (e) => {
+      const { value } = e.target;
+      startTransition(() => setSearch(value));
+    },
     [startTransition]
   );
 


### PR DESCRIPTION
## Summary
- prevent React event pooling from dropping values in YouTube app transitions
- allow sorting to work after changing categories
- add regression test for sorting after category switch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce9b8064832884e25ba827c3cc8c