### PR TITLE
Add Playwright E2E scaffold and API check

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,21 @@ The GitHub Actions workflow relies on the following secrets configured in the re
 - `NEXT_PUBLIC_USER_ID`
 
 These secrets provide the values for the corresponding environment variables during the build step.
+
+## E2E Testing
+
+The project uses [Playwright](https://playwright.dev/) for end-to-end tests.
+
+### Setup
+
+1. Install the Playwright browsers (Chromium is sufficient):
+   ```bash
+   npx playwright install chromium
+   npx playwright install-deps chromium  # on Linux
+   ```
+2. Run the tests:
+   ```bash
+   yarn test:e2e
+   ```
+
+The Playwright configuration automatically starts the development server before running the tests.

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('renders CVE dashboard app', async ({ page }) => {
+  await page.goto('/apps/cve-dashboard');
+  await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
+});
+
+test('cve API returns json', async ({ request }) => {
+  const res = await request.get('/api/cve?keyword=test');
+  expect(res.ok()).toBeTruthy();
+  const data = await res.json();
+  expect(data).toHaveProperty('vulnerabilities');
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "export": "next export",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "npx playwright test"
   },
   "engines": {
     "node": "20.x"
@@ -36,7 +37,6 @@
     "cannon-es": "^0.20.0",
     "canvas-confetti": "1.9.3",
     "cfb": "1.2.2",
-
     "chart.js": "^4.5.0",
     "cheerio": "^1.1.2",
     "chess.js": "^1.0.0",
@@ -77,18 +77,13 @@
     "react-markdown": "^10.1.0",
     "react-twitter-embed": "^4.0.4",
     "rfc4648": "^1.5.4",
-
     "sax": "^1.4.1",
-
-
     "react-window": "^1.8.11",
-
     "safe-regex": "^2.1.1",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "spdx-license-ids": "^3.0.17",
     "ssdeep.js": "^0.0.3",
-
     "spdx-license-list": "^6.10.0",
     "sshpk": "^1.18.0",
     "stockfish": "^16.0.0",
@@ -98,7 +93,6 @@
     "url-parse": "^1.5.10",
     "ws": "^8.18.3",
     "xmllint-wasm": "^5.0.0",
-
     "zod": "^4.1.0",
     "zxcvbn": "^4.4.2"
   },
@@ -116,9 +110,7 @@
     "@types/plist": "^3.0.2",
     "@types/react": "^18.2.0",
     "@types/ssdeep.js": "^0",
-
     "@types/sax": "^1",
-
     "@types/react-window": "^1",
     "@types/three": "^0.179.0",
     "eslint": "^9.34.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'node node_modules/next/dist/cli/next-dev.js',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright config and sample E2E tests for the CVE dashboard app
- document how to run Playwright E2E tests
- expose `yarn test:e2e` script

## Testing
- `yarn test:e2e` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*
- `npx playwright test` *(fails: Cannot find module 'next/dist/compiled/commander')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a34c7648328b579144f8b415eb9