### PR TITLE
feat: expand pcap viewer capabilities

### DIFF
--- a/apps/pcap-viewer/index.tsx
+++ b/apps/pcap-viewer/index.tsx
@@ -3,69 +3,109 @@ import React, { useState, useEffect } from 'react';
 const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
 type FlowInfo = { flow: string; start: number; end: number };
-
-type ParseResult = { flows: FlowInfo[]; protocols: Record<string, number> };
+type PacketInfo = { flow: string; proto: string; data: Uint8Array };
+type ParseResult = { flows: FlowInfo[]; protocols: Record<string, number>; packets: PacketInfo[] };
 
 const PcapViewer: React.FC = () => {
-  const [parser, setParser] = useState<null | ((data: Uint8Array) => ParseResult)>(null);
+  const [worker, setWorker] = useState<Worker | null>(null);
   const [flows, setFlows] = useState<FlowInfo[]>([]);
   const [protocols, setProtocols] = useState<Record<string, number>>({});
+  const [packets, setPackets] = useState<PacketInfo[]>([]);
   const [filter, setFilter] = useState('');
   const [error, setError] = useState('');
+  const [selected, setSelected] = useState<PacketInfo | null>(null);
 
   useEffect(() => {
-    // @ts-ignore - WASM module is generated at build time
-    import(/* webpackIgnore: true */ './pcap-wasm/pkg/pcap_wasm.js').then(async (mod) => {
-      await mod.default();
-      setParser(() => mod.parse_pcap);
-    });
+    const w = new Worker(new URL('./parserWorker.ts', import.meta.url));
+    w.onmessage = (e) => {
+      const { type, result, error } = e.data;
+      if (type === 'result') {
+        const r: ParseResult = result;
+        setFlows(r.flows);
+        setProtocols(r.protocols);
+        setPackets(r.packets);
+        setSelected(null);
+        setError('');
+      } else if (type === 'error') {
+        setError(error);
+      }
+    };
+    setWorker(w);
+    return () => w.terminate();
   }, []);
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file || !parser) return;
+    if (!file || !worker) return;
     if (file.size > MAX_SIZE) {
       setError('File too large');
       return;
     }
     const buffer = new Uint8Array(await file.arrayBuffer());
-    try {
-      const result = parser(buffer);
-      setFlows(result.flows);
-      setProtocols(result.protocols);
-      setError('');
-    } catch (err) {
-      setError('Failed to parse');
-    }
+    worker.postMessage({ type: 'parse', buffer }, { transfer: [buffer.buffer] });
   };
 
