### PR TITLE
Add timeline builder app with CSV support

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -105,6 +105,8 @@ const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
+const TimelineBuilderApp = createDynamicApp('timeline-builder', 'Timeline Builder');
+
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -160,6 +162,8 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 const displayReportViewer = createDisplay(ReportViewerApp);
 
 const displayCookieJar = createDisplay(CookieJarApp);
+
+const displayTimelineBuilder = createDisplay(TimelineBuilderApp);
  
 
 
@@ -649,6 +653,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'timeline-builder',
+    title: 'Timeline Builder',
+    icon: icon('project-gallery.svg'),
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTimelineBuilder,
   },
   {
     id: 'favicon-hash',

--- a/components/apps/timeline-builder.tsx
+++ b/components/apps/timeline-builder.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Papa from 'papaparse';
+import mermaid from 'mermaid';
+
+mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
+
+interface TimelineEvent {
+  time: string;
+  event: string;
+}
+
+const TimelineBuilder: React.FC = () => {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const diagramRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!events.length) {
+      if (diagramRef.current) diagramRef.current.innerHTML = '';
+      return;
+    }
+    const sorted = [...events].sort(
+      (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime()
+    );
+    const lines = ['timeline', '    title Timeline'];
+    sorted.forEach((e) => lines.push(`    ${e.time} : ${e.event}`));
+    const id = `timeline-${Date.now()}`;
+    try {
+      mermaid
+        .render(id, lines.join('\n'))
+        .then(({ svg }) => {
+          if (diagramRef.current) diagramRef.current.innerHTML = svg;
+        })
+        .catch((err) => {
+          if (diagramRef.current)
+            diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+        });
+    } catch (err) {
+      if (diagramRef.current)
+        diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+    }
+  }, [events]);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    const promises = Array.from(files).map(
+      (file) =>
+        new Promise<TimelineEvent[]>((resolve) => {
+          Papa.parse(file, {
+            header: true,
+            skipEmptyLines: true,
+            complete: (results) => {
+              const rows = results.data as any[];
+              const parsed = rows
+                .map((r) => ({
+                  time: r.time || r.date || r.timestamp,
+                  event: r.event || r.title || r.description,
+                }))
+                .filter((e) => e.time && e.event);
+              resolve(parsed);
+            },
+          });
+        })
+    );
+    Promise.all(promises).then((all) => {
+      const merged = [...events, ...all.flat()];
+      const unique = Array.from(
+        new Map(merged.map((e) => [`${e.time}-${e.event}`, e])).values()
+      );
+      setEvents(unique);
+    });
+  };
+
+  const exportCsv = () => {
+    const csv = Papa.unparse(events);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'timeline.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-2 space-y-2">
+      <div className="flex space-x-2">
+        <input
+          type="file"
+          accept=".csv"
+          multiple
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        <button
+          className="bg-gray-700 hover:bg-gray-600 px-2 rounded"
+          onClick={exportCsv}
+        >
+          Export CSV
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto bg-white rounded" ref={diagramRef} />
+    </div>
+  );
+};
+
+export default TimelineBuilder;
+
+export const displayTimelineBuilder = () => <TimelineBuilder />;
+

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "socket.io-client": "^4.7.5",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
+    "papaparse": "^5.4.1",
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
     "ws": "^8.18.3",

--- a/pages/apps/timeline-builder.tsx
+++ b/pages/apps/timeline-builder.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const TimelineBuilder = dynamic(() => import('../../components/apps/timeline-builder'), { ssr: false });
+
+export default function TimelineBuilderPage() {
+  return <TimelineBuilder />;
+}
+


### PR DESCRIPTION
## Summary
- add timeline builder React app using PapaParse and Mermaid
- allow CSV import/export and visualize merged events
- register timeline builder in app config and add papaparse dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a90d9245e08328bc1718e8c938cb6d