### PR TITLE
feat: add TLS certificate viewer

### DIFF
--- a/apps/tls-viewer/index.tsx
+++ b/apps/tls-viewer/index.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+
+interface CertInfo {
+  subject: Record<string, string>;
+  issuer: Record<string, string>;
+  san: string[];
+  validFrom: string;
+  validTo: string;
+  daysRemaining: number;
+}
+
+interface ApiResponse {
+  host: string;
+  port: number;
+  ocspStapled: boolean;
+  chain: CertInfo[];
+  explanations: Record<string, string>;
+}
+
+const TLSViewer: React.FC = () => {
+  const [host, setHost] = useState('');
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchData = async () => {
+    if (!host) return;
+    setLoading(true);
+    setError('');
+    setData(null);
+    try {
+      const res = await fetch(`/api/tls-chain?host=${encodeURIComponent(host)}`);
+      if (!res.ok) throw new Error('Failed to fetch');
+      const json = await res.json();
+      setData(json);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4 overflow-auto">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={host}
+          onChange={(e) => setHost(e.target.value)}
+          placeholder="example.com"
+          className="flex-1 px-2 text-black"
+        />
+        <button
+          type="button"
+          onClick={fetchData}
+          className="px-4 py-2 bg-blue-600 rounded"
+        >
+          Fetch
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {data && (
+        <div className="space-y-4">
+          <div>
+            <strong>OCSP Stapling:</strong> {data.ocspStapled ? 'Present' : 'Not Provided'}
+            <div className="text-sm text-gray-400">{data.explanations.ocspStapled}</div>
+          </div>
+          <ul className="space-y-4">
+            {data.chain.map((cert, idx) => (
+              <li key={idx} className="border-l-2 border-gray-500 pl-4">
+                <div>
+                  <strong>Subject:</strong> {cert.subject.CN || ''}
+                  <div className="text-sm text-gray-400">{data.explanations.subject}</div>
+                </div>
+                <div>
+                  <strong>Issuer:</strong> {cert.issuer.CN || ''}
+                  <div className="text-sm text-gray-400">{data.explanations.issuer}</div>
+                </div>
+                {cert.san.length > 0 && (
+                  <div>
+                    <strong>SANs:</strong> {cert.san.join(', ')}
+                    <div className="text-sm text-gray-400">{data.explanations.san}</div>
+                  </div>
+                )}
+                <div>
+                  <strong>Valid From:</strong> {new Date(cert.validFrom).toLocaleString()}
+                  <div className="text-sm text-gray-400">{data.explanations.validFrom}</div>
+                </div>
+                <div>
+                  <strong>Valid To:</strong>{' '}
+                  <span className={cert.daysRemaining <= 30 ? 'text-yellow-400' : ''}>
+                    {new Date(cert.validTo).toLocaleString()}
+                  </span>
+                  <div className="text-sm text-gray-400">{data.explanations.validTo}</div>
+                </div>
+                <div>
+                  <strong>Days Remaining:</strong>{' '}
+                  <span className={cert.daysRemaining <= 30 ? 'text-red-500' : ''}>
+                    {cert.daysRemaining}
+                  </span>
+                  <div className="text-sm text-gray-400">{data.explanations.daysRemaining}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TLSViewer;
+

--- a/pages/api/tls-chain.ts
+++ b/pages/api/tls-chain.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import tls, { PeerCertificate } from 'tls';
+
+interface FormattedCert {
+  subject: Record<string, string>;
+  issuer: Record<string, string>;
+  san: string[];
+  validFrom: string;
+  validTo: string;
+  daysRemaining: number;
+}
+
+const explanations = {
+  subject: 'The entity this certificate was issued to.',
+  issuer: 'The certificate authority that issued this certificate.',
+  san: 'Subject Alternative Names that this certificate is valid for.',
+  validFrom: 'The date when this certificate becomes valid.',
+  validTo: 'The date when this certificate expires.',
+  daysRemaining: 'Number of days until the certificate expires.',
+  ocspStapled: 'Whether the server provided an OCSP stapling response indicating revocation status.'
+};
+
+function parseSAN(input?: string): string[] {
+  if (!input) return [];
+  return input.split(',').map((s) => s.trim().replace(/^DNS:/i, ''));
+}
+
+function formatCert(cert: PeerCertificate): FormattedCert {
+  const san = parseSAN((cert as any).subjectaltname);
+  const validFrom = new Date((cert as any).valid_from);
+  const validTo = new Date((cert as any).valid_to);
+  const daysRemaining = Math.round((validTo.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+
+  return {
+    subject: cert.subject || {},
+    issuer: cert.issuer || {},
+    san,
+    validFrom: validFrom.toISOString(),
+    validTo: validTo.toISOString(),
+    daysRemaining
+  };
+}
+
+function collectChain(cert: PeerCertificate): PeerCertificate[] {
+  const chain: PeerCertificate[] = [];
+  let current: any = cert;
+  const seen = new Set<string>();
+  while (current && Object.keys(current).length) {
+    if (seen.has(current.fingerprint256)) break;
+    chain.push(current);
+    seen.add(current.fingerprint256);
+    if (!current.issuerCertificate || current.issuerCertificate === current) break;
+    current = current.issuerCertificate;
+  }
+  return chain;
+}
+
+function getTLSInfo(host: string, port: number): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect({ host, port, servername: host, rejectUnauthorized: false, requestOCSP: true }, () => {
+      try {
+        const peer = socket.getPeerCertificate(true);
+        const chain = collectChain(peer).map(formatCert);
+        const ocspStapled = Boolean((socket as any).ocspResponse || (socket as any).getOCSPResponse?.());
+        socket.end();
+        resolve({ host, port, ocspStapled, chain, explanations });
+      } catch (err) {
+        reject(err);
+      }
+    });
+    socket.on('error', reject);
+  });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { host, port } = req.query;
+  if (!host || typeof host !== 'string') {
+    res.status(400).json({ error: 'host query parameter required' });
+    return;
+  }
+
+  const portNum = typeof port === 'string' ? parseInt(port, 10) || 443 : 443;
+
+  try {
+    const info = await getTLSInfo(host, portNum);
+    res.status(200).json(info);
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+}
+

--- a/pages/apps/tls-viewer.tsx
+++ b/pages/apps/tls-viewer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import TLSViewer from '../../apps/tls-viewer';
+
+const TLSViewerPage: React.FC = () => {
+  return <TLSViewer />;
+};
+
+export default TLSViewerPage;
+


### PR DESCRIPTION
## Summary
- expose `/api/tls-chain` for inspecting TLS certificate chains, SANs and OCSP stapling
- add TLS Viewer app that visualizes certificate chains with expiry warnings

## Testing
- `yarn test --runInBand`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10943c083289702511e65ac00f4