### PR TITLE
Include apps and lib directories in Tailwind content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   mode: 'jit',
-  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './apps/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}'
+  ],
   theme: {
     backgroundColor: theme => ({
       ...theme('colors'),


### PR DESCRIPTION
## Summary
- include `apps` and `lib` directories in Tailwind CSS content scanning so classes there are rendered

## Testing
- `yarn build` *(fails: TypeError Cannot read properties of undefined (reading 'toUpperCase'))*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa24253f083289f7555efcf9a6fdf