### PR TITLE
Add mixed content scanner using worker and proxy

### DIFF
--- a/apps/mixed-content/index.tsx
+++ b/apps/mixed-content/index.tsx
@@ -1,23 +1,46 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { ScanResult } from './worker';
 
 const MixedContent: React.FC = () => {
   const [url, setUrl] = useState('');
-  const [items, setItems] = useState<Record<string, string[]> | null>(null);
+  const [html, setHtml] = useState('');
+  const [results, setResults] = useState<ScanResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const workerRef = useRef<Worker | null>(null);
 
-  const check = async () => {
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    const worker = workerRef.current;
+    worker.onmessage = (e: MessageEvent<ScanResult[]>) => {
+      setResults(e.data);
+    };
+    return () => {
+      worker.terminate();
+    };
+  }, []);
+
+  const scan = () => {
+    setError(null);
+    setResults([]);
+    workerRef.current?.postMessage(html);
+  };
+
+  const fetchAndScan = async () => {
     if (!url) return;
     setLoading(true);
     setError(null);
-    setItems(null);
+    setResults([]);
     try {
       const res = await fetch(`/api/mixed-content?url=${encodeURIComponent(url)}`);
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error || 'Failed to check');
+        setError(data.error || 'Fetch failed');
       } else {
-        setItems(data.items || {});
+        setHtml(data.body);
+        workerRef.current?.postMessage(data.body);
       }
     } catch (e) {
       setError('Request failed');
@@ -28,38 +51,65 @@ const MixedContent: React.FC = () => {
 
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
-      <input
-        type="text"
-        className="p-2 text-black"
-        placeholder="https://example.com"
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          className="p-2 text-black flex-1"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={fetchAndScan}
+          disabled={loading || !url}
+          className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
+        >
+          {loading ? 'Fetching...' : 'Fetch & Scan'}
+        </button>
+      </div>
+      <textarea
+        className="w-full h-40 text-black p-2"
+        placeholder="Paste HTML here"
+        value={html}
+        onChange={(e) => setHtml(e.target.value)}
       />
-      <button
-        type="button"
-        onClick={check}
-        disabled={loading || !url}
-        className="bg-blue-600 px-4 py-2 rounded disabled:opacity-50"
-      >
-        {loading ? 'Checking...' : 'Check'}
-      </button>
+      <div>
+        <button
+          type="button"
+          onClick={scan}
+          className="bg-green-600 px-4 py-2 rounded"
+        >
+          Scan Pasted HTML
+        </button>
+      </div>
       {error && <div className="text-red-400">{error}</div>}
-      {items && (
+      {results.length > 0 && (
         <div className="overflow-auto text-sm flex-1">
-          {Object.keys(items).length === 0 ? (
-            <div>No mixed content found.</div>
-          ) : (
-            Object.entries(items).map(([tag, urls]) => (
-              <div key={tag} className="mb-2">
-                <h3 className="font-bold">{tag}</h3>
-                <ul className="list-disc list-inside">
-                  {urls.map((u) => (
-                    <li key={u}>{u}</li>
-                  ))}
-                </ul>
-              </div>
-            ))
-          )}
+          <table className="min-w-full">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 text-left">Tag</th>
+                <th className="px-2 py-1 text-left">Attribute</th>
+                <th className="px-2 py-1 text-left">HTTP URL</th>
+                <th className="px-2 py-1 text-left">HTTPS Hint</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r, i) => (
+                <tr key={i} className="odd:bg-gray-800">
+                  <td className="px-2 py-1">{r.tag}</td>
+                  <td className="px-2 py-1">{r.attr}</td>
+                  <td className="px-2 py-1 break-all">
+                    <a href={r.url} target="_blank" rel="noopener noreferrer" className="underline">
+                      {r.url}
+                    </a>
+                  </td>
+                  <td className="px-2 py-1 break-all">{r.httpsUrl}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
     </div>
@@ -67,3 +117,4 @@ const MixedContent: React.FC = () => {
 };
 
 export default MixedContent;
+

--- a/apps/mixed-content/worker.ts
+++ b/apps/mixed-content/worker.ts
@@ -1,0 +1,32 @@
+export interface ScanResult {
+  tag: string;
+  attr: string;
+  url: string;
+  httpsUrl: string;
+}
+
+self.onmessage = (e: MessageEvent<string>) => {
+  const html = e.data;
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const elements = Array.from(doc.querySelectorAll('[src],[href]'));
+  const results: ScanResult[] = [];
+
+  elements.forEach((el) => {
+    const attr = el.getAttribute('src') ? 'src' : 'href';
+    const url = el.getAttribute(attr);
+    if (url && url.startsWith('http://')) {
+      results.push({
+        tag: el.tagName.toLowerCase(),
+        attr,
+        url,
+        httpsUrl: url.replace(/^http:\/\//i, 'https://'),
+      });
+    }
+  });
+
+  (self as any).postMessage(results);
+};
+
+export {};
+


### PR DESCRIPTION
## Summary
- Scan pasted or fetched HTML for insecure HTTP links
- Suggest HTTPS alternatives using a DOM-parsing Web Worker
- Add rate-limited proxy API to fetch pages and surface errors

## Testing
- `yarn lint`
- `yarn test` *(fails: TypeError: (0 , _react.act) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81b97c7c8328a6570a4147e795c2