### PR TITLE
feat: enhance Sokoban engine with solver hints and instant undo

### DIFF
--- a/apps/sokoban/engine.ts
+++ b/apps/sokoban/engine.ts
@@ -80,7 +80,7 @@ function cloneState(state: State): HistoryEntry {
   };
 }
 
-const DIRS: Record<string, Position> = {
+export const DIRS: Record<string, Position> = {
   ArrowUp: { x: 0, y: -1 },
   ArrowDown: { x: 0, y: 1 },
   ArrowLeft: { x: -1, y: 0 },

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import ReactGA from 'react-ga4';
 import { defaultLevelMetas, parseLevels, loadPublicLevels, LevelMeta, defaultLevels } from './levels';
 import {
@@ -11,6 +11,7 @@ import {
   isSolved,
   State,
   directionKeys,
+  DIRS,
 } from './engine';
 
 const CELL = 32;
@@ -28,6 +29,21 @@ const Sokoban: React.FC = () => {
     });
     return c;
   });
+  const workerRef = useRef<Worker>();
+  const [hint, setHint] = useState<(typeof directionKeys)[number] | null>(null);
+  const [animate, setAnimate] = useState(true);
+
+  useEffect(() => {
+    if (typeof Worker !== 'undefined') {
+      workerRef.current = new Worker(new URL('./solverWorker.ts', import.meta.url));
+      workerRef.current.onmessage = (e) => {
+        const data = e.data as { moves?: (typeof directionKeys)[number][] };
+        if (data.moves && data.moves.length) setHint(data.moves[0]);
+        else setHint(null);
+      };
+    }
+    return () => workerRef.current?.terminate();
+  }, []);
 
   useEffect(() => {
     loadPublicLevels().then((lvls) => {
@@ -52,7 +68,15 @@ const Sokoban: React.FC = () => {
     setBest(b ? Number(b) : null);
   }, [index, levels]);
 
+  useEffect(() => {
+    if (!animate) {
+      const id = requestAnimationFrame(() => setAnimate(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [animate]);
+
   const handleMove = (dir: (typeof directionKeys)[number]) => {
+    setHint(null);
     const newState = move(state, dir);
     if (newState === state) return;
     setState(newState);
@@ -116,6 +140,8 @@ const Sokoban: React.FC = () => {
   const selectLevel = (i: number) => {
     const lvl = levels[i];
     const st = loadLevel(lvl.lines);
+    setAnimate(false);
+    setHint(null);
     setIndex(i);
     setState(st);
     setReach(reachable(st));
@@ -127,6 +153,8 @@ const Sokoban: React.FC = () => {
   const handleUndo = () => {
     const st = undoMove(state);
     if (st !== state) {
+      setAnimate(false);
+      setHint(null);
       setState(st);
       setReach(reachable(st));
       ReactGA.event('undo');
@@ -136,6 +164,8 @@ const Sokoban: React.FC = () => {
   const handleRedo = () => {
     const st = redoMove(state);
     if (st !== state) {
+      setAnimate(false);
+      setHint(null);
       setState(st);
       setReach(reachable(st));
       ReactGA.event('redo');
@@ -144,8 +174,24 @@ const Sokoban: React.FC = () => {
 
   const handleReset = () => {
     const st = resetLevel(levels[index].lines);
+    setAnimate(false);
+    setHint(null);
     setState(st);
     setReach(reachable(st));
+  };
+
+  const handleHint = () => {
+    if (!workerRef.current) return;
+    workerRef.current.postMessage({
+      state: {
+        width: state.width,
+        height: state.height,
+        walls: Array.from(state.walls),
+        targets: Array.from(state.targets),
+        boxes: Array.from(state.boxes),
+        player: state.player,
+      },
+    });
   };
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -161,6 +207,8 @@ const Sokoban: React.FC = () => {
     if (parsed.length) {
       setLevels(parsed);
       const st = loadLevel(parsed[0].lines);
+      setAnimate(false);
+      setHint(null);
       setIndex(0);
       setState(st);
       setReach(reachable(st));
@@ -171,6 +219,8 @@ const Sokoban: React.FC = () => {
     width: CELL,
     height: CELL,
   } as React.CSSProperties;
+
+  const hintPos = hint ? { x: state.player.x + DIRS[hint].x, y: state.player.y + DIRS[hint].y } : null;
 
   return (
     <div className="p-4 space-y-2 select-none">
@@ -191,6 +241,9 @@ const Sokoban: React.FC = () => {
         </button>
         <button type="button" onClick={handleReset} className="px-2 py-1 bg-gray-300 rounded">
           Reset
+        </button>
+        <button type="button" onClick={handleHint} className="px-2 py-1 bg-gray-300 rounded">
+          Hint
         </button>
         <div className="ml-4">Pushes: {state.pushes}</div>
         <div>Best: {best ?? '-'}</div>
@@ -223,15 +276,24 @@ const Sokoban: React.FC = () => {
             );
           })
         )}
+        {hintPos && (
+          <div
+            className="absolute bg-yellow-300 opacity-50 pointer-events-none"
+            style={{
+              ...cellStyle,
+              transform: `translate(${hintPos.x * CELL}px, ${hintPos.y * CELL}px)`,
+            }}
+          />
+        )}
         {Array.from(state.boxes).map((b) => {
           const [x, y] = b.split(',').map(Number);
           const dead = state.deadlocks.has(b);
           return (
             <div
               key={b}
-              className={`absolute transition-transform duration-100 ${
-                dead ? 'bg-red-500' : 'bg-orange-400'
-              }`}
+              className={`absolute ${
+                animate ? 'transition-transform duration-100' : ''
+              } ${dead ? 'bg-red-500' : 'bg-orange-400'}`}
               style={{
                 ...cellStyle,
                 transform: `translate(${x * CELL}px, ${y * CELL}px)`,
@@ -240,7 +302,9 @@ const Sokoban: React.FC = () => {
           );
         })}
         <div
-          className="absolute bg-blue-400 transition-transform duration-100"
+          className={`absolute bg-blue-400 ${
+            animate ? 'transition-transform duration-100' : ''
+          }`}
           style={{
             ...cellStyle,
             transform: `translate(${state.player.x * CELL}px, ${state.player.y * CELL}px)`,

--- a/apps/sokoban/solverWorker.ts
+++ b/apps/sokoban/solverWorker.ts
@@ -1,0 +1,143 @@
+const ctx: Worker = self as any;
+
+export type Position = { x: number; y: number };
+interface WorkerState {
+  width: number;
+  height: number;
+  walls: string[];
+  targets: string[];
+  boxes: string[];
+  player: Position;
+}
+interface SolveRequest {
+  state: WorkerState;
+}
+interface SolveResponse {
+  moves: string[];
+}
+
+const DIRS: Record<string, Position> = {
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+};
+const dirKeys = Object.keys(DIRS) as (keyof typeof DIRS)[];
+
+const key = (p: Position) => `${p.x},${p.y}`;
+
+function isWallOrBox(state: SimpleState, pos: Position): boolean {
+  const k = key(pos);
+  if (pos.x < 0 || pos.y < 0 || pos.x >= state.width || pos.y >= state.height) return true;
+  return state.walls.has(k) || state.boxes.has(k);
+}
+
+function isDeadlock(state: SimpleState, pos: Position): boolean {
+  const k = key(pos);
+  if (state.targets.has(k)) return false;
+  const up = isWallOrBox(state, { x: pos.x, y: pos.y - 1 });
+  const down = isWallOrBox(state, { x: pos.x, y: pos.y + 1 });
+  const left = isWallOrBox(state, { x: pos.x - 1, y: pos.y });
+  const right = isWallOrBox(state, { x: pos.x + 1, y: pos.y });
+  return (up && left) || (up && right) || (down && left) || (down && right);
+}
+
+interface SimpleState {
+  width: number;
+  height: number;
+  walls: Set<string>;
+  targets: Set<string>;
+  boxes: Set<string>;
+  player: Position;
+}
+
+function heuristic(state: SimpleState): number {
+  const targetArr = Array.from(state.targets).map((t) => t.split(',').map(Number));
+  let h = 0;
+  state.boxes.forEach((b) => {
+    const [bx, by] = b.split(',').map(Number);
+    let min = Infinity;
+    for (const [tx, ty] of targetArr) {
+      const d = Math.abs(bx - tx) + Math.abs(by - ty);
+      if (d < min) min = d;
+    }
+    h += min;
+  });
+  return h;
+}
+
+function stateKey(state: SimpleState): string {
+  const boxes = Array.from(state.boxes).sort().join('|');
+  return `${state.player.x},${state.player.y};${boxes}`;
+}
+
+function moveState(state: SimpleState, dir: keyof typeof DIRS): SimpleState | null {
+  const d = DIRS[dir];
+  const next = { x: state.player.x + d.x, y: state.player.y + d.y };
+  const nextKey = key(next);
+  if (state.walls.has(nextKey)) return null;
+  const boxes = new Set(state.boxes);
+  if (boxes.has(nextKey)) {
+    const beyond = { x: next.x + d.x, y: next.y + d.y };
+    const beyondKey = key(beyond);
+    if (isWallOrBox(state, beyond)) return null;
+    boxes.delete(nextKey);
+    boxes.add(beyondKey);
+    if (isDeadlock({ ...state, boxes }, beyond)) return null;
+  }
+  return { ...state, player: next, boxes };
+}
+
+function isSolved(state: SimpleState): boolean {
+  let solved = true;
+  state.boxes.forEach((b) => {
+    if (!state.targets.has(b)) solved = false;
+  });
+  return solved;
+}
+
+interface Node {
+  state: SimpleState;
+  g: number;
+  f: number;
+  path: string[];
+}
+
+function solve(start: SimpleState): string[] {
+  const open: Node[] = [{ state: start, g: 0, f: heuristic(start), path: [] }];
+  const visited = new Map<string, number>();
+  visited.set(stateKey(start), 0);
+  while (open.length) {
+    open.sort((a, b) => a.f - b.f);
+    const cur = open.shift()!;
+    if (isSolved(cur.state)) return cur.path;
+    for (const dir of dirKeys) {
+      const next = moveState(cur.state, dir);
+      if (!next) continue;
+      const g = cur.g + 1;
+      const keyStr = stateKey(next);
+      if (visited.has(keyStr) && visited.get(keyStr)! <= g) continue;
+      visited.set(keyStr, g);
+      const h = heuristic(next);
+      open.push({ state: next, g, f: g + h, path: [...cur.path, dir] });
+    }
+  }
+  return [];
+}
+
+ctx.onmessage = (e: MessageEvent<SolveRequest>) => {
+  const { state: raw } = e.data;
+  const state: SimpleState = {
+    width: raw.width,
+    height: raw.height,
+    walls: new Set(raw.walls),
+    targets: new Set(raw.targets),
+    boxes: new Set(raw.boxes),
+    player: raw.player,
+  };
+  const moves = solve(state);
+  const res: SolveResponse = { moves };
+  ctx.postMessage(res);
+};
+
+export {};


### PR DESCRIPTION
## Summary
- expose direction vectors and retain deadlock detection in Sokoban engine
- add worker-based A* solver providing next-move hints
- disable transitions on undo/redo for instant state changes

## Testing
- `yarn test apps/sokoban --passWithNoTests`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aabcfe034083288c588fe42b58aee1