### PR TITLE
feat: open about page on startup

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -41,6 +41,10 @@ export class Desktop extends Component {
         this.setContextListeners();
         this.setEventListeners();
         this.checkForNewFolders();
+
+        setTimeout(() => {
+            this.openApp("about-alex");
+        }, 500);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
## Summary
- automatically open About Alex after desktop init so visitors see Alex Unnippillil info first

## Testing
- `npm test` *(fails: Invalid package.json)*
- `yarn test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4d122c48328821f7a49da0ce7ed