### PR TITLE
feat: add tower defense app with pathfinding

### DIFF
--- a/apps/tower-defense/engine.ts
+++ b/apps/tower-defense/engine.ts
@@ -1,0 +1,115 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface MapData {
+  width: number;
+  height: number;
+  start: Point;
+  goal: Point;
+  walls: Set<string>;
+}
+
+const key = (p: Point) => `${p.x},${p.y}`;
+
+interface Node extends Point {
+  g: number;
+  f: number;
+  parent: Node | null;
+}
+
+/**
+ * Run A* and return all optimal paths from start to goal.
+ */
+export function astarPaths(map: MapData): Point[][] {
+  const { width, height, start, goal, walls } = map;
+  const open: Node[] = [
+    { x: start.x, y: start.y, g: 0, f: Math.abs(start.x - goal.x) + Math.abs(start.y - goal.y), parent: null },
+  ];
+  const closed = new Map<string, number>();
+  let best = Infinity;
+  const paths: Point[][] = [];
+
+  while (open.length) {
+    open.sort((a, b) => a.f - b.f);
+    const current = open.shift()!;
+    if (current.f > best) break;
+    const cKey = key(current);
+    if (current.x === goal.x && current.y === goal.y) {
+      if (current.g <= best) {
+        best = current.g;
+        const path: Point[] = [];
+        let n: Node | null = current;
+        while (n) {
+          path.unshift({ x: n.x, y: n.y });
+          n = n.parent;
+        }
+        paths.push(path);
+      }
+      continue;
+    }
+    closed.set(cKey, current.g);
+    const dirs = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 },
+    ];
+    for (const d of dirs) {
+      const nx = current.x + d.x;
+      const ny = current.y + d.y;
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+      const nKey = `${nx},${ny}`;
+      if (walls.has(nKey)) continue;
+      const g = current.g + 1;
+      if (g > best) continue;
+      if (closed.has(nKey) && closed.get(nKey)! <= g) continue;
+      const h = Math.abs(nx - goal.x) + Math.abs(ny - goal.y);
+      const existing = open.find((n) => n.x === nx && n.y === ny);
+      if (existing) {
+        if (g < existing.g) {
+          existing.g = g;
+          existing.f = g + h;
+          existing.parent = current;
+        }
+      } else {
+        open.push({ x: nx, y: ny, g, f: g + h, parent: current });
+      }
+    }
+  }
+
+  return paths;
+}
+
+export interface Enemy {
+  id: number;
+  path: number;
+  index: number;
+  x: number;
+  y: number;
+}
+
+export const spawnWave = (count: number, paths: Point[][]): Enemy[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i,
+    path: i % Math.max(paths.length, 1),
+    index: 0,
+    x: paths[i % Math.max(paths.length, 1)][0].x,
+    y: paths[i % Math.max(paths.length, 1)][0].y,
+  }));
+
+export const stepEnemies = (enemies: Enemy[], paths: Point[][]): Enemy[] =>
+  enemies.map((e) => {
+    const path = paths[e.path];
+    const next = Math.min(e.index + 1, path.length - 1);
+    return { ...e, index: next, x: path[next].x, y: path[next].y };
+  });
+
+export const createEmptyMap = (size: number): MapData => ({
+  width: size,
+  height: size,
+  start: { x: 0, y: Math.floor(size / 2) },
+  goal: { x: size - 1, y: Math.floor(size / 2) },
+  walls: new Set(),
+});

