### PR TITLE
feat: add jwt inspector app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -19,6 +19,7 @@ import { displayAsciiArt } from './components/apps/ascii_art';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
+import { displayJwtInspector } from './components/apps/jwt-inspector';
 
 const createDynamicApp = (path, name) =>
   dynamic(
@@ -600,6 +601,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'jwt-inspector',
+    title: 'JWT Inspector',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayJwtInspector,
   },
   {
     id: 'weather',

--- a/apps/jwt-inspector/index.tsx
+++ b/apps/jwt-inspector/index.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import {
+  decodeJwt,
+  decodeProtectedHeader,
+  jwtVerify,
+  createRemoteJWKSet,
+} from 'jose';
+
+const JwtInspector: React.FC = () => {
+  const [token, setToken] = useState('');
+  const [header, setHeader] = useState<Record<string, unknown> | null>(null);
+  const [payload, setPayload] = useState<Record<string, unknown> | null>(null);
+  const [warning, setWarning] = useState('');
+  const [jwkUrl, setJwkUrl] = useState('');
+  const [verification, setVerification] = useState('');
+
+  const parseToken = (t: string) => {
+    setWarning('');
+    setHeader(null);
+    setPayload(null);
+    setVerification('');
+    if (!t) return;
+    try {
+      const h = decodeProtectedHeader(t);
+      const p = decodeJwt(t);
+      setHeader(h as Record<string, unknown>);
+      setPayload(p as Record<string, unknown>);
+      if (typeof p.exp === 'number' && p.exp * 1000 < Date.now()) {
+        setWarning('Token expired');
+      }
+    } catch {
+      setWarning('Malformed token');
+    }
+  };
+
+  const verify = async () => {
+    if (!token || !jwkUrl) {
+      setVerification('');
+      return;
+    }
+    try {
+      const JWKS = createRemoteJWKSet(new URL(jwkUrl));
+      await jwtVerify(token, JWKS);
+      setVerification('Signature valid');
+    } catch (err) {
+      setVerification(`Invalid: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto">
+      <textarea
+        value={token}
+        onChange={(e) => {
+          const t = e.target.value.trim();
+          setToken(t);
+          parseToken(t);
+        }}
+        placeholder="Enter JWT"
+        className="w-full h-24 p-2 mb-2 rounded text-black"
+      />
+      <input
+        type="text"
+        value={jwkUrl}
+        onChange={(e) => setJwkUrl(e.target.value)}
+        placeholder="JWK URL (optional)"
+        className="w-full p-2 mb-2 rounded text-black"
+      />
+      <button
+        onClick={verify}
+        className="px-4 py-2 bg-blue-600 rounded mb-4"
+      >
+        Verify
+      </button>
+      {warning && <div className="mb-2 text-yellow-300">{warning}</div>}
+      {verification && <div className="mb-2">{verification}</div>}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h3 className="font-bold mb-1">Header</h3>
+          <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">
+            {header ? JSON.stringify(header, null, 2) : ''}
+          </pre>
+        </div>
+        <div>
+          <h3 className="font-bold mb-1">Payload</h3>
+          <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">
+            {payload ? JSON.stringify(payload, null, 2) : ''}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JwtInspector;
+export const displayJwtInspector = () => <JwtInspector />;

--- a/components/apps/jwt-inspector.tsx
+++ b/components/apps/jwt-inspector.tsx
@@ -1,0 +1,1 @@
+export { default, displayJwtInspector } from '../../apps/jwt-inspector';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chess.js": "^1.0.0",
     "expr-eval": "^2.0.2",
     "html-to-image": "^1.11.13",
+    "jose": "^5.2.3",
     "jsonwebtoken": "^9.0.2",
     "jspdf": "^2.5.1",
     "matter-js": "^0.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,6 +5299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^5.2.3":
+  version: 5.10.0
+  resolution: "jose@npm:5.10.0"
+  checksum: 10c0/e20d9fc58d7e402f2e5f04e824b8897d5579aae60e64cb88ebdea1395311c24537bf4892f7de413fab1acf11e922797fb1b42269bc8fc65089a3749265ccb7b0
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -7955,6 +7962,7 @@ __metadata:
     html-to-image: "npm:^1.11.13"
     jest: "npm:^30.0.5"
     jest-environment-jsdom: "npm:^30.0.5"
+    jose: "npm:^5.2.3"
     jsonwebtoken: "npm:^9.0.2"
     jspdf: "npm:^2.5.1"
     matter-js: "npm:^0.20.0"


### PR DESCRIPTION
## Summary
- add JWT Inspector utility to decode JWTs and optionally verify via JWKs
- wire app into launcher config and add jose dependency

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10066808328bfaa6647ed92ec65