### PR TITLE
Add desktop e2e coverage and run Playwright in CI

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: E2E tests
+        run: yarn test:e2e
+
       - name: Building
         run: yarn build
         env:

--- a/e2e/desktop.spec.ts
+++ b/e2e/desktop.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+// Helper to close an app window by title if it is open
+async function closeWindowByTitle(page, title) {
+  const window = page.getByRole('dialog', { name: title });
+  if (await window.isVisible().catch(() => false)) {
+    await window.getByRole('button', { name: 'Close window' }).click();
+    await expect(window).toBeHidden();
+  }
+}
+
+test('desktop icons open apps', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('booting_screen', 'false');
+    window.localStorage.setItem('screen-locked', 'false');
+  });
+  await page.goto('/');
+
+  // Wait for desktop to load
+  const firefoxIcon = page.getByLabel('Open Firefox');
+  await firefoxIcon.waitFor();
+
+  // Close the automatically opened About Alex window if present
+  await closeWindowByTitle(page, 'About Alex');
+
+  // Open Firefox
+  await firefoxIcon.dblclick();
+  const firefoxWindow = page.getByRole('dialog', { name: 'Firefox' });
+  await expect(firefoxWindow).toBeVisible();
+  await firefoxWindow.getByRole('button', { name: 'Close window' }).click();
+  await expect(firefoxWindow).toBeHidden();
+
+  // Open Contact Me app
+  const contactIcon = page.getByLabel('Open Contact Me');
+  await contactIcon.dblclick();
+  const contactWindow = page.getByRole('dialog', { name: 'Contact Me' });
+  await expect(contactWindow).toBeVisible();
+  await contactWindow.getByRole('button', { name: 'Close window' }).click();
+  await expect(contactWindow).toBeHidden();
+});

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.51.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   webServer: {
-    command: 'node node_modules/next/dist/cli/next-dev.js',
+    command: 'yarn dev',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.51.1":
+  version: 1.55.0
+  resolution: "@playwright/test@npm:1.55.0"
+  dependencies:
+    playwright: "npm:1.55.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/e68b59cd8271f1b57c0649fc0562ab2d5f6bba8c3653dd7bd52ca1338dc380fde34588d0254e3cd3f0f2b20af04a80dfb080419ceb7475990bb2fc4d8c474984
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
@@ -5505,12 +5516,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.3, fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -8692,6 +8722,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.55.0":
+  version: 1.55.0
+  resolution: "playwright-core@npm:1.55.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c39d6aa30e7a4e73965942ca5e13405ae05c9cb49f755a35f04248c864c0b24cf662d9767f1797b3ec48d1cf4e54774dce4a19c16534bd5cfd2aa3da81c9dc3a
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.55.0":
+  version: 1.55.0
+  resolution: "playwright@npm:1.55.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.55.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/51605b7e57a5650e57972c5fdfc09d7a9934cca1cbee5beacca716fa801e25cb5bb7c1663de90c22b300fde884e5545a2b13a0505a93270b660687791c478304
+  languageName: node
+  linkType: hard
+
 "plist@npm:^3.1.0":
   version: 3.1.0
   resolution: "plist@npm:3.1.0"
@@ -10711,6 +10765,7 @@ __metadata:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@emailjs/browser": "npm:^3.10.0"
+    "@playwright/test": "npm:^1.51.1"
     "@stephen-riley/pcre2-wasm": "npm:^1.2.4"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"


### PR DESCRIPTION
## Summary
- add Playwright spec that double-clicks desktop icons and closes windows
- run Playwright tests in GitHub Actions and install required browsers
- switch Playwright config to start server with `yarn dev`
- include `@playwright/test` as a dev dependency

## Testing
- `yarn test:e2e` *(fails: Search button not found; API returned invalid JSON; desktop icons test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac67059c83288d26c861738b084b