### PR TITLE
feat: add worker-based YARA tester with diagnostics

### DIFF
--- a/apps/yara-tester/index.tsx
+++ b/apps/yara-tester/index.tsx
@@ -1,98 +1,189 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-const exampleRule = `rule Example {
+const examples = [
+  {
+    name: 'Simple string match',
+    rule: `rule Example {
   strings:
     $a = "test"
   condition:
     $a
-}`;
+}`,
+  },
+  {
+    name: 'Hex bytes',
+    rule: `rule HexExample {
+  strings:
+    $a = { 31 32 33 }
+  condition:
+    $a
+}`,
+  },
+];
 
 interface MatchDetail {
   rule: string;
   matches: { identifier: string; data: string; offset: number; length: number }[];
 }
 
+interface CompileError {
+  message: string;
+  line?: number;
+  warning?: boolean;
+}
+
+const toHex = (s: string): string =>
+  Array.from(s)
+    .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
+    .join(' ');
+
 const YaraTester: React.FC = () => {
-  const [yara, setYara] = useState<any>(null);
-  const [rules, setRules] = useState(exampleRule);
+  const ruleRef = useRef<HTMLTextAreaElement>(null);
+  const workerRef = useRef<Worker | null>(null);
+  const runTimer = useRef<NodeJS.Timeout | null>(null);
+
+  const [rules, setRules] = useState(examples[0].rule);
   const [input, setInput] = useState('');
   const [matches, setMatches] = useState<MatchDetail[]>([]);
-  const [errors, setErrors] = useState<{ message: string; line?: number; warning?: boolean }[]>([]);
+  const [compileErrors, setCompileErrors] = useState<CompileError[]>([]);
+  const [runtimeError, setRuntimeError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const createWorker = () => {
+    const w = new Worker(new URL('./worker.ts', import.meta.url));
+    w.onmessage = (ev: MessageEvent) => {
+      const data = ev.data as any;
+      if (data.type === 'lintResult') {
+        setCompileErrors(data.errors);
+      } else if (data.type === 'result') {
+        if (runTimer.current) clearTimeout(runTimer.current);
+        setMatches(data.matches);
+        setCompileErrors(data.compileErrors);
+        setRuntimeError(null);
+        setRunning(false);
+      } else if (data.type === 'runtimeError') {
+        if (runTimer.current) clearTimeout(runTimer.current);
+        setMatches([]);
+        setRuntimeError(data.error);
+        setRunning(false);
+      }
+    };
+    return w;
+  };
 
   useEffect(() => {
-    let mounted = true;
-    if (typeof window !== 'undefined') {
-      import(/* webpackIgnore: true */ 'libyara-wasm')
-        .then((m) => (m.default ? m.default() : m()))
-        .then((mod) => {
-          if (mounted) setYara(mod);
-        })
-        .catch(() => {
-          // ignore load errors
-        });
-    }
+    workerRef.current = createWorker();
     return () => {
-      mounted = false;
+      workerRef.current?.terminate();
     };
   }, []);
 
-  const handleFile = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const res = e.target?.result;
-      if (typeof res === 'string') setInput(res);
-    };
-    reader.readAsBinaryString(file);
+  useEffect(() => {
+    const id = setTimeout(() => {
+      workerRef.current?.postMessage({ type: 'lint', rules });
+    }, 300);
+    return () => clearTimeout(id);
+  }, [rules]);
+
+  const gotoLine = (line?: number) => {
+    if (!line || !ruleRef.current) return;
+    const textarea = ruleRef.current;
+    const lines = textarea.value.split('\n');
+    let pos = 0;
+    for (let i = 0; i < line - 1 && i < lines.length; i += 1) pos += lines[i].length + 1;
+    textarea.focus();
+    textarea.setSelectionRange(pos, pos);
+  };
+
+  const handleFile = async (file: File) => {
+    const reader = file.stream().getReader();
+    const decoder = new TextDecoder('utf-8');
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+    setInput(result);
   };
 
   const runRules = () => {
-    if (!yara) return;
-    try {
-      const res = yara.run(input, rules);
-      const ruleVec = res.matchedRules;
-      const found: MatchDetail[] = [];
-      for (let i = 0; i < ruleVec.size(); i += 1) {
-        const r = ruleVec.get(i);
-        const det: MatchDetail['matches'] = [];
-        const rm = r.resolvedMatches;
-        for (let j = 0; j < rm.size(); j += 1) {
-          const m = rm.get(j);
-          det.push({
-            identifier: m.stringIdentifier,
-            data: m.data,
-            offset: m.location,
-            length: m.matchLength,
-          });
-        }
-        found.push({ rule: r.ruleName, matches: det });
-      }
-      const errVec = res.compileErrors;
-      const errArr: { message: string; line?: number; warning?: boolean }[] = [];
-      for (let i = 0; i < errVec.size(); i += 1) {
-        const e = errVec.get(i);
-        errArr.push({ message: e.message, line: e.lineNumber, warning: e.warning });
-      }
-      setMatches(found);
-      setErrors(errArr);
-    } catch (e) {
-      setErrors([{ message: String(e) }]);
-      setMatches([]);
-    }
+    if (!workerRef.current) return;
+    setRunning(true);
+    setRuntimeError(null);
+    workerRef.current.postMessage({ type: 'run', rules, input, timeout: 5000 });
+    runTimer.current = setTimeout(() => {
+      workerRef.current?.terminate();
+      workerRef.current = createWorker();
+      setRuntimeError('Scan timed out');
+      setRunning(false);
+    }, 5000);
   };
 
   return (
     <div className="h-full w-full flex flex-col bg-gray-900 text-white p-4 space-y-4">
+      <div className="flex space-x-2 items-center">
+        <select
+          className="bg-black text-green-200 p-1"
+          defaultValue=""
+          onChange={(e) => {
+            const idx = parseInt(e.target.value, 10);
+            if (!Number.isNaN(idx)) setRules(examples[idx].rule);
+          }}
+        >
+          <option value="" disabled>
+            Example rules
+          </option>
+          {examples.map((ex, idx) => (
+            <option key={ex.name} value={idx}>
+              {ex.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
+          onClick={runRules}
+          disabled={running}
+        >
+          Run
+        </button>
+      </div>
       <textarea
+        ref={ruleRef}
         className="w-full h-32 p-2 bg-black text-green-200 font-mono"
         value={rules}
         onChange={(e) => setRules(e.target.value)}
       />
+      {compileErrors.length > 0 && (
+        <div className="bg-red-800 p-2 overflow-auto">
+          <strong>Compile Errors:</strong>
+          <ul>
+            {compileErrors.map((e, idx) => (
+              <li
+                key={idx}
+                className="cursor-pointer"
+                onClick={() => gotoLine(e.line)}
+              >
+                {e.line ? `Line ${e.line}: ` : ''}
+                {e.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="flex space-x-2 items-center">
         <textarea
           className="flex-1 h-24 p-2 bg-black text-green-200 font-mono"
           placeholder="Paste text to scan..."
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const file = e.dataTransfer.files?.[0];
+            if (file) handleFile(file);
+          }}
         />
         <input
           type="file"
@@ -101,24 +192,9 @@ const YaraTester: React.FC = () => {
             if (file) handleFile(file);
           }}
         />
-        <button
-          type="button"
-          className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
-          onClick={runRules}
-          disabled={!yara}
-        >
-          Run
-        </button>
       </div>
-      {errors.length > 0 && (
-        <div className="bg-red-800 p-2 overflow-auto">
-          <strong>Errors:</strong>
-          <ul>
-            {errors.map((e, idx) => (
-              <li key={idx}>{e.line ? `Line ${e.line}: ` : ''}{e.message}</li>
-            ))}
-          </ul>
-        </div>
+      {runtimeError && (
+        <div className="bg-red-900 p-2">Runtime error: {runtimeError}</div>
       )}
       {matches.length > 0 && (
         <div className="bg-gray-800 p-2 overflow-auto">
@@ -129,8 +205,8 @@ const YaraTester: React.FC = () => {
                 <div className="font-bold">{m.rule}</div>
                 <ul className="ml-4 list-disc">
                   {m.matches.map((d, j) => (
-                    <li key={j}>
-                      {d.identifier} @ {d.offset} len {d.length}: "{d.data}"
+                    <li key={j} className="font-mono">
+                      {d.identifier} @ {d.offset} len {d.length}: "{d.data}" ({toHex(d.data)})
                     </li>
                   ))}
                 </ul>

--- a/apps/yara-tester/worker.ts
+++ b/apps/yara-tester/worker.ts
@@ -1,0 +1,68 @@
+import yaraFactory from 'libyara-wasm';
+
+interface MatchDetail {
+  rule: string;
+  matches: { identifier: string; data: string; offset: number; length: number }[];
+}
+
+interface CompileError {
+  message: string;
+  line?: number;
+  warning?: boolean;
+}
+
+let yara: any;
+
+(async () => {
+  const m = await (yaraFactory as any).default?.() ?? (yaraFactory as any)();
+  yara = m;
+  (self as any).postMessage({ type: 'ready' });
+})();
+
+const runYara = (input: string, rules: string) => {
+  const res = yara.run(input, rules);
+  const ruleVec = res.matchedRules;
+  const found: MatchDetail[] = [];
+  for (let i = 0; i < ruleVec.size(); i += 1) {
+    const r = ruleVec.get(i);
+    const det: MatchDetail['matches'] = [];
+    const rm = r.resolvedMatches;
+    for (let j = 0; j < rm.size(); j += 1) {
+      const m = rm.get(j);
+      det.push({
+        identifier: m.stringIdentifier,
+        data: m.data,
+        offset: m.location,
+        length: m.matchLength,
+      });
+    }
+    found.push({ rule: r.ruleName, matches: det });
+  }
+  const errVec = res.compileErrors;
+  const errArr: CompileError[] = [];
+  for (let i = 0; i < errVec.size(); i += 1) {
+    const e = errVec.get(i);
+    errArr.push({ message: e.message, line: e.lineNumber, warning: e.warning });
+  }
+  return { matches: found, compileErrors: errArr };
+};
+
+self.onmessage = (ev: MessageEvent) => {
+  const data: any = ev.data;
+  if (!yara) return;
+  if (data.type === 'run') {
+    try {
+      const result = runYara(data.input, data.rules);
+      (self as any).postMessage({ type: 'result', ...result });
+    } catch (e) {
+      (self as any).postMessage({ type: 'runtimeError', error: String(e) });
+    }
+  } else if (data.type === 'lint') {
+    try {
+      const result = runYara('', data.rules);
+      (self as any).postMessage({ type: 'lintResult', errors: result.compileErrors });
+    } catch (e) {
+      (self as any).postMessage({ type: 'lintResult', errors: [{ message: String(e) }] });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add YARA worker that returns matches and compile diagnostics
- enhance YARA tester with linting, examples, drag-drop input, and hex preview

## Testing
- `yarn test`
- `yarn lint apps/yara-tester/index.tsx apps/yara-tester/worker.ts` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81a45bac8328b3e9a5ba7da01b18