### PR TITLE
feat: enhance regex redactor

### DIFF
--- a/components/apps/regex-redactor/presets.js
+++ b/components/apps/regex-redactor/presets.js
@@ -1,0 +1,42 @@
+export const PRESETS = [
+  {
+    label: 'Email',
+    pattern: '\\b[\\w.-]+@[\\w.-]+\\.\\w+\\b',
+    mask(match, option) {
+      const [user, domain] = match.split('@');
+      if (option === 'partial') {
+        return `${user[0]}***@${domain}`;
+      }
+      return '█'.repeat(user.length) + '@' + domain;
+    },
+  },
+  {
+    label: 'Phone',
+    pattern: '\\b(?:\\+?\\d{1,3}[ -]?)?(?:\\d{3}[ -]?){2}\\d{4}\\b',
+    mask(match, option) {
+      if (option === 'partial') {
+        return '***-***-' + match.slice(-4);
+      }
+      return '█'.repeat(match.length);
+    },
+  },
+  {
+    label: 'IP',
+    pattern: '\\b(?:(?:\\d{1,3}\\.){3}\\d{1,3}|(?:[A-Fa-f0-9]{0,4}:){2,7}[A-Fa-f0-9]{0,4})\\b',
+    mask(match, option) {
+      if (option === 'partial') {
+        if (match.includes('.')) {
+          const parts = match.split('.');
+          parts[parts.length - 1] = '***';
+          return parts.join('.');
+        }
+        const parts = match.split(':');
+        parts[parts.length - 1] = '****';
+        return parts.join(':');
+      }
+      return '█'.repeat(match.length);
+    },
+  },
+];
+
+export default PRESETS;

--- a/components/apps/regex-redactor/worker.js
+++ b/components/apps/regex-redactor/worker.js
@@ -1,0 +1,33 @@
+import { diffWords } from 'diff';
+import safeRegex from 'safe-regex';
+import { PRESETS } from './presets';
+
+self.onmessage = (e) => {
+  const { text, pattern, preset, mask } = e.data;
+  let error = '';
+  let unsafe = false;
+  let redacted = text;
+  const highlights = [];
+  let diff = [];
+
+  if (pattern) {
+    unsafe = !safeRegex(pattern);
+    let regex;
+    try {
+      regex = new RegExp(pattern, 'g');
+    } catch (err) {
+      error = err.message;
+    }
+    if (regex) {
+      redacted = text.replace(regex, (match, offset) => {
+        highlights.push({ start: offset, end: offset + match.length });
+        const p = PRESETS.find((p) => p.label === preset);
+        if (p && typeof p.mask === 'function') return p.mask(match, mask);
+        return '█'.repeat(match.length);
+      });
+      diff = diffWords(text, redacted);
+    }
+  }
+
+  self.postMessage({ redacted, highlights, diff, error, unsafe });
+};

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-twitter-embed": "^4.0.4",
+    "safe-regex": "^2.1.1",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "spdx-license-ids": "^3.0.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8430,6 +8430,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp-tree@npm:~0.1.1":
+  version: 0.1.27
+  resolution: "regexp-tree@npm:0.1.27"
+  bin:
+    regexp-tree: bin/regexp-tree
+  checksum: 10c0/f636f44b4a0d93d7d6926585ecd81f63e4ce2ac895bc417b2ead0874cd36b337dcc3d0fedc63f69bf5aaeaa4340f36ca7e750c9687cceaf8087374e5284e843c
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -8655,6 +8664,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-regex: "npm:^1.2.1"
   checksum: 10c0/f2c25281bbe5d39cddbbce7f86fca5ea9b3ce3354ea6cd7c81c31b006a5a9fff4286acc5450a3b9122c56c33eba69c56b9131ad751457b2b4a585825e6a10665
+  languageName: node
+  linkType: hard
+
+"safe-regex@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "safe-regex@npm:2.1.1"
+  dependencies:
+    regexp-tree: "npm:~0.1.1"
+  checksum: 10c0/53eb5d3ecf4b3c0954dff465eb179af4d2f5f77f74ba7b57489adbc4fa44454c3d391f37379cd28722d9ac6fa5b70be3f4645d4bd25df395fd99b934f6ec9265
   languageName: node
   linkType: hard
 
@@ -9835,6 +9853,7 @@ __metadata:
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-twitter-embed: "npm:^4.0.4"
+    safe-regex: "npm:^2.1.1"
     socket.io: "npm:^4.7.5"
     socket.io-client: "npm:^4.7.5"
     spdx-license-ids: "npm:^3.0.17"


### PR DESCRIPTION
## Summary
- add configurable presets for common patterns
- process redaction in a Web Worker with diff preview
- warn on potentially unsafe regex inputs

## Testing
- `yarn test` (fails: window.test.tsx, ubuntu.test.tsx)
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa81d554a483288a6ef249184805e9