### PR TITLE
docs: document server deployment and remove static export

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,14 @@ The GitHub Actions workflow relies on the following secrets configured in the re
 - `NEXT_PUBLIC_USER_ID`
 
 These secrets provide the values for the corresponding environment variables during the build step.
+
+## Deployment
+
+This project relies on Next.js server features such as API routes and Socket.IO websockets. For production deployments, build and run the server:
+
+```bash
+yarn build
+yarn start
+```
+
+Deploy to any platform that can run a Next.js server; static export is not supported.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,10 @@
+# Deployment
+
+This application requires a running Next.js server to handle API routes and real-time features such as Socket.IO. Production builds should be created and started with:
+
+```bash
+yarn build
+yarn start
+```
+
+Platforms that support running a Node.js server (Vercel, Render, Fly.io, etc.) can host the application. Static export via `next export` is unsupported because WebSocket endpoints and API routes need server execution.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next export",
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- remove `next export` script to avoid static exports
- document server-side deployment with API routes and websockets

## Testing
- `npm run build` *(fails: Cannot find module 'es-abstract/2024/ToString')*
- `npm run start` *(fails: Could not find a production build in the '.next' directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a2cd470832899ebef8d83e9eb28