### PR TITLE
feat: add request builder app

### DIFF
--- a/apps/request-builder/index.tsx
+++ b/apps/request-builder/index.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+
+interface HistoryEntry {
+  method: string;
+  url: string;
+  headers: string;
+  body: string;
+}
+
+const STORAGE_KEY = 'request-builder-history';
+
+const RequestBuilder: React.FC = () => {
+  const [method, setMethod] = useState('GET');
+  const [url, setUrl] = useState('');
+  const [headers, setHeaders] = useState('{}');
+  const [body, setBody] = useState('');
+  const [response, setResponse] = useState<any>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          setHistory(JSON.parse(saved));
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  const sendRequest = async () => {
+    let parsedHeaders: Record<string, string> = {};
+    if (headers.trim()) {
+      try {
+        parsedHeaders = JSON.parse(headers);
+      } catch {
+        alert('Invalid headers JSON');
+        return;
+      }
+    }
+
+    const res = await fetch('/api/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ method, url, headers: parsedHeaders, body }),
+    });
+    const data = await res.json();
+    setResponse(data);
+  };
+
+  const saveCurrent = () => {
+    const entry: HistoryEntry = { method, url, headers, body };
+    const newHistory = [entry, ...history];
+    setHistory(newHistory);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newHistory));
+    }
+  };
+
+  const loadHistory = (index: number) => {
+    const item = history[index];
+    if (item) {
+      setMethod(item.method);
+      setUrl(item.url);
+      setHeaders(item.headers);
+      setBody(item.body);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex space-x-2">
+        <select
+          className="border p-1"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        >
+          {['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <input
+          className="flex-1 border p-1"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <button
+          className="bg-blue-600 text-white px-2"
+          onClick={sendRequest}
+        >
+          Send
+        </button>
+        <button
+          className="bg-gray-600 text-white px-2"
+          onClick={saveCurrent}
+        >
+          Save
+        </button>
+      </div>
+      {history.length > 0 && (
+        <div>
+          <select
+            className="border p-1"
+            onChange={(e) =>
+              e.target.value !== '' && loadHistory(parseInt(e.target.value, 10))
+            }
+          >
+            <option value="">History...</option>
+            {history.map((h, i) => (
+              <option key={i} value={i}>{`${h.method} ${h.url}`}</option>
+            ))}
+          </select>
+        </div>
+      )}
+      <textarea
+        className="w-full border p-1"
+        rows={4}
+        placeholder='{"Content-Type":"application/json"}'
+        value={headers}
+        onChange={(e) => setHeaders(e.target.value)}
+      />
+      <textarea
+        className="w-full border p-1"
+        rows={4}
+        placeholder="Request body"
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+      />
+      {response && (
+        <div className="border p-2 space-y-2">
+          <div>
+            <strong>Duration:</strong> {response.duration} ms
+          </div>
+          <div>
+            <strong>Status:</strong> {response.status} {response.statusText || ''}
+          </div>
+          <div>
+            <strong>Headers:</strong>
+            <pre className="whitespace-pre-wrap">
+              {JSON.stringify(response.headers, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <strong>Body:</strong>
+            <pre className="whitespace-pre-wrap">{response.body}</pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RequestBuilder;
+

--- a/pages/api/request.ts
+++ b/pages/api/request.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { method = 'GET', url, headers = {}, body } = req.body || {};
+
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'Missing url' });
+  }
+
+  const start = Date.now();
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: ['GET', 'HEAD'].includes(method.toUpperCase()) ? undefined : body,
+    });
+
+    const duration = Date.now() - start;
+    const text = await response.text();
+    const headersObj: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headersObj[key] = value;
+    });
+
+    return res.status(200).json({
+      duration,
+      status: response.status,
+      statusText: response.statusText,
+      headers: headersObj,
+      body: text,
+    });
+  } catch (error: any) {
+    const duration = Date.now() - start;
+    return res.status(500).json({
+      error: error?.message || 'Request failed',
+      duration,
+    });
+  }
+}

--- a/pages/apps/request-builder.tsx
+++ b/pages/apps/request-builder.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const RequestBuilderApp = dynamic(() => import('../../apps/request-builder'), {
+  ssr: false,
+});
+
+export default function RequestBuilderPage() {
+  return <RequestBuilderApp />;
+}


### PR DESCRIPTION
## Summary
- forward arbitrary HTTP requests via new `/api/request` endpoint
- add request builder app with method/url/headers/body editors and response panel
- support request history in localStorage

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f0fd73fc8328b26e5a6684491c73