### PR TITLE
feat: add license classifier app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -103,6 +103,7 @@ const NmapViewerApp = createDynamicApp('nmap-viewer', 'Nmap Viewer');
 
 const ReportViewerApp = createDynamicApp('report-viewer', 'Report Viewer');
 
+const LicenseClassifierApp = createDynamicApp('license-classifier', 'License Classifier');
 const CookieJarApp = createDynamicApp('cookie-jar', 'Cookie Jar');
 
 
@@ -159,6 +160,7 @@ const displayNmapViewer = createDisplay(NmapViewerApp);
 
 const displayReportViewer = createDisplay(ReportViewerApp);
 
+const displayLicenseClassifier = createDisplay(LicenseClassifierApp);
 const displayCookieJar = createDisplay(CookieJarApp);
  
 
@@ -640,6 +642,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
+  },
+  {
+    id: 'license-classifier',
+    title: 'License Classifier',
+    icon: icon('gedit.png'),
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLicenseClassifier,
   },
   {
     id: 'quote-generator',

--- a/components/apps/license-classifier.tsx
+++ b/components/apps/license-classifier.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import licenseIds from 'spdx-license-ids';
+
+interface Result {
+  counts: Record<string, number>;
+  unknowns: string[];
+}
+
+const LicenseClassifier: React.FC = () => {
+  const [treeText, setTreeText] = useState('');
+  const [result, setResult] = useState<Result>({ counts: {}, unknowns: [] });
+  const [error, setError] = useState('');
+
+  const analyze = () => {
+    try {
+      const tree = JSON.parse(treeText);
+      const counts: Record<string, number> = {};
+      const unknowns = new Set<string>();
+
+      const processLicense = (lic: any) => {
+        if (typeof lic !== 'string') return;
+        const normalized = lic.trim();
+        if (licenseIds.includes(normalized)) {
+          counts[normalized] = (counts[normalized] || 0) + 1;
+        } else if (normalized) {
+          unknowns.add(normalized);
+        }
+      };
+
+      const traverse = (node: any) => {
+        if (!node || typeof node !== 'object') return;
+        const license = node.license;
+        if (license) {
+          if (Array.isArray(license)) {
+            license.forEach((l) =>
+              typeof l === 'string'
+                ? processLicense(l)
+                : processLicense(l.type)
+            );
+          } else if (typeof license === 'object') {
+            processLicense(license.type);
+          } else {
+            processLicense(license);
+          }
+        }
+        if (node.dependencies && typeof node.dependencies === 'object') {
+          Object.values(node.dependencies).forEach(traverse);
+        }
+        if (node.packages && typeof node.packages === 'object') {
+          Object.values(node.packages).forEach(traverse);
+        }
+      };
+
+      traverse(tree);
+      setResult({ counts, unknowns: Array.from(unknowns).sort() });
+      setError('');
+    } catch (err) {
+      setError('Invalid JSON');
+      setResult({ counts: {}, unknowns: [] });
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <textarea
+        className="flex-1 text-black p-2"
+        placeholder="Paste package tree JSON here..."
+        value={treeText}
+        onChange={(e) => setTreeText(e.target.value)}
+      />
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={analyze}
+          className="px-4 py-1 bg-blue-600 rounded"
+        >
+          Analyze
+        </button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      {Object.keys(result.counts).length > 0 && (
+        <div>
+          <h3 className="font-bold mb-2">License Counts</h3>
+          <ul className="list-disc list-inside">
+            {Object.entries(result.counts).map(([lic, count]) => (
+              <li key={lic}>{`${lic}: ${count}`}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {result.unknowns.length > 0 && (
+        <div>
+          <h3 className="font-bold mt-4 mb-2">Unknown Licenses</h3>
+          <ul className="list-disc list-inside">
+            {result.unknowns.map((lic) => (
+              <li key={lic}>{lic}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const displayLicenseClassifier = () => <LicenseClassifier />;
+
+export default LicenseClassifier;
+

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prop-types": "^15.8.1",
     "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.4",
+    "spdx-license-ids": "^3.0.17",
     "react": "^19.1.1",
     "react-activity-calendar": "^2.7.13",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add license classifier React app that tallies licenses and flags unknown ones
- configure app loader and menu entry for License Classifier
- include spdx-license-ids dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90d9c78c4832881f3c2999ce382a0