### PR TITLE
Add precise audio scheduling and accessibility modes to Simon app

### DIFF
--- a/__tests__/simonAudio.test.ts
+++ b/__tests__/simonAudio.test.ts
@@ -1,0 +1,12 @@
+import { createToneSchedule } from '../components/apps/simon';
+
+describe('createToneSchedule', () => {
+  test('tone schedule drift under 5 ms per step across 20 steps', () => {
+    const schedule = createToneSchedule(20, 0, 0.6);
+    schedule.forEach((time, idx) => {
+      const expected = idx * 0.6;
+      const drift = Math.abs(time - expected);
+      expect(drift).toBeLessThan(0.005);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- schedule Simon tones using WebAudio for low-latency playback
- add classic, speed-up, and colorblind modes with haptic touch support
- verify tone scheduling drift stays under 5ms across 20 steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a898173f208328bba9c80ac8a64698