### PR TITLE
feat: add CSP builder and evaluation API

### DIFF
--- a/apps/csp-builder/index.tsx
+++ b/apps/csp-builder/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+interface BlockedItem {
+  directive: string;
+  url: string;
+  host: string;
+}
+
+const CspBuilder: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [csp, setCsp] = useState("default-src 'self';");
+  const [blocked, setBlocked] = useState<BlockedItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const testCsp = async () => {
+    setLoading(true);
+    setError('');
+    setBlocked([]);
+    try {
+      const res = await fetch('/api/csp-test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url, csp }),
+      });
+      const data = await res.json();
+      if (data.error) {
+        setError(data.error);
+      } else {
+        setBlocked(data.blocked || []);
+      }
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div>
+        <label htmlFor="url" className="block">Target URL</label>
+        <input
+          id="url"
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+          className="w-full text-black px-2 py-1"
+        />
+      </div>
+      <div>
+        <label htmlFor="csp" className="block">CSP</label>
+        <input
+          id="csp"
+          type="text"
+          value={csp}
+          onChange={(e) => setCsp(e.target.value)}
+          className="w-full text-black px-2 py-1"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={testCsp}
+        className="px-4 py-2 bg-blue-600 rounded self-start"
+      >
+        Test
+      </button>
+      {loading && <div>Testing...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {!loading && !error && blocked.length === 0 && <div>No violations found.</div>}
+      {blocked.length > 0 && (
+        <div>
+          <h2 className="text-lg mb-2">Blocked Resources</h2>
+          <ul className="list-disc list-inside space-y-1">
+            {blocked.map((b, idx) => (
+              <li key={idx}>
+                {b.directive} blocked {b.url}. Suggest adding <code>{b.host}</code> to {b.directive}.
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CspBuilder;

--- a/pages/api/csp-test.ts
+++ b/pages/api/csp-test.ts
@@ -1,0 +1,76 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Resource = {
+  url: string;
+  host: string;
+  directive: string;
+};
+
+const DIRECTIVE_PATTERNS: Record<string, RegExp> = {
+  'script-src': /<script[^>]*src=["']([^"']+)["'][^>]*>/gi,
+  'img-src': /<img[^>]*src=["']([^"']+)["'][^>]*>/gi,
+  'style-src': /<link[^>]*rel=["']stylesheet["'][^>]*href=["']([^"']+)["'][^>]*>/gi,
+};
+
+function parseCsp(csp: string, origin: string): Record<string, string[]> {
+  const directives: Record<string, string[]> = {};
+  csp
+    .split(';')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .forEach((part) => {
+      const [dir, ...sources] = part.split(/\s+/);
+      directives[dir] = sources.map((src) => (src === "'self'" ? origin : src));
+    });
+  return directives;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    | { resources: Record<string, Resource[]>; blocked: Resource[]; suggestions: { directive: string; host: string }[] }
+    | { error: string }
+  >
+) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { url, csp } = req.body || {};
+  if (!url || !csp) {
+    res.status(400).json({ error: 'Missing url or csp' });
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const origin = new URL(url).origin;
+    const allowed = parseCsp(csp, origin);
+
+    const resources: Record<string, Resource[]> = {};
+    const blocked: Resource[] = [];
+
+    Object.entries(DIRECTIVE_PATTERNS).forEach(([directive, regex]) => {
+      const list: Resource[] = [];
+      let match;
+      while ((match = regex.exec(html)) !== null) {
+        const resourceUrl = new URL(match[1], url).href;
+        const host = new URL(resourceUrl).origin;
+        const allowedList = allowed[directive] || allowed['default-src'] || [];
+        const isAllowed = allowedList.some((src) => src === '*' || src === host);
+        const item = { url: resourceUrl, host, directive };
+        list.push(item);
+        if (!isAllowed) blocked.push(item);
+      }
+      if (list.length) resources[directive] = list;
+    });
+
+    const suggestions = blocked.map((b) => ({ directive: b.directive, host: b.host }));
+
+    res.status(200).json({ resources, blocked, suggestions });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/pages/apps/csp-builder.tsx
+++ b/pages/apps/csp-builder.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import CspBuilder from '../../apps/csp-builder';
+
+const CspBuilderPage: React.FC = () => {
+  return <CspBuilder />;
+};
+
+export default CspBuilderPage;


### PR DESCRIPTION
## Summary
- add CSP builder frontend for mapping blocked resources to directives
- introduce `/api/csp-test` route to fetch target URL and evaluate CSP violations
- expose new app via `/apps/csp-builder` page

## Testing
- `CI=1 yarn test --runInBand`
- `CI=1 yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f107d63c8328a8f0a97071c1fd61