### PR TITLE
feat: add minimax reversi AI

### DIFF
--- a/__tests__/reversi.test.ts
+++ b/__tests__/reversi.test.ts
@@ -1,0 +1,47 @@
+import {
+  createBoard,
+  computeLegalMoves,
+  applyMove,
+  countPieces,
+  bestMove,
+} from '../components/apps/reversiLogic';
+
+describe('Reversi rules', () => {
+  test('initial legal moves and flipping', () => {
+    const board = createBoard();
+    const moves = computeLegalMoves(board, 'B');
+    expect(Object.keys(moves).sort()).toEqual(['2-3', '3-2', '4-5', '5-4']);
+    const newBoard = applyMove(board, 2, 3, 'B', moves['2-3']);
+    expect(newBoard[3][3]).toBe('B');
+    expect(newBoard[2][3]).toBe('B');
+  });
+
+  test('pass when no legal moves', () => {
+    const board = Array.from({ length: 8 }, () => Array(8).fill('W'));
+    board[0][1] = 'B';
+    board[0][2] = null;
+    const blackMoves = computeLegalMoves(board, 'B');
+    const whiteMoves = computeLegalMoves(board, 'W');
+    expect(Object.keys(blackMoves)).toHaveLength(0);
+    expect(Object.keys(whiteMoves)).toHaveLength(1);
+  });
+
+  test('endgame scoring', () => {
+    const board = Array.from({ length: 8 }, () => Array(8).fill('B'));
+    board[0][0] = 'W';
+    board[0][1] = 'W';
+    const { black, white } = countPieces(board);
+    expect(black).toBe(62);
+    expect(white).toBe(2);
+    expect(Object.keys(computeLegalMoves(board, 'B'))).toHaveLength(0);
+    expect(Object.keys(computeLegalMoves(board, 'W'))).toHaveLength(0);
+  });
+
+  test('AI favors corners', () => {
+    const board = createBoard();
+    board[1][1] = 'W';
+    board[2][2] = 'B';
+    const move = bestMove(board, 'B', 3);
+    expect(move).toEqual([0, 0]);
+  });
+});

--- a/components/apps/reversi.worker.js
+++ b/components/apps/reversi.worker.js
@@ -1,0 +1,7 @@
+import { bestMove } from './reversiLogic';
+
+onmessage = (e) => {
+  const { board, player, depth } = e.data;
+  const move = bestMove(board, player, depth);
+  postMessage({ move });
+};