-  const filtered = flows.filter((f) => f.flow.toLowerCase().includes(filter.toLowerCase()));
+  const matchesFilter = (p: PacketInfo) => {
+    const q = filter.toLowerCase();
+    if (q.startsWith('proto:')) return p.proto.toLowerCase() === q.slice(6);
+    if (q.startsWith('flow:')) return p.flow.toLowerCase().includes(q.slice(5));
+    return p.flow.toLowerCase().includes(q) || p.proto.toLowerCase().includes(q);
+  };
+
+  const filteredPackets = packets.filter(matchesFilter);
+
+  const downloadFiltered = () => {
+    const data = JSON.stringify(
+      filteredPackets.map((p) => ({ flow: p.flow, proto: p.proto, data: Array.from(p.data) }))
+    );
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'filtered.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div className="p-2 text-white bg-ub-cool-grey h-full overflow-auto text-xs">
-      <input type="file" accept=".pcap" onChange={handleFile} disabled={!parser} className="mb-2" />
+      <input type="file" accept=".pcap,.pcapng" onChange={handleFile} disabled={!worker} className="mb-2" />
       {error && <div className="text-red-500 mb-2">{error}</div>}
       <input
         type="text"
-        placeholder="Filter flows"
+        placeholder="Filter (proto:tcp or flow:1.2.3.4)"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
         className="mb-2 w-full text-black px-1"
       />
+      <button onClick={downloadFiltered} className="mb-2 px-2 py-1 bg-ub-blue text-white">
+        Download Filtered
+      </button>
       <div className="mb-2">
         {Object.entries(protocols).map(([p, c]) => (
           <span key={p} className="mr-2">{p}: {c}</span>
         ))}
       </div>
       <ul>
-        {filtered.map((f, i) => (
-          <li key={i} className="mb-1">
-            {f.flow} ({f.start} - {f.end})
+        {filteredPackets.map((p, i) => (
+          <li key={i} className="mb-1 cursor-pointer" onClick={() => setSelected(p)}>
+            {p.flow} [{p.proto}]
           </li>
         ))}
       </ul>
+      {selected && (
+        <div className="mt-2">
+          <div className="mb-1">Hex:</div>
+          <pre className="overflow-x-auto">
+            {Array.from(selected.data)
+              .map((b) => b.toString(16).padStart(2, '0'))
+              .join(' ')}
+          </pre>
+        </div>
+      )}
     </div>
   );
 };
 
 export default PcapViewer;
+

--- a/apps/pcap-viewer/parserWorker.ts
+++ b/apps/pcap-viewer/parserWorker.ts
@@ -1,0 +1,18 @@
+// Web Worker for parsing pcap/pcapng files using WASM parser
+
+self.onmessage = async (e: MessageEvent) => {
+  if (e.data.type === 'parse') {
+    try {
+      // @ts-ignore - generated at build time
+      const mod = await import(/* webpackIgnore: true */ './pcap-wasm/pkg/pcap_wasm.js');
+      await mod.default();
+      const result = mod.parse_pcap(new Uint8Array(e.data.buffer));
+      (self as any).postMessage({ type: 'result', result });
+    } catch (err: any) {
+      (self as any).postMessage({ type: 'error', error: err.toString() });
+    }
+  }
+};
+
+export {};
+

--- a/apps/pcap-viewer/pcap-wasm/src/lib.rs
+++ b/apps/pcap-viewer/pcap-wasm/src/lib.rs
@@ -1,6 +1,9 @@
 use wasm_bindgen::prelude::*;
-use pcap_parser::{LegacyPcapSlice, PcapBlockOwned};
+use pcap_parser::{create_reader, PcapBlockOwned};
+use pcap_parser::pcapng::Block;
+use pcap_parser::traits::PcapNGPacketBlock;
 use std::collections::HashMap;
+use std::io::Cursor;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -11,36 +14,109 @@ pub struct FlowInfo {
 }
 
 #[derive(Serialize)]
+pub struct PacketInfo {
+    flow: String,
+    proto: String,
+    data: Vec<u8>,
+}
+
+#[derive(Serialize)]
 pub struct ParseResult {
     flows: Vec<FlowInfo>,
     protocols: HashMap<String, u32>,
+    packets: Vec<PacketInfo>,
 }
 
 #[wasm_bindgen]
 pub fn parse_pcap(data: &[u8]) -> Result<JsValue, JsValue> {
-    let mut slice = LegacyPcapSlice::from_slice(data).map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
     let mut flows: HashMap<String, (u32, u32)> = HashMap::new();
     let mut protocols: HashMap<String, u32> = HashMap::new();
+    let mut packets: Vec<PacketInfo> = Vec::new();
 
-    while let Some(res) = slice.next() {
-        let block = res.map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
-        if let PcapBlockOwned::Legacy(b) = block {
-            let packet = b.data;
-            if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
-                let proto = packet[23];
-                let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
-                let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
-                let flow_key = format!("{src} -> {dst}");
-                let ts = b.ts_sec;
-                let entry = flows.entry(flow_key).or_insert((ts, ts));
-                entry.1 = ts;
-                let proto_name = match proto {
-                    6 => "TCP",
-                    17 => "UDP",
-                    1 => "ICMP",
-                    _ => "OTHER",
-                };
-                *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
+    let cursor = Cursor::new(data);
+    let mut reader = create_reader(65536, cursor)
+        .map_err(|e| JsValue::from_str(&format!("failed to parse header: {:?}", e)))?;
+
+    loop {
+        match reader.next() {
+            Ok((offset, block)) => {
+                if let PcapBlockOwned::Legacy(b) = &block {
+                    let packet = b.data;
+                    if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
+                        let proto = packet[23];
+                        let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
+                        let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
+                        let flow_key = format!("{src} -> {dst}");
+                        let ts = b.ts_sec;
+                        let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
+                        entry.1 = ts;
+                        let proto_name = match proto {
+                            6 => "TCP",
+                            17 => "UDP",
+                            1 => "ICMP",
+                            _ => "OTHER",
+                        };
+                        *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
+                        packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                    }
+                } else if let PcapBlockOwned::NG(b) = &block {
+                    match b {
+                        Block::EnhancedPacket(epb) => {
+                            let packet = epb.packet_data();
+                            if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
+                                let proto = packet[23];
+                                let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
+                                let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
+                                let flow_key = format!("{src} -> {dst}");
+                                let ts = epb.decode_ts(0, 1).0;
+                                let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
+                                entry.1 = ts;
+                                let proto_name = match proto {
+                                    6 => "TCP",
+                                    17 => "UDP",
+                                    1 => "ICMP",
+                                    _ => "OTHER",
+                                };
+                                *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
+                                packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                            }
+                        }
+                        Block::SimplePacket(spb) => {
+                            let packet = spb.packet_data();
+                            if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
+                                let proto = packet[23];
+                                let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
+                                let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
+                                let flow_key = format!("{src} -> {dst}");
+                                let ts = 0;
+                                let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
+                                entry.1 = ts;
+                                let proto_name = match proto {
+                                    6 => "TCP",
+                                    17 => "UDP",
+                                    1 => "ICMP",
+                                    _ => "OTHER",
+                                };
+                                *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
+                                packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                reader.consume(offset);
+            }
+            Err(pcap_parser::PcapError::Eof) => break,
+            Err(pcap_parser::PcapError::Incomplete) => {
+                reader
+                    .refill()
+                    .map_err(|e| JsValue::from_str(&format!("refill error: {:?}", e)))?;
+            }
+            Err(e) => {
+                return Err(JsValue::from_str(&format!(
+                    "parse error {:?}. file may be truncated or unsupported",
+                    e
+                )));
             }
         }
     }
@@ -49,6 +125,6 @@ pub fn parse_pcap(data: &[u8]) -> Result<JsValue, JsValue> {
         .into_iter()
         .map(|(flow, (start, end))| FlowInfo { flow, start, end })
         .collect();
-    let result = ParseResult { flows: flows_vec, protocols };
+    let result = ParseResult { flows: flows_vec, protocols, packets };
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsValue::from_str(&e.to_string()))
 }


### PR DESCRIPTION
## Summary
- parse both legacy pcap and pcapng, capturing flows, protocol counts and packet data
- move capture parsing into a web worker and expose hex viewer with filtered download

## Testing
- `cargo build` in `apps/pcap-viewer/pcap-wasm`
- `yarn test __tests__/window.test.tsx __tests__/ubuntu.test.tsx` *(fails: TypeError: (0 , _react.act) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81a21e248328b856b999661baa8b