### PR TITLE
Remove invalid font-display from global CSS

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -2,7 +2,6 @@ body{
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    font-display: swap;
 }
 
 pre,


### PR DESCRIPTION
## Summary
- drop `font-display: swap` from global `body` rule since this descriptor belongs only in `@font-face`

## Testing
- `yarn lint` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaa24b6894832886b9951c7925f4d2