### PR TITLE
Add DNSSEC validator tool and API

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -85,6 +85,7 @@ const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const MailAuthApp = createDynamicApp('mail-auth', 'Mail Auth');
+const DnssecValidatorApp = createDynamicApp('dnssec-validator', 'DNSSEC Validator');
 
 const CveDashboardApp = createDynamicApp('cve-dashboard', 'CVE Dashboard');
 
@@ -141,6 +142,7 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayMailAuth = createDisplay(MailAuthApp);
+const displayDnssecValidator = createDisplay(DnssecValidatorApp);
 
 const displayCveDashboard = createDisplay(CveDashboardApp);
 
@@ -705,6 +707,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayThreatModeler,
+  },
+  {
+    id: 'dnssec-validator',
+    title: 'DNSSEC Validator',
+    icon: './themes/Yaru/apps/bash.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDnssecValidator,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/dnssec-validator.tsx
+++ b/components/apps/dnssec-validator.tsx
@@ -27,8 +27,12 @@ function DnssecValidator() {
       const res = await fetch(`/api/dnssec-validator?${params.toString()}`);
       const data = await res.json();
       setResult(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('An unknown error occurred');
+      }
     } finally {
       setLoading(false);
     }

--- a/components/apps/dnssec-validator.tsx
+++ b/components/apps/dnssec-validator.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+
+type Result = {
+  ok: boolean;
+  ad: number;
+  cd: number;
+  status: string;
+};
+
+function DnssecValidator() {
+  const [domain, setDomain] = useState('');
+  const [type, setType] = useState('A');
+  const [result, setResult] = useState<Result | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const validate = async () => {
+    setError('');
+    setResult(null);
+    if (!domain.trim()) {
+      setError('Domain is required');
+      return;
+    }
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ domain: domain.trim(), type: type.trim() });
+      const res = await fetch(`/api/dnssec-validator?${params.toString()}`);
+      const data = await res.json();
+      setResult(data);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-surface text-white flex flex-col gap-4">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="flex-1 px-2 py-1 text-black rounded"
+        />
+        <input
+          type="text"
+          value={type}
+          onChange={(e) => setType(e.target.value.toUpperCase())}
+          placeholder="A"
+          className="w-24 px-2 py-1 text-black rounded"
+        />
+        <button
+          onClick={validate}
+          className="px-3 py-1 bg-highlight text-black rounded disabled:opacity-50"
+          disabled={loading}
+        >
+          Validate
+        </button>
+      </div>
+      {error && <div className="text-red-400">{error}</div>}
+      {result && (
+        <div className="space-y-1">
+          <div>AD: {result.ad}</div>
+          <div>CD: {result.cd}</div>
+          <div>Status: {result.status}</div>
+          {result.ok && result.ad === 1 && result.status === 'NOERROR' ? (
+            <div className="text-green-400">DNSSEC validation successful</div>
+          ) : (
+            <div className="text-red-400">DNSSEC validation failed</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DnssecValidator;
+
+export const displayDnssecValidator = () => <DnssecValidator />;
+

--- a/pages/api/dnssec-validator.ts
+++ b/pages/api/dnssec-validator.ts
@@ -45,8 +45,12 @@ export default async function handler(
       cd: data.CD ?? 0,
       status: statusText,
     });
-  } catch (e: any) {
-    return res.status(500).json({ ok: false, error: e.message || 'Request failed' });
+  } catch (e: unknown) {
+    let errorMessage = 'Request failed';
+    if (e instanceof Error) {
+      errorMessage = e.message;
+    }
+    return res.status(500).json({ ok: false, error: errorMessage });
   }
 }
 

--- a/pages/api/dnssec-validator.ts
+++ b/pages/api/dnssec-validator.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS', 'SOA', 'DNSKEY', 'DS', 'CAA'];
+
+const STATUS_CODES: Record<number, string> = {
+  0: 'NOERROR',
+  1: 'FORMERR',
+  2: 'SERVFAIL',
+  3: 'NXDOMAIN',
+  4: 'NOTIMP',
+  5: 'REFUSED',
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { domain, type } = req.query;
+
+  if (!domain || typeof domain !== 'string') {
+    return res.status(400).json({ error: 'Missing domain' });
+  }
+  if (!type || typeof type !== 'string') {
+    return res.status(400).json({ error: 'Missing type' });
+  }
+
+  const recordType = type.toUpperCase();
+  if (!ALLOWED_TYPES.includes(recordType)) {
+    return res.status(400).json({ error: 'Invalid record type' });
+  }
+
+  try {
+    const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=${recordType}&cd=0`;
+    const response = await fetch(endpoint);
+    const data = await response.json();
+    const statusText = STATUS_CODES[data.Status] || String(data.Status);
+    return res.status(200).json({
+      ok: response.ok,
+      ad: data.AD ?? 0,
+      cd: data.CD ?? 0,
+      status: statusText,
+    });
+  } catch (e: any) {
+    return res.status(500).json({ ok: false, error: e.message || 'Request failed' });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add DNSSEC validator API endpoint for Google DNS resolve
- create desktop app to query DNSSEC validation status
- register DNSSEC validator in app configuration

## Testing
- `npm test`
- `npx jest __tests__/calc.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a90d7a603483288ab093d1c0239fc8