### PR TITLE
feat: enhance project gallery

### DIFF
--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -1,49 +1,89 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
-
-const GITHUB_USER = 'Alex-Unnippillil';
+import projectsData from '../../data/projects.json';
 
 export default function ProjectGallery() {
   const [projects, setProjects] = useState([]);
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState('All');
+  const cardRefs = useRef([]);
 
   useEffect(() => {
     ReactGA.event({ category: 'Application', action: 'Loaded Project Gallery' });
   }, []);
 
   useEffect(() => {
-    const fetchRepos = async () => {
-      try {
-        const res = await fetch(
-          `https://api.github.com/users/${GITHUB_USER}/repos?sort=updated&per_page=9`
-        );
-        const data = await res.json();
-        const mapped = data.map((repo) => ({
-          title: repo.name,
-          description: repo.description || 'No description provided.',
-          image: `https://opengraph.githubassets.com/1/${GITHUB_USER}/${repo.name}`,
-          tech: [repo.language].filter(Boolean),
-          live: repo.homepage,
-          repo: repo.html_url,
-        }));
-        setProjects(mapped);
-      } catch (err) {
-        console.error('Failed to load repos', err);
-      }
-    };
-    fetchRepos();
+    setProjects(projectsData);
   }, []);
+
+  const tags = useMemo(
+    () => ['All', ...Array.from(new Set(projects.flatMap((p) => p.tags)))],
+    [projects]
+  );
+
+  const filtered = useMemo(
+    () =>
+      projects.filter(
+        (p) =>
+          (tag === 'All' || p.tags.includes(tag)) &&
+          (p.title.toLowerCase().includes(search.toLowerCase()) ||
+            p.description.toLowerCase().includes(search.toLowerCase()))
+      ),
+    [projects, search, tag]
+  );
+
+  useEffect(() => {
+    cardRefs.current = cardRefs.current.slice(0, filtered.length);
+  }, [filtered]);
+
+  const handleKeyDown = (e, index) => {
+    if (['ArrowRight', 'ArrowDown'].includes(e.key)) {
+      const next = (index + 1) % filtered.length;
+      cardRefs.current[next]?.focus();
+      e.preventDefault();
+    } else if (['ArrowLeft', 'ArrowUp'].includes(e.key)) {
+      const prev = (index - 1 + filtered.length) % filtered.length;
+      cardRefs.current[prev]?.focus();
+      e.preventDefault();
+    }
+  };
 
   return (
     <div className="p-4 w-full h-full overflow-y-auto bg-panel text-white">
-      {projects.length === 0 ? (
-        <p className="text-center">Loading projects...</p>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search..."
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-grow"
+        />
+        <div className="flex flex-wrap gap-2">
+          {tags.map((t) => (
+            <button
+              key={t}
+              onClick={() => setTag(t)}
+              className={`px-2 py-0.5 text-sm rounded ${
+                tag === t ? 'bg-blue-600' : 'bg-gray-700'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <p className="text-center">No projects found.</p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {projects.map((project, index) => (
+        <div className="columns-1 sm:columns-2 lg:columns-3 gap-4">
+          {filtered.map((project, index) => (
             <div
               key={index}
-              className="rounded-md bg-surface bg-opacity-20 border border-gray-700 overflow-hidden flex flex-col"
+              ref={(el) => (cardRefs.current[index] = el)}
+              tabIndex={0}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className="mb-4 break-inside-avoid rounded-md bg-surface bg-opacity-20 border border-gray-700 overflow-hidden flex flex-col"
             >
               <div className="relative h-40 w-full">
                 <Image
@@ -52,6 +92,11 @@ export default function ProjectGallery() {
                   fill
                   className="object-cover"
                   sizes="100%"
+                  loading="lazy"
+                  onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = '/images/logos/logo.png';
+                  }}
                 />
               </div>
               <div className="p-3 flex flex-col flex-grow">

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,47 @@
+[
+  {
+    "title": "Portfolio Website",
+    "description": "Personal site built with Next.js.",
+    "image": "/images/logos/logo.png",
+    "tech": ["Next.js", "Tailwind"],
+    "tags": ["web", "portfolio"],
+    "live": "https://unnippillil.com",
+    "repo": "https://github.com/Alex-Unnippillil/kali-linux-portfolio"
+  },
+  {
+    "title": "Tower Defense Game",
+    "description": "A simple tower defense game.",
+    "image": "/images/logos/logo.png",
+    "tech": ["JavaScript"],
+    "tags": ["game"],
+    "live": "",
+    "repo": "https://github.com/Alex-Unnippillil/tower-defense"
+  },
+  {
+    "title": "Checkers",
+    "description": "Classic checkers game.",
+    "image": "/images/logos/logo.png",
+    "tech": ["React"],
+    "tags": ["game"],
+    "live": "",
+    "repo": "https://github.com/Alex-Unnippillil/checkers"
+  },
+  {
+    "title": "QR Tool",
+    "description": "Generate and scan QR codes.",
+    "image": "/images/logos/logo.png",
+    "tech": ["React"],
+    "tags": ["utility", "web"],
+    "live": "",
+    "repo": "https://github.com/Alex-Unnippillil/qr-tool"
+  },
+  {
+    "title": "Regex Redactor",
+    "description": "Redact text using regular expressions.",
+    "image": "/images/logos/logo.png",
+    "tech": ["JavaScript"],
+    "tags": ["utility"],
+    "live": "",
+    "repo": "https://github.com/Alex-Unnippillil/regex-redactor"
+  }
+]


### PR DESCRIPTION
## Summary
- load projects from JSON config instead of GitHub API
- add search, tag filters, masonry layout, and keyboard navigation
- lazy-load thumbnails and replace broken images with fallbacks

## Testing
- `yarn test --runInBand` *(fails: act is not a function in ubuntu.test.tsx and window.test.tsx)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa81d048b88328adb6f16c407d0aa1