### PR TITLE
feat: expand Space Invaders gameplay

### DIFF
--- a/apps/space-invaders/mothership.ts
+++ b/apps/space-invaders/mothership.ts
@@ -1,0 +1,30 @@
+export default class Mothership {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  dir: number;
+  speed: number;
+  active: boolean;
+
+  constructor(boundsW: number, dir: number) {
+    this.w = 40;
+    this.h = 20;
+    this.y = 20;
+    this.dir = dir;
+    this.speed = 60;
+    this.x = dir === 1 ? -this.w : boundsW;
+    this.active = true;
+  }
+
+  update(dt: number, boundsW: number) {
+    this.x += this.speed * this.dir * dt;
+    if ((this.dir === 1 && this.x > boundsW) || (this.dir === -1 && this.x + this.w < 0)) this.active = false;
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    if (!this.active) return;
+    ctx.fillStyle = 'red';
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+}

--- a/apps/space-invaders/projectile.ts
+++ b/apps/space-invaders/projectile.ts
@@ -1,19 +1,24 @@
 export default class Projectile {
   x: number;
   y: number;
+  prevY: number;
   dy: number;
   active: boolean;
 
   constructor(x: number, y: number, dy: number) {
     this.x = x;
     this.y = y;
+     this.prevY = y;
     this.dy = dy;
     this.active = true;
   }
 
   update(dt: number, boundsH: number) {
+    this.prevY = this.y;
     this.y += this.dy * dt;
-    if (this.y < 0 || this.y > boundsH) this.active = false;
+    const minY = Math.min(this.prevY, this.y);
+    const maxY = Math.max(this.prevY, this.y);
+    if (minY < 0 || maxY > boundsH) this.active = false;
   }
 
   draw(ctx: CanvasRenderingContext2D, color: string) {
@@ -23,12 +28,10 @@ export default class Projectile {
   }
 
   collides(rect: { x: number; y: number; w: number; h: number }) {
-    return (
-      this.active &&
-      this.x >= rect.x &&
-      this.x <= rect.x + rect.w &&
-      this.y >= rect.y &&
-      this.y <= rect.y + rect.h
-    );
+    if (!this.active) return false;
+    if (this.x < rect.x || this.x > rect.x + rect.w) return false;
+    const minY = Math.min(this.prevY, this.y);
+    const maxY = Math.max(this.prevY, this.y);
+    return maxY >= rect.y && minY <= rect.y + rect.h;
   }
 }

--- a/apps/space-invaders/shield.ts
+++ b/apps/space-invaders/shield.ts
@@ -1,0 +1,30 @@
+export default class Shield {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  hp: number;
+
+  constructor(x: number, y: number, w = 30, h = 20, hp = 5) {
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+    this.hp = hp;
+  }
+
+  hit() {
+    this.hp -= 1;
+  }
+
+  get alive() {
+    return this.hp > 0;
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    if (!this.alive) return;
+    const intensity = (this.hp / 5) * 255;
+    ctx.fillStyle = `rgb(${intensity},${intensity},0)`;
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+}


### PR DESCRIPTION
## Summary
- add destructible shields and mothership encounters
- batch invaders into marching formation with faster cadence as numbers drop
- prevent projectile tunneling and support mobile controls

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aabd05178483288669746a0ef799e2