### PR TITLE
feat: add header analyzer app

### DIFF
--- a/apps/header-analyzer/index.tsx
+++ b/apps/header-analyzer/index.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+
+interface HeaderReport {
+  header: string;
+  value: string | null;
+  grade: string;
+  message: string;
+}
+
+interface ApiResponse {
+  url: string;
+  overallGrade: string;
+  results: HeaderReport[];
+}
+
+const HeaderAnalyzer: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [report, setReport] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const analyze = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError('');
+    setReport(null);
+    try {
+      const res = await fetch(`/api/headers?url=${encodeURIComponent(url)}`);
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+      const data = (await res.json()) as ApiResponse;
+      setReport(data);
+    } catch (err) {
+      setError('Could not fetch headers.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+          className="flex-1 px-2 py-1 text-black"
+        />
+        <button
+          type="button"
+          onClick={analyze}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Analyze
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {report && (
+        <div className="overflow-auto">
+          <div className="mb-2 font-bold">Overall Grade: {report.overallGrade}</div>
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr>
+                <th className="border px-2 py-1">Header</th>
+                <th className="border px-2 py-1">Value</th>
+                <th className="border px-2 py-1">Grade</th>
+                <th className="border px-2 py-1">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.results.map((r) => (
+                <tr key={r.header}>
+                  <td className="border px-2 py-1">{r.header}</td>
+                  <td className="border px-2 py-1 break-all">{r.value || '—'}</td>
+                  <td className="border px-2 py-1">{r.grade}</td>
+                  <td className="border px-2 py-1">{r.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HeaderAnalyzer;

--- a/pages/api/headers.ts
+++ b/pages/api/headers.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface HeaderReport {
+  header: string;
+  value: string | null;
+  grade: string;
+  message: string;
+}
+
+interface ApiResponse {
+  url: string;
+  overallGrade: string;
+  results: HeaderReport[];
+}
+
+const checks = [
+  {
+    key: 'content-security-policy',
+    name: 'Content-Security-Policy',
+    validate: (val: string | null) => !!val,
+    remediation: 'Add a strong Content-Security-Policy header to mitigate XSS attacks.',
+  },
+  {
+    key: 'strict-transport-security',
+    name: 'Strict-Transport-Security',
+    validate: (val: string | null) => !!val && /max-age/i.test(val),
+    remediation: 'Serve Strict-Transport-Security with an appropriate max-age to enforce HTTPS.',
+  },
+  {
+    key: 'x-frame-options',
+    name: 'X-Frame-Options',
+    validate: (val: string | null) => !!val && ['deny', 'sameorigin'].includes(val.toLowerCase()),
+    remediation: 'Set X-Frame-Options to SAMEORIGIN or DENY to protect against clickjacking.',
+  },
+  {
+    key: 'x-content-type-options',
+    name: 'X-Content-Type-Options',
+    validate: (val: string | null) => val?.toLowerCase() === 'nosniff',
+    remediation: 'Set X-Content-Type-Options to nosniff to prevent MIME sniffing.',
+  },
+  {
+    key: 'referrer-policy',
+    name: 'Referrer-Policy',
+    validate: (val: string | null) => !!val,
+    remediation: 'Set an explicit Referrer-Policy header to control referrer information.',
+  },
+];
+
+function gradeFromRatio(ratio: number): string {
+  if (ratio === 1) return 'A';
+  if (ratio >= 0.8) return 'B';
+  if (ratio >= 0.6) return 'C';
+  return 'F';
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse | { error: string }>
+) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  let target = url;
+  if (!/^https?:\/\//i.test(target)) {
+    target = `https://${target}`;
+  }
+
+  try {
+    const response = await fetch(target, { method: 'GET' });
+    const headersObj = Object.fromEntries(response.headers.entries());
+
+    const results: HeaderReport[] = checks.map((check) => {
+      const value = headersObj[check.key] ?? null;
+      const ok = check.validate(value);
+      return {
+        header: check.name,
+        value,
+        grade: ok ? 'A' : 'F',
+        message: ok ? 'Present' : check.remediation,
+      };
+    });
+
+    const score =
+      results.filter((r) => r.grade === 'A').length / results.length;
+    const overallGrade = gradeFromRatio(score);
+
+    res.status(200).json({ url: target, overallGrade, results });
+  } catch (err: unknown) {
+    res.status(500).json({ error: 'Failed to fetch url' });
+  }
+}

--- a/pages/apps/header-analyzer.tsx
+++ b/pages/apps/header-analyzer.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import HeaderAnalyzer from '../../apps/header-analyzer';
+
+const HeaderAnalyzerPage: React.FC = () => <HeaderAnalyzer />;
+
+export default HeaderAnalyzerPage;


### PR DESCRIPTION
## Summary
- add API to fetch remote headers and grade common security protections
- build header analyzer UI with URL input and report card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f0fa69fc8328bc207061dad0cad5