### PR TITLE
Add Sudoku app with solver, generator and hints

### DIFF
--- a/apps/sudoku/board.tsx
+++ b/apps/sudoku/board.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import type { Board } from './types';
+
+interface Props {
+  puzzle: Board;
+  solution: Board;
+  storageKey: string;
+  onComplete: () => void;
+}
+
+function cloneBoard(b: Board): Board {
+  return b.map((row) => [...row]);
+}
+
+const BoardComponent: React.FC<Props> = ({ puzzle, solution, storageKey, onComplete }) => {
+  const [board, setBoard] = useState<Board>(() => cloneBoard(puzzle));
+  const [pencil, setPencil] = useState(false);
+  const [marks, setMarks] = useState<Set<number>[][]>(() =>
+    Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => new Set<number>()))
+  );
+
+  useEffect(() => {
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        setBoard(parsed.board);
+        setMarks(
+          parsed.marks.map((row: number[][]) => row.map((arr) => new Set(arr)))
+        );
+      } catch {
+        // ignore
+      }
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify({ board, marks: marks.map((row) => row.map((s) => Array.from(s))) })
+    );
+    const complete = board.every((row) => row.every((v) => v !== 0));
+    if (complete) {
+      const correct = board.every((row, r) => row.every((v, c) => v === solution[r][c]));
+      if (correct) {
+        localStorage.removeItem(storageKey);
+        onComplete();
+      }
+    }
+  }, [board, marks, storageKey, solution, onComplete]);
+
+  const handleInput = (r: number, c: number, val: number) => {
+    if (puzzle[r][c] !== 0) return;
+    if (pencil) {
+      const newMarks = marks.map((row) => row.map((s) => new Set(s)));
+      if (newMarks[r][c].has(val)) newMarks[r][c].delete(val);
+      else newMarks[r][c].add(val);
+      setMarks(newMarks);
+    } else {
+      const newBoard = cloneBoard(board);
+      newBoard[r][c] = val;
+      setBoard(newBoard);
+      const newMarks = marks.map((row) => row.map((s) => new Set(s)));
+      newMarks[r][c].clear();
+      setMarks(newMarks);
+    }
+  };
+
+  const renderCell = (r: number, c: number) => {
+    const val = board[r][c];
+    const mark = marks[r][c];
+    const prefilled = puzzle[r][c] !== 0;
+    const cls = `w-10 h-10 border flex items-center justify-center text-lg font-bold select-none ${
+      prefilled ? 'bg-gray-200' : 'cursor-pointer'
+    }`;
+    return (
+      <div key={`${r}-${c}`} className={cls}>
+        {val !== 0 ? (
+          <span>{val}</span>
+        ) : mark.size ? (
+          <span className="text-xs leading-3">
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9]
+              .map((n) => (mark.has(n) ? n : '.'))
+              .join('')}
+          </span>
+        ) : (
+          ''
+        )}
+      </div>
+    );
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>, r: number, c: number) => {
+    const num = parseInt(e.key, 10);
+    if (Number.isInteger(num) && num >= 1 && num <= 9) {
+      handleInput(r, c, num);
+    }
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      handleInput(r, c, 0);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-2">
+        <label>
+          <input type="checkbox" checked={pencil} onChange={(e) => setPencil(e.target.checked)} />
+          {' '}Pencil Marks
+        </label>
+      </div>
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: 'repeat(9, 2.5rem)', gridTemplateRows: 'repeat(9, 2.5rem)' }}
+      >
+        {board.map((row, r) =>
+          row.map((_, c) => (
+            <div
+              key={`c-${r}-${c}`}
+              tabIndex={0}
+              onKeyDown={(e) => handleKey(e, r, c)}
+              onClick={() => !pencil && handleInput(r, c, (board[r][c] % 9) + 1)}
+            >
+              {renderCell(r, c)}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BoardComponent;

--- a/apps/sudoku/generator.ts
+++ b/apps/sudoku/generator.ts
@@ -1,0 +1,77 @@
+import type { Board } from './types';
+import { countSolutions, solve } from './solver';
+
+function shuffle<T>(arr: T[]): T[] {
+  return arr
+    .map((x) => ({ x, r: Math.random() }))
+    .sort((a, b) => a.r - b.r)
+    .map((o) => o.x);
+}
+
+function generateFullBoard(): Board {
+  const board: Board = Array.from({ length: 9 }, () => Array(9).fill(0));
+  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  function fill(r: number, c: number): boolean {
+    if (r === 9) return true;
+    const nextR = c === 8 ? r + 1 : r;
+    const nextC = (c + 1) % 9;
+    const nums = shuffle(digits);
+    for (const n of nums) {
+      if (isValid(board, r, c, n)) {
+        board[r][c] = n;
+        if (fill(nextR, nextC)) return true;
+        board[r][c] = 0;
+      }
+    }
+    return false;
+  }
+  fill(0, 0);
+  return board;
+}
+
+function isValid(board: Board, row: number, col: number, val: number): boolean {
+  for (let i = 0; i < 9; i += 1) {
+    if (board[row][i] === val || board[i][col] === val) return false;
+  }
+  const boxRow = Math.floor(row / 3) * 3;
+  const boxCol = Math.floor(col / 3) * 3;
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      if (board[boxRow + r][boxCol + c] === val) return false;
+    }
+  }
+  return true;
+}
+
+const DIFFICULTY_REMOVALS: Record<'easy' | 'medium' | 'hard', number> = {
+  easy: 40,
+  medium: 50,
+  hard: 60,
+};
+
+export function generatePuzzle(difficulty: 'easy' | 'medium' | 'hard' = 'easy'): Board {
+  const solved = generateFullBoard();
+  const puzzle = solved.map((row) => [...row]);
+  const removeTarget = DIFFICULTY_REMOVALS[difficulty];
+  const cells = shuffle(Array.from({ length: 81 }, (_, i) => i));
+  let removed = 0;
+  for (const idx of cells) {
+    if (removed >= removeTarget) break;
+    const r = Math.floor(idx / 9);
+    const c = idx % 9;
+    const backup = puzzle[r][c];
+    puzzle[r][c] = 0;
+    const solutions = countSolutions(puzzle, 2);
+    if (solutions !== 1) {
+      puzzle[r][c] = backup;
+    } else {
+      removed += 1;
+    }
+  }
+  return puzzle;
+}
+
+export function getSolution(puzzle: Board): Board | null {
+  const copy = puzzle.map((row) => [...row]);
+  return solve(copy);
+}

--- a/apps/sudoku/hints.ts
+++ b/apps/sudoku/hints.ts
@@ -1,0 +1,65 @@
+import type { Board, Hint } from './types';
+
+function candidates(board: Board, row: number, col: number): number[] {
+  if (board[row][col] !== 0) return [];
+  const nums = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  for (let i = 0; i < 9; i += 1) {
+    nums.delete(board[row][i]);
+    nums.delete(board[i][col]);
+  }
+  const boxRow = Math.floor(row / 3) * 3;
+  const boxCol = Math.floor(col / 3) * 3;
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      nums.delete(board[boxRow + r][boxCol + c]);
+    }
+  }
+  return Array.from(nums);
+}
+
+function singleCandidate(board: Board): Hint | null {
+  for (let r = 0; r < 9; r += 1) {
+    for (let c = 0; c < 9; c += 1) {
+      const cand = candidates(board, r, c);
+      if (cand.length === 1) {
+        return { row: r, col: c, value: cand[0], type: 'single' };
+      }
+    }
+  }
+  return null;
+}
+
+function pointingPairs(board: Board): Hint | null {
+  for (let br = 0; br < 3; br += 1) {
+    for (let bc = 0; bc < 3; bc += 1) {
+      const startR = br * 3;
+      const startC = bc * 3;
+      for (let n = 1; n <= 9; n += 1) {
+        const cells: { r: number; c: number }[] = [];
+        for (let r = 0; r < 3; r += 1) {
+          for (let c = 0; c < 3; c += 1) {
+            const rr = startR + r;
+            const cc = startC + c;
+            if (board[rr][cc] === 0 && candidates(board, rr, cc).includes(n)) {
+              cells.push({ r: rr, c: cc });
+            }
+          }
+        }
+        if (cells.length === 2) {
+          const sameRow = cells[0].r === cells[1].r;
+          const sameCol = cells[0].c === cells[1].c;
+          if (sameRow || sameCol) {
+            return { row: cells[0].r, col: cells[0].c, value: n, type: 'pointing' };
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function getHint(board: Board): Hint | null {
+  return singleCandidate(board) || pointingPairs(board);
+}
+
+export { candidates };

--- a/apps/sudoku/index.tsx
+++ b/apps/sudoku/index.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import Board from './board';
+import type { Board as BoardType, UserStats } from './types';
+import { generatePuzzle, getSolution } from './generator';
+import { getHint } from './hints';
+
+const SudokuApp: React.FC = () => {
+  const [user, setUser] = useState<string | null>(null);
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [puzzle, setPuzzle] = useState<BoardType | null>(null);
+  const [solution, setSolution] = useState<BoardType | null>(null);
+  const [difficulty, setDifficulty] = useState<'easy' | 'medium' | 'hard'>('easy');
+
+  // load user
+  useEffect(() => {
+    const u = localStorage.getItem('sudoku_user');
+    if (u) {
+      setUser(u);
+      const s = localStorage.getItem(`sudoku_stats_${u}`);
+      if (s) setStats(JSON.parse(s));
+    } else {
+      const name = prompt('Enter username');
+      if (name) {
+        setUser(name);
+        localStorage.setItem('sudoku_user', name);
+      }
+    }
+  }, []);
+
+  const newPuzzle = () => {
+    const p = generatePuzzle(difficulty);
+    setPuzzle(p);
+    const sol = getSolution(p);
+    setSolution(sol);
+  };
+
+  useEffect(() => {
+    if (user && !puzzle) {
+      newPuzzle();
+    }
+  }, [user]);
+
+  const complete = () => {
+    if (!user) return;
+    const today = new Date().toISOString().slice(0, 10);
+    let newStats: UserStats;
+    if (stats) {
+      const last = stats.lastSolved;
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yStr = yesterday.toISOString().slice(0, 10);
+      const streak = last === yStr ? stats.streak + 1 : 1;
+      newStats = {
+        puzzlesSolved: stats.puzzlesSolved + 1,
+        streak,
+        lastSolved: today,
+        achievements: [...stats.achievements],
+      };
+      if (newStats.puzzlesSolved === 1) newStats.achievements.push('First Solve');
+      if (newStats.puzzlesSolved === 10 && !newStats.achievements.includes('Tenacious'))
+        newStats.achievements.push('Tenacious');
+    } else {
+      newStats = { puzzlesSolved: 1, streak: 1, lastSolved: today, achievements: ['First Solve'] };
+    }
+    setStats(newStats);
+    localStorage.setItem(`sudoku_stats_${user}`, JSON.stringify(newStats));
+    alert('Solved!');
+    newPuzzle();
+  };
+
+  const hint = () => {
+    if (!puzzle) return;
+    const h = getHint(puzzle);
+    if (h) {
+      const newPuzzle = puzzle.map((row) => [...row]);
+      newPuzzle[h.row][h.col] = h.value;
+      setPuzzle(newPuzzle);
+      alert(`Hint: fill ${h.value} at (${h.row + 1},${h.col + 1}) [${h.type}]`);
+    } else {
+      alert('No hints available');
+    }
+  };
+
+  if (!puzzle || !solution) return <div>Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 space-x-2">
+        <select value={difficulty} onChange={(e) => setDifficulty(e.target.value as any)}>
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+        <button
+          type="button"
+          className="px-2 py-1 bg-blue-600 text-white rounded"
+          onClick={newPuzzle}
+        >
+          New Puzzle
+        </button>
+        <button
+          type="button"
+          className="px-2 py-1 bg-green-600 text-white rounded"
+          onClick={hint}
+        >
+          Hint
+        </button>
+      </div>
+      <Board puzzle={puzzle} solution={solution} storageKey={`sudoku_${user}`} onComplete={complete} />
+      {stats && (
+        <div className="mt-4">
+          <p>Puzzles solved: {stats.puzzlesSolved}</p>
+          <p>Streak: {stats.streak}</p>
+          <p>Achievements: {stats.achievements.join(', ')}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SudokuApp;

--- a/apps/sudoku/solver.ts
+++ b/apps/sudoku/solver.ts
@@ -1,0 +1,54 @@
+import type { Board } from './types';
+
+function isValid(board: Board, row: number, col: number, val: number): boolean {
+  for (let i = 0; i < 9; i += 1) {
+    if (board[row][i] === val || board[i][col] === val) return false;
+  }
+  const boxRow = Math.floor(row / 3) * 3;
+  const boxCol = Math.floor(col / 3) * 3;
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      if (board[boxRow + r][boxCol + c] === val) return false;
+    }
+  }
+  return true;
+}
+
+export function solve(board: Board): Board | null {
+  for (let r = 0; r < 9; r += 1) {
+    for (let c = 0; c < 9; c += 1) {
+      if (board[r][c] === 0) {
+        for (let val = 1; val <= 9; val += 1) {
+          if (isValid(board, r, c, val)) {
+            board[r][c] = val;
+            const solved = solve(board);
+            if (solved) return solved;
+            board[r][c] = 0;
+          }
+        }
+        return null;
+      }
+    }
+  }
+  return board.map((row) => [...row]);
+}
+
+export function countSolutions(board: Board, limit = 2): number {
+  for (let r = 0; r < 9; r += 1) {
+    for (let c = 0; c < 9; c += 1) {
+      if (board[r][c] === 0) {
+        let count = 0;
+        for (let val = 1; val <= 9; val += 1) {
+          if (isValid(board, r, c, val)) {
+            board[r][c] = val;
+            count += countSolutions(board, limit);
+            board[r][c] = 0;
+            if (count >= limit) return count;
+          }
+        }
+        return count;
+      }
+    }
+  }
+  return 1;
+}

--- a/apps/sudoku/types.ts
+++ b/apps/sudoku/types.ts
@@ -1,0 +1,15 @@
+export type Board = number[][]; // 0 represents empty cell
+
+export interface Hint {
+  row: number;
+  col: number;
+  value: number;
+  type: 'single' | 'pointing';
+}
+
+export interface UserStats {
+  puzzlesSolved: number;
+  streak: number;
+  lastSolved: string; // ISO date string
+  achievements: string[];
+}

--- a/pages/apps/sudoku.tsx
+++ b/pages/apps/sudoku.tsx
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic';
+
+const SudokuApp = dynamic(() => import('../../apps/sudoku'), { ssr: false });
+
+export default SudokuApp;


### PR DESCRIPTION
## Summary
- add Sudoku puzzle generator ensuring unique solutions and variable difficulty
- implement constraint solver and hint engine with pencil marks support
- persist progress, user stats and achievements in new Sudoku app

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d549d2dc8328b5f327400bee284d