### PR TITLE
Add Breakout game placeholder

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -65,6 +65,7 @@ const SolitaireApp = createDynamicApp('solitaire', 'Solitaire');
 const TowerDefenseApp = createDynamicApp('tower-defense', 'Tower Defense');
 const WordSearchApp = createDynamicApp('word-search', 'Word Search');
 const BlackjackApp = createDynamicApp('blackjack', 'Blackjack');
+const BreakoutApp = createDynamicApp('breakout', 'Breakout');
 const AsteroidsApp = createDynamicApp('asteroids', 'Asteroids');
 const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
 const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
@@ -93,6 +94,7 @@ const displaySolitaire = createDisplay(SolitaireApp);
 const displayTowerDefense = createDisplay(TowerDefenseApp);
 const displayWordSearch = createDisplay(WordSearchApp);
 const displayBlackjack = createDisplay(BlackjackApp);
+const displayBreakout = createDisplay(BreakoutApp);
 const displayAsteroids = createDisplay(AsteroidsApp);
 const displaySudoku = createDisplay(SudokuApp);
 const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
@@ -135,6 +137,15 @@ export const games = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayBlackjack,
+  },
+  {
+    id: 'breakout',
+    title: 'Breakout',
+    icon: './themes/Yaru/apps/breakout.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayBreakout,
   },
   {
     id: 'car-racer',

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,0 +1,88 @@
+import React, { useRef, useEffect } from 'react';
+
+const Breakout = () => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+
+    const paddle = { x: width / 2 - 40, y: height - 20, w: 80, h: 10 };
+    const ball = { x: width / 2, y: height / 2, vx: 150, vy: -150, r: 5 };
+
+    const keys = { left: false, right: false };
+
+    const keyDown = (e) => {
+      if (e.key === 'ArrowLeft') keys.left = true;
+      if (e.key === 'ArrowRight') keys.right = true;
+    };
+    const keyUp = (e) => {
+      if (e.key === 'ArrowLeft') keys.left = false;
+      if (e.key === 'ArrowRight') keys.right = false;
+    };
+    window.addEventListener('keydown', keyDown);
+    window.addEventListener('keyup', keyUp);
+
+    let lastTime = 0;
+    const loop = (time) => {
+      const dt = (time - lastTime) / 1000;
+      lastTime = time;
+
+      paddle.x += (keys.right - keys.left) * 300 * dt;
+      paddle.x = Math.max(0, Math.min(width - paddle.w, paddle.x));
+
+      ball.x += ball.vx * dt;
+      ball.y += ball.vy * dt;
+
+      if (ball.x < ball.r || ball.x > width - ball.r) ball.vx *= -1;
+      if (ball.y < ball.r) ball.vy *= -1;
+
+      if (
+        ball.y + ball.r > paddle.y &&
+        ball.x > paddle.x &&
+        ball.x < paddle.x + paddle.w
+      ) {
+        ball.vy *= -1;
+        ball.y = paddle.y - ball.r;
+      }
+
+      if (ball.y > height + ball.r) {
+        ball.x = width / 2;
+        ball.y = height / 2;
+        ball.vx = 150 * (Math.random() > 0.5 ? 1 : -1);
+        ball.vy = -150;
+      }
+
+      ctx.fillStyle = 'black';
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.fillStyle = 'white';
+      ctx.fillRect(paddle.x, paddle.y, paddle.w, paddle.h);
+      ctx.beginPath();
+      ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI * 2);
+      ctx.fill();
+
+      requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+
+    return () => {
+      window.removeEventListener('keydown', keyDown);
+      window.removeEventListener('keyup', keyUp);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={640}
+      height={480}
+      className="h-full w-full bg-black"
+    />
+  );
+};
+
+export default Breakout;

--- a/public/themes/Yaru/apps/breakout.svg
+++ b/public/themes/Yaru/apps/breakout.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <rect x="12" y="8" width="40" height="12" fill="#ffffff"/>
+  <rect x="20" y="54" width="24" height="4" fill="#ffffff"/>
+  <circle cx="32" cy="40" r="4" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- implement simple Breakout canvas game with paddle and ball
- register Breakout in app config and game launcher
- add Breakout icon for Yaru theme

## Testing
- `npx jest __tests__/simonAudio.test.ts __tests__/battleship-ai.test.js --runInBand --forceExit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8aebab4508328b7047c4ac8c125b1