### PR TITLE
Add sanitization playground app

### DIFF
--- a/__tests__/sanitization-playground.test.tsx
+++ b/__tests__/sanitization-playground.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SanitizationPlayground, {
+  encodeHTML,
+  encodeJS,
+  encodeURL,
+  encodeSQL,
+} from '../apps/sanitization-playground';
+
+describe('encoders', () => {
+  const payload = "<script>alert('x')</script>";
+
+  it('html encoder escapes markup', () => {
+    expect(encodeHTML(payload)).toBe('&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;');
+  });
+
+  it('js encoder escapes for scripts', () => {
+    expect(encodeJS(payload)).toBe('\\x3Cscript\\x3Ealert(\\x27x\\x27)\\x3C/script\\x3E');
+  });
+
+  it('url encoder uses encodeURIComponent', () => {
+    expect(encodeURL(payload)).toBe('%3Cscript%3Ealert(\'x\')%3C%2Fscript%3E');
+  });
+
+  it('sql encoder doubles single quotes', () => {
+    expect(encodeSQL("' OR 1=1; --")).toBe("'' OR 1=1; --");
+  });
+});
+
+describe('SanitizationPlayground component', () => {
+  it('shows encoded output for each tab', () => {
+    const { getByText, getByRole, getByTestId, getAllByText } = render(<SanitizationPlayground />);
+    const input = "<script>alert('x')</script>";
+    const textarea = getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: input } });
+
+    fireEvent.click(getByText('HTML'));
+    expect(getByTestId('output').textContent).toBe(encodeHTML(input));
+
+    fireEvent.click(getByText('JavaScript'));
+    expect(getByTestId('output').textContent).toBe(encodeJS(input));
+
+    fireEvent.click(getAllByText('URL')[1]);
+    expect(getByTestId('output').textContent).toBe(encodeURL(input));
+
+    fireEvent.click(getAllByText('SQL')[1]);
+    expect(getByTestId('output').textContent).toBe(encodeSQL(input));
+  });
+});

--- a/apps/sanitization-playground/index.tsx
+++ b/apps/sanitization-playground/index.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+
+export const encodeHTML = (str: string): string =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const encodeJS = (str: string): string =>
+  str
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, '\\x27')
+    .replace(/"/g, '\\x22')
+    .replace(/</g, '\\x3C')
+    .replace(/>/g, '\\x3E')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+
+export const encodeURL = (str: string): string => encodeURIComponent(str);
+
+export const encodeSQL = (str: string): string => str.replace(/'/g, "''");
+
+const contexts = {
+  html: {
+    label: 'HTML',
+    encode: encodeHTML,
+    note:
+      'Escapes <, >, &, " and \x27 so the browser renders text instead of interpreting markup.',
+  },
+  js: {
+    label: 'JavaScript',
+    encode: encodeJS,
+    note:
+      'Escapes quotes, backslashes and angle brackets so the string is safe inside a <script> block.',
+  },
+  url: {
+    label: 'URL',
+    encode: encodeURL,
+    note: 'Uses encodeURIComponent to make the value safe for URLs and query strings.',
+  },
+  sql: {
+    label: 'SQL',
+    encode: encodeSQL,
+    note:
+      "Doubles single quotes to keep input within string literals. Parameterized queries are recommended.",
+  },
+};
+
+const examples = [
+  { label: 'Script tag', value: "<script>alert('xss')</script>" },
+  { label: 'JS string', value: "'; alert('xss'); //" },
+  { label: 'URL', value: "https://example.com/?q=<script>alert(1)</script>" },
+  { label: 'SQL', value: "' OR 1=1; --" },
+];
+
+const SanitizationPlayground: React.FC = () => {
+  const [input, setInput] = useState(examples[0].value);
+  const [tab, setTab] = useState<keyof typeof contexts>('html');
+
+  const ctx = contexts[tab];
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 overflow-auto">
+      <h1 className="text-xl font-bold mb-2">Sanitization Playground</h1>
+      <textarea
+        className="w-full p-2 rounded text-black mb-2"
+        rows={3}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <div className="flex flex-wrap gap-2 mb-4">
+        {examples.map((ex) => (
+          <button
+            key={ex.label}
+            type="button"
+            className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
+            onClick={() => setInput(ex.value)}
+          >
+            {ex.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2 mb-2">
+        {Object.entries(contexts).map(([key, { label }]) => (
+          <button
+            key={key}
+            type="button"
+            className={`px-3 py-1 rounded ${tab === key ? 'bg-blue-600' : 'bg-gray-700 hover:bg-gray-600'}`}
+            onClick={() => setTab(key as keyof typeof contexts)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <pre
+        className="bg-gray-800 p-2 rounded text-sm whitespace-pre-wrap break-all"
+        data-testid="output"
+      >
+        {ctx.encode(input)}
+      </pre>
+      <p className="text-sm mt-2" data-testid="note">
+        {ctx.note}
+      </p>
+    </div>
+  );
+};
+
+export default SanitizationPlayground;
+

--- a/components/apps/sanitization-playground.js
+++ b/components/apps/sanitization-playground.js
@@ -1,0 +1,9 @@
+import SanitizationPlayground, {
+  encodeHTML,
+  encodeJS,
+  encodeURL,
+  encodeSQL,
+} from '../../apps/sanitization-playground';
+
+export default SanitizationPlayground;
+export { encodeHTML, encodeJS, encodeURL, encodeSQL };


### PR DESCRIPTION
## Summary
- add sanitization playground app with HTML, JavaScript, URL and SQL encoders
- include example payloads, tabbed output and contextual notes
- cover encoding utilities and UI with tests

## Testing
- `yarn lint`
- `yarn test __tests__/sanitization-playground.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10d608c8328856a67581ca532a7