### PR TITLE
feat: add password strength checker app

### DIFF
--- a/__tests__/passwordStrength.test.tsx
+++ b/__tests__/passwordStrength.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import PasswordStrength from '../apps/password-strength';
+
+describe('PasswordStrength', () => {
+  it('shows analysis details', () => {
+    const { getByLabelText, getByText } = render(<PasswordStrength />);
+    fireEvent.change(getByLabelText(/password/i), { target: { value: 'password' } });
+    fireEvent.click(getByText('Check'));
+    expect(getByText(/Score:/)).toBeInTheDocument();
+    expect(getByText(/Entropy:/)).toBeInTheDocument();
+    expect(getByText(/Guesses:/)).toBeInTheDocument();
+  });
+
+  it('warns on reused passwords', () => {
+    const { getByLabelText, getByText } = render(<PasswordStrength />);
+    const input = getByLabelText(/password/i);
+    fireEvent.change(input, { target: { value: 'secret123' } });
+    fireEvent.click(getByText('Check'));
+    fireEvent.change(input, { target: { value: 'secret123' } });
+    fireEvent.click(getByText('Check'));
+    expect(getByText(/used this password before/i)).toBeInTheDocument();
+  });
+});

--- a/apps/password-strength/index.tsx
+++ b/apps/password-strength/index.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import zxcvbn from 'zxcvbn';
+
+const scoreColors = ['bg-red-500','bg-orange-500','bg-yellow-500','bg-green-500','bg-green-700'];
+const scoreLabels = ['Very Weak','Weak','Fair','Good','Strong'];
+
+const PasswordStrength: React.FC = () => {
+  const [password, setPassword] = useState('');
+  const [result, setResult] = useState<zxcvbn.ZXCVBNResult | null>(null);
+  const [history, setHistory] = useState<string[]>([]);
+  const [reused, setReused] = useState(false);
+
+  const analyze = () => {
+    const reusedBefore = history.includes(password);
+    setReused(reusedBefore);
+    if (!reusedBefore) {
+      setHistory([...history, password]);
+    }
+    setResult(zxcvbn(password));
+  };
+
+  const entropy = result ? Math.log2(result.guesses).toFixed(2) : '';
+  const width = result ? `${((result.score + 1) / 5) * 100}%` : '0%';
+  const color = result ? scoreColors[result.score] : 'bg-gray-500';
+  const label = result ? scoreLabels[result.score] : '';
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2 items-center">
+        <input
+          aria-label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="flex-1 text-black px-2 py-1"
+        />
+        <button
+          type="button"
+          onClick={analyze}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          Check
+        </button>
+      </div>
+      {result && (
+        <div className="space-y-2">
+          <div>
+            <div className="h-2 w-full bg-gray-700 rounded">
+              <div className={`h-full ${color} rounded`} style={{ width }} />
+            </div>
+            <div className="text-sm mt-1">Strength: {label} (Score: {result.score}/4)</div>
+          </div>
+          <div className="text-sm">Entropy: {entropy} bits</div>
+          <div className="text-sm">Guesses: {result.guesses.toLocaleString()}</div>
+          {reused && (
+            <div className="text-red-400 text-sm">You've used this password before.</div>
+          )}
+          {result.feedback.warning && (
+            <div className="text-yellow-400 text-sm">{result.feedback.warning}</div>
+          )}
+          {result.feedback.suggestions.length > 0 && (
+            <ul className="text-sm list-disc ml-5">
+              {result.feedback.suggestions.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PasswordStrength;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/zxcvbn": "^4.4.5",
     "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
@@ -48,7 +49,8 @@
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/pages/apps/password-strength.tsx
+++ b/pages/apps/password-strength.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const PasswordStrength = dynamic(() => import('../../apps/password-strength'), { ssr: false });
+
+export default function PasswordStrengthPage() {
+  return <PasswordStrength />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,6 +1734,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/zxcvbn@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@types/zxcvbn@npm:4.4.5"
+  checksum: 10c0/b0f2f8a310de61860d66ee24964e9746cadcc166f3b44df384147ebddab186555bef701dcba0a47d04bc80dfa47d5de15f2a08e0abd713fe3a77304342ae68a8
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.40.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.40.0"
@@ -7943,6 +7950,7 @@ __metadata:
     "@types/node": "npm:^24.2.1"
     "@types/react": "npm:^19.1.10"
     "@types/three": "npm:^0.179.0"
+    "@types/zxcvbn": "npm:^4.4.5"
     "@vercel/analytics": "npm:^1.5.0"
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
@@ -7979,6 +7987,7 @@ __metadata:
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
     ws: "npm:^8.18.3"
+    zxcvbn: "npm:^4.4.2"
   languageName: unknown
   linkType: soft
 
@@ -8468,5 +8477,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zxcvbn@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "zxcvbn@npm:4.4.2"
+  checksum: 10c0/862f101cc95247b30290bad67ade333e430a16763bb771ce4e4c5414396d987f9a64288225675c96bd6f8d3eba65da0dee119b2a4eaa2e249da3f540b036942e
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary
- add password strength app leveraging zxcvbn library
- show score, entropy, guess count, and feedback
- include tests for analysis and password reuse warnings

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f1022c0083289d38ecb032ff6e7e