### PR TITLE
Add Git Secrets Tester app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -16,6 +16,7 @@ import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
 import { displayQrTool } from './components/apps/qr_tool';
 import { displayRegexRedactor } from './components/apps/regex-redactor';
+import { displayGitSecretsTester } from './components/apps/git-secrets-tester';
 import { displayAsciiArt } from './components/apps/ascii_art';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
@@ -96,6 +97,11 @@ const PcapViewerApp = createDynamicApp('pcap-viewer', 'PCAP Viewer');
 
 const YaraTesterApp = createDynamicApp('yara-tester', 'YARA Tester');
 
+const GitSecretsTesterApp = createDynamicApp(
+  'git-secrets-tester',
+  'Git Secrets Tester'
+);
+
 const ThreatModelerApp = createDynamicApp('threat-modeler', 'Threat Modeler');
 
 const ContentFingerprintApp = createDynamicApp('content-fingerprint', 'Content Fingerprint');
@@ -151,6 +157,8 @@ const displayFaviconHash = createDisplay(FaviconHashApp);
 const displayPcapViewer = createDisplay(PcapViewerApp);
 
 const displayYaraTester = createDisplay(YaraTesterApp);
+
+const displayGitSecretsTester = createDisplay(GitSecretsTesterApp);
 
 const displayThreatModeler = createDisplay(ThreatModelerApp);
 
@@ -677,6 +685,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayYaraTester,
+  },
+  {
+    id: 'git-secrets-tester',
+    title: 'Git Secrets Tester',
+    icon: './themes/Yaru/apps/git-secrets-tester.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayGitSecretsTester,
   },
   {
     id: 'weather',

--- a/apps/git-secrets-tester/index.tsx
+++ b/apps/git-secrets-tester/index.tsx
@@ -1,0 +1,1 @@
+export { default, displayGitSecretsTester } from '../../components/apps/git-secrets-tester';

--- a/components/apps/git-secrets-tester.tsx
+++ b/components/apps/git-secrets-tester.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+
+interface MatchInfo {
+  pattern: string;
+  match: string;
+  index: number;
+  groups: string[];
+  error?: string;
+}
+
+const GitSecretsTester: React.FC = () => {
+  const [patterns, setPatterns] = useState('');
+  const [text, setText] = useState('');
+  const [matches, setMatches] = useState<MatchInfo[]>([]);
+  const [falsePositives, setFalsePositives] = useState<MatchInfo[]>([]);
+
+  useEffect(() => {
+    const res: MatchInfo[] = [];
+    patterns.split('\n').forEach((pat) => {
+      const p = pat.trim();
+      if (!p) return;
+      try {
+        const re = new RegExp(p, 'g');
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(text)) !== null) {
+          res.push({
+            pattern: p,
+            match: m[0],
+            index: m.index,
+            groups: m.slice(1),
+          });
+        }
+      } catch (e: any) {
+        res.push({ pattern: p, match: '', index: -1, groups: [], error: e.message });
+      }
+    });
+    setMatches(res);
+  }, [patterns, text]);
+
+  const markFalsePositive = (m: MatchInfo) => {
+    setFalsePositives((prev) => [...prev, m]);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-gray-900 text-white p-4 space-y-4">
+      <textarea
+        className="w-full h-24 p-2 bg-black text-green-200 font-mono"
+        placeholder="Enter regex patterns, one per line"
+        value={patterns}
+        onChange={(e) => setPatterns(e.target.value)}
+      />
+      <textarea
+        className="w-full h-32 p-2 bg-black text-green-200 font-mono"
+        placeholder="Sample text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex-1 overflow-auto space-y-2">
+        {matches.map((m, idx) => (
+          <div key={idx} className="p-2 bg-gray-800 rounded">
+            {m.error ? (
+              <div className="text-red-400">
+                {m.pattern}: {m.error}
+              </div>
+            ) : (
+              <>
+                <div>
+                  <span className="font-mono">{m.pattern}</span> matched &quot;
+                  <span className="bg-yellow-600 text-black">{m.match}</span>&quot; at {m.index}
+                </div>
+                {m.groups.length > 0 && (
+                  <ul className="ml-4 list-disc">
+                    {m.groups.map((g, gi) => (
+                      <li key={gi}>
+                        Group {gi + 1}: <span className="font-mono">{g || '(empty)'}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <button
+                  type="button"
+                  className="mt-2 px-2 py-1 bg-blue-600 rounded"
+                  onClick={() => markFalsePositive(m)}
+                >
+                  Mark false positive
+                </button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+      {falsePositives.length > 0 && (
+        <div className="bg-yellow-900 p-2 overflow-auto rounded">
+          <strong>False Positives:</strong>
+          <ul className="list-disc ml-4">
+            {falsePositives.map((fp, idx) => (
+              <li key={idx}>
+                <span className="font-mono">{fp.pattern}</span> - &quot;
+                <span className="bg-yellow-600 text-black">{fp.match}</span>&quot; at {fp.index}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GitSecretsTester;
+
+export const displayGitSecretsTester = () => {
+  return <GitSecretsTester />;
+};
+

--- a/public/themes/Yaru/apps/git-secrets-tester.svg
+++ b/public/themes/Yaru/apps/git-secrets-tester.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4c566a"/>
+  <text x="32" y="38" font-size="28" text-anchor="middle" fill="#eceff4">GS</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Git Secrets Tester to experiment with regex patterns and sample text
- list regex matches with capture groups and mark false positives
- wire up app exports, config, and icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90d9d4f108328bc6fc20b532e4dd0