### PR TITLE
Add Flappy Bird game

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -48,6 +48,7 @@ const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
 const ChessApp = createDynamicApp('chess', 'Chess');
 const HangmanApp = createDynamicApp('hangman', 'Hangman');
 const FroggerApp = createDynamicApp('frogger', 'Frogger');
+const FlappyBirdApp = createDynamicApp('flappy-bird', 'Flappy Bird');
 const Game2048App = createDynamicApp('2048', '2048');
 const SnakeApp = createDynamicApp('snake', 'Snake');
 const MemoryApp = createDynamicApp('memory', 'Memory');
@@ -76,6 +77,7 @@ const displayTicTacToe = createDisplay(TicTacToeApp);
 const displayChess = createDisplay(ChessApp);
 const displayHangman = createDisplay(HangmanApp);
 const displayFrogger = createDisplay(FroggerApp);
+const displayFlappyBird = createDisplay(FlappyBirdApp);
 const display2048 = createDisplay(Game2048App);
 const displaySnake = createDisplay(SnakeApp);
 const displayMemory = createDisplay(MemoryApp);
@@ -324,6 +326,15 @@ export const games = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySudoku,
+  },
+  {
+    id: 'flappy-bird',
+    title: 'Flappy Bird',
+    icon: './themes/Yaru/apps/flappy-bird.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayFlappyBird,
   },
 ];
 

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -1,0 +1,137 @@
+import React, { useRef, useEffect } from 'react';
+
+const FlappyBird = () => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+
+    let bird = { x: 50, y: height / 2, vy: 0 };
+    const gravity = 0.5;
+    const jump = -8;
+    let pipes = [];
+    let frame = 0;
+    let score = 0;
+    let running = true;
+
+    const addPipe = () => {
+      const gap = 80;
+      const top = Math.random() * (height - gap - 40) + 20;
+      pipes.push({ x: width, top, bottom: top + gap });
+    };
+
+    const reset = () => {
+      bird = { x: 50, y: height / 2, vy: 0 };
+      pipes = [];
+      frame = 0;
+      score = 0;
+      running = true;
+    };
+
+    const flap = () => {
+      bird.vy = jump;
+    };
+
+    const handleKey = (e) => {
+      if (e.code === 'Space') {
+        if (running) {
+          flap();
+        } else {
+          reset();
+          addPipe();
+          requestAnimationFrame(update);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+
+    const update = () => {
+      if (!running) return;
+
+      frame += 1;
+
+      if (frame % 100 === 0) addPipe();
+
+      bird.vy += gravity;
+      bird.y += bird.vy;
+
+      if (bird.y + 10 > height || bird.y - 10 < 0) {
+        running = false;
+      }
+
+      pipes.forEach((pipe) => {
+        pipe.x -= 2;
+        if (pipe.x + 40 < 0) {
+          pipes.shift();
+          score += 1;
+        }
+        if (
+          pipe.x < bird.x + 10 &&
+          pipe.x + 40 > bird.x - 10 &&
+          (bird.y - 10 < pipe.top || bird.y + 10 > pipe.bottom)
+        ) {
+          running = false;
+        }
+      });
+
+      draw();
+
+      if (running) requestAnimationFrame(update);
+    };
+
+    const draw = () => {
+      ctx.fillStyle = '#87CEEB';
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.fillStyle = '#228B22';
+      pipes.forEach((pipe) => {
+        ctx.fillRect(pipe.x, 0, 40, pipe.top);
+        ctx.fillRect(pipe.x, pipe.bottom, 40, height - pipe.bottom);
+      });
+
+      ctx.fillStyle = 'yellow';
+      ctx.beginPath();
+      ctx.arc(bird.x, bird.y, 10, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = 'black';
+      ctx.font = '16px sans-serif';
+      ctx.fillText(`Score: ${score}`, 10, 20);
+
+      if (!running) {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, width, height);
+        ctx.fillStyle = 'white';
+        ctx.textAlign = 'center';
+        ctx.font = '24px sans-serif';
+        ctx.fillText('Game Over', width / 2, height / 2);
+        ctx.font = '16px sans-serif';
+        ctx.fillText('Press Space to restart', width / 2, height / 2 + 30);
+        ctx.textAlign = 'left';
+      }
+    };
+
+    addPipe();
+    requestAnimationFrame(update);
+
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={400}
+      height={300}
+      className="w-full h-full bg-black"
+    />
+  );
+};
+
+export default FlappyBird;
+

--- a/public/themes/Yaru/apps/flappy-bird.svg
+++ b/public/themes/Yaru/apps/flappy-bird.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="20" fill="#f4d03f"/>
+  <polygon points="44,32 60,26 60,38" fill="#e67e22"/>
+  <circle cx="37" cy="25" r="3" fill="#000"/>
+  <path d="M20 32 q12 12 24 0" stroke="#fff" stroke-width="2" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- implement simple canvas-based Flappy Bird with pipes, gravity, and flap controls
- register Flappy Bird in the app configuration and games list
- include Flappy Bird icon in Yaru theme assets

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8aebdb9b883289531fcad801ede09