### PR TITLE
Add environment example and setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Example environment variables
+# Copy this file to ".env.local" and fill in the values.
+# Keep this file in sync when new environment variables are introduced.
+
+# Required
+JWT_SECRET=
+
+# Analytics (optional)
+NEXT_PUBLIC_TRACKING_ID=
+
+# Other optional variables
+NEXT_PUBLIC_SERVICE_ID=
+NEXT_PUBLIC_TEMPLATE_ID=
+NEXT_PUBLIC_USER_ID=
+NEXT_PUBLIC_YOUTUBE_API_KEY=
+NEXT_PUBLIC_THEME=

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Setup
+
+1. Copy `.env.example` to `.env.local`.
+2. Set `JWT_SECRET` to a secure value.
+3. Optionally set analytics variables such as `NEXT_PUBLIC_TRACKING_ID`.
+4. Update `.env.example` whenever new environment variables are added.
+
 ## Adding New Apps
 
 Heavy applications should be loaded with [`next/dynamic`](https://nextjs.org/docs/advanced-features/dynamic-import) so that they do not bloat the initial bundle.


### PR DESCRIPTION
## Summary
- add `.env.example` template with JWT_SECRET and optional analytics variables
- document environment setup and maintaining `.env.example` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa9a36f8908328a0b3cb03546c2841