### PR TITLE
docs: block middleware subrequests

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,33 +1,6 @@
 # Deployment
 
-When deploying this application, enforce a firewall rule at your CDN or WAF to reject any request containing the header `x-middleware-subrequest`. This header is reserved for internal Next.js middleware calls and should never be present in external traffic.
-
-## Cloudflare firewall rule
-
-```
-Expression: http.request.headers["x-middleware-subrequest"][0] exists
-Action: Block
-```
-
-## AWS WAF rule
-
-```
-{
-  "Name": "BlockMiddlewareSubrequest",
-  "Priority": 0,
-  "Statement": {
-    "ByteMatchStatement": {
-      "SearchString": "1",
-      "FieldToMatch": { "SingleHeader": { "Name": "x-middleware-subrequest" } },
-      "TextTransformations": [{ "Priority": 0, "Type": "NONE" }],
-      "PositionalConstraint": "EXACTLY"
-    }
-  },
-  "Action": { "Block": {} }
-}
-```
-
-By filtering this header, you ensure that only legitimate middleware invocations occur within the application.
+For security-related deployment steps, including firewall rules for sensitive headers, see [security.md](./security.md).
 
 This application requires a running Next.js server to handle API routes and real-time features such as Socket.IO. Production builds should be created and started with:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,30 @@
+# Deployment
+
+When deploying this application, enforce a firewall rule at your CDN or WAF to reject any request containing the header `x-middleware-subrequest`. This header is reserved for internal Next.js middleware calls and should never be present in external traffic.
+
+## Cloudflare firewall rule
+
+```
+Expression: http.request.headers["x-middleware-subrequest"][0] exists
+Action: Block
+```
+
+## AWS WAF rule
+
+```
+{
+  "Name": "BlockMiddlewareSubrequest",
+  "Priority": 0,
+  "Statement": {
+    "ByteMatchStatement": {
+      "SearchString": "1",
+      "FieldToMatch": { "SingleHeader": { "Name": "x-middleware-subrequest" } },
+      "TextTransformations": [{ "Priority": 0, "Type": "NONE" }],
+      "PositionalConstraint": "EXACTLY"
+    }
+  },
+  "Action": { "Block": {} }
+}
+```
+
+By filtering this header, you ensure that only legitimate middleware invocations occur within the application.

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,8 +2,8 @@
 
 ## Middleware subrequest header
 
-To prevent abuse of the Next.js middleware internals, block any public request carrying the `x-middleware-subrequest` header. This value is used solely by internal middleware logic and must not be exposed to the internet.
 
+If this header is not blocked, attackers could craft requests with the `x-middleware-subrequest` header to bypass middleware protections, interfere with internal routing, or gain unauthorized access to resources. This could lead to privilege escalation, information disclosure, or other security vulnerabilities.
 ### CDN/WAF configuration
 
 - **Cloudflare firewall rule**

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,32 @@
+# Security
+
+## Middleware subrequest header
+
+To prevent abuse of the Next.js middleware internals, block any public request carrying the `x-middleware-subrequest` header. This value is used solely by internal middleware logic and must not be exposed to the internet.
+
+### CDN/WAF configuration
+
+- **Cloudflare firewall rule**
+  ```
+  Expression: http.request.headers["x-middleware-subrequest"][0] exists
+  Action: Block
+  ```
+
+- **AWS WAF rule**
+  ```
+  {
+    "Name": "BlockMiddlewareSubrequest",
+    "Priority": 0,
+    "Statement": {
+      "ByteMatchStatement": {
+        "SearchString": "1",
+        "FieldToMatch": { "SingleHeader": { "Name": "x-middleware-subrequest" } },
+        "TextTransformations": [{ "Priority": 0, "Type": "NONE" }],
+        "PositionalConstraint": "EXACTLY"
+      }
+    },
+    "Action": { "Block": {} }
+  }
+  ```
+
+Deployments should ensure requests with this header never reach the application servers.


### PR DESCRIPTION
## Summary
- advise deployments to block `x-middleware-subrequest` header
- document security rule snippets for Cloudflare and AWS

## Testing
- `yarn lint` *(fails: TypeError Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: TypeError Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a31891483288451592a345c2c9f