### PR TITLE
feat: add gomoku game

### DIFF
--- a/apps/gomoku/engine.ts
+++ b/apps/gomoku/engine.ts
@@ -1,0 +1,269 @@
+export const SIZE = 15;
+export const WIN = 5;
+
+export enum Player {
+  Black = 1,
+  White = -1,
+}
+
+export type Board = Int8Array;
+
+export interface Move {
+  x: number;
+  y: number;
+}
+
+export const index = (x: number, y: number) => y * SIZE + x;
+
+export const createBoard = (): Board => new Int8Array(SIZE * SIZE);
+
+const cloneBoard = (board: Board): Board => Int8Array.from(board);
+
+const inBounds = (x: number, y: number) => x >= 0 && x < SIZE && y >= 0 && y < SIZE;
+
+export const applyMove = (
+  board: Board,
+  move: Move,
+  player: Player,
+  capture = false,
+): { board: Board; captured: number } => {
+  const b = cloneBoard(board);
+  const idx = index(move.x, move.y);
+  b[idx] = player;
+  let captured = 0;
+  if (capture) {
+    const dirs = [
+      [1, 0],
+      [0, 1],
+      [1, 1],
+      [1, -1],
+    ];
+    for (const [dx, dy] of dirs) {
+      const x1 = move.x + dx;
+      const y1 = move.y + dy;
+      const x2 = move.x + 2 * dx;
+      const y2 = move.y + 2 * dy;
+      const x3 = move.x + 3 * dx;
+      const y3 = move.y + 3 * dy;
+      if (inBounds(x3, y3)) {
+        const i1 = index(x1, y1);
+        const i2 = index(x2, y2);
+        const i3 = index(x3, y3);
+        if (b[i1] === -player && b[i2] === -player && b[i3] === player) {
+          b[i1] = 0;
+          b[i2] = 0;
+          captured += 2;
+        }
+      }
+      const xm1 = move.x - dx;
+      const ym1 = move.y - dy;
+      const xm2 = move.x - 2 * dx;
+      const ym2 = move.y - 2 * dy;
+      const xm3 = move.x - 3 * dx;
+      const ym3 = move.y - 3 * dy;
+      if (inBounds(xm3, ym3)) {
+        const j1 = index(xm1, ym1);
+        const j2 = index(xm2, ym2);
+        const j3 = index(xm3, ym3);
+        if (b[j1] === -player && b[j2] === -player && b[j3] === player) {
+          b[j1] = 0;
+          b[j2] = 0;
+          captured += 2;
+        }
+      }
+    }
+  }
+  return { board: b, captured };
+};
+
+export const checkWin = (board: Board, player: Player): boolean => {
+  const dirs = [
+    [1, 0],
+    [0, 1],
+    [1, 1],
+    [1, -1],
+  ];
+  for (let y = 0; y < SIZE; y += 1) {
+    for (let x = 0; x < SIZE; x += 1) {
+      if (board[index(x, y)] !== player) continue;
+      for (const [dx, dy] of dirs) {
+        let count = 1;
+        let cx = x + dx;
+        let cy = y + dy;
+        while (inBounds(cx, cy) && board[index(cx, cy)] === player) {
+          count += 1;
+          cx += dx;
+          cy += dy;
+        }
+        if (count >= WIN) return true;
+      }
+    }
+  }
+  return false;
+};
+
+function evaluateLine(line: Int8Array, player: Player): number {
+  let score = 0;
+  const opp = -player;
+  let i = 0;
+  const len = line.length;
+  while (i < len) {
+    if (line[i] === player) {
+      let cnt = 1;
+      let j = i + 1;
+      while (j < len && line[j] === player) {
+        cnt += 1;
+        j += 1;
+      }
+      const left = i - 1 >= 0 ? line[i - 1] : opp;
+      const right = j < len ? line[j] : opp;
+      if (cnt >= 5) score += 100000;
+      else if (cnt === 4) {
+        if (left === 0 && right === 0) score += 10000; // open four
+        else if (left === 0 || right === 0) score += 1000; // closed four
+      } else if (cnt === 3) {
+        if (left === 0 && right === 0) score += 100; // open three
+        else if (left === 0 || right === 0) score += 10; // closed three
+      }
+      i = j;
+    } else {
+      i += 1;
+    }
+  }
+  return score;
+}
+
+export const evaluate = (board: Board, player: Player): number => {
+  const opp = -player;
+  let score = 0;
+  for (let y = 0; y < SIZE; y += 1) {
+    const row = board.subarray(y * SIZE, y * SIZE + SIZE);
+    score += evaluateLine(row, player);
+    score -= evaluateLine(row, opp);
+  }
+  for (let x = 0; x < SIZE; x += 1) {
+    const col = new Int8Array(SIZE);
+    for (let y = 0; y < SIZE; y += 1) col[y] = board[index(x, y)];
+    score += evaluateLine(col, player);
+    score -= evaluateLine(col, opp);
+  }
+  for (let k = 0; k <= 2 * (SIZE - 1); k += 1) {
+    const diag: number[] = [];
+    for (let y = 0; y < SIZE; y += 1) {
+      const x = k - y;
+      if (x >= 0 && x < SIZE) diag.push(board[index(x, y)]);
+    }
+    if (diag.length >= 5) {
+      const arr = Int8Array.from(diag);
+      score += evaluateLine(arr, player);
+      score -= evaluateLine(arr, opp);
+    }
+  }
+  for (let k = -(SIZE - 1); k <= SIZE - 1; k += 1) {
+    const diag: number[] = [];
+    for (let y = 0; y < SIZE; y += 1) {
+      const x = y + k;
+      if (x >= 0 && x < SIZE) diag.push(board[index(x, y)]);
+    }
+    if (diag.length >= 5) {
+      const arr = Int8Array.from(diag);
+      score += evaluateLine(arr, player);
+      score -= evaluateLine(arr, opp);
+    }
+  }
+  return score;
+};
+
+export const generateMoves = (board: Board): Move[] => {
+  const moves: Move[] = [];
+  let filled = false;
+  for (let i = 0; i < board.length; i += 1) {
+    if (board[i] !== 0) {
+      filled = true;
+      break;
+    }
+  }
+  if (!filled) {
+    const c = Math.floor(SIZE / 2);
+    return [{ x: c, y: c }];
+  }
+  const seen = new Set<number>();
+  for (let y = 0; y < SIZE; y += 1) {
+    for (let x = 0; x < SIZE; x += 1) {
+      if (board[index(x, y)] !== 0) {
+        for (let dy = -1; dy <= 1; dy += 1) {
+          for (let dx = -1; dx <= 1; dx += 1) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (!inBounds(nx, ny)) continue;
+            const idx = index(nx, ny);
+            if (board[idx] === 0 && !seen.has(idx)) {
+              seen.add(idx);
+              moves.push({ x: nx, y: ny });
+            }
+          }
+        }
+      }
+    }
+  }
+  return moves;
+};
+
+interface SearchResult {
+  score: number;
+  move?: Move;
+}
+
+export const minimax = (
+  board: Board,
+  depth: number,
+  player: Player,
+  alpha = -Infinity,
+  beta = Infinity,
+  capture = false,
+  killer: Move[][] = [],
+  ply = 0,
+): SearchResult => {
+  if (depth === 0) return { score: evaluate(board, player) };
+  const moves = generateMoves(board);
+  const killerMove = killer[ply]?.[0];
+  moves.sort((a, b) => {
+    if (killerMove && a.x === killerMove.x && a.y === killerMove.y) return -1;
+    if (killerMove && b.x === killerMove.x && b.y === killerMove.y) return 1;
+    return 0;
+  });
+  let bestScore = -Infinity;
+  let bestMove: Move | undefined;
+  for (const m of moves) {
+    const { board: nb } = applyMove(board, m, player, capture);
+    const { score } = minimax(nb, depth - 1, -player, -beta, -alpha, capture, killer, ply + 1);
+    const val = -score;
+    if (val > bestScore) {
+      bestScore = val;
+      bestMove = m;
+    }
+    if (val > alpha) alpha = val;
+    if (alpha >= beta) {
+      if (!killer[ply]) killer[ply] = [];
+      killer[ply][0] = m;
+      break;
+    }
+  }
+  return { score: bestScore, move: bestMove };
+};
+
+export const iterativeDeepening = (
+  board: Board,
+  maxDepth: number,
+  player: Player,
+  capture = false,
+): Move | null => {
+  const killer: Move[][] = [];
+  let best: Move | null = null;
+  for (let d = 1; d <= maxDepth; d += 1) {
+    const { move } = minimax(board, d, player, -Infinity, Infinity, capture, killer, 0);
+    if (move) best = move;
+  }
+  return best;
+};
+

