### PR TITLE
feat: add mail authentication checker

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -79,6 +79,7 @@ const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
+const MailAuthApp = createDynamicApp('mail-auth', 'Mail Auth');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -117,6 +118,7 @@ const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
+const displayMailAuth = createDisplay(MailAuthApp);
 
 const displayGomoku = createDisplay(GomokuApp);
 
@@ -609,6 +611,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'mail-auth',
+    title: 'Mail Auth',
+    icon: './themes/Yaru/apps/mail-auth.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMailAuth,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/apps/mail-auth/index.tsx
+++ b/apps/mail-auth/index.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+
+type Result = {
+  pass: boolean;
+  record?: string;
+  message?: string;
+  recommendation?: string;
+};
+
+type Response = {
+  spf: Result;
+  dkim: Result;
+  dmarc: Result;
+  error?: string;
+};
+
+const MailAuth: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [selector, setSelector] = useState('');
+  const [results, setResults] = useState<Response | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    if (!domain) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ domain });
+      if (selector) params.append('selector', selector);
+      const res = await fetch(`/api/mail-auth?${params.toString()}`);
+      const data = await res.json();
+      setResults(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderCard = (label: string, r: Result) => {
+    const color = r.pass ? 'bg-green-600' : 'bg-red-600';
+    return (
+      <div key={label} className={`p-4 rounded text-white ${color}`}>
+        <h3 className="font-bold uppercase">{label}</h3>
+        {r.record && <p className="mt-2 break-words text-xs">{r.record}</p>}
+        {r.message && <p className="mt-2 text-xs">{r.message}</p>}
+        {r.recommendation && <p className="mt-1 text-xs italic">{r.recommendation}</p>}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-1"
+          placeholder="domain.com"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+        />
+        <input
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-1"
+          placeholder="DKIM selector (optional)"
+          value={selector}
+          onChange={(e) => setSelector(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={check}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 rounded disabled:opacity-50"
+        >
+          {loading ? 'Checking...' : 'Check'}
+        </button>
+      </div>
+      {results && !results.error && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          {renderCard('SPF', results.spf)}
+          {renderCard('DKIM', results.dkim)}
+          {renderCard('DMARC', results.dmarc)}
+        </div>
+      )}
+      {results?.error && <div className="text-red-400">{results.error}</div>}
+    </div>
+  );
+};
+
+export default MailAuth;

--- a/pages/api/mail-auth.ts
+++ b/pages/api/mail-auth.ts
@@ -1,0 +1,97 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+async function lookupTxt(name: string): Promise<string[]> {
+  const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(name)}&type=TXT`;
+  const res = await fetch(url, { headers: { Accept: 'application/dns-json' } });
+  if (!res.ok) throw new Error('DNS query failed');
+  const data = await res.json();
+  const answers = data.Answer || [];
+  return answers.map((a: any) =>
+    String(a.data)
+      .replace(/^"|"$/g, '')
+      .replace(/"\s"/g, '')
+  );
+}
+
+function parseSpf(records: string[]) {
+  const record = records.find((r) => r.startsWith('v=spf1'));
+  if (!record) {
+    return {
+      pass: false,
+      message: 'No SPF record found',
+      recommendation: 'Add a TXT record starting with v=spf1 and ending with -all or ~all',
+    };
+  }
+  const policy = record.match(/\s([~-]?all)/)?.[1] || '';
+  let recommendation = '';
+  if (policy === '~all') {
+    recommendation = 'Consider using -all for strict enforcement';
+  } else if (policy !== '-all') {
+    recommendation = 'SPF record should end with -all or ~all';
+  }
+  return { pass: policy === '-all' || policy === '~all', record, recommendation };
+}
+
+function parseDkim(records: string[]) {
+  const record = records.find((r) => r.includes('v=DKIM1'));
+  if (!record) {
+    return {
+      pass: false,
+      message: 'No DKIM record found for selector',
+      recommendation: 'Ensure the selector is correct and DKIM is configured',
+    };
+  }
+  if (!record.includes('p=')) {
+    return { pass: false, record, recommendation: 'DKIM record missing p= public key' };
+  }
+  return { pass: true, record };
+}
+
+function parseDmarc(records: string[]) {
+  const record = records.find((r) => r.startsWith('v=DMARC1'));
+  if (!record) {
+    return {
+      pass: false,
+      message: 'No DMARC record found',
+      recommendation: 'Add a TXT record at _dmarc with v=DMARC1 and a p= policy',
+    };
+  }
+  const policy = record.match(/p=([^;]+)/)?.[1];
+  let recommendation = '';
+  if (!policy) {
+    recommendation = 'DMARC record missing p= policy';
+  } else if (policy === 'none') {
+    recommendation = 'Consider setting policy to quarantine or reject';
+  }
+  return { pass: !!policy, record, recommendation };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { domain, selector } = req.query;
+  if (typeof domain !== 'string') {
+    res.status(400).json({ error: 'domain parameter required' });
+    return;
+  }
+  try {
+    const spfRecords = await lookupTxt(domain);
+    const dmarcRecords = await lookupTxt(`_dmarc.${domain}`);
+    let dkimRecords: string[] = [];
+    if (typeof selector === 'string' && selector) {
+      dkimRecords = await lookupTxt(`${selector}._domainkey.${domain}`);
+    }
+    res.status(200).json({
+      spf: parseSpf(spfRecords),
+      dkim: selector ? parseDkim(dkimRecords) : {
+        pass: false,
+        message: 'No selector provided',
+        recommendation: 'Provide a DKIM selector to check the record',
+      },
+      dmarc: parseDmarc(dmarcRecords),
+    });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message || 'Lookup failed' });
+  }
+}

--- a/pages/apps/mail-auth.tsx
+++ b/pages/apps/mail-auth.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const MailAuth = dynamic(() => import('../../apps/mail-auth'), { ssr: false });
+
+export default function MailAuthPage() {
+  return <MailAuth />;
+}

--- a/public/themes/Yaru/apps/mail-auth.svg
+++ b/public/themes/Yaru/apps/mail-auth.svg
@@ -1,0 +1,1 @@
+404: Not Found


### PR DESCRIPTION
## Summary
- add API endpoint using DNS-over-HTTPS to evaluate SPF, DKIM, and DMARC records
- create Mail Auth app with color-coded result cards and integrate into app list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10a053883289b64480f008a6c32