### PR TITLE
feat: enhance Simon game with editor and backend API

### DIFF
--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -30,8 +30,57 @@ const Simon = () => {
   const [isPlayerTurn, setIsPlayerTurn] = useState(false);
   const [activePad, setActivePad] = useState(null);
   const [status, setStatus] = useState('Press Start');
-  const [mode, setMode] = useState('classic');
+  const [difficulty, setDifficulty] = useState('classic');
+  const [accessibility, setAccessibility] = useState('normal');
+  const [highScore, setHighScore] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [customPattern, setCustomPattern] = useState([]);
+  const [sharedPatterns, setSharedPatterns] = useState([]);
   const audioCtx = useRef(null);
+
+  useEffect(() => {
+    fetch('/api/simon/high-scores')
+      .then((res) => res.json())
+      .then((data) => setHighScore(data.highScore || 0))
+      .catch(() => {});
+  }, []);
+
+  const submitScore = async (score) => {
+    try {
+      const res = await fetch('/api/simon/high-scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score }),
+      });
+      const data = await res.json();
+      setHighScore(data.highScore || score);
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  const savePattern = async () => {
+    try {
+      await fetch('/api/simon/patterns', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pattern: customPattern }),
+      });
+      setCustomPattern([]);
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  const loadPatterns = async () => {
+    try {
+      const res = await fetch('/api/simon/patterns');
+      const data = await res.json();
+      setSharedPatterns(data.patterns || []);
+    } catch (e) {
+      setSharedPatterns([]);
+    }
+  };
 
   const scheduleTone = (freq, startTime) => {
     const ctx =
@@ -56,7 +105,7 @@ const Simon = () => {
   };
 
   const stepDuration = () => {
-    if (mode === 'speed') {
+    if (difficulty === 'speed') {
       return Math.max(0.6 - sequence.length * 0.02, 0.2);
     }
     return 0.6;
@@ -93,12 +142,29 @@ const Simon = () => {
   }, [sequence]);
 
   const startGame = () => {
-    setSequence([Math.floor(Math.random() * 4)]);
+    const initial = customPattern.length
+      ? [...customPattern]
+      : [Math.floor(Math.random() * 4)];
+    setSequence(initial);
     setStatus('Listen...');
+    setCustomPattern([]);
+    setEditing(false);
   };
 
   const handlePadClick = (idx) => {
+    if (editing) {
+      if (!audioCtx.current) {
+        audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      flashPad(idx);
+      scheduleTone(tones[idx], audioCtx.current.currentTime);
+      setCustomPattern((p) => [...p, idx]);
+      return;
+    }
     if (!isPlayerTurn) return;
+    if (!audioCtx.current) {
+      audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
+    }
     flashPad(idx);
     scheduleTone(tones[idx], audioCtx.current.currentTime);
     if (sequence[step] === idx) {
@@ -111,6 +177,7 @@ const Simon = () => {
         setStep(step + 1);
       }
     } else {
+      submitScore(sequence.length - 1);
       setStatus('Wrong! Press Start');
       setSequence([]);
       setIsPlayerTurn(false);
@@ -119,9 +186,12 @@ const Simon = () => {
   };
 
   const padClass = (pad, idx) => {
-    const colors = mode === 'colorblind'
+    let colors = accessibility === 'colorblind'
       ? { base: 'bg-gray-700', active: 'bg-gray-500' }
       : pad.color;
+    if (difficulty === 'inverted') {
+      colors = { base: colors.active, active: colors.base };
+    }
     return `h-32 w-32 rounded flex items-center justify-center text-3xl ${
       activePad === idx ? colors.active : colors.base
     }`;
@@ -137,19 +207,28 @@ const Simon = () => {
             className={padClass(pad, idx)}
             onPointerDown={() => handlePadClick(idx)}
           >
-            {mode === 'colorblind' ? pad.symbol : ''}
+            {accessibility === 'colorblind' ? pad.symbol : ''}
           </button>
         ))}
       </div>
-      <div className="mb-4">{status}</div>
-      <div className="flex gap-4">
+      <div className="mb-2">{status}</div>
+      <div className="mb-4 text-sm">High Score: {highScore}</div>
+      <div className="flex flex-wrap gap-4 justify-center">
         <select
           className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
-          value={mode}
-          onChange={(e) => setMode(e.target.value)}
+          value={difficulty}
+          onChange={(e) => setDifficulty(e.target.value)}
         >
           <option value="classic">Classic</option>
           <option value="speed">Speed Up</option>
+          <option value="inverted">Inverted</option>
+        </select>
+        <select
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          value={accessibility}
+          onChange={(e) => setAccessibility(e.target.value)}
+        >
+          <option value="normal">Normal</option>
           <option value="colorblind">Colorblind</option>
         </select>
         <button
@@ -158,7 +237,51 @@ const Simon = () => {
         >
           Start
         </button>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={() => {
+            setEditing((prev) => {
+              const next = !prev;
+              setStatus(next ? 'Editing Pattern' : 'Press Start');
+              return next;
+            });
+            setCustomPattern([]);
+          }}
+        >
+          {editing ? 'Close Editor' : 'Pattern Editor'}
+        </button>
       </div>
+      {editing && (
+        <div className="flex flex-col items-center w-full mt-4">
+          <div className="mb-2">Pattern: {customPattern.join('-')}</div>
+          <div className="flex gap-2 mb-2 flex-wrap justify-center">
+            <button
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={savePattern}
+            >
+              Share Pattern
+            </button>
+            <button
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={loadPatterns}
+            >
+              Load Shared
+            </button>
+            <button
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={() => setCustomPattern([])}
+            >
+              Clear
+            </button>
+          </div>
+          <ul className="text-sm max-h-24 overflow-y-auto w-full">
+            {sharedPatterns.map((p, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={i}>{p.join('-')}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/pages/api/simon/high-scores.ts
+++ b/pages/api/simon/high-scores.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+let highScore = 0;
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    res.status(200).json({ highScore });
+    return;
+  }
+  if (req.method === 'POST') {
+    const { score } = req.body || {};
+    if (typeof score === 'number' && score > highScore) {
+      highScore = score;
+    }
+    res.status(200).json({ highScore });
+    return;
+  }
+  res.status(405).end();
+}

--- a/pages/api/simon/patterns.ts
+++ b/pages/api/simon/patterns.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const patterns: number[][] = [];
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    res.status(200).json({ patterns });
+    return;
+  }
+  if (req.method === 'POST') {
+    const { pattern } = req.body || {};
+    if (
+      Array.isArray(pattern) &&
+      pattern.every((n) => typeof n === 'number' && n >= 0 && n < 4)
+    ) {
+      patterns.push(pattern);
+    }
+    res.status(200).json({ patterns });
+    return;
+  }
+  res.status(405).end();
+}


### PR DESCRIPTION
## Summary
- add pattern editor with shareable sequences and high score storage
- expand Simon with inverted difficulty and colorblind accessibility options
- expose simple API routes for saving scores and shared patterns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d53ae0008328b59e118b6ed6fa5b