### PR TITLE
Add icon validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 2. In `.env.local`, set `JWT_SECRET` to a secure value; this variable is required.
 3. Optionally set analytics variables such as `NEXT_PUBLIC_ENABLE_ANALYTICS` and `NEXT_PUBLIC_TRACKING_ID`.
 4. Update `.env.example` whenever new environment variables are added.
+5. Run `yarn validate:icons` to ensure all icon paths in `apps.config.js` exist under `public/themes/` before committing.
 
 ## Adding New Apps
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "jest --watch",
     "lint": "next lint",
     "test:e2e": "npx playwright test",
-    "check:node-core": "node scripts/check-node-core-modules.js"
+    "check:node-core": "node scripts/check-node-core-modules.js",
+    "validate:icons": "node scripts/validate-icons.js"
   },
   "engines": {
     "node": "20.x"

--- a/public/themes/Yaru/apps/spf-flattener.svg
+++ b/public/themes/Yaru/apps/spf-flattener.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M22 16h4v32h-4zM38 16h4v32h-4zM16 24h32v4H16zM16 40h32v4H16z" fill="#fff"/>
+</svg>

--- a/scripts/validate-icons.js
+++ b/scripts/validate-icons.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const CONFIG = path.join(ROOT, 'apps.config.js');
+const PUBLIC = path.join(ROOT, 'public');
+
+const content = fs.readFileSync(CONFIG, 'utf8');
+const missing = new Set();
+
+// Match direct icon paths: icon: './themes/...'
+const iconPathRegex = /icon\s*:\s*['"](\.\/themes\/[^'\"]+)['"]/g;
+for (const match of content.matchAll(iconPathRegex)) {
+  const rel = match[1].replace(/^\.\//, '');
+  const file = path.join(PUBLIC, rel);
+  if (!fs.existsSync(file)) {
+    missing.add(rel.split(path.sep).join('/'));
+  }
+}
+
+// Match icon('filename') helper usage
+const iconFuncRegex = /icon\(\s*['"]([^'\"]+)['"]\s*\)/g;
+for (const match of content.matchAll(iconFuncRegex)) {
+  const rel = path.join('themes', 'Yaru', 'apps', match[1]);
+  const file = path.join(PUBLIC, rel);
+  if (!fs.existsSync(file)) {
+    missing.add(rel.split(path.sep).join('/'));
+  }
+}
+
+if (missing.size) {
+  console.error('Missing icon files:');
+  for (const m of missing) console.error(` - ${m}`);
+  process.exit(1);
+}
+
+console.log('All icon files exist.');


### PR DESCRIPTION
## Summary
- add script to verify icons referenced in apps.config.js exist
- wire up `yarn validate:icons` npm script
- document icon validation step in README

## Testing
- `yarn lint`
- `yarn test`
- `yarn validate:icons`


------
https://chatgpt.com/codex/tasks/task_e_68aaba9316048328abaff0bf1fe0afe2