### PR TITLE
refactor: add kv adapter and use for storage

### DIFF
--- a/__tests__/blackjack-api.test.ts
+++ b/__tests__/blackjack-api.test.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-import os from 'os';
 import jwt from 'jsonwebtoken';
 
 function mockReqRes({ method, query, body, headers }: { method: string; query: any; body?: any; headers?: any }) {
@@ -16,8 +14,9 @@ describe('blackjack api', () => {
 
   test('rejects when JWT secret missing', async () => {
     delete process.env.JWT_SECRET;
-    process.env.USER_STORE_FILE = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
     jest.resetModules();
+    const { setKVAdapter, MemoryKV } = await import('../lib/kv');
+    setKVAdapter(new MemoryKV());
     const { default: handler } = await import('../pages/api/users/[id]/blackjack');
     const token = jwt.sign({ sub: id }, 'temp');
     const { req, res } = mockReqRes({ method: 'GET', query: { id }, headers: { authorization: `Bearer ${token}` } });
@@ -27,8 +26,9 @@ describe('blackjack api', () => {
 
   test('validates token subject', async () => {
     process.env.JWT_SECRET = 'secret';
-    process.env.USER_STORE_FILE = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
     jest.resetModules();
+    const { setKVAdapter, MemoryKV } = await import('../lib/kv');
+    setKVAdapter(new MemoryKV());
     const { default: handler } = await import('../pages/api/users/[id]/blackjack');
     const token = jwt.sign({ sub: 'other' }, process.env.JWT_SECRET!);
     const { req, res } = mockReqRes({ method: 'GET', query: { id }, headers: { authorization: `Bearer ${token}` } });
@@ -38,9 +38,9 @@ describe('blackjack api', () => {
 
   test('persists stats and rate limits', async () => {
     process.env.JWT_SECRET = 'secret';
-    const storePath = path.join(os.tmpdir(), `bj-${Date.now()}.json`);
-    process.env.USER_STORE_FILE = storePath;
     jest.resetModules();
+    const { setKVAdapter, MemoryKV } = await import('../lib/kv');
+    setKVAdapter(new MemoryKV());
     const { default: handler } = await import('../pages/api/users/[id]/blackjack');
     const token = jwt.sign({ sub: id }, process.env.JWT_SECRET!);
 

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,0 +1,53 @@
+export interface KVAdapter {
+  get<T = unknown>(key: string): Promise<T | null>;
+  set<T = unknown>(key: string, value: T): Promise<void>;
+}
+
+class MemoryKV implements KVAdapter {
+  private store = new Map<string, string>();
+
+  async get<T>(key: string): Promise<T | null> {
+    const val = this.store.get(key);
+    return val ? (JSON.parse(val) as T) : null;
+    }
+
+  async set<T>(key: string, value: T): Promise<void> {
+    this.store.set(key, JSON.stringify(value));
+  }
+}
+
+class RedisKV implements KVAdapter {
+  constructor(_url: string) {}
+  async get<T>(_key: string): Promise<T | null> {
+    throw new Error('RedisKV not implemented');
+  }
+  async set<T>(_key: string, _value: T): Promise<void> {
+    throw new Error('RedisKV not implemented');
+  }
+}
+
+class S3KV implements KVAdapter {
+  constructor(_bucket: string) {}
+  async get<T>(_key: string): Promise<T | null> {
+    throw new Error('S3KV not implemented');
+  }
+  async set<T>(_key: string, _value: T): Promise<void> {
+    throw new Error('S3KV not implemented');
+  }
+}
+
+export let kv: KVAdapter = (() => {
+  if (process.env.REDIS_URL) {
+    return new RedisKV(process.env.REDIS_URL);
+  }
+  if (process.env.S3_BUCKET) {
+    return new S3KV(process.env.S3_BUCKET);
+  }
+  return new MemoryKV();
+})();
+
+export function setKVAdapter(adapter: KVAdapter) {
+  kv = adapter;
+}
+
+export { MemoryKV, RedisKV, S3KV };

--- a/lib/reversi-db.ts
+++ b/lib/reversi-db.ts
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import path from 'path';
+import { kv } from './kv';
 
 export interface ReversiDB {
   ratings: Record<string, number>;
@@ -7,18 +6,12 @@ export interface ReversiDB {
   tournaments: Array<{ id: number; players: string[]; bracket: string[][] }>;
 }
 
-const file = path.join(process.cwd(), 'data', 'reversi.json');
+const KEY = 'reversi-db';
 
-export function readDB(): ReversiDB {
-  try {
-    const data = fs.readFileSync(file, 'utf-8');
-    return JSON.parse(data) as ReversiDB;
-  } catch (e) {
-    return { ratings: {}, matches: [], tournaments: [] };
-  }
+export async function readDB(): Promise<ReversiDB> {
+  return (await kv.get<ReversiDB>(KEY)) ?? { ratings: {}, matches: [], tournaments: [] };
 }
 
-export function writeDB(db: ReversiDB) {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(db, null, 2));
+export async function writeDB(db: ReversiDB) {
+  await kv.set(KEY, db);
 }

--- a/lib/user-store.ts
+++ b/lib/user-store.ts
@@ -1,5 +1,4 @@
-import fs from 'fs/promises';
-import path from 'path';
+import { kv } from './kv';
 
 export interface Stats {
   wins: number;
@@ -8,29 +7,13 @@ export interface Stats {
   bankroll: number;
 }
 
-const DATA_PATH = process.env.USER_STORE_FILE || path.join(process.cwd(), 'data', 'blackjack.json');
-
-let cache: Record<string, Stats> | null = null;
-
-async function load(): Promise<Record<string, Stats>> {
-  if (cache) return cache;
-  try {
-    const raw = await fs.readFile(DATA_PATH, 'utf8');
-    cache = JSON.parse(raw || '{}');
-  } catch {
-    cache = {};
-  }
-  return cache;
-}
+const PREFIX = 'blackjack:';
 
 export async function getStats(id: string): Promise<Stats> {
-  const data = await load();
-  return data[id] || { wins: 0, losses: 0, pushes: 0, bankroll: 1000 };
+  const stats = await kv.get<Stats>(PREFIX + id);
+  return stats ?? { wins: 0, losses: 0, pushes: 0, bankroll: 1000 };
 }
 
 export async function setStats(id: string, stats: Stats): Promise<void> {
-  const data = await load();
-  data[id] = stats;
-  await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
-  await fs.writeFile(DATA_PATH, JSON.stringify(data, null, 2), 'utf8');
+  await kv.set(PREFIX + id, stats);
 }

--- a/pages/api/reversi/match.ts
+++ b/pages/api/reversi/match.ts
@@ -7,8 +7,8 @@ function expected(a: number, b: number) {
   return 1 / (1 + 10 ** ((b - a) / 400));
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const db = readDB();
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = await readDB();
   if (req.method === 'GET') {
     res.status(200).json({ matches: db.matches, ratings: db.ratings });
     return;
@@ -28,7 +28,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     db.ratings[white] = Math.round(rw + K * (sw - ew));
     db.ratings[black] = Math.round(rb + K * (sb - eb));
     db.matches.push({ white, black, winner, time: Date.now() });
-    writeDB(db);
+    await writeDB(db);
     res.status(200).json({ ratings: db.ratings });
     return;
   }

--- a/pages/api/reversi/tournament.ts
+++ b/pages/api/reversi/tournament.ts
@@ -10,8 +10,8 @@ function pairings(players: string[]): string[][] {
   return pairs;
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const db = readDB();
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = await readDB();
   if (req.method === 'GET') {
     res.status(200).json({ tournaments: db.tournaments });
     return;
@@ -25,7 +25,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     const id = Date.now();
     const bracket = pairings(players);
     db.tournaments.push({ id, players, bracket });
-    writeDB(db);
+    await writeDB(db);
     res.status(200).json({ id, bracket });
     return;
   }

--- a/pages/api/tower-defense/maps.ts
+++ b/pages/api/tower-defense/maps.ts
@@ -1,15 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
-import path from 'path';
+import { kv } from '../../../lib/kv';
 
-const mapsDir = path.join(process.cwd(), 'public', 'tower-defense-maps');
+const PREFIX = 'tower-defense-map:';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     const data = req.body;
-    if (!fs.existsSync(mapsDir)) fs.mkdirSync(mapsDir, { recursive: true });
-    const file = path.join(mapsDir, `${Date.now()}.json`);
-    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    const key = PREFIX + Date.now();
+    await kv.set(key, data);
     res.status(200).json({ saved: true });
   } else {
     res.status(405).end();


### PR DESCRIPTION
## Summary
- introduce pluggable key-value adapter with in-memory default and stubs for Redis/S3
- refactor user store, reversi DB, and tower-defense map API to use the adapter
- update blackjack API tests to use in-memory storage

## Testing
- `yarn install` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaa245203c832880fff007c3478ee9