### PR TITLE
chore: remove manual font links

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -56,8 +56,6 @@ export default function Meta() {
             <link rel="canonical" href="https://unnippillil.com/" />
             <link rel="icon" href="images/logos/fevicon.svg" />
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <link rel="preload" href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap" as="style" />
-            <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap" rel="stylesheet"></link>
         </Head>
         <Script id="person-jsonld" type="application/ld+json">
             {JSON.stringify(jsonLd)}


### PR DESCRIPTION
## Summary
- remove Google Fonts `<link>` tags from SEO meta component to rely solely on `next/font`

## Testing
- `yarn lint` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn build` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*
- `npx --yes jest` *(fails: Cannot find module 'next/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a35a1c88328bbe4ecd9cddfb89f