### PR TITLE
Enhance CAA checker with policy analysis and caching

### DIFF
--- a/components/apps/caa-checker.tsx
+++ b/components/apps/caa-checker.tsx
@@ -10,6 +10,9 @@ interface ApiResult {
   ok: boolean;
   records: CaaRecord[];
   issues: string[];
+  policyDomain: string;
+  recommendation?: string;
+  notes: string[];
 }
 
 const CaaChecker: React.FC = () => {
@@ -54,30 +57,61 @@ const CaaChecker: React.FC = () => {
         </button>
       </form>
       {error && <div className="text-red-500">{error}</div>}
-      {result && result.records.length > 0 && (
-        <table className="w-full text-sm">
-          <thead>
-            <tr>
-              <th className="text-left">Flags</th>
-              <th className="text-left">Tag</th>
-              <th className="text-left">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {result.records.map((r, i) => (
-              <tr key={i}>
-                <td>{r.flags}</td>
-                <td>{r.tag}</td>
-                <td>{r.value}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {result && (
+        <>
+          <div className="text-sm">
+            Effective policy from <span className="font-mono">{result.policyDomain}</span>
+          </div>
+          {result.records.length > 0 && (
+            <table className="w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="text-left">Flags</th>
+                  <th className="text-left">Tag</th>
+                  <th className="text-left">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.records.map((r, i) => (
+                  <tr key={i}>
+                    <td>{r.flags}</td>
+                    <td>{r.tag}</td>
+                    <td>{r.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {result.recommendation && (
+            <div className="text-sm space-y-1">
+              <div>Recommended CAA stanza:</div>
+              <div className="relative">
+                <pre className="bg-gray-800 p-2 overflow-x-auto" id="rec-block">
+{result.recommendation}
+                </pre>
+                <button
+                  type="button"
+                  className="absolute top-1 right-1 bg-blue-600 px-2 py-1 text-xs rounded"
+                  onClick={() => navigator.clipboard.writeText(result.recommendation || '')}
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+          )}
+        </>
       )}
       {result && result.issues.length > 0 && (
         <div className="text-yellow-400 text-sm space-y-1">
           {result.issues.map((iss, i) => (
             <div key={i}>{iss}</div>
+          ))}
+        </div>
+      )}
+      {result && result.notes.length > 0 && (
+        <div className="text-xs text-gray-300 space-y-1">
+          {result.notes.map((n, i) => (
+            <div key={i}>{n}</div>
           ))}
         </div>
       )}

--- a/pages/api/caa-checker.ts
+++ b/pages/api/caa-checker.ts
@@ -10,7 +10,63 @@ interface CaaResponse {
   ok: boolean;
   records: CaaRecord[];
   issues: string[];
-  error?: string;
+  policyDomain: string;
+  recommendation?: string;
+  notes: string[];
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // five minutes
+const cache = new Map<string, { expires: number; records: CaaRecord[] }>();
+
+async function fetchCaa(domain: string): Promise<CaaRecord[]> {
+  const cached = cache.get(domain);
+  if (cached && cached.expires > Date.now()) {
+    return cached.records;
+  }
+  const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=CAA`;
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error('Upstream server error');
+  }
+  const data = await response.json();
+  const records: CaaRecord[] = (data.Answer || []).map((ans: any) => {
+    const match = ans.data.match(/^(\d+)\s+([a-zA-Z0-9]+)\s+"?(.*?)"?$/);
+    if (match) {
+      return {
+        flags: parseInt(match[1], 10),
+        tag: match[2].toLowerCase(),
+        value: match[3].replace(/^"|"$/g, ''),
+      };
+    }
+    return { flags: 0, tag: '', value: ans.data };
+  });
+  cache.set(domain, { expires: Date.now() + CACHE_TTL_MS, records });
+  return records;
+}
+
+function parentDomain(domain: string): string | null {
+  const parts = domain.split('.');
+  if (parts.length <= 1) return null;
+  parts.shift();
+  return parts.join('.');
+}
+
+async function getEffectiveCaa(domain: string): Promise<{
+  records: CaaRecord[];
+  policyDomain: string;
+}> {
+  let current = domain;
+  while (true) {
+    const records = await fetchCaa(current);
+    if (records.length > 0) {
+      return { records, policyDomain: current };
+    }
+    const parent = parentDomain(current);
+    if (!parent) {
+      return { records: [], policyDomain: domain };
+    }
+    current = parent;
+  }
 }
 
 export default async function handler(
@@ -28,33 +84,49 @@ export default async function handler(
   }
 
   try {
-    const endpoint = `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=CAA`;
-    const response = await fetch(endpoint);
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: 'Upstream server error' });
-    }
-    const data = await response.json();
-    const records: CaaRecord[] = (data.Answer || []).map((ans: any) => {
-      const match = ans.data.match(/^(\d+)\s+([a-zA-Z0-9]+)\s+"?(.*?)"?$/);
-      if (match) {
-        return {
-          flags: parseInt(match[1], 10),
-          tag: match[2].toLowerCase(),
-          value: match[3].replace(/^"|"$/g, ''),
-        };
-      }
-      return { flags: 0, tag: '', value: ans.data };
-    });
+    const { records, policyDomain } = await getEffectiveCaa(domain);
 
     const issues: string[] = [];
+    if (records.length === 0) {
+      issues.push('No CAA records found');
+    }
+
+    const hasIssue = records.some((r) => r.tag === 'issue');
+    const hasIssueWild = records.some((r) => r.tag === 'issuewild');
+    const hasIodef = records.some((r) => r.tag === 'iodef');
+
+    if (!hasIssue) issues.push('Missing issue record');
+    if (!hasIodef) issues.push('Missing iodef record');
+
     const issuers = records.filter((r) => r.tag === 'issue').map((r) => r.value);
     const uniqueIssuers = Array.from(new Set(issuers));
     if (uniqueIssuers.length > 1) issues.push('Multiple issuers present');
-    if (!records.some((r) => r.tag === 'iodef')) issues.push('Missing iodef record');
 
-    return res.status(200).json({ ok: issues.length === 0, records, issues });
+    const recParts: string[] = [];
+    if (!hasIssue) recParts.push(`0 issue "letsencrypt.org"`);
+    if (!hasIssueWild) recParts.push(`0 issuewild "letsencrypt.org"`);
+    if (!hasIodef) recParts.push(`0 iodef "mailto:security@${domain}"`);
+    const recommendation =
+      recParts.length > 0 ? recParts.join('\n') + '\n' : undefined;
+
+    const notes: string[] = [];
+    if (records.some((r) => (r.flags & 0x80) !== 0)) {
+      notes.push(
+        'Critical flag set: unrecognized tags must be understood by CAs or issuance is forbidden.'
+      );
+    }
+    notes.push(
+      `Records at ${policyDomain} apply to ${domain}. More specific subdomains override parent policies.`
+    );
+
+    return res.status(200).json({
+      ok: issues.length === 0,
+      records,
+      issues,
+      policyDomain,
+      recommendation,
+      notes,
+    });
   } catch (e: any) {
     return res.status(500).json({ error: e.message || 'Request failed' });
   }


### PR DESCRIPTION
## Summary
- cache CAA DNS lookups and evaluate effective policy across parent domains
- flag missing issue/iodef tags and offer copyable recommended CAA stanza
- explain critical flag behavior and policy inheritance in API and UI

## Testing
- `yarn lint`
- `yarn test` *(fails: TypeError: (0 , _react.act) is not a function in window.test.tsx and ubuntu.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81c3bf088328814f7129e382a195