### PR TITLE
feat: strengthen security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,18 @@ const securityHeaders = [
     value: 'camera=(), microphone=(), geolocation=()',
   },
   {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Cross-Origin-Opener-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'Cross-Origin-Resource-Policy',
+    value: 'same-site',
+  },
+  {
     // Allow same-origin framing so the PDF resume renders in an <object>
     key: 'X-Frame-Options',
     value: 'SAMEORIGIN',


### PR DESCRIPTION
## Summary
- add HSTS and cross-origin policies to security headers

## Testing
- `npm test` *(fails: Cannot find module '@playwright/test')*
- `npm run build -- --no-lint` *(fails: Type error in apps/hash-toolkit/hashWorker.ts)*
- `curl -s -D - http://127.0.0.1:3000 -o /dev/null`
- `curl -s -D - http://127.0.0.1:3000/about -o /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68aaa247e80c8328841aadb3e5d136e4