### PR TITLE
Add CORS checker API and UI

### DIFF
--- a/apps/cors-checker/index.tsx
+++ b/apps/cors-checker/index.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+
+interface Result {
+  url: string;
+  origin: string | null;
+  methods: string[];
+  credentials: boolean | null;
+  error?: string;
+}
+
+interface Breakdown {
+  origins: Record<string, number>;
+  methods: Record<string, number>;
+  credentials: { true: number; false: number; null: number };
+}
+
+const CorsChecker: React.FC = () => {
+  const [urlsText, setUrlsText] = useState('');
+  const [results, setResults] = useState<Result[]>([]);
+  const [breakdown, setBreakdown] = useState<Breakdown | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const runCheck = async () => {
+    const urls = urlsText
+      .split(/\n|,/)
+      .map((u) => u.trim())
+      .filter(Boolean);
+    if (!urls.length) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/cors-check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ urls }),
+      });
+      const data = await res.json();
+      setResults(data.results || []);
+      setBreakdown(data.breakdown || null);
+    } catch (e) {
+      setResults([]);
+      setBreakdown(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <textarea
+        className="flex-1 p-2 text-black"
+        placeholder="Enter URLs (one per line)"
+        value={urlsText}
+        onChange={(e) => setUrlsText(e.target.value)}
+      />
+      <button
+        type="button"
+        onClick={runCheck}
+        disabled={loading}
+        className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
+      >
+        {loading ? 'Checking...' : 'Check CORS'}
+      </button>
+      {results.length > 0 && (
+        <div className="overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="border px-2">URL</th>
+                <th className="border px-2">Allowed Origin</th>
+                <th className="border px-2">Methods</th>
+                <th className="border px-2">Credentials</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r) => (
+                <tr key={r.url}>
+                  <td className="border px-2">{r.url}</td>
+                  <td className="border px-2">{r.error ? 'Error' : r.origin || 'None'}</td>
+                  <td className="border px-2">{r.methods.join(', ')}</td>
+                  <td className="border px-2">
+                    {r.credentials === null ? 'N/A' : r.credentials ? 'true' : 'false'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {breakdown && (
+        <div className="text-sm space-y-1">
+          <div>Origins: {Object.entries(breakdown.origins).map(([o, c]) => `${o} (${c})`).join(', ') || 'None'}</div>
+          <div>Methods: {Object.entries(breakdown.methods).map(([m, c]) => `${m} (${c})`).join(', ') || 'None'}</div>
+          <div>
+            Credentials: true ({breakdown.credentials.true}), false ({breakdown.credentials.false}), none ({breakdown.credentials.null})
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CorsChecker;
+

--- a/pages/api/cors-check.ts
+++ b/pages/api/cors-check.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface CorsResult {
+  url: string;
+  origin: string | null;
+  methods: string[];
+  credentials: boolean | null;
+  error?: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { urls } = req.body as { urls?: string[] };
+  if (!Array.isArray(urls)) {
+    return res.status(400).json({ error: 'Invalid urls' });
+  }
+
+  const results: CorsResult[] = await Promise.all(
+    urls.map(async (url) => {
+      try {
+        const response = await fetch(url, { method: 'HEAD' });
+        const origin = response.headers.get('access-control-allow-origin');
+        const methodsHeader = response.headers.get(
+          'access-control-allow-methods'
+        );
+        const credentialsHeader = response.headers.get(
+          'access-control-allow-credentials'
+        );
+        const methods = methodsHeader
+          ? methodsHeader.split(/\s*,\s*/).filter(Boolean)
+          : [];
+        const credentials =
+          credentialsHeader === null
+            ? null
+            : credentialsHeader.toLowerCase() === 'true';
+        return { url, origin, methods, credentials };
+      } catch (e) {
+        return { url, origin: null, methods: [], credentials: null, error: (e as Error).message };
+      }
+    })
+  );
+
+  const originBreakdown: Record<string, number> = {};
+  const methodBreakdown: Record<string, number> = {};
+  const credentialsBreakdown = { true: 0, false: 0, null: 0 };
+
+  results.forEach((r) => {
+    if (r.origin) originBreakdown[r.origin] = (originBreakdown[r.origin] || 0) + 1;
+    r.methods.forEach((m) => {
+      methodBreakdown[m] = (methodBreakdown[m] || 0) + 1;
+    });
+    if (r.credentials === true) credentialsBreakdown.true += 1;
+    else if (r.credentials === false) credentialsBreakdown.false += 1;
+    else credentialsBreakdown.null += 1;
+  });
+
+  return res.status(200).json({
+    results,
+    breakdown: {
+      origins: originBreakdown,
+      methods: methodBreakdown,
+      credentials: credentialsBreakdown,
+    },
+  });
+}
+

--- a/pages/apps/cors-checker.tsx
+++ b/pages/apps/cors-checker.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const CorsChecker = dynamic(() => import('../../apps/cors-checker'), { ssr: false });
+
+export default function CorsCheckerPage() {
+  return <CorsChecker />;
+}
+


### PR DESCRIPTION
## Summary
- implement `/api/cors-check` endpoint that fetches URLs and summarizes CORS headers
- add React UI for entering URL list and viewing CORS results
- expose new app via `/apps/cors-checker`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f1086c688328aaf8ee171e11ae74