--- a/components/apps/reversiLogic.js
+++ b/components/apps/reversiLogic.js
@@ -1,0 +1,160 @@
+export const SIZE = 8;
+export const DIRECTIONS = [
+  [0, 1],
+  [1, 0],
+  [0, -1],
+  [-1, 0],
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
+
+export const createBoard = () => {
+  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
+  board[3][3] = 'W';
+  board[3][4] = 'B';
+  board[4][3] = 'B';
+  board[4][4] = 'W';
+  return board;
+};
+
+const inside = (r, c) => r >= 0 && r < SIZE && c >= 0 && c < SIZE;
+
+export const computeLegalMoves = (board, player) => {
+  const opponent = player === 'B' ? 'W' : 'B';
+  const moves = {};
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if (board[r][c]) continue;
+      const flips = [];
+      DIRECTIONS.forEach(([dr, dc]) => {
+        let i = r + dr;
+        let j = c + dc;
+        const cells = [];
+        while (inside(i, j) && board[i][j] === opponent) {
+          cells.push([i, j]);
+          i += dr;
+          j += dc;
+        }
+        if (cells.length && inside(i, j) && board[i][j] === player) {
+          flips.push(...cells);
+        }
+      });
+      if (flips.length) moves[`${r}-${c}`] = flips;
+    }
+  }
+  return moves;
+};
+
+export const applyMove = (board, r, c, player, flips) => {
+  const newBoard = board.map((row) => row.slice());
+  newBoard[r][c] = player;
+  flips.forEach(([fr, fc]) => {
+    newBoard[fr][fc] = player;
+  });
+  return newBoard;
+};
+
+export const countPieces = (board) => {
+  let black = 0;
+  let white = 0;
+  board.forEach((row) =>
+    row.forEach((cell) => {
+      if (cell === 'B') black += 1;
+      if (cell === 'W') white += 1;
+    }),
+  );
+  return { black, white };
+};
+
+const corners = [
+  [0, 0],
+  [0, SIZE - 1],
+  [SIZE - 1, 0],
+  [SIZE - 1, SIZE - 1],
+];
+
+export const evaluateBoard = (board, player) => {
+  const opponent = player === 'B' ? 'W' : 'B';
+  let cornerScore = 0;
+  corners.forEach(([r, c]) => {
+    if (board[r][c] === player) cornerScore += 1;
+    else if (board[r][c] === opponent) cornerScore -= 1;
+  });
+  const mobility =
+    Object.keys(computeLegalMoves(board, player)).length -
+    Object.keys(computeLegalMoves(board, opponent)).length;
+  const { black, white } = countPieces(board);
+  const parity = player === 'B' ? black - white : white - black;
+  return 25 * cornerScore + 5 * mobility + parity;
+};
+
+export const minimax = (
+  board,
+  player,
+  depth,
+  maximizer,
+  alpha = -Infinity,
+  beta = Infinity,
+) => {
+  const movesObj = computeLegalMoves(board, player);
+  const entries = Object.entries(movesObj);
+  const opponent = player === 'B' ? 'W' : 'B';
+  if (depth === 0 || entries.length === 0) {
+    if (entries.length === 0) {
+      const oppMoves = Object.keys(computeLegalMoves(board, opponent));
+      if (oppMoves.length !== 0) {
+        return minimax(board, opponent, depth - 1, maximizer, alpha, beta);
+      }
+      const { black, white } = countPieces(board);
+      const diff = maximizer === 'B' ? black - white : white - black;
+      return diff * 1000;
+    }
+    return evaluateBoard(board, maximizer);
+  }
+
+  if (player === maximizer) {
+    let value = -Infinity;
+    for (const [key, flips] of entries) {
+      const [r, c] = key.split('-').map(Number);
+      const newBoard = applyMove(board, r, c, player, flips);
+      const val = minimax(newBoard, opponent, depth - 1, maximizer, alpha, beta);
+      value = Math.max(value, val);
+      alpha = Math.max(alpha, val);
+      if (alpha >= beta) break;
+    }
+    return value;
+  }
+
+  let value = Infinity;
+  for (const [key, flips] of entries) {
+    const [r, c] = key.split('-').map(Number);
+    const newBoard = applyMove(board, r, c, player, flips);
+    const val = minimax(newBoard, opponent, depth - 1, maximizer, alpha, beta);
+    value = Math.min(value, val);
+    beta = Math.min(beta, val);
+    if (beta <= alpha) break;
+  }
+  return value;
+};
+
+export const bestMove = (board, player, depth) => {
+  const movesObj = computeLegalMoves(board, player);
+  const entries = Object.entries(movesObj);
+  if (entries.length === 0) return null;
+  const opponent = player === 'B' ? 'W' : 'B';
+  let best = null;
+  let bestVal = -Infinity;
+  for (const [key, flips] of entries) {
+    const [r, c] = key.split('-').map(Number);
+    const newBoard = applyMove(board, r, c, player, flips);
+    const val = minimax(newBoard, opponent, depth - 1, player, -Infinity, Infinity);
+    if (val > bestVal) {
+      bestVal = val;
+      best = [r, c];
+    }
+  }
+  return best;
+};
+


### PR DESCRIPTION
## Summary
- add core Reversi logic with move generation, heuristics and minimax
- run minimax in web worker and integrate with UI
- cover Reversi rules and AI behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a89809a128832892023d9162e5aa73