### PR TITLE
Add service worker security checker

### DIFF
--- a/apps/sw-checker/index.tsx
+++ b/apps/sw-checker/index.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+
+interface Finding {
+  pattern: string;
+  explanation: string;
+  remediation: string;
+  docs: string;
+}
+
+const SwChecker: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [findings, setFindings] = useState<Finding[] | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    setError('');
+    setFindings(null);
+    if (!url) {
+      setError('Please enter a URL');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/sw-check?url=${encodeURIComponent(url)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to check service worker');
+      } else {
+        setFindings(data.findings);
+      }
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col space-y-4">
+      <h1 className="text-2xl font-bold">Service Worker Checker</h1>
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="flex-1 px-2 py-1 text-black"
+        />
+        <button
+          type="button"
+          onClick={check}
+          className="px-4 py-1 bg-blue-600 rounded"
+          disabled={loading}
+        >
+          {loading ? 'Checking...' : 'Check'}
+        </button>
+      </div>
+      {error && <div className="text-red-400">{error}</div>}
+      {findings && (
+        <div className="flex-1 overflow-auto">
+          {findings.length === 0 && (
+            <div>No risky patterns found in service-worker.js</div>
+          )}
+          {findings.length > 0 && (
+            <ul className="space-y-4">
+              {findings.map((f, idx) => (
+                <li key={idx} className="border border-gray-700 p-3 rounded">
+                  <div className="font-mono text-yellow-300">{f.pattern}</div>
+                  <div className="mt-1">{f.explanation}</div>
+                  <div className="mt-1 font-semibold">Remediation: {f.remediation}</div>
+                  <a
+                    href={f.docs}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 underline mt-1 inline-block"
+                  >
+                    Learn more
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SwChecker;
+

--- a/pages/api/sw-check.ts
+++ b/pages/api/sw-check.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface Finding {
+  pattern: string;
+  explanation: string;
+  remediation: string;
+  docs: string;
+}
+
+const PATTERNS: { regex: RegExp; explanation: string; remediation: string; docs: string }[] = [
+  {
+    regex: /self\.skipWaiting\s*\(\s*\)/,
+    explanation: 'self.skipWaiting() allows a new service worker to activate immediately, which may leave older tabs running previous versions and lead to unexpected behavior or security risks.',
+    remediation: 'Remove automatic skipWaiting or prompt users before activating a new service worker.',
+    docs: 'https://developer.chrome.com/docs/workbox/handling-service-worker-updates/',
+  },
+  {
+    regex: /clients\.claim\s*\(\s*\)/,
+    explanation: 'clients.claim() forces uncontrolled pages to be controlled by the service worker without a reload, which can cause inconsistent state if used prematurely.',
+    remediation: 'Call clients.claim() only after ensuring the service worker is ready to safely control pages.',
+    docs: 'https://developer.mozilla.org/docs/Web/API/Clients/claim',
+  },
+];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'Missing url parameter' });
+  }
+
+  try {
+    const swUrl = url.endsWith('/') ? `${url}service-worker.js` : `${url}/service-worker.js`;
+    const response = await fetch(swUrl);
+    if (!response.ok) {
+      return res.status(response.status).json({ error: `Unable to fetch service worker: ${response.statusText}` });
+    }
+    const text = await response.text();
+    const findings: Finding[] = [];
+    PATTERNS.forEach((p) => {
+      if (p.regex.test(text)) {
+        findings.push({ pattern: p.regex.source, explanation: p.explanation, remediation: p.remediation, docs: p.docs });
+      }
+    });
+    return res.status(200).json({ findings });
+  } catch (e: any) {
+    return res.status(500).json({ error: e.message || 'Failed to check service worker' });
+  }
+}
+

--- a/pages/apps/sw-checker.tsx
+++ b/pages/apps/sw-checker.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const SwChecker = dynamic(() => import('../../apps/sw-checker'), { ssr: false });
+
+export default function SwCheckerPage() {
+  return <SwChecker />;
+}
+


### PR DESCRIPTION
## Summary
- add API to fetch service-worker.js and scan for risky patterns
- add UI app to display findings with remediation guidance

## Testing
- `yarn lint --file pages/api/sw-check.ts --file apps/sw-checker/index.tsx --file pages/apps/sw-checker.tsx`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f11aa9588328a89893f7feb55b91