### PR TITLE
feat: add RDAP lookup tool

### DIFF
--- a/apps/rdap-lookup/index.tsx
+++ b/apps/rdap-lookup/index.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+const RDAPLookup: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const lookup = async () => {
+    if (!domain) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/rdap?domain=${encodeURIComponent(domain)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Lookup failed');
+      } else {
+        setResult(data);
+      }
+    } catch (e) {
+      setError('Lookup failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="flex-1 px-2 py-1 text-black"
+        />
+        <button
+          type="button"
+          onClick={lookup}
+          className="px-4 py-2 bg-blue-600 rounded"
+        >
+          Lookup
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {result && (
+        <pre className="flex-1 overflow-auto bg-gray-800 p-2 rounded text-sm">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default RDAPLookup;
+

--- a/pages/api/rdap.ts
+++ b/pages/api/rdap.ts
@@ -1,0 +1,67 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+let tldCache: Set<string> | null = null;
+
+async function getTlds() {
+  if (tldCache) return tldCache;
+  try {
+    const resp = await fetch('https://data.iana.org/rdap/dns.json');
+    const data = await resp.json();
+    tldCache = new Set(
+      data.services.flatMap((service: [string[], string[]]) =>
+        service[0].map((tld) => tld.toLowerCase())
+      )
+    );
+  } catch {
+    tldCache = new Set();
+  }
+  return tldCache;
+}
+
+function normalizeRdap(data: any) {
+  return {
+    objectClassName: data.objectClassName,
+    handle: data.handle,
+    ldhName: data.ldhName,
+    unicodeName: data.unicodeName,
+    status: data.status,
+    events: data.events?.map(({ eventAction, eventDate }: any) => ({ eventAction, eventDate })),
+    nameservers: data.nameservers?.map(({ ldhName, status }: any) => ({ ldhName, status })),
+    entities: data.entities?.map(({ handle, roles, vcardArray }: any) => ({ handle, roles, vcardArray })),
+  };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { domain } = req.query;
+  if (typeof domain !== 'string') {
+    res.status(400).json({ error: 'domain query parameter required' });
+    return;
+  }
+
+  const tld = domain.split('.').pop()?.toLowerCase();
+  const tlds = await getTlds();
+  if (!tld || !tlds.has(tld)) {
+    res.status(400).json({ error: 'Unsupported TLD' });
+    return;
+  }
+
+  try {
+    const response = await fetch(`https://rdap.org/domain/${domain}`);
+    if (response.status === 429) {
+      res.status(429).json({ error: 'Rate limit exceeded' });
+      return;
+    }
+    if (!response.ok) {
+      res.status(response.status).json({ error: 'RDAP lookup failed' });
+      return;
+    }
+    const json = await response.json();
+    res.status(200).json(normalizeRdap(json));
+  } catch {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}
+

--- a/pages/apps/rdap-lookup.tsx
+++ b/pages/apps/rdap-lookup.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const RDAPLookup = dynamic(() => import('../../apps/rdap-lookup'), { ssr: false });
+
+export default function RDAPLookupPage() {
+  return <RDAPLookup />;
+}
+


### PR DESCRIPTION
## Summary
- add API route to perform RDAP lookup with TLD validation and rate limit errors
- create RDAP lookup app with domain input and formatted results
- expose lookup app through /apps/rdap-lookup page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f0ff019c8328a5c212688c0d21e9