### PR TITLE
Add Tor exit node checker app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -104,6 +104,7 @@ const NmapViewerApp = createDynamicApp('nmap-viewer', 'Nmap Viewer');
 const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
+const TorExitCheckApp = createDynamicApp('tor-exit-check', 'Tor Exit Check');
 
 
 
@@ -160,6 +161,7 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 const displayReportViewer = createDisplay(ReportViewerApp);
 
 const displayCookieJar = createDisplay(CookieJarApp);
+const displayTorExitCheck = createDisplay(TorExitCheckApp);
  
 
 
@@ -705,6 +707,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayThreatModeler,
+  },
+  {
+    id: 'tor-exit-check',
+    title: 'Tor Exit Check',
+    icon: './themes/Yaru/apps/hash.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTorExitCheck,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/tor-exit-check.tsx
+++ b/components/apps/tor-exit-check.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+type Result = {
+  ip: string;
+  isExit: boolean;
+  fetchedAt: string;
+  error?: string;
+};
+
+const TorExitCheck: React.FC = () => {
+  const [ip, setIp] = useState('');
+  const [result, setResult] = useState<Result | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const check = async () => {
+    if (!ip) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tor-exit-check?ip=${encodeURIComponent(ip)}`);
+      const data = await res.json();
+      setResult(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-1"
+          placeholder="IP address"
+          value={ip}
+          onChange={(e) => setIp(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={check}
+          disabled={loading}
+          className="px-4 py-1 bg-blue-600 rounded disabled:opacity-50"
+        >
+          {loading ? 'Checking...' : 'Check'}
+        </button>
+      </div>
+      {result && !result.error && (
+        <div>
+          <p>
+            {result.ip} {result.isExit ? 'is' : 'is not'} a Tor exit node.
+          </p>
+          <p className="text-xs text-gray-400">
+            List fetched at {new Date(result.fetchedAt).toLocaleString()}
+          </p>
+        </div>
+      )}
+      {result?.error && <div className="text-red-400">{result.error}</div>}
+    </div>
+  );
+};
+
+export default TorExitCheck;

--- a/components/apps/tor-exit-check.tsx
+++ b/components/apps/tor-exit-check.tsx
@@ -17,8 +17,20 @@ const TorExitCheck: React.FC = () => {
     setLoading(true);
     try {
       const res = await fetch(`/api/tor-exit-check?ip=${encodeURIComponent(ip)}`);
-      const data = await res.json();
-      setResult(data);
+      let data;
+      if (res.ok) {
+        data = await res.json();
+        setResult(data);
+      } else {
+        // Try to parse error response as JSON, fallback to text
+        try {
+          const errData = await res.json();
+          setResult({ error: errData.error || 'Failed to check IP', ip, isExit: false, fetchedAt: new Date().toISOString() });
+        } catch {
+          const errText = await res.text();
+          setResult({ error: errText || 'Failed to check IP', ip, isExit: false, fetchedAt: new Date().toISOString() });
+        }
+      }
     } finally {
       setLoading(false);
     }

--- a/pages/api/tor-exit-check.ts
+++ b/pages/api/tor-exit-check.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { ip } = req.query;
+  if (typeof ip !== 'string') {
+    res.status(400).json({ error: 'ip parameter required' });
+    return;
+  }
+  try {
+    const response = await fetch('https://check.torproject.org/torbulkexitlist');
+    if (!response.ok) {
+      throw new Error('Failed to fetch exit list');
+    }
+    const text = await response.text();
+    const ips = text
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const isExit = ips.includes(ip);
+    const fetchedAt =
+      response.headers.get('last-modified') || new Date().toISOString();
+    res.status(200).json({ ip, isExit, fetchedAt });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message || 'Lookup failed' });
+  }
+}

--- a/pages/apps/tor-exit-check.tsx
+++ b/pages/apps/tor-exit-check.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const TorExitCheck = dynamic(() => import('../../components/apps/tor-exit-check'), {
+  ssr: false,
+});
+
+export default function TorExitCheckPage() {
+  return <TorExitCheck />;
+}


### PR DESCRIPTION
## Summary
- add API endpoint to verify if an IP appears in Tor exit node list
- add Tor exit checker UI for entering an IP and viewing results
- register Tor exit checker in desktop app configuration

## Testing
- `yarn lint` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68a90d963e6083288aca86ddc5d4fa68