### PR TITLE
Fix desktop overlay blocking pointer events

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -286,6 +286,7 @@ export class Window extends Component {
                         onKeyDown={this.handleKeyDown}
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
                         className={
+                            "pointer-events-auto " +
                             this.state.cursorType +
                             " " +
                             (this.state.closed ? " closed-window " : "") +

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -513,7 +513,7 @@ export class Desktop extends Component {
             <div className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
-                <div className="absolute h-full w-full bg-transparent" data-context="desktop-area">
+                <div className="pointer-events-none absolute h-full w-full bg-transparent" data-context="desktop-area">
                     {this.renderWindows()}
                 </div>
 


### PR DESCRIPTION
## Summary
- allow desktop overlay to ignore pointer events
- make window components explicitly interactive

## Testing
- `yarn test window.test.tsx`
- `yarn build` *(fails: Parsing error in pages/api/request.ts and pages/api/robots.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac63de708328bd24f898ee61b123