### PR TITLE
Add Reversi app with AI and tournament API

### DIFF
--- a/apps/reversi/engine.ts
+++ b/apps/reversi/engine.ts
@@ -1,0 +1,165 @@
+export interface Board {
+  black: bigint;
+  white: bigint;
+}
+
+export const enum Player {
+  Black = 1,
+  White = -1,
+}
+
+const FULL = 0xffffffffffffffffn;
+
+const DIRS: Array<[number, number]> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
+
+export const initialBoard = (): Board => ({
+  black: (1n << 28n) | (1n << 35n),
+  white: (1n << 27n) | (1n << 36n),
+});
+
+const bit = (index: number) => 1n << BigInt(index);
+
+const inBounds = (x: number, y: number) => x >= 0 && x < 8 && y >= 0 && y < 8;
+
+export const countBits = (bb: bigint): number => {
+  let c = 0;
+  let b = bb & FULL;
+  while (b) {
+    b &= b - 1n;
+    c++;
+  }
+  return c;
+};
+
+export const getMoves = (player: bigint, opponent: bigint): bigint => {
+  const empty = ~(player | opponent) & FULL;
+  let moves = 0n;
+  for (let i = 0; i < 64; i += 1) {
+    const m = bit(i);
+    if ((empty & m) === 0n) continue;
+    const x = i % 8;
+    const y = Math.floor(i / 8);
+    for (const [dx, dy] of DIRS) {
+      let cx = x + dx;
+      let cy = y + dy;
+      let seen = false;
+      while (inBounds(cx, cy)) {
+        const b = bit(cy * 8 + cx);
+        if ((opponent & b) !== 0n) {
+          seen = true;
+          cx += dx;
+          cy += dy;
+          continue;
+        }
+        if (seen && (player & b) !== 0n) {
+          moves |= m;
+        }
+        break;
+      }
+      if ((moves & m) !== 0n) break;
+    }
+  }
+  return moves;
+};
+
+export const makeMove = (
+  player: bigint,
+  opponent: bigint,
+  move: bigint
+): { player: bigint; opponent: bigint } => {
+  const idx = (() => {
+    for (let i = 0; i < 64; i += 1) {
+      if (move === bit(i)) return i;
+    }
+    return 0;
+  })();
+  const x = idx % 8;
+  const y = Math.floor(idx / 8);
+  let flips = 0n;
+  for (const [dx, dy] of DIRS) {
+    let cx = x + dx;
+    let cy = y + dy;
+    let path = 0n;
+    while (inBounds(cx, cy)) {
+      const b = bit(cy * 8 + cx);
+      if ((opponent & b) !== 0n) {
+        path |= b;
+        cx += dx;
+        cy += dy;
+        continue;
+      }
+      if ((player & b) !== 0n) {
+        flips |= path;
+      }
+      break;
+    }
+  }
+  const newPlayer = player | move | flips;
+  const newOpponent = opponent & ~flips;
+  return { player: newPlayer, opponent: newOpponent };
+};
+
+const mobility = (player: bigint, opponent: bigint) =>
+  countBits(getMoves(player, opponent)) - countBits(getMoves(opponent, player));
+
+const stability = (player: bigint, opponent: bigint) => {
+  const corners = [0, 7, 56, 63].map(bit);
+  let score = 0;
+  corners.forEach((c) => {
+    if (player & c) score += 1;
+    else if (opponent & c) score -= 1;
+  });
+  return score;
+};
+
+const parity = (player: bigint, opponent: bigint) => {
+  const empty = 64 - countBits(player | opponent);
+  return empty % 2 === 0 ? 1 : -1;
+};
+
+const evaluate = (player: bigint, opponent: bigint) =>
+  10 * mobility(player, opponent) + 5 * stability(player, opponent) + parity(player, opponent);
+
+export const negamax = (
+  player: bigint,
+  opponent: bigint,
+  depth: number,
+  alpha = -Infinity,
+  beta = Infinity
+): { score: number; move: bigint } => {
+  const moves = getMoves(player, opponent);
+  if (depth === 0 || moves === 0n) {
+    const score = evaluate(player, opponent);
+    return { score, move: 0n };
+  }
+  let bestMove = 0n;
+  let bestScore = -Infinity;
+  let m = moves;
+  while (m) {
+    const move = m & -m;
+    const { player: newPlayer, opponent: newOpponent } = makeMove(
+      player,
+      opponent,
+      move
+    );
+    const { score } = negamax(newOpponent, newPlayer, depth - 1, -beta, -alpha);
+    const val = -score;
+    if (val > bestScore) {
+      bestScore = val;
+      bestMove = move;
+    }
+    alpha = Math.max(alpha, val);
+    if (alpha >= beta) break;
+    m ^= move;
+  }
+  return { score: bestScore, move: bestMove };
+};

