### PR TITLE
Add HSTS preload checker

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -103,6 +103,7 @@ const NmapViewerApp = createDynamicApp('nmap-viewer', 'Nmap Viewer');
 
 const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
+const HstsPreloadApp = createDynamicApp('hsts-preload', 'HSTS Preload');
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
 
@@ -159,6 +160,7 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 
 const displayReportViewer = createDisplay(ReportViewerApp);
 
+const displayHstsPreload = createDisplay(HstsPreloadApp);
 const displayCookieJar = createDisplay(CookieJarApp);
  
 
@@ -658,10 +660,17 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFaviconHash,
-
+  },
+  {
     id: 'cve-dashboard',
     title: 'CVE Dashboard',
     icon: './themes/Yaru/apps/calc.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCveDashboard,
+  },
+  {
     id: 'pcap-viewer',
     title: 'PCAP Viewer',
     icon: './themes/Yaru/apps/pcap-viewer.svg',
@@ -669,7 +678,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayPcapViewer,
-
+  },
+  {
     id: 'yara-tester',
     title: 'YARA Tester',
     icon: './themes/Yaru/apps/bash.png',
@@ -685,10 +695,8 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
-    screen: displayCveDashboard,
+    screen: displayWeather,
   },
-
-
   {
     id: 'mail-auth',
     title: 'Mail Auth',
@@ -697,7 +705,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMailAuth,
-
+  },
+  {
     id: 'threat-modeler',
     title: 'Threat Modeler',
     icon: './themes/Yaru/apps/threat-modeler.svg',
@@ -706,57 +715,53 @@ const apps = [
     desktop_shortcut: false,
     screen: displayThreatModeler,
   },
+  {
+    id: 'cookie-jar',
+    title: 'Cookie Jar',
+    icon: './themes/Yaru/apps/cookie-jar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCookieJar,
+  },
+  {
+    id: 'content-fingerprint',
+    title: 'Content Fingerprint',
+    icon: './themes/Yaru/apps/content-fingerprint.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayContentFingerprint,
+  },
+  {
+    id: 'nmap-viewer',
+    title: 'Nmap Viewer',
+    icon: './themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNmapViewer,
+  },
+  {
+    id: 'report-viewer',
+    title: 'Report Viewer',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayReportViewer,
+  },
+  {
+    id: 'hsts-preload',
+    title: 'HSTS Preload',
+    icon: './themes/Yaru/apps/hash.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHstsPreload,
+  },
   // Games are included so they appear alongside apps
   ...games,
 ];
-
-    {
-      id: 'weather',
-      title: 'Weather',
-      icon: './themes/Yaru/apps/weather.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayWeather,
-    },
-    {
-      id: 'cookie-jar',
-      title: 'Cookie Jar',
-      icon: './themes/Yaru/apps/cookie-jar.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayCookieJar,
-    },
-    {
-      id: 'content-fingerprint',
-      title: 'Content Fingerprint',
-      icon: './themes/Yaru/apps/content-fingerprint.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayContentFingerprint,
-    },
-    {
-
-id: 'nmap-viewer',
-      title: 'Nmap Viewer',
-      icon: './themes/Yaru/apps/resource-monitor.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayNmapViewer,
-
-      id: 'report-viewer',
-      title: 'Report Viewer',
-      icon: './themes/Yaru/apps/gedit.png',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayReportViewer,
-    },
-    // Games are included so they appear alongside apps
-    ...games,
-  ];
 
 export default apps;

