### PR TITLE
feat: add battleship game with puzzle mode

### DIFF
--- a/__tests__/battleship-app.test.ts
+++ b/__tests__/battleship-app.test.ts
@@ -1,0 +1,25 @@
+import { BattleshipAI } from '../apps/battleship/ai';
+import generatePuzzle, { countSolutions } from '../apps/battleship/puzzle';
+
+test('Hunt & Target AI produces move quickly', () => {
+  const ai = new BattleshipAI(10);
+  const board = Array.from({ length: 10 }, () => Array(10).fill(0));
+  const start = Date.now();
+  const shot = ai.nextShot(board, 2);
+  const duration = Date.now() - start;
+  expect(shot).toBeDefined();
+  expect(duration).toBeLessThan(50);
+});
+
+test('Puzzle generator yields unique solution under 200ms', () => {
+  const start = Date.now();
+  const puzzle = generatePuzzle(6);
+  const duration = Date.now() - start;
+  expect(duration).toBeLessThan(200);
+  const solutions = countSolutions(
+    puzzle.puzzle.map((r) => r.slice()),
+    puzzle.rowCounts.slice(),
+    puzzle.colCounts.slice(),
+  );
+  expect(solutions).toBe(1);
+});

--- a/apps/battleship/ai.ts
+++ b/apps/battleship/ai.ts
@@ -1,0 +1,184 @@
+// Simple Battleship AI using Hunt & Target strategy with probability density maps
+// The AI keeps an internal representation of the opponent board. Cells are:
+// 0 = unknown, 1 = miss, 2 = hit, 3 = sunk
+export type CellState = 0 | 1 | 2 | 3;
+
+export interface Shot {
+  row: number;
+  col: number;
+}
+
+// Fleet lengths for classic Battleship
+const FLEET = [5, 4, 3, 3, 2];
+
+export class BattleshipAI {
+  private size: number;
+  private parity: number;
+
+  constructor(size = 10) {
+    this.size = size;
+    this.parity = 2; // parity optimisation when all remaining ships > 1
+  }
+
+  // Compute remaining ships from board knowledge
+  private remainingShips(board: CellState[][]): number[] {
+    const hits = board.flat().filter((c) => c === 2).length;
+    const sunk = board.flat().filter((c) => c === 3).length;
+    const total = FLEET.reduce((a, b) => a + b, 0);
+    const remaining = total - hits - sunk;
+    const ships: number[] = [];
+    let acc = remaining;
+    for (const len of FLEET) {
+      if (acc >= len) {
+        ships.push(len);
+        acc -= len;
+      }
+    }
+    if (ships.every((l) => l === 1)) this.parity = 1;
+    return ships;
+  }
+
+  // Generate probability density map for current board state
+  private probabilityMap(board: CellState[][]): number[][] {
+    const map = Array.from({ length: this.size }, () => Array(this.size).fill(0));
+    const ships = this.remainingShips(board);
+    const valid = (r: number, c: number) => r >= 0 && c >= 0 && r < this.size && c < this.size;
+    for (const len of ships) {
+      // horizontal placements
+      for (let r = 0; r < this.size; r++) {
+        for (let c = 0; c <= this.size - len; c++) {
+          let ok = true;
+          for (let k = 0; k < len; k++) {
+            const cell = board[r][c + k];
+            if (cell === 1 || cell === 3) {
+              ok = false;
+              break;
+            }
+          }
+          if (ok) {
+            for (let k = 0; k < len; k++) map[r][c + k]++;
+          }
+        }
+      }
+      // vertical placements
+      for (let c = 0; c < this.size; c++) {
+        for (let r = 0; r <= this.size - len; r++) {
+          let ok = true;
+          for (let k = 0; k < len; k++) {
+            const cell = board[r + k][c];
+            if (cell === 1 || cell === 3) {
+              ok = false;
+              break;
+            }
+          }
+          if (ok) {
+            for (let k = 0; k < len; k++) map[r + k][c]++;
+          }
+        }
+      }
+    }
+
+    // Apply parity optimisation
+    for (let r = 0; r < this.size; r++) {
+      for (let c = 0; c < this.size; c++) {
+        if ((r + c) % this.parity !== 0) map[r][c] = 0;
+      }
+    }
+
+    // Never shoot at known cells
+    for (let r = 0; r < this.size; r++) {
+      for (let c = 0; c < this.size; c++) {
+        if (board[r][c] !== 0) map[r][c] = 0;
+      }
+    }
+    return map;
+  }
+
+  // Find neighbouring cells of unresolved hits
+  private targetMode(board: CellState[][]): Shot | null {
+    const dirs = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ];
+    for (let r = 0; r < this.size; r++) {
+      for (let c = 0; c < this.size; c++) {
+        if (board[r][c] === 2) {
+          for (const [dr, dc] of dirs) {
+            const nr = r + dr;
+            const nc = c + dc;
+            if (
+              nr >= 0 &&
+              nc >= 0 &&
+              nr < this.size &&
+              nc < this.size &&
+              board[nr][nc] === 0
+            ) {
+              return { row: nr, col: nc };
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  // Select next shot based on difficulty
+  public nextShot(board: CellState[][], difficulty = 1): Shot {
+    // Try targeting if there are hits
+    const target = this.targetMode(board);
+    if (target && difficulty > 0) return target;
+
+    const map = this.probabilityMap(board);
+    const cells: Shot[] = [];
+    let best = 0;
+    for (let r = 0; r < this.size; r++) {
+      for (let c = 0; c < this.size; c++) {
+        const val = map[r][c];
+        if (val > best) {
+          best = val;
+          cells.length = 0;
+          cells.push({ row: r, col: c });
+        } else if (val === best && val > 0) {
+          cells.push({ row: r, col: c });
+        }
+      }
+    }
+
+    if (cells.length === 0) {
+      // fallback to random
+      const all: Shot[] = [];
+      for (let r = 0; r < this.size; r++) {
+        for (let c = 0; c < this.size; c++) {
+          if (board[r][c] === 0 && (r + c) % this.parity === 0) all.push({ row: r, col: c });
+        }
+      }
+      return all[Math.floor(Math.random() * all.length)];
+    }
+
+    if (difficulty === 0) {
+      return cells[Math.floor(Math.random() * cells.length)];
+    }
+    if (difficulty === 2) {
+      // simple look-ahead: choose shot leaving fewest candidate placements if miss
+      let bestShot = cells[0];
+      let minPlacements = Infinity;
+      for (const shot of cells) {
+        const clone = board.map((row) => row.slice());
+        clone[shot.row][shot.col] = 1; // assume miss
+        const placements = this.probabilityMap(clone)
+          .flat()
+          .reduce((a, b) => a + b, 0);
+        if (placements < minPlacements) {
+          minPlacements = placements;
+          bestShot = shot;
+        }
+      }
+      return bestShot;
+    }
+    return cells[Math.floor(Math.random() * cells.length)];
+  }
+}
+
+export default BattleshipAI;

--- a/apps/battleship/index.tsx
+++ b/apps/battleship/index.tsx
@@ -1,0 +1,247 @@
+import React, { useState, useEffect } from 'react';
+import BattleshipAI, { CellState } from './ai';
+import generatePuzzle, { Cell, countSolutions } from './puzzle';
+
+// Utility to create empty board
+const createBoard = (size: number, fill: CellState = 0): CellState[][] =>
+  Array.from({ length: size }, () => Array(size).fill(fill));
+
+// Random fleet placement for classic mode
+const FLEET = [5, 4, 3, 3, 2];
+const dirs: [number, number][] = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const placeFleet = (size: number): CellState[][] => {
+  const board = createBoard(size, 0);
+  const canPlace = (r: number, c: number, len: number, vertical: boolean): boolean => {
+    for (let k = 0; k < len; k++) {
+      const nr = r + (vertical ? k : 0);
+      const nc = c + (vertical ? 0 : k);
+      if (nr < 0 || nc < 0 || nr >= size || nc >= size) return false;
+      if (board[nr][nc] !== 0) return false;
+      for (const [dr, dc] of dirs) {
+        const ar = nr + dr;
+        const ac = nc + dc;
+        if (ar >= 0 && ac >= 0 && ar < size && ac < size) {
+          if (board[ar][ac] === 1) return false;
+        }
+      }
+    }
+    return true;
+  };
+  const place = (r: number, c: number, len: number, vertical: boolean, val: CellState) => {
+    for (let k = 0; k < len; k++) {
+      const nr = r + (vertical ? k : 0);
+      const nc = c + (vertical ? 0 : k);
+      board[nr][nc] = val;
+    }
+  };
+  for (const len of FLEET) {
+    let placed = false;
+    while (!placed) {
+      const r = Math.floor(Math.random() * size);
+      const c = Math.floor(Math.random() * size);
+      const vertical = Math.random() < 0.5;
+      if (canPlace(r, c, len, vertical)) {
+        place(r, c, len, vertical, 1);
+        placed = true;
+      }
+    }
+  }
+  return board;
+};
+
+const Battleship: React.FC = () => {
+  const [mode, setMode] = useState<'classic' | 'puzzle'>('classic');
+  // classic mode state
+  const size = 10;
+  const [playerBoard, setPlayerBoard] = useState<CellState[][]>(() => placeFleet(size));
+  const [aiBoard, setAiBoard] = useState<CellState[][]>(() => placeFleet(size));
+  const [aiKnowledge, setAiKnowledge] = useState<CellState[][]>(() => createBoard(size));
+  const [message, setMessage] = useState('Your turn');
+  const [difficulty, setDifficulty] = useState(1); // 0 easy,1 normal,2 hard
+  const ai = new BattleshipAI(size);
+
+  const shoot = (board: CellState[][], r: number, c: number): CellState[][] => {
+    const clone = board.map((row) => row.slice());
+    clone[r][c] = clone[r][c] === 1 ? 2 : 1; // 1=ship,2=hit
+    return clone;
+  };
+
+  const playerShot = (r: number, c: number) => {
+    if (mode !== 'classic') return;
+    if (aiBoard[r][c] === 2 || aiBoard[r][c] === 3) return;
+    if (aiBoard[r][c] === 1) {
+      setAiBoard((b) => shoot(b, r, c));
+      setMessage(`Hit at ${String.fromCharCode(65 + c)}-${r + 1}`);
+    } else {
+      setAiBoard((b) => {
+        const clone = b.map((row) => row.slice());
+        clone[r][c] = 3; // miss marker
+        return clone;
+      });
+      setMessage(`Miss at ${String.fromCharCode(65 + c)}-${r + 1}`);
+      aiTurn();
+    }
+  };
+
+  const aiTurn = () => {
+    const shot = ai.nextShot(aiKnowledge, difficulty);
+    setAiKnowledge((k) => {
+      const clone = k.map((row) => row.slice());
+      const hit = playerBoard[shot.row][shot.col] === 1;
+      clone[shot.row][shot.col] = hit ? 2 : 1;
+      setPlayerBoard((b) => {
+        const nb = b.map((row) => row.slice());
+        if (hit) nb[shot.row][shot.col] = 2;
+        else nb[shot.row][shot.col] = 3;
+        return nb;
+      });
+      setMessage(`${hit ? 'AI hit' : 'AI miss'} at ${String.fromCharCode(65 + shot.col)}-${
+        shot.row + 1
+      }`);
+      return clone;
+    });
+  };
+
+  // puzzle mode state
+  const [puzzle, setPuzzle] = useState<ReturnType<typeof generatePuzzle> | null>(null);
+  const [userPuzzle, setUserPuzzle] = useState<Cell[][]>([]);
+
+  useEffect(() => {
+    if (mode === 'puzzle') {
+      const p = generatePuzzle();
+      setPuzzle(p);
+      setUserPuzzle(p.puzzle.map((r) => r.slice()));
+    }
+  }, [mode]);
+
+  const toggleCell = (r: number, c: number) => {
+    if (!userPuzzle.length) return;
+    setUserPuzzle((p) => {
+      const clone = p.map((row) => row.slice());
+      const val = clone[r][c];
+      clone[r][c] = val === 'unknown' ? 'ship' : val === 'ship' ? 'water' : 'unknown';
+      return clone;
+    });
+  };
+
+  const checkPuzzle = () => {
+    if (!puzzle) return;
+    const solution = countSolutions(
+      userPuzzle.map((r) => r.slice()),
+      puzzle.rowCounts.slice(),
+      puzzle.colCounts.slice(),
+    );
+    setMessage(solution === 1 ? 'Puzzle solved!' : 'Not solved');
+  };
+
+  const boardView = (board: CellState[][], click: (r: number, c: number) => void) => (
+    <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${board.length}, 1fr)` }}>
+      {board.map((row, r) =>
+        row.map((cell, c) => {
+          let label = `${String.fromCharCode(65 + c)}-${r + 1}`;
+          let className = 'w-8 h-8 flex items-center justify-center border';
+          if (cell === 2) {
+            className += ' bg-red-500';
+            label += ', hit';
+          } else if (cell === 3) {
+            className += ' bg-gray-300';
+            label += ', miss';
+          }
+          return (
+            <button
+              key={`${r}-${c}`}
+              aria-label={label}
+              className={className}
+              onClick={() => click(r, c)}
+            />
+          );
+        }),
+      )}
+    </div>
+  );
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Battleship</h1>
+      <div>
+        <label>
+          Mode:
+          <select value={mode} onChange={(e) => setMode(e.target.value as any)} className="ml-2">
+            <option value="classic">Classic PvE</option>
+            <option value="puzzle">Yubotu Puzzle</option>
+          </select>
+        </label>
+        {mode === 'classic' && (
+          <label className="ml-4">
+            Difficulty:
+            <select
+              value={difficulty}
+              onChange={(e) => setDifficulty(Number(e.target.value))}
+              className="ml-2"
+            >
+              <option value={0}>Easy</option>
+              <option value={1}>Normal</option>
+              <option value={2}>Hard</option>
+            </select>
+          </label>
+        )}
+      </div>
+      <div className="text-sm" aria-live="polite">
+        {message}
+      </div>
+      {mode === 'classic' && (
+        <div className="flex space-x-4">
+          <div>
+            <h2>Your Board</h2>
+            {boardView(playerBoard, () => {})}
+          </div>
+          <div>
+            <h2>Enemy Board</h2>
+            {boardView(aiBoard, playerShot)}
+          </div>
+        </div>
+      )}
+      {mode === 'puzzle' && puzzle && (
+        <div>
+          <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${puzzle.puzzle.length}, 1fr)` }}>
+            {userPuzzle.map((row, r) =>
+              row.map((cell, c) => {
+                let className = 'w-8 h-8 flex items-center justify-center border';
+                let label = `${String.fromCharCode(65 + c)}-${r + 1}`;
+                if (cell === 'ship') {
+                  className += ' bg-blue-500';
+                  label += ', ship';
+                } else if (cell === 'water') {
+                  className += ' bg-gray-200';
+                  label += ', water';
+                }
+                return (
+                  <button
+                    key={`${r}-${c}`}
+                    aria-label={label}
+                    className={className}
+                    onClick={() => toggleCell(r, c)}
+                  />
+                );
+              }),
+            )}
+          </div>
+          <div className="mt-2">
+            Row: {puzzle.rowCounts.join(', ')} | Col: {puzzle.colCounts.join(', ')}
+          </div>
+          <button className="mt-2 px-2 py-1 border" onClick={checkPuzzle}>
+            Check
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Battleship;

--- a/apps/battleship/puzzle.ts
+++ b/apps/battleship/puzzle.ts
@@ -154,9 +154,11 @@ export const generatePuzzle = (size = 6): Puzzle => {
     puzzle[r][c] = solution[r][c];
   };
   const cells = Array.from({ length: size * size }, (_, i) => [Math.floor(i / size), i % size]);
-  while (countSolutions(puzzle.map((r) => r.slice()), row.slice(), col.slice()) !== 1 && cells.length) {
+  const cache = new Map<string, number>();
+  while (countSolutions(puzzle.map((r) => r.slice()), row.slice(), col.slice(), 0, 0, cache) !== 1 && cells.length) {
     const [r, c] = cells.splice(Math.floor(Math.random() * cells.length), 1)[0];
     reveal(r, c);
+    cache.clear(); // Clear cache after each reveal, as puzzle changes
   }
 
   return { puzzle, solution, rowCounts: row, colCounts: col };

--- a/apps/battleship/puzzle.ts
+++ b/apps/battleship/puzzle.ts
@@ -1,0 +1,165 @@
+// Yubotu puzzle generator and solver
+// Generates a fleet placement puzzle with row/column counts and no-touch constraint
+
+export type Cell = 'unknown' | 'water' | 'ship';
+
+interface Puzzle {
+  puzzle: Cell[][];
+  solution: Cell[][];
+  rowCounts: number[];
+  colCounts: number[];
+}
+
+const FLEET = [3, 2, 2, 1, 1]; // small fleet for 6x6 board
+
+const dirs = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
+
+// Ensure no adjacent ships including diagonals
+const canPlace = (board: Cell[][], r: number, c: number, len: number, vertical: boolean): boolean => {
+  const size = board.length;
+  for (let k = 0; k < len; k++) {
+    const nr = r + (vertical ? k : 0);
+    const nc = c + (vertical ? 0 : k);
+    if (nr < 0 || nc < 0 || nr >= size || nc >= size) return false;
+    if (board[nr][nc] !== 'water' && board[nr][nc] !== 'unknown') return false;
+    for (const [dr, dc] of dirs) {
+      const ar = nr + dr;
+      const ac = nc + dc;
+      if (ar >= 0 && ac >= 0 && ar < size && ac < size) {
+        if (board[ar][ac] === 'ship') return false;
+      }
+    }
+  }
+  return true;
+};
+
+const placeShip = (
+  board: Cell[][],
+  r: number,
+  c: number,
+  len: number,
+  vertical: boolean,
+  val: Cell,
+) => {
+  for (let k = 0; k < len; k++) {
+    const nr = r + (vertical ? k : 0);
+    const nc = c + (vertical ? 0 : k);
+    board[nr][nc] = val;
+  }
+};
+
+// Generate a full solution by placing ships randomly with backtracking
+export const generateSolution = (size = 6): Cell[][] => {
+  const board: Cell[][] = Array.from({ length: size }, () => Array(size).fill('water'));
+  const ships = FLEET.slice();
+
+  const backtrack = (idx: number): boolean => {
+    if (idx === ships.length) return true;
+    const len = ships[idx];
+    const cells: [number, number, boolean][] = [];
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        for (const vertical of [true, false]) {
+          if (canPlace(board, r, c, len, vertical)) cells.push([r, c, vertical]);
+        }
+      }
+    }
+    while (cells.length) {
+      const i = Math.floor(Math.random() * cells.length);
+      const [r, c, v] = cells.splice(i, 1)[0];
+      placeShip(board, r, c, len, v, 'ship');
+      if (backtrack(idx + 1)) return true;
+      placeShip(board, r, c, len, v, 'water');
+    }
+    return false;
+  };
+
+  backtrack(0);
+  return board;
+};
+
+const counts = (board: Cell[][]): { row: number[]; col: number[] } => {
+  const size = board.length;
+  const row = Array(size).fill(0);
+  const col = Array(size).fill(0);
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (board[r][c] === 'ship') {
+        row[r]++;
+        col[c]++;
+      }
+    }
+  }
+  return { row, col };
+};
+
+// Solver counting number of valid solutions using backtracking with constraints
+export const countSolutions = (
+  puzzle: Cell[][],
+  rowCounts: number[],
+  colCounts: number[],
+  r = 0,
+  c = 0,
+): number => {
+  const size = puzzle.length;
+  if (r === size) return 1;
+  const nr = c === size - 1 ? r + 1 : r;
+  const nc = c === size - 1 ? 0 : c + 1;
+  const cell = puzzle[r][c];
+  if (cell !== 'unknown') return countSolutions(puzzle, rowCounts, colCounts, nr, nc);
+
+  let total = 0;
+  // try water
+  puzzle[r][c] = 'water';
+  if (rowCounts[r] >= 0 && colCounts[c] >= 0) {
+    total += countSolutions(puzzle, rowCounts, colCounts, nr, nc);
+  }
+  // try ship if no-touch respected and counts allow
+  let ok = true;
+  for (const [dr, dc] of dirs) {
+    const ar = r + dr;
+    const ac = c + dc;
+    if (ar >= 0 && ac >= 0 && ar < size && ac < size) {
+      if (puzzle[ar][ac] === 'ship') ok = false;
+    }
+  }
+  if (ok && rowCounts[r] > 0 && colCounts[c] > 0) {
+    puzzle[r][c] = 'ship';
+    rowCounts[r]--;
+    colCounts[c]--;
+    total += countSolutions(puzzle, rowCounts, colCounts, nr, nc);
+    rowCounts[r]++;
+    colCounts[c]++;
+  }
+  puzzle[r][c] = 'unknown';
+  return total;
+};
+
+export const generatePuzzle = (size = 6): Puzzle => {
+  const solution = generateSolution(size);
+  const { row, col } = counts(solution);
+  const puzzle: Cell[][] = Array.from({ length: size }, () => Array(size).fill('unknown'));
+
+  // Reveal random cells until unique solution
+  const reveal = (r: number, c: number) => {
+    puzzle[r][c] = solution[r][c];
+  };
+  const cells = Array.from({ length: size * size }, (_, i) => [Math.floor(i / size), i % size]);
+  while (countSolutions(puzzle.map((r) => r.slice()), row.slice(), col.slice()) !== 1 && cells.length) {
+    const [r, c] = cells.splice(Math.floor(Math.random() * cells.length), 1)[0];
+    reveal(r, c);
+  }
+
+  return { puzzle, solution, rowCounts: row, colCounts: col };
+};
+
+export default generatePuzzle;


### PR DESCRIPTION
## Summary
- add Battleship app with classic PvE and Yubotu puzzle modes
- implement hunt-and-target AI with probability density and difficulty slider
- generate Yubotu puzzles via backtracking solver ensuring unique solutions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68aabcf0595483288177cae53eb670c3