--- a/apps/reversi/index.tsx
+++ b/apps/reversi/index.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {
+  initialBoard,
+  getMoves,
+  makeMove,
+  negamax,
+  Player,
+  countBits,
+} from './engine';
+
+const Reversi: React.FC = () => {
+  const [board, setBoard] = useState(initialBoard());
+  const [turn, setTurn] = useState<Player>(Player.Black);
+  const [hint, setHint] = useState<bigint | null>(null);
+
+  const playerBits = turn === Player.Black ? board.black : board.white;
+  const oppBits = turn === Player.Black ? board.white : board.black;
+  const moves = getMoves(playerBits, oppBits);
+
+  const handleClick = (idx: number) => {
+    const m = 1n << BigInt(idx);
+    if ((moves & m) === 0n) return;
+    const { player, opponent } = makeMove(playerBits, oppBits, m);
+    if (turn === Player.Black) {
+      setBoard({ black: player, white: opponent });
+    } else {
+      setBoard({ black: opponent, white: player });
+    }
+    setTurn(turn === Player.Black ? Player.White : Player.Black);
+    setHint(null);
+  };
+
+  const showHint = () => {
+    const { move } = negamax(playerBits, oppBits, 3);
+    setHint(move === 0n ? null : move);
+  };
+
+  const renderSquare = (idx: number) => {
+    const b = 1n << BigInt(idx);
+    const hasBlack = (board.black & b) !== 0n;
+    const hasWhite = (board.white & b) !== 0n;
+    const isHint = hint === b;
+    const isMove = (moves & b) !== 0n;
+    return (
+      <div
+        key={idx}
+        onClick={() => handleClick(idx)}
+        className={`w-10 h-10 flex items-center justify-center bg-green-700 border border-green-800 ${
+          isHint ? 'ring-4 ring-yellow-400' : ''
+        }`}
+      >
+        {hasBlack && <div className="w-8 h-8 rounded-full bg-black" />}
+        {hasWhite && <div className="w-8 h-8 rounded-full bg-white" />}
+        {!hasBlack && !hasWhite && isMove && (
+          <div className="w-3 h-3 rounded-full bg-blue-300 opacity-60" />
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-2 select-none">
+      <div className="flex space-x-4 items-center">
+        <div>Black: {countBits(board.black)}</div>
+        <div>White: {countBits(board.white)}</div>
+        <div>Turn: {turn === Player.Black ? 'Black' : 'White'}</div>
+        <button
+          type="button"
+          onClick={showHint}
+          className="px-2 py-1 bg-gray-300 rounded"
+        >
+          Hint
+        </button>
+      </div>
+      <div className="grid grid-cols-8 w-max" style={{ lineHeight: 0 }}>
+        {Array.from({ length: 64 }, (_, i) => renderSquare(i))}
+      </div>
+    </div>
+  );
+};
+
+export default Reversi;

--- a/data/reversi.json
+++ b/data/reversi.json
@@ -1,0 +1,5 @@
+{
+  "ratings": {},
+  "matches": [],
+  "tournaments": []
+}

--- a/lib/reversi-db.ts
+++ b/lib/reversi-db.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ReversiDB {
+  ratings: Record<string, number>;
+  matches: Array<{ white: string; black: string; winner: string; time: number }>;
+  tournaments: Array<{ id: number; players: string[]; bracket: string[][] }>;
+}
+
+const file = path.join(process.cwd(), 'data', 'reversi.json');
+
+export function readDB(): ReversiDB {
+  try {
+    const data = fs.readFileSync(file, 'utf-8');
+    return JSON.parse(data) as ReversiDB;
+  } catch (e) {
+    return { ratings: {}, matches: [], tournaments: [] };
+  }
+}
+
+export function writeDB(db: ReversiDB) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(db, null, 2));
+}

--- a/pages/api/reversi/match.ts
+++ b/pages/api/reversi/match.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { readDB, writeDB } from '../../../lib/reversi-db';
+
+const K = 32;
+
+function expected(a: number, b: number) {
+  return 1 / (1 + 10 ** ((b - a) / 400));
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = readDB();
+  if (req.method === 'GET') {
+    res.status(200).json({ matches: db.matches, ratings: db.ratings });
+    return;
+  }
+  if (req.method === 'POST') {
+    const { white, black, winner } = req.body as { white: string; black: string; winner: string };
+    if (!white || !black || !winner) {
+      res.status(400).json({ error: 'missing fields' });
+      return;
+    }
+    const rw = db.ratings[white] ?? 1200;
+    const rb = db.ratings[black] ?? 1200;
+    const ew = expected(rw, rb);
+    const eb = expected(rb, rw);
+    const sw = winner === white ? 1 : 0;
+    const sb = winner === black ? 1 : 0;
+    db.ratings[white] = Math.round(rw + K * (sw - ew));
+    db.ratings[black] = Math.round(rb + K * (sb - eb));
+    db.matches.push({ white, black, winner, time: Date.now() });
+    writeDB(db);
+    res.status(200).json({ ratings: db.ratings });
+    return;
+  }
+  res.status(405).end();
+}

--- a/pages/api/reversi/tournament.ts
+++ b/pages/api/reversi/tournament.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { readDB, writeDB } from '../../../lib/reversi-db';
+
+function pairings(players: string[]): string[][] {
+  const shuffled = [...players].sort(() => Math.random() - 0.5);
+  const pairs: string[][] = [];
+  for (let i = 0; i < shuffled.length; i += 2) {
+    pairs.push([shuffled[i], shuffled[i + 1] ?? null]);
+  }
+  return pairs;
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = readDB();
+  if (req.method === 'GET') {
+    res.status(200).json({ tournaments: db.tournaments });
+    return;
+  }
+  if (req.method === 'POST') {
+    const { players } = req.body as { players: string[] };
+    if (!players || !Array.isArray(players) || players.length === 0) {
+      res.status(400).json({ error: 'players required' });
+      return;
+    }
+    const id = Date.now();
+    const bracket = pairings(players);
+    db.tournaments.push({ id, players, bracket });
+    writeDB(db);
+    res.status(200).json({ id, bracket });
+    return;
+  }
+  res.status(405).end();
+}

--- a/pages/apps/reversi.tsx
+++ b/pages/apps/reversi.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const Reversi = dynamic(() => import('../../apps/reversi'), { ssr: false });
+
+export default function ReversiPage() {
+  return <Reversi />;
+}


### PR DESCRIPTION
## Summary
- add Reversi game with bitboard engine, minimax AI and hint overlay
- expose REST APIs for tournaments and ratings with file persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d538b1d0832881a2e1f1dce02713