### PR TITLE
feat(theme): add theme helpers and env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Games are organized in `apps.config.js` using a `games` array that mirrors the s
 
 To introduce a new game:
 
-1. **Icon** – Add the game's icon to `public/themes/Yaru/apps/` and reference it with a relative path like `./themes/Yaru/apps/my-game.png`.
+1. **Icon** – Add the game's icon to `public/themes/Yaru/apps/` and reference it with the helper `icon('my-game.png')`.
 2. **Dynamic import** – Create the game component in `components/apps/` and load it with `next/dynamic` to keep the initial bundle small:
 
     ```js
@@ -62,12 +62,19 @@ To introduce a new game:
     games.push({
       id: 'my-game',
       title: 'My Game',
-      icon: './themes/Yaru/apps/my-game.png',
+      icon: icon('my-game.png'),
       screen: displayMyGame,
     });
     ```
 
 The new game will then appear alongside the other games on the desktop.
+
+## Theme Selection
+
+Icon themes can be changed at runtime by setting the `NEXT_PUBLIC_THEME`
+environment variable. It should correspond to a directory inside
+`public/themes/`. When unspecified, the application defaults to the
+`Yaru` theme.
 
 ## Privacy
 

--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,10 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 
+export const THEME = process.env.NEXT_PUBLIC_THEME || 'Yaru';
+export const icon = (name) => `./themes/${THEME}/apps/${name}`;
+export const sys = (name) => `./themes/${THEME}/system/${name}`;
+
 const createDynamicApp = (path, name) =>
   dynamic(
     () =>
@@ -134,7 +138,7 @@ const gameList = [
   {
     id: '2048',
     title: '2048',
-    icon: './themes/Yaru/apps/2048.svg',
+    icon: icon('2048.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -145,7 +149,7 @@ const gameList = [
   {
     id: 'asteroids',
     title: 'Asteroids',
-    icon: './themes/Yaru/apps/asteroids.svg',
+    icon: icon('asteroids.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -154,7 +158,7 @@ const gameList = [
   {
     id: 'battleship',
     title: 'Battleship',
-    icon: './themes/Yaru/apps/battleship.svg',
+    icon: icon('battleship.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -163,7 +167,7 @@ const gameList = [
   {
     id: 'blackjack',
     title: 'Blackjack',
-    icon: './themes/Yaru/apps/blackjack.svg',
+    icon: icon('blackjack.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -172,7 +176,7 @@ const gameList = [
   {
     id: 'breakout',
     title: 'Breakout',
-    icon: './themes/Yaru/apps/breakout.svg',
+    icon: icon('breakout.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -181,7 +185,7 @@ const gameList = [
   {
     id: 'car-racer',
     title: 'Car Racer',
-    icon: './themes/Yaru/apps/car-racer.svg',
+    icon: icon('car-racer.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -190,7 +194,7 @@ const gameList = [
   {
     id: 'checkers',
     title: 'Checkers',
-    icon: './themes/Yaru/apps/checkers.svg',
+    icon: icon('checkers.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -199,7 +203,7 @@ const gameList = [
   {
     id: 'chess',
     title: 'Chess',
-    icon: './themes/Yaru/apps/chess.svg',
+    icon: icon('chess.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -208,7 +212,7 @@ const gameList = [
   {
     id: 'connect-four',
     title: 'Connect Four',
-    icon: './themes/Yaru/apps/connect-four.svg',
+    icon: icon('connect-four.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -217,7 +221,7 @@ const gameList = [
   {
     id: 'frogger',
     title: 'Frogger',
-    icon: './themes/Yaru/apps/frogger.svg',
+    icon: icon('frogger.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -226,7 +230,7 @@ const gameList = [
   {
     id: 'hangman',
     title: 'Hangman',
-    icon: './themes/Yaru/apps/hangman.svg',
+    icon: icon('hangman.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -235,7 +239,7 @@ const gameList = [
   {
     id: 'memory',
     title: 'Memory',
-    icon: './themes/Yaru/apps/memory.svg',
+    icon: icon('memory.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -244,7 +248,7 @@ const gameList = [
   {
     id: 'minesweeper',
     title: 'Minesweeper',
-    icon: './themes/Yaru/apps/minesweeper.svg',
+    icon: icon('minesweeper.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -253,7 +257,7 @@ const gameList = [
   {
     id: 'pacman',
     title: 'Pacman',
-    icon: './themes/Yaru/apps/pacman.svg',
+    icon: icon('pacman.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -262,7 +266,7 @@ const gameList = [
   {
     id: 'platformer',
     title: 'Platformer',
-    icon: './themes/Yaru/apps/platformer.svg',
+    icon: icon('platformer.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -271,7 +275,7 @@ const gameList = [
   {
     id: 'pong',
     title: 'Pong',
-    icon: './themes/Yaru/apps/pong.svg',
+    icon: icon('pong.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -280,7 +284,7 @@ const gameList = [
   {
     id: 'reversi',
     title: 'Reversi',
-    icon: './themes/Yaru/apps/reversi.svg',
+    icon: icon('reversi.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -289,7 +293,7 @@ const gameList = [
   {
     id: 'simon',
     title: 'Simon',
-    icon: './themes/Yaru/apps/simon.svg',
+    icon: icon('simon.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -298,7 +302,7 @@ const gameList = [
   {
     id: 'snake',
     title: 'Snake',
-    icon: './themes/Yaru/apps/snake.svg',
+    icon: icon('snake.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -307,7 +311,7 @@ const gameList = [
   {
     id: 'sokoban',
     title: 'Sokoban',
-    icon: './themes/Yaru/apps/sokoban.svg',
+    icon: icon('sokoban.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -316,7 +320,7 @@ const gameList = [
   {
     id: 'solitaire',
     title: 'Solitaire',
-    icon: './themes/Yaru/apps/solitaire.svg',
+    icon: icon('solitaire.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -325,7 +329,7 @@ const gameList = [
   {
     id: 'tictactoe',
     title: 'Tic Tac Toe',
-    icon: './themes/Yaru/apps/tictactoe.svg',
+    icon: icon('tictactoe.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -334,7 +338,7 @@ const gameList = [
   {
     id: 'tetris',
     title: 'Tetris',
-    icon: './themes/Yaru/apps/tetris.svg',
+    icon: icon('tetris.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -343,7 +347,7 @@ const gameList = [
   {
     id: 'tower-defense',
     title: 'Tower Defense',
-    icon: './themes/Yaru/apps/tower-defense.svg',
+    icon: icon('tower-defense.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -352,7 +356,7 @@ const gameList = [
   {
     id: 'word-search',
     title: 'Word Search',
-    icon: './themes/Yaru/apps/word-search.svg',
+    icon: icon('word-search.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -361,7 +365,7 @@ const gameList = [
   {
     id: 'wordle',
     title: 'Wordle',
-    icon: './themes/Yaru/apps/wordle.svg',
+    icon: icon('wordle.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -370,7 +374,7 @@ const gameList = [
   {
     id: 'nonogram',
     title: 'Nonogram',
-    icon: './themes/Yaru/apps/nonogram.svg',
+    icon: icon('nonogram.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -379,7 +383,7 @@ const gameList = [
   {
     id: 'space-invaders',
     title: 'Space Invaders',
-    icon: './themes/Yaru/apps/space-invaders.svg',
+    icon: icon('space-invaders.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -388,7 +392,7 @@ const gameList = [
   {
     id: 'sudoku',
     title: 'Sudoku',
-    icon: './themes/Yaru/apps/sudoku.svg',
+    icon: icon('sudoku.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -397,7 +401,7 @@ const gameList = [
   {
     id: 'flappy-bird',
     title: 'Flappy Bird',
-    icon: './themes/Yaru/apps/flappy-bird.svg',
+    icon: icon('flappy-bird.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -406,7 +410,7 @@ const gameList = [
   {
     id: 'candy-crush',
     title: 'Candy Crush',
-    icon: './themes/Yaru/apps/candy-crush.svg',
+    icon: icon('candy-crush.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -415,7 +419,7 @@ const gameList = [
   {
     id: 'gomoku',
     title: 'Gomoku',
-    icon: './themes/Yaru/apps/gomoku.svg',
+    icon: icon('gomoku.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -424,7 +428,7 @@ const gameList = [
   {
     id: 'pinball',
     title: 'Pinball',
-    icon: './themes/Yaru/apps/pinball.svg',
+    icon: icon('pinball.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -438,7 +442,7 @@ const apps = [
   {
     id: 'chrome',
     title: 'Firefox',
-    icon: './themes/Yaru/apps/kali-browser.svg',
+    icon: icon('kali-browser.svg'),
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -447,7 +451,7 @@ const apps = [
   {
     id: 'calc',
     title: 'Calc',
-    icon: './themes/Yaru/apps/calc.png',
+    icon: icon('calc.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -460,7 +464,7 @@ const apps = [
   {
     id: 'terminal',
     title: 'Terminal',
-    icon: './themes/Yaru/apps/bash.png',
+    icon: icon('bash.png'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -469,7 +473,7 @@ const apps = [
   {
     id: 'vscode',
     title: 'Visual Studio Code',
-    icon: './themes/Yaru/apps/vscode.png',
+    icon: icon('vscode.png'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -478,7 +482,7 @@ const apps = [
   {
     id: 'x',
     title: 'X',
-    icon: './themes/Yaru/apps/x.png',
+    icon: icon('x.png'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -487,7 +491,7 @@ const apps = [
   {
     id: 'spotify',
     title: 'Spotify',
-    icon: './themes/Yaru/apps/spotify.svg',
+    icon: icon('spotify.svg'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -496,7 +500,7 @@ const apps = [
   {
     id: 'youtube',
     title: 'YouTube',
-    icon: './themes/Yaru/apps/youtube.svg',
+    icon: icon('youtube.svg'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -505,7 +509,7 @@ const apps = [
   {
     id: 'about-alex',
     title: 'About Alex',
-    icon: './themes/Yaru/system/user-home.png',
+    icon: sys('user-home.png'),
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -514,7 +518,7 @@ const apps = [
   {
     id: 'settings',
     title: 'Settings',
-    icon: './themes/Yaru/apps/gnome-control-center.png',
+    icon: icon('gnome-control-center.png'),
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -523,7 +527,7 @@ const apps = [
   {
     id: 'resource-monitor',
     title: 'Resource Monitor',
-    icon: './themes/Yaru/apps/resource-monitor.svg',
+    icon: icon('resource-monitor.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -532,7 +536,7 @@ const apps = [
   {
     id: 'project-gallery',
     title: 'Project Gallery',
-    icon: './themes/Yaru/apps/project-gallery.svg',
+    icon: icon('project-gallery.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -541,7 +545,7 @@ const apps = [
   {
     id: 'todoist',
     title: 'Todoist',
-    icon: './themes/Yaru/apps/todoist.png',
+    icon: icon('todoist.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -550,7 +554,7 @@ const apps = [
   {
     id: 'trash',
     title: 'Trash',
-    icon: './themes/Yaru/system/user-trash-full.png',
+    icon: sys('user-trash-full.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
@@ -559,7 +563,7 @@ const apps = [
   {
     id: 'gedit',
     title: 'Contact Me',
-    icon: './themes/Yaru/apps/gedit.png',
+    icon: icon('gedit.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
@@ -568,7 +572,7 @@ const apps = [
   {
     id: 'converter',
     title: 'Converter',
-    icon: './themes/Yaru/apps/calc.png',
+    icon: icon('calc.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -577,7 +581,7 @@ const apps = [
   {
     id: 'qr-tool',
     title: 'QR Tool',
-    icon: './themes/Yaru/apps/qr.svg',
+    icon: icon('qr.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -586,7 +590,7 @@ const apps = [
   {
     id: 'ascii-art',
     title: 'ASCII Art',
-    icon: './themes/Yaru/apps/gedit.png',
+    icon: icon('gedit.png'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -595,7 +599,7 @@ const apps = [
   {
     id: 'quote-generator',
     title: 'Quote Generator',
-    icon: './themes/Yaru/apps/quote.svg',
+    icon: icon('quote.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -604,7 +608,7 @@ const apps = [
   {
     id: 'weather',
     title: 'Weather',
-    icon: './themes/Yaru/apps/weather.svg',
+    icon: icon('weather.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import BackgroundImage from '../util-components/background-image';
 import SideBar from './side_bar';
-import apps, { games } from '../../apps.config';
+import apps, { games, sys } from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
@@ -62,7 +62,7 @@ export class Desktop extends Component {
                 apps.push({
                     id: `new-folder-${folder.id}`,
                     title: folder.name,
-                    icon: './themes/Yaru/system/folder.png',
+                    icon: sys('folder.png'),
                     disabled: true,
                     favourite: false,
                     desktop_shortcut: true,
@@ -465,7 +465,7 @@ export class Desktop extends Component {
         apps.push({
             id: `new-folder-${folder_id}`,
             title: folder_name,
-            icon: './themes/Yaru/system/folder.png',
+            icon: sys('folder.png'),
             disabled: true,
             favourite: false,
             desktop_shortcut: true,


### PR DESCRIPTION
## Summary
- add theme constant and icon/sys helpers
- allow theme selection via NEXT_PUBLIC_THEME
- replace hardcoded Yaru paths with helper calls
- update docs for new helpers and env var

## Testing
- `npm test` *(fails: jest: not found)*
- `npx --yes jest` *(fails: Cannot find module 'next/jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef29e5c083288ec4213b3c5f9384