### PR TITLE
chore: pin Node runtime to 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "next lint"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": "20.x"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",


### PR DESCRIPTION
## Summary
- pin required Node version to 20.x so deployments use the intended runtime

## Testing
- `yarn test --runInBand` *(fails: process did not exit; see console for PASS output)*

------
https://chatgpt.com/codex/tasks/task_e_68a95d60c70083288cf397cd3f5752cd