### PR TITLE
feat: add mixed content checker

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -104,6 +104,7 @@ const NmapViewerApp = createDynamicApp('nmap-viewer', 'Nmap Viewer');
 const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
+const MixedContentApp = createDynamicApp('mixed-content', 'Mixed Content');
 
 
 
@@ -160,6 +161,7 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 const displayReportViewer = createDisplay(ReportViewerApp);
 
 const displayCookieJar = createDisplay(CookieJarApp);
+const displayMixedContent = createDisplay(MixedContentApp);
  
 
 
@@ -658,10 +660,17 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFaviconHash,
-
+  },
+  {
     id: 'cve-dashboard',
     title: 'CVE Dashboard',
     icon: './themes/Yaru/apps/calc.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCveDashboard,
+  },
+  {
     id: 'pcap-viewer',
     title: 'PCAP Viewer',
     icon: './themes/Yaru/apps/pcap-viewer.svg',
@@ -669,7 +678,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayPcapViewer,
-
+  },
+  {
     id: 'yara-tester',
     title: 'YARA Tester',
     icon: './themes/Yaru/apps/bash.png',
@@ -685,10 +695,8 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
-    screen: displayCveDashboard,
+    screen: displayWeather,
   },
-
-
   {
     id: 'mail-auth',
     title: 'Mail Auth',
@@ -697,7 +705,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMailAuth,
-
+  },
+  {
     id: 'threat-modeler',
     title: 'Threat Modeler',
     icon: './themes/Yaru/apps/threat-modeler.svg',
@@ -705,6 +714,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayThreatModeler,
+  },
+  {
+    id: 'mixed-content',
+    title: 'Mixed Content',
+    icon: './themes/Yaru/apps/hash.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMixedContent,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/apps/mixed-content/index.tsx
+++ b/apps/mixed-content/index.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+
+const MixedContent: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [items, setItems] = useState<Record<string, string[]> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    if (!url) return;
+    setLoading(true);
+    setError(null);
+    setItems(null);
+    try {
+      const res = await fetch(`/api/mixed-content?url=${encodeURIComponent(url)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to check');
+      } else {
+        setItems(data.items || {});
+      }
+    } catch (e) {
+      setError('Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <input
+        type="text"
+        className="p-2 text-black"
+        placeholder="https://example.com"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+      />
+      <button
+        type="button"
+        onClick={check}
+        disabled={loading || !url}
+        className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
+      >
+        {loading ? 'Checking...' : 'Check'}
+      </button>
+      {error && <div className="text-red-400">{error}</div>}
+      {items && (
+        <div className="overflow-auto text-sm flex-1">
+          {Object.keys(items).length === 0 ? (
+            <div>No mixed content found.</div>
+          ) : (
+            Object.entries(items).map(([tag, urls]) => (
+              <div key={tag} className="mb-2">
+                <h3 className="font-bold">{tag}</h3>
+                <ul className="list-disc list-inside">
+                  {urls.map((u) => (
+                    <li key={u}>{u}</li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MixedContent;

--- a/components/apps/mixed-content.tsx
+++ b/components/apps/mixed-content.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../apps/mixed-content';

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "bad-words": "^3.0.4",
     "cannon-es": "^0.20.0",
     "canvas-confetti": "1.9.3",
+    "cheerio": "^1.1.2",
     "chess.js": "^1.0.0",
     "crypto-js": "4",
-
     "diff": "^8.0.2",
     "expr-eval": "^2.0.2",
     "html-to-image": "^1.11.13",
@@ -54,6 +54,7 @@
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
+    "url-parse": "^1.5.10",
     "ws": "^8.18.3",
     "zxcvbn": "^4.4.2"
   },

--- a/pages/api/mixed-content.ts
+++ b/pages/api/mixed-content.ts
@@ -1,0 +1,58 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { load } from 'cheerio';
+import URLParse from 'url-parse';
+
+interface ApiResponse {
+  ok: boolean;
+  items: Record<string, string[]>;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse | { error: string }>
+) {
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  let target = url.trim();
+  if (!/^https?:\/\//i.test(target)) {
+    target = `https://${target}`;
+  }
+
+  let pageUrl: URLParse;
+  try {
+    pageUrl = new URLParse(target);
+  } catch (e) {
+    res.status(400).json({ error: 'Invalid url' });
+    return;
+  }
+
+  try {
+    const response = await fetch(pageUrl.href);
+    const html = await response.text();
+    const $ = load(html);
+
+    const items: Record<string, string[]> = {};
+
+    if (pageUrl.protocol === 'https:') {
+      $('script[src], img[src], link[href], iframe[src], audio[src], video[src], source[src]').each((_, el) => {
+        const tag = (el.tagName || (el as any).name || '').toLowerCase();
+        const attr = tag === 'link' ? 'href' : 'src';
+        const val = $(el).attr(attr);
+        if (!val) return;
+        const parsed = new URLParse(val, pageUrl.href);
+        if (parsed.protocol === 'http:') {
+          if (!items[tag]) items[tag] = [];
+          items[tag].push(parsed.href);
+        }
+      });
+    }
+
+    res.status(200).json({ ok: Object.keys(items).length === 0, items });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch url' });
+  }
+}


### PR DESCRIPTION
## Summary
- add API to scan HTTPS pages for insecure HTTP subresources
- create Mixed Content app to display grouped insecure resources
- register Mixed Content tool in app config and add dependencies

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a90d7e8ba88328ae91aee6a4203159