### PR TITLE
feat: use Script for JSON-LD with CSP hash

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,8 +1,17 @@
 import React from 'react'
 import Head from 'next/head';
+import Script from 'next/script';
 
 export default function Meta() {
+    const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        name: "Alex Unnippillil",
+        url: "https://unnippillil.com/",
+    };
+
     return (
+        <>
         <Head>
             {/* Primary Meta Tags */}
              <title>Alex Unnippillil&apos;s Portfolio </title>
@@ -49,17 +58,10 @@ export default function Meta() {
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
             <link rel="preload" href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap" as="style" />
             <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap" rel="stylesheet"></link>
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                        "@context": "https://schema.org",
-                        "@type": "Person",
-                        name: "Alex Unnippillil",
-                        url: "https://unnippillil.com/",
-                    }),
-                }}
-            />
         </Head>
+        <Script id="person-jsonld" type="application/ld+json">
+            {JSON.stringify(jsonLd)}
+        </Script>
+        </>
     )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const ContentSecurityPolicy = [
   // Allow external font resources
   "font-src 'self' https://fonts.gstatic.com https://vercel.live",
   // External scripts required for embedded timelines and Vercel Live feedback
-  "script-src 'self' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com",
+  "script-src 'self' 'sha256-sCtKdl8lmFnXdKQrapehMSU5ep0FtQK3ZYtS+GNmcQg=' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content


### PR DESCRIPTION
## Summary
- replace raw JSON-LD tag with Next.js `Script`
- whitelist JSON-LD inline script via `script-src` hash

## Testing
- `yarn lint`
- `yarn test` *(fails: ReactCurrentDispatcher undefined)*
- `yarn build` *(terminated: no output)*
- `npx -y -p puppeteer node -e '...'` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa61e331d8832899c082322f4e1092