### PR TITLE
feat: enhance ASCII art with preview and safe scaling

### DIFF
--- a/components/apps/ascii_art/worker.js
+++ b/components/apps/ascii_art/worker.js
@@ -1,8 +1,13 @@
 self.onmessage = async (e) => {
-  const { bitmap, charSet, cellSize, useColor, palette } = e.data;
+  const { bitmap, charSet, fontSize, useColor, palette } = e.data;
+  const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+  const safeFont = clamp(fontSize || 8, 1, 100);
+  const rawWidth = Math.floor(bitmap.width / safeFont);
+  const rawHeight = Math.floor(bitmap.height / safeFont);
+  const MAX_DIM = 1000;
+  const width = clamp(rawWidth, 1, MAX_DIM);
+  const height = clamp(rawHeight, 1, MAX_DIM);
   const chars = charSet.split('');
-  const width = Math.floor(bitmap.width / cellSize);
-  const height = Math.floor(bitmap.height / cellSize);
   let canvas;
   if (typeof OffscreenCanvas !== 'undefined') {
     canvas = new OffscreenCanvas(width, height);


### PR DESCRIPTION
## Summary
- add side-by-side image preview with copyable ASCII output
- support adjustable font size and selectable character ramps
- process images via canvas+worker pipeline with clamped dimensions

## Testing
- `yarn lint`
- `yarn test` *(fails: act is not a function in some tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81d7350c8328b54cb2ea06e5aa3a