### PR TITLE
feat: enhance CVE search with EPSS and KEV

### DIFF
--- a/components/vulnerability-search.tsx
+++ b/components/vulnerability-search.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'react';
+import useSWR from 'swr';
+import Papa from 'papaparse';
+
+interface Vuln {
+  cve: { id: string; descriptions?: { value: string }[] };
+  kev: boolean;
+  epss: number | null;
+  severity?: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+const allColumns = [
+  { key: 'id', label: 'CVE' },
+  { key: 'description', label: 'Description' },
+  { key: 'severity', label: 'Severity' },
+  { key: 'epss', label: 'EPSS' },
+  { key: 'kev', label: 'CISA KEV' },
+];
+
+export default function VulnerabilitySearch() {
+  const [keyword, setKeyword] = useState('');
+  const [domain, setDomain] = useState('');
+  const [severity, setSeverity] = useState<string[]>([]);
+  const [columns, setColumns] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('vuln_columns') || '') || ['id', 'description', 'epss', 'kev'];
+    } catch {
+      return ['id', 'description', 'epss', 'kev'];
+    }
+  });
+  const [views, setViews] = useState<Record<string, any>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('vuln_views') || '') || {};
+    } catch {
+      return {};
+    }
+  });
+
+  const params = new URLSearchParams({ keyword, domain, severity: severity.join(','), sort: 'epss' });
+  const { data } = useSWR(`/api/cve?${params.toString()}`, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  useEffect(() => {
+    localStorage.setItem('vuln_columns', JSON.stringify(columns));
+  }, [columns]);
+
+  const saveView = () => {
+    const name = prompt('View name?');
+    if (!name) return;
+    const newViews = { ...views, [name]: { keyword, domain, severity, columns } };
+    setViews(newViews);
+    localStorage.setItem('vuln_views', JSON.stringify(newViews));
+  };
+
+  const loadView = (name: string) => {
+    const v = views[name];
+    if (!v) return;
+    setKeyword(v.keyword);
+    setDomain(v.domain);
+    setSeverity(v.severity);
+    setColumns(v.columns);
+  };
+
+  const exportCsv = () => {
+    if (!data) return;
+    const rows = data.vulnerabilities.map((v: Vuln) => ({
+      id: v.cve.id,
+      description: v.cve.descriptions?.[0]?.value || '',
+      severity: v.severity || '',
+      epss: v.epss ?? '',
+      kev: v.kev ? 'yes' : 'no',
+    }));
+    const csv = Papa.unparse(rows);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'vulnerabilities.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const toggleColumn = (key: string) => {
+    setColumns((cols) =>
+      cols.includes(key) ? cols.filter((c) => c !== key) : [...cols, key]
+    );
+  };
+
+  const toggleSeverity = (sev: string) => {
+    setSeverity((s) =>
+      s.includes(sev) ? s.filter((x) => x !== sev) : [...s, sev]
+    );
+  };
+
+  const vulns: Vuln[] = data?.vulnerabilities || [];
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <input
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="Keyword"
+          className="border p-1"
+        />
+        <input
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="Domain"
+          className="border p-1"
+        />
+        {['critical', 'high', 'medium', 'low'].map((sev) => (
+          <label key={sev} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={severity.includes(sev)}
+              onChange={() => toggleSeverity(sev)}
+            />
+            {sev}
+          </label>
+        ))}
+        <button onClick={saveView} className="border px-2">Save View</button>
+        <select onChange={(e) => loadView(e.target.value)} className="border">
+          <option value="">Load View</option>
+          {Object.keys(views).map((n) => (
+            <option key={n}>{n}</option>
+          ))}
+        </select>
+        <button onClick={exportCsv} className="border px-2">CSV</button>
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        {allColumns.map((col) => (
+          <label key={col.key} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={columns.includes(col.key)}
+              onChange={() => toggleColumn(col.key)}
+            />
+            {col.label}
+          </label>
+        ))}
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            {columns.includes('id') && <th className="border px-2">CVE</th>}
+            {columns.includes('description') && (
+              <th className="border px-2">Description</th>
+            )}
+            {columns.includes('severity') && (
+              <th className="border px-2">Severity</th>
+            )}
+            {columns.includes('epss') && <th className="border px-2">EPSS</th>}
+            {columns.includes('kev') && <th className="border px-2">KEV</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {vulns.map((v) => (
+            <tr key={v.cve.id} className="border-t">
+              {columns.includes('id') && <td className="border px-2">{v.cve.id}</td>}
+              {columns.includes('description') && (
+                <td className="border px-2">
+                  {v.cve.descriptions?.[0]?.value || ''}
+                </td>
+              )}
+              {columns.includes('severity') && (
+                <td className="border px-2">{v.severity || ''}</td>
+              )}
+              {columns.includes('epss') && (
+                <td className="border px-2">{v.epss ?? ''}</td>
+              )}
+              {columns.includes('kev') && (
+                <td className="border px-2">{v.kev ? '✔' : ''}</td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/epss.ts
+++ b/lib/epss.ts
@@ -1,0 +1,42 @@
+interface EpssEntry {
+  epss: number;
+  percentile: number;
+}
+
+interface CacheEntry {
+  data: EpssEntry;
+  expiry: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const TTL = 24 * 60 * 60 * 1000; // 24h
+
+export async function fetchEpssScores(ids: string[]): Promise<Record<string, EpssEntry>> {
+  const result: Record<string, EpssEntry> = {};
+  const toFetch: string[] = [];
+  for (const id of ids) {
+    const cached = cache.get(id);
+    if (cached && cached.expiry > Date.now()) {
+      result[id] = cached.data;
+    } else {
+      toFetch.push(id);
+    }
+  }
+  if (toFetch.length) {
+    try {
+      const url = `https://api.first.org/data/v1/epss?cve=${encodeURIComponent(toFetch.join(','))}`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const json = await res.json();
+        for (const item of json.data || []) {
+          const entry = { epss: parseFloat(item.epss), percentile: parseFloat(item.percentile) };
+          cache.set(item.cve, { data: entry, expiry: Date.now() + TTL });
+          result[item.cve] = entry;
+        }
+      }
+    } catch {
+      // ignore network errors
+    }
+  }
+  return result;
+}

--- a/lib/kev.ts
+++ b/lib/kev.ts
@@ -1,0 +1,20 @@
+const KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+
+let kevCache: { set: Set<string>; expiry: number } = { set: new Set(), expiry: 0 };
+
+export async function loadKevSet(): Promise<Set<string>> {
+  if (kevCache.expiry > Date.now()) return kevCache.set;
+  try {
+    const res = await fetch(KEV_URL);
+    if (!res.ok) return kevCache.set;
+    const json = await res.json();
+    const set = new Set<string>();
+    for (const v of json.vulnerabilities || []) {
+      if (v.cveID) set.add(v.cveID);
+    }
+    kevCache = { set, expiry: Date.now() + 24 * 60 * 60 * 1000 };
+  } catch {
+    // ignore network errors
+  }
+  return kevCache.set;
+}

--- a/pages/vulnerabilities.tsx
+++ b/pages/vulnerabilities.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const VulnerabilitySearch = dynamic(() => import('../components/vulnerability-search'), {
+  ssr: false,
+});
+
+export default function VulnerabilitiesPage() {
+  return <VulnerabilitySearch />;
+}


### PR DESCRIPTION
## Summary
- expand CVE API with domain filtering, severity facets, EPSS scores and CISA KEV flags
- add client vulnerability search with saved views, column chooser, CSV export and SWR

## Testing
- `yarn test` *(fails: ubuntu.test.tsx, window.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81a1cbc88328b3ea803adebecb75