### PR TITLE
feat: add jose JWS/JWE workbench

### DIFF
--- a/components/apps/jose.worker.ts
+++ b/components/apps/jose.worker.ts
@@ -1,0 +1,123 @@
+import {
+  generateKeyPair,
+  exportPKCS8,
+  exportSPKI,
+  exportJWK,
+  SignJWT,
+  jwtVerify,
+  CompactEncrypt,
+  compactDecrypt,
+  importJWK,
+  importPKCS8,
+  importSPKI,
+} from 'jose';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+(async () => {
+  const rsa = await generateKeyPair('RS256');
+  const rsaPrivatePem = await exportPKCS8(rsa.privateKey);
+  const rsaPublicPem = await exportSPKI(rsa.publicKey);
+  const rsaPrivateJwk = await exportJWK(rsa.privateKey);
+  const rsaPublicJwk = await exportJWK(rsa.publicKey);
+
+  const ec = await generateKeyPair('ES256');
+  const ecPrivatePem = await exportPKCS8(ec.privateKey);
+  const ecPublicPem = await exportSPKI(ec.publicKey);
+  const ecPrivateJwk = await exportJWK(ec.privateKey);
+  const ecPublicJwk = await exportJWK(ec.publicKey);
+
+  (self as any).postMessage({
+    id: 'init',
+    rsa: {
+      privatePem: rsaPrivatePem,
+      publicPem: rsaPublicPem,
+      privateJwk: rsaPrivateJwk,
+      publicJwk: rsaPublicJwk,
+    },
+    ec: {
+      privatePem: ecPrivatePem,
+      publicPem: ecPublicPem,
+      privateJwk: ecPrivateJwk,
+      publicJwk: ecPublicJwk,
+    },
+  });
+})();
+
+async function parseKey(
+  key: string,
+  type: 'private' | 'public',
+  alg: string,
+): Promise<CryptoKey> {
+  const trimmed = key.trim();
+  if (trimmed.startsWith('{')) {
+    const obj = JSON.parse(trimmed);
+    const jwk = 'keys' in obj ? obj.keys[0] : obj;
+    if (jwk.kty === 'RSA' && !/^RS|PS|RSA-OAEP/.test(alg)) {
+      throw new Error(`Algorithm mismatch: RSA key cannot be used with ${alg}`);
+    }
+    if (jwk.kty === 'EC' && !/^ES|ECDH/.test(alg)) {
+      throw new Error(`Algorithm mismatch: EC key cannot be used with ${alg}`);
+    }
+    return importJWK(jwk, alg);
+  }
+  if (trimmed.includes('BEGIN')) {
+    if (/EC PRIVATE|EC PUBLIC/.test(trimmed) && !/^ES|ECDH/.test(alg)) {
+      throw new Error(`Algorithm mismatch: EC key cannot be used with ${alg}`);
+    }
+    if (!/EC/.test(trimmed) && !/^RS|PS|RSA-OAEP/.test(alg)) {
+      throw new Error(`Algorithm mismatch: RSA key cannot be used with ${alg}`);
+    }
+    return type === 'private'
+      ? importPKCS8(trimmed, alg)
+      : importSPKI(trimmed, alg);
+  }
+  throw new Error('Unsupported key format');
+}
+
+(self as any).onmessage = async (e: MessageEvent) => {
+  const { id, action, payload, token, key, alg, enc, kid } = e.data as any;
+  if (id === 'init') return;
+  try {
+    let result: any;
+    if (action === 'sign') {
+      const cryptoKey = await parseKey(key, 'private', alg);
+      result = await new SignJWT(payload)
+        .setProtectedHeader({ alg, kid })
+        .sign(cryptoKey);
+    } else if (action === 'verify') {
+      const cryptoKey = await parseKey(key, 'public', alg);
+      const { payload: pl, protectedHeader } = await jwtVerify(token, cryptoKey, {
+        algorithms: [alg],
+      });
+      result = { payload: pl, header: protectedHeader };
+    } else if (action === 'encrypt') {
+      const cryptoKey = await parseKey(key, 'public', alg);
+      const jwe = await new CompactEncrypt(
+        encoder.encode(JSON.stringify(payload)),
+      )
+        .setProtectedHeader({ alg, enc, kid })
+        .encrypt(cryptoKey);
+      result = jwe;
+    } else if (action === 'decrypt') {
+      const cryptoKey = await parseKey(key, 'private', alg);
+      const { plaintext, protectedHeader } = await compactDecrypt(
+        token,
+        cryptoKey,
+      );
+      result = {
+        payload: JSON.parse(decoder.decode(plaintext)),
+        header: protectedHeader,
+      };
+    } else {
+      throw new Error('Unknown action');
+    }
+    (self as any).postMessage({ id, result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    (self as any).postMessage({ id, error: msg });
+  }
+};
+
+export default null as any;

--- a/components/apps/jws-jwe-workbench.tsx
+++ b/components/apps/jws-jwe-workbench.tsx
@@ -1,168 +1,289 @@
-import React, { useState } from 'react';
-import {
-  SignJWT,
-  jwtVerify,
-  CompactEncrypt,
-  compactDecrypt,
-  FlattenedSign,
-  FlattenedEncrypt,
-} from 'jose';
+import React, { useEffect, useRef, useState } from 'react';
 
-const JwsJweWorkbench = () => {
-  const [mode, setMode] = useState('sign');
-  const [payload, setPayload] = useState('');
-  const [key, setKey] = useState('');
-  const [alg, setAlg] = useState('');
-  const [kid, setKid] = useState('');
-  const [aud, setAud] = useState('');
-  const [compact, setCompact] = useState('');
-  const [json, setJson] = useState('');
-  const [result, setResult] = useState('');
+const JwsJweWorkbench: React.FC = () => {
+  const workerRef = useRef<Worker>();
+  const callbacks = useRef(new Map<string, { resolve: (v: any) => void; reject: (e: any) => void }>());
 
-  const handleRun = async () => {
-    const enc = new TextEncoder();
-    const dec = new TextDecoder();
-    const keyData = enc.encode(key);
+  const [keys, setKeys] = useState<null | { rsa: any; ec: any }>(null);
+  const [format, setFormat] = useState<'pem' | 'jwks'>('pem');
+  const [jwsAlg, setJwsAlg] = useState('RS256');
+  const [jweAlg, setJweAlg] = useState('RSA-OAEP');
+
+  const [jws, setJws] = useState('');
+  const [verifyResult, setVerifyResult] = useState('');
+  const [jwe, setJwe] = useState('');
+  const [decryptResult, setDecryptResult] = useState('');
+
+  const [signErr, setSignErr] = useState('');
+  const [verifyErr, setVerifyErr] = useState('');
+  const [encryptErr, setEncryptErr] = useState('');
+  const [decryptErr, setDecryptErr] = useState('');
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./jose.worker.ts', import.meta.url), { type: 'module' });
+    workerRef.current.onmessage = (e: MessageEvent) => {
+      const { id, rsa, ec, result, error } = e.data as any;
+      if (id === 'init') {
+        setKeys({ rsa, ec });
+        return;
+      }
+      const cb = callbacks.current.get(id);
+      if (cb) {
+        callbacks.current.delete(id);
+        if (error) cb.reject(error);
+        else cb.resolve(result);
+      }
+    };
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  const callWorker = (action: string, data: any) =>
+    new Promise<any>((resolve, reject) => {
+      const id = crypto.randomUUID();
+      callbacks.current.set(id, { resolve, reject });
+      workerRef.current?.postMessage({ id, action, ...data });
+    });
+
+  if (!keys) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-gray-900 text-white">
+        Generating keys...
+      </div>
+    );
+  }
+
+  const privateKeyData =
+    format === 'pem'
+      ? keys.rsa.privatePem
+      : JSON.stringify({ keys: [keys.rsa.privateJwk] }, null, 2);
+  const publicKeyData =
+    format === 'pem'
+      ? keys.rsa.publicPem
+      : JSON.stringify({ keys: [keys.rsa.publicJwk] }, null, 2);
+
+  const signSnippet =
+    format === 'pem'
+      ? `import { SignJWT, importPKCS8 } from 'jose';
+
+const privateKeyPem = \`${privateKeyData}\`;
+const privateKey = await importPKCS8(privateKeyPem, '${jwsAlg}');
+const jws = await new SignJWT({ msg: 'hello' })
+  .setProtectedHeader({ alg: '${jwsAlg}', kid: 'demo' })
+  .sign(privateKey);`
+      : `import { SignJWT, importJWK } from 'jose';
+
+const jwks = ${privateKeyData};
+const privateKey = await importJWK(jwks.keys[0], '${jwsAlg}');
+const jws = await new SignJWT({ msg: 'hello' })
+  .setProtectedHeader({ alg: '${jwsAlg}', kid: 'demo' })
+  .sign(privateKey);`;
+
+  const verifySnippet =
+    format === 'pem'
+      ? `import { jwtVerify, importSPKI } from 'jose';
+
+const publicKeyPem = \`${publicKeyData}\`;
+const publicKey = await importSPKI(publicKeyPem, '${jwsAlg}');
+const { payload } = await jwtVerify(jws, publicKey, { algorithms: ['${jwsAlg}'] });`
+      : `import { jwtVerify, importJWK } from 'jose';
+
+const jwks = ${publicKeyData};
+const publicKey = await importJWK(jwks.keys[0], '${jwsAlg}');
+const { payload } = await jwtVerify(jws, publicKey, { algorithms: ['${jwsAlg}'] });`;
+
+  const encryptSnippet =
+    format === 'pem'
+      ? `import { CompactEncrypt, importSPKI } from 'jose';
+
+const publicKeyPem = \`${publicKeyData}\`;
+const publicKey = await importSPKI(publicKeyPem, '${jweAlg}');
+const jwe = await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(payload)))
+  .setProtectedHeader({ alg: '${jweAlg}', enc: 'A256GCM', kid: 'demo' })
+  .encrypt(publicKey);`
+      : `import { CompactEncrypt, importJWK } from 'jose';
+
+const jwks = ${publicKeyData};
+const publicKey = await importJWK(jwks.keys[0], '${jweAlg}');
+const jwe = await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(payload)))
+  .setProtectedHeader({ alg: '${jweAlg}', enc: 'A256GCM', kid: 'demo' })
+  .encrypt(publicKey);`;
+
+  const decryptSnippet =
+    format === 'pem'
+      ? `import { compactDecrypt, importPKCS8 } from 'jose';
+
+const privateKeyPem = \`${privateKeyData}\`;
+const privateKey = await importPKCS8(privateKeyPem, '${jweAlg}');
+const { plaintext } = await compactDecrypt(jwe, privateKey);
+const payload = JSON.parse(new TextDecoder().decode(plaintext));`
+      : `import { compactDecrypt, importJWK } from 'jose';
+
+const jwks = ${privateKeyData};
+const privateKey = await importJWK(jwks.keys[0], '${jweAlg}');
+const { plaintext } = await compactDecrypt(jwe, privateKey);
+const payload = JSON.parse(new TextDecoder().decode(plaintext));`;
+
+  const copy = (text: string) => navigator.clipboard.writeText(text);
+
+  const sign = async () => {
+    setSignErr('');
     try {
-      if (mode === 'sign') {
-        const payloadObj = payload ? JSON.parse(payload) : {};
-        if (aud) payloadObj.aud = aud;
-        const jws = await new SignJWT(payloadObj)
-          .setProtectedHeader({ alg, ...(kid ? { kid } : {}) })
-          .sign(keyData);
-        const jwsJson = await new FlattenedSign(enc.encode(JSON.stringify(payloadObj)))
-          .setProtectedHeader({ alg, ...(kid ? { kid } : {}) })
-          .sign(keyData);
-        setCompact(jws);
-        setJson(JSON.stringify(jwsJson, null, 2));
-        setResult('');
-      } else if (mode === 'verify') {
-        const { payload: pl, protectedHeader } = await jwtVerify(payload, keyData, {
-          audience: aud || undefined,
-          algorithms: alg ? [alg] : undefined,
-        });
-        setResult(
-          JSON.stringify({ payload: pl, header: protectedHeader }, null, 2)
-        );
-        setCompact('');
-        setJson('');
-      } else if (mode === 'encrypt') {
-        const payloadObj = payload ? JSON.parse(payload) : {};
-        if (aud) payloadObj.aud = aud;
-        const input = enc.encode(JSON.stringify(payloadObj));
-        const header = { alg: 'dir', enc: alg, ...(kid ? { kid } : {}) };
-        const jweCompact = await new CompactEncrypt(input)
-          .setProtectedHeader(header)
-          .encrypt(keyData);
-        const jweJson = await new FlattenedEncrypt(input)
-          .setProtectedHeader(header)
-          .encrypt(keyData);
-        setCompact(jweCompact);
-        setJson(JSON.stringify(jweJson, null, 2));
-        setResult('');
-      } else if (mode === 'decrypt') {
-        const { plaintext, protectedHeader } = await compactDecrypt(payload, keyData);
-        const pl = JSON.parse(dec.decode(plaintext));
-        if (aud && pl.aud && pl.aud !== aud) {
-          setResult('aud mismatch');
-        } else {
-          setResult(
-            JSON.stringify({ payload: pl, header: protectedHeader }, null, 2)
-          );
-        }
-        setCompact('');
-        setJson('');
-      }
-    } catch (e: unknown) {
-      let errorMsg = 'Unknown error';
-      if (e instanceof Error) {
-        errorMsg = e.message;
-      } else if (typeof e === 'string') {
-        errorMsg = e;
-      }
-      setResult(`Error: ${errorMsg}`);
-      setCompact('');
-      setJson('');
+      const token = await callWorker('sign', {
+        payload: { msg: 'hello' },
+        key: privateKeyData,
+        alg: jwsAlg,
+        kid: 'demo',
+      });
+      setJws(token);
+    } catch (e) {
+      setSignErr(String(e));
+    }
+  };
+
+  const verify = async () => {
+    setVerifyErr('');
+    try {
+      const res = await callWorker('verify', {
+        token: jws,
+        key: publicKeyData,
+        alg: jwsAlg,
+      });
+      setVerifyResult(JSON.stringify(res, null, 2));
+    } catch (e) {
+      setVerifyErr(String(e));
+    }
+  };
+
+  const encrypt = async () => {
+    setEncryptErr('');
+    try {
+      const token = await callWorker('encrypt', {
+        payload: { msg: 'hello' },
+        key: publicKeyData,
+        alg: jweAlg,
+        enc: 'A256GCM',
+        kid: 'demo',
+      });
+      setJwe(token);
+    } catch (e) {
+      setEncryptErr(String(e));
+    }
+  };
+
+  const decrypt = async () => {
+    setDecryptErr('');
+    try {
+      const res = await callWorker('decrypt', {
+        token: jwe,
+        key: privateKeyData,
+        alg: jweAlg,
+      });
+      setDecryptResult(JSON.stringify(res, null, 2));
+    } catch (e) {
+      setDecryptErr(String(e));
     }
   };
 
   return (
-    <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto space-y-4">
+    <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto space-y-6">
       <div className="flex flex-wrap gap-4">
-        <label className="flex items-center">Mode:
+        <label className="flex items-center">
+          Key Format:
           <select
-            className="ml-2 p-1 rounded text-black"
-            value={mode}
-            onChange={(e) => setMode(e.target.value)}
+            className="ml-2 p-1 text-black rounded"
+            value={format}
+            onChange={(e) => setFormat(e.target.value as 'pem' | 'jwks')}
           >
-            <option value="sign">Sign</option>
-            <option value="verify">Verify</option>
-            <option value="encrypt">Encrypt</option>
-            <option value="decrypt">Decrypt</option>
+            <option value="pem">PEM</option>
+            <option value="jwks">JWKS</option>
           </select>
         </label>
-        <label className="flex items-center">Alg:
+        <label className="flex items-center">
+          JWS alg:
           <input
-            className="ml-2 p-1 rounded text-black"
-            value={alg}
-            onChange={(e) => setAlg(e.target.value)}
-            placeholder="HS256 or A256GCM"
+            className="ml-2 p-1 text-black rounded w-32"
+            value={jwsAlg}
+            onChange={(e) => setJwsAlg(e.target.value)}
           />
         </label>
-        <label className="flex items-center">kid:
+        <label className="flex items-center">
+          JWE alg:
           <input
-            className="ml-2 p-1 rounded text-black"
-            value={kid}
-            onChange={(e) => setKid(e.target.value)}
-            placeholder="optional"
-          />
-        </label>
-        <label className="flex items-center">aud:
-          <input
-            className="ml-2 p-1 rounded text-black"
-            value={aud}
-            onChange={(e) => setAud(e.target.value)}
-            placeholder="optional"
+            className="ml-2 p-1 text-black rounded w-32"
+            value={jweAlg}
+            onChange={(e) => setJweAlg(e.target.value)}
           />
         </label>
       </div>
-      <textarea
-        className="w-full h-40 p-2 rounded text-black"
-        placeholder={mode === 'sign' || mode === 'encrypt' ? 'Payload JSON' : 'Input token'}
-        value={payload}
-        onChange={(e) => setPayload(e.target.value)}
-      />
-      <input
-        type="text"
-        className="w-full p-2 rounded text-black"
-        placeholder="Key"
-        value={key}
-        onChange={(e) => setKey(e.target.value)}
-      />
-      <button
-        onClick={handleRun}
-        className="px-4 py-2 bg-blue-600 rounded"
-      >
-        Run
-      </button>
-      {compact && (
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <h3 className="font-bold mb-2">Compact</h3>
-          <pre className="whitespace-pre-wrap break-all bg-black p-2 rounded">{compact}</pre>
+          <h3 className="font-bold mb-2">Private {format.toUpperCase()}</h3>
+          <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{privateKeyData}</pre>
+          <button
+            type="button"
+            onClick={() => copy(privateKeyData)}
+            className="mt-2 px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
         </div>
-      )}
-      {json && (
         <div>
-          <h3 className="font-bold mb-2">JSON</h3>
-          <pre className="whitespace-pre-wrap break-all bg-black p-2 rounded">{json}</pre>
+          <h3 className="font-bold mb-2">Public {format.toUpperCase()}</h3>
+          <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{publicKeyData}</pre>
+          <button
+            type="button"
+            onClick={() => copy(publicKeyData)}
+            className="mt-2 px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
         </div>
-      )}
-      {result && (
-        <div>
-          <h3 className="font-bold mb-2">Result</h3>
-          <pre className="whitespace-pre-wrap break-all bg-black p-2 rounded">{result}</pre>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Step 1: Sign JWS</h2>
+        <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{signSnippet}</pre>
+        <div className="mt-2 flex gap-2">
+          <button onClick={() => copy(signSnippet)} className="px-3 py-1 bg-blue-600 rounded">Copy</button>
+          <button onClick={sign} className="px-3 py-1 bg-green-600 rounded">Sign</button>
         </div>
-      )}
+        {signErr && <div className="text-red-400 mt-2">{signErr}</div>}
+        {jws && <pre className="bg-black p-2 rounded mt-2 break-all whitespace-pre-wrap">{jws}</pre>}
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Step 2: Verify JWS</h2>
+        <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{verifySnippet}</pre>
+        <div className="mt-2 flex gap-2">
+          <button onClick={() => copy(verifySnippet)} className="px-3 py-1 bg-blue-600 rounded">Copy</button>
+          <button onClick={verify} className="px-3 py-1 bg-green-600 rounded" disabled={!jws}>Verify</button>
+        </div>
+        {verifyErr && <div className="text-red-400 mt-2">{verifyErr}</div>}
+        {verifyResult && <pre className="bg-black p-2 rounded mt-2 break-all whitespace-pre-wrap">{verifyResult}</pre>}
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Step 3: Encrypt JWE</h2>
+        <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{encryptSnippet}</pre>
+        <div className="mt-2 flex gap-2">
+          <button onClick={() => copy(encryptSnippet)} className="px-3 py-1 bg-blue-600 rounded">Copy</button>
+          <button onClick={encrypt} className="px-3 py-1 bg-green-600 rounded">Encrypt</button>
+        </div>
+        {encryptErr && <div className="text-red-400 mt-2">{encryptErr}</div>}
+        {jwe && <pre className="bg-black p-2 rounded mt-2 break-all whitespace-pre-wrap">{jwe}</pre>}
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Step 4: Decrypt JWE</h2>
+        <pre className="bg-black p-2 rounded whitespace-pre-wrap break-all">{decryptSnippet}</pre>
+        <div className="mt-2 flex gap-2">
+          <button onClick={() => copy(decryptSnippet)} className="px-3 py-1 bg-blue-600 rounded">Copy</button>
+          <button onClick={decrypt} className="px-3 py-1 bg-green-600 rounded" disabled={!jwe}>Decrypt</button>
+        </div>
+        {decryptErr && <div className="text-red-400 mt-2">{decryptErr}</div>}
+        {decryptResult && <pre className="bg-black p-2 rounded mt-2 break-all whitespace-pre-wrap">{decryptResult}</pre>}
+      </div>
     </div>
   );
 };
@@ -170,4 +291,3 @@ const JwsJweWorkbench = () => {
 export default JwsJweWorkbench;
 
 export const displayJwsJweWorkbench = () => <JwsJweWorkbench />;
-

--- a/pages/apps/jws-jwe-workbench.tsx
+++ b/pages/apps/jws-jwe-workbench.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const JwsJweWorkbench = dynamic(() => import('../../components/apps/jws-jwe-workbench'), { ssr: false });
+
+export default function JwsJweWorkbenchPage() {
+  return <JwsJweWorkbench />;
+}


### PR DESCRIPTION
## Summary
- add Web Worker that generates demo RSA/EC keys and runs JWS/JWE operations with alg mismatch checks
- create step-by-step JWS/JWE workbench with copyable snippets using jose
- expose workbench via `/apps/jws-jwe-workbench`

## Testing
- `yarn lint`
- `yarn test` *(fails: TypeError: (0 , _react.act) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81c4bde083289ec8c54cf520e1a5