### PR TITLE
chore: configure yarn node-modules linker

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Summary
- add `.yarnrc.yml` to use node-modules linker

## Testing
- `yarn install` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a328aa88328881bd9d43daa4fa9