### PR TITLE
Add redirect visualizer tool

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -105,6 +105,11 @@ const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
+const RedirectVisualizerApp = createDynamicApp(
+  'redirect-visualizer',
+  'Redirect Visualizer'
+);
+
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -160,6 +165,8 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 const displayReportViewer = createDisplay(ReportViewerApp);
 
 const displayCookieJar = createDisplay(CookieJarApp);
+
+const displayRedirectVisualizer = createDisplay(RedirectVisualizerApp);
  
 
 
@@ -738,15 +745,15 @@ const apps = [
       screen: displayContentFingerprint,
     },
     {
-
-id: 'nmap-viewer',
+      id: 'nmap-viewer',
       title: 'Nmap Viewer',
       icon: './themes/Yaru/apps/resource-monitor.svg',
       disabled: false,
       favourite: false,
       desktop_shortcut: false,
       screen: displayNmapViewer,
-
+    },
+    {
       id: 'report-viewer',
       title: 'Report Viewer',
       icon: './themes/Yaru/apps/gedit.png',
@@ -754,6 +761,15 @@ id: 'nmap-viewer',
       favourite: false,
       desktop_shortcut: false,
       screen: displayReportViewer,
+    },
+    {
+      id: 'redirect-visualizer',
+      title: 'Redirect Visualizer',
+      icon: './themes/Yaru/apps/resource-monitor.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayRedirectVisualizer,
     },
     // Games are included so they appear alongside apps
     ...games,

--- a/components/apps/redirect-visualizer.tsx
+++ b/components/apps/redirect-visualizer.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+interface ChainItem {
+  url: string;
+  status: number;
+  location?: string;
+}
+
+const METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'];
+
+const RedirectVisualizer: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [method, setMethod] = useState('GET');
+  const [chain, setChain] = useState<ChainItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleRun = async () => {
+    setLoading(true);
+    setError('');
+    setChain([]);
+    try {
+      const res = await fetch('/api/redirect-visualizer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url, method }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        setChain(json.chain || []);
+      } else {
+        setChain(json.chain || []);
+        setError('Failed to follow redirects');
+      }
+    } catch {
+      setError('Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const finalUrl = chain.length > 0 ? chain[chain.length - 1].url : '';
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 text-black px-2 py-1"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <select
+          className="text-black px-2 py-1"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        >
+          {METHODS.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleRun}
+          className="px-4 py-1 bg-blue-600 rounded"
+          disabled={loading}
+        >
+          Go
+        </button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {chain.length > 0 && (
+        <div className="overflow-auto flex-1">
+          <ol className="space-y-1">
+            {chain.map((item, idx) => (
+              <li key={idx} className="break-all">
+                {idx + 1}. {item.url} — {item.status}
+                {item.location ? ` → ${item.location}` : ''}
+              </li>
+            ))}
+          </ol>
+          <div className="mt-4 font-bold break-all">Final URL: {finalUrl}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RedirectVisualizer;
+

--- a/pages/api/redirect-visualizer.ts
+++ b/pages/api/redirect-visualizer.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const MAX_HOPS = 10;
+const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ ok: false, chain: [] });
+  }
+
+  const { url, method = 'GET' } = req.body || {};
+
+  if (typeof url !== 'string' || !url) {
+    return res.status(400).json({ ok: false, chain: [] });
+  }
+
+  const upperMethod = typeof method === 'string' ? method.toUpperCase() : '';
+  if (!ALLOWED_METHODS.includes(upperMethod)) {
+    return res.status(400).json({ ok: false, chain: [] });
+  }
+
+  try {
+    // Validate URL format
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch {
+    return res.status(400).json({ ok: false, chain: [] });
+  }
+
+  const chain: { url: string; status: number; location?: string }[] = [];
+  let current = url;
+  const visited = new Set<string>([current]);
+
+  try {
+    for (let i = 0; i < MAX_HOPS; i += 1) {
+      const response = await fetch(current, {
+        method: upperMethod,
+        redirect: 'manual',
+      });
+      const location = response.headers.get('location') || undefined;
+      chain.push({ url: current, status: response.status, location });
+
+      if (response.status >= 300 && response.status < 400 && location) {
+        const nextUrl = new URL(location, current).toString();
+        if (visited.has(nextUrl)) {
+          return res.status(200).json({ ok: false, chain });
+        }
+        visited.add(nextUrl);
+        current = nextUrl;
+      } else {
+        return res.status(200).json({ ok: true, chain });
+      }
+    }
+
+    return res.status(200).json({ ok: false, chain });
+  } catch {
+    return res.status(500).json({ ok: false, chain });
+  }
+}
+

--- a/pages/api/redirect-visualizer.ts
+++ b/pages/api/redirect-visualizer.ts
@@ -9,13 +9,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ ok: false, chain: [] });
   }
 
-  const { url, method = 'GET' } = req.body || {};
+  const { url, method } = req.body || {};
 
   if (typeof url !== 'string' || !url) {
     return res.status(400).json({ ok: false, chain: [] });
   }
 
-  const upperMethod = typeof method === 'string' ? method.toUpperCase() : '';
+  const upperMethod =
+    typeof method === 'string' && method.trim()
+      ? method.toUpperCase()
+      : 'GET';
   if (!ALLOWED_METHODS.includes(upperMethod)) {
     return res.status(400).json({ ok: false, chain: [] });
   }


### PR DESCRIPTION
## Summary
- add API to trace redirect chains with validation and cycle detection
- add Redirect Visualizer UI for exploring redirect hops
- register Redirect Visualizer in app configuration

## Testing
- `yarn test` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn lint` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*


------
https://chatgpt.com/codex/tasks/task_e_68a90d7c11b08328962654f9fd9c4b78