### PR TITLE
Add CI check for Node core modules in client bundle

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -36,6 +36,9 @@ jobs:
           NEXT_PUBLIC_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_TEMPLATE_ID }}
           NEXT_PUBLIC_USER_ID: ${{ secrets.NEXT_PUBLIC_USER_ID }}
 
+      - name: Check for bundled Node core modules
+        run: yarn check:node-core
+
       - name: Exporting Bundle File
         run: yarn export
       - run: touch ./out/.nojekyll

--- a/next.config.js
+++ b/next.config.js
@@ -62,7 +62,12 @@ module.exports = {
   },
   webpack: (config) => {
     config.resolve = config.resolve || {};
-    config.resolve.fallback = { ...(config.resolve.fallback || {}), fs: false };
+    config.resolve.fallback = {
+      ...(config.resolve.fallback || {}),
+      fs: false,
+      net: false,
+      tls: false,
+    };
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       mermaid: require('path').resolve(__dirname, 'lib/mermaidStub.js'),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "next lint",
-    "test:e2e": "npx playwright test"
+    "test:e2e": "npx playwright test",
+    "check:node-core": "node scripts/check-node-core-modules.js"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/check-node-core-modules.js
+++ b/scripts/check-node-core-modules.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { builtinModules } = require('module');
+
+const CLIENT_DIR = path.join(__dirname, '..', '.next', 'static');
+
+if (!fs.existsSync(CLIENT_DIR)) {
+  console.error('Client build output not found at .next/static. Run `yarn build` first.');
+  process.exit(1);
+}
+
+function getJsFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...getJsFiles(res));
+    else if (res.endsWith('.js')) files.push(res);
+  }
+  return files;
+}
+
+const jsFiles = getJsFiles(CLIENT_DIR);
+const coreModules = Array.from(new Set(
+  builtinModules
+    .map((m) => m.replace(/^node:/, '').split('/')[0])
+    .filter((m) => !m.startsWith('_') && m !== 'buffer' && m !== 'process')
+));
+
+for (const file of jsFiles) {
+  const content = fs.readFileSync(file, 'utf8');
+  for (const mod of coreModules) {
+    const pattern = new RegExp(`['\"]${mod}['\"]`);
+    if (pattern.test(content)) {
+      console.error(`Node core module \"${mod}\" found in client bundle: ${path.relative(process.cwd(), file)}`);
+      process.exit(1);
+    }
+  }
+}
+
+console.log('No Node core modules found in client bundles.');


### PR DESCRIPTION
## Summary
- extend webpack fallbacks to include `net` and `tls`
- add script and workflow step to fail if Node core modules are bundled in client output

## Testing
- `yarn lint` *(fails: Parsing error: Identifier expected)*
- `yarn test` *(fails: Cannot find module '@playwright/test')*
- `yarn build` *(fails: Parsing error: Identifier expected)*
- `yarn check:node-core` *(fails: Client build output not found at .next/static)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac665d308328b65c183ffab5a6e9