--- a/components/apps/hsts-preload.tsx
+++ b/components/apps/hsts-preload.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+
+interface HeaderCheck {
+  hasHeader: boolean;
+  maxAge: boolean;
+  includeSubDomains: boolean;
+  preload: boolean;
+}
+
+interface ApiResponse {
+  ok: boolean;
+  status: string;
+  reasons: string[];
+  headerCheck: HeaderCheck;
+  error?: string;
+}
+
+const HstsPreload: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [result, setResult] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    if (!domain) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/hsts-preload?domain=${encodeURIComponent(domain)}`);
+      const data = await res.json();
+      setResult(data);
+    } catch {
+      setResult({ ok: false, status: 'error', reasons: [], headerCheck: { hasHeader: false, maxAge: false, includeSubDomains: false, preload: false }, error: 'Request failed' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-gray-900 text-white space-y-4 overflow-auto">
+      <div className="flex gap-2">
+        <input
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-1"
+          placeholder="example.com"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+        />
+        <button
+          onClick={check}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 rounded disabled:opacity-50"
+        >
+          {loading ? 'Checking...' : 'Check'}
+        </button>
+      </div>
+      {result && result.error && (
+        <div className="text-red-400">{result.error}</div>
+      )}
+      {result && !result.error && (
+        <div className="space-y-2">
+          <p>
+            Preload status: <span className="font-mono">{result.status}</span>
+          </p>
+          <p>Header OK: {result.ok ? 'Yes' : 'No'}</p>
+          {!result.ok && result.reasons.length > 0 && (
+            <ul className="list-disc list-inside text-sm text-red-400">
+              {result.reasons.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          )}
+          <div>
+            <h3 className="font-bold mt-2">Header Check</h3>
+            <ul className="list-disc list-inside text-sm">
+              <li>Has header: {String(result.headerCheck.hasHeader)}</li>
+              <li>max-age ≥ 31536000: {String(result.headerCheck.maxAge)}</li>
+              <li>includeSubDomains: {String(result.headerCheck.includeSubDomains)}</li>
+              <li>preload: {String(result.headerCheck.preload)}</li>
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HstsPreload;
+export const displayHstsPreload = () => <HstsPreload />;

--- a/pages/api/hsts-preload.ts
+++ b/pages/api/hsts-preload.ts
@@ -1,0 +1,76 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface HeaderCheck {
+  hasHeader: boolean;
+  maxAge: boolean;
+  includeSubDomains: boolean;
+  preload: boolean;
+}
+
+interface ApiResponse {
+  ok: boolean;
+  status: string;
+  reasons: string[];
+  headerCheck: HeaderCheck;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse | { error: string }>
+) {
+  const { domain } = req.query;
+  if (!domain || typeof domain !== 'string') {
+    res.status(400).json({ error: 'Missing domain parameter' });
+    return;
+  }
+
+  try {
+    const statusRes = await fetch(
+      `https://hstspreload.org/api/v2/status?domain=${encodeURIComponent(domain)}`
+    );
+    const statusData = await statusRes.json();
+
+    const siteRes = await fetch(`https://${domain}/`, { method: 'GET' });
+    const stsHeader = siteRes.headers.get('strict-transport-security');
+
+    const headerCheck: HeaderCheck = {
+      hasHeader: !!stsHeader,
+      maxAge: false,
+      includeSubDomains: false,
+      preload: false,
+    };
+    const reasons: string[] = [];
+
+    if (stsHeader) {
+      const lower = stsHeader.toLowerCase();
+      const maxAgeMatch = lower.match(/max-age=([0-9]+)/);
+      headerCheck.maxAge =
+        !!maxAgeMatch && parseInt(maxAgeMatch[1], 10) >= 31536000;
+      headerCheck.includeSubDomains = lower.includes('includesubdomains');
+      headerCheck.preload = lower.includes('preload');
+
+      if (!headerCheck.maxAge)
+        reasons.push('max-age must be at least 31536000');
+      if (!headerCheck.includeSubDomains)
+        reasons.push('includeSubDomains directive missing');
+      if (!headerCheck.preload) reasons.push('preload directive missing');
+    } else {
+      reasons.push('Missing Strict-Transport-Security header');
+    }
+
+    const ok =
+      headerCheck.hasHeader &&
+      headerCheck.maxAge &&
+      headerCheck.includeSubDomains &&
+      headerCheck.preload;
+
+    res.status(200).json({
+      ok,
+      status: statusData.status || 'unknown',
+      reasons,
+      headerCheck,
+    });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch data' });
+  }
+}

--- a/pages/apps/hsts-preload.tsx
+++ b/pages/apps/hsts-preload.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const HstsPreload = dynamic(() => import('../../components/apps/hsts-preload'), { ssr: false });
+
+export default function HstsPreloadPage() {
+  return <HstsPreload />;
+}


### PR DESCRIPTION
## Summary
- add API endpoint to check HSTS preload status and header directives
- add HSTS Preload app with domain input and results display
- register HSTS Preload tool in app configuration

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d7a9d34832891a3da6dff60dc3a