### PR TITLE
Deduplicate key dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,7 @@
     "cvss": "^1.0.5",
 
     "diff": "^8.0.2",
-    "fast-xml-parser": "^4.4.2",
-
     "eml-format": "^0.6.1",
-
     "expr-eval": "^2.0.2",
     "fast-xml-parser": "^5.2.5",
     "html-to-image": "^1.11.13",
@@ -49,10 +46,6 @@
     "jose": "^6.0.13",
     "jspdf": "^2.5.1",
     "jszip": "^3.10.1",
-
-    "jose": "^5.2.3",
-
-    "cheerio": "^1.1.2",
     "libyara-wasm": "^1.2.1",
     "matter-js": "^0.20.0",
     "mermaid": "^11.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9775,11 +9775,6 @@ __metadata:
   resolution: "re2-wasm@npm:1.0.2"
   checksum: 10c0/55751d812894ac4fd66579fa814215548b20d3e1e9e953d93ce68709acbe3ae14acbabbff24b6678d11ff94e6a480f23cc6185b20f23ac336ed41787a73da924
 
-"jose@npm:^5.2.3":
-  version: 5.2.3
-  resolution: "jose@npm:5.2.3"
-  checksum: 10c0/2945dd6dcb66d6e1d52fc058867c87920a77cc35f9296f198402951447d46d4d8ff00969ce36fee3c847be339d408c8fb21a1b961cecbaa3b010401bb47562ac
-
 "cvss@npm:^1.0.5":
   version: 1.0.5
   resolution: "cvss@npm:1.0.5"


### PR DESCRIPTION
## Summary
- remove duplicate `cheerio`, `fast-xml-parser`, and `jose` entries
- clean lockfile of outdated `jose` reference

## Testing
- `yarn install` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `curl -I https://registry.npmjs.org` *(fails: Couldn't connect to server)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9317d743c8328b5c18f31bff9efc7