### PR TITLE
test: add firefox icon e2e spec

### DIFF
--- a/e2e/open-apps.spec.ts
+++ b/e2e/open-apps.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+export default test('open apps from desktop', async ({ page }) => {
+  await page.goto('/');
+  const firefoxIcon = page.getByAltText('Kali Firefox');
+  await expect(firefoxIcon).toBeVisible();
+  await firefoxIcon.dblclick();
+  const chromeWindow = page.getByTestId('window-chrome');
+  await expect(chromeWindow).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- test that clicking the Firefox icon shows the Chrome window

## Testing
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba8a25bc8328a48e37c91f3976fb