### PR TITLE
Reduce game window sizes for better fit

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -106,8 +106,14 @@ const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 
+// Default window sizing for games to prevent oversized frames
+const gameDefaults = {
+  defaultWidth: 50,
+  defaultHeight: 60,
+};
+
 // Games list used for the "Games" folder on the desktop
-export const games = [
+const gameList = [
   {
     id: '2048',
     title: '2048',
@@ -370,6 +376,8 @@ export const games = [
     screen: displayFlappyBird,
   },
 ];
+
+export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
 
 const apps = [
   {


### PR DESCRIPTION
## Summary
- standardize game windows using default 50x60% dimensions to avoid oversized frames

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b945d6e88328b2f4d46bedd0b11c