### PR TITLE
Fix ReactGA exception usage for Next.js build

### DIFF
--- a/__tests__/dynamicAppLoadError.test.tsx
+++ b/__tests__/dynamicAppLoadError.test.tsx
@@ -5,7 +5,6 @@ import ReactGA from 'react-ga4';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
-  exception: jest.fn(),
 }));
 
 jest.mock('next/dynamic', () => {
@@ -35,6 +34,9 @@ describe('createDynamicApp', () => {
     await waitFor(() =>
       expect(screen.getByText('Failed to load FailApp.')).toBeInTheDocument()
     );
-    expect(ReactGA.exception).toHaveBeenCalled();
+    expect(ReactGA.event).toHaveBeenCalledWith(
+      'exception',
+      expect.objectContaining({ description: expect.any(String) })
+    );
   });
 });

--- a/apps.config.js
+++ b/apps.config.js
@@ -101,7 +101,7 @@ class DynamicAppErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error) {
-    ReactGA.exception({
+    ReactGA.event('exception', {
       description: `Dynamic app render error: ${error.message}`,
       fatal: false,
     });

--- a/lib/createDynamicApp.tsx
+++ b/lib/createDynamicApp.tsx
@@ -16,7 +16,7 @@ const createDynamicApp = (path: string, name: string) =>
             action: `Failed to load ${name}`,
             label: error.message,
           });
-          ReactGA.exception({ description: error.message });
+          ReactGA.event('exception', { description: error.message });
           return function DynamicAppError() {
             return (
               <div className="h-full w-full flex items-center justify-center bg-panel text-white">


### PR DESCRIPTION
## Summary
- use ReactGA.event('exception') instead of removed ReactGA.exception
- update dynamic app error boundary and related test

## Testing
- `yarn lint`
- `yarn test`
- `yarn test __tests__/dynamicAppLoadError.test.tsx`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce6862c883289c200d006c454a3c