### PR TITLE
Add exploit explainer app with draggable flow diagram

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,7 @@ import { displayAsciiArt } from './components/apps/ascii_art';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
+import { displayExploitExplainer } from './components/apps/exploit-explainer';
 
 export const THEME = process.env.NEXT_PUBLIC_THEME || 'Yaru';
 export const icon = (name) => `./themes/${THEME}/apps/${name}`;
@@ -658,10 +659,17 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFaviconHash,
-
+  },
+  {
     id: 'cve-dashboard',
     title: 'CVE Dashboard',
     icon: './themes/Yaru/apps/calc.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCveDashboard,
+  },
+  {
     id: 'pcap-viewer',
     title: 'PCAP Viewer',
     icon: './themes/Yaru/apps/pcap-viewer.svg',
@@ -669,7 +677,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayPcapViewer,
-
+  },
+  {
     id: 'yara-tester',
     title: 'YARA Tester',
     icon: './themes/Yaru/apps/bash.png',
@@ -685,10 +694,44 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
-    screen: displayCveDashboard,
+    screen: displayWeather,
   },
-
-
+  {
+    id: 'cookie-jar',
+    title: 'Cookie Jar',
+    icon: './themes/Yaru/apps/cookie-jar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCookieJar,
+  },
+  {
+    id: 'content-fingerprint',
+    title: 'Content Fingerprint',
+    icon: './themes/Yaru/apps/content-fingerprint.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayContentFingerprint,
+  },
+  {
+    id: 'nmap-viewer',
+    title: 'Nmap Viewer',
+    icon: './themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNmapViewer,
+  },
+  {
+    id: 'report-viewer',
+    title: 'Report Viewer',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayReportViewer,
+  },
   {
     id: 'mail-auth',
     title: 'Mail Auth',
@@ -697,7 +740,8 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMailAuth,
-
+  },
+  {
     id: 'threat-modeler',
     title: 'Threat Modeler',
     icon: './themes/Yaru/apps/threat-modeler.svg',
@@ -706,57 +750,17 @@ const apps = [
     desktop_shortcut: false,
     screen: displayThreatModeler,
   },
+  {
+    id: 'exploit-explainer',
+    title: 'Exploit Explainer',
+    icon: './themes/Yaru/apps/threat-modeler.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayExploitExplainer,
+  },
   // Games are included so they appear alongside apps
   ...games,
 ];
-
-    {
-      id: 'weather',
-      title: 'Weather',
-      icon: './themes/Yaru/apps/weather.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayWeather,
-    },
-    {
-      id: 'cookie-jar',
-      title: 'Cookie Jar',
-      icon: './themes/Yaru/apps/cookie-jar.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayCookieJar,
-    },
-    {
-      id: 'content-fingerprint',
-      title: 'Content Fingerprint',
-      icon: './themes/Yaru/apps/content-fingerprint.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayContentFingerprint,
-    },
-    {
-
-id: 'nmap-viewer',
-      title: 'Nmap Viewer',
-      icon: './themes/Yaru/apps/resource-monitor.svg',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayNmapViewer,
-
-      id: 'report-viewer',
-      title: 'Report Viewer',
-      icon: './themes/Yaru/apps/gedit.png',
-      disabled: false,
-      favourite: false,
-      desktop_shortcut: false,
-      screen: displayReportViewer,
-    },
-    // Games are included so they appear alongside apps
-    ...games,
-  ];
 
 export default apps;

