### PR TITLE
feat: add es module dependency graph visualizer

### DIFF
--- a/components/apps/import-graph.tsx
+++ b/components/apps/import-graph.tsx
@@ -1,63 +1,226 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import JSZip from 'jszip';
 
-interface ImportEntry {
-  module: string;
-  name: string;
+interface GraphNode {
+  deps: string[];
+  size: number;
 }
 
-const ImportGraph: React.FC = () => {
-  const [imports, setImports] = useState<ImportEntry[]>([]);
-  const [error, setError] = useState<string>('');
+interface FileError {
+  file: string;
+  error: string;
+}
 
-  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setError('');
-    setImports([]);
-    try {
-      const buf = await file.arrayBuffer();
-      const mod = await WebAssembly.compile(buf);
-      const imps = WebAssembly.Module.imports(mod) as ImportEntry[];
-      setImports(imps);
-    } catch (err) {
-      setError('Failed to parse imports. Please upload a valid WebAssembly binary.');
-    }
+const LARGE_THRESHOLD = 5000;
+
+const ImportGraph: React.FC = () => {
+  const [pasted, setPasted] = useState('');
+  const [graph, setGraph] = useState<Record<string, GraphNode>>({});
+  const [errors, setErrors] = useState<FileError[]>([]);
+  const [cycles, setCycles] = useState<string[][]>([]);
+  const [depth, setDepth] = useState(3);
+  const workerRef = useRef<Worker>();
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./import-graph.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    const worker = workerRef.current;
+    worker.onmessage = (e) => {
+      const { type } = e.data;
+      if (type === 'progress') {
+        setGraph((g) => ({ ...g, ...e.data.partial }));
+      } else if (type === 'done') {
+        setGraph(e.data.graph);
+        setErrors(e.data.errors);
+        setCycles(e.data.cycles);
+      }
+    };
+    return () => worker.terminate();
+  }, []);
+
+  const parseFiles = (files: Record<string, string>) => {
+    setGraph({});
+    setErrors([]);
+    setCycles([]);
+    workerRef.current?.postMessage({ files });
   };
 
-  const height = Math.max(imports.length * 30 + 40, 120);
+  const handlePaste = () => {
+    if (pasted.trim()) parseFiles({ 'index.js': pasted });
+  };
+
+  const handleZip = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const zip = await JSZip.loadAsync(file);
+    const files: Record<string, string> = {};
+    const errs: FileError[] = [];
+    await Promise.all(
+      Object.keys(zip.files).map(async (name) => {
+        const entry = zip.files[name];
+        if (entry.dir) return;
+        try {
+          files[name] = await entry.async('string');
+        } catch {
+          errs.push({ file: name, error: 'unreadable file' });
+        }
+      }),
+    );
+    setErrors(errs);
+    parseFiles(files);
+  };
 
   return (
-    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
-      <input
-        type="file"
-        accept=".wasm,application/wasm,application/octet-stream"
-        onChange={handleFile}
-        className="mb-4"
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <textarea
+        value={pasted}
+        onChange={(e) => setPasted(e.target.value)}
+        placeholder="Paste JS/TS module code here..."
+        className="w-full h-32 text-black p-2"
       />
-      {error && <div className="text-red-400">{error}</div>}
-      {imports.length > 0 && (
-        <svg width={400} height={height} className="border border-gray-700 bg-gray-800">
-          <circle cx={50} cy={20} r={10} fill="#4ade80" />
-          <text x={50} y={20} dy={4} textAnchor="middle" className="text-xs fill-white">
-            Binary
-          </text>
-          {imports.map((imp, idx) => (
-            <g key={`${imp.module}.${imp.name}`}>
-              <circle cx={300} cy={40 + idx * 30} r={8} fill="#60a5fa" />
-              <text
-                x={315}
-                y={40 + idx * 30}
-                dy={4}
-                className="text-xs fill-white"
-              >{`${imp.module}.${imp.name}`}</text>
-              <line x1={60} y1={20} x2={292} y2={40 + idx * 30} stroke="#fff" />
-            </g>
+      <button onClick={handlePaste} className="bg-blue-600 px-2 py-1 rounded w-fit">
+        Parse Pasted Code
+      </button>
+      <input type="file" accept=".zip" onChange={handleZip} />
+      <label className="flex items-center space-x-2">
+        <span>Depth: {depth}</span>
+        <input
+          type="range"
+          min={1}
+          max={10}
+          value={depth}
+          onChange={(e) => setDepth(parseInt(e.target.value))}
+        />
+      </label>
+      <GraphView graph={graph} cycles={cycles} depth={depth} />
+      {errors.length > 0 && (
+        <div className="text-red-400 overflow-auto max-h-32">
+          {errors.map((e) => (
+            <div key={e.file}>
+              {e.file}: {e.error}
+            </div>
           ))}
-        </svg>
+        </div>
       )}
     </div>
   );
 };
+
+interface GraphViewProps {
+  graph: Record<string, GraphNode>;
+  cycles: string[][];
+  depth: number;
+}
+
+const GraphView: React.FC<GraphViewProps> = ({ graph, cycles, depth }) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
+  const [panning, setPanning] = useState<null | { x: number; y: number }>(null);
+
+  const nodes = Object.keys(graph);
+  if (nodes.length === 0) return <div className="flex-1 border border-gray-700" />;
+
+  const root = nodes[0];
+  const visible = filterByDepth(graph, root, depth);
+  const filteredNodes = nodes.filter((n) => visible.has(n));
+  const edges = filteredNodes.flatMap((n) =>
+    graph[n].deps.filter((d) => visible.has(d)).map((d) => [n, d] as [string, string]),
+  );
+
+  const positions = computePositions(filteredNodes);
+  const cycleNodes = new Set(cycles.flat());
+  const cycleEdges = new Set<string>();
+  cycles.forEach((c) => {
+    for (let i = 0; i < c.length - 1; i++) cycleEdges.add(c[i] + '->' + c[i + 1]);
+  });
+
+  const handleWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const scale = e.deltaY < 0 ? view.scale * 1.1 : view.scale / 1.1;
+    setView({ ...view, scale });
+  };
+
+  const handleDown = (e: React.MouseEvent) => {
+    setPanning({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMove = (e: React.MouseEvent) => {
+    if (!panning) return;
+    setView((v) => ({ ...v, x: v.x + e.clientX - panning.x, y: v.y + e.clientY - panning.y }));
+    setPanning({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleUp = () => setPanning(null);
+
+  return (
+    <svg
+      ref={svgRef}
+      className="flex-1 border border-gray-700 bg-gray-800 cursor-move"
+      onWheel={handleWheel}
+      onMouseDown={handleDown}
+      onMouseMove={handleMove}
+      onMouseUp={handleUp}
+      onMouseLeave={handleUp}
+    >
+      <g transform={`translate(${view.x},${view.y}) scale(${view.scale})`}>
+        {edges.map(([a, b]) => {
+          const key = a + '->' + b;
+          const col = cycleEdges.has(key) ? '#f87171' : '#fff';
+          return (
+            <line
+              key={key}
+              x1={positions[a].x}
+              y1={positions[a].y}
+              x2={positions[b].x}
+              y2={positions[b].y}
+              stroke={col}
+            />
+          );
+        })}
+        {filteredNodes.map((n) => {
+          const pos = positions[n];
+          const large = graph[n].size > LARGE_THRESHOLD;
+          const fill = cycleNodes.has(n) ? '#f87171' : large ? '#f97316' : '#60a5fa';
+          return (
+            <g key={n}>
+              <circle cx={pos.x} cy={pos.y} r={10} fill={fill} />
+              <text x={pos.x} y={pos.y + 15} textAnchor="middle" className="text-xs fill-white">
+                {n}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+};
+
+function computePositions(nodes: string[]): Record<string, { x: number; y: number }> {
+  const radius = 100 + nodes.length * 10;
+  return Object.fromEntries(
+    nodes.map((id, i) => {
+      const angle = (2 * Math.PI * i) / nodes.length;
+      return [id, { x: radius * Math.cos(angle), y: radius * Math.sin(angle) }];
+    }),
+  );
+}
+
+function filterByDepth(
+  graph: Record<string, GraphNode>,
+  root: string,
+  depth: number,
+): Set<string> {
+  const visited = new Set<string>();
+  const queue: [string, number][] = [[root, 0]];
+  while (queue.length) {
+    const [node, d] = queue.shift()!;
+    if (d > depth || visited.has(node)) continue;
+    visited.add(node);
+    graph[node]?.deps.forEach((dep) => queue.push([dep, d + 1]));
+  }
+  return visited;
+}
 
 export default ImportGraph;
 export const displayImportGraph = () => <ImportGraph />;

--- a/components/apps/import-graph.worker.ts
+++ b/components/apps/import-graph.worker.ts
@@ -1,0 +1,70 @@
+import { init, parse } from 'es-module-lexer';
+
+interface GraphNode {
+  deps: string[];
+  size: number;
+}
+
+interface FileError {
+  file: string;
+  error: string;
+}
+
+function resolvePath(from: string, to: string): string {
+  if (!to.startsWith('.')) return to;
+  const fromParts = from.split('/');
+  fromParts.pop();
+  const toParts = to.split('/');
+  for (const part of toParts) {
+    if (part === '.' || part === '') continue;
+    if (part === '..') fromParts.pop();
+    else fromParts.push(part);
+  }
+  return fromParts.join('/');
+}
+
+function findCycles(graph: Record<string, GraphNode>): string[][] {
+  const cycles: string[][] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  const dfs = (node: string) => {
+    if (visiting.has(node)) {
+      const idx = stack.indexOf(node);
+      cycles.push([...stack.slice(idx), node]);
+      return;
+    }
+    if (visited.has(node)) return;
+    visiting.add(node);
+    stack.push(node);
+    for (const dep of graph[node]?.deps || []) dfs(dep);
+    stack.pop();
+    visiting.delete(node);
+    visited.add(node);
+  };
+
+  Object.keys(graph).forEach((n) => dfs(n));
+  return cycles;
+}
+
+self.onmessage = async (e: MessageEvent) => {
+  const files: Record<string, string> = e.data.files;
+  await init;
+  const graph: Record<string, GraphNode> = {};
+  const errors: FileError[] = [];
+
+  for (const [path, content] of Object.entries(files)) {
+    try {
+      const [imports] = parse(content);
+      const deps = imports.map((i) => resolvePath(path, content.slice(i.s, i.e)));
+      graph[path] = { deps, size: content.length };
+      (self as any).postMessage({ type: 'progress', partial: { [path]: graph[path] } });
+    } catch (err: any) {
+      errors.push({ file: path, error: err.message || String(err) });
+    }
+  }
+
+  const cycles = findCycles(graph);
+  (self as any).postMessage({ type: 'done', graph, errors, cycles });
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cvss": "^1.0.5",
     "diff": "^8.0.2",
     "eml-format": "^0.6.1",
+    "es-module-lexer": "^1.5.4",
     "expr-eval": "^2.0.2",
     "fast-xml-parser": "^5.2.5",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4675,6 +4675,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.5.4":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -9803,6 +9810,7 @@ __metadata:
     cvss: "npm:^1.0.5"
     diff: "npm:^8.0.2"
     eml-format: "npm:^0.6.1"
+    es-module-lexer: "npm:^1.5.4"
     eslint: "npm:^9.34.0"
     eslint-config-next: "npm:^15.5.0"
     expr-eval: "npm:^2.0.2"


### PR DESCRIPTION
## Summary
- parse pasted or zipped ES modules and build dependency graph
- highlight cycles, large modules and support zoom with depth filtering
- parse in a web worker with incremental updates and error reporting

## Testing
- `yarn lint`
- `yarn test` *(fails: Window lifecycle › invokes callbacks on close, Ubuntu component › renders boot screen then desktop)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81cabb9483289368822487e03d2e