### PR TITLE
feat: add 2048 game with solver and undo/redo

### DIFF
--- a/apps/2048/__tests__/engine.test.ts
+++ b/apps/2048/__tests__/engine.test.ts
@@ -1,0 +1,54 @@
+import { move, undo, redo, isGameOver } from '../engine';
+import type { Board, GameState } from '../engine';
+
+describe('2048 engine', () => {
+  const rng = () => 0; // deterministic
+
+  test('swipe merges identical tiles', () => {
+    const start: GameState = {
+      board: [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      score: 0,
+      history: [],
+      future: [],
+    };
+    const next = move(start, 'left', rng);
+    expect(next.board.slice(0, 4)).toEqual([4, 2, 0, 0]);
+    expect(next.score).toBe(4);
+  });
+
+  test('blocked multiple merges', () => {
+    const start: GameState = {
+      board: [2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      score: 0,
+      history: [],
+      future: [],
+    };
+    const next = move(start, 'left', rng);
+    expect(next.board.slice(0, 4)).toEqual([4, 4, 2, 0]);
+    expect(next.score).toBe(8);
+  });
+
+  test('undo and redo', () => {
+    const start: GameState = {
+      board: [2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      score: 0,
+      history: [],
+      future: [],
+    };
+    const moved = move(start, 'left', rng);
+    const undone = undo(moved);
+    expect(undone.board).toEqual(start.board);
+    const redone = redo(undone);
+    expect(redone.board.slice(0, 4)).toEqual([4, 2, 0, 0]);
+  });
+
+  test('game over detection', () => {
+    const board: Board = [
+      2, 4, 2, 4,
+      4, 2, 4, 2,
+      2, 4, 2, 4,
+      4, 2, 4, 2,
+    ];
+    expect(isGameOver(board)).toBe(true);
+  });
+});

--- a/apps/2048/engine.ts
+++ b/apps/2048/engine.ts
@@ -1,0 +1,145 @@
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+export type Board = number[]; // 16 length
+
+export interface GameState {
+  board: Board;
+  score: number;
+  history: { board: Board; score: number }[];
+  future: { board: Board; score: number }[];
+}
+
+export const createRng = (seed: number) => {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+};
+
+export const spawnTile = (board: Board, rng: () => number): Board => {
+  const empty: number[] = [];
+  board.forEach((v, i) => v === 0 && empty.push(i));
+  if (empty.length === 0) return board.slice();
+  const idx = empty[Math.floor(rng() * empty.length)];
+  const value = rng() < 0.9 ? 2 : 4;
+  const newBoard = board.slice();
+  newBoard[idx] = value;
+  return newBoard;
+};
+
+const slide = (line: number[]): { line: number[]; gained: number } => {
+  const arr = line.filter((n) => n !== 0);
+  const res: number[] = [];
+  let gained = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] === arr[i + 1]) {
+      const merged = arr[i] * 2;
+      gained += merged;
+      res.push(merged);
+      i++;
+    } else {
+      res.push(arr[i]);
+    }
+  }
+  while (res.length < 4) res.push(0);
+  return { line: res, gained };
+};
+
+const rotate = (board: Board): Board => {
+  const res = new Array(16).fill(0);
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      res[c * 4 + (3 - r)] = board[r * 4 + c];
+    }
+  }
+  return res;
+};
+
+export const moveBoard = (
+  board: Board,
+  dir: Direction,
+): { board: Board; gained: number } => {
+  let b = board.slice();
+  let gained = 0;
+  // rotate board so movement is to left
+  const rotations: Record<Direction, number> = {
+    left: 0,
+    up: 1,
+    right: 2,
+    down: 3,
+  };
+  const times = rotations[dir];
+  for (let i = 0; i < times; i++) b = rotate(b);
+  for (let r = 0; r < 4; r++) {
+    const { line, gained: g } = slide(b.slice(r * 4, r * 4 + 4));
+    b.splice(r * 4, 4, ...line);
+    gained += g;
+  }
+  for (let i = 0; i < (4 - times) % 4; i++) b = rotate(b);
+  return { board: b, gained };
+};
+
+export const move = (
+  state: GameState,
+  dir: Direction,
+  rng: () => number,
+): GameState => {
+  const { board, score } = state;
+  const { board: moved, gained } = moveBoard(board, dir);
+  if (moved.every((v, i) => v === board[i])) return state; // no change
+  const spawned = spawnTile(moved, rng);
+  return {
+    board: spawned,
+    score: score + gained,
+    history: [...state.history, { board, score }],
+    future: [],
+  };
+};
+
+export const undo = (state: GameState): GameState => {
+  const history = state.history.slice();
+  if (!history.length) return state;
+  const prev = history.pop()!;
+  return {
+    board: prev.board,
+    score: prev.score,
+    history,
+    future: [{ board: state.board, score: state.score }, ...state.future],
+  };
+};
+
+export const redo = (state: GameState): GameState => {
+  const future = state.future.slice();
+  if (!future.length) return state;
+  const next = future.shift()!;
+  return {
+    board: next.board,
+    score: next.score,
+    history: [...state.history, { board: state.board, score: state.score }],
+    future,
+  };
+};
+
+export const isGameOver = (board: Board): boolean => {
+  if (board.includes(0)) return false;
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      const idx = r * 4 + c;
+      const v = board[idx];
+      if ((c < 3 && v === board[idx + 1]) || (r < 3 && v === board[idx + 4])) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export const score = (board: Board): number => board.reduce((a, b) => a + b, 0);
+
+export const initialState = (rng: () => number): GameState => {
+  let board = Array(16).fill(0);
+  board = spawnTile(board, rng);
+  board = spawnTile(board, rng);
+  return { board, score: 0, history: [], future: [] };
+};

--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  initialState,
+  move,
+  undo,
+  redo,
+  isGameOver,
+  createRng,
+  GameState,
+  Direction,
+} from './engine';
+
+const dailySeed = Number(new Date().toISOString().slice(0, 10).replace(/-/g, ''));
+
+const size = 4;
+const positions = Array.from({ length: size * size }, (_, i) => ({
+  x: (i % size) * 100,
+  y: Math.floor(i / size) * 100,
+}));
+
+const Tile: React.FC<{ value: number; index: number }> = ({ value, index }) => {
+  const { x, y } = positions[index];
+  return (
+    <div
+      className={`absolute flex items-center justify-center rounded bg-orange-200 text-xl font-bold transition-transform duration-150 ease-out ${
+        value ? 'opacity-100' : 'opacity-0'
+      }`}
+      style={{
+        width: 90,
+        height: 90,
+        transform: `translate(${x + 5}px, ${y + 5}px)`,
+      }}
+    >
+      {value || ''}
+    </div>
+  );
+};
+
+const Game2048: React.FC = () => {
+  const rngRef = useRef(createRng(dailySeed));
+  const [state, setState] = useState<GameState>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const saved = localStorage.getItem('2048_board');
+        const score = parseInt(localStorage.getItem('2048_score') || '0', 10);
+        if (saved) {
+          return { board: JSON.parse(saved), score, history: [], future: [] };
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    return initialState(rngRef.current);
+  });
+  const [best, setBest] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const b = parseInt(localStorage.getItem('2048_best') || '0', 10);
+      return b;
+    }
+    return 0;
+  });
+  const workerRef = useRef<Worker>();
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./solver.worker.ts', import.meta.url));
+    workerRef.current.onmessage = (e) => {
+      const dir = e.data as Direction;
+      setState((s) => move(s, dir, rngRef.current));
+    };
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('2048_board', JSON.stringify(state.board));
+      localStorage.setItem('2048_score', String(state.score));
+      if (state.score > best) {
+        setBest(state.score);
+        localStorage.setItem('2048_best', String(state.score));
+      }
+    }
+  }, [state, best]);
+
+  const handleMove = (dir: Direction) => {
+    setState((s) => move(s, dir, rngRef.current));
+  };
+
+  const onKey = (e: KeyboardEvent) => {
+    const map: Record<string, Direction> = {
+      ArrowUp: 'up',
+      ArrowDown: 'down',
+      ArrowLeft: 'left',
+      ArrowRight: 'right',
+    };
+    const d = map[e.key];
+    if (d) {
+      e.preventDefault();
+      handleMove(d);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    startRef.current = { x: e.clientX, y: e.clientY };
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    const start = startRef.current;
+    if (!start) return;
+    const dx = e.clientX - start.x;
+    const dy = e.clientY - start.y;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      handleMove(dx > 0 ? 'right' : 'left');
+    } else {
+      handleMove(dy > 0 ? 'down' : 'up');
+    }
+    startRef.current = null;
+  };
+
+  const solver = () => {
+    workerRef.current?.postMessage({ board: state.board, depth: 4, timeout: 200 });
+  };
+
+  return (
+    <div className="p-2 select-none">
+      <div className="mb-2 flex justify-between">
+        <div>Score: {state.score}</div>
+        <div>Best: {best}</div>
+      </div>
+      <div
+        className="relative h-[400px] w-[400px] bg-gray-300"
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+      >
+        {state.board.map((v, i) => (
+          <Tile key={i} value={v} index={i} />
+        ))}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button className="rounded bg-blue-500 px-2 py-1 text-white" onClick={() => setState(undo)}>
+          Undo
+        </button>
+        <button className="rounded bg-blue-500 px-2 py-1 text-white" onClick={() => setState(redo)}>
+          Redo
+        </button>
+        <button className="rounded bg-green-500 px-2 py-1 text-white" onClick={solver}>
+          Solver
+        </button>
+      </div>
+      {isGameOver(state.board) && <div className="mt-2 text-red-500">Game Over</div>}
+    </div>
+  );
+};
+
+export default Game2048;

