### PR TITLE
Add SPDX license matcher with fuzzy scoring

### DIFF
--- a/__tests__/licenseMatcher.test.ts
+++ b/__tests__/licenseMatcher.test.ts
@@ -1,0 +1,19 @@
+import licenseList from 'spdx-license-list/full';
+import { matchLicense } from '../lib/licenseMatcher';
+
+describe('matchLicense', () => {
+  it('identifies MIT license text', () => {
+    const mitText = (licenseList as any).MIT.licenseText as string;
+    const result = matchLicense(mitText);
+    expect(result.ambiguous).toBe(false);
+    expect(result.matches[0].spdxId).toBe('MIT');
+    expect(result.matches[0].confidence).toBe(1);
+  });
+
+  it('flags ambiguous license text', () => {
+    const result = matchLicense('This license text is too short to identify.');
+    expect(result.ambiguous).toBe(true);
+    expect(result.message).toBeDefined();
+  });
+});
+

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { act } from 'react';
+import { render, screen, act } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
 
 jest.mock('../components/screen/desktop', () => () => <div data-testid="desktop" />);

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { act } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import Window from '../components/base/window';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));

--- a/lib/licenseMatcher.ts
+++ b/lib/licenseMatcher.ts
@@ -1,0 +1,57 @@
+import spdxLicenseIds from 'spdx-license-ids';
+import licenseList from 'spdx-license-list/full';
+
+export interface LicenseMatch {
+  spdxId: string;
+  confidence: number;
+  url: string;
+}
+
+export interface LicenseMatchResult {
+  matches: LicenseMatch[];
+  ambiguous: boolean;
+  message?: string;
+}
+
+const TOKEN_REGEX = /\b[a-z0-9]+\b/g;
+
+function tokenize(text: string): Set<string> {
+  return new Set((text.toLowerCase().match(TOKEN_REGEX)) || []);
+}
+
+// Pre-tokenize license texts for performance
+const tokenizedLicenses: Record<string, Set<string>> = {};
+for (const id of spdxLicenseIds) {
+  const info: { licenseText?: string } | undefined = (licenseList as any)[id];
+  const text = info?.licenseText || '';
+  tokenizedLicenses[id] = tokenize(text);
+}
+
+export function matchLicense(licenseText: string): LicenseMatchResult {
+  const inputTokens = tokenize(licenseText);
+  const matches: LicenseMatch[] = [];
+
+  for (const id of spdxLicenseIds) {
+    const tokens = tokenizedLicenses[id];
+    if (!tokens || tokens.size === 0) continue;
+    const intersectionSize = [...inputTokens].filter(t => tokens.has(t)).length;
+    const unionSize = new Set([...inputTokens, ...tokens]).size;
+    const confidence = unionSize === 0 ? 0 : intersectionSize / unionSize;
+    matches.push({
+      spdxId: id,
+      confidence,
+      url: `https://spdx.org/licenses/${id}.html`,
+    });
+  }
+
+  matches.sort((a, b) => b.confidence - a.confidence);
+  const top = matches[0];
+  const second = matches[1];
+  const ambiguous = !top || top.confidence < 0.8 || (second && second.confidence >= top.confidence - 0.05);
+  const message = ambiguous
+    ? 'Multiple potential licenses detected. Please review the matches to select the correct SPDX identifier.'
+    : undefined;
+
+  return { matches: matches.slice(0, 5), ambiguous, message };
+}
+

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "spdx-license-ids": "^3.0.17",
+    "spdx-license-list": "^6.10.0",
     "sshpk": "^1.18.0",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9037,6 +9037,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"spdx-license-list@npm:^6.10.0":
+  version: 6.10.0
+  resolution: "spdx-license-list@npm:6.10.0"
+  checksum: 10c0/6cb6b2e6753134ea2f8f8e42afc8fe94ddc9e15433bf235bc782f26ee297eae0e670a6481d09b111cd84782374b079f9d5858767ef7a07bcbff51939b4cac58a
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -9838,6 +9845,7 @@ __metadata:
     socket.io: "npm:^4.7.5"
     socket.io-client: "npm:^4.7.5"
     spdx-license-ids: "npm:^3.0.17"
+    spdx-license-list: "npm:^6.10.0"
     sshpk: "npm:^1.18.0"
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"


### PR DESCRIPTION
## Summary
- add utility to compare uploaded license text against pre-tokenized SPDX license texts with Jaccard scoring
- return confidence scores and SPDX links, flagging ambiguous results
- add tests and fix react act imports

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aa81d82998832895629aaf94880f49