### PR TITLE
feat: add killchain diagram app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -97,6 +97,10 @@ const PcapViewerApp = createDynamicApp('pcap-viewer', 'PCAP Viewer');
 const YaraTesterApp = createDynamicApp('yara-tester', 'YARA Tester');
 
 const ThreatModelerApp = createDynamicApp('threat-modeler', 'Threat Modeler');
+const KillchainDiagramApp = createDynamicApp(
+  'killchain-diagram',
+  'Killchain Diagram'
+);
 
 const ContentFingerprintApp = createDynamicApp('content-fingerprint', 'Content Fingerprint');
 const NmapViewerApp = createDynamicApp('nmap-viewer', 'Nmap Viewer');
@@ -153,6 +157,7 @@ const displayPcapViewer = createDisplay(PcapViewerApp);
 const displayYaraTester = createDisplay(YaraTesterApp);
 
 const displayThreatModeler = createDisplay(ThreatModelerApp);
+const displayKillchainDiagram = createDisplay(KillchainDiagramApp);
 
 const displayContentFingerprint = createDisplay(ContentFingerprintApp);
 const displayNmapViewer = createDisplay(NmapViewerApp);
@@ -697,7 +702,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMailAuth,
-
+  },
+  {
     id: 'threat-modeler',
     title: 'Threat Modeler',
     icon: './themes/Yaru/apps/threat-modeler.svg',
@@ -705,6 +711,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayThreatModeler,
+  },
+  {
+    id: 'killchain-diagram',
+    title: 'Killchain Diagram',
+    icon: './themes/Yaru/apps/threat-modeler.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKillchainDiagram,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/killchain-diagram.tsx
+++ b/components/apps/killchain-diagram.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+import mermaid from 'mermaid';
+import { toPng } from 'html-to-image';
+
+mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
+
+const defaultStages = [
+  'Reconnaissance',
+  'Weaponization',
+  'Delivery',
+  'Exploitation',
+  'Installation',
+  'Command & Control',
+  'Actions on Objectives',
+].join('\n');
+
+const KillchainDiagram: React.FC = () => {
+  const [stages, setStages] = useState<string>(defaultStages);
+  const diagramRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const items = stages
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const graph = items.length
+      ? `graph LR\n${items
+          .map((stage, i) => `${i}["${stage}"]`)
+          .join(' --> ')}`
+      : 'graph LR';
+    const id = `mermaid-${Date.now()}`;
+    try {
+      mermaid
+        .render(id, graph)
+        .then(({ svg }) => {
+          if (diagramRef.current) {
+            diagramRef.current.innerHTML = svg;
+          }
+        })
+        .catch((err) => {
+          if (diagramRef.current) {
+            diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+          }
+        });
+    } catch (err) {
+      if (diagramRef.current) {
+        diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+      }
+    }
+  }, [stages]);
+
+  const exportPng = async () => {
+    if (diagramRef.current) {
+      const dataUrl = await toPng(diagramRef.current);
+      const link = document.createElement('a');
+      link.href = dataUrl;
+      link.download = 'killchain.png';
+      link.click();
+    }
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col md:flex-row bg-ub-cool-grey text-white p-2 space-y-2 md:space-y-0 md:space-x-2">
+      <div className="flex-1 flex flex-col space-y-2">
+        <textarea
+          value={stages}
+          onChange={(e) => setStages(e.target.value)}
+          className="flex-1 bg-gray-800 text-sm p-2 rounded resize-none"
+          placeholder="Enter one stage per line"
+        />
+        <button
+          onClick={exportPng}
+          className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
+        >
+          Export PNG
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto bg-white rounded p-2 flex items-center justify-center">
+        <div ref={diagramRef} />
+      </div>
+    </div>
+  );
+};
+
+export default KillchainDiagram;
+

--- a/components/apps/killchain-diagram.tsx
+++ b/components/apps/killchain-diagram.tsx
@@ -39,12 +39,20 @@ const KillchainDiagram: React.FC = () => {
         })
         .catch((err) => {
           if (diagramRef.current) {
-            diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+            diagramRef.current.innerHTML = '';
+            const pre = document.createElement('pre');
+            pre.className = 'text-red-400';
+            pre.textContent = String(err);
+            diagramRef.current.appendChild(pre);
           }
         });
     } catch (err) {
       if (diagramRef.current) {
-        diagramRef.current.innerHTML = `<pre class="text-red-400">${err}</pre>`;
+        diagramRef.current.innerHTML = '';
+        const pre = document.createElement('pre');
+        pre.className = 'text-red-400';
+        pre.textContent = String(err);
+        diagramRef.current.appendChild(pre);
       }
     }
   }, [stages]);


### PR DESCRIPTION
## Summary
- add KillchainDiagram component leveraging mermaid to render custom kill chain stages and export PNG
- register killchain-diagram app in app configuration

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: dependency tree ERESOLVE)*

------
https://chatgpt.com/codex/tasks/task_e_68a90d97b700832882a75564cf73005c