### PR TITLE
feat: add DNS lookup toolkit

### DIFF
--- a/apps/dns-toolkit/index.tsx
+++ b/apps/dns-toolkit/index.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+
+const RECORD_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'NS'];
+
+const DnsToolkit: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [type, setType] = useState('A');
+  const [results, setResults] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const lookup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setResults([]);
+    if (!domain) {
+      setError('Domain is required');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/dns?domain=${encodeURIComponent(domain)}&type=${type}`
+      );
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || 'Request failed');
+      }
+      const data = await res.json();
+      if (data.error) setError(data.error);
+      else if (data.Answer) setResults(data.Answer);
+      else setError('No records found');
+    } catch (err: any) {
+      setError(err.message || 'Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="text-yellow-400 text-sm">Only test domains you own</div>
+      <form onSubmit={lookup} className="flex space-x-2 items-center">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="text-black px-2 py-1 flex-1"
+        />
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="text-black px-2 py-1"
+        >
+          {RECORD_TYPES.map((rt) => (
+            <option key={rt} value={rt}>
+              {rt}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          {loading ? '...' : 'Lookup'}
+        </button>
+      </form>
+      {error && <div className="text-red-500">{error}</div>}
+      {results.length > 0 && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">Name</th>
+              <th className="text-left">Type</th>
+              <th className="text-left">TTL</th>
+              <th className="text-left">Data</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r, i) => (
+              <tr key={i}>
+                <td>{r.name}</td>
+                <td>{r.type}</td>
+                <td>{r.TTL}</td>
+                <td>{r.data}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default DnsToolkit;
+

--- a/pages/api/dns.ts
+++ b/pages/api/dns.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'NS'];
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { domain, type } = req.query;
+
+  if (!domain || typeof domain !== 'string') {
+    return res.status(400).json({ error: 'Missing domain' });
+  }
+
+  const recordType =
+    typeof type === 'string' ? type.toUpperCase() : 'A';
+
+  if (!ALLOWED_TYPES.includes(recordType)) {
+    return res.status(400).json({ error: 'Invalid record type' });
+  }
+
+  try {
+    const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(
+      domain
+    )}&type=${recordType}`;
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: 'Upstream server error' });
+    }
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (e: any) {
+    return res.status(500).json({ error: e.message || 'Request failed' });
+  }
+}
+

--- a/pages/apps/dns-toolkit.tsx
+++ b/pages/apps/dns-toolkit.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const DnsToolkit = dynamic(() => import('../../apps/dns-toolkit'), {
+  ssr: false,
+});
+
+export default function DnsToolkitPage() {
+  return <DnsToolkit />;
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to perform DNS over HTTPS lookups for common record types
- introduce DNS Toolkit app with domain and record-type form and results table
- provide page wrapper to load DNS Toolkit

## Testing
- `CI=true yarn test` (all reported test suites passed, command had to be interrupted due to open handles)
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8f0f983f88328a2656e0346570eb5