### PR TITLE
feat(pkce-helper): enhance PKCE helper with OAuth samples

### DIFF
--- a/components/apps/pkce-helper.tsx
+++ b/components/apps/pkce-helper.tsx
@@ -5,9 +5,11 @@ const PKCEHelper: React.FC = () => {
   const [method, setMethod] = useState<'S256' | 'plain'>('S256');
   const [codeVerifier, setCodeVerifier] = useState('');
   const [codeChallenge, setCodeChallenge] = useState('');
+  const [authUrl, setAuthUrl] = useState('');
+  const [lengthWarning, setLengthWarning] = useState('');
   const [counter, setCounter] = useState(60);
 
-  const generate = () => {
+  const generate = async () => {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
     const array = new Uint8Array(length);
     if (window.crypto && window.crypto.getRandomValues) {
@@ -25,16 +27,13 @@ const PKCEHelper: React.FC = () => {
 
     if (method === 'S256') {
       const encoder = new TextEncoder();
-      window.crypto.subtle
-        .digest('SHA-256', encoder.encode(verifier))
-        .then((hash) => {
-          const bytes = Array.from(new Uint8Array(hash));
-          const base64 = btoa(String.fromCharCode(...bytes))
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-          setCodeChallenge(base64);
-        });
+      const hash = await crypto.subtle.digest('SHA-256', encoder.encode(verifier));
+      const bytes = Array.from(new Uint8Array(hash));
+      const base64 = btoa(String.fromCharCode(...bytes))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+      setCodeChallenge(base64);
     } else {
       setCodeChallenge(verifier);
     }
@@ -56,6 +55,19 @@ const PKCEHelper: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [counter]);
 
+  useEffect(() => {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: 'CLIENT_ID',
+      redirect_uri: 'https://client.example.com/callback',
+      scope: 'SCOPE',
+      state: 'STATE',
+      code_challenge: codeChallenge,
+      code_challenge_method: method,
+    });
+    setAuthUrl(`https://auth.example.com/authorize?${params.toString()}`);
+  }, [codeChallenge, method]);
+
   const copy = async (text: string) => {
     try {
       await navigator.clipboard?.writeText(text);
@@ -63,6 +75,28 @@ const PKCEHelper: React.FC = () => {
       // ignore
     }
   };
+
+  const handleLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    if (Number.isNaN(value)) {
+      setLength(43);
+      setLengthWarning('');
+      return;
+    }
+    const clamped = Math.min(Math.max(value, 43), 128);
+    setLength(clamped);
+    setLengthWarning(
+      value !== clamped ? 'Verifier length must be between 43 and 128 characters.' : ''
+    );
+  };
+
+  const tokenRequest = `curl -X POST https://auth.example.com/token \\
+  -d "grant_type=authorization_code" \\
+  -d "code=AUTH_CODE" \\
+  -d "redirect_uri=https://client.example.com/callback" \\
+  -d "code_verifier=${codeVerifier}"`;
+
+  const callbackSnippet = `const params = new URLSearchParams(window.location.search);\nconst code = params.get('code');\nconst state = params.get('state');`;
 
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
@@ -74,7 +108,7 @@ const PKCEHelper: React.FC = () => {
             min={43}
             max={128}
             value={length}
-            onChange={(e) => setLength(parseInt(e.target.value, 10) || 43)}
+            onChange={handleLengthChange}
             className="text-black px-2 py-1 w-24"
           />
         </label>
@@ -98,6 +132,12 @@ const PKCEHelper: React.FC = () => {
         </button>
         <span className="self-center text-sm">Refresh in {counter}s</span>
       </div>
+      {lengthWarning && <div className="text-yellow-300 text-sm">{lengthWarning}</div>}
+      {method === 'plain' && (
+        <div className="text-yellow-300 text-sm">
+          Warning: plain method is less secure. Prefer S256.
+        </div>
+      )}
       <div className="flex items-center space-x-2">
         <input
           type="text"
@@ -128,9 +168,33 @@ const PKCEHelper: React.FC = () => {
           Copy
         </button>
       </div>
+      <div className="flex items-center space-x-2">
+        <input
+          type="text"
+          readOnly
+          value={authUrl}
+          className="flex-1 text-black px-2 py-1"
+        />
+        <button
+          type="button"
+          onClick={() => copy(authUrl)}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          Copy
+        </button>
+      </div>
+      <div className="space-y-2 text-sm">
+        <div>
+          Token request:
+          <pre className="bg-gray-800 p-2 mt-1 overflow-auto text-xs">{tokenRequest}</pre>
+        </div>
+        <div>
+          Callback handling:
+          <pre className="bg-gray-800 p-2 mt-1 overflow-auto text-xs">{callbackSnippet}</pre>
+        </div>
+      </div>
     </div>
   );
 };
 
 export default PKCEHelper;
-


### PR DESCRIPTION
## Summary
- generate PKCE verifier and SHA-256 challenge using SubtleCrypto
- add OAuth authorization URL with copy button and sample token/callback snippets
- validate verifier length and warn when using plain method

## Testing
- `yarn test components/apps/pkce-helper.tsx --passWithNoTests`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa81c5ce2083288bd614993a2b6771