### PR TITLE
feat: add evidence notebook app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,7 @@ import { displayAsciiArt } from './components/apps/ascii_art';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
+import { displayEvidenceNotebook } from './components/apps/evidence-notebook';
 
 export const THEME = process.env.NEXT_PUBLIC_THEME || 'Yaru';
 export const icon = (name) => `./themes/${THEME}/apps/${name}`;
@@ -649,6 +650,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'evidence-notebook',
+    title: 'Evidence Notebook',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEvidenceNotebook,
   },
   {
     id: 'favicon-hash',

--- a/components/apps/evidence-notebook.tsx
+++ b/components/apps/evidence-notebook.tsx
@@ -1,0 +1,79 @@
+import React, { useState, ChangeEvent } from 'react';
+import JSZip from 'jszip';
+
+interface Entry {
+  file: File;
+  note: string;
+}
+
+const EvidenceNotebook: React.FC = () => {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    setEntries((prev) => [...prev, ...files.map((file) => ({ file, note: '' }))]);
+  };
+
+  const onNoteChange = (index: number, note: string) => {
+    setEntries((prev) => prev.map((entry, i) => (i === index ? { ...entry, note } : entry)));
+  };
+
+  const hashFile = async (file: File): Promise<string> => {
+    const buffer = await file.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  };
+
+  const exportZip = async () => {
+    const zip = new JSZip();
+    const manifest: { files: { name: string; hash: string; note: string }[] } = { files: [] };
+
+    for (const entry of entries) {
+      const arrayBuffer = await entry.file.arrayBuffer();
+      zip.file(entry.file.name, arrayBuffer);
+      const hash = await hashFile(entry.file);
+      manifest.files.push({ name: entry.file.name, hash, note: entry.note });
+    }
+
+    zip.file('manifest.json', JSON.stringify(manifest, null, 2));
+    const blob = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'evidence.zip';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-panel text-white p-4 space-y-4 overflow-hidden">
+      <input type="file" multiple onChange={onFileChange} />
+      <div className="flex-1 overflow-auto">
+        {entries.map((entry, idx) => (
+          <div key={idx} className="mb-4">
+            <div className="mb-1">{entry.file.name}</div>
+            <textarea
+              className="w-full p-1 text-black"
+              placeholder="Notes"
+              value={entry.note}
+              onChange={(e) => onNoteChange(idx, e.target.value)}
+            />
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        className="bg-blue-600 hover:bg-blue-700 text-white py-1 px-2 rounded disabled:opacity-50"
+        onClick={exportZip}
+        disabled={entries.length === 0}
+      >
+        Export
+      </button>
+    </div>
+  );
+};
+
+export default EvidenceNotebook;
+
+export const displayEvidenceNotebook = () => <EvidenceNotebook />;

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "canvas-confetti": "1.9.3",
     "chess.js": "^1.0.0",
     "crypto-js": "4",
-
     "diff": "^8.0.2",
     "expr-eval": "^2.0.2",
     "html-to-image": "^1.11.13",
     "jsonwebtoken": "^9.0.2",
     "jspdf": "^2.5.1",
+    "jszip": "^3.10.1",
     "libyara-wasm": "^1.2.1",
     "matter-js": "^0.20.0",
     "mermaid": "^11.10.1",


### PR DESCRIPTION
## Summary
- add evidence notebook app that zips uploaded files with hashed manifest and notes
- wire evidence notebook into app configuration
- include jszip dependency

## Testing
- `npx jest --runInBand --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_68a90d99a81c8328840d000df2ed508c