### PR TITLE
Guard service worker registration for production only

### DIFF
--- a/__tests__/serviceWorkerRegistration.test.tsx
+++ b/__tests__/serviceWorkerRegistration.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('../lib/axiom', () => ({ initAxiom: jest.fn(), logEvent: jest.fn() }));
+jest.mock('react-ga4', () => ({ event: jest.fn(), send: jest.fn(), initialize: jest.fn() }));
+jest.mock('@vercel/analytics/next', () => ({ Analytics: () => null }));
+jest.mock('next/font/google', () => ({ Inter: () => ({ className: 'inter' }) }));
+
+describe('service worker registration', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    delete (navigator as any).serviceWorker;
+  });
+
+  it('does not register service worker in development', async () => {
+    process.env.NODE_ENV = 'development';
+    const register = jest.fn();
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { register },
+      configurable: true,
+    });
+
+    const MyApp = require('../pages/_app').default;
+    render(<MyApp Component={() => <div />} pageProps={{}} />);
+
+    await act(async () => {});
+
+    expect(register).not.toHaveBeenCalled();
+  });
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -64,7 +64,10 @@ function MyApp({ Component, pageProps }: AppProps) {
       });
     }
 
-    if ('serviceWorker' in navigator) {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      'serviceWorker' in navigator
+    ) {
       navigator.serviceWorker.register('/sw.js').catch(() => {});
     }
   }, []);


### PR DESCRIPTION
## Summary
- register the service worker only in production environments
- add a test to ensure no registration occurs during development

## Testing
- `npm test` *(fails: Playwright Test needs to be invoked via 'npx playwright test')*
- `npm run lint` *(fails: parsing error in pages/api/robots.ts and unescaped entities in git-secrets-tester.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa248752483288221106c4a9cf776