### PR TITLE
feat: add app launch animations

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -2,15 +2,22 @@ import React, { Component } from 'react'
 import Image from 'next/image'
 
 export class UbuntuApp extends Component {
+    constructor() {
+        super();
+        this.state = { launching: false };
+    }
 
     openApp = () => {
+        this.setState({ launching: true }, () => {
+            setTimeout(() => this.setState({ launching: false }), 300);
+        });
         this.props.openApp(this.props.id);
     }
 
     render() {
         return (
             <div
-                className="p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "
+                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 tabIndex={0}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -53,7 +53,7 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95">
+            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"

--- a/styles/index.css
+++ b/styles/index.css
@@ -173,6 +173,42 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
 }
 
+/* Show Applications overlay animation */
+.all-apps-anim {
+    animation: allAppsScale 200ms ease-out;
+}
+
+@keyframes allAppsScale {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* App icon click animation */
+.app-icon-launch {
+    animation: appIconLaunch 200ms ease-in-out;
+}
+
+@keyframes appIconLaunch {
+    0% {
+        transform: scale(1);
+    }
+
+    50% {
+        transform: scale(0.9);
+    }
+
+    100% {
+        transform: scale(1);
+    }
+}
+
 /* Context Menu */
 .context-menu-bg {
     background-color: rgb(43, 43, 43);


### PR DESCRIPTION
## Summary
- animate show applications overlay with a subtle fade/scale effect
- pulse app icons on open for OS-like feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88e7d05488328b496a4a4cf479ebe