### PR TITLE
feat: add http diff tool

### DIFF
--- a/apps/http-diff/index.tsx
+++ b/apps/http-diff/index.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+
+interface DiffPart {
+  value: string;
+  added?: boolean;
+  removed?: boolean;
+}
+
+interface FetchMeta {
+  finalUrl: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  redirects: { url: string; status: number }[];
+}
+
+interface ApiResult {
+  url1: FetchMeta;
+  url2: FetchMeta;
+  bodyDiff: DiffPart[];
+  headersDiff: DiffPart[];
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[c as keyof Record<string, string>]);
+}
+
+function renderSideBySide(diff: DiffPart[]) {
+  const left: string[] = [];
+  const right: string[] = [];
+
+  diff.forEach((part) => {
+    const lines = part.value.split('\n');
+    lines.forEach((line, i) => {
+      if (i === lines.length - 1 && line === '') return;
+      const escaped = escapeHtml(line);
+      if (part.added) {
+        left.push('<span class="block"></span>');
+        right.push(`<span class="bg-green-500/30">${escaped}</span>`);
+      } else if (part.removed) {
+        left.push(`<span class="bg-red-500/30">${escaped}</span>`);
+        right.push('<span class="block"></span>');
+      } else {
+        left.push(`<span>${escaped}</span>`);
+        right.push(`<span>${escaped}</span>`);
+      }
+    });
+  });
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <pre
+        className="bg-gray-800 text-white p-2 overflow-auto"
+        dangerouslySetInnerHTML={{ __html: left.join('\n') }}
+      />
+      <pre
+        className="bg-gray-800 text-white p-2 overflow-auto"
+        dangerouslySetInnerHTML={{ __html: right.join('\n') }}
+      />
+    </div>
+  );
+}
+
+const HttpDiff: React.FC = () => {
+  const [url1, setUrl1] = useState('');
+  const [url2, setUrl2] = useState('');
+  const [data, setData] = useState<ApiResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleCompare = async () => {
+    setLoading(true);
+    setData(null);
+    try {
+      const res = await fetch('/api/http-diff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url1, url2 }),
+      });
+      const json = await res.json();
+      setData(json);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 text-black px-2 py-1"
+          placeholder="First URL"
+          value={url1}
+          onChange={(e) => setUrl1(e.target.value)}
+        />
+        <input
+          className="flex-1 text-black px-2 py-1"
+          placeholder="Second URL"
+          value={url2}
+          onChange={(e) => setUrl2(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={handleCompare}
+          className="px-4 py-1 bg-blue-600 rounded"
+          disabled={loading}
+        >
+          Compare
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {data && (
+        <div className="flex flex-col space-y-4 overflow-auto">
+          <div>
+            <h2 className="font-bold mb-1">Body Diff</h2>
+            {renderSideBySide(data.bodyDiff)}
+          </div>
+          <div>
+            <h2 className="font-bold mb-1">Headers Diff</h2>
+            {renderSideBySide(data.headersDiff)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HttpDiff;
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cannon-es": "^0.20.0",
     "canvas-confetti": "1.9.3",
     "chess.js": "^1.0.0",
+    "diff": "^8.0.2",
     "expr-eval": "^2.0.2",
     "html-to-image": "^1.11.13",
     "jsonwebtoken": "^9.0.2",

--- a/pages/api/http-diff.ts
+++ b/pages/api/http-diff.ts
@@ -1,0 +1,69 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { diffLines } from 'diff';
+
+interface FetchResult {
+  finalUrl: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  redirects: { url: string; status: number }[];
+}
+
+const MAX_REDIRECTS = 10;
+
+async function fetchWithRedirects(url: string): Promise<FetchResult> {
+  const redirects: { url: string; status: number }[] = [];
+  let current = url;
+  let response: Response;
+
+  for (let i = 0; i < MAX_REDIRECTS; i += 1) {
+    response = await fetch(current, { redirect: 'manual' });
+    redirects.push({ url: current, status: response.status });
+    if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
+      const location = response.headers.get('location') as string;
+      current = new URL(location, current).toString();
+    } else {
+      break;
+    }
+  }
+
+  const body = await response.text();
+  const headers = Object.fromEntries(response.headers.entries());
+
+  return {
+    finalUrl: current,
+    status: response.status,
+    headers,
+    body,
+    redirects,
+  };
+}
+
+function headersToString(headers: Record<string, string>): string {
+  return Object.entries(headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const { url1, url2 } = req.body as { url1?: string; url2?: string };
+  if (!url1 || !url2) {
+    res.status(400).json({ error: 'Missing urls' });
+    return;
+  }
+
+  try {
+    const [r1, r2] = await Promise.all([fetchWithRedirects(url1), fetchWithRedirects(url2)]);
+    const bodyDiff = diffLines(r1.body, r2.body);
+    const headersDiff = diffLines(headersToString(r1.headers), headersToString(r2.headers));
+    res.status(200).json({ url1: r1, url2: r2, bodyDiff, headersDiff });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message || 'Error' });
+  }
+}
+

--- a/pages/apps/http-diff.tsx
+++ b/pages/apps/http-diff.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const HttpDiff = dynamic(() => import('../../apps/http-diff'), { ssr: false });
+
+export default function HttpDiffPage() {
+  return <HttpDiff />;
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,6 +3158,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "diff@npm:8.0.2"
+  checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
+  languageName: node
+  linkType: hard
+
 "dijkstrajs@npm:^1.0.1":
   version: 1.0.3
   resolution: "dijkstrajs@npm:1.0.3"
@@ -7949,6 +7956,7 @@ __metadata:
     cannon-es: "npm:^0.20.0"
     canvas-confetti: "npm:1.9.3"
     chess.js: "npm:^1.0.0"
+    diff: "npm:^8.0.2"
     eslint: "npm:^9.34.0"
     eslint-config-next: "npm:^15.5.0"
     expr-eval: "npm:^2.0.2"


### PR DESCRIPTION
## Summary
- add `diff` dependency
- introduce `/api/http-diff` to compare URLs' bodies and headers
- add `http-diff` app for side-by-side comparison

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f11cbee48328a53742aa2b876704