--- a/apps/2048/solver.worker.ts
+++ b/apps/2048/solver.worker.ts
@@ -1,0 +1,84 @@
+import { moveBoard, isGameOver, Direction } from './engine';
+
+const dirs: Direction[] = ['up', 'down', 'left', 'right'];
+
+const heuristic = (board: number[]): number => {
+  let empty = 0;
+  let smooth = 0;
+  let mono = 0;
+  let max = 0;
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      const v = board[r * 4 + c];
+      if (v === 0) empty++;
+      if (v > max) max = v;
+      if (c < 3) smooth -= Math.abs(v - board[r * 4 + c + 1]);
+      if (r < 3) smooth -= Math.abs(v - board[(r + 1) * 4 + c]);
+    }
+  }
+  // monotonicity
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 3; c++) {
+      if (board[r * 4 + c] >= board[r * 4 + c + 1]) mono += 1;
+    }
+  }
+  for (let c = 0; c < 4; c++) {
+    for (let r = 0; r < 3; r++) {
+      if (board[r * 4 + c] >= board[(r + 1) * 4 + c]) mono += 1;
+    }
+  }
+  return empty * 100 + mono * 1 + smooth * 0.1 + Math.log2(max) * 10;
+};
+
+const expectimax = (board: number[], depth: number, player: boolean): number => {
+  if (depth === 0 || isGameOver(board)) return heuristic(board);
+  if (player) {
+    let maxScore = -Infinity;
+    for (const dir of dirs) {
+      const { board: b } = moveBoard(board, dir);
+      if (b.every((v, i) => v === board[i])) continue;
+      const score = expectimax(b, depth - 1, false);
+      if (score > maxScore) maxScore = score;
+    }
+    return maxScore === -Infinity ? heuristic(board) : maxScore;
+  }
+  const empty: number[] = [];
+  board.forEach((v, i) => v === 0 && empty.push(i));
+  let total = 0;
+  for (const idx of empty) {
+    const b2 = board.slice();
+    b2[idx] = 2;
+    total += 0.9 / empty.length * expectimax(b2, depth - 1, true);
+    const b4 = board.slice();
+    b4[idx] = 4;
+    total += 0.1 / empty.length * expectimax(b4, depth - 1, true);
+  }
+  return total;
+};
+
+const bestMove = (board: number[], depth: number, timeout: number): Direction => {
+  const start = Date.now();
+  let bestDir: Direction = 'up';
+  let best = -Infinity;
+  for (const dir of dirs) {
+    const { board: b } = moveBoard(board, dir);
+    if (b.every((v, i) => v === board[i])) continue;
+    const score = expectimax(b, depth - 1, false);
+    if (score > best) {
+      best = score;
+      bestDir = dir;
+    }
+    if (Date.now() - start > timeout) break;
+  }
+  return bestDir;
+};
+
+self.onmessage = (e: MessageEvent) => {
+  const { board, depth = 4, timeout = 200 } = e.data as {
+    board: number[];
+    depth: number;
+    timeout: number;
+  };
+  const dir = bestMove(board, depth, timeout);
+  (self as unknown as Worker).postMessage(dir);
+};


### PR DESCRIPTION
## Summary
- add functional 2048 engine with deterministic RNG, move logic, undo/redo and game-over checks
- build React UI with swipe gestures, localStorage persistence and web-worker expectimax solver
- cover engine logic with unit tests for merges, blocked merges, undo/redo and game-over detection

## Testing
- `yarn test apps/2048/__tests__/engine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aabceee1e48328b5ca60cbca1b408c