### PR TITLE
Add Sokoban game with analytics and undo support

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -1,0 +1,19 @@
+import { defaultLevels } from '../apps/sokoban/levels';
+import { loadLevel, move, undo, isSolved } from '../apps/sokoban/engine';
+
+describe('sokoban engine', () => {
+  test('simple level solvable', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const moved = move(state, 'ArrowRight');
+    expect(isSolved(moved)).toBe(true);
+  });
+
+  test('undo restores previous state', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const moved = move(state, 'ArrowRight');
+    const undone = undo(moved);
+    expect(undone.player).toEqual(state.player);
+    expect(Array.from(undone.boxes)).toEqual(Array.from(state.boxes));
+    expect(undone.pushes).toBe(state.pushes);
+  });
+});

--- a/apps/sokoban/engine.ts
+++ b/apps/sokoban/engine.ts
@@ -1,0 +1,184 @@
+export type Position = { x: number; y: number };
+export interface State {
+  width: number;
+  height: number;
+  walls: Set<string>;
+  targets: Set<string>;
+  boxes: Set<string>;
+  player: Position;
+  pushes: number;
+  moves: number;
+  history: HistoryEntry[];
+  deadlocks: Set<string>;
+}
+interface HistoryEntry {
+  player: Position;
+  boxes: string[];
+  pushes: number;
+}
+const key = (p: Position) => `${p.x},${p.y}`;
+
+export function loadLevel(lines: string[]): State {
+  const walls = new Set<string>();
+  const targets = new Set<string>();
+  const boxes = new Set<string>();
+  let player: Position = { x: 0, y: 0 };
+  lines.forEach((line, y) => {
+    [...line].forEach((ch, x) => {
+      const k = key({ x, y });
+      switch (ch) {
+        case '#':
+          walls.add(k);
+          break;
+        case '.':
+          targets.add(k);
+          break;
+        case '$':
+          boxes.add(k);
+          break;
+        case '*':
+          boxes.add(k);
+          targets.add(k);
+          break;
+        case '@':
+          player = { x, y };
+          break;
+        case '+':
+          player = { x, y };
+          targets.add(k);
+          break;
+        default:
+          break;
+      }
+    });
+  });
+  const width = Math.max(...lines.map((l) => l.length));
+  const height = lines.length;
+  const state: State = {
+    width,
+    height,
+    walls,
+    targets,
+    boxes,
+    player,
+    pushes: 0,
+    moves: 0,
+    history: [],
+    deadlocks: new Set(),
+  };
+  state.deadlocks = computeDeadlocks(state);
+  return state;
+}
+
+function cloneState(state: State): HistoryEntry {
+  return {
+    player: { ...state.player },
+    boxes: Array.from(state.boxes),
+    pushes: state.pushes,
+  };
+}
+
+const DIRS: Record<string, Position> = {
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+};
+
+function isWallOrBox(state: State, pos: Position): boolean {
+  const k = key(pos);
+  if (pos.x < 0 || pos.y < 0 || pos.x >= state.width || pos.y >= state.height) return true;
+  return state.walls.has(k) || state.boxes.has(k);
+}
+
+export function isDeadlockPosition(state: State, pos: Position): boolean {
+  const k = key(pos);
+  if (state.targets.has(k)) return false;
+  const up = isWallOrBox(state, { x: pos.x, y: pos.y - 1 });
+  const down = isWallOrBox(state, { x: pos.x, y: pos.y + 1 });
+  const left = isWallOrBox(state, { x: pos.x - 1, y: pos.y });
+  const right = isWallOrBox(state, { x: pos.x + 1, y: pos.y });
+  return (up && left) || (up && right) || (down && left) || (down && right);
+}
+
+function computeDeadlocks(state: State): Set<string> {
+  const d = new Set<string>();
+  state.boxes.forEach((b) => {
+    const [x, y] = b.split(',').map(Number);
+    const pos = { x, y };
+    if (isDeadlockPosition(state, pos)) d.add(b);
+  });
+  return d;
+}
+
+export function move(state: State, dirKey: keyof typeof DIRS): State {
+  const dir = DIRS[dirKey];
+  if (!dir) return state;
+  const next: Position = { x: state.player.x + dir.x, y: state.player.y + dir.y };
+  const nextKey = key(next);
+  if (state.walls.has(nextKey)) return state;
+  const result = { ...state, player: { ...state.player }, boxes: new Set(state.boxes), history: [...state.history] };
+  result.history.push(cloneState(state));
+  if (result.boxes.has(nextKey)) {
+    const beyond: Position = { x: next.x + dir.x, y: next.y + dir.y };
+    const beyondKey = key(beyond);
+    if (isWallOrBox(state, beyond)) {
+      result.history.pop();
+      return state;
+    }
+    result.boxes.delete(nextKey);
+    result.boxes.add(beyondKey);
+    result.pushes += 1;
+  }
+  result.player = next;
+  result.moves += 1;
+  result.deadlocks = computeDeadlocks(result);
+  return result;
+}
+
+export function undo(state: State): State {
+  if (!state.history.length) return state;
+  const prev = state.history[state.history.length - 1];
+  const boxes = new Set(prev.boxes);
+  const restored: State = {
+    ...state,
+    player: { ...prev.player },
+    boxes,
+    pushes: prev.pushes,
+    moves: state.moves + 1,
+    history: state.history.slice(0, -1),
+  };
+  restored.deadlocks = computeDeadlocks(restored);
+  return restored;
+}
+
+export function reset(lines: string[]): State {
+  return loadLevel(lines);
+}
+
+export function reachable(state: State): Set<string> {
+  const visited = new Set<string>();
+  const q: Position[] = [state.player];
+  visited.add(key(state.player));
+  while (q.length) {
+    const p = q.shift()!;
+    Object.values(DIRS).forEach((d) => {
+      const n = { x: p.x + d.x, y: p.y + d.y };
+      const k = key(n);
+      if (visited.has(k) || isWallOrBox(state, n)) return;
+      if (state.boxes.has(k)) return; // cannot walk through boxes
+      visited.add(k);
+      q.push(n);
+    });
+  }
+  return visited;
+}
+
+export function isSolved(state: State): boolean {
+  for (const b of state.boxes) {
+    if (!state.targets.has(b)) return false;
+  }
+  return true;
+}
+
+export const directionKeys = Object.keys(DIRS) as (keyof typeof DIRS)[];

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
+import { defaultLevels, parseLevels } from './levels';
+import {
+  loadLevel,
+  move,
+  undo as undoMove,
+  reset as resetLevel,
+  reachable,
+  isSolved,
+  State,
+  directionKeys,
+} from './engine';
+
+const CELL = 32;
+
+const Sokoban: React.FC = () => {
+  const [levels, setLevels] = useState<string[][]>(defaultLevels);
+  const [index, setIndex] = useState(0);
+  const [state, setState] = useState<State>(() => loadLevel(defaultLevels[0]));
+  const [reach, setReach] = useState<Set<string>>(reachable(loadLevel(defaultLevels[0])));
+  const [best, setBest] = useState<number | null>(null);
+
+  useEffect(() => {
+    const k = `sokoban-best-${index}`;
+    const b = localStorage.getItem(k);
+    setBest(b ? Number(b) : null);
+  }, [index]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!directionKeys.includes(e.key as any)) return;
+      e.preventDefault();
+      const newState = move(state, e.key as any);
+      if (newState === state) return;
+      setState(newState);
+      setReach(reachable(newState));
+      if (newState.pushes > state.pushes) {
+        ReactGA.event('push');
+      }
+      if (isSolved(newState)) {
+        ReactGA.event('level_complete', { moves: newState.pushes });
+        const bestKey = `sokoban-best-${index}`;
+        const prevBest = localStorage.getItem(bestKey);
+        if (!prevBest || newState.pushes < Number(prevBest)) {
+          localStorage.setItem(bestKey, String(newState.pushes));
+          setBest(newState.pushes);
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [state, index]);
+
+  const selectLevel = (i: number) => {
+    const st = loadLevel(levels[i]);
+    setIndex(i);
+    setState(st);
+    setReach(reachable(st));
+    ReactGA.event('level_select', { level: i });
+  };
+
+  const handleUndo = () => {
+    const st = undoMove(state);
+    if (st !== state) {
+      setState(st);
+      setReach(reachable(st));
+      ReactGA.event('undo');
+    }
+  };
+
+  const handleReset = () => {
+    const st = resetLevel(levels[index]);
+    setState(st);
+    setReach(reachable(st));
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const lvl = parseLevels(text);
+    if (lvl.length) {
+      setLevels(lvl);
+      selectLevel(0);
+    }
+  };
+
+  const cellStyle = {
+    width: CELL,
+    height: CELL,
+  } as React.CSSProperties;
+
+  return (
+    <div className="p-4 space-y-2 select-none">
+      <div className="flex space-x-2 mb-2">
+        <select value={index} onChange={(e) => selectLevel(Number(e.target.value))}>
+          {levels.map((_, i) => (
+            <option key={i} value={i}>{`Level ${i + 1}`}</option>
+          ))}
+        </select>
+        <input type="file" accept=".txt,.sas" onChange={handleFile} />
+        <button type="button" onClick={handleUndo} className="px-2 py-1 bg-gray-300 rounded">
+          Undo
+        </button>
+        <button type="button" onClick={handleReset} className="px-2 py-1 bg-gray-300 rounded">
+          Reset
+        </button>
+        <div className="ml-4">Pushes: {state.pushes}</div>
+        <div>Best: {best ?? '-'}</div>
+      </div>
+      <div
+        className="relative bg-gray-700"
+        style={{ width: state.width * CELL, height: state.height * CELL }}
+      >
+        {Array.from({ length: state.height }).map((_, y) =>
+          Array.from({ length: state.width }).map((_, x) => {
+            const k = `${x},${y}`;
+            const isWall = state.walls.has(k);
+            const isTarget = state.targets.has(k);
+            const isReach = reach.has(k);
+            return (
+              <React.Fragment key={k}>
+                <div
+                  className={`absolute ${isWall ? 'bg-gray-800' : 'bg-gray-600'} ${
+                    isTarget ? 'ring-2 ring-yellow-400' : ''
+                  }`}
+                  style={{ ...cellStyle, left: x * CELL, top: y * CELL }}
+                />
+                {isReach && !isWall && (
+                  <div
+                    className="absolute bg-green-400 opacity-30"
+                    style={{ ...cellStyle, left: x * CELL, top: y * CELL }}
+                  />
+                )}
+              </React.Fragment>
+            );
+          })
+        )}
+        {[...state.boxes].map((b) => {
+          const [x, y] = b.split(',').map(Number);
+          const dead = state.deadlocks.has(b);
+          return (
+            <div
+              key={b}
+              className={`absolute transition-transform duration-100 ${
+                dead ? 'bg-red-500' : 'bg-orange-400'
+              }`}
+              style={{
+                ...cellStyle,
+                transform: `translate(${x * CELL}px, ${y * CELL}px)`,
+              }}
+            />
+          );
+        })}
+        <div
+          className="absolute bg-blue-400 transition-transform duration-100"
+          style={{
+            ...cellStyle,
+            transform: `translate(${state.player.x * CELL}px, ${state.player.y * CELL}px)`,
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Sokoban;

--- a/apps/sokoban/levels.ts
+++ b/apps/sokoban/levels.ts
@@ -1,0 +1,30 @@
+export const RAW_LEVELS = `
+; Simple tutorial level
+#####
+#@$.#
+#####
+
+; Two box level
+######
+#@ $.#
+######
+`;
+
+export function parseLevels(data: string): string[][] {
+  const levels: string[][] = [];
+  let current: string[] = [];
+  data.split(/\r?\n/).forEach((line) => {
+    if (line.trim() === '' || line.trim().startsWith(';')) {
+      if (current.length) {
+        levels.push(current);
+        current = [];
+      }
+    } else {
+      current.push(line);
+    }
+  });
+  if (current.length) levels.push(current);
+  return levels;
+}
+
+export const defaultLevels = parseLevels(RAW_LEVELS);

--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const Sokoban = dynamic(() => import('../../apps/sokoban'), { ssr: false });
+
+export default function SokobanPage() {
+  return <Sokoban />;
+}


### PR DESCRIPTION
## Summary
- add Sokoban engine with deadlock detection, undo/reset and reachability logic
- create React UI for level pack upload, best push tracking, GA events and animations
- add unit tests for solvability and undo

## Testing
- `npm test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac13450c8328831ecd9f79099628