### PR TITLE
feat: add SRI audit tool

### DIFF
--- a/apps/sri-audit/index.tsx
+++ b/apps/sri-audit/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+interface Result {
+  src: string;
+  status: string;
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  computedIntegrity: string;
+  providedIntegrity: string | null;
+  recommendation?: string;
+}
+
+const SriAudit: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [results, setResults] = useState<Result[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const runAudit = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError('');
+    setResults(null);
+    try {
+      const res = await fetch(`/api/sri-audit?url=${encodeURIComponent(url)}`);
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      setResults(data.results);
+    } catch (e: any) {
+      setError(e.message || 'Failed to audit');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const color = (sev: Result['severity']) => {
+    if (sev === 'error') return 'text-red-500';
+    if (sev === 'warning') return 'text-yellow-500';
+    return 'text-green-500';
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+          className="flex-1 px-2 py-1 text-black"
+        />
+        <button
+          type="button"
+          onClick={runAudit}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Audit
+        </button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      {loading && <div>Loading...</div>}
+      {results && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">Script</th>
+              <th className="text-left">Status</th>
+              <th className="text-left">Fix</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <tr key={r.src} className={color(r.severity)}>
+                <td className="pr-2 break-all">{r.src}</td>
+                <td className="pr-2">{r.message}</td>
+                <td className="break-all">{r.recommendation || 'None'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default SriAudit;
+

--- a/pages/api/sri-audit.ts
+++ b/pages/api/sri-audit.ts
@@ -1,0 +1,92 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import crypto from 'crypto';
+
+interface ScriptResult {
+  src: string;
+  providedIntegrity: string | null;
+  computedIntegrity: string;
+  status: 'match' | 'mismatch' | 'missing' | 'error';
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  recommendation?: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'url query parameter is required' });
+  }
+
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+
+    const scriptRegex = /<script\b[^>]*src=["']([^"']+)["'][^>]*>/gi;
+    const results: ScriptResult[] = [];
+    let match;
+
+    while ((match = scriptRegex.exec(html)) !== null) {
+      const tag = match[0];
+      const src = match[1];
+      const integrityMatch = tag.match(/integrity=["']([^"']+)["']/i);
+      const provided = integrityMatch ? integrityMatch[1] : null;
+      const scriptUrl = src.startsWith('http') ? src : new URL(src, url).href;
+
+      try {
+        const scriptRes = await fetch(scriptUrl);
+        const buffer = Buffer.from(await scriptRes.arrayBuffer());
+        const algo = provided?.split('-')[0] || 'sha384';
+        const hash = crypto.createHash(algo).update(buffer).digest('base64');
+        const computed = `${algo}-${hash}`;
+
+        if (!provided) {
+          results.push({
+            src: scriptUrl,
+            providedIntegrity: null,
+            computedIntegrity: computed,
+            status: 'missing',
+            severity: 'warning',
+            message: 'Missing integrity attribute',
+            recommendation: `Add integrity="${computed}"`,
+          });
+        } else if (provided !== computed) {
+          results.push({
+            src: scriptUrl,
+            providedIntegrity: provided,
+            computedIntegrity: computed,
+            status: 'mismatch',
+            severity: 'error',
+            message: 'Integrity mismatch',
+            recommendation: `Update integrity to "${computed}"`,
+          });
+        } else {
+          results.push({
+            src: scriptUrl,
+            providedIntegrity: provided,
+            computedIntegrity: computed,
+            status: 'match',
+            severity: 'info',
+            message: 'Integrity OK',
+          });
+        }
+      } catch (err: any) {
+        results.push({
+          src: scriptUrl,
+          providedIntegrity: provided,
+          computedIntegrity: '',
+          status: 'error',
+          severity: 'error',
+          message: 'Failed to fetch script',
+        });
+      }
+    }
+
+    return res.status(200).json({ url, results });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message });
+  }
+}
+

--- a/pages/apps/sri-audit.tsx
+++ b/pages/apps/sri-audit.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const SriAudit = dynamic(() => import('../../apps/sri-audit'), { ssr: false });
+
+export default function SriAuditPage() {
+  return <SriAudit />;
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to compute script SRI hashes and highlight issues
- new SRI audit app UI to scan pages and show recommendations

## Testing
- `CI=1 yarn test __tests__/passwordGenerator.test.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f119c2248328a809373ad5aa973b