### PR TITLE
Handle missing metadata in YouTube app sorting

### DIFF
--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -111,6 +111,25 @@ describe('YouTubeApp', () => {
     ]);
   });
 
+  it('handles videos missing metadata when sorting', async () => {
+    const user = userEvent.setup();
+    const videosWithMissing = [
+      ...mockVideos,
+      { id: '4', thumbnail: 'thumb4.jpg', url: 'https://youtu.be/4' },
+    ];
+    render(<YouTubeApp initialVideos={videosWithMissing} />);
+    const select = screen.getByLabelText(/sort by/i);
+
+    await user.selectOptions(select, 'title');
+    expect(screen.getAllByTestId('video-card')).toHaveLength(4);
+
+    await user.selectOptions(select, 'playlist');
+    expect(screen.getAllByTestId('video-card')).toHaveLength(4);
+
+    await user.selectOptions(select, 'date');
+    expect(screen.getAllByTestId('video-card')).toHaveLength(4);
+  });
+
   it('fetches all pages from a playlist', async () => {
     const responses = {
       channel: { items: [{ id: 'chan' }] },

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -110,10 +110,12 @@ export default function YouTubeApp({ initialVideos = [] }) {
     () => [
       'All',
       ...Array.from(
-        new Set([
-          ...playlists.map((p) => p.title),
-          ...videos.map((v) => v.playlist),
-        ])
+        new Set(
+          [
+            ...playlists.map((p) => p.title),
+            ...videos.map((v) => v.playlist),
+          ].filter(Boolean)
+        )
       ),
     ],
     [playlists, videos]
@@ -124,7 +126,7 @@ export default function YouTubeApp({ initialVideos = [] }) {
       videos
         .filter((v) => activeCategory === 'All' || v.playlist === activeCategory)
         .filter((v) =>
-          v.title.toLowerCase().includes(search.toLowerCase())
+          (v.title || '').toLowerCase().includes(search.toLowerCase())
         ),
     [videos, activeCategory, search]
   );
@@ -133,17 +135,21 @@ export default function YouTubeApp({ initialVideos = [] }) {
     const list = [...filtered];
     switch (sortBy) {
       case 'dateAsc':
-        return list.sort(
-          (a, b) => new Date(a.publishedAt) - new Date(b.publishedAt)
+        return list.sort((a, b) =>
+          new Date(a.publishedAt || 0) - new Date(b.publishedAt || 0)
         );
       case 'title':
-        return list.sort((a, b) => a.title.localeCompare(b.title));
+        return list.sort((a, b) =>
+          (a.title || '').localeCompare(b.title || '')
+        );
       case 'playlist':
-        return list.sort((a, b) => a.playlist.localeCompare(b.playlist));
+        return list.sort((a, b) =>
+          (a.playlist || '').localeCompare(b.playlist || '')
+        );
       case 'date':
       default:
-        return list.sort(
-          (a, b) => new Date(b.publishedAt) - new Date(a.publishedAt)
+        return list.sort((a, b) =>
+          new Date(b.publishedAt || 0) - new Date(a.publishedAt || 0)
         );
     }
   }, [filtered, sortBy]);


### PR DESCRIPTION
## Summary
- Guard YouTube video filtering and sorting against missing title, playlist or date fields
- Ignore empty playlist names when generating category tabs
- Test sorting when videos lack metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88f5f589c832883ab8d91c66f52c6