--- a/apps/gomoku/index.tsx
+++ b/apps/gomoku/index.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import {
+  createBoard,
+  Player,
+  index,
+  applyMove,
+  checkWin,
+  iterativeDeepening,
+  SIZE,
+  Board,
+} from './engine';
+
+const Gomoku: React.FC = () => {
+  const [board, setBoard] = useState<Board>(createBoard());
+  const [turn, setTurn] = useState<Player>(Player.Black);
+  const [capture, setCapture] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [winner, setWinner] = useState<Player | null>(null);
+  const [captures, setCaptures] = useState<Record<Player, number>>({
+    [Player.Black]: 0,
+    [Player.White]: 0,
+  });
+
+  const reset = () => {
+    setBoard(createBoard());
+    setTurn(Player.Black);
+    setGameOver(false);
+    setWinner(null);
+    setCaptures({ [Player.Black]: 0, [Player.White]: 0 });
+  };
+
+  const handleClick = (x: number, y: number) => {
+    if (gameOver || board[index(x, y)] !== 0 || turn !== Player.Black) return;
+    const { board: nb, captured } = applyMove(board, { x, y }, Player.Black, capture);
+    const newCaps = { ...captures, [Player.Black]: captures[Player.Black] + captured / 2 };
+    setBoard(nb);
+    setCaptures(newCaps);
+    if (checkWin(nb, Player.Black) || (capture && newCaps[Player.Black] >= 5)) {
+      setGameOver(true);
+      setWinner(Player.Black);
+      return;
+    }
+    setTurn(Player.White);
+    setTimeout(() => aiMove(nb, newCaps), 0);
+  };
+
+  const aiMove = (b: Board, caps: Record<Player, number>) => {
+    const start = performance.now();
+    const move = iterativeDeepening(b, 3, Player.White, capture);
+    const end = performance.now();
+    console.log(`Depth-3 time: ${end - start}ms`);
+    if (!move) {
+      setTurn(Player.Black);
+      return;
+    }
+    const { board: nb, captured } = applyMove(b, move, Player.White, capture);
+    const newCaps = { ...caps, [Player.White]: caps[Player.White] + captured / 2 };
+    setBoard(nb);
+    setCaptures(newCaps);
+    if (checkWin(nb, Player.White) || (capture && newCaps[Player.White] >= 5)) {
+      setGameOver(true);
+      setWinner(Player.White);
+    } else {
+      setTurn(Player.Black);
+    }
+  };
+
+  const renderCell = (x: number, y: number) => {
+    const v = board[index(x, y)];
+    return (
+      <div
+        key={`${x}-${y}`}
+        onClick={() => handleClick(x, y)}
+        className="w-6 h-6 border border-gray-400 flex items-center justify-center bg-orange-100"
+      >
+        {v === Player.Black && <div className="w-4 h-4 rounded-full bg-black" />}
+        {v === Player.White && <div className="w-4 h-4 rounded-full bg-white" />}
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-2 select-none">
+      <div className="flex space-x-4 items-center">
+        <label className="flex items-center space-x-1">
+          <input
+            type="checkbox"
+            checked={capture}
+            onChange={(e) => setCapture(e.target.checked)}
+          />
+          <span>Captures</span>
+        </label>
+        <div>
+          B:{captures[Player.Black]} W:{captures[Player.White]}
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="px-2 py-1 bg-gray-300 rounded"
+        >
+          Reset
+        </button>
+      </div>
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `repeat(${SIZE},1fr)` }}
+      >
+        {Array.from({ length: SIZE * SIZE }, (_, i) => renderCell(i % SIZE, Math.floor(i / SIZE)))}
+      </div>
+      {gameOver && (
+        <div>
+          {winner === Player.Black ? 'You win!' : 'AI wins'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Gomoku;


### PR DESCRIPTION
## Summary
- add gomoku game with optional capture rules
- implement minimax AI with heuristics and killer move ordering
- support 15x15 board with iterative deepening search

## Testing
- `node -e "const e=require('/tmp/gomoku/engine.js'); const board=e.createBoard(); const b1=e.applyMove(board,{x:7,y:7},e.Player.Black,false).board; const b2=e.applyMove(b1,{x:7,y:8},e.Player.White,false).board; const b3=e.applyMove(b2,{x:8,y:8},e.Player.Black,false).board; console.time('search'); const move=e.iterativeDeepening(b3,3,e.Player.White,false); console.timeEnd('search'); console.log(move);"`
- `yarn test apps/gomoku --passWithNoTests`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68aabd0afb648328ba143df7bda15c02