### PR TITLE
chore: unoptimize images for static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,6 +45,7 @@ const securityHeaders = [
 
 module.exports = {
   images: {
+    unoptimized: true,
     domains: ['opengraph.githubassets.com', 'raw.githubusercontent.com', 'avatars.githubusercontent.com'],
   },
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- enable unoptimized images when statically exporting
- verify existing `<Image>` elements use local assets

## Testing
- `yarn build` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a3052c8832898e2a89911e3900b