### PR TITLE
Add seeded word search puzzle

### DIFF
--- a/__tests__/wordSearch.test.ts
+++ b/__tests__/wordSearch.test.ts
@@ -1,0 +1,20 @@
+import { generateGrid } from '../apps/word_search/generator';
+
+describe('word search generator', () => {
+  it('places words without conflicts', () => {
+    const words = ['CAT', 'DOG'];
+    const { grid, placements } = generateGrid(words, 8, 'seed');
+    placements.forEach(({ word, positions }) => {
+      const placed = positions.map((p) => grid[p.row][p.col]).join('');
+      const reversed = placed.split('').reverse().join('');
+      expect([placed, reversed]).toContain(word);
+    });
+  });
+
+  it('is deterministic with the same seed', () => {
+    const words = ['ALPHA', 'BETA'];
+    const a = generateGrid(words, 10, 'same');
+    const b = generateGrid(words, 10, 'same');
+    expect(a.grid).toEqual(b.grid);
+  });
+});

--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -1,0 +1,93 @@
+import type { Position, WordPlacement } from './types';
+
+// simple seeded RNG using xmur3 and mulberry32
+function xmur3(str: string) {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return function () {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createRNG(seed: string) {
+  const seedFunc = xmur3(seed);
+  return mulberry32(seedFunc());
+}
+
+const DIRECTIONS = [
+  { dx: 1, dy: 0 },
+  { dx: -1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: 0, dy: -1 },
+  { dx: 1, dy: 1 },
+  { dx: -1, dy: -1 },
+  { dx: 1, dy: -1 },
+  { dx: -1, dy: 1 },
+];
+
+export interface GenerateResult {
+  grid: string[][];
+  placements: WordPlacement[];
+}
+
+export function generateGrid(
+  words: string[],
+  size = 12,
+  seed = 'seed'
+): GenerateResult {
+  const rng = createRNG(seed);
+  const grid: string[][] = Array.from({ length: size }, () => Array(size).fill(''));
+  const placements: WordPlacement[] = [];
+  words.forEach((w) => {
+    const word = w.toUpperCase();
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const dir = DIRECTIONS[Math.floor(rng() * DIRECTIONS.length)];
+      const maxRow = dir.dy > 0 ? size - word.length : dir.dy < 0 ? word.length - 1 : size - 1;
+      const maxCol = dir.dx > 0 ? size - word.length : dir.dx < 0 ? word.length - 1 : size - 1;
+      const startRow = Math.floor(rng() * (maxRow + 1));
+      const startCol = Math.floor(rng() * (maxCol + 1));
+      let ok = true;
+      const positions: Position[] = [];
+      for (let i = 0; i < word.length; i += 1) {
+        const r = startRow + dir.dy * i;
+        const c = startCol + dir.dx * i;
+        const existing = grid[r][c];
+        if (existing && existing !== word[i]) {
+          ok = false;
+          break;
+        }
+        positions.push({ row: r, col: c });
+      }
+      if (!ok) continue;
+      positions.forEach((p, i) => {
+        grid[p.row][p.col] = word[i];
+      });
+      placements.push({ word, positions });
+      return;
+    }
+  });
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  for (let r = 0; r < size; r += 1) {
+    for (let c = 0; c < size; c += 1) {
+      if (!grid[r][c]) {
+        grid[r][c] = letters[Math.floor(rng() * letters.length)];
+      }
+    }
+  }
+  return { grid, placements };
+}

--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { generateGrid } from './generator';
+import type { Position, WordPlacement } from './types';
+
+const DEFAULT_WORDS = ['REACT', 'NODE', 'JAVASCRIPT', 'CODE', 'NEXTJS'];
+const GRID_SIZE = 12;
+
+function key(p: Position) {
+  return `${p.row}-${p.col}`;
+}
+
+function computePath(start: Position, end: Position): Position[] {
+  const dx = Math.sign(end.col - start.col);
+  const dy = Math.sign(end.row - start.row);
+  const len = Math.max(Math.abs(end.col - start.col), Math.abs(end.row - start.row));
+  if (dx !== 0 && dy !== 0 && Math.abs(end.col - start.col) !== Math.abs(end.row - start.row)) {
+    return [start];
+  }
+  const path: Position[] = [];
+  for (let i = 0; i <= len; i += 1) {
+    path.push({ row: start.row + dy * i, col: start.col + dx * i });
+  }
+  return path;
+}
+
+const WordSearch: React.FC = () => {
+  const router = useRouter();
+  const { seed: seedQuery, words: wordsQuery } = router.query as { seed?: string; words?: string };
+  const [seed, setSeed] = useState('');
+  const [words, setWords] = useState<string[]>(DEFAULT_WORDS);
+  const [grid, setGrid] = useState<string[][]>([]);
+  const [placements, setPlacements] = useState<WordPlacement[]>([]);
+  const [found, setFound] = useState<Set<string>>(new Set());
+  const [foundCells, setFoundCells] = useState<Set<string>>(new Set());
+  const [selecting, setSelecting] = useState(false);
+  const [start, setStart] = useState<Position | null>(null);
+  const [selection, setSelection] = useState<Position[]>([]);
+
+  useEffect(() => {
+    const queryWords =
+      typeof wordsQuery === 'string'
+        ? wordsQuery.split(',').map((w) => w.trim().toUpperCase()).filter(Boolean)
+        : [];
+    const s = typeof seedQuery === 'string' ? seedQuery : Math.random().toString(36).slice(2);
+    setSeed(s);
+    setWords(queryWords.length ? queryWords : DEFAULT_WORDS);
+  }, [seedQuery, wordsQuery]);
+
+  useEffect(() => {
+    if (!seed || !words.length) return;
+    const { grid: g, placements: p } = generateGrid(words, GRID_SIZE, seed);
+    setGrid(g);
+    setPlacements(p);
+    setFound(new Set());
+    setFoundCells(new Set());
+  }, [seed, words]);
+
+  const handleMouseDown = (r: number, c: number) => {
+    setSelecting(true);
+    const s = { row: r, col: c };
+    setStart(s);
+    setSelection([s]);
+  };
+
+  const handleMouseEnter = (r: number, c: number) => {
+    if (!selecting || !start) return;
+    const path = computePath(start, { row: r, col: c });
+    setSelection(path);
+  };
+
+  const handleMouseUp = () => {
+    if (!selecting) return;
+    setSelecting(false);
+    if (!selection.length) {
+      setStart(null);
+      setSelection([]);
+      return;
+    }
+    const letters = selection.map((p) => grid[p.row][p.col]).join('');
+    const reversed = letters.split('').reverse().join('');
+    const match = words.find((w) => w === letters || w === reversed);
+    if (match && !found.has(match)) {
+      const newFound = new Set(found);
+      newFound.add(match);
+      setFound(newFound);
+      const newCells = new Set(foundCells);
+      selection.forEach((p) => newCells.add(key(p)));
+      setFoundCells(newCells);
+    }
+    setStart(null);
+    setSelection([]);
+  };
+
+  const copyLink = async () => {
+    const params = new URLSearchParams({ seed, words: words.join(',') });
+    const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+    try {
+      await navigator.clipboard?.writeText(url);
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  const newPuzzle = () => {
+    const newSeed = Math.random().toString(36).slice(2);
+    router.replace(
+      { pathname: router.pathname, query: { seed: newSeed, words: words.join(',') } },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  return (
+    <div className="p-4 select-none">
+      <div className="flex space-x-2 mb-2 print:hidden">
+        <button
+          type="button"
+          onClick={newPuzzle}
+          className="px-2 py-1 bg-blue-600 text-white rounded"
+        >
+          New
+        </button>
+        <button
+          type="button"
+          onClick={copyLink}
+          className="px-2 py-1 bg-green-600 text-white rounded"
+        >
+          Copy Link
+        </button>
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="px-2 py-1 bg-gray-600 text-white rounded"
+        >
+          Print
+        </button>
+      </div>
+      <div
+        style={{
+          gridTemplateColumns: `repeat(${GRID_SIZE}, 2rem)`,
+          gridTemplateRows: `repeat(${GRID_SIZE}, 2rem)`,
+        }}
+        className="grid border w-max"
+        onMouseLeave={handleMouseUp}
+      >
+        {grid.map((row, r) =>
+          row.map((letter, c) => {
+            const posKey = key({ row: r, col: c });
+            const isSelected = selection.some((p) => p.row === r && p.col === c);
+            const isFound = foundCells.has(posKey);
+            return (
+              <div
+                key={posKey}
+                onMouseDown={() => handleMouseDown(r, c)}
+                onMouseEnter={() => handleMouseEnter(r, c)}
+                onMouseUp={handleMouseUp}
+                className={`w-8 h-8 flex items-center justify-center border text-sm font-bold cursor-pointer select-none ${isFound ? 'bg-green-300' : isSelected ? 'bg-yellow-300' : 'bg-white'}`}
+              >
+                {letter}
+              </div>
+            );
+          })
+        )}
+      </div>
+      <ul className="mt-4 columns-2 md:columns-3">
+        {words.map((w) => (
+          <li key={w} className={found.has(w) ? 'line-through text-gray-500' : ''}>
+            {w}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default WordSearch;

--- a/apps/word_search/types.ts
+++ b/apps/word_search/types.ts
@@ -1,0 +1,9 @@
+export interface Position {
+  row: number;
+  col: number;
+}
+
+export interface WordPlacement {
+  word: string;
+  positions: Position[];
+}

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const WordSearch = dynamic(() => import('../../apps/word_search'), { ssr: false });
+
+export default function WordSearchPage() {
+  return <WordSearch />;
+}


### PR DESCRIPTION
## Summary
- implement seeded word search generator with forward/backward/diagonal word placement
- add interactive puzzle with drag selection, shareable links, and print view
- test deterministic generation and conflict-free placements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8987a44f8832882bc8dbdd3fceb9e