### PR TITLE
Improve car racer handling and lap timing

### DIFF
--- a/__tests__/carRacer.test.ts
+++ b/__tests__/carRacer.test.ts
@@ -1,0 +1,53 @@
+import { advanceCheckpoints, CHECKPOINTS } from '../components/apps/car-racer';
+
+jest.mock('react-ga4', () => ({ event: jest.fn() }));
+
+describe('car racer checkpoints', () => {
+  test('checkpoint order enforced', () => {
+    let next = 0;
+    let lapLineCrossed = false;
+    let res = advanceCheckpoints(
+      { x: CHECKPOINTS[0].x - 1, y: CHECKPOINTS[0].y1 + 1 },
+      { x: CHECKPOINTS[0].x + 1, y: CHECKPOINTS[0].y1 + 1 },
+      next,
+      lapLineCrossed,
+      CHECKPOINTS
+    );
+    next = res.nextCheckpoint;
+    lapLineCrossed = res.lapLineCrossed;
+    expect(res.lapStarted).toBe(true);
+    expect(next).toBe(1);
+    res = advanceCheckpoints(
+      { x: CHECKPOINTS[2].x - 1, y: CHECKPOINTS[2].y1 + 1 },
+      { x: CHECKPOINTS[2].x + 1, y: CHECKPOINTS[2].y1 + 1 },
+      next,
+      lapLineCrossed,
+      CHECKPOINTS
+    );
+    expect(res.nextCheckpoint).toBe(1);
+  });
+
+  test('lap line counts only once per lap', () => {
+    let next = 0;
+    let lapLineCrossed = false;
+    let res = advanceCheckpoints(
+      { x: CHECKPOINTS[0].x - 1, y: CHECKPOINTS[0].y1 + 1 },
+      { x: CHECKPOINTS[0].x + 1, y: CHECKPOINTS[0].y1 + 1 },
+      next,
+      lapLineCrossed,
+      CHECKPOINTS
+    );
+    next = res.nextCheckpoint;
+    lapLineCrossed = res.lapLineCrossed;
+    res = advanceCheckpoints(
+      { x: CHECKPOINTS[0].x - 1, y: CHECKPOINTS[0].y1 + 1 },
+      { x: CHECKPOINTS[0].x + 1, y: CHECKPOINTS[0].y1 + 1 },
+      next,
+      lapLineCrossed,
+      CHECKPOINTS
+    );
+    expect(res.lapCompleted).toBe(false);
+    expect(res.lapStarted).toBe(false);
+    expect(res.nextCheckpoint).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add fixed-step physics with drift and speed-based steering
- enforce checkpoint order with ghost laps and analytics events
- mobile button steering, HUD with timers and best-lap replay

## Testing
- `npm install`
- `npm test __tests__/carRacer.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a8abd2e72c832890f07db9ceb6267b