### PR TITLE
Add cookie simulator for Set-Cookie attribute decisions

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -187,6 +187,7 @@ const dynamicAppEntries = [
   ['license-classifier', 'License Classifier'],
   ['hsts-preload', 'HSTS Preload'],
   ['cookie-jar', 'Cookie Jar'],
+  ['cookie-simulator', 'Cookie Simulator'],
   ['mixed-content', 'Mixed Content'],
   ['tls-explainer', 'TLS Explainer'],
   ['cache-policy', 'Cache Policy'],
@@ -676,6 +677,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: getScreen('cookie-jar'),
+  },
+  {
+    id: 'cookie-simulator',
+    title: 'Cookie Simulator',
+    icon: './themes/Yaru/apps/cookie-jar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: getScreen('cookie-simulator'),
   },
   {
     id: 'content-fingerprint',

--- a/apps/cookie-simulator/index.tsx
+++ b/apps/cookie-simulator/index.tsx
@@ -38,16 +38,22 @@ const CookieSimulator: React.FC = () => {
     [targets],
   );
 
-  let originUrl: URL | null = null;
-  try {
-    originUrl = new URL(origin);
-  } catch {
-    originUrl = null;
-  }
-
-  const originValid = originUrl !== null;
+  const originValid = useMemo(() => {
+    try {
+      new URL(origin);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [origin]);
 
   const results = useMemo(() => {
+    let originUrl: URL | null = null;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      originUrl = null;
+    }
     if (!originUrl) return [] as TargetResult[];
     const originSite = getSite(originUrl.hostname);
 

--- a/apps/cookie-simulator/index.tsx
+++ b/apps/cookie-simulator/index.tsx
@@ -1,0 +1,219 @@
+import React, { useState, useMemo } from 'react';
+
+interface TargetResult {
+  url: string;
+  included: boolean;
+  curl: string;
+  reasons: string[];
+}
+
+function getSite(host: string): string {
+  const parts = host.split('.').filter(Boolean);
+  if (parts.length <= 2) return host;
+  return parts.slice(-2).join('.');
+}
+
+function isValidDomain(domain: string): boolean {
+  return /^[a-zA-Z0-9.-]+$/.test(domain) && domain.includes('.');
+}
+
+const CookieSimulator: React.FC = () => {
+  const [origin, setOrigin] = useState('https://example.com');
+  const [name, setName] = useState('test');
+  const [value, setValue] = useState('1');
+  const [domain, setDomain] = useState('');
+  const [path, setPath] = useState('/');
+  const [secure, setSecure] = useState(false);
+  const [sameSite, setSameSite] = useState('');
+  const [targets, setTargets] = useState('https://example.com/\nhttps://sub.example.com/\nhttp://example.com/');
+
+  const domainValid = useMemo(() => !domain || isValidDomain(domain), [domain]);
+  const sameSiteValid = useMemo(
+    () => !sameSite || ['lax', 'strict', 'none'].includes(sameSite.toLowerCase()),
+    [sameSite],
+  );
+
+  const targetList = useMemo(
+    () => targets.split(/\n+/).map((t) => t.trim()).filter(Boolean),
+    [targets],
+  );
+
+  let originUrl: URL | null = null;
+  try {
+    originUrl = new URL(origin);
+  } catch {
+    originUrl = null;
+  }
+
+  const originValid = originUrl !== null;
+
+  const results = useMemo(() => {
+    if (!originUrl) return [] as TargetResult[];
+    const originSite = getSite(originUrl.hostname);
+
+    return targetList.map((input) => {
+      try {
+        const t = new URL(input);
+        const reasons: string[] = [];
+        let included = true;
+
+        if (secure && t.protocol !== 'https:') {
+          included = false;
+          reasons.push('Secure requires HTTPS');
+        }
+
+        if (!domainValid) {
+          included = false;
+          reasons.push('Invalid Domain attribute');
+        }
+        if (!sameSiteValid) {
+          included = false;
+          reasons.push('Invalid SameSite value');
+        }
+
+        const hostMatch = (() => {
+          if (domain) {
+            const d = domain.replace(/^\./, '').toLowerCase();
+            return t.hostname === d || t.hostname.endsWith(`.${d}`);
+          }
+          return t.hostname === originUrl!.hostname;
+        })();
+        if (!hostMatch) {
+          included = false;
+          reasons.push('Domain mismatch');
+        }
+
+        if (path && !t.pathname.startsWith(path)) {
+          included = false;
+          reasons.push('Path mismatch');
+        }
+
+        if (sameSite) {
+          const crossSite = getSite(t.hostname) !== originSite;
+          const ss = sameSite.toLowerCase();
+          if ((ss === 'lax' || ss === 'strict') && crossSite) {
+            included = false;
+            reasons.push(`SameSite=${sameSite} blocks cross-site`);
+          }
+          if (ss === 'none' && !secure) {
+            included = false;
+            reasons.push('SameSite=None requires Secure');
+          }
+        }
+
+        const curl = `curl -H \"Cookie: ${name}=${value}\" ${t.href}`;
+        return { url: t.href, included, curl, reasons };
+      } catch {
+        return { url: input, included: false, curl: '', reasons: ['Invalid URL'] };
+      }
+    });
+  }, [targetList, originUrl, domain, path, secure, sameSite, name, value, domainValid, sameSiteValid]);
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <input
+          className="text-black p-1"
+          value={origin}
+          onChange={(e) => setOrigin(e.target.value)}
+          placeholder="Origin URL"
+        />
+        <input
+          className={`text-black p-1 ${!domainValid ? 'border-2 border-red-500' : ''}`}
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="Domain attribute"
+        />
+        <input
+          className="text-black p-1"
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          placeholder="Path attribute"
+        />
+        <select
+          className={`text-black p-1 ${!sameSiteValid ? 'border-2 border-red-500' : ''}`}
+          value={sameSite}
+          onChange={(e) => setSameSite(e.target.value)}
+        >
+          <option value="">(no SameSite)</option>
+          <option value="Lax">Lax</option>
+          <option value="Strict">Strict</option>
+          <option value="None">None</option>
+        </select>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={secure}
+            onChange={(e) => setSecure(e.target.checked)}
+          />
+          <span>Secure</span>
+        </label>
+        <input
+          className="text-black p-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Cookie name"
+        />
+        <input
+          className="text-black p-1"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Cookie value"
+        />
+      </div>
+      <textarea
+        className="w-full h-24 text-black p-1"
+        value={targets}
+        onChange={(e) => setTargets(e.target.value)}
+        placeholder="Target URLs, one per line"
+      />
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">URL</th>
+              <th className="px-2 py-1">Included</th>
+              <th className="px-2 py-1">curl</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <React.Fragment key={r.url}>
+                <tr className="odd:bg-gray-800">
+                  <td className="px-2 py-1 break-all">{r.url}</td>
+                  <td className={`px-2 py-1 text-center ${r.included ? 'text-green-500' : 'text-red-500'}`}>
+                    {r.included ? 'Yes' : 'No'}
+                  </td>
+                  <td className="px-2 py-1 text-center">
+                    {r.curl && (
+                      <button
+                        type="button"
+                        onClick={() => navigator.clipboard.writeText(r.curl)}
+                        className="px-2 py-1 bg-blue-600 rounded"
+                      >
+                        Copy
+                      </button>
+                    )}
+                  </td>
+                </tr>
+                {r.reasons.length > 0 && (
+                  <tr className="odd:bg-gray-800">
+                    <td colSpan={3} className="px-2 pb-2 text-xs text-red-400">
+                      {r.reasons.join('; ')}
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {!originValid && (
+        <div className="text-red-500 text-sm">Invalid origin URL</div>
+      )}
+    </div>
+  );
+};
+
+export default CookieSimulator;
+

--- a/components/apps/cookie-simulator.tsx
+++ b/components/apps/cookie-simulator.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../apps/cookie-simulator';

--- a/pages/apps/cookie-simulator.tsx
+++ b/pages/apps/cookie-simulator.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const CookieSimulator = dynamic(() => import('../../apps/cookie-simulator'), { ssr: false });
+
+export default function CookieSimulatorPage() {
+  return <CookieSimulator />;
+}


### PR DESCRIPTION
## Summary
- add cookie simulator tool to evaluate cookie inclusion on target URLs
- show inclusion matrix with copyable curl examples
- validate Domain/SameSite values and memoize decisions

## Testing
- `yarn lint`
- `yarn test` *(fails: window.test.tsx, ubuntu.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81a9a8dc83288577f197ff797a30