### PR TITLE
feat: add Shodan + NVD search tool

### DIFF
--- a/apps/shodan-nvd/index.tsx
+++ b/apps/shodan-nvd/index.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+
+interface NvdInfo {
+  id: string;
+  description: string;
+}
+
+interface ShodanMatch {
+  ip_str: string;
+  port: number;
+  hostnames?: string[];
+  data?: string;
+  nvd: NvdInfo[];
+}
+
+const ShodanNvd: React.FC = () => {
+  const [key, setKey] = useState('');
+  const [query, setQuery] = useState('');
+  const [agree, setAgree] = useState(false);
+  const [results, setResults] = useState<ShodanMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const search = async () => {
+    setLoading(true);
+    setError('');
+    setResults([]);
+    try {
+      const res = await fetch('/api/shodan-nvd', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key, query, agree }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || 'Error');
+      } else {
+        setResults(json.matches || []);
+      }
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4 overflow-auto">
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 text-black px-2 py-1"
+          placeholder="Shodan API Key"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+        <input
+          className="flex-1 text-black px-2 py-1"
+          placeholder="Search query or IP"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={search}
+          disabled={loading || !agree}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Search
+        </button>
+      </div>
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          checked={agree}
+          onChange={(e) => setAgree(e.target.checked)}
+        />
+        <span className="text-sm">I agree to the terms of service</span>
+      </label>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      <div className="grid gap-4">
+        {results.map((m, i) => (
+          <div key={`${m.ip_str}-${m.port}-${i}`} className="bg-gray-800 p-4 rounded">
+            <h3 className="font-bold mb-1">
+              {m.ip_str}:{m.port}
+            </h3>
+            {m.hostnames && m.hostnames.length > 0 && (
+              <div className="text-sm mb-1">
+                Hostnames: {m.hostnames.join(', ')}
+              </div>
+            )}
+            {m.nvd && m.nvd.length > 0 && (
+              <div className="mt-2">
+                <h4 className="font-semibold">Vulnerabilities</h4>
+                <ul className="list-disc list-inside text-sm space-y-1">
+                  {m.nvd.map((n) => (
+                    <li key={n.id}>
+                      <span className="font-mono">{n.id}</span>: {n.description}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ShodanNvd;
+

--- a/pages/api/shodan-nvd.ts
+++ b/pages/api/shodan-nvd.ts
@@ -1,0 +1,140 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface CacheEntry<T> {
+  expiry: number;
+  data: T;
+}
+
+const cache = new Map<string, CacheEntry<any>>();
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX = 5;
+const rateLimit = new Map<string, { count: number; start: number }>();
+
+function getCache<T>(key: string): T | null {
+  const entry = cache.get(key);
+  if (entry && entry.expiry > Date.now()) {
+    return entry.data as T;
+  }
+  if (entry) cache.delete(key);
+  return null;
+}
+
+function setCache<T>(key: string, data: T, ttl = 5 * 60 * 1000) {
+  cache.set(key, { data, expiry: Date.now() + ttl });
+}
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const record = rateLimit.get(ip);
+  if (!record || now - record.start > RATE_LIMIT_WINDOW) {
+    rateLimit.set(ip, { count: 1, start: now });
+    return true;
+  }
+  if (record.count >= RATE_LIMIT_MAX) return false;
+  record.count += 1;
+  return true;
+}
+
+async function fetchShodan(key: string, query: string) {
+  const cacheKey = `shodan:${query}`;
+  const cached = getCache<any>(cacheKey);
+  if (cached) return cached;
+  const url = `https://api.shodan.io/shodan/host/search?key=${encodeURIComponent(
+    key
+  )}&query=${encodeURIComponent(query)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Shodan error: ${res.status}`);
+  }
+  const data = await res.json();
+  setCache(cacheKey, data, 60 * 1000); // cache 1 minute
+  return data;
+}
+
+interface NvdInfo {
+  id: string;
+  description: string;
+}
+
+async function fetchCve(id: string): Promise<NvdInfo> {
+  const cacheKey = `cve:${id}`;
+  const cached = getCache<NvdInfo>(cacheKey);
+  if (cached) return cached;
+  const url = `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=${encodeURIComponent(
+    id
+  )}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('NVD fetch failed');
+  const json = await res.json();
+  const cve = json.vulnerabilities?.[0]?.cve;
+  const description = cve?.descriptions?.[0]?.value || '';
+  const info = { id, description };
+  setCache(cacheKey, info, 5 * 60 * 1000); // 5 minutes
+  return info;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const { key, query, agree } = req.body as {
+    key?: string;
+    query?: string;
+    agree?: boolean;
+  };
+
+  if (!agree) {
+    res
+      .status(400)
+      .json({ error: 'You must agree to the terms of service.' });
+    return;
+  }
+
+  if (!key || typeof key !== 'string') {
+    res.status(400).json({ error: 'API key is required.' });
+    return;
+  }
+  if (!query || typeof query !== 'string') {
+    res.status(400).json({ error: 'Query is required.' });
+    return;
+  }
+
+  const ip =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0] ||
+    req.socket.remoteAddress ||
+    'unknown';
+  if (!checkRateLimit(ip)) {
+    res.status(429).json({ error: 'Rate limit exceeded.' });
+    return;
+  }
+
+  try {
+    const shodanData = await fetchShodan(key, query);
+    const matches = await Promise.all(
+      (shodanData.matches || []).map(async (m: any) => {
+        const vulns = m.vulns ? Object.keys(m.vulns) : [];
+        const nvd: NvdInfo[] = [];
+        // sequential fetch with Promise.all
+        for (const id of vulns) {
+          try {
+            const info = await fetchCve(id);
+            nvd.push(info);
+          } catch (e) {
+            // ignore failure for individual CVE
+          }
+        }
+        return { ...m, nvd };
+      })
+    );
+
+    res.status(200).json({ query, matches });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message || 'Error fetching data.' });
+  }
+}
+

--- a/pages/apps/shodan-nvd.tsx
+++ b/pages/apps/shodan-nvd.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const ShodanNvd = dynamic(() => import('../../apps/shodan-nvd'), { ssr: false });
+
+export default function ShodanNvdPage() {
+  return <ShodanNvd />;
+}
+


### PR DESCRIPTION
## Summary
- add API route that queries Shodan and NVD with caching, rate limiting and TOS agreement check
- add Shodan/NVD search UI with API key input and vulnerability cards
- expose new app through dynamic page loader

## Testing
- `yarn test` (fails: killed after showing 27/28 suites due to environment limits)

------
https://chatgpt.com/codex/tasks/task_e_68a90168c3ec83289c3aa09238126161