### PR TITLE
feat: expand breakout with power-ups and level editor

### DIFF
--- a/apps/breakout/Ball.ts
+++ b/apps/breakout/Ball.ts
@@ -1,0 +1,37 @@
+export default class Ball {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  canvasWidth: number;
+  canvasHeight: number;
+
+  constructor(canvasWidth: number, canvasHeight: number) {
+    this.r = 5;
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
+    this.reset();
+  }
+
+  reset() {
+    this.x = this.canvasWidth / 2;
+    this.y = this.canvasHeight / 2;
+    this.vx = 150 * (Math.random() > 0.5 ? 1 : -1);
+    this.vy = -150;
+  }
+
+  update(dt: number) {
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+    if (this.x < this.r || this.x > this.canvasWidth - this.r) this.vx *= -1;
+    if (this.y < this.r) this.vy *= -1;
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2);
+    ctx.fillStyle = 'white';
+    ctx.fill();
+  }
+}

--- a/apps/breakout/Brick.ts
+++ b/apps/breakout/Brick.ts
@@ -1,0 +1,22 @@
+export default class Brick {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  destroyed = false;
+  powerUp: 'multiball' | 'laser' | null;
+
+  constructor(x: number, y: number, w: number, h: number, powerUp: 'multiball' | 'laser' | null = null) {
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+    this.powerUp = powerUp;
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    if (this.destroyed) return;
+    ctx.fillStyle = this.powerUp ? 'gold' : 'blue';
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+}

--- a/apps/breakout/Paddle.ts
+++ b/apps/breakout/Paddle.ts
@@ -1,0 +1,45 @@
+export default class Paddle {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  speed: number;
+  canvasWidth: number;
+  lasers: { x: number; y: number }[] = [];
+  laserActive = false;
+
+  constructor(canvasWidth: number, canvasHeight: number) {
+    this.width = 80;
+    this.height = 10;
+    this.x = canvasWidth / 2 - this.width / 2;
+    this.y = canvasHeight - this.height * 2;
+    this.speed = 300;
+    this.canvasWidth = canvasWidth;
+  }
+
+  move(dir: number, dt: number) {
+    this.x += dir * this.speed * dt;
+    if (this.x < 0) this.x = 0;
+    if (this.x + this.width > this.canvasWidth) this.x = this.canvasWidth - this.width;
+  }
+
+  shoot() {
+    if (!this.laserActive) return;
+    this.lasers.push({ x: this.x + this.width / 2, y: this.y });
+  }
+
+  updateLasers(dt: number) {
+    this.lasers = this.lasers
+      .map((l) => ({ ...l, y: l.y - 400 * dt }))
+      .filter((l) => l.y > 0);
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    ctx.fillStyle = 'white';
+    ctx.fillRect(this.x, this.y, this.width, this.height);
+    ctx.fillStyle = 'red';
+    this.lasers.forEach((l) => {
+      ctx.fillRect(l.x - 1, l.y - 10, 2, 10);
+    });
+  }
+}

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,23 +1,125 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
+import Paddle from '../../apps/breakout/Paddle';
+import Ball from '../../apps/breakout/Ball';
+import Brick from '../../apps/breakout/Brick';
+
+const rowsByDifficulty = { easy: 3, medium: 5, hard: 7 };
+const speedByDifficulty = { easy: 150, medium: 200, hard: 250 };
+
+const LevelEditor = ({ onSave, onCancel }) => {
+  const rows = 6;
+  const cols = 10;
+  const [grid, setGrid] = useState(
+    Array.from({ length: rows }, () => Array(cols).fill(0))
+  );
+  const toggle = (r, c) => {
+    setGrid((g) => {
+      const ng = g.map((row) => row.slice());
+      ng[r][c] = ng[r][c] ? 0 : 1;
+      return ng;
+    });
+  };
+  const save = async () => {
+    await fetch('/api/breakout/levels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(grid),
+    });
+    onSave(grid);
+  };
+  return (
+    <div className="p-2 space-y-2 text-white">
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+      >
+        {grid.map((row, r) =>
+          row.map((cell, c) => (
+            <div
+              key={`${r}-${c}`}
+              onClick={() => toggle(r, c)}
+              className={`w-8 h-4 border cursor-pointer ${cell ? 'bg-blue-500' : 'bg-gray-700'}`}
+            />
+          ))
+        )}
+      </div>
+      <div className="space-x-2">
+        <button
+          type="button"
+          onClick={save}
+          className="px-2 py-1 bg-green-600"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-2 py-1 bg-red-600"
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const Breakout = () => {
   const canvasRef = useRef(null);
+  const containerRef = useRef(null);
+  const [difficulty, setDifficulty] = useState('easy');
+  const [editing, setEditing] = useState(false);
+  const [customLayout, setCustomLayout] = useState(null);
 
   useEffect(() => {
+    if (editing) return; // don't run game loop while editing
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
     const ctx = canvas.getContext('2d');
-    const width = canvas.width;
-    const height = canvas.height;
+    let width = container.clientWidth;
+    let height = container.clientHeight;
+    canvas.width = width;
+    canvas.height = height;
 
-    const paddle = { x: width / 2 - 40, y: height - 20, w: 80, h: 10 };
-    const ball = { x: width / 2, y: height / 2, vx: 150, vy: -150, r: 5 };
+    const resizeObserver = new ResizeObserver((entries) => {
+      const cr = entries[0].contentRect;
+      width = cr.width;
+      height = cr.height;
+      canvas.width = width;
+      canvas.height = height;
+      paddle.canvasWidth = width;
+      balls.forEach((b) => {
+        b.canvasWidth = width;
+        b.canvasHeight = height;
+      });
+    });
+    resizeObserver.observe(container);
+
+    const paddle = new Paddle(width, height);
+    const balls = [new Ball(width, height)];
+    const bricks = [];
+    const powerUps = [];
+    let particles = [];
+
+    const rows = customLayout ? customLayout.length : rowsByDifficulty[difficulty];
+    const cols = 10;
+    const bw = width / cols;
+    const bh = 20;
+    for (let r = 0; r < rows; r += 1) {
+      for (let c = 0; c < cols; c += 1) {
+        if (customLayout && !customLayout[r][c]) continue;
+        const powerUp = Math.random() < 0.1 ? (Math.random() < 0.5 ? 'multiball' : 'laser') : null;
+        bricks.push(new Brick(c * bw, r * bh + 40, bw - 2, bh - 2, powerUp));
+      }
+    }
+    balls[0].vx *= speedByDifficulty[difficulty] / 150;
+    balls[0].vy *= speedByDifficulty[difficulty] / 150;
 
     const keys = { left: false, right: false };
-
     const keyDown = (e) => {
       if (e.key === 'ArrowLeft') keys.left = true;
       if (e.key === 'ArrowRight') keys.right = true;
+      if (e.key === ' ') paddle.shoot();
     };
     const keyUp = (e) => {
       if (e.key === 'ArrowLeft') keys.left = false;
@@ -26,62 +128,185 @@ const Breakout = () => {
     window.addEventListener('keydown', keyDown);
     window.addEventListener('keyup', keyUp);
 
+    const pointerMove = (e) => {
+      const rect = canvas.getBoundingClientRect();
+      paddle.x = e.clientX - rect.left - paddle.width / 2;
+      if (paddle.x < 0) paddle.x = 0;
+      if (paddle.x + paddle.width > width) paddle.x = width - paddle.width;
+    };
+    const pointerDown = () => paddle.shoot();
+    canvas.addEventListener('pointermove', pointerMove);
+    canvas.addEventListener('pointerdown', pointerDown);
+
     let lastTime = 0;
+
+    const playSound = (freq) => {
+      try {
+        const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = audioCtx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = freq;
+        osc.connect(audioCtx.destination);
+        osc.start();
+        osc.stop(audioCtx.currentTime + 0.1);
+      } catch (e) {
+        // ignore
+      }
+    };
+
+    const spawnParticles = (x, y) => {
+      const arr = [];
+      for (let i = 0; i < 10; i += 1) {
+        arr.push({
+          x,
+          y,
+          vx: (Math.random() - 0.5) * 100,
+          vy: (Math.random() - 0.5) * 100,
+          life: 1,
+        });
+      }
+      return arr;
+    };
+
     const loop = (time) => {
       const dt = (time - lastTime) / 1000;
       lastTime = time;
+      ctx.clearRect(0, 0, width, height);
 
-      paddle.x += (keys.right - keys.left) * 300 * dt;
-      paddle.x = Math.max(0, Math.min(width - paddle.w, paddle.x));
+      paddle.move((keys.right ? 1 : 0) - (keys.left ? 1 : 0), dt);
+      paddle.updateLasers(dt);
 
-      ball.x += ball.vx * dt;
-      ball.y += ball.vy * dt;
+      balls.forEach((b) => b.update(dt));
 
-      if (ball.x < ball.r || ball.x > width - ball.r) ball.vx *= -1;
-      if (ball.y < ball.r) ball.vy *= -1;
+      balls.forEach((b) => {
+        if (b.y + b.r > paddle.y && b.x > paddle.x && b.x < paddle.x + paddle.width && b.vy > 0) {
+          b.vy *= -1;
+          b.y = paddle.y - b.r;
+          playSound(200);
+        }
+        if (b.y > height + b.r) b.reset();
+      });
 
-      if (
-        ball.y + ball.r > paddle.y &&
-        ball.x > paddle.x &&
-        ball.x < paddle.x + paddle.w
-      ) {
-        ball.vy *= -1;
-        ball.y = paddle.y - ball.r;
+      paddle.lasers.forEach((l) => {
+        bricks.forEach((br) => {
+          if (!br.destroyed && l.x > br.x && l.x < br.x + br.w && l.y > br.y && l.y < br.y + br.h) {
+            br.destroyed = true;
+            particles.push(...spawnParticles(br.x + br.w / 2, br.y + br.h / 2));
+            if (br.powerUp)
+              powerUps.push({ x: br.x + br.w / 2, y: br.y + br.h / 2, type: br.powerUp, vy: 50 });
+          }
+        });
+      });
+
+      console.time('collision');
+      balls.forEach((b) => {
+        bricks.forEach((br) => {
+          if (
+            !br.destroyed &&
+            b.x > br.x &&
+            b.x < br.x + br.w &&
+            b.y - b.r < br.y + br.h &&
+            b.y + b.r > br.y
+          ) {
+            br.destroyed = true;
+            b.vy *= -1;
+            playSound(400);
+            particles.push(...spawnParticles(br.x + br.w / 2, br.y + br.h / 2));
+            if (br.powerUp)
+              powerUps.push({ x: br.x + br.w / 2, y: br.y + br.h / 2, type: br.powerUp, vy: 50 });
+          }
+        });
+      });
+      console.timeEnd('collision');
+
+      for (let i = powerUps.length - 1; i >= 0; i -= 1) {
+        const p = powerUps[i];
+        p.y += p.vy * dt;
+        if (p.y > paddle.y && p.x > paddle.x && p.x < paddle.x + paddle.width) {
+          if (p.type === 'multiball') {
+            const nb = new Ball(width, height);
+            nb.x = balls[0].x;
+            nb.y = balls[0].y;
+            nb.vx = -balls[0].vx;
+            nb.vy = balls[0].vy;
+            balls.push(nb);
+          } else if (p.type === 'laser') {
+            paddle.laserActive = true;
+            setTimeout(() => {
+              paddle.laserActive = false;
+            }, 5000);
+          }
+          playSound(600);
+          powerUps.splice(i, 1);
+        } else if (p.y > height) {
+          powerUps.splice(i, 1);
+        }
       }
 
-      if (ball.y > height + ball.r) {
-        ball.x = width / 2;
-        ball.y = height / 2;
-        ball.vx = 150 * (Math.random() > 0.5 ? 1 : -1);
-        ball.vy = -150;
-      }
+      particles = particles
+        .map((pt) => ({ ...pt, x: pt.x + pt.vx * dt, y: pt.y + pt.vy * dt, life: pt.life - dt }))
+        .filter((pt) => pt.life > 0);
 
-      ctx.fillStyle = 'black';
-      ctx.fillRect(0, 0, width, height);
-
-      ctx.fillStyle = 'white';
-      ctx.fillRect(paddle.x, paddle.y, paddle.w, paddle.h);
-      ctx.beginPath();
-      ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI * 2);
-      ctx.fill();
+      bricks.forEach((br) => br.draw(ctx));
+      balls.forEach((b) => b.draw(ctx));
+      paddle.draw(ctx);
+      powerUps.forEach((p) => {
+        ctx.fillStyle = p.type === 'multiball' ? 'yellow' : 'red';
+        ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
+      });
+      particles.forEach((pt) => {
+        ctx.fillStyle = `rgba(255,255,255,${pt.life})`;
+        ctx.fillRect(pt.x, pt.y, 2, 2);
+      });
 
       requestAnimationFrame(loop);
     };
-    requestAnimationFrame(loop);
+    const id = requestAnimationFrame(loop);
 
     return () => {
       window.removeEventListener('keydown', keyDown);
       window.removeEventListener('keyup', keyUp);
+      canvas.removeEventListener('pointermove', pointerMove);
+      canvas.removeEventListener('pointerdown', pointerDown);
+      resizeObserver.disconnect();
+      cancelAnimationFrame(id);
     };
-  }, []);
+  }, [difficulty, editing, customLayout]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={640}
-      height={480}
-      className="h-full w-full bg-black"
-    />
+    <div ref={containerRef} className="h-full w-full bg-black relative overflow-hidden">
+      {editing ? (
+        <LevelEditor
+          onSave={(layout) => {
+            setCustomLayout(layout);
+            setEditing(false);
+          }}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        <>
+          <canvas ref={canvasRef} className="touch-none" />
+          <div className="absolute top-2 left-2 space-x-2 text-white">
+            <select
+              value={difficulty}
+              onChange={(e) => setDifficulty(e.target.value)}
+              className="text-black px-1"
+            >
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="hard">Hard</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="px-2 py-1 bg-blue-600"
+            >
+              Edit Level
+            </button>
+          </div>
+        </>
+      )}
+    </div>
   );
 };
 

--- a/pages/api/breakout/levels.ts
+++ b/pages/api/breakout/levels.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  try {
+    const dir = path.join(process.cwd(), 'apps', 'breakout', 'levels');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `level-${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(req.body));
+    res.status(200).json({ saved: true });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to save' });
+  }
+}


### PR DESCRIPTION
## Summary
- modularize Breakout with Paddle, Ball, and Brick classes
- add power-ups, particle effects, sound and touch controls
- include level editor saving layouts via API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d51de2508328aa28b6c9f8561721