### PR TITLE
Add test for Desktop closeApp state handling

### DIFF
--- a/__tests__/desktop.closeApp.test.tsx
+++ b/__tests__/desktop.closeApp.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { Desktop } from '@components/screen/desktop';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('../apps.config', () => ({
+  __esModule: true,
+  default: [
+    {
+      id: 'calc',
+      title: 'Calc',
+      icon: '',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: () => null,
+    },
+  ],
+  games: [],
+  sys: () => '',
+}));
+jest.mock('next/image', () => (props: any) => React.createElement('img', props));
+
+describe('Desktop.closeApp', () => {
+  it('marks window as closed without mutating other entries', () => {
+    jest.useFakeTimers();
+
+    const componentDidMountSpy = jest
+      .spyOn(Desktop.prototype as any, 'componentDidMount')
+      .mockImplementation(function (this: Desktop) {
+        this.fetchAppsData();
+      });
+
+    const ref = React.createRef<Desktop>();
+    render(<Desktop ref={ref} />);
+    const instance = ref.current!;
+
+    act(() => {
+      instance.openApp('calc');
+      jest.advanceTimersByTime(200);
+    });
+
+    const prevClosedRef = instance.state.closed_windows;
+    const prevClosedCopy = { ...prevClosedRef };
+
+    act(() => {
+      instance.closeApp('calc');
+    });
+
+    expect(instance.state.closed_windows['calc']).toBe(true);
+    expect(instance.state.closed_windows).toEqual({
+      ...prevClosedCopy,
+      calc: true,
+    });
+    expect(instance.state.closed_windows).not.toBe(prevClosedRef);
+
+    componentDidMountSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -434,13 +434,18 @@ export class Desktop extends Component {
         this.hideSideBar(null, false);
 
         // close window
-        let closed_windows = this.state.closed_windows;
-        let favourite_apps = this.state.favourite_apps;
+        this.setState((state) => {
+            const favourite_updates =
+                this.initFavourite[objId] === false ? { [objId]: false } : {};
 
-        if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
-        closed_windows[objId] = true; // closes the app's window
-
-        this.setState({ closed_windows, favourite_apps });
+            return {
+                closed_windows: { ...state.closed_windows, [objId]: true },
+                favourite_apps: {
+                    ...state.favourite_apps,
+                    ...favourite_updates,
+                },
+            };
+        });
     }
 
     focus = (objId) => {


### PR DESCRIPTION
## Summary
- Ensure `Desktop.closeApp` updates state immutably
- Add `desktop.closeApp.test.tsx` verifying windows are marked closed without mutating existing entries

## Testing
- `yarn test __tests__/desktop.closeApp.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68aaba91cd4083289e5c99e0c7278787