### PR TITLE
refactor: dynamically load app pages client-side

### DIFF
--- a/pages/apps/argon-bcrypt-demo.tsx
+++ b/pages/apps/argon-bcrypt-demo.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const ArgonBcryptDemo = dynamic(() => import('../../components/apps/argon-bcrypt-demo'), {
+const ArgonBcryptDemo = dynamic(() => import('../../apps/argon-bcrypt-demo'), {
   ssr: false,
 });
 

--- a/pages/apps/blackjack.tsx
+++ b/pages/apps/blackjack.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import Blackjack from '../../apps/blackjack';
+import dynamic from 'next/dynamic';
 
-const BlackjackPage: React.FC = () => {
+const Blackjack = dynamic(() => import('../../apps/blackjack'), {
+  ssr: false,
+});
+
+export default function BlackjackPage() {
   return <Blackjack />;
-};
-
-export default BlackjackPage;
+}

--- a/pages/apps/cache-policy.tsx
+++ b/pages/apps/cache-policy.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const CachePolicy = dynamic(() => import('../../components/apps/cache-policy'), {
+const CachePolicy = dynamic(() => import('../../apps/cache-policy'), {
   ssr: false,
 });
 

--- a/pages/apps/csp-builder.tsx
+++ b/pages/apps/csp-builder.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import CspBuilder from '../../apps/csp-builder';
+import dynamic from 'next/dynamic';
 
-const CspBuilderPage: React.FC = () => {
+const CspBuilder = dynamic(() => import('../../apps/csp-builder'), {
+  ssr: false,
+});
+
+export default function CspBuilderPage() {
   return <CspBuilder />;
-};
-
-export default CspBuilderPage;
+}

--- a/pages/apps/csp-reporter.tsx
+++ b/pages/apps/csp-reporter.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const CspReporter = dynamic(() => import('../../components/apps/csp-reporter'), { ssr: false });
+const CspReporter = dynamic(() => import('../../apps/csp-reporter'), { ssr: false });
 
 export default function CspReporterPage() {
   return <CspReporter />;

--- a/pages/apps/ct-search.tsx
+++ b/pages/apps/ct-search.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const CtSearch = dynamic(() => import('../../components/apps/ct-search'), {
+const CtSearch = dynamic(() => import('../../apps/ct-search'), {
   ssr: false,
 });
 

--- a/pages/apps/dga-demo.tsx
+++ b/pages/apps/dga-demo.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const DgaDemoApp = dynamic(() => import('../../components/apps/dga-demo'), {
+const DgaDemoApp = dynamic(() => import('../../apps/dga-demo'), {
   ssr: false,
 });
 

--- a/pages/apps/eml-msg-parser.tsx
+++ b/pages/apps/eml-msg-parser.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 const EmlMsgParser = dynamic(
-  () => import('../../components/apps/eml-msg-parser'),
+  () => import('../../apps/eml-msg-parser'),
   { ssr: false }
 );
 

--- a/pages/apps/entropy-explorer.tsx
+++ b/pages/apps/entropy-explorer.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import EntropyExplorer from '../../apps/entropy-explorer';
+import dynamic from 'next/dynamic';
 
-const EntropyExplorerPage: React.FC = () => {
+const EntropyExplorer = dynamic(() => import('../../apps/entropy-explorer'), {
+  ssr: false,
+});
+
+export default function EntropyExplorerPage() {
   return <EntropyExplorer />;
-};
-
-export default EntropyExplorerPage;
+}

--- a/pages/apps/header-analyzer.tsx
+++ b/pages/apps/header-analyzer.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import HeaderAnalyzer from '../../apps/header-analyzer';
+import dynamic from 'next/dynamic';
 
-const HeaderAnalyzerPage: React.FC = () => <HeaderAnalyzer />;
+const HeaderAnalyzer = dynamic(() => import('../../apps/header-analyzer'), {
+  ssr: false,
+});
 
-export default HeaderAnalyzerPage;
+export default function HeaderAnalyzerPage() {
+  return <HeaderAnalyzer />;
+}

--- a/pages/apps/hsts-preload.tsx
+++ b/pages/apps/hsts-preload.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const HstsPreload = dynamic(() => import('../../components/apps/hsts-preload'), { ssr: false });
+const HstsPreload = dynamic(() => import('../../apps/hsts-preload'), { ssr: false });
 
 export default function HstsPreloadPage() {
   return <HstsPreload />;

--- a/pages/apps/ip-dns-leak.tsx
+++ b/pages/apps/ip-dns-leak.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const IpDnsLeak = dynamic(() => import('../../components/apps/ip-dns-leak'), {
+const IpDnsLeak = dynamic(() => import('../../apps/ip-dns-leak'), {
   ssr: false,
 });
 

--- a/pages/apps/jws-jwe-workbench.tsx
+++ b/pages/apps/jws-jwe-workbench.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const JwsJweWorkbench = dynamic(() => import('../../components/apps/jws-jwe-workbench'), { ssr: false });
+const JwsJweWorkbench = dynamic(() => import('../../apps/jws-jwe-workbench'), { ssr: false });
 
 export default function JwsJweWorkbenchPage() {
   return <JwsJweWorkbench />;

--- a/pages/apps/mail-security-matrix.tsx
+++ b/pages/apps/mail-security-matrix.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const MailSecurityMatrix = dynamic(() => import('../../components/apps/mail-security-matrix'), {
+const MailSecurityMatrix = dynamic(() => import('../../apps/mail-security-matrix'), {
   ssr: false,
 });
 

--- a/pages/apps/meta-inspector.tsx
+++ b/pages/apps/meta-inspector.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const MetaInspector = dynamic(() => import('../../components/apps/meta-inspector'), { ssr: false });
+const MetaInspector = dynamic(() => import('../../apps/meta-inspector'), { ssr: false });
 
 export default function MetaInspectorPage() {
   return <MetaInspector />;

--- a/pages/apps/minesweeper.tsx
+++ b/pages/apps/minesweeper.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const Minesweeper = dynamic(() => import('../../components/apps/minesweeper'), {
+const Minesweeper = dynamic(() => import('../../apps/minesweeper'), {
   ssr: false,
 });
 

--- a/pages/apps/nmap-viewer.tsx
+++ b/pages/apps/nmap-viewer.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const NmapViewerApp = dynamic(() => import('../../components/apps/nmap-viewer'), { ssr: false });
+const NmapViewerApp = dynamic(() => import('../../apps/nmap-viewer'), { ssr: false });
 
 export default function NmapViewerPage() {
   return <NmapViewerApp />;

--- a/pages/apps/pkce-helper.tsx
+++ b/pages/apps/pkce-helper.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const PkceHelper = dynamic(() => import('../../components/apps/pkce-helper'), { ssr: false });
+const PkceHelper = dynamic(() => import('../../apps/pkce-helper'), { ssr: false });
 
 export default function PkceHelperPage() {
   return <PkceHelper />;

--- a/pages/apps/robots-auditor.tsx
+++ b/pages/apps/robots-auditor.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const RobotsAuditor = dynamic(() => import('../../components/apps/robots-auditor'), {
+const RobotsAuditor = dynamic(() => import('../../apps/robots-auditor'), {
   ssr: false,
 });
 

--- a/pages/apps/robots-sitemap.tsx
+++ b/pages/apps/robots-sitemap.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
-import RobotsSitemap from '../../apps/robots-sitemap';
+import dynamic from 'next/dynamic';
 
-const RobotsSitemapPage: React.FC = () => <RobotsSitemap />;
+const RobotsSitemap = dynamic(() => import('../../apps/robots-sitemap'), {
+  ssr: false,
+});
 
-export default RobotsSitemapPage;
+export default function RobotsSitemapPage() {
+  return <RobotsSitemap />;
+}
 

--- a/pages/apps/samesite-lab.tsx
+++ b/pages/apps/samesite-lab.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SameSiteLab = dynamic(() => import('../../components/apps/samesite-lab'), { ssr: false });
+const SameSiteLab = dynamic(() => import('../../apps/samesite-lab'), { ssr: false });
 
 export default function SameSiteLabPage() {
   return <SameSiteLab />;

--- a/pages/apps/sqlite-viewer.tsx
+++ b/pages/apps/sqlite-viewer.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SqliteViewer = dynamic(() => import('../../components/apps/sqlite-viewer'), {
+const SqliteViewer = dynamic(() => import('../../apps/sqlite-viewer'), {
   ssr: false,
 });
 

--- a/pages/apps/ssh-fingerprint.tsx
+++ b/pages/apps/ssh-fingerprint.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 const SshFingerprint = dynamic(
-  () => import('../../components/apps/ssh-fingerprint'),
+  () => import('../../apps/ssh-fingerprint'),
   { ssr: false }
 );
 

--- a/pages/apps/timeline-builder.tsx
+++ b/pages/apps/timeline-builder.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const TimelineBuilder = dynamic(() => import('../../components/apps/timeline-builder'), { ssr: false });
+const TimelineBuilder = dynamic(() => import('../../apps/timeline-builder'), { ssr: false });
 
 export default function TimelineBuilderPage() {
   return <TimelineBuilder />;

--- a/pages/apps/tls-viewer.tsx
+++ b/pages/apps/tls-viewer.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import TLSViewer from '../../apps/tls-viewer';
+import dynamic from 'next/dynamic';
 
-const TLSViewerPage: React.FC = () => {
+const TLSViewer = dynamic(() => import('../../apps/tls-viewer'), {
+  ssr: false,
+});
+
+export default function TLSViewerPage() {
   return <TLSViewer />;
-};
-
-export default TLSViewerPage;
+}
 

--- a/pages/apps/tor-exit-check.tsx
+++ b/pages/apps/tor-exit-check.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const TorExitCheck = dynamic(() => import('../../components/apps/tor-exit-check'), {
+const TorExitCheck = dynamic(() => import('../../apps/tor-exit-check'), {
   ssr: false,
 });
 

--- a/pages/apps/wayback-viewer.tsx
+++ b/pages/apps/wayback-viewer.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 const WaybackViewer = dynamic(
-  () => import('../../components/apps/wayback-viewer'),
+  () => import('../../apps/wayback-viewer'),
   { ssr: false },
 );
 

--- a/pages/apps/weather.tsx
+++ b/pages/apps/weather.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const WeatherApp = dynamic(() => import('../../components/apps/weather'), { ssr: false });
+const WeatherApp = dynamic(() => import('../../apps/weather'), { ssr: false });
 
 export default function WeatherPage() {
   return <WeatherApp />;

--- a/pages/apps/well-known.tsx
+++ b/pages/apps/well-known.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import WellKnown from '../../apps/well-known';
+import dynamic from 'next/dynamic';
 
-const WellKnownPage: React.FC = () => {
+const WellKnown = dynamic(() => import('../../apps/well-known'), {
+  ssr: false,
+});
+
+export default function WellKnownPage() {
   return <WellKnown />;
-};
-
-export default WellKnownPage;
+}
 


### PR DESCRIPTION
## Summary
- import all apps with next/dynamic and disable SSR

## Testing
- `npm test` (fails: Cannot find module '@playwright/test')
- `npm run build` (fails: Parsing error in pages/api/robots.ts)


------
https://chatgpt.com/codex/tasks/task_e_68aaa249bcf48328bbd07837713aac3b