### PR TITLE
Add well-known endpoint checker and UI

### DIFF
--- a/apps/well-known/index.tsx
+++ b/apps/well-known/index.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+interface Result {
+  path: string;
+  present: boolean;
+  status: number;
+  contacts?: string[];
+}
+
+const WellKnown: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [results, setResults] = useState<Result[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    if (!domain) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/well-known?domain=${encodeURIComponent(domain)}`);
+      const data = await res.json();
+      setResults(data.results);
+    } catch (e) {
+      setResults(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="flex-1 px-2 text-black"
+        />
+        <button
+          type="button"
+          onClick={check}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          Check
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {results && (
+        <ul className="space-y-2">
+          {results.map((r) => (
+            <li key={r.path} className="flex items-center space-x-2">
+              <span className="w-48 truncate">/.well-known/{r.path}</span>
+              <span>{r.present ? '✅' : '❌'}</span>
+              <span className="text-sm text-gray-400">({r.status})</span>
+              {r.contacts && r.contacts.length > 0 && (
+                <span className="text-sm">{r.contacts.join(', ')}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default WellKnown;
+

--- a/pages/api/well-known.ts
+++ b/pages/api/well-known.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface WellKnownResult {
+  path: string;
+  present: boolean;
+  status: number;
+  contacts?: string[];
+}
+
+const PATHS = [
+  'security.txt',
+  'mta-sts.txt',
+  'change-password',
+  'dnt-policy.txt',
+  'gpc.json',
+];
+
+async function check(domain: string, path: string): Promise<WellKnownResult> {
+  const protocol = /^https?:\/\//i.test(domain) ? '' : 'https://';
+  const url = `${protocol}${domain}/.well-known/${path}`;
+  try {
+    const res = await fetch(url);
+    const status = res.status;
+    const present = status >= 200 && status < 400;
+    let contacts: string[] | undefined;
+    if (present && path === 'security.txt') {
+      const body = await res.text();
+      contacts = body
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => /^contact:/i.test(line))
+        .map((line) => line.split(':').slice(1).join(':').trim());
+    }
+    return { path, present, status, contacts };
+  } catch (e) {
+    return { path, present: false, status: 0 };
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const domain = (req.query.domain as string) || req.headers.host;
+  if (!domain) {
+    return res.status(400).json({ error: 'No domain provided' });
+  }
+  const results = await Promise.all(PATHS.map((p) => check(domain, p)));
+  res.status(200).json({ domain, results });
+}
+

--- a/pages/apps/well-known.tsx
+++ b/pages/apps/well-known.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import WellKnown from '../../apps/well-known';
+
+const WellKnownPage: React.FC = () => {
+  return <WellKnown />;
+};
+
+export default WellKnownPage;
+


### PR DESCRIPTION
## Summary
- add `/api/well-known` route that verifies common `.well-known` endpoints like `security.txt`, `mta-sts.txt`, and `change-password`
- build `apps/well-known` tool to query domains and display endpoint status with pass/fail indicators
- expose interface at `/apps/well-known`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f10c452883288657cf273ebd1887