### PR TITLE
refactor: add pluggable rate limiter backend

### DIFF
--- a/lib/rateLimiter.ts
+++ b/lib/rateLimiter.ts
@@ -3,32 +3,92 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 const WINDOW_MS = 60 * 1000; // 1 minute
 const MAX_REQUESTS = 60;
 
+interface RateLimiterBackend {
+  increment(key: string, limit: number): Promise<{ allowed: boolean; remaining: number; reset: number }>;
+}
+
 type Entry = { count: number; expires: number };
-const map = new Map<string, Entry>();
+
+class MemoryBackend implements RateLimiterBackend {
+  private map = new Map<string, Entry>();
+  async increment(key: string, limit: number) {
+    const now = Date.now();
+    let entry = this.map.get(key);
+    if (!entry || entry.expires <= now) {
+      entry = { count: 0, expires: now + WINDOW_MS };
+    }
+    entry.count += 1;
+    this.map.set(key, entry);
+    const remaining = limit - entry.count;
+    return {
+      allowed: entry.count <= limit,
+      remaining,
+      reset: Math.ceil((entry.expires - now) / 1000),
+    };
+  }
+}
+
+class UpstashBackend implements RateLimiterBackend {
+  private url = process.env.UPSTASH_REDIS_REST_URL!;
+  private token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+
+  async increment(key: string, limit: number) {
+    const script =
+      'local c = redis.call("incr", KEYS[1])\n' +
+      'if c == 1 then redis.call("pexpire", KEYS[1], ARGV[1]) end\n' +
+      'return {c, redis.call("pttl", KEYS[1])}';
+    const res = await fetch(`${this.url}/eval`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        script,
+        keys: [`rl:${key}`],
+        argv: [WINDOW_MS],
+      }),
+    });
+    const data = (await res.json()) as { result: [number, number] };
+    const [count, ttl] = data.result;
+    const remaining = limit - count;
+    return {
+      allowed: count <= limit,
+      remaining,
+      reset: Math.ceil(ttl / 1000),
+    };
+  }
+}
+
+const backend: RateLimiterBackend =
+  process.env.RATE_LIMITER_BACKEND === 'upstash'
+    ? new UpstashBackend()
+    : new MemoryBackend();
 
 function getKey(req: NextApiRequest | Request): string {
-  const headers = req instanceof Request ? req.headers : req.headers as any;
-  const xf = headers.get ? headers.get('x-forwarded-for') : (headers['x-forwarded-for'] as string);
-  const ip = xf ? xf.split(',')[0].trim() :
-    (req instanceof Request ? undefined : req.socket.remoteAddress);
+  const headers = req instanceof Request ? req.headers : (req.headers as any);
+  const xf = headers.get
+    ? headers.get('x-forwarded-for')
+    : (headers['x-forwarded-for'] as string);
+  const ip = xf
+    ? xf.split(',')[0].trim()
+    : req instanceof Request
+      ? undefined
+      : req.socket.remoteAddress;
   return ip || 'unknown';
 }
 
-function checkLimit(key: string, limit: number) {
-  const now = Date.now();
-  let entry = map.get(key);
-  if (!entry || entry.expires <= now) {
-    entry = { count: 0, expires: now + WINDOW_MS };
-  }
-  entry.count += 1;
-  map.set(key, entry);
-  const remaining = limit - entry.count;
-  return { allowed: entry.count <= limit, remaining, reset: Math.ceil((entry.expires - now) / 1000) };
+async function checkLimit(key: string, limit: number) {
+  return backend.increment(key, limit);
 }
 
-export function rateLimit(req: NextApiRequest, res: NextApiResponse, limit = MAX_REQUESTS) {
+export async function rateLimit(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  limit = MAX_REQUESTS
+) {
   const key = getKey(req);
-  const { allowed, remaining, reset } = checkLimit(key, limit);
+  const { allowed, remaining, reset } = await checkLimit(key, limit);
   res.setHeader('X-RateLimit-Limit', String(limit));
   res.setHeader('X-RateLimit-Remaining', String(Math.max(0, remaining)));
   if (!allowed) {
@@ -39,9 +99,9 @@ export function rateLimit(req: NextApiRequest, res: NextApiResponse, limit = MAX
   return true;
 }
 
-export function rateLimitEdge(req: Request, limit = MAX_REQUESTS) {
+export async function rateLimitEdge(req: Request, limit = MAX_REQUESTS) {
   const key = getKey(req);
-  const { allowed, remaining, reset } = checkLimit(key, limit);
+  const { allowed, remaining, reset } = await checkLimit(key, limit);
   const headers: Record<string, string> = {
     'X-RateLimit-Limit': String(limit),
     'X-RateLimit-Remaining': String(Math.max(0, remaining)),

--- a/pages/api/cve.ts
+++ b/pages/api/cve.ts
@@ -69,7 +69,7 @@ function parseCSV(line: string): string[] {
 }
 
 export default async function handler(req: Request): Promise<Response> {
-  const rate = rateLimitEdge(req);
+  const rate = await rateLimitEdge(req);
   if (rate.limited) {
     return new Response(JSON.stringify({ error: 'Too many requests' }), {
       status: 429,

--- a/pages/api/hibp-check.ts
+++ b/pages/api/hibp-check.ts
@@ -11,7 +11,7 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  if (!rateLimit(req, res)) return;
+  if (!(await rateLimit(req, res))) return;
 
   const { password } = req.body as { password?: string };
   if (typeof password !== 'string' || password.length === 0) {


### PR DESCRIPTION
## Summary
- abstract rate limiter behind configurable backend with in-memory and Upstash Redis implementations
- make API routes await the new async limiter

## Testing
- `yarn install` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaa246d67083289e02e820a02e2c26