### PR TITLE
Add Tetris game with icon

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -69,6 +69,7 @@ const AsteroidsApp = createDynamicApp('asteroids', 'Asteroids');
 const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
 const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
+const TetrisApp = createDynamicApp('tetris', 'Tetris');
 
 const displayTerminal = createDisplay(TerminalApp);
 const displayTerminalCalc = createDisplay(CalcApp);
@@ -97,6 +98,7 @@ const displayAsteroids = createDisplay(AsteroidsApp);
 const displaySudoku = createDisplay(SudokuApp);
 const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
+const displayTetris = createDisplay(TetrisApp);
 
 // Games list used for the "Games" folder on the desktop
 export const games = [
@@ -279,6 +281,15 @@ export const games = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTicTacToe,
+  },
+  {
+    id: 'tetris',
+    title: 'Tetris',
+    icon: './themes/Yaru/apps/tetris.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTetris,
   },
   {
     id: 'tower-defense',

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+const WIDTH = 10;
+const HEIGHT = 20;
+
+const createBoard = () => Array.from({ length: HEIGHT }, () => Array(WIDTH).fill(0));
+
+const Tetris = () => {
+  const [board, setBoard] = useState(createBoard());
+  const [pos, setPos] = useState({ x: Math.floor(WIDTH / 2), y: 0 });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPos((p) => {
+        if (p.y + 1 >= HEIGHT) {
+          setBoard((b) => {
+            const newBoard = b.map((row) => row.slice());
+            newBoard[p.y][p.x] = 1;
+            return newBoard;
+          });
+          return { x: Math.floor(WIDTH / 2), y: 0 };
+        }
+        return { ...p, y: p.y + 1 };
+      });
+    }, 500);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleKey = useCallback((e) => {
+    if (e.key === 'ArrowLeft') {
+      setPos((p) => ({ ...p, x: Math.max(0, p.x - 1) }));
+    }
+    if (e.key === 'ArrowRight') {
+      setPos((p) => ({ ...p, x: Math.min(WIDTH - 1, p.x + 1) }));
+    }
+    if (e.key === 'ArrowDown') {
+      setPos((p) => ({ ...p, y: Math.min(HEIGHT - 1, p.y + 1) }));
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [handleKey]);
+
+  const cells = [];
+  for (let y = 0; y < HEIGHT; y += 1) {
+    for (let x = 0; x < WIDTH; x += 1) {
+      const filled = board[y][x] || (pos.x === x && pos.y === y);
+      cells.push(
+        <div
+          key={`${x}-${y}`}
+          className={`w-4 h-4 border border-gray-700 ${filled ? 'bg-blue-500' : 'bg-ub-cool-grey'}`}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+      <div className="grid" style={{ gridTemplateColumns: `repeat(${WIDTH}, minmax(0, 1fr))` }}>
+        {cells}
+      </div>
+    </div>
+  );
+};
+
+export default Tetris;
+

--- a/public/themes/Yaru/apps/tetris.svg
+++ b/public/themes/Yaru/apps/tetris.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3436"/>
+  <rect x="8" y="8" width="16" height="16" fill="#4caf50"/>
+  <rect x="24" y="8" width="16" height="16" fill="#4caf50"/>
+  <rect x="40" y="8" width="16" height="16" fill="#4caf50"/>
+  <rect x="24" y="24" width="16" height="16" fill="#4caf50"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simple falling-block Tetris component
- wire Tetris into dynamic app configuration and games list
- include Tetris launcher icon

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aeb6fbcc832886908759b3a75df0