### PR TITLE
feat: add HTTP/3 probe utility

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -105,6 +105,8 @@ const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
+const Http3ProbeApp = createDynamicApp('http3-probe', 'HTTP/3 Probe');
+
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -160,6 +162,8 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 const displayReportViewer = createDisplay(ReportViewerApp);
 
 const displayCookieJar = createDisplay(CookieJarApp);
+
+const displayHttp3Probe = createDisplay(Http3ProbeApp);
  
 
 
@@ -754,6 +758,15 @@ id: 'nmap-viewer',
       favourite: false,
       desktop_shortcut: false,
       screen: displayReportViewer,
+    },
+    {
+      id: 'http3-probe',
+      title: 'HTTP/3 Probe',
+      icon: './themes/Yaru/apps/resource-monitor.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayHttp3Probe,
     },
     // Games are included so they appear alongside apps
     ...games,

--- a/components/apps/http3-probe.tsx
+++ b/components/apps/http3-probe.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+interface ProbeResult {
+  ok: boolean;
+  altSvc: string | null;
+  alpnHints: string[];
+}
+
+const Http3Probe: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [result, setResult] = useState<ProbeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const probe = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/http3-probe?url=${encodeURIComponent(url)}`);
+      const data = (await res.json()) as ProbeResult;
+      setResult(data);
+    } catch {
+      setError('Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-2 text-sm text-gray-900 dark:text-gray-100">
+      <div className="flex gap-2 mb-2">
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="example.com"
+          className="border px-2 py-1 flex-grow"
+        />
+        <button onClick={probe} className="px-2 py-1 border" disabled={loading}>
+          Probe
+        </button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      {result && (
+        <div>
+          <div className="font-bold mb-1">
+            {result.ok ? 'HTTP/3 advertised' : 'No HTTP/3 hint'}
+          </div>
+          {result.altSvc && (
+            <div className="break-all">Alt-Svc: {result.altSvc}</div>
+          )}
+          {!result.ok && (
+            <div className="mt-1">Fallback to HTTP/1.1/2</div>
+          )}
+          {result.ok && result.alpnHints.length > 0 && (
+            <div className="mt-1">Protocols: {result.alpnHints.join(', ')}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Http3Probe;

--- a/pages/api/http3-probe.ts
+++ b/pages/api/http3-probe.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface ProbeResult {
+  ok: boolean;
+  altSvc: string | null;
+  alpnHints: string[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ProbeResult>
+) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ ok: false, altSvc: null, alpnHints: [] });
+    return;
+  }
+
+  let target: URL;
+  try {
+    target = new URL(`https://${url}`);
+  } catch {
+    res.status(400).json({ ok: false, altSvc: null, alpnHints: [] });
+    return;
+  }
+
+  try {
+    const response = await fetch(target.toString(), { method: 'HEAD' });
+    const altSvc = response.headers.get('alt-svc');
+    const alpnHints = altSvc
+      ? altSvc
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => /^h3(-\d+)?/.test(s))
+          .map((s) => s.split('=')[0])
+      : [];
+    res.status(200).json({ ok: alpnHints.length > 0, altSvc, alpnHints });
+  } catch {
+    res.status(500).json({ ok: false, altSvc: null, alpnHints: [] });
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint that inspects Alt-Svc for HTTP/3 hints
- add HTTP/3 Probe UI component
- register tool in app configuration

## Testing
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn lint` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*


------
https://chatgpt.com/codex/tasks/task_e_68a90d7b66e88328899f9efe7972d244