### PR TITLE
feat: enhance qr toolkit

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { act } from 'react';
+import { render, screen, act } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
 
 jest.mock('../components/screen/desktop', () => () => <div data-testid="desktop" />);

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { act } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import Window from '../components/base/window';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));

--- a/apps/qr-toolkit/index.html
+++ b/apps/qr-toolkit/index.html
@@ -51,8 +51,11 @@
       <option value="Q">Q - 25% redundancy</option>
       <option value="H">H - 30% redundancy</option>
     </select>
-    <button id="generate-btn">Generate</button>
-    <button id="download-btn">Download</button>
+    <label for="size-slider">Size: <span id="size-value">256</span>px</label>
+    <input type="range" id="size-slider" min="64" max="1024" step="32" value="256" />
+    <p id="error-msg" style="color:red"></p>
+    <button id="download-png-btn">Download PNG</button>
+    <button id="download-svg-btn">Download SVG</button>
     <canvas id="qr-canvas"></canvas>
   </section>
   <section id="decoder">


### PR DESCRIPTION
## Summary
- add error correction and size controls to QR generator
- enable PNG/SVG downloads with debounced rendering
- enforce content length and canvas-based decoding

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aa81d38a18832885b13d350d5a928e