### PR TITLE
Add test IDs and desktop window Playwright test

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -22,6 +22,7 @@ export class UbuntuApp extends Component {
                 onDoubleClick={this.openApp}
                 tabIndex={0}
                 aria-label={`Open ${this.props.name}`}
+                data-testid={`ubuntu-app-${this.props.id}`}
             >
                 <Image
                     width={40}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -297,6 +297,7 @@ export class Window extends Component {
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
+                        data-testid={`window-${this.id}`}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/e2e/desktop-open.spec.ts
+++ b/e2e/desktop-open.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test('open, minimize, restore, and focus windows', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for desktop to be ready
+  const chromeIcon = page.getByTestId('ubuntu-app-chrome');
+  await expect(chromeIcon).toBeVisible();
+
+  // Ensure About window is present (auto-opened)
+  const aboutWindow = page.getByTestId('window-about-alex');
+  await expect(aboutWindow).toBeVisible();
+
+  // Open chrome window
+  await chromeIcon.dblclick();
+  const chromeWindow = page.getByTestId('window-chrome');
+  await expect(chromeWindow).toBeVisible();
+
+  // Minimize and verify hidden
+  await chromeWindow.getByRole('button', { name: 'Minimize window' }).click();
+  await expect(chromeWindow).toBeHidden();
+
+  // Restore via icon
+  await chromeIcon.dblclick();
+  await expect(chromeWindow).toBeVisible();
+
+  // Switch focus to About window
+  await aboutWindow.click();
+  await expect(aboutWindow).toHaveClass(/z-30/);
+  await expect(chromeWindow).toHaveClass(/notFocused/);
+
+  // Bring focus back to Chrome window
+  await chromeWindow.click();
+  await expect(chromeWindow).toHaveClass(/z-30/);
+  await expect(aboutWindow).toHaveClass(/notFocused/);
+});


### PR DESCRIPTION
## Summary
- add `data-testid` hooks to Ubuntu app icons and window components
- cover minimize, restore and focus behaviour with new Playwright test

## Testing
- `yarn test __tests__/window.test.tsx __tests__/ubuntu.test.tsx`
- `yarn test:e2e e2e/desktop-open.spec.ts` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac6461788328b2e99895d08e5031