### PR TITLE
Add CAA checker app and API

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,7 @@ import { displayAsciiArt } from './components/apps/ascii_art';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
+import { displayCaaChecker } from './components/apps/caa-checker';
 
 export const THEME = process.env.NEXT_PUBLIC_THEME || 'Yaru';
 export const icon = (name) => `./themes/${THEME}/apps/${name}`;
@@ -649,6 +650,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'caa-checker',
+    title: 'CAA Checker',
+    icon: icon('mail-auth.svg'),
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCaaChecker,
   },
   {
     id: 'favicon-hash',

--- a/components/apps/caa-checker.tsx
+++ b/components/apps/caa-checker.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+
+interface CaaRecord {
+  flags: number;
+  tag: string;
+  value: string;
+}
+
+interface ApiResult {
+  ok: boolean;
+  records: CaaRecord[];
+  issues: string[];
+}
+
+const CaaChecker: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [result, setResult] = useState<ApiResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setResult(null);
+    if (!domain) {
+      setError('Domain is required');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/caa-checker?domain=${encodeURIComponent(domain)}`);
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || 'Request failed');
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || 'Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <form onSubmit={check} className="flex space-x-2 items-center">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="text-black px-2 py-1 flex-1"
+        />
+        <button type="submit" disabled={loading} className="px-3 py-1 bg-blue-600 rounded">
+          {loading ? '...' : 'Check'}
+        </button>
+      </form>
+      {error && <div className="text-red-500">{error}</div>}
+      {result && result.records.length > 0 && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left">Flags</th>
+              <th className="text-left">Tag</th>
+              <th className="text-left">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.records.map((r, i) => (
+              <tr key={i}>
+                <td>{r.flags}</td>
+                <td>{r.tag}</td>
+                <td>{r.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {result && result.issues.length > 0 && (
+        <div className="text-yellow-400 text-sm space-y-1">
+          {result.issues.map((iss, i) => (
+            <div key={i}>{iss}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CaaChecker;
+export const displayCaaChecker = () => <CaaChecker />;
+

--- a/components/apps/index.ts
+++ b/components/apps/index.ts
@@ -1,0 +1,1 @@
+export { displayCaaChecker } from './caa-checker';

--- a/pages/api/caa-checker.ts
+++ b/pages/api/caa-checker.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface CaaRecord {
+  flags: number;
+  tag: string;
+  value: string;
+}
+
+interface CaaResponse {
+  ok: boolean;
+  records: CaaRecord[];
+  issues: string[];
+  error?: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CaaResponse | { error: string }>
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { domain } = req.query;
+  if (!domain || typeof domain !== 'string' || !/^[A-Za-z0-9.-]+$/.test(domain)) {
+    return res.status(400).json({ error: 'Invalid domain' });
+  }
+
+  try {
+    const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=CAA`;
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: 'Upstream server error' });
+    }
+    const data = await response.json();
+    const records: CaaRecord[] = (data.Answer || []).map((ans: any) => {
+      const match = ans.data.match(/^(\d+)\s+([a-zA-Z0-9]+)\s+"?(.*?)"?$/);
+      if (match) {
+        return {
+          flags: parseInt(match[1], 10),
+          tag: match[2].toLowerCase(),
+          value: match[3].replace(/^"|"$/g, ''),
+        };
+      }
+      return { flags: 0, tag: '', value: ans.data };
+    });
+
+    const issues: string[] = [];
+    const issuers = records.filter((r) => r.tag === 'issue').map((r) => r.value);
+    const uniqueIssuers = Array.from(new Set(issuers));
+    if (uniqueIssuers.length > 1) issues.push('Multiple issuers present');
+    if (!records.some((r) => r.tag === 'iodef')) issues.push('Missing iodef record');
+
+    return res.status(200).json({ ok: issues.length === 0, records, issues });
+  } catch (e: any) {
+    return res.status(500).json({ error: e.message || 'Request failed' });
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement CAA lookup API using Google DNS
- add CAA Checker app for querying and displaying CAA records
- register CAA Checker in app configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90d7a321c8328b1d8f44a4becdb30