### PR TITLE
Report GA exceptions on dynamic app load failures

### DIFF
--- a/lib/createDynamicApp.tsx
+++ b/lib/createDynamicApp.tsx
@@ -16,6 +16,7 @@ const createDynamicApp = (path: string, name: string) =>
             action: `Failed to load ${name}`,
             label: error.message,
           });
+          ReactGA.exception({ description: error.message });
           return function DynamicAppError() {
             return (
               <div className="h-full w-full flex items-center justify-center bg-panel text-white">


### PR DESCRIPTION
## Summary
- report Google Analytics exceptions when dynamic app imports fail

## Testing
- `yarn install`
- `yarn test __tests__/dynamicAppLoadError.test.tsx`
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a97184624c832894e48a11a59f8869