### PR TITLE
feat(platformer): expand physics and level support

### DIFF
--- a/apps/platformer/Terrain.js
+++ b/apps/platformer/Terrain.js
@@ -4,8 +4,25 @@ export class Terrain {
     this.tiles = tiles;
   }
 
+  getTile(tx, ty) {
+    return this.tiles[ty] ? this.tiles[ty][tx] || 0 : 0;
+  }
+
   isSolid(tx, ty) {
-    return !!(this.tiles[ty] && this.tiles[ty][tx]);
+    const tile = this.getTile(tx, ty);
+    // treat non-zero tiles that aren't collectibles or slopes as solid blocks
+    return tile !== 0 && tile !== 5 && !this.isSlopeTile(tile);
+  }
+
+  isSlopeTile(tile) {
+    return tile === 2 || tile === 3;
+  }
+
+  getSlopeY(tile, x) {
+    // x is the x offset within the tile (0..tileSize)
+    if (tile === 2) return this.tileSize - x; // rising left -> right
+    if (tile === 3) return x; // falling left -> right
+    return 0;
   }
 
   isSolidPixel(x, y) {

--- a/apps/platformer/levelLoader.js
+++ b/apps/platformer/levelLoader.js
@@ -1,5 +1,6 @@
 import { Terrain } from './Terrain.js';
 import { Enemy } from './Enemy.js';
+import { Checkpoint } from './checkpoint.js';
 
 function chunk(data, size) {
   const rows = [];
@@ -14,7 +15,12 @@ export async function loadLevel(name) {
   const map = await res.json();
   const terrainLayer = map.layers.find((l) => l.name === 'terrain');
   const enemyLayer = map.layers.find((l) => l.name === 'enemies');
+  const collectibleLayer = map.layers.find((l) => l.name === 'collectibles');
+  const checkpointLayer = map.layers.find((l) => l.name === 'checkpoints');
   const tiles = terrainLayer ? chunk(terrainLayer.data, map.width) : [];
+  const collectibles = collectibleLayer
+    ? chunk(collectibleLayer.data, map.width)
+    : [];
   const terrain = new Terrain(map.tilewidth, tiles);
   const enemies = [];
   if (enemyLayer && enemyLayer.objects) {
@@ -22,5 +28,22 @@ export async function loadLevel(name) {
       enemies.push(new Enemy(o.x, o.y, o.properties?.patrol || 0));
     });
   }
-  return { terrain, enemies, width: map.width, height: map.height };
+  const checkpoints = [];
+  if (checkpointLayer && checkpointLayer.objects) {
+    checkpointLayer.objects.forEach((o) => {
+      checkpoints.push(new Checkpoint(o.x, o.y));
+    });
+  }
+  const parallax = map.layers
+    .filter((l) => l.type === 'imagelayer')
+    .map((l) => l.image);
+  return {
+    terrain,
+    enemies,
+    collectibles,
+    checkpoints,
+    parallax,
+    width: map.width,
+    height: map.height,
+  };
 }

--- a/apps/platformer/physics.js
+++ b/apps/platformer/physics.js
@@ -6,63 +6,132 @@ export const FRICTION = 800;
 export const MAX_SPEED = 200;
 export const JUMP_SPEED = 600;
 
-export function updatePhysics(player, input, dt, terrain = null) {
-  // horizontal acceleration and friction
-  if (input.right) {
-    player.vx += ACCEL * dt;
-  } else if (input.left) {
-    player.vx -= ACCEL * dt;
-  } else {
-    if (player.vx > 0) player.vx = Math.max(0, player.vx - FRICTION * dt);
-    else if (player.vx < 0) player.vx = Math.min(0, player.vx + FRICTION * dt);
-  }
-  // clamp horizontal speed
-  if (player.vx > MAX_SPEED) player.vx = MAX_SPEED;
-  if (player.vx < -MAX_SPEED) player.vx = -MAX_SPEED;
+export const ACCEL_RATE = 12;
+export const FRICTION_RATE = 20;
+const MAX_STEP = 1 / 60; // fixed step for consistent physics
 
-  // timers
-  if (player.onGround) player.coyoteTimer = COYOTE_TIME;
-  else player.coyoteTimer -= dt;
+function approach(current, target, rate, dt) {
+  return current + (target - current) * (1 - Math.exp(-rate * dt));
+}
 
-  if (input.jump) player.jumpBufferTimer = JUMP_BUFFER_TIME;
-  else player.jumpBufferTimer -= dt;
-
-  // jump
-  if (player.jumpBufferTimer > 0 && (player.onGround || player.coyoteTimer > 0)) {
-    player.vy = -JUMP_SPEED;
-    player.onGround = false;
-    player.jumpBufferTimer = 0;
-  }
-
-  // variable jump height
-  if (!input.jump && player.vy < 0) player.vy += GRAVITY * dt * 0.5;
-
-  // gravity
-  player.vy += GRAVITY * dt;
-
-  // clamp vertical speed
-  if (player.vy > 1000) player.vy = 1000;
-  if (player.vy < -1000) player.vy = -1000;
-
-  // integrate position
-  player.x += player.vx * dt;
-  player.y += player.vy * dt;
-
-  // simple terrain collision with ground
-  if (terrain) {
-    const tileSize = terrain.tileSize;
-    const bottom = player.y + player.h;
-    const left = player.x;
-    const right = player.x + player.w;
-    if (
-      terrain.isSolidPixel(left, bottom) ||
-      terrain.isSolidPixel(right - 1, bottom)
-    ) {
-      player.y = Math.floor(bottom / tileSize) * tileSize - player.h;
-      player.vy = 0;
-      player.onGround = true;
-    } else {
-      player.onGround = false;
+function resolveHorizontal(player, terrain) {
+  const tileSize = terrain.tileSize;
+  if (player.vx > 0) {
+    const right = Math.floor((player.x + player.w - 1) / tileSize);
+    const top = Math.floor(player.y / tileSize);
+    const bottom = Math.floor((player.y + player.h - 1) / tileSize);
+    for (let ty = top; ty <= bottom; ty++) {
+      if (terrain.isSolid(right, ty)) {
+        player.x = right * tileSize - player.w;
+        player.vx = 0;
+        break;
+      }
     }
+  } else if (player.vx < 0) {
+    const left = Math.floor(player.x / tileSize);
+    const top = Math.floor(player.y / tileSize);
+    const bottom = Math.floor((player.y + player.h - 1) / tileSize);
+    for (let ty = top; ty <= bottom; ty++) {
+      if (terrain.isSolid(left, ty)) {
+        player.x = (left + 1) * tileSize;
+        player.vx = 0;
+        break;
+      }
+    }
+  }
+}
+
+function resolveVertical(player, terrain) {
+  const tileSize = terrain.tileSize;
+  if (player.vy >= 0) {
+    const bottom = Math.floor((player.y + player.h - 1) / tileSize);
+    const left = Math.floor(player.x / tileSize);
+    const right = Math.floor((player.x + player.w - 1) / tileSize);
+    let grounded = false;
+    for (let tx = left; tx <= right; tx++) {
+      const tile = terrain.getTile(tx, bottom);
+      if (terrain.isSlopeTile(tile)) {
+        const localX = player.x + player.w / 2 - tx * tileSize;
+        const surfaceY = bottom * tileSize + terrain.getSlopeY(tile, localX);
+        if (player.y + player.h > surfaceY) {
+          player.y = surfaceY - player.h;
+          player.vy = 0;
+          grounded = true;
+          break;
+        }
+      } else if (terrain.isSolid(tx, bottom)) {
+        player.y = bottom * tileSize - player.h;
+        player.vy = 0;
+        grounded = true;
+        break;
+      }
+    }
+    player.onGround = grounded;
+  } else {
+    const top = Math.floor(player.y / tileSize);
+    const left = Math.floor(player.x / tileSize);
+    const right = Math.floor((player.x + player.w - 1) / tileSize);
+    for (let tx = left; tx <= right; tx++) {
+      if (terrain.isSolid(tx, top)) {
+        player.y = (top + 1) * tileSize;
+        player.vy = 0;
+        break;
+      }
+    }
+    // check if standing on ground after moving up
+    const checkBottom = Math.floor((player.y + player.h) / tileSize);
+    let grounded = false;
+    for (let tx = left; tx <= right; tx++) {
+      const tile = terrain.getTile(tx, checkBottom);
+      if (terrain.isSlopeTile(tile)) {
+        const localX = player.x + player.w / 2 - tx * tileSize;
+        const surfaceY = checkBottom * tileSize + terrain.getSlopeY(tile, localX);
+        if (player.y + player.h >= surfaceY - 1) {
+          grounded = true;
+          break;
+        }
+      } else if (terrain.isSolid(tx, checkBottom)) {
+        grounded = true;
+        break;
+      }
+    }
+    player.onGround = grounded;
+  }
+}
+
+export function updatePhysics(player, input, dt, terrain = null) {
+  let remaining = dt;
+  while (remaining > 0) {
+    const step = Math.min(remaining, MAX_STEP);
+
+    const targetSpeed = input.right ? MAX_SPEED : input.left ? -MAX_SPEED : 0;
+    const rate = targetSpeed === 0 ? FRICTION_RATE : ACCEL_RATE;
+    player.vx = approach(player.vx, targetSpeed, rate, step);
+
+    // timers
+    if (player.onGround) player.coyoteTimer = COYOTE_TIME;
+    else player.coyoteTimer -= step;
+
+    if (input.jump) player.jumpBufferTimer = JUMP_BUFFER_TIME;
+    else player.jumpBufferTimer -= step;
+
+    if (player.jumpBufferTimer > 0 && (player.onGround || player.coyoteTimer > 0)) {
+      player.vy = -JUMP_SPEED;
+      player.onGround = false;
+      player.jumpBufferTimer = 0;
+    }
+
+    if (!input.jump && player.vy < 0) player.vy += GRAVITY * step * 0.5;
+
+    player.vy += GRAVITY * step;
+
+    // integrate
+    player.onGround = false;
+    player.x += player.vx * step;
+    if (terrain) resolveHorizontal(player, terrain);
+    player.y += player.vy * step;
+    if (terrain) resolveVertical(player, terrain);
+
+    remaining -= step;
   }
 }


### PR DESCRIPTION
## Summary
- add slope-aware terrain queries and axis-separated collision for smooth movement
- introduce curved acceleration/friction, variable jump height and fixed-step physics
- load collectibles, checkpoints and parallax images from JSON tilemaps

## Testing
- `yarn lint`
- `yarn test apps/platformer` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aabcfada188328a849a343897fec7d