### PR TITLE
feat: add JWKS verification utility

### DIFF
--- a/components/apps/jwks-fetcher.tsx
+++ b/components/apps/jwks-fetcher.tsx
@@ -5,19 +5,35 @@ const JwksFetcher: React.FC = () => {
   const [keys, setKeys] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [jwt, setJwt] = useState('');
+  const [verifyResult, setVerifyResult] = useState<string | null>(null);
 
   const fetchKeys = async () => {
     if (!jwksUrl) return;
     setLoading(true);
     setError(null);
+    setVerifyResult(null);
     setKeys([]);
     try {
-      const res = await fetch(`/api/jwks-fetcher?jwksUrl=${encodeURIComponent(jwksUrl)}`);
+      const res = await fetch('/api/jwks-fetcher', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jwksUrl, jwt }),
+      });
       const data = await res.json();
       if (!res.ok || !data.ok) {
-        setError('Failed to fetch keys');
+        let msg = data.error || 'Failed to fetch keys';
+        if (data.error === 'unsupported_alg') msg = 'Unsupported alg';
+        if (data.error === 'missing_kid') msg = 'Missing kid';
+        if (data.error === 'kid_not_found') msg = 'kid not found';
+        setError(msg);
       } else {
         setKeys(data.keys || []);
+        if (data.payload) {
+          setVerifyResult(
+            JSON.stringify({ payload: data.payload, header: data.header }, null, 2)
+          );
+        }
       }
     } catch {
       setError('Failed to fetch keys');
@@ -26,44 +42,79 @@ const JwksFetcher: React.FC = () => {
     }
   };
 
-  const copy = (key: any) => {
+  const copyJson = (key: any) => {
     navigator.clipboard.writeText(JSON.stringify(key, null, 2));
+  };
+
+  const copyPem = (pem: string) => {
+    navigator.clipboard.writeText(pem);
   };
 
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
-      <div className="flex space-x-2">
-        <input
-          type="text"
-          value={jwksUrl}
-          onChange={(e) => setJwksUrl(e.target.value)}
-          placeholder="https://example.com/.well-known/jwks.json"
-          className="flex-1 px-2 py-1 text-black"
+      <div className="flex flex-col space-y-2">
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={jwksUrl}
+            onChange={(e) => setJwksUrl(e.target.value)}
+            placeholder="https://example.com/.well-known/jwks.json"
+            className="flex-1 px-2 py-1 text-black"
+          />
+          <button
+            type="button"
+            onClick={fetchKeys}
+            disabled={loading || !jwksUrl}
+            className="px-4 py-1 bg-blue-600 rounded disabled:opacity-50"
+          >
+            {loading ? 'Fetching...' : 'Fetch'}
+          </button>
+        </div>
+        <textarea
+          className="w-full h-24 p-2 text-black"
+          placeholder="Paste JWT here (optional)"
+          value={jwt}
+          onChange={(e) => setJwt(e.target.value)}
         />
-        <button
-          type="button"
-          onClick={fetchKeys}
-          disabled={loading || !jwksUrl}
-          className="px-4 py-1 bg-blue-600 rounded disabled:opacity-50"
-        >
-          {loading ? 'Fetching...' : 'Fetch'}
-        </button>
       </div>
       {error && <div className="text-red-500">{error}</div>}
+      {verifyResult && (
+        <div>
+          <h3 className="font-bold mb-1">Verification Result</h3>
+          <pre className="text-xs overflow-auto bg-gray-800 p-2 rounded">{verifyResult}</pre>
+        </div>
+      )}
       <div className="space-y-2 overflow-auto">
         {keys.map((k, idx) => (
           <div key={k.kid || idx} className="bg-gray-800 p-2 rounded">
             <div className="flex justify-between items-center mb-2">
               <span className="font-mono text-xs break-all">{k.kid || `Key ${idx + 1}`}</span>
-              <button
-                type="button"
-                onClick={() => copy(k)}
-                className="px-2 py-1 bg-gray-700 rounded text-xs"
-              >
-                Copy
-              </button>
+              <div className="space-x-2">
+                <button
+                  type="button"
+                  onClick={() => copyJson(k)}
+                  className="px-2 py-1 bg-gray-700 rounded text-xs"
+                >
+                  Copy JSON
+                </button>
+                {k.pem && (
+                  <button
+                    type="button"
+                    onClick={() => copyPem(k.pem)}
+                    className="px-2 py-1 bg-gray-700 rounded text-xs"
+                  >
+                    Copy PEM
+                  </button>
+                )}
+              </div>
             </div>
             <pre className="text-xs overflow-auto">{JSON.stringify(k, null, 2)}</pre>
+            {k.x5t !== undefined && (
+              <div className="text-xs mt-1">x5t valid: {String(k.x5tValid)}</div>
+            )}
+            {k['x5t#S256'] !== undefined && (
+              <div className="text-xs">x5t#S256 valid: {String(k.x5tS256Valid)}</div>
+            )}
           </div>
         ))}
       </div>

--- a/pages/api/jwks-fetcher.ts
+++ b/pages/api/jwks-fetcher.ts
@@ -1,20 +1,78 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { decodeProtectedHeader, importJWK, jwtVerify } from 'jose';
+import { createHash } from 'crypto';
 
 interface CacheEntry {
-  keys: any[];
+  jwk: any;
   expiry: number;
 }
 
 const cache = new Map<string, CacheEntry>();
-const TTL = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_TTL = 5 * 60 * 1000; // 5 minutes fallback
+const SUPPORTED_ALGS = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'EdDSA',
+];
+
+async function fetchAndCacheKeys(jwksUrl: string) {
+  const resp = await fetch(jwksUrl);
+  if (!resp.ok) throw new Error('fetch failed');
+  const json = await resp.json();
+  const keys = Array.isArray(json.keys) ? json.keys : [];
+  let maxAge = DEFAULT_TTL / 1000;
+  const cc = resp.headers.get('cache-control');
+  const m = cc && /max-age=(\d+)/i.exec(cc);
+  if (m) maxAge = parseInt(m[1], 10);
+  const expiry = Date.now() + maxAge * 1000;
+  for (const k of keys) {
+    if (k.kid) cache.set(k.kid, { jwk: k, expiry });
+  }
+  return keys;
+}
+
+function augmentKey(k: any) {
+  const result: any = { ...k };
+  const certB64 = k.x5c?.[0];
+  if (certB64) {
+    const der = Buffer.from(certB64, 'base64');
+    const sha1 = createHash('sha1').update(der).digest('base64url');
+    const sha256 = createHash('sha256').update(der).digest('base64url');
+    result.thumbprintSHA1 = sha1;
+    result.thumbprintSHA256 = sha256;
+    if (k.x5t) result.x5tValid = k.x5t === sha1;
+    if (k['x5t#S256']) result.x5tS256Valid = k['x5t#S256'] === sha256;
+    result.pem =
+      '-----BEGIN CERTIFICATE-----\n' +
+      certB64.match(/.{1,64}/g)!.join('\n') +
+      '\n-----END CERTIFICATE-----';
+  }
+  return result;
+}
+
+async function getKey(jwksUrl: string, kid: string) {
+  const entry = cache.get(kid);
+  if (entry && entry.expiry > Date.now()) return entry.jwk;
+  const keys = await fetchAndCacheKeys(jwksUrl);
+  return keys.find((k: any) => k.kid === kid);
+}
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const { jwksUrl } = req.query;
+  const { jwksUrl, jwt } =
+    req.method === 'POST' ? req.body : (req.query as { [key: string]: any });
+
   if (typeof jwksUrl !== 'string') {
-    res.status(400).json({ ok: false, keys: [] });
+    res.status(400).json({ ok: false, error: 'invalid_url', keys: [] });
     return;
   }
 
