### PR TITLE
Require JWT_SECRET configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ NEXT_PUBLIC_AXIOM_DATASET=
 # Keep this file in sync when new environment variables are introduced.
 
 # Required
+# Secret used to sign JWT tokens
 JWT_SECRET=
 
 # Analytics (optional)
@@ -18,9 +19,6 @@ NEXT_PUBLIC_TEMPLATE_ID=
 NEXT_PUBLIC_USER_ID=
 NEXT_PUBLIC_YOUTUBE_API_KEY=
 NEXT_PUBLIC_THEME=
-
-# Secret used to sign JWT tokens
-JWT_SECRET=
 
 # Optional path for user stats storage
 USER_STORE_FILE=./data/blackjack.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Setup
 
 1. Copy `.env.example` to `.env.local`.
-2. Set `JWT_SECRET` to a secure value.
+2. In `.env.local`, set `JWT_SECRET` to a secure value; this variable is required.
 3. Optionally set analytics variables such as `NEXT_PUBLIC_TRACKING_ID`.
 4. Update `.env.example` whenever new environment variables are added.
 

--- a/pages/api/users/[id]/blackjack.ts
+++ b/pages/api/users/[id]/blackjack.ts
@@ -2,6 +2,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import jwt from 'jsonwebtoken';
 import { getStats, setStats, type Stats } from '../../../../lib/user-store';
 
+if (!process.env.JWT_SECRET && process.env.NODE_ENV !== 'test') {
+  throw new Error('JWT_SECRET is required');
+}
+
 const BUCKET_CAPACITY = 5;
 const REFILL_INTERVAL = 60_000; // 1 minute
 const buckets = new Map<string, { tokens: number; last: number }>();


### PR DESCRIPTION
## Summary
- remove duplicate JWT_SECRET entry from `.env.example`
- require `JWT_SECRET` at runtime for blackjack API route
- document JWT_SECRET requirement in setup instructions

## Testing
- `yarn test` *(fails: TypeError: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2438b1c83289efd178369ceec32