### PR TITLE
feat: improve CSP reporting and visualization

### DIFF
--- a/__tests__/csp-reporter.test.ts
+++ b/__tests__/csp-reporter.test.ts
@@ -1,0 +1,58 @@
+import { normalizeReports, computeTop, validateReport } from '../pages/api/csp-reporter';
+
+describe('csp-reporter utilities', () => {
+  test('normalizes report-uri format', () => {
+    const body = {
+      'csp-report': {
+        'document-uri': 'https://example.com',
+        'violated-directive': 'script-src',
+        'blocked-uri': 'https://evil.com/script.js',
+      },
+    };
+    const res = normalizeReports(body);
+    expect(res).toHaveLength(1);
+    expect(res[0]['document-uri']).toBe('https://example.com');
+  });
+
+  test('normalizes report-to format array', () => {
+    const body = [
+      {
+        body: {
+          documentURL: 'https://example.com',
+          effectiveDirective: 'img-src',
+          blockedURI: 'https://evil.com/img.png',
+        },
+      },
+    ];
+    const res = normalizeReports(body);
+    expect(res[0]['effective-directive']).toBe('img-src');
+  });
+
+  test('computes top offenders', () => {
+    const list = [
+      {
+        'document-uri': 'a',
+        'violated-directive': 'script-src',
+        'blocked-uri': 'b',
+      },
+      {
+        'document-uri': 'a',
+        'violated-directive': 'script-src',
+        'blocked-uri': 'b',
+      },
+      {
+        'document-uri': 'a',
+        'violated-directive': 'script-src',
+        'blocked-uri': 'c',
+      },
+    ];
+    const top = computeTop(list);
+    expect(top['script-src'][0]).toEqual({ uri: 'b', count: 2 });
+  });
+
+  test('validate report returns helpful errors', () => {
+    const errors = validateReport({ 'blocked-uri': '' } as any);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+

--- a/pages/api/csp-reporter.ts
+++ b/pages/api/csp-reporter.ts
@@ -1,59 +1,108 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-// Interface for CSP reports
+// Interface for normalized CSP reports
 interface CSPReport {
-  "document-uri": string;
-  "referrer"?: string;
-  "violated-directive": string;
-  "effective-directive"?: string;
-  "original-policy"?: string;
-  "disposition"?: string;
-  "blocked-uri": string;
-  "line-number"?: number;
-  "column-number"?: number;
-  "source-file"?: string;
-  "status-code"?: number;
-  [key: string]: any; // Allow additional fields if present
+  'document-uri': string;
+  'referrer'?: string;
+  'violated-directive'?: string;
+  'effective-directive'?: string;
+  'original-policy'?: string;
+  'disposition'?: string;
+  'blocked-uri': string;
+  'line-number'?: number;
+  'column-number'?: number;
+  'source-file'?: string;
+  'status-code'?: number;
+  [key: string]: any;
 }
 
-// In-memory store for CSP reports
-const reports: CSPReport[] = [];
+interface StoredReport {
+  ts: number;
+  report: CSPReport;
+}
 
-// Validate CSP report structure
-function isValidCspReport(body: any): boolean {
-  if (
-    typeof body === 'object' &&
-    body !== null &&
-    typeof body['csp-report'] === 'object' &&
-    body['csp-report'] !== null
-  ) {
-    // Optionally check for required fields inside csp-report
-    const report = body['csp-report'];
-    return (
-      typeof report['document-uri'] === 'string' &&
-      typeof report['violated-directive'] === 'string'
-    );
+const reports: StoredReport[] = [];
+const MAX_REPORTS = 500;
+const MAX_AGE_MS = 1000 * 60 * 60 * 24; // 24 hours
+
+function normalizeReports(body: any): CSPReport[] {
+  const list = Array.isArray(body) ? body : [body];
+  return list
+    .map((item) => item?.['csp-report'] || item?.body || item)
+    .filter(Boolean)
+    .map((rep) => ({
+      'document-uri': rep['document-uri'] || rep['documentURL'] || rep['url'] || '',
+      'referrer': rep['referrer'],
+      'violated-directive': rep['violated-directive'] || rep['violatedDirective'],
+      'effective-directive': rep['effective-directive'] || rep['effectiveDirective'],
+      'original-policy': rep['original-policy'] || rep['originalPolicy'],
+      'disposition': rep['disposition'],
+      'blocked-uri': rep['blocked-uri'] || rep['blockedURI'] || rep['blocked-url'] || '',
+      'line-number': rep['line-number'] || rep['lineNumber'],
+      'column-number': rep['column-number'] || rep['columnNumber'],
+      'source-file': rep['source-file'] || rep['sourceFile'],
+      'status-code': rep['status-code'] || rep['statusCode'],
+    }));
+}
+
+function validateReport(rep: CSPReport): string[] {
+  const errors: string[] = [];
+  if (!rep['document-uri']) errors.push('Missing document-uri');
+  if (!rep['blocked-uri']) errors.push('Missing blocked-uri');
+  if (!rep['violated-directive'] && !rep['effective-directive'])
+    errors.push('Missing violated-directive');
+  return errors;
+}
+
+function prune() {
+  const cutoff = Date.now() - MAX_AGE_MS;
+  while (reports.length > MAX_REPORTS || (reports[0] && reports[0].ts < cutoff)) {
+    reports.shift();
   }
-  return false;
 }
 
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<any>
-) {
+function computeTop(list: CSPReport[]): Record<string, { uri: string; count: number }[]> {
+  const dirMap: Record<string, Record<string, number>> = {};
+  list.forEach((r) => {
+    const dir = r['effective-directive'] || r['violated-directive'] || 'unknown';
+    const uri = r['blocked-uri'] || 'unknown';
+    dirMap[dir] ??= {};
+    dirMap[dir][uri] = (dirMap[dir][uri] || 0) + 1;
+  });
+  return Object.fromEntries(
+    Object.entries(dirMap).map(([dir, m]) => [
+      dir,
+      Object.entries(m)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([uri, count]) => ({ uri, count })),
+    ])
+  );
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<any>) {
   if (req.method === 'POST') {
-    // validate and store incoming report
-    if (!isValidCspReport(req.body)) {
-      res.status(400).json({ error: 'Invalid CSP report structure' });
+    const parsed = normalizeReports(req.body);
+    if (parsed.length === 0) {
+      res.status(400).json({ error: 'No reports found in request' });
       return;
     }
-    reports.push(req.body);
-    res.status(200).json({ ok: true });
+    const invalid = parsed
+      .map((r, i) => ({ i, errors: validateReport(r) }))
+      .find((r) => r.errors.length);
+    if (invalid) {
+      res.status(400).json({ error: 'Invalid CSP report', details: invalid.errors });
+      return;
+    }
+    parsed.forEach((r) => reports.push({ ts: Date.now(), report: r }));
+    prune();
+    res.status(200).json({ ok: true, count: parsed.length });
     return;
   }
 
   if (req.method === 'GET') {
-    res.status(200).json(reports);
+    const list = reports.map((r) => r.report);
+    res.status(200).json({ reports: list, top: computeTop(list) });
     return;
   }
 
@@ -61,4 +110,4 @@ export default function handler(
   res.status(405).end('Method Not Allowed');
 }
 
-export { reports };
+export { reports, normalizeReports, validateReport, computeTop };


### PR DESCRIPTION
## Summary
- handle both report-uri and report-to CSP violation formats
- aggregate violations by directive and highlight top offenders
- add client-side demo that captures `securitypolicyviolation` events in a timeline

## Testing
- `yarn test` *(fails: ubuntu.test.tsx, window.test.tsx)*
- `yarn test __tests__/csp-reporter.test.ts`
- `yarn lint pages/api/csp-reporter.ts components/apps/csp-reporter.tsx __tests__/csp-reporter.test.ts` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81bf22108328af55456d0640d9e2