--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef, useState } from 'react';
+import upgrades from './upgrades.json';
+import { createEmptyMap, MapData, Enemy } from './engine';
+import LevelEditor from './levelEditor';
+
+const SIZE = 10;
+
+const TowerDefense: React.FC = () => {
+  const [map, setMap] = useState<MapData>(() => createEmptyMap(SIZE));
+  const [enemies, setEnemies] = useState<Enemy[]>([]);
+  const workerRef = useRef<Worker>();
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./waveWorker.ts', import.meta.url), {
+      type: 'module',
+    });
+    const worker = workerRef.current;
+    worker.onmessage = (e) => {
+      if (e.data.type === 'state') setEnemies(e.data.enemies);
+    };
+    worker.postMessage({ type: 'init', map });
+    const id = setInterval(() => worker.postMessage({ type: 'tick' }), 500);
+    return () => {
+      clearInterval(id);
+      worker.terminate();
+    };
+  }, [map]);
+
+  return (
+    <div className="p-4 space-y-4 text-white">
+      <div className="grid grid-cols-10" style={{ lineHeight: 0 }}>
+        {Array.from({ length: map.height }).map((_, y) =>
+          Array.from({ length: map.width }).map((_, x) => {
+            const enemy = enemies.find((e) => e.x === x && e.y === y);
+            let bg = 'bg-green-700';
+            if (enemy) bg = 'bg-red-600';
+            else if (map.walls.has(`${x},${y}`)) bg = 'bg-gray-800';
+            else if (map.start.x === x && map.start.y === y) bg = 'bg-blue-500';
+            else if (map.goal.x === x && map.goal.y === y) bg = 'bg-yellow-500';
+            return <div key={`${x}-${y}`} className={`w-6 h-6 border border-gray-900 ${bg}`} />;
+          })
+        )}
+      </div>
+      <LevelEditor map={map} onChange={setMap} />
+      <pre className="text-xs">{JSON.stringify(upgrades, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default TowerDefense;

--- a/apps/tower-defense/levelEditor.tsx
+++ b/apps/tower-defense/levelEditor.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { MapData } from './engine';
+
+interface Props {
+  map: MapData;
+  onChange: (m: MapData) => void;
+}
+
+const LevelEditor: React.FC<Props> = ({ map, onChange }) => {
+  const toggle = (x: number, y: number) => {
+    const k = `${x},${y}`;
+    const walls = new Set(map.walls);
+    if (walls.has(k)) walls.delete(k);
+    else walls.add(k);
+    onChange({ ...map, walls });
+  };
+
+  const save = async () => {
+    await fetch('/api/tower-defense/maps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        width: map.width,
+        height: map.height,
+        start: map.start,
+        goal: map.goal,
+        walls: Array.from(map.walls),
+      }),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-10" style={{ lineHeight: 0 }}>
+        {Array.from({ length: map.height }).map((_, y) =>
+          Array.from({ length: map.width }).map((_, x) => {
+            let bg = 'bg-green-700';
+            if (map.walls.has(`${x},${y}`)) bg = 'bg-gray-800';
+            if (map.start.x === x && map.start.y === y) bg = 'bg-blue-500';
+            if (map.goal.x === x && map.goal.y === y) bg = 'bg-yellow-500';
+            return (
+              <div
+                key={`${x}-${y}`}
+                className={`w-6 h-6 border border-gray-900 ${bg}`}
+                onClick={() => toggle(x, y)}
+              />
+            );
+          })
+        )}
+      </div>
+      <button type="button" onClick={save} className="px-2 py-1 bg-gray-700">
+        Save
+      </button>
+    </div>
+  );
+};
+
+export default LevelEditor;

--- a/apps/tower-defense/upgrades.json
+++ b/apps/tower-defense/upgrades.json
@@ -1,0 +1,17 @@
+{
+  "single": [
+    { "damage": 1, "range": 2, "fireRate": 1 },
+    { "damage": 2, "range": 3, "fireRate": 0.8 },
+    { "damage": 3, "range": 3, "fireRate": 0.6 }
+  ],
+  "splash": [
+    { "damage": 1, "range": 2, "fireRate": 1, "splash": 1 },
+    { "damage": 2, "range": 3, "fireRate": 0.9, "splash": 1 },
+    { "damage": 3, "range": 3, "fireRate": 0.8, "splash": 2 }
+  ],
+  "slow": [
+    { "damage": 0, "range": 3, "fireRate": 1, "slow": { "amount": 0.5, "duration": 2 } },
+    { "damage": 0, "range": 3, "fireRate": 0.8, "slow": { "amount": 0.6, "duration": 2.5 } },
+    { "damage": 0, "range": 4, "fireRate": 0.6, "slow": { "amount": 0.7, "duration": 3 } }
+  ]
+}

--- a/apps/tower-defense/waveWorker.ts
+++ b/apps/tower-defense/waveWorker.ts
@@ -1,0 +1,25 @@
+import { astarPaths, spawnWave, stepEnemies, MapData, Enemy, Point } from './engine';
+
+let enemies: Enemy[] = [];
+let paths: Point[][] = [];
+
+self.onmessage = (e: MessageEvent) => {
+  const { type } = e.data;
+  switch (type) {
+    case 'init': {
+      const map: MapData = e.data.map;
+      const count: number = e.data.count || 5;
+      paths = astarPaths(map);
+      enemies = spawnWave(count, paths);
+      (self as any).postMessage({ type: 'state', enemies, paths });
+      break;
+    }
+    case 'tick': {
+      enemies = stepEnemies(enemies, paths);
+      (self as any).postMessage({ type: 'state', enemies });
+      break;
+    }
+    default:
+      break;
+  }
+};

--- a/pages/api/tower-defense/maps.ts
+++ b/pages/api/tower-defense/maps.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+const mapsDir = path.join(process.cwd(), 'public', 'tower-defense-maps');
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const data = req.body;
+    if (!fs.existsSync(mapsDir)) fs.mkdirSync(mapsDir, { recursive: true });
+    const file = path.join(mapsDir, `${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    res.status(200).json({ saved: true });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/apps/tower-defense.tsx
+++ b/pages/apps/tower-defense.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const TowerDefense = dynamic(() => import('../../apps/tower-defense'), { ssr: false });
+
+export default function TowerDefensePage() {
+  return <TowerDefense />;
+}


### PR DESCRIPTION
## Summary
- add Tower Defense app with grid map and enemy waves
- implement A* pathfinding supporting multiple paths
- store tower upgrade tree in JSON and load in game
- create level editor that saves maps via `/api/tower-defense/maps`
- run wave simulation inside a Web Worker for responsive UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d543f13483288c623f8def140048