### PR TITLE
Add JSON ↔ YAML converter utility

### DIFF
--- a/apps/json-yaml/index.html
+++ b/apps/json-yaml/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JSON ⇄ YAML Converter</title>
+  <link id="hljs-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f5f5;
+      color: #222;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    body.dark {
+      background: #1e1e1e;
+      color: #eee;
+    }
+    header {
+      padding: 1rem;
+      text-align: center;
+    }
+    main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: 0 1rem 1rem;
+    }
+    textarea {
+      width: 100%;
+      height: 120px;
+      padding: 0.5rem;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      font-family: monospace;
+      resize: vertical;
+    }
+    pre {
+      flex: 1;
+      padding: 1rem;
+      overflow: auto;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background: #fff;
+    }
+    body.dark pre {
+      background: #2e2e2e;
+      border-color: #555;
+    }
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    button {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      background: #007bff;
+      color: #fff;
+      cursor: pointer;
+    }
+    button:hover {
+      background: #0069d9;
+    }
+    .error {
+      color: #c00;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>JSON ⇄ YAML Converter</h1>
+  </header>
+  <main>
+    <textarea id="input" placeholder="Enter JSON or YAML..."></textarea>
+    <textarea id="schema" placeholder="Optional JSON Schema..."></textarea>
+    <div class="controls">
+      <button id="toYaml">JSON → YAML</button>
+      <button id="toJson">YAML → JSON</button>
+      <button id="validate">Validate</button>
+      <button id="download">Download</button>
+      <button id="theme-toggle">Toggle Theme</button>
+    </div>
+    <pre><code id="output" class="hljs"></code></pre>
+    <div id="errors" class="error"></div>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/json.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/yaml.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ajv@8/dist/ajv.min.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/apps/json-yaml/main.js
+++ b/apps/json-yaml/main.js
@@ -1,0 +1,103 @@
+const input = document.getElementById('input');
+const schemaInput = document.getElementById('schema');
+const output = document.getElementById('output');
+const errors = document.getElementById('errors');
+const toYamlBtn = document.getElementById('toYaml');
+const toJsonBtn = document.getElementById('toJson');
+const validateBtn = document.getElementById('validate');
+const downloadBtn = document.getElementById('download');
+const themeBtn = document.getElementById('theme-toggle');
+
+const themes = {
+  light: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css',
+  dark: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/monokai-sublime.min.css'
+};
+let currentTheme = 'light';
+let lastObject = null;
+let lastType = 'json';
+
+function highlight(code, lang) {
+  output.textContent = code;
+  output.className = 'hljs ' + lang;
+  if (window.hljs) {
+    window.hljs.highlightElement(output);
+  }
+}
+
+function showError(msg) {
+  errors.textContent = msg;
+}
+
+function clearError() {
+  errors.textContent = '';
+}
+
+toYamlBtn.addEventListener('click', () => {
+  clearError();
+  try {
+    const obj = JSON.parse(input.value);
+    lastObject = obj;
+    lastType = 'yaml';
+    const yaml = jsyaml.dump(obj);
+    highlight(yaml, 'yaml');
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+toJsonBtn.addEventListener('click', () => {
+  clearError();
+  try {
+    const obj = jsyaml.load(input.value);
+    lastObject = obj;
+    lastType = 'json';
+    const json = JSON.stringify(obj, null, 2);
+    highlight(json, 'json');
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+validateBtn.addEventListener('click', () => {
+  clearError();
+  try {
+    const schemaText = schemaInput.value.trim();
+    if (!schemaText) {
+      showError('Schema input is empty');
+      return;
+    }
+    const schema = JSON.parse(schemaText);
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+    const valid = validate(lastObject);
+    if (valid) {
+      showError('Valid!');
+    } else {
+      showError(ajv.errorsText(validate.errors));
+    }
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+downloadBtn.addEventListener('click', () => {
+  if (!output.textContent) return;
+  const blob = new Blob([output.textContent], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = lastType === 'json' ? 'output.json' : 'output.yaml';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+});
+
+themeBtn.addEventListener('click', () => {
+  currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+  document.getElementById('hljs-theme').href = themes[currentTheme];
+  document.body.classList.toggle('dark', currentTheme === 'dark');
+});
+
+// initial highlight
+highlight('', 'json');


### PR DESCRIPTION
## Summary
- add `apps/json-yaml` for converting between JSON and YAML with syntax highlighting
- include optional JSON Schema validation, downloadable output and theme toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f11795d88328be2878fcfb906816