@@ -22,24 +80,43 @@ export default async function handler(
     const url = new URL(jwksUrl);
     if (!/^https?:$/.test(url.protocol)) throw new Error('invalid');
   } catch {
-    res.status(400).json({ ok: false, keys: [] });
+    res.status(400).json({ ok: false, error: 'invalid_url', keys: [] });
     return;
   }
 
-  const cached = cache.get(jwksUrl);
-  if (cached && cached.expiry > Date.now()) {
-    res.status(200).json({ ok: true, keys: cached.keys });
-    return;
-  }
+  const token = typeof jwt === 'string' ? jwt : null;
 
   try {
-    const resp = await fetch(jwksUrl);
-    if (!resp.ok) throw new Error('fetch failed');
-    const json = await resp.json();
-    const keys = Array.isArray(json.keys) ? json.keys : [];
-    cache.set(jwksUrl, { keys, expiry: Date.now() + TTL });
-    res.status(200).json({ ok: true, keys });
-  } catch {
-    res.status(500).json({ ok: false, keys: [] });
+    if (token) {
+      const { kid, alg } = decodeProtectedHeader(token);
+      if (!kid) {
+        res.status(400).json({ ok: false, error: 'missing_kid', keys: [] });
+        return;
+      }
+      if (!alg || !SUPPORTED_ALGS.includes(alg)) {
+        res.status(400).json({ ok: false, error: 'unsupported_alg', keys: [] });
+        return;
+      }
+      let jwk = await getKey(jwksUrl, kid);
+      if (!jwk) {
+        res.status(400).json({ ok: false, error: 'kid_not_found', keys: [] });
+        return;
+      }
+      const key = await importJWK(jwk, alg);
+      const { payload, protectedHeader } = await jwtVerify(token, key);
+      const keys = await fetchAndCacheKeys(jwksUrl);
+      const augmented = keys.map(augmentKey);
+      res
+        .status(200)
+        .json({ ok: true, keys: augmented, payload, header: protectedHeader });
+    } else {
+      const keys = await fetchAndCacheKeys(jwksUrl);
+      const augmented = keys.map(augmentKey);
+      res.status(200).json({ ok: true, keys: augmented });
+    }
+  } catch (e: any) {
+    res
+      .status(500)
+      .json({ ok: false, error: 'server_error', message: e?.message, keys: [] });
   }
 }


### PR DESCRIPTION
## Summary
- fetch JWKS and cache keys by `kid`/`max-age`
- validate cert thumbprints and expose PEM for copying
- verify JWTs and surface unsupported `alg` or missing `kid` errors

## Testing
- `yarn test` *(fails: TypeError (0 , _react.act) is not a function)*
- `yarn lint components/apps/jwks-fetcher.tsx pages/api/jwks-fetcher.ts` *(fails: Couldn't find any `pages` or `app` directory)*
- `npx eslint components/apps/jwks-fetcher.tsx pages/api/jwks-fetcher.ts` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81bab33c8328981204f047729c56