--- a/components/apps/exploit-explainer.tsx
+++ b/components/apps/exploit-explainer.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useRef } from 'react';
+import Draggable from 'react-draggable';
+import { toPng } from 'html-to-image';
+
+interface Node {
+  id: string;
+  x: number;
+  y: number;
+  label: string;
+}
+
+interface Edge {
+  id: string;
+  from: string;
+  to: string;
+  label: string;
+}
+
+const NODE_WIDTH = 120;
+const NODE_HEIGHT = 40;
+
+const ExploitExplainer: React.FC = () => {
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [connectStart, setConnectStart] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const addNode = () => {
+    const id = `n${Date.now()}`;
+    setNodes([...nodes, { id, x: 40, y: 40, label: `Node ${nodes.length + 1}` }]);
+  };
+
+  const updatePosition = (id: string, x: number, y: number) => {
+    setNodes(nodes.map((n) => (n.id === id ? { ...n, x, y } : n)));
+  };
+
+  const handleNodeClick = (id: string) => {
+    if (connectStart && connectStart !== id) {
+      const label = window.prompt('Arrow annotation', '') || '';
+      setEdges([
+        ...edges,
+        { id: `e${Date.now()}`, from: connectStart, to: id, label },
+      ]);
+      setConnectStart(null);
+    } else {
+      setConnectStart(id);
+    }
+  };
+
+  const editNode = (id: string) => {
+    const current = nodes.find((n) => n.id === id);
+    const label = window.prompt('Node label', current?.label || '');
+    if (label !== null) {
+      setNodes(nodes.map((n) => (n.id === id ? { ...n, label } : n)));
+    }
+  };
+
+  const exportPng = async () => {
+    if (canvasRef.current) {
+      const dataUrl = await toPng(canvasRef.current);
+      const link = document.createElement('a');
+      link.href = dataUrl;
+      link.download = 'exploit-flow.png';
+      link.click();
+    }
+  };
+
+  const exportJson = () => {
+    const data = { nodes, edges };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'exploit-flow.json';
+    link.click();
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-2">
+      <div className="mb-2 space-x-2">
+        <button
+          onClick={addNode}
+          className="bg-gray-700 hover:bg-gray-600 px-2 rounded"
+        >
+          Add Node
+        </button>
+        <button
+          onClick={exportPng}
+          className="bg-gray-700 hover:bg-gray-600 px-2 rounded"
+        >
+          Export PNG
+        </button>
+        <button
+          onClick={exportJson}
+          className="bg-gray-700 hover:bg-gray-600 px-2 rounded"
+        >
+          Export JSON
+        </button>
+      </div>
+      <div
+        ref={canvasRef}
+        className="relative flex-1 bg-white rounded overflow-hidden"
+      >
+        <svg className="absolute inset-0 pointer-events-none">
+          <defs>
+            <marker
+              id="arrow"
+              markerWidth="10"
+              markerHeight="10"
+              refX="10"
+              refY="5"
+              orient="auto"
+              markerUnits="strokeWidth"
+            >
+              <path d="M0,0 L10,5 L0,10 z" fill="#000" />
+            </marker>
+          </defs>
+          {edges.map((edge) => {
+            const from = nodes.find((n) => n.id === edge.from);
+            const to = nodes.find((n) => n.id === edge.to);
+            if (!from || !to) return null;
+            const x1 = from.x + NODE_WIDTH / 2;
+            const y1 = from.y + NODE_HEIGHT / 2;
+            const x2 = to.x + NODE_WIDTH / 2;
+            const y2 = to.y + NODE_HEIGHT / 2;
+            const mx = (x1 + x2) / 2;
+            const my = (y1 + y2) / 2;
+            return (
+              <g key={edge.id}>
+                <line
+                  x1={x1}
+                  y1={y1}
+                  x2={x2}
+                  y2={y2}
+                  stroke="#000"
+                  strokeWidth={2}
+                  markerEnd="url(#arrow)"
+                />
+                {edge.label && (
+                  <text x={mx} y={my - 5} textAnchor="middle" fill="#000">
+                    {edge.label}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+        {nodes.map((node) => (
+          <Draggable
+            key={node.id}
+            position={{ x: node.x, y: node.y }}
+            onStop={(_, data) => updatePosition(node.id, data.x, data.y)}
+          >
+            <div
+              onClick={() => handleNodeClick(node.id)}
+              onDoubleClick={() => editNode(node.id)}
+              className={`absolute bg-blue-200 text-black px-2 py-1 rounded cursor-move select-none ${
+                connectStart === node.id ? 'ring-2 ring-blue-500' : ''
+              }`}
+              style={{ width: NODE_WIDTH, height: NODE_HEIGHT }}
+            >
+              {node.label}
+            </div>
+          </Draggable>
+        ))}
+      </div>
+      <div className="mt-2 text-sm">
+        {connectStart
+          ? 'Select a target node to finish the arrow'
+          : 'Click one node then another to draw an arrow'}
+      </div>
+    </div>
+  );
+};
+
+export default ExploitExplainer;
+export const displayExploitExplainer = () => <ExploitExplainer />;
+

--- a/components/apps/exploit-explainer.tsx
+++ b/components/apps/exploit-explainer.tsx
@@ -36,12 +36,12 @@ const ExploitExplainer: React.FC = () => {
 
   const handleNodeClick = (id: string) => {
     if (connectStart && connectStart !== id) {
-      const label = window.prompt('Arrow annotation', '') || '';
-      setEdges([
-        ...edges,
-        { id: `e${Date.now()}`, from: connectStart, to: id, label },
-      ]);
-      setConnectStart(null);
+      // Open modal for arrow annotation
+      setModalType('arrow');
+      setModalOpen(true);
+      setModalValue('');
+      setModalNodeId(connectStart);
+      setModalArrowToId(id);
     } else {
       setConnectStart(id);
     }


### PR DESCRIPTION
## Summary
- add Exploit Explainer app for building annotated drag-and-drop flow diagrams
- hook new app into application registry
- tidy app config list

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a90d98c4e88328b096989eb0f30059