### PR TITLE
Improve accessibility for desktop icons

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -17,10 +17,11 @@ export class UbuntuApp extends Component {
     render() {
         return (
             <div
-                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
+                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 focus:ring-2 focus:ring-yellow-500 focus:ring-offset-1 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 tabIndex={0}
+                aria-label={`Open ${this.props.name}`}
             >
                 <Image
                     width={40}

--- a/styles/index.css
+++ b/styles/index.css
@@ -266,3 +266,10 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .reveal {
     animation: reveal 0.3s ease-out;
 }
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
## Summary
- add aria-labels and visible keyboard focus styles to desktop icons
- respect prefers-reduced-motion by disabling animations and transitions

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef2ab5488328b8e48f5643b9d10c