### PR TITLE
feat: expand frogger engine with multi-input support

### DIFF
--- a/apps/frogger/index.ts
+++ b/apps/frogger/index.ts
@@ -45,11 +45,11 @@ export const updateCars = (
     let timer = lane.timer - dt;
     const items = lane.items
       .map((c) => ({ ...c, x: c.x + lane.speed * lane.dir * dt }))
-      .filter((c) => c.x + c.width > 0 && c.x < TILE * 10);
+      .filter((c) => c.x + c.width > 0 && c.x < TILE * NUM_TILES_WIDE);
 
     if (timer <= 0) {
       const width = lane.length * TILE;
-      const x = lane.dir === 1 ? -width : TILE * 10;
+      const x = lane.dir === 1 ? -width : TILE * NUM_TILES_WIDE;
       items.push({ x, width, height: TILE });
       timer += lane.spawnRate + lane.rng() * lane.spawnRate;
     }

--- a/apps/frogger/index.ts
+++ b/apps/frogger/index.ts
@@ -1,0 +1,115 @@
+export const TILE = 40;
+export const PAD_POSITIONS = [TILE, TILE * 3, TILE * 5, TILE * 7, TILE * 9];
+
+// linear congruential generator for deterministic lane RNG
+const rng = (seed: number) => () => {
+  seed = (seed * 1664525 + 1013904223) % 4294967296;
+  return seed / 4294967296;
+};
+
+export interface LaneDef {
+  y: number;
+  dir: 1 | -1;
+  speed: number;
+  spawnRate: number;
+  length: number;
+  type?: 'car' | 'log';
+}
+
+export interface Lane extends LaneDef {
+  items: { x: number; width: number; height: number }[];
+  timer: number;
+  rng: () => number;
+}
+
+export const initLane = (def: LaneDef, seed = Date.now()): Lane => {
+  const rand = rng(seed);
+  const type = def.type || 'car';
+  return {
+    ...def,
+    type,
+    speed: def.speed * (0.8 + rand() * 0.4),
+    items: [],
+    timer: rand() * def.spawnRate,
+    rng: rand,
+  };
+};
+
+export const updateCars = (
+  lanes: Lane[],
+  frog: { x: number; y: number },
+  dt: number
+) => {
+  let frogDx = 0;
+  const newLanes = lanes.map((lane) => {
+    let timer = lane.timer - dt;
+    const items = lane.items
+      .map((c) => ({ ...c, x: c.x + lane.speed * lane.dir * dt }))
+      .filter((c) => c.x + c.width > 0 && c.x < TILE * 10);
+
+    if (timer <= 0) {
+      const width = lane.length * TILE;
+      const x = lane.dir === 1 ? -width : TILE * 10;
+      items.push({ x, width, height: TILE });
+      timer += lane.spawnRate + lane.rng() * lane.spawnRate;
+    }
+
+    if (lane.type === 'log' && frog.y === lane.y) {
+      const onLog = items.find(
+        (c) => frog.x < c.x + c.width && frog.x + TILE > c.x
+      );
+      if (onLog) frogDx = lane.speed * lane.dir * dt;
+    }
+
+    return { ...lane, items, timer };
+  });
+
+  const frogBox = { x: frog.x, y: frog.y, width: TILE, height: TILE };
+  let dead = newLanes.some(
+    (lane) =>
+      lane.type === 'car' &&
+      lane.y === frog.y &&
+      lane.items.some(
+        (c) => frogBox.x < c.x + c.width && frogBox.x + frogBox.width > c.x
+      )
+  );
+
+  if (!dead) {
+    const logLane = newLanes.find(
+      (l) => l.type === 'log' && l.y === frog.y
+    );
+    if (logLane && frogDx === 0) dead = true;
+  }
+
+  return { lanes: newLanes, dead, frogDx };
+};
+
+export const handlePads = (
+  frog: { x: number; y: number },
+  pads: boolean[]
+): { pads: boolean[]; padHit: boolean; dead: boolean } => {
+  const index = PAD_POSITIONS.indexOf(frog.x);
+  if (frog.y !== 0 || index === -1)
+    return { pads, padHit: false, dead: true };
+  if (pads[index]) return { pads, padHit: false, dead: true };
+  const next = [...pads];
+  next[index] = true;
+  return { pads: next, padHit: true, dead: false };
+};
+
+export const rampLane = (lane: LaneDef, level: number, minRate: number) => {
+  const inc = level - 1;
+  return {
+    ...lane,
+    speed: lane.speed * (1 + 0.2 * inc),
+    spawnRate: Math.max(minRate, lane.spawnRate * (1 - 0.1 * inc)),
+  };
+};
+
+export const carLaneDefs: LaneDef[] = [
+  { y: 0, dir: 1, speed: 1, spawnRate: 1, length: 1, type: 'car' },
+];
+
+export const logLaneDefs: LaneDef[] = [
+  { y: 0, dir: 1, speed: 1, spawnRate: 1, length: 1, type: 'log' },
+];

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -1,72 +1,14 @@
 import React, { useRef, useEffect } from 'react';
-
-export const TILE = 40;
-export const PAD_POSITIONS = [TILE, TILE * 3, TILE * 5, TILE * 7, TILE * 9];
-
-const rng = (seed) => () => {
-  seed = (seed * 1664525 + 1013904223) % 4294967296;
-  return seed / 4294967296;
-};
-
-export const initLane = (def, seed = Date.now()) => ({
-  ...def,
-  cars: [],
-  timer: rng(seed)() * def.spawnRate,
-  rng: rng(seed),
-});
-
-export const updateCars = (lanes, frog, dt) => {
-  const newLanes = lanes.map((lane) => {
-    let timer = lane.timer - dt;
-    const cars = lane.cars
-      .map((c) => ({ ...c, x: c.x + lane.speed * lane.dir * dt }))
-      .filter((c) => c.x + c.width > 0 && c.x < 400);
-
-    if (timer <= 0) {
-      const width = lane.length * TILE;
-      const x = lane.dir === 1 ? -width : 400;
-      cars.push({ x, width, height: TILE });
-      timer += lane.spawnRate + lane.rng() * lane.spawnRate;
-    }
-    return { ...lane, cars, timer };
-  });
-
-  const frogBox = { x: frog.x, y: frog.y, width: TILE, height: TILE };
-  const dead = newLanes.some(
-    (lane) =>
-      lane.y === frog.y &&
-      lane.cars.some(
-        (c) => frogBox.x < c.x + c.width && frogBox.x + frogBox.width > c.x
-      )
-  );
-  return { lanes: newLanes, dead };
-};
-
-export const handlePads = (frog, pads) => {
-  const index = PAD_POSITIONS.indexOf(frog.x);
-  if (frog.y !== 0 || index === -1)
-    return { pads, padHit: false, dead: true };
-  if (pads[index]) return { pads, padHit: false, dead: true };
-  const next = [...pads];
-  next[index] = true;
-  return { pads: next, padHit: true, dead: false };
-};
-
-export const rampLane = (lane, level, minRate) => {
-  const inc = level - 1;
-  return {
-    ...lane,
-    speed: lane.speed * (1 + 0.2 * inc),
-    spawnRate: Math.max(minRate, lane.spawnRate * (1 - 0.1 * inc)),
-  };
-};
-
-export const carLaneDefs = [
-  { y: 0, dir: 1, speed: 1, spawnRate: 1, length: 1 },
-];
-export const logLaneDefs = [
-  { y: 0, dir: 1, speed: 1, spawnRate: 1, length: 1 },
-];
+import {
+  TILE,
+  PAD_POSITIONS,
+  initLane,
+  updateCars,
+  handlePads,
+  rampLane,
+  carLaneDefs,
+  logLaneDefs,
+} from '../../apps/frogger';
 
 const Frogger = () => {
   const bgRef = useRef(null);
@@ -81,8 +23,14 @@ const Frogger = () => {
     const height = fg.height;
     const tile = TILE;
 
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    const speedScale = prefersReducedMotion ? 0.5 : 1;
+
     let level = parseInt(localStorage.getItem('frogger-level') || '1', 10);
     let score = 0;
+    let pads = PAD_POSITIONS.map(() => false);
 
     const lanes = [];
 
@@ -115,36 +63,35 @@ const Frogger = () => {
       bgCtx.fillRect(0, height - tile, width, tile);
     };
 
-    const initLevel = () => {
-      lanes.length = 0;
-      const baseSpeed = 1 + level * 0.5;
-      const patterns = [
-        { dir: 1, spawnRate: 120 },
-        { dir: -1, spawnRate: 100 },
-        { dir: 1, spawnRate: 80 },
-      ];
-      patterns.forEach((p, i) => {
-        lanes.push(
-          initLane(
-            {
-              y: height - tile * (2 + i),
-              dir: p.dir,
-              speed: baseSpeed + i * 0.2,
-              spawnRate: p.spawnRate,
-              length: 2,
-            },
-            i + 1
-          )
-        );
-      });
-      resetFrog();
-    };
-
     const frog = { x: width / 2 - tile / 2, y: height - tile, size: tile };
 
     const resetFrog = () => {
       frog.x = width / 2 - tile / 2;
       frog.y = height - tile;
+    };
+
+    const initLevel = () => {
+      lanes.length = 0;
+      carLaneDefs.forEach((def, i) => {
+        const lane = rampLane(
+          { ...def, y: height - tile * (2 + i) },
+          level,
+          0.3
+        );
+        lane.speed *= speedScale;
+        lanes.push(initLane(lane, i + 1));
+      });
+      logLaneDefs.forEach((def, i) => {
+        const lane = rampLane(
+          { ...def, y: tile * (1 + i) },
+          level,
+          0.5
+        );
+        lane.speed *= speedScale;
+        lanes.push(initLane(lane, i + 10));
+      });
+      pads = PAD_POSITIONS.map(() => false);
+      resetFrog();
     };
 
     const moveFrog = (dx, dy) => {
@@ -160,7 +107,6 @@ const Frogger = () => {
       else if (e.key === 'ArrowLeft') moveFrog(-1, 0);
       else if (e.key === 'ArrowRight') moveFrog(1, 0);
     };
-
     window.addEventListener('keydown', handleKey);
 
     let touchStart = null;
@@ -178,24 +124,74 @@ const Frogger = () => {
       if (Math.max(absX, absY) > 20) {
         if (absX > absY) moveFrog(dx > 0 ? 1 : -1, 0);
         else moveFrog(0, dy > 0 ? 1 : -1);
+      } else {
+        moveFrog(0, -1);
       }
       touchStart = null;
     };
     fg.addEventListener('touchstart', handleTouchStart);
     fg.addEventListener('touchend', handleTouchEnd);
+    const handleTap = () => moveFrog(0, -1);
+    fg.addEventListener('click', handleTap);
 
-    const reset = () => {
-      level = 1;
-      score = 0;
-      localStorage.setItem('frogger-level', level.toString());
-      initLevel();
+    let tilt = { x: 0, y: 0 };
+    const handleOrientation = (e) => {
+      tilt = { x: e.gamma || 0, y: e.beta || 0 };
     };
+    window.addEventListener('deviceorientation', handleOrientation);
 
-    const update = () => {
+    let tiltCooldown = 0;
+    let padCooldown = 0;
+
+    let lastTime = performance.now();
+    const update = (time) => {
+      const dt = Math.min((time - lastTime) / (1000 / 60), 3);
+      lastTime = time;
+
+      tiltCooldown = Math.max(0, tiltCooldown - dt);
+      padCooldown = Math.max(0, padCooldown - dt);
+
+      const gp = navigator.getGamepads ? navigator.getGamepads()[0] : null;
+      if (gp && padCooldown <= 0) {
+        const axX = gp.axes[0];
+        const axY = gp.axes[1];
+        const btn = gp.buttons;
+        if (btn[12]?.pressed || axY < -0.5) {
+          moveFrog(0, -1);
+          padCooldown = 10;
+        } else if (btn[13]?.pressed || axY > 0.5) {
+          moveFrog(0, 1);
+          padCooldown = 10;
+        } else if (btn[14]?.pressed || axX < -0.5) {
+          moveFrog(-1, 0);
+          padCooldown = 10;
+        } else if (btn[15]?.pressed || axX > 0.5) {
+          moveFrog(1, 0);
+          padCooldown = 10;
+        }
+      }
+
+      if (tiltCooldown <= 0) {
+        if (tilt.y < -15) {
+          moveFrog(0, -1);
+          tiltCooldown = 10;
+        } else if (tilt.y > 15) {
+          moveFrog(0, 1);
+          tiltCooldown = 10;
+        } else if (tilt.x < -15) {
+          moveFrog(-1, 0);
+          tiltCooldown = 10;
+        } else if (tilt.x > 15) {
+          moveFrog(1, 0);
+          tiltCooldown = 10;
+        }
+      }
+
       ctx.clearRect(0, 0, width, height);
 
-      const result = updateCars(lanes, frog, 1);
+      const result = updateCars(lanes, frog, dt);
       lanes.splice(0, lanes.length, ...result.lanes);
+      frog.x += result.frogDx;
       if (result.dead) {
         playTone(200, 0.2);
         resetFrog();
@@ -203,16 +199,18 @@ const Frogger = () => {
       }
 
       if (frog.y <= 0) {
-        const padResult = handlePads(
-          { x: frog.x, y: 0 },
-          PAD_POSITIONS.map(() => false)
-        );
+        const padResult = handlePads({ x: frog.x, y: 0 }, pads);
+        pads = padResult.pads;
         if (padResult.padHit) {
           playTone(800, 0.2);
-          level += 1;
           score += 100;
-          localStorage.setItem('frogger-level', level.toString());
-          initLevel();
+          if (pads.every(Boolean)) {
+            level += 1;
+            localStorage.setItem('frogger-level', level.toString());
+            initLevel();
+          } else {
+            resetFrog();
+          }
         } else {
           playTone(200, 0.2);
           resetFrog();
@@ -220,8 +218,8 @@ const Frogger = () => {
       }
 
       lanes.forEach((lane) => {
-        ctx.fillStyle = '#888';
-        lane.cars.forEach((v) => {
+        ctx.fillStyle = lane.type === 'car' ? '#888' : '#964B00';
+        lane.items.forEach((v) => {
           ctx.fillRect(v.x, lane.y, v.width, TILE);
         });
       });
@@ -243,6 +241,8 @@ const Frogger = () => {
       window.removeEventListener('keydown', handleKey);
       fg.removeEventListener('touchstart', handleTouchStart);
       fg.removeEventListener('touchend', handleTouchEnd);
+      fg.removeEventListener('click', handleTap);
+      window.removeEventListener('deviceorientation', handleOrientation);
     };
   }, []);
 
@@ -264,5 +264,14 @@ const Frogger = () => {
   );
 };
 
-export default Frogger;
+export {
+  initLane,
+  updateCars,
+  handlePads,
+  PAD_POSITIONS,
+  rampLane,
+  carLaneDefs,
+  logLaneDefs,
+};
 
+export default Frogger;

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -126,12 +126,20 @@ const Frogger = () => {
         else moveFrog(0, dy > 0 ? 1 : -1);
       } else {
         moveFrog(0, -1);
+        suppressClick = true;
+        setTimeout(() => { suppressClick = false; }, 400);
       }
       touchStart = null;
     };
     fg.addEventListener('touchstart', handleTouchStart);
     fg.addEventListener('touchend', handleTouchEnd);
-    const handleTap = () => moveFrog(0, -1);
+    const handleTap = (e) => {
+      if (suppressClick) {
+        e.preventDefault && e.preventDefault();
+        return;
+      }
+      moveFrog(0, -1);
+    };
     fg.addEventListener('click', handleTap);
 
     let tilt = { x: 0, y: 0 };


### PR DESCRIPTION
## Summary
- add standalone Frogger engine with randomized lane speeds, log platforms, hazards and goal pads
- integrate reduced-motion scaling plus tap, tilt, and gamepad input handling
- use delta-time updates for consistent collisions across frame rates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabcf726fc8328a3badf2418a04ae9