### PR TITLE
feat: expand mail auth checker

### DIFF
--- a/apps/mail-auth/index.tsx
+++ b/apps/mail-auth/index.tsx
@@ -3,8 +3,13 @@ import React, { useState } from 'react';
 type Result = {
   pass: boolean;
   record?: string;
+  policy?: string;
+  aspf?: string;
+  adkim?: string;
   message?: string;
   recommendation?: string;
+  example?: string;
+  spec: string;
 };
 
 type Response = {
@@ -35,13 +40,36 @@ const MailAuth: React.FC = () => {
   };
 
   const renderCard = (label: string, r: Result) => {
-    const color = r.pass ? 'bg-green-600' : 'bg-red-600';
+    const badgeColor = r.pass ? 'bg-green-600' : 'bg-red-600';
     return (
-      <div key={label} className={`p-4 rounded text-white ${color}`}>
-        <h3 className="font-bold uppercase">{label}</h3>
-        {r.record && <p className="mt-2 break-words text-xs">{r.record}</p>}
-        {r.message && <p className="mt-2 text-xs">{r.message}</p>}
-        {r.recommendation && <p className="mt-1 text-xs italic">{r.recommendation}</p>}
+      <div key={label} className="p-4 rounded bg-gray-800 space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="font-bold uppercase">{label}</h3>
+          <span className={`px-2 py-0.5 rounded text-xs text-white ${badgeColor}`}>
+            {r.pass ? 'PASS' : 'FAIL'}
+          </span>
+        </div>
+        {r.record && <p className="text-xs break-words">{r.record}</p>}
+        {r.policy && <p className="text-xs">Policy: {r.policy}</p>}
+        {r.adkim && <p className="text-xs">DKIM Align: {r.adkim}</p>}
+        {r.aspf && <p className="text-xs">SPF Align: {r.aspf}</p>}
+        {r.message && <p className="text-xs">{r.message}</p>}
+        {r.recommendation && (
+          <p className="text-xs italic">{r.recommendation}</p>
+        )}
+        {r.example && (
+          <p className="text-xs">
+            Example: <code>{r.example}</code>
+          </p>
+        )}
+        <a
+          href={r.spec}
+          className="text-blue-400 text-xs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Spec
+        </a>
       </div>
     );
   };
@@ -71,11 +99,61 @@ const MailAuth: React.FC = () => {
         </button>
       </div>
       {results && !results.error && (
-        <div className="grid gap-4 sm:grid-cols-3">
-          {renderCard('SPF', results.spf)}
-          {renderCard('DKIM', results.dkim)}
-          {renderCard('DMARC', results.dmarc)}
-        </div>
+        <>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {renderCard('SPF', results.spf)}
+            {renderCard('DKIM', results.dkim)}
+            {renderCard('DMARC', results.dmarc)}
+          </div>
+          <div className="overflow-auto">
+            <h3 className="font-bold mt-4 mb-2">Explain</h3>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="pb-2">Check</th>
+                  <th className="pb-2">Status</th>
+                  <th className="pb-2">Details</th>
+                  <th className="pb-2">Spec</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ['SPF', results.spf],
+                  ['DKIM', results.dkim],
+                  ['DMARC', results.dmarc],
+                ].map(([label, r]) => (
+                  <tr key={label as string} className="border-t border-gray-700">
+                    <td className="py-2 font-semibold">{label}</td>
+                    <td className="py-2">
+                      <span
+                        className={`px-2 py-0.5 rounded text-white text-xs ${
+                          (r as Result).pass ? 'bg-green-600' : 'bg-red-600'
+                        }`}
+                      >
+                        {(r as Result).pass ? 'PASS' : 'FAIL'}
+                      </span>
+                    </td>
+                    <td className="py-2 text-xs">
+                      {(r as Result).policy
+                        ? `Policy: ${(r as Result).policy}`
+                        : (r as Result).message || ''}
+                    </td>
+                    <td className="py-2 text-xs">
+                      <a
+                        href={(r as Result).spec}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-400"
+                      >
+                        RFC
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
       {results?.error && <div className="text-red-400">{results.error}</div>}
     </div>

--- a/pages/api/mail-auth.ts
+++ b/pages/api/mail-auth.ts
@@ -1,69 +1,168 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+type CacheEntry = {
+  data: string[];
+  expires: number;
+  promise?: Promise<string[]>;
+};
+
+const TXT_CACHE: Record<string, CacheEntry> = {};
+const TXT_TTL = 5 * 60 * 1000; // 5 minutes
+
 async function lookupTxt(name: string): Promise<string[]> {
+  const now = Date.now();
+  const cached = TXT_CACHE[name];
+  if (cached) {
+    if (cached.data.length && cached.expires > now) return cached.data;
+    if (cached.promise) return cached.promise;
+  }
+
   const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(name)}&type=TXT`;
-  const res = await fetch(url, { headers: { Accept: 'application/dns-json' } });
-  if (!res.ok) throw new Error('DNS query failed');
-  const data = await res.json();
-  const answers = data.Answer || [];
-  return answers.map((a: any) =>
-    String(a.data)
-      .replace(/^"|"$/g, '')
-      .replace(/"\s"/g, '')
-  );
+  const promise = fetch(url, { headers: { Accept: 'application/dns-json' } })
+    .then((res) => {
+      if (!res.ok) throw new Error('DNS query failed');
+      return res.json();
+    })
+    .then((data) => {
+      const answers = data.Answer || [];
+      const records = answers.map((a: any) =>
+        String(a.data)
+          .replace(/^"|"$/g, '')
+          .replace(/"\s"/g, '')
+      );
+      TXT_CACHE[name] = { data: records, expires: now + TXT_TTL };
+      return records;
+    })
+    .catch((err) => {
+      delete TXT_CACHE[name];
+      throw err;
+    });
+
+  TXT_CACHE[name] = { data: [], expires: 0, promise };
+  return promise;
 }
 
+const SPF_SPEC = 'https://datatracker.ietf.org/doc/html/rfc7208';
+
 function parseSpf(records: string[]) {
-  const record = records.find((r) => r.startsWith('v=spf1'));
-  if (!record) {
+  const spfRecords = records.filter((r) => r.toLowerCase().startsWith('v=spf1'));
+  if (spfRecords.length === 0) {
     return {
       pass: false,
       message: 'No SPF record found',
-      recommendation: 'Add a TXT record starting with v=spf1 and ending with -all or ~all',
+      recommendation:
+        'Add a TXT record starting with v=spf1 and ending with -all or ~all',
+      example: 'v=spf1 mx -all',
+      spec: SPF_SPEC,
     };
   }
-  const policy = record.match(/\s([~-]?all)/)?.[1] || '';
+  if (spfRecords.length > 1) {
+    return {
+      pass: false,
+      record: spfRecords.join(' | '),
+      message: 'Multiple SPF records found',
+      recommendation: 'Consolidate into a single SPF record',
+      example: 'v=spf1 a mx -all',
+      spec: SPF_SPEC,
+    };
+  }
+  const record = spfRecords[0];
+  const policy = record.match(/\s([+-]?all)/)?.[1] || '';
   let recommendation = '';
   if (policy === '~all') {
     recommendation = 'Consider using -all for strict enforcement';
   } else if (policy !== '-all') {
     recommendation = 'SPF record should end with -all or ~all';
   }
-  return { pass: policy === '-all' || policy === '~all', record, recommendation };
+  const pass = policy === '-all' || policy === '~all';
+  return {
+    pass,
+    record,
+    policy,
+    recommendation,
+    example: pass ? undefined : 'v=spf1 mx -all',
+    spec: SPF_SPEC,
+  };
 }
 
+const DKIM_SPEC = 'https://datatracker.ietf.org/doc/html/rfc6376';
+
 function parseDkim(records: string[]) {
-  const record = records.find((r) => r.includes('v=DKIM1'));
+  const record = records.find((r) => r.toLowerCase().includes('v=dkim1'));
   if (!record) {
     return {
       pass: false,
       message: 'No DKIM record found for selector',
       recommendation: 'Ensure the selector is correct and DKIM is configured',
+      example: 'v=DKIM1; k=rsa; p=base64publickey',
+      spec: DKIM_SPEC,
     };
   }
   if (!record.includes('p=')) {
-    return { pass: false, record, recommendation: 'DKIM record missing p= public key' };
+    return {
+      pass: false,
+      record,
+      message: 'DKIM record missing p= public key',
+      recommendation: 'Include the p= tag with your public key',
+      example: 'v=DKIM1; k=rsa; p=base64publickey',
+      spec: DKIM_SPEC,
+    };
   }
-  return { pass: true, record };
+  return { pass: true, record, spec: DKIM_SPEC };
 }
 
+const DMARC_SPEC = 'https://datatracker.ietf.org/doc/html/rfc7489';
+
 function parseDmarc(records: string[]) {
-  const record = records.find((r) => r.startsWith('v=DMARC1'));
-  if (!record) {
+  const dmarcRecords = records.filter((r) => r.toLowerCase().startsWith('v=dmarc1'));
+  if (dmarcRecords.length === 0) {
     return {
       pass: false,
       message: 'No DMARC record found',
       recommendation: 'Add a TXT record at _dmarc with v=DMARC1 and a p= policy',
+      example: 'v=DMARC1; p=reject; rua=mailto:postmaster@domain.com',
+      spec: DMARC_SPEC,
     };
   }
+  if (dmarcRecords.length > 1) {
+    return {
+      pass: false,
+      record: dmarcRecords.join(' | '),
+      message: 'Multiple DMARC records found',
+      recommendation: 'Only one DMARC record should exist',
+      example: 'v=DMARC1; p=reject; adkim=s; aspf=s',
+      spec: DMARC_SPEC,
+    };
+  }
+  const record = dmarcRecords[0];
   const policy = record.match(/p=([^;]+)/)?.[1];
+  const aspf = record.match(/aspf=([rs])/i)?.[1] || 'r';
+  const adkim = record.match(/adkim=([rs])/i)?.[1] || 'r';
   let recommendation = '';
+  let message: string | undefined;
+  let pass = true;
   if (!policy) {
-    recommendation = 'DMARC record missing p= policy';
+    pass = false;
+    message = 'DMARC record missing p= policy';
+    recommendation = 'Specify a p= policy such as quarantine or reject';
+  } else if (!['none', 'quarantine', 'reject'].includes(policy)) {
+    pass = false;
+    message = 'Invalid DMARC policy';
+    recommendation = 'Valid policies are none, quarantine, or reject';
   } else if (policy === 'none') {
     recommendation = 'Consider setting policy to quarantine or reject';
   }
-  return { pass: !!policy, record, recommendation };
+  return {
+    pass,
+    record,
+    policy,
+    aspf,
+    adkim,
+    message,
+    recommendation,
+    example: pass ? undefined : 'v=DMARC1; p=reject; rua=mailto:postmaster@domain.com',
+    spec: DMARC_SPEC,
+  };
 }
 
 export default async function handler(
@@ -84,11 +183,14 @@ export default async function handler(
     }
     res.status(200).json({
       spf: parseSpf(spfRecords),
-      dkim: selector ? parseDkim(dkimRecords) : {
-        pass: false,
-        message: 'No selector provided',
-        recommendation: 'Provide a DKIM selector to check the record',
-      },
+      dkim: selector
+        ? parseDkim(dkimRecords)
+        : {
+            pass: false,
+            message: 'No selector provided',
+            recommendation: 'Provide a DKIM selector to check the record',
+            spec: DKIM_SPEC,
+          },
       dmarc: parseDmarc(dmarcRecords),
     });
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- cache DNS TXT lookups and parse SPF, DKIM, and DMARC with alignment and policy details
- add mail auth UI with pass/fail badges, spec links, and explanation table

## Testing
- `yarn test` *(fails: Ubuntu component › renders boot screen then desktop; Window lifecycle › invokes callbacks on close)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa81b5b13c8328a32afb01d6dc85e8