### PR TITLE
fix: improve youtube title readability

### DIFF
--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -230,7 +230,16 @@ export default function YouTubeApp({ initialVideos = [] }) {
                   {video.thumbnail && (
                     <img src={video.thumbnail} alt={video.title} className="w-full" />
                   )}
-                  <div className="p-2 font-semibold text-sm line-clamp-2">
+                  <div
+                    className="p-2 font-semibold text-sm"
+                    title={video.title}
+                    style={{
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                    }}
+                  >
                     {video.title}
                   </div>
                 </a>


### PR DESCRIPTION
## Summary
- clamp long YouTube titles to two lines and add tooltip to show full title

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc26121883289925c5f212ab53be