### PR TITLE
Fix game config syntax

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -37,9 +37,13 @@ const createDynamicApp = (path, name) =>
     }
   );
 
-const createDisplay = (Component) => (addFolder, openApp) => (
-  <Component addFolder={addFolder} openApp={openApp} />
-);
+const createDisplay = (Component) => {
+  const DisplayComponent = (addFolder, openApp) => (
+    <Component addFolder={addFolder} openApp={openApp} />
+  );
+  DisplayComponent.displayName = Component.displayName || Component.name || 'Component';
+  return DisplayComponent;
+};
 
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
@@ -407,7 +411,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayCandyCrush,
-
+  },
+  {
     id: 'gomoku',
     title: 'Gomoku',
     icon: './themes/Yaru/apps/gomoku.svg',
@@ -415,7 +420,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayGomoku,
-
+  },
+  {
     id: 'pinball',
     title: 'Pinball',
     icon: './themes/Yaru/apps/pinball.svg',


### PR DESCRIPTION
## Summary
- ensure createDisplay components have explicit display names for ESLint
- correct Candy Crush, Gomoku, and Pinball entries in game list

## Testing
- `npx eslint apps.config.js`
- `npm test` *(fails: Test Suites: 26 passed, 26 of 27 total; tests hang afterwards)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cabd64808328ad9d86461bd1fe3f