### PR TITLE
Enhance memory game with modes and fair shuffling

### DIFF
--- a/__tests__/shuffle.test.ts
+++ b/__tests__/shuffle.test.ts
@@ -1,0 +1,18 @@
+import { fisherYatesShuffle } from '../components/apps/memory_utils';
+
+describe('fisherYatesShuffle fairness', () => {
+  test('distribution is roughly uniform', () => {
+    const iterations = 6000;
+    const counts = [0, 0, 0];
+    const arr = [1, 2, 3];
+    for (let i = 0; i < iterations; i++) {
+      const shuffled = fisherYatesShuffle(arr);
+      counts[shuffled[0] - 1]++;
+    }
+    const expected = iterations / 3;
+    const tolerance = iterations * 0.05; // 5%
+    counts.forEach((c) => {
+      expect(Math.abs(c - expected)).toBeLessThan(tolerance);
+    });
+  });
+});

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,63 +1,179 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { createDeck } from './memory_utils';
 
-const createDeck = () => {
-  const emojis = ['\u{1F34E}', '\u{1F34C}', '\u{1F347}', '\u{1F353}', '\u{1F34D}', '\u{1F95D}', '\u{1F351}', '\u{1F951}'];
-  return [...emojis, ...emojis]
-    .sort(() => Math.random() - 0.5)
-    .map((value, index) => ({ id: index, value }));
-};
+const modes = [2, 4, 6];
 
 const Memory = () => {
+  const [size, setSize] = useState(4);
+  const [timed, setTimed] = useState(false);
+  const [assistive, setAssistive] = useState(false);
   const [cards, setCards] = useState([]);
   const [flipped, setFlipped] = useState([]);
   const [matched, setMatched] = useState([]);
+  const [moves, setMoves] = useState(0);
+  const [time, setTime] = useState(0);
+  const [stats, setStats] = useState({ games: 0, bestTime: null, bestMoves: null });
+  const timerRef = useRef(null);
+
+  const key = (s = size, t = timed) => `memory_${s}_${t ? 'timed' : 'casual'}`;
+
+  const reset = (newSize = size) => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setTime(0);
+    setMoves(0);
+    setFlipped([]);
+    setMatched([]);
+    setCards(createDeck(newSize));
+  };
 
   useEffect(() => {
-    setCards(createDeck());
-  }, []);
+    reset(size);
+  }, [size]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = JSON.parse(localStorage.getItem(key()) || '{}');
+    setStats({
+      games: stored.games || 0,
+      bestTime: stored.bestTime ?? null,
+      bestMoves: stored.bestMoves ?? null,
+    });
+  }, [size, timed]);
+
+  const startTimer = () => {
+    if (timed && !timerRef.current) {
+      timerRef.current = setInterval(() => setTime((t) => t + 1), 1000);
+    }
+  };
+
+  const saveStats = () => {
+    if (typeof window === 'undefined') return;
+    const current = JSON.parse(localStorage.getItem(key()) || '{}');
+    const updated = {
+      games: (current.games || 0) + 1,
+      bestTime: timed
+        ? current.bestTime
+          ? Math.min(current.bestTime, time)
+          : time
+        : current.bestTime || null,
+      bestMoves: !timed
+        ? current.bestMoves
+          ? Math.min(current.bestMoves, moves)
+          : moves
+        : current.bestMoves || null,
+    };
+    localStorage.setItem(key(), JSON.stringify(updated));
+    setStats(updated);
+  };
+
+  useEffect(() => {
+    if (cards.length && matched.length === cards.length) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      saveStats();
+    }
+  }, [matched, cards]);
 
   const handleFlip = (idx) => {
-    if (flipped.length === 2 || flipped.includes(idx) || matched.includes(idx)) return;
+    if (flipped.includes(idx) || matched.includes(idx)) return;
 
-    const newFlipped = [...flipped, idx];
-    setFlipped(newFlipped);
+    if (flipped.length === 0) {
+      startTimer();
+      setFlipped([idx]);
+    } else if (flipped.length === 1) {
+      const first = flipped[0];
+      const second = idx;
+      const newFlipped = [first, second];
+      setFlipped(newFlipped);
+      setMoves((m) => m + 1);
 
-    if (newFlipped.length === 2) {
-      const [first, second] = newFlipped;
       if (cards[first].value === cards[second].value) {
         setMatched([...matched, first, second]);
-        setTimeout(() => setFlipped([]), 500);
+        setTimeout(() => setFlipped([]), 600);
       } else {
-        setTimeout(() => setFlipped([]), 1000);
+        setTimeout(() => setFlipped([]), assistive ? 800 : 200);
       }
     }
   };
 
-  const reset = () => {
-    setCards(createDeck());
-    setFlipped([]);
-    setMatched([]);
-  };
+  const gridStyle = { gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))` };
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
-      <div className="grid grid-cols-4 gap-2 mb-4">
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4 select-none">
+      <div className="mb-2 flex flex-wrap items-center justify-center space-x-4">
+        <label className="flex items-center">
+          Size
+          <select
+            className="ml-1 text-black"
+            value={size}
+            onChange={(e) => setSize(Number(e.target.value))}
+          >
+            {modes.map((m) => (
+              <option key={m} value={m}>{`${m}x${m}`}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={timed}
+            onChange={(e) => {
+              setTimed(e.target.checked);
+              reset(size);
+            }}
+          />
+          <span className="ml-1">Timed</span>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={assistive}
+            onChange={(e) => setAssistive(e.target.checked)}
+          />
+          <span className="ml-1">Assistive</span>
+        </label>
+      </div>
+      {timed && <div className="mb-2">Time: {time}s</div>}
+      <div className="grid gap-2 mb-4" style={gridStyle}>
         {cards.map((card, idx) => {
           const isFlipped = flipped.includes(idx) || matched.includes(idx);
           return (
-            <button
-              key={card.id}
-              className="h-16 w-16 bg-gray-700 hover:bg-gray-600 flex items-center justify-center text-2xl"
-              onClick={() => handleFlip(idx)}
-            >
-              {isFlipped ? card.value : ''}
-            </button>
+            <div key={card.id} className="aspect-square" onClick={() => handleFlip(idx)}>
+              <div
+                className="relative w-full h-full transition-transform duration-500 transform-gpu"
+                style={{
+                  transformStyle: 'preserve-3d',
+                  transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+                }}
+              >
+                <div
+                  className="absolute inset-0 bg-gray-700 rounded flex items-center justify-center text-2xl"
+                  style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+                >
+                  {card.value}
+                </div>
+                <div
+                  className="absolute inset-0 bg-gray-600 rounded"
+                  style={{ backfaceVisibility: 'hidden' }}
+                />
+              </div>
+            </div>
           );
         })}
       </div>
+      <div className="flex space-x-4 mb-2">
+        <div>Moves: {moves}</div>
+        {timed && stats.bestTime != null && <div>Best: {stats.bestTime}s</div>}
+        {!timed && stats.bestMoves != null && <div>Best: {stats.bestMoves}</div>}
+      </div>
       <button
         className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-        onClick={reset}
+        onClick={() => reset(size)}
       >
         Reset
       </button>

--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -1,0 +1,36 @@
+export const EMOJIS = [
+  '\u{1F34E}', // apple
+  '\u{1F34C}', // banana
+  '\u{1F347}', // grapes
+  '\u{1F353}', // strawberry
+  '\u{1F34D}', // pineapple
+  '\u{1F95D}', // kiwi
+  '\u{1F351}', // peach
+  '\u{1F951}', // avocado
+  '\u{1F346}', // eggplant
+  '\u{1F955}', // carrot
+  '\u{1F33D}', // ear of corn
+  '\u{1F954}', // potato
+  '\u{1F34A}', // tangerine
+  '\u{1F350}', // pear
+  '\u{1F965}', // coconut
+  '\u{1FAD0}', // blueberry
+  '\u{1F96D}', // mango
+  '\u{1F345}'  // tomato
+];
+
+export function fisherYatesShuffle(array) {
+  const arr = array.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function createDeck(size) {
+  const pairs = (size * size) / 2;
+  const selected = EMOJIS.slice(0, pairs);
+  const doubled = [...selected, ...selected].map((value, index) => ({ id: index, value }));
+  return fisherYatesShuffle(doubled);
+}


### PR DESCRIPTION
## Summary
- Expand memory game with selectable grid sizes, timed and assistive modes, and animated card flips
- Implement Fisher-Yates shuffle and persist per-mode statistics to localStorage
- Add Jest test verifying shuffle fairness

## Testing
- `npm test`
- `npm run lint` *(warn: React Hook useEffect has a missing dependency: 'reset'. Either include it or remove the dependency array.)*

------
https://chatgpt.com/codex/tasks/task_e_68a897d2e0b883288376171a12e87685