### PR TITLE
feat: enhance email parsing with worker decoding

### DIFF
--- a/components/apps/eml-msg-parser.tsx
+++ b/components/apps/eml-msg-parser.tsx
@@ -2,9 +2,48 @@ import React, { useState } from 'react';
 import * as emlformat from 'eml-format';
 import MsgReader from 'msgreader';
 
+function canonicalizeHeaders(headers: Record<string, any>) {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    const canonical = k
+      .toLowerCase()
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join('-');
+    out[canonical] = v;
+  }
+  return out;
+}
+
+async function decodeWorker(data: string, encoding: string) {
+  return await new Promise<Uint8Array>((resolve, reject) => {
+    const worker = new Worker(
+      new URL('../../lib/emailDecoder.worker.ts', import.meta.url)
+    );
+    const id = Math.random().toString(36).slice(2);
+    worker.onmessage = (e: MessageEvent<any>) => {
+      if (e.data.id !== id) return;
+      if (e.data.error) {
+        reject(new Error(e.data.error));
+      } else {
+        resolve(new Uint8Array(e.data.decoded));
+      }
+      worker.terminate();
+    };
+    worker.postMessage({ id, data, encoding });
+  });
+}
+
+function sanitizeHtml(html: string) {
+  return html.replace(/<script.*?>[\s\S]*?<\/script>/gi, '');
+}
+
 interface Attachment {
   filename: string;
   url: string;
+  type: string;
+  preview?: string;
+  error?: string;
 }
 
 interface ParsedMessage {
@@ -12,6 +51,8 @@ interface ParsedMessage {
   headers: Record<string, any>;
   received: string[];
   attachments: Attachment[];
+  body?: { type: 'text' | 'html'; content: string };
+  error?: string;
 }
 
 export default function EmlMsgParser() {
@@ -30,31 +71,56 @@ export default function EmlMsgParser() {
       if (name.toLowerCase().endsWith('.eml')) {
         const text = new TextDecoder().decode(buffer);
         await new Promise<void>((resolve) => {
-          emlformat.read(text, true, (err: any, data: any) => {
+          emlformat.read(text, true, async (err: any, data: any) => {
             if (err || !data) {
               parsed.push({
                 name,
                 headers: { Error: err?.message || 'Unable to parse' },
                 received: [],
                 attachments: [],
+                error: err?.message || 'Unable to parse',
               });
             } else {
-              const headers = data.headers || {};
+              const headers = canonicalizeHeaders(data.headers || {});
               const received = ([] as string[]).concat(
-                headers['received'] || headers['Received'] || []
+                headers['Received'] || []
               );
-              const attachments = (data.attachments || []).map(
-                (att: any, idx: number) => {
-                  const base64 = att.data || att.content || '';
-                  const type =
-                    att.contentType || att.mimeType || 'application/octet-stream';
-                  return {
+              const attachments: Attachment[] = [];
+              for (const [idx, att] of (data.attachments || []).entries()) {
+                const base64 = att.data || att.content || '';
+                const type =
+                  att.contentType || att.mimeType || 'application/octet-stream';
+                const encoding =
+                  (att.encoding || att.transferEncoding || 'base64').toLowerCase();
+                try {
+                  const bytes = await decodeWorker(base64, encoding);
+                  const blob = new Blob([bytes], { type });
+                  const url = URL.createObjectURL(blob);
+                  const preview = type.startsWith('text/')
+                    ? new TextDecoder().decode(bytes.slice(0, 4096))
+                    : undefined;
+                  attachments.push({
                     filename: att.filename || `attachment-${idx}`,
-                    url: `data:${type};base64,${base64}`,
-                  } as Attachment;
+                    url,
+                    type,
+                    preview,
+                  });
+                } catch (e: any) {
+                  attachments.push({
+                    filename: att.filename || `attachment-${idx}`,
+                    url: '',
+                    type,
+                    error: e.message || 'Decode error',
+                  });
                 }
-              );
-              parsed.push({ name, headers, received, attachments });
+              }
+              let body: ParsedMessage['body'];
+              if (data.html) {
+                body = { type: 'html', content: sanitizeHtml(data.html) };
+              } else if (data.text) {
+                body = { type: 'text', content: data.text };
+              }
+              parsed.push({ name, headers, received, attachments, body });
             }
             resolve();
           });
@@ -62,28 +128,50 @@ export default function EmlMsgParser() {
       } else if (name.toLowerCase().endsWith('.msg')) {
         const reader = new MsgReader(buffer);
         const data = reader.getFileData();
-        const headers: Record<string, any> = data.headers || {};
-        if (data.senderEmail) headers['sender'] = data.senderEmail;
-        if (data.subject) headers['subject'] = data.subject;
-        const received = ([] as string[]).concat(headers['received'] || []);
-        const attachments = (data.attachments || []).map(
-          (att: any, idx: number) => {
+        const headers: Record<string, any> = canonicalizeHeaders(
+          data.headers || {}
+        );
+        if (data.senderEmail) headers['Sender'] = data.senderEmail;
+        if (data.subject) headers['Subject'] = data.subject;
+        const received = ([] as string[]).concat(headers['Received'] || []);
+        const attachments: Attachment[] = [];
+        for (const [idx, att] of (data.attachments || []).entries()) {
+          try {
             const blob = new Blob([att.content], {
               type: att.mimeType || 'application/octet-stream',
             });
-            return {
+            const url = URL.createObjectURL(blob);
+            let preview: string | undefined;
+            if ((att.mimeType || '').startsWith('text/')) {
+              preview = new TextDecoder().decode(att.content.slice(0, 4096));
+            }
+            attachments.push({
               filename: att.fileName || `attachment-${idx}`,
-              url: URL.createObjectURL(blob),
-            } as Attachment;
+              url,
+              type: att.mimeType || 'application/octet-stream',
+              preview,
+            });
+          } catch (e: any) {
+            attachments.push({
+              filename: att.fileName || `attachment-${idx}`,
+              url: '',
+              type: att.mimeType || 'application/octet-stream',
+              error: e.message || 'Decode error',
+            });
           }
-        );
-        parsed.push({ name, headers, received, attachments });
+        }
+        let body: ParsedMessage['body'];
+        if (data.body) {
+          body = { type: 'text', content: data.body };
+        }
+        parsed.push({ name, headers, received, attachments, body });
       } else {
         parsed.push({
           name,
           headers: { Error: 'Unsupported file type' },
           received: [],
           attachments: [],
+          error: 'Unsupported file type',
         });
       }
     }
@@ -103,17 +191,22 @@ export default function EmlMsgParser() {
       {messages.map((msg, idx) => (
         <div key={idx} className="border border-gray-700 rounded p-2">
           <h2 className="font-bold mb-2">{msg.name}</h2>
+          {msg.error && (
+            <div className="text-red-400 text-sm mb-2">{msg.error}</div>
+          )}
           {Object.keys(msg.headers).length > 0 && (
             <table className="text-sm w-full mb-2 border-collapse">
               <tbody>
-                {Object.entries(msg.headers).map(([k, v]) => (
-                  <tr key={k} className="border-t border-gray-700">
-                    <td className="p-1 font-semibold align-top">{k}</td>
-                    <td className="p-1 break-all">
-                      {Array.isArray(v) ? v.join('; ') : v}
-                    </td>
-                  </tr>
-                ))}
+                {Object.entries(msg.headers)
+                  .sort(([a], [b]) => a.localeCompare(b))
+                  .map(([k, v]) => (
+                    <tr key={k} className="border-t border-gray-700">
+                      <td className="p-1 font-semibold align-top">{k}</td>
+                      <td className="p-1 break-all">
+                        {Array.isArray(v) ? v.join('; ') : v}
+                      </td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           )}
@@ -127,19 +220,56 @@ export default function EmlMsgParser() {
               </ol>
             </div>
           )}
+          {msg.body && (
+            <div className="mb-2">
+              <h3 className="font-semibold">Body</h3>
+              {msg.body.type === 'html' ? (
+                <iframe
+                  className="w-full border border-gray-700"
+                  sandbox=""
+                  srcDoc={msg.body.content}
+                />
+              ) : (
+                <pre className="whitespace-pre-wrap break-all text-sm">
+                  {msg.body.content}
+                </pre>
+              )}
+            </div>
+          )}
           {msg.attachments.length > 0 && (
             <div>
               <h3 className="font-semibold">Attachments</h3>
-              <ul className="list-disc list-inside text-sm">
+              <ul className="list-disc list-inside text-sm space-y-2">
                 {msg.attachments.map((att, i) => (
                   <li key={i}>
-                    <a
-                      className="text-blue-400 underline"
-                      href={att.url}
-                      download={att.filename}
-                    >
-                      {att.filename}
-                    </a>
+                    {att.error ? (
+                      <span className="text-red-400">
+                        {att.filename} - {att.error}
+                      </span>
+                    ) : (
+                      <div className="space-y-1">
+                        {att.type.startsWith('image/') && (
+                          <img
+                            src={att.url}
+                            alt={att.filename}
+                            className="max-w-xs max-h-64"
+                          />
+                        )}
+                        {att.preview && (
+                          <pre className="whitespace-pre-wrap break-all max-h-64 overflow-auto border border-gray-700 p-1">
+                            {att.preview}
+                          </pre>
+                        )}
+                        <a
+                          className="text-blue-400 underline"
+                          href={att.url}
+                          download={att.filename}
+                          rel="noopener noreferrer"
+                        >
+                          {att.filename}
+                        </a>
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/lib/emailDecoder.worker.ts
+++ b/lib/emailDecoder.worker.ts
@@ -1,0 +1,75 @@
+const ctx: Worker = self as any;
+
+interface DecodeRequest {
+  id: string;
+  data: string;
+  encoding: string;
+}
+
+interface DecodeResponse {
+  id: string;
+  decoded?: ArrayBuffer;
+  error?: string;
+}
+
+function decodeBase64(data: string): Uint8Array {
+  const clean = data.replace(/\s+/g, '');
+  if (clean.length % 4 !== 0) {
+    throw new Error('Invalid base64 length');
+  }
+  let binary = '';
+  try {
+    binary = atob(clean);
+  } catch (e) {
+    throw new Error('Invalid base64 data');
+  }
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function decodeQuotedPrintable(input: string): Uint8Array {
+  const str = input.replace(/=\r?\n/g, '');
+  const out: number[] = [];
+  for (let i = 0; i < str.length; i++) {
+    const ch = str[i];
+    if (ch === '=') {
+      if (i + 2 >= str.length) {
+        throw new Error('Truncated quoted-printable escape');
+      }
+      const hex = str.slice(i + 1, i + 3);
+      if (!/^[0-9A-Fa-f]{2}$/.test(hex)) {
+        throw new Error(`Invalid quoted-printable escape '='${hex}`);
+      }
+      out.push(parseInt(hex, 16));
+      i += 2;
+    } else {
+      out.push(ch.charCodeAt(0));
+    }
+  }
+  return new Uint8Array(out);
+}
+
+ctx.onmessage = (e: MessageEvent<DecodeRequest>) => {
+  const { id, data, encoding } = e.data;
+  try {
+    let bytes: Uint8Array;
+    if (encoding === 'base64') {
+      bytes = decodeBase64(data);
+    } else if (encoding === 'quoted-printable') {
+      bytes = decodeQuotedPrintable(data);
+    } else {
+      bytes = new TextEncoder().encode(data);
+    }
+    const buffer = bytes.buffer;
+    const response: DecodeResponse = { id, decoded: buffer };
+    ctx.postMessage(response, [buffer]);
+  } catch (err: any) {
+    ctx.postMessage({ id, error: err.message || String(err) });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- parse .eml and .msg files with header canonicalization and body extraction
- stream-decode base64/quoted-printable attachments in a dedicated worker with corruption detection
- preview safe attachments inline while flagging errors

## Testing
- `yarn lint`
- `yarn test` *(fails: TypeError: (0 , _react.act) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81c112388328b414e8c47dc8c722