### PR TITLE
feat: add DGA generator with classifier

### DIFF
--- a/components/apps/dga-demo.worker.js
+++ b/components/apps/dga-demo.worker.js
@@ -1,0 +1,30 @@
+// Simple Web Worker generating domains using toy DGAs
+const algorithms = {
+  lcg(seed) {
+    return (1664525 * seed + 1013904223) >>> 0;
+  },
+  xorshift(seed) {
+    let x = seed >>> 0;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    return x >>> 0;
+  },
+};
+
+self.onmessage = (e) => {
+  const { seed, length, count, alphabet, algorithm } = e.data;
+  const gen = algorithms[algorithm] || algorithms.lcg;
+  const domains = [];
+  let s = seed >>> 0;
+  for (let i = 0; i < count; i++) {
+    let name = '';
+    for (let j = 0; j < length; j++) {
+      s = gen(s);
+      name += alphabet[s % alphabet.length];
+    }
+    domains.push(name + '.com');
+  }
+  self.postMessage({ domains });
+};
+


### PR DESCRIPTION
## Summary
- add worker-based DGA generator with LCG and XORShift options
- classify generated domains by entropy and n-gram frequency, noting suspicious traits
- provide real-time preview controls with seed/length sliders and input validation

## Testing
- `yarn test --runInBand` *(fails: TypeError: (0 , _react.act) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81a561f88328afe9c9f71558f3c3