### PR TITLE
feat: add robots sitemap analyzer

### DIFF
--- a/apps/robots-sitemap/index.tsx
+++ b/apps/robots-sitemap/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useMemo } from 'react';
+
+interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+interface RobotsData {
+  disallows: string[];
+  sitemapEntries: SitemapEntry[];
+  missingRobots?: boolean;
+}
+
+const RobotsSitemap: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [data, setData] = useState<RobotsData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setError(null);
+    setData(null);
+    if (!url) return;
+    try {
+      const res = await fetch(`/api/robots?url=${encodeURIComponent(url)}`);
+      const json = await res.json();
+      setData(json);
+    } catch (e) {
+      setError('Failed to fetch');
+    }
+  };
+
+  const heatmap = useMemo(() => {
+    if (!data) return [] as { date: string; count: number }[];
+    const counts: Record<string, number> = {};
+    data.sitemapEntries.forEach((entry) => {
+      if (!entry.lastmod) return;
+      const date = entry.lastmod.split('T')[0];
+      counts[date] = (counts[date] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .map(([date, count]) => ({ date, count }))
+      .sort((a, b) => (a.date < b.date ? -1 : 1));
+  }, [data]);
+
+  const maxCount = Math.max(0, ...heatmap.map((d) => d.count));
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+          className="flex-1 px-2 text-black"
+        />
+        <button
+          type="button"
+          onClick={load}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Load
+        </button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      {data && (
+        <div className="space-y-4">
+          {data.missingRobots && (
+            <div className="text-yellow-500">robots.txt not found</div>
+          )}
+          <div>
+            <h2 className="font-bold mb-1">Disallowed Paths</h2>
+            {data.disallows.length ? (
+              <ul className="list-disc ml-5">
+                {data.disallows.map((d) => (
+                  <li key={d}>{d}</li>
+                ))}
+              </ul>
+            ) : (
+              <div>No disallow rules</div>
+            )}
+          </div>
+          <div>
+            <h2 className="font-bold mb-1">Sitemap Lastmod Heatmap</h2>
+            {heatmap.length ? (
+              <div className="grid grid-cols-7 gap-1">
+                {heatmap.map(({ date, count }) => {
+                  const intensity = maxCount ? Math.round((count / maxCount) * 255) : 0;
+                  const color = `rgb(${255 - intensity}, ${255 - intensity}, 255)`;
+                  return (
+                    <div
+                      key={date}
+                      title={`${date}: ${count}`}
+                      className="w-6 h-6"
+                      style={{ backgroundColor: color }}
+                    />
+                  );
+                })}
+              </div>
+            ) : (
+              <div>No sitemap entries</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RobotsSitemap;
+

--- a/pages/api/robots.ts
+++ b/pages/api/robots.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+interface RobotsResponse {
+  disallows: string[];
+  sitemapEntries: SitemapEntry[];
+  missingRobots?: boolean;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<RobotsResponse | { error: string }>
+) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url query parameter' });
+    return;
+  }
+
+  const base = url.replace(/\/$/, '');
+  let robotsText = '';
+  try {
+    const robotsRes = await fetch(`${base}/robots.txt`);
+    if (!robotsRes.ok) {
+      res.status(200).json({ disallows: [], sitemapEntries: [], missingRobots: true });
+      return;
+    }
+    robotsText = await robotsRes.text();
+  } catch (e) {
+    res.status(200).json({ disallows: [], sitemapEntries: [], missingRobots: true });
+    return;
+  }
+
+  const disallows: string[] = [];
+  const sitemapUrls: string[] = [];
+  robotsText.split(/\r?\n/).forEach((line) => {
+    const cleaned = line.split('#')[0].trim();
+    if (!cleaned) return;
+    const [directive, value] = cleaned.split(':').map((s) => s.trim());
+    if (/^disallow$/i.test(directive)) {
+      disallows.push(value || '/');
+    } else if (/^sitemap$/i.test(directive) && value) {
+      sitemapUrls.push(value);
+    }
+  });
+
+  const sitemapEntries: SitemapEntry[] = [];
+  await Promise.all(
+    sitemapUrls.map(async (sitemapUrl) => {
+      try {
+        const sitemapRes = await fetch(sitemapUrl);
+        if (!sitemapRes.ok) return;
+        const xml = await sitemapRes.text();
+        const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/gi)].map((m) => m[1]);
+        const lastmods = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/gi)].map((m) => m[1]);
+        locs.forEach((loc, idx) => {
+          sitemapEntries.push({ loc, lastmod: lastmods[idx] });
+        });
+      } catch (e) {
+        // ignore individual sitemap errors
+      }
+    })
+  );
+
+  res.status(200).json({ disallows, sitemapEntries });
+}
+

--- a/pages/apps/robots-sitemap.tsx
+++ b/pages/apps/robots-sitemap.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import RobotsSitemap from '../../apps/robots-sitemap';
+
+const RobotsSitemapPage: React.FC = () => <RobotsSitemap />;
+
+export default RobotsSitemapPage;
+


### PR DESCRIPTION
## Summary
- add API endpoint to parse robots.txt and sitemaps
- create robots-sitemap UI to visualize disallowed paths and lastmod heatmap

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10b04c08328ac7cda1103633449