### PR TITLE
feat: secure blackjack stats storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Secret used to sign JWT tokens
+JWT_SECRET=
+
+# Optional path for user stats storage
+USER_STORE_FILE=./data/blackjack.json

--- a/__tests__/blackjack-api.test.ts
+++ b/__tests__/blackjack-api.test.ts
@@ -1,0 +1,78 @@
+import path from 'path';
+import os from 'os';
+import jwt from 'jsonwebtoken';
+
+function mockReqRes({ method, query, body, headers }: { method: string; query: any; body?: any; headers?: any }) {
+  const req: any = { method, query, body, headers: headers || {} };
+  const res: any = { statusCode: 200 };
+  res.status = (code: number) => { res.statusCode = code; return res; };
+  res.json = (data: any) => { res.data = data; return res; };
+  res.end = () => res;
+  return { req, res };
+}
+
+describe('blackjack api', () => {
+  const id = 'user1';
+
+  test('rejects when JWT secret missing', async () => {
+    delete process.env.JWT_SECRET;
+    process.env.USER_STORE_FILE = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
+    jest.resetModules();
+    const { default: handler } = await import('../pages/api/users/[id]/blackjack');
+    const token = jwt.sign({ sub: id }, 'temp');
+    const { req, res } = mockReqRes({ method: 'GET', query: { id }, headers: { authorization: `Bearer ${token}` } });
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  test('validates token subject', async () => {
+    process.env.JWT_SECRET = 'secret';
+    process.env.USER_STORE_FILE = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
+    jest.resetModules();
+    const { default: handler } = await import('../pages/api/users/[id]/blackjack');
+    const token = jwt.sign({ sub: 'other' }, process.env.JWT_SECRET!);
+    const { req, res } = mockReqRes({ method: 'GET', query: { id }, headers: { authorization: `Bearer ${token}` } });
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('persists stats and rate limits', async () => {
+    process.env.JWT_SECRET = 'secret';
+    const storePath = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
+    process.env.USER_STORE_FILE = storePath;
+    jest.resetModules();
+    const { default: handler } = await import('../pages/api/users/[id]/blackjack');
+    const token = jwt.sign({ sub: id }, process.env.JWT_SECRET!);
+
+    // initial update
+    let { req, res } = mockReqRes({
+      method: 'POST',
+      query: { id },
+      body: { result: 'win' },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+
+    // verify persistence
+    ({ req, res } = mockReqRes({
+      method: 'GET',
+      query: { id },
+      headers: { authorization: `Bearer ${token}` },
+    }));
+    await handler(req, res);
+    expect(res.data.wins).toBe(1);
+
+    // exceed rate limit
+    for (let i = 0; i < 5; i++) {
+      ({ req, res } = mockReqRes({
+        method: 'POST',
+        query: { id },
+        body: { result: 'win' },
+        headers: { authorization: `Bearer ${token}` },
+      }));
+      await handler(req, res);
+    }
+    expect(res.statusCode).toBe(429);
+  });
+});

--- a/lib/user-store.ts
+++ b/lib/user-store.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface Stats {
+  wins: number;
+  losses: number;
+  pushes: number;
+  bankroll: number;
+}
+
+const DATA_PATH = process.env.USER_STORE_FILE || path.join(process.cwd(), 'data', 'blackjack.json');
+
+let cache: Record<string, Stats> | null = null;
+
+async function load(): Promise<Record<string, Stats>> {
+  if (cache) return cache;
+  try {
+    const raw = await fs.readFile(DATA_PATH, 'utf8');
+    cache = JSON.parse(raw || '{}');
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+export async function getStats(id: string): Promise<Stats> {
+  const data = await load();
+  return data[id] || { wins: 0, losses: 0, pushes: 0, bankroll: 1000 };
+}
+
+export async function setStats(id: string, stats: Stats): Promise<void> {
+  const data = await load();
+  data[id] = stats;
+  await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
+  await fs.writeFile(DATA_PATH, JSON.stringify(data, null, 2), 'utf8');
+}

--- a/pages/api/users/[id]/blackjack.ts
+++ b/pages/api/users/[id]/blackjack.ts
@@ -1,60 +1,74 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
-import path from 'path';
 import jwt from 'jsonwebtoken';
+import { getStats, setStats, type Stats } from '../../../../lib/user-store';
 
-const DATA_PATH = path.join(process.cwd(), 'data', 'blackjack.json');
+const BUCKET_CAPACITY = 5;
+const REFILL_INTERVAL = 60_000; // 1 minute
+const buckets = new Map<string, { tokens: number; last: number }>();
 
-interface Stats {
-  wins: number;
-  losses: number;
-  pushes: number;
-  bankroll: number;
-}
-
-function readStats(): Record<string, Stats> {
-  if (!fs.existsSync(DATA_PATH)) {
-    fs.writeFileSync(DATA_PATH, '{}', 'utf8');
+function allowRequest(id: string): boolean {
+  const now = Date.now();
+  const bucket = buckets.get(id) || { tokens: BUCKET_CAPACITY, last: now };
+  const elapsed = now - bucket.last;
+  if (elapsed > 0) {
+    const refill = Math.floor((elapsed / REFILL_INTERVAL) * BUCKET_CAPACITY);
+    if (refill > 0) {
+      bucket.tokens = Math.min(BUCKET_CAPACITY, bucket.tokens + refill);
+      bucket.last = now;
+    }
   }
-  const raw = fs.readFileSync(DATA_PATH, 'utf8');
-  return JSON.parse(raw || '{}');
+  if (bucket.tokens <= 0) {
+    buckets.set(id, bucket);
+    return false;
+  }
+  bucket.tokens -= 1;
+  buckets.set(id, bucket);
+  return true;
 }
 
-function writeStats(data: Record<string, Stats>) {
-  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2), 'utf8');
-}
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
   const token = req.headers.authorization?.split(' ')[1];
-  const secret = process.env.JWT_SECRET || 'secret';
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret) {
+    return res.status(500).json({ error: 'Missing JWT secret' });
+  }
 
   if (!token) {
     return res.status(401).json({ error: 'Missing token' });
   }
 
+  let payload: jwt.JwtPayload;
   try {
-    jwt.verify(token, secret);
-  } catch (e) {
+    payload = jwt.verify(token, secret) as jwt.JwtPayload;
+  } catch {
     return res.status(401).json({ error: 'Invalid token' });
   }
 
-  const stats = readStats();
-  const userStats = stats[id as string] || { wins: 0, losses: 0, pushes: 0, bankroll: 1000 };
+  if (payload.sub !== id) {
+    return res.status(403).json({ error: 'Token subject mismatch' });
+  }
+
+  const userId = id as string;
+  const userStats = await getStats(userId);
 
   if (req.method === 'GET') {
     return res.status(200).json(userStats);
   }
 
   if (req.method === 'POST') {
+    if (!allowRequest(userId)) {
+      return res.status(429).json({ error: 'Too many requests' });
+    }
     const { result, bankroll } = req.body;
-    if (result === 'win') userStats.wins++;
-    if (result === 'loss') userStats.losses++;
-    if (result === 'push') userStats.pushes++;
-    if (typeof bankroll === 'number') userStats.bankroll = bankroll;
-    stats[id as string] = userStats;
-    writeStats(stats);
-    return res.status(200).json(userStats);
+    const stats: Stats = { ...userStats };
+    if (result === 'win') stats.wins++;
+    if (result === 'loss') stats.losses++;
+    if (result === 'push') stats.pushes++;
+    if (typeof bankroll === 'number') stats.bankroll = bankroll;
+    await setStats(userId, stats);
+    return res.status(200).json(stats);
   }
 
   return res.status(405).end();


### PR DESCRIPTION
## Summary
- require JWT_SECRET and validate subject when updating blackjack stats
- move blackjack stats to a user store and add per-user rate limiting
- document JWT_SECRET and user store path in example env

## Testing
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*


------
https://chatgpt.com/codex/tasks/task_e_68aa9a2e0234832891ece9a124ef5b7f