### PR TITLE
feat: add url guard for external fetches

### DIFF
--- a/lib/urlGuard.ts
+++ b/lib/urlGuard.ts
@@ -1,0 +1,75 @@
+import dns from 'dns/promises';
+import { isIP } from 'net';
+
+function ipToLong(ip: string): number {
+  return ip
+    .split('.')
+    .map((octet) => parseInt(octet, 10))
+    .reduce((acc, octet) => (acc << 8) + octet);
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const long = ipToLong(ip);
+  const ranges = [
+    [ipToLong('10.0.0.0'), ipToLong('10.255.255.255')],
+    [ipToLong('172.16.0.0'), ipToLong('172.31.255.255')],
+    [ipToLong('192.168.0.0'), ipToLong('192.168.255.255')],
+    [ipToLong('127.0.0.0'), ipToLong('127.255.255.255')],
+    [ipToLong('169.254.0.0'), ipToLong('169.254.255.255')],
+  ];
+  return ranges.some(([start, end]) => long >= start && long <= end);
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  return (
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe80')
+  );
+}
+
+async function assertSafeUrl(input: string) {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Invalid protocol');
+  }
+  if (url.hostname.endsWith('.local')) {
+    throw new Error('Disallowed TLD');
+  }
+  const records = await dns.lookup(url.hostname, { all: true });
+  for (const record of records) {
+    if (isIP(record.address) === 4 && isPrivateIPv4(record.address)) {
+      throw new Error('Private IPv4 address');
+    }
+    if (isIP(record.address) === 6 && isPrivateIPv6(record.address)) {
+      throw new Error('Private IPv6 address');
+    }
+  }
+}
+
+export function setupUrlGuard(timeout = 5000) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async function (input: any, init: RequestInit = {}) {
+    if (typeof input === 'string' || input instanceof URL) {
+      try {
+        await assertSafeUrl(input.toString());
+      } catch {
+        return new Response('Invalid or disallowed URL', { status: 400 });
+      }
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      return await originalFetch(input, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/pages/api/asn-explorer.ts
+++ b/pages/api/asn-explorer.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/caa-checker.ts
+++ b/pages/api/caa-checker.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface CaaRecord {
   flags: number;

--- a/pages/api/cache-policy.ts
+++ b/pages/api/cache-policy.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface PolicyHeaders {
   'cache-control': string | null;

--- a/pages/api/cors-check.ts
+++ b/pages/api/cors-check.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface CorsResult {
   url: string;

--- a/pages/api/csp-test.ts
+++ b/pages/api/csp-test.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 type Resource = {
   url: string;

--- a/pages/api/ct-search.ts
+++ b/pages/api/ct-search.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 type CtResult = {
   certId: number;

--- a/pages/api/cve.ts
+++ b/pages/api/cve.ts
@@ -1,3 +1,10 @@
+import { setupUrlGuard } from "../../lib/urlGuard";
+import { loadKevSet } from '../../lib/kev';
+import { fetchEpssScores } from '../../lib/epss';
+import { rateLimitEdge } from '../../lib/rateLimiter';
+
+setupUrlGuard();
+
 export const config = {
   runtime: 'edge',
 };
@@ -8,10 +15,6 @@ interface ExploitInfo {
   description: string;
   source_url: string;
 }
-
-import { loadKevSet } from '../../lib/kev';
-import { fetchEpssScores } from '../../lib/epss';
-import { rateLimitEdge } from '../../lib/rateLimiter';
 
 const responseCache = new Map<string, { data: unknown; expiry: number }>();
 let exploitMapPromise: Promise<Map<string, ExploitInfo[]>> | null = null;

--- a/pages/api/dns.ts
+++ b/pages/api/dns.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { validateRequest } from '../../lib/validate';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'NS'];
 

--- a/pages/api/dnssec-validator.ts
+++ b/pages/api/dnssec-validator.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS', 'SOA', 'DNSKEY', 'DS', 'CAA'];
 

--- a/pages/api/headers.ts
+++ b/pages/api/headers.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { logEvent } from '../../lib/axiom';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface HeaderReport {
   header: string;

--- a/pages/api/hibp-check.ts
+++ b/pages/api/hibp-check.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createHash } from 'crypto';
 import { rateLimit } from '../../lib/rateLimiter';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/hsts-preload.ts
+++ b/pages/api/hsts-preload.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface HeaderCheck {
   hasHeader: boolean;

--- a/pages/api/http-diff.ts
+++ b/pages/api/http-diff.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { diffLines } from 'diff';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface FetchResult {
   finalUrl: string;

--- a/pages/api/http3-probe.ts
+++ b/pages/api/http3-probe.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface ProbeResult {
   ok: boolean;

--- a/pages/api/ip-dns-leak.ts
+++ b/pages/api/ip-dns-leak.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface TraceInfo {
   [key: string]: string;

--- a/pages/api/jwks-fetcher.ts
+++ b/pages/api/jwks-fetcher.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { decodeProtectedHeader, importJWK, jwtVerify } from 'jose';
 import { createHash } from 'crypto';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 import { z } from 'zod';
 import { validateRequest } from '../../lib/validate';

--- a/pages/api/mail-auth.ts
+++ b/pages/api/mail-auth.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 type CacheEntry = {
   data: string[];

--- a/pages/api/mail-security-matrix.ts
+++ b/pages/api/mail-security-matrix.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 type DnsResponse = { Answer?: { data: string }[]; [key: string]: any };
 

--- a/pages/api/meta-inspector.ts
+++ b/pages/api/meta-inspector.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { load } from 'cheerio';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { url } = req.query;

--- a/pages/api/mixed-content.ts
+++ b/pages/api/mixed-content.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 // Simple in-memory rate limiter
 const RATE_LIMIT = 5; // requests

--- a/pages/api/rdap.ts
+++ b/pages/api/rdap.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 let tldCache: Set<string> | null = null;
 

--- a/pages/api/redirect-visualizer.ts
+++ b/pages/api/redirect-visualizer.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Agent } from 'undici';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 const MAX_HOPS = 15;
 const MAX_HEADER_BYTES = 1024 * 1024; // 1MB

--- a/pages/api/request.ts
+++ b/pages/api/request.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import {
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
   UserInputError,
   UpstreamError,
   withErrorHandler,

--- a/pages/api/shodan-nvd.ts
+++ b/pages/api/shodan-nvd.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface CacheEntry<T> {
   expiry: number;

--- a/pages/api/sitemap-heatmap.ts
+++ b/pages/api/sitemap-heatmap.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { XMLParser } from 'fast-xml-parser';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface UrlEntry {
   loc: string;

--- a/pages/api/spf-flattener.ts
+++ b/pages/api/spf-flattener.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { validateRequest } from '../../lib/validate';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 const MAX_LOOKUPS = 10;
 const CONCURRENCY_LIMIT = 5;

--- a/pages/api/sri-audit.ts
+++ b/pages/api/sri-audit.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import crypto from 'crypto';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface ScriptResult {
   src: string;

--- a/pages/api/sw-check.ts
+++ b/pages/api/sw-check.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface Finding {
   pattern: string;

--- a/pages/api/tor-exit-check.ts
+++ b/pages/api/tor-exit-check.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/wayback-viewer.ts
+++ b/pages/api/wayback-viewer.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface Snapshot {
   timestamp: string;

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { lat, lon, units } = req.query;

--- a/pages/api/well-known.ts
+++ b/pages/api/well-known.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
 
 interface WellKnownResult {
   path: string;


### PR DESCRIPTION
## Summary
- add `setupUrlGuard` to validate URLs, resolve DNS and enforce timeouts
- apply guard across all API routes before performing external fetches

## Testing
- `yarn lint` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2461ffc83289a09d3aadb43fae6