### PR TITLE
feat: add HTTP3 Alt-Svc check API

### DIFF
--- a/docs/h3-check.md
+++ b/docs/h3-check.md
@@ -1,0 +1,32 @@
+# HTTP/3 Alt-Svc Checker
+
+The `/api/h3-check` endpoint fetches headers from a target URL and reports
+whether the server advertises HTTP/3 via the `Alt-Svc` header. The
+negotiated protocol (ALPN) is returned along with a link to
+[documentation](https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc).
+
+- **QUIC attempt** – the handler sends a UDP datagram to the server to mimic a
+  QUIC connection. Browsers expose little detail on UDP failures, so the API
+  includes any socket error message but callers should expect generic network
+  errors when HTTP/3 cannot be reached.
+- **Caching** – HEAD responses are cached for five minutes to avoid repeated
+  network requests.
+
+Example request:
+
+```text
+/api/h3-check?url=https://example.com
+```
+
+Example response:
+
+```json
+{
+  "altSvc": "h3=\":443\"; ma=2592000",
+  "negotiatedProtocol": "h2",
+  "h3Advertised": true,
+  "documentation": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc",
+  "udpError": null,
+  "note": "Browsers limit UDP error details; HTTP/3 failures often appear as generic network errors."
+}
+```

--- a/lib/headCache.ts
+++ b/lib/headCache.ts
@@ -1,0 +1,30 @@
+import https from 'https';
+import type { IncomingHttpHeaders } from 'http';
+
+interface CacheEntry {
+  headers: IncomingHttpHeaders;
+  alpn: string;
+  timestamp: number;
+}
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const cache = new Map<string, CacheEntry>();
+
+export async function fetchHead(url: string): Promise<{ headers: IncomingHttpHeaders; alpn: string }> {
+  const now = Date.now();
+  const cached = cache.get(url);
+  if (cached && now - cached.timestamp < CACHE_TTL) {
+    return { headers: cached.headers, alpn: cached.alpn };
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method: 'HEAD' }, (res) => {
+      const alpn = (res.socket as any).alpnProtocol || 'unknown';
+      const headers = res.headers;
+      cache.set(url, { headers, alpn, timestamp: Date.now() });
+      resolve({ headers, alpn });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}

--- a/pages/api/h3-check.ts
+++ b/pages/api/h3-check.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fetchHead } from '../../lib/headCache';
+import { URL } from 'url';
+import dgram from 'dgram';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { url } = req.query;
+  if (typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    res.status(400).json({ error: 'Invalid URL' });
+    return;
+  }
+
+  let head;
+  try {
+    head = await fetchHead(url);
+  } catch {
+    res.status(502).json({ error: 'Failed to fetch headers' });
+    return;
+  }
+
+  const altSvc = head.headers['alt-svc'] as string | undefined;
+  const h3Advertised = !!altSvc && /(?:^|,\s*)h3(?:=|\s|$)/i.test(altSvc);
+
+  let udpError: string | null = null;
+  try {
+    await new Promise<void>((resolve) => {
+      const socket = dgram.createSocket(parsed.hostname.includes(':') ? 'udp6' : 'udp4');
+      socket.once('error', (err) => {
+        udpError = err.message;
+        socket.close();
+        resolve();
+      });
+      socket.send(Buffer.alloc(1), Number(parsed.port) || 443, parsed.hostname, (err) => {
+        if (err) {
+          udpError = err.message;
+        }
+        socket.close();
+        resolve();
+      });
+    });
+  } catch (err: any) {
+    udpError = err.message;
+  }
+
+  res.status(200).json({
+    altSvc: altSvc ?? null,
+    negotiatedProtocol: head.alpn,
+    h3Advertised,
+    documentation: 'https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc',
+    udpError,
+    note: 'Browsers limit UDP error details; HTTP/3 failures often appear as generic network errors.'
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/h3-check` endpoint to inspect `Alt-Svc` and attempt UDP reachability
- cache HEAD requests and expose negotiated protocol
- document usage and browser UDP error limitations

## Testing
- `yarn test` *(fails: window.test.tsx, ubuntu.test.tsx)*
- `yarn lint` *(deprecation warning, no results)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81be432483288fd4e89ebfc21825