### PR TITLE
feat: add cookie jar analyzer

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -83,6 +83,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
 const ContentFingerprintApp = createDynamicApp('content-fingerprint', 'Content Fingerprint');
+const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -123,6 +124,7 @@ const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
 const displayContentFingerprint = createDisplay(ContentFingerprintApp);
+const displayCookieJar = createDisplay(CookieJarApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -611,6 +613,15 @@ const apps = [
       favourite: false,
       desktop_shortcut: false,
       screen: displayWeather,
+    },
+    {
+      id: 'cookie-jar',
+      title: 'Cookie Jar',
+      icon: './themes/Yaru/apps/cookie-jar.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayCookieJar,
     },
     {
       id: 'content-fingerprint',

--- a/apps/cookie-jar/index.tsx
+++ b/apps/cookie-jar/index.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react';
+
+interface CookieInfo {
+  name: string;
+  value: string;
+  secure: boolean;
+  httpOnly: boolean;
+  sameSite: string | null;
+  expires: string | null;
+  expired: boolean;
+  issues: string[];
+}
+
+function parseCookies(headers: string): CookieInfo[] {
+  const results: CookieInfo[] = [];
+  const lines = headers.split(/\r?\n/);
+  lines.forEach((line) => {
+    const match = line.match(/^set-cookie:\s*(.*)$/i);
+    if (!match) return;
+    const cookieStr = match[1];
+    const parts = cookieStr.split(';').map((p) => p.trim());
+    if (parts.length === 0) return;
+    const [nameValue, ...attrs] = parts;
+    const eqIndex = nameValue.indexOf('=');
+    const name = eqIndex >= 0 ? nameValue.slice(0, eqIndex) : nameValue;
+    const value = eqIndex >= 0 ? nameValue.slice(eqIndex + 1) : '';
+
+    const attrsLower = attrs.map((a) => a.toLowerCase());
+    const secure = attrsLower.includes('secure');
+    const httpOnly = attrsLower.includes('httponly');
+    const sameSiteAttr = attrs.find((a) => a.toLowerCase().startsWith('samesite='));
+    const sameSite = sameSiteAttr ? sameSiteAttr.split('=')[1] : null;
+    const expiresAttr = attrs.find((a) => a.toLowerCase().startsWith('expires='));
+    const maxAgeAttr = attrs.find((a) => a.toLowerCase().startsWith('max-age='));
+
+    let expires: string | null = null;
+    let expired = false;
+    if (expiresAttr) {
+      const dateStr = expiresAttr.split('=')[1];
+      expires = dateStr;
+      const date = new Date(dateStr);
+      if (!Number.isNaN(date.getTime())) {
+        expired = date.getTime() <= Date.now();
+      }
+    } else if (maxAgeAttr) {
+      const age = parseInt(maxAgeAttr.split('=')[1], 10);
+      const date = new Date(Date.now() + age * 1000);
+      expires = `Max-Age=${age} (exp: ${date.toUTCString()})`;
+      expired = age <= 0;
+    }
+
+    const issues: string[] = [];
+    if (!secure) issues.push('Add Secure attribute to transmit cookie only over HTTPS.');
+    if (!httpOnly) issues.push('Add HttpOnly to prevent access via JavaScript.');
+    if (!sameSite) {
+      issues.push('Add SameSite=Lax or Strict to mitigate CSRF.');
+    } else if (sameSite.toLowerCase() === 'none') {
+      issues.push('Avoid SameSite=None unless necessary.');
+    }
+    if (!expiresAttr && !maxAgeAttr) {
+      issues.push('No expiry set; cookie will be a session cookie.');
+    } else if (expired) {
+      issues.push('Cookie is already expired.');
+    }
+    if (sameSite && sameSite.toLowerCase() === 'none' && !secure) {
+      issues.push('SameSite=None requires the Secure attribute.');
+    }
+
+    results.push({
+      name,
+      value,
+      secure,
+      httpOnly,
+      sameSite,
+      expires,
+      expired,
+      issues,
+    });
+  });
+  return results;
+}
+
+const CookieJar: React.FC = () => {
+  const [headers, setHeaders] = useState('');
+  const [cookies, setCookies] = useState<CookieInfo[]>([]);
+
+  const analyze = () => {
+    setCookies(parseCookies(headers));
+  };
+
+  const exportReport = () => {
+    const blob = new Blob([JSON.stringify(cookies, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'cookie-jar-report.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <textarea
+        className="flex-1 text-black p-2"
+        placeholder="Paste HTTP response headers here..."
+        value={headers}
+        onChange={(e) => setHeaders(e.target.value)}
+      />
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={analyze}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Analyze
+        </button>
+        {cookies.length > 0 && (
+          <button
+            type="button"
+            onClick={exportReport}
+            className="px-4 py-1 bg-green-600 rounded"
+          >
+            Export
+          </button>
+        )}
+      </div>
+      {cookies.length > 0 && (
+        <div className="overflow-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 text-left">Cookie</th>
+                <th className="px-2 py-1">Secure</th>
+                <th className="px-2 py-1">HttpOnly</th>
+                <th className="px-2 py-1">SameSite</th>
+                <th className="px-2 py-1">Expiry</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cookies.map((c) => (
+                <tr key={c.name} className="odd:bg-gray-800">
+                  <td className="px-2 py-1 text-left break-all">{c.name}</td>
+                  <td className={`px-2 py-1 ${c.secure ? 'text-green-500' : 'text-red-500'}`}>{c.secure ? 'Yes' : 'No'}</td>
+                  <td className={`px-2 py-1 ${c.httpOnly ? 'text-green-500' : 'text-red-500'}`}>{c.httpOnly ? 'Yes' : 'No'}</td>
+                  <td className={`px-2 py-1 ${c.sameSite && c.sameSite.toLowerCase() !== 'none' ? 'text-green-500' : 'text-red-500'}`}>{c.sameSite || 'Missing'}</td>
+                  <td className={`px-2 py-1 ${c.expires ? (c.expired ? 'text-red-500' : 'text-green-500') : 'text-yellow-500'}`}>{c.expires || 'Session'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="mt-4 space-y-2">
+            {cookies.map((c) => (
+              <div key={c.name}>
+                <div className="font-bold">{c.name}</div>
+                {c.issues.length > 0 ? (
+                  <ul className="list-disc list-inside text-sm">
+                    {c.issues.map((issue) => (
+                      <li key={issue}>{issue}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="text-green-500 text-sm">No issues detected.</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CookieJar;
+

--- a/components/apps/cookie-jar.tsx
+++ b/components/apps/cookie-jar.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../apps/cookie-jar';

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/apps/cookie-jar.tsx
+++ b/pages/apps/cookie-jar.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const CookieJar = dynamic(() => import('../../apps/cookie-jar'), { ssr: false });
+
+export default function CookieJarPage() {
+  return <CookieJar />;
+}
+

--- a/public/themes/Yaru/apps/cookie-jar.svg
+++ b/public/themes/Yaru/apps/cookie-jar.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="16" y="10" width="32" height="46" rx="4" ry="4" fill="#ffe0b2" stroke="#c97a00" stroke-width="2"/>
+  <rect x="20" y="4" width="24" height="12" rx="2" ry="2" fill="#c97a00"/>
+  <circle cx="32" cy="38" r="14" fill="#d2a679"/>
+  <circle cx="26" cy="32" r="3" fill="#5d4037"/>
+  <circle cx="38" cy="34" r="3" fill="#5d4037"/>
+  <circle cx="32" cy="44" r="3" fill="#5d4037"/>
+  <circle cx="24" cy="40" r="3" fill="#5d4037"/>
+  <circle cx="40" cy="42" r="3" fill="#5d4037"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Cookie Jar app to parse Set-Cookie headers and highlight security attributes
- register Cookie Jar in app configuration and provide icon

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a901674b3c832888596b9693ed6e10