### PR TITLE
Fix window hydration and stabilise clock time

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -49,7 +49,8 @@ function DraggableContainer({ id, defaultPosition, bounds, onDrag, onStart, onSt
 export class Window extends Component {
     constructor(props) {
         super(props);
-        this.id = null;
+        // Use a stable id immediately so the first render has it
+        this.id = props.id;
         this.startX = 60;
         this.startY = 10;
         this.state = {
@@ -66,7 +67,6 @@ export class Window extends Component {
     }
 
     componentDidMount() {
-        this.id = this.props.id;
         this.setDefaultWindowDimenstion();
 
         // google analytics
@@ -218,9 +218,20 @@ export class Window extends Component {
                 onDrag={this.checkOverlap}
             >
                 {({ attributes, listeners }) => (
-                    <div style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                    <div
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
+                        role="dialog"
+                        aria-label={this.props.title}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -79,6 +79,8 @@ class AllApplications extends React.Component {
                     />
                 </button>
                 <input
+                    id="all-apps-search"
+                    name="query"
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
                     value={this.state.query}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -386,8 +386,6 @@ export class Desktop extends Component {
         //if app is already opened
         if (this.app_stack.includes(objId)) this.focus(objId);
         else {
-            let closed_windows = this.state.closed_windows;
-            let favourite_apps = this.state.favourite_apps;
             var frequentApps = localStorage.getItem('frequentApps') ? JSON.parse(localStorage.getItem('frequentApps')) : [];
             var currentApp = frequentApps.find(app => app.id === objId);
             if (currentApp) {
@@ -413,9 +411,14 @@ export class Desktop extends Component {
             localStorage.setItem("frequentApps", JSON.stringify(frequentApps));
 
             setTimeout(() => {
-                favourite_apps[objId] = true; // adds opened app to sideBar
-                closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, this.focus(objId));
+                this.setState(
+                    (s) => ({
+                        closed_windows: { ...s.closed_windows, [objId]: false },
+                        favourite_apps: { ...s.favourite_apps, [objId]: true },
+                        allAppsView: false,
+                    }),
+                    () => this.focus(objId)
+                );
                 this.app_stack.push(objId);
             }, 200);
         }

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -1,50 +1,65 @@
-import { Component } from 'react'
+import { useEffect, useState } from 'react';
 
-export default class Clock extends Component {
-    constructor() {
-        super();
-        this.month_list = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-        this.day_list = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-        this.state = {
-            hour_12: true,
-            current_time: new Date()
-        };
-    }
+export default function Clock(props) {
+  const month_list = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  const day_list = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const [time, setTime] = useState(null);
+  const hour12 = true;
 
-    componentDidMount() {
-        this.update_time = setInterval(() => {
-            this.setState({ current_time: new Date() });
-        }, 10 * 1000);
-    }
+  useEffect(() => {
+    setTime(new Date());
+    const t = setInterval(() => setTime(new Date()), 10_000);
+    return () => clearInterval(t);
+  }, []);
 
-    componentWillUnmount() {
-        clearInterval(this.update_time);
-    }
+  if (!time)
+    return <span suppressHydrationWarning>{"--:--"}</span>;
 
-    render() {
-        const { current_time } = this.state;
+  let day = day_list[time.getDay()];
+  let hour = time.getHours();
+  let minute = time.getMinutes();
+  let month = month_list[time.getMonth()];
+  let date = time.getDate().toLocaleString();
+  let meridiem = hour < 12 ? "AM" : "PM";
 
-        let day = this.day_list[current_time.getDay()];
-        let hour = current_time.getHours();
-        let minute = current_time.getMinutes();
-        let month = this.month_list[current_time.getMonth()];
-        let date = current_time.getDate().toLocaleString();
-        let meridiem = (hour < 12 ? "AM" : "PM");
+  if (minute.toLocaleString().length === 1) {
+    minute = "0" + minute;
+  }
 
-        if (minute.toLocaleString().length === 1) {
-            minute = "0" + minute
-        }
+  if (hour12 && hour > 12) hour -= 12;
 
-        if (this.state.hour_12 && hour > 12) hour -= 12;
-
-        let display_time;
-        if (this.props.onlyTime) {
-            display_time = hour + ":" + minute + " " + meridiem;
-        }
-        else if (this.props.onlyDay) {
-            display_time = day + " " + month + " " + date;
-        }
-        else display_time = day + " " + month + " " + date + " " + hour + ":" + minute + " " + meridiem;
-        return <span>{display_time}</span>;
-    }
+  let display_time;
+  if (props.onlyTime) {
+    display_time = hour + ":" + minute + " " + meridiem;
+  } else if (props.onlyDay) {
+    display_time = day + " " + month + " " + date;
+  } else {
+    display_time =
+      day +
+      " " +
+      month +
+      " " +
+      date +
+      " " +
+      hour +
+      ":" +
+      minute +
+      " " +
+      meridiem;
+  }
+  return <span suppressHydrationWarning>{display_time}</span>;
 }
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,7 +19,11 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }, []);
   return (
-    <main className={inter.className}>
+    <main
+      className={inter.className}
+      suppressHydrationWarning
+      data-app-root
+    >
       <Component {...pageProps} />
       <Analytics />
     </main>


### PR DESCRIPTION
## Summary
- avoid server-side time drift by making Clock client-only
- ensure windows have stable ids and dialog roles on first render
- prevent race conditions when opening apps and add missing form identifiers

## Testing
- `yarn test` *(fails: act is not a function in ubuntu.test.tsx, window.test.tsx)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa796cd6288328a0b6dfe46d3c0c2b