### PR TITLE
feat(blackjack): expand gameplay options

### DIFF
--- a/__tests__/house-edge.test.ts
+++ b/__tests__/house-edge.test.ts
@@ -1,0 +1,43 @@
+import { BlackjackGame, basicStrategy } from '@components/apps/blackjack/engine';
+
+describe('house edge', () => {
+  test('basic strategy yields small negative expectation', () => {
+    let seed = 42;
+    function random() {
+      seed = (seed * 16807) % 2147483647;
+      return (seed - 1) / 2147483646;
+    }
+    const original = Math.random;
+    Math.random = random;
+
+    const starting = 1_000_000;
+    const game = new BlackjackGame({ decks: 6, bankroll: starting });
+    const rounds = 10_000;
+    const bet = 100;
+
+    for (let i = 0; i < rounds; i += 1) {
+      game.startRound(bet);
+      while (game.playerHands.some((h) => !h.finished)) {
+        const hand = game.playerHands[game.current];
+        const dealerUp = game.dealerHand[0];
+        const options = {
+          canSplit:
+            hand.cards[0]?.value === hand.cards[1]?.value && game.playerHands.length === 1,
+          canDouble: hand.cards.length === 2,
+          canSurrender: hand.cards.length === 2 && !hand.finished,
+        };
+        const action = basicStrategy(hand.cards, dealerUp, options);
+        if (action === 'hit') game.hit();
+        else if (action === 'stand') game.stand();
+        else if (action === 'double') game.double();
+        else if (action === 'split') game.split();
+        else if (action === 'surrender') game.surrender();
+      }
+    }
+
+    const edge = (game.bankroll - starting) / (rounds * bet);
+    Math.random = original;
+    expect(edge).toBeLessThan(0);
+    expect(edge).toBeGreaterThan(-0.02);
+  });
+});

--- a/__tests__/shuffle.test.ts
+++ b/__tests__/shuffle.test.ts
@@ -1,18 +1,27 @@
-import { fisherYatesShuffle } from '@components/apps/memory_utils';
+import { fisherYates } from '@components/apps/blackjack/engine';
 
-describe('fisherYatesShuffle fairness', () => {
-  test('distribution is roughly uniform', () => {
-    const iterations = 6000;
-    const counts = [0, 0, 0];
-    const arr = [1, 2, 3];
-    for (let i = 0; i < iterations; i++) {
-      const shuffled = fisherYatesShuffle(arr);
-      counts[shuffled[0] - 1]++;
+describe('fisherYates shuffle', () => {
+  test('produces roughly uniform permutations', () => {
+    let seed = 42;
+    function random() {
+      seed = (seed * 16807) % 2147483647;
+      return (seed - 1) / 2147483646;
     }
-    const expected = iterations / 3;
-    const tolerance = iterations * 0.05; // 5%
-    counts.forEach((c) => {
-      expect(Math.abs(c - expected)).toBeLessThan(tolerance);
+    const original = Math.random;
+    Math.random = random;
+
+    const counts: Record<string, number> = {};
+    const runs = 6000;
+    for (let i = 0; i < runs; i += 1) {
+      const perm = fisherYates([1, 2, 3]).join('');
+      counts[perm] = (counts[perm] || 0) + 1;
+    }
+    Math.random = original;
+
+    const expected = runs / 6;
+    Object.values(counts).forEach((c) => {
+      expect(c).toBeGreaterThan(expected * 0.9);
+      expect(c).toBeLessThan(expected * 1.1);
     });
   });
 });

--- a/apps/blackjack/Controls.tsx
+++ b/apps/blackjack/Controls.tsx
@@ -6,9 +6,13 @@ interface ControlsProps {
   onSplit: () => void;
   onDouble: () => void;
   onInsurance: () => void;
+  onSurrender: () => void;
+  onUndo: () => void;
   canSplit: boolean;
   canDouble: boolean;
   canInsurance: boolean;
+  canSurrender: boolean;
+  canUndo: boolean;
   disabled: boolean;
 }
 
@@ -18,9 +22,13 @@ const Controls: React.FC<ControlsProps> = ({
   onSplit,
   onDouble,
   onInsurance,
+  onSurrender,
+  onUndo,
   canSplit,
   canDouble,
   canInsurance,
+  canSurrender,
+  canUndo,
   disabled,
 }) => (
   <div className="space-x-2" aria-label="Controls">
@@ -28,6 +36,8 @@ const Controls: React.FC<ControlsProps> = ({
     <button aria-label="Stand" disabled={disabled} className="btn" onClick={onStand}>Stand</button>
     <button aria-label="Split" disabled={disabled || !canSplit} className="btn" onClick={onSplit}>Split</button>
     <button aria-label="Double down" disabled={disabled || !canDouble} className="btn" onClick={onDouble}>Double</button>
+    <button aria-label="Surrender" disabled={disabled || !canSurrender} className="btn" onClick={onSurrender}>Surrender</button>
+    <button aria-label="Undo" disabled={disabled || !canUndo} className="btn" onClick={onUndo}>Undo</button>
     <button aria-label="Insurance" disabled={disabled || !canInsurance} className="btn" onClick={onInsurance}>Insurance</button>
   </div>
 );

--- a/apps/blackjack/PlayerHand.tsx
+++ b/apps/blackjack/PlayerHand.tsx
@@ -10,19 +10,18 @@ function cardValue(card: { value: string; suit: string }) {
   return card.value + card.suit;
 }
 
-const PlayerHand: React.FC<PlayerHandProps> = ({ hand, active }) => {
-  return (
-    <div aria-label="Player hand" className={`p-2 ${active ? 'ring-2 ring-blue-500' : ''}`}>
-      <div className="flex space-x-2">
-        {hand.cards.map((card, idx) => (
-          <span key={idx} className="border p-1" aria-label={cardValue(card)}>
-            {cardValue(card)}
-          </span>
-        ))}
-      </div>
-      <div className="text-sm">Bet: {hand.bet}</div>
+const PlayerHand: React.FC<PlayerHandProps> = ({ hand, active }) => (
+  <div aria-label="Player hand" className={`p-2 ${active ? 'ring-2 ring-blue-500' : ''}`}>
+    <div className="flex space-x-2">
+      {hand.cards.map((card, idx) => (
+        <span key={idx} className="border p-1" aria-label={cardValue(card)}>
+          {cardValue(card)}
+        </span>
+      ))}
     </div>
-  );
-};
+    <div className="text-sm">Bet: {hand.bet}</div>
+    {hand.surrendered && <div className="text-sm text-red-500">Surrendered</div>}
+  </div>
+);
 
 export default React.memo(PlayerHand);

--- a/apps/blackjack/index.tsx
+++ b/apps/blackjack/index.tsx
@@ -1,29 +1,27 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import Dealer from './Dealer';
 import PlayerHand from './PlayerHand';
 import Controls from './Controls';
 import { Card, Hand } from './types';
+import { basicStrategy, fisherYates } from '@components/apps/blackjack/engine';
 
 const suits = ['♠', '♥', '♦', '♣'];
 const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
 
-function createDeck(): Card[] {
+function createDeck(numDecks = 1): Card[] {
   const deck: Card[] = [];
-  for (const suit of suits) {
-    for (const value of values) {
-      deck.push({ suit, value });
+  for (let d = 0; d < numDecks; d++) {
+    for (const suit of suits) {
+      for (const value of values) {
+        deck.push({ suit, value });
+      }
     }
   }
   return deck;
 }
 
 function shuffle(deck: Card[]): Card[] {
-  const copy = [...deck];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [copy[i], copy[j]] = [copy[j], copy[i]];
-  }
-  return copy;
+  return fisherYates([...deck]);
 }
 
 function cardScore(card: Card): number {
@@ -53,16 +51,50 @@ function handValue(hand: Card[]): number {
   return total;
 }
 
+function isSoft(hand: Card[]): boolean {
+  let total = 0;
+  let aces = 0;
+  hand.forEach((c) => {
+    total += cardScore(c);
+    if (c.value === 'A') aces++;
+  });
+  return aces > 0 && total <= 21;
+}
+
 const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, token }) => {
+  const [decks, setDecks] = useState(1);
+  const [hitSoft17, setHitSoft17] = useState(true);
   const [showCount, setShowCount] = useState(false);
-  const [deck, setDeck] = useState<Card[]>(() => shuffle(createDeck()));
+  const [showStrategy, setShowStrategy] = useState(false);
+  const [deck, setDeck] = useState<Card[]>(() => shuffle(createDeck(1)));
   const [dealer, setDealer] = useState<Card[]>([]);
   const [playerHands, setPlayerHands] = useState<Hand[]>([]);
   const [active, setActive] = useState(0);
   const [bankroll, setBankroll] = useState(1000);
   const [bet, setBet] = useState(10);
   const [runningCount, setRunningCount] = useState(0);
-  const trueCount = useMemo(() => runningCount / (deck.length / 52 || 1), [runningCount, deck.length]);
+  const [history, setHistory] = useState<any[]>([]);
+  const [betting, setBetting] = useState(false);
+  const trueCount = useMemo(() => runningCount / Math.max(1, deck.length / 52), [runningCount, deck.length]);
+
+  useEffect(() => {
+    setDeck(shuffle(createDeck(decks)));
+    setRunningCount(0);
+  }, [decks]);
+
+  const saveHistory = useCallback(() => {
+    setHistory((h) => [
+      ...h,
+      {
+        deck: [...deck],
+        dealer: [...dealer],
+        playerHands: playerHands.map((ph) => ({ ...ph, cards: [...ph.cards] })),
+        active,
+        bankroll,
+        runningCount,
+      },
+    ]);
+  }, [deck, dealer, playerHands, active, bankroll, runningCount]);
 
   const dealCard = useCallback((hand: Card[]) => {
     const card = deck[0];
@@ -73,9 +105,13 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
 
   const startRound = useCallback(() => {
     if (deck.length < 15) {
-      setDeck(shuffle(createDeck()));
+      setDeck(shuffle(createDeck(decks)));
       setRunningCount(0);
     }
+    setHistory([]);
+    setTookInsurance(false);
+    setBetting(true);
+    setTimeout(() => setBetting(false), 500);
     const newDealer: Card[] = [];
     const player: Hand = { cards: [], bet };
     dealCard(newDealer);
@@ -86,17 +122,19 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
     setPlayerHands([player]);
     setActive(0);
     setBankroll((b) => b - bet);
-  }, [bet, dealCard, deck.length]);
+  }, [bet, dealCard, deck.length, decks]);
 
   const hit = useCallback(() => {
+    saveHistory();
     const hands = [...playerHands];
     const hand = hands[active];
     dealCard(hand.cards);
     setPlayerHands(hands);
     if (handValue(hand.cards) > 21) stand();
-  }, [active, playerHands, dealCard]);
+  }, [active, playerHands, dealCard, stand, saveHistory]);
 
   const stand = useCallback(() => {
+    saveHistory();
     const hands = [...playerHands];
     hands[active].isFinished = true;
     setPlayerHands(hands);
@@ -106,18 +144,26 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
     } else {
       // dealer turn
       const dealerHand = [...dealer];
-      while (handValue(dealerHand) < 17) {
+      while (
+        handValue(dealerHand) < 17 ||
+        (hitSoft17 && handValue(dealerHand) === 17 && isSoft(dealerHand))
+      ) {
         dealCard(dealerHand);
       }
       setDealer(dealerHand);
+      setHistory([]);
       resolveHands(dealerHand, hands);
     }
-  }, [active, playerHands, dealer, dealCard]);
+  }, [active, playerHands, dealer, dealCard, resolveHands, hitSoft17, saveHistory]);
 
   const resolveHands = useCallback((dealerHand: Card[], hands: Hand[]) => {
     const dealerVal = handValue(dealerHand);
     const results: ('win' | 'loss' | 'push')[] = [];
     hands.forEach((h) => {
+      if (h.surrendered) {
+        results.push('loss');
+        return;
+      }
       const val = handValue(h.cards);
       let result: 'win' | 'loss' | 'push' = 'loss';
       if (val > 21) result = 'loss';
@@ -141,6 +187,7 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
 
   const canSplit = playerHands[active]?.cards[0]?.value === playerHands[active]?.cards[1]?.value && playerHands.length === 1;
   const split = useCallback(() => {
+    saveHistory();
     const hands = [...playerHands];
     const hand = hands[active];
     const card = hand.cards.pop()!;
@@ -149,10 +196,11 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
     dealCard(newHand.cards);
     hands.push(newHand);
     setPlayerHands(hands);
-  }, [playerHands, active, dealCard]);
+  }, [playerHands, active, dealCard, saveHistory]);
 
   const canDouble = playerHands[active]?.cards.length === 2;
   const doubleDown = useCallback(() => {
+    saveHistory();
     const hands = [...playerHands];
     const hand = hands[active];
     setBankroll((b) => b - hand.bet);
@@ -160,21 +208,118 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
     dealCard(hand.cards);
     setPlayerHands(hands);
     stand();
-  }, [playerHands, active, dealCard, stand]);
+  }, [playerHands, active, dealCard, stand, saveHistory]);
+
+  const canSurrender = playerHands[active]?.cards.length === 2 && playerHands.length === 1 && !playerHands[active]?.isFinished;
+  const surrender = useCallback(() => {
+    saveHistory();
+    const hands = [...playerHands];
+    const hand = hands[active];
+    hand.isFinished = true;
+    hand.surrendered = true;
+    setPlayerHands(hands);
+    setBankroll((b) => b + Math.floor(hand.bet / 2));
+    const next = hands.findIndex((h) => !h.isFinished);
+    if (next !== -1) {
+      setActive(next);
+    } else {
+      setHistory([]);
+      resolveHands(dealer, hands);
+    }
+  }, [playerHands, active, dealer, resolveHands, saveHistory]);
 
   const [tookInsurance, setTookInsurance] = useState(false);
   const canInsurance = dealer[0]?.value === 'A' && !tookInsurance;
   const takeInsurance = useCallback(() => {
+    saveHistory();
     setBankroll((b) => b - bet / 2);
     setTookInsurance(true);
-  }, [bet]);
+  }, [bet, saveHistory]);
+
+  const canUndo = history.length > 0;
+  const undo = useCallback(() => {
+    const prev = history[history.length - 1];
+    if (!prev) return;
+    setDeck(prev.deck);
+    setDealer(prev.dealer);
+    setPlayerHands(prev.playerHands);
+    setActive(prev.active);
+    setBankroll(prev.bankroll);
+    setRunningCount(prev.runningCount);
+    setHistory(history.slice(0, -1));
+  }, [history]);
+
+  const strategy = useMemo(() => {
+    if (!showStrategy || dealer.length === 0 || playerHands.length === 0) return '';
+    const hand = playerHands[active];
+    const dealerUp = dealer[0];
+    return basicStrategy(hand.cards, dealerUp, {
+      canSplit,
+      canDouble,
+      canSurrender,
+    });
+  }, [showStrategy, dealer, playerHands, active, canSplit, canDouble, canSurrender]);
 
   return (
     <div className="p-4" aria-label="Blackjack game">
-      <div className="mb-2">Bankroll: {bankroll}</div>
-      <div className="mb-2"><label><input type="checkbox" checked={showCount} onChange={e=>setShowCount(e.target.checked)} aria-label="Toggle card counting" /> Card counting</label></div>
-      {showCount && <div className="mb-2">True count: {trueCount.toFixed(2)}</div>}
-      {dealer.length > 0 && <Dealer hand={dealer} hideHoleCard={playerHands.some((h) => !h.isFinished)} />}
+      <div className="mb-2">
+        Bankroll: {bankroll}
+        {betting && <span aria-hidden="true" className="inline-block animate-bounce ml-1">💰</span>}
+      </div>
+      <div className="mb-2">
+        <label>
+          Decks:
+          <input
+            type="number"
+            min={1}
+            max={8}
+            value={decks}
+            onChange={(e) => setDecks(parseInt(e.target.value, 10) || 1)}
+            className="ml-1 w-16 border"
+            aria-label="Number of decks"
+          />
+        </label>
+      </div>
+      <div className="mb-2">
+        <label>
+          <input
+            type="checkbox"
+            checked={hitSoft17}
+            onChange={(e) => setHitSoft17(e.target.checked)}
+            aria-label="Dealer hits soft 17"
+          />{' '}
+          Dealer hits soft 17
+        </label>
+      </div>
+      <div className="mb-2">
+        <label>
+          <input
+            type="checkbox"
+            checked={showCount}
+            onChange={(e) => setShowCount(e.target.checked)}
+            aria-label="Toggle card counting"
+          />{' '}
+          Card counting
+        </label>
+      </div>
+      {showCount && (
+        <div className="mb-2">Running count: {runningCount} True count: {trueCount.toFixed(2)}</div>
+      )}
+      <div className="mb-2">
+        <label>
+          <input
+            type="checkbox"
+            checked={showStrategy}
+            onChange={(e) => setShowStrategy(e.target.checked)}
+            aria-label="Toggle basic strategy helper"
+          />{' '}
+          Basic strategy
+        </label>
+      </div>
+      {showStrategy && strategy && <div className="mb-2">Strategy: {strategy}</div>}
+      {dealer.length > 0 && (
+        <Dealer hand={dealer} hideHoleCard={playerHands.some((h) => !h.isFinished)} />
+      )}
       <div className="space-y-2">
         {playerHands.map((h, idx) => (
           <PlayerHand key={idx} hand={h} active={idx === active} />
@@ -185,9 +330,13 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
         onStand={stand}
         onSplit={split}
         onDouble={doubleDown}
+        onSurrender={surrender}
+        onUndo={undo}
         onInsurance={takeInsurance}
         canSplit={!!canSplit}
         canDouble={canDouble}
+        canSurrender={!!canSurrender}
+        canUndo={canUndo}
         canInsurance={canInsurance}
         disabled={playerHands.length === 0}
       />

--- a/apps/blackjack/types.ts
+++ b/apps/blackjack/types.ts
@@ -7,4 +7,5 @@ export interface Hand {
   cards: Card[];
   bet: number;
   isFinished?: boolean;
+  surrendered?: boolean;
 }

--- a/components/apps/blackjack/engine.js
+++ b/components/apps/blackjack/engine.js
@@ -13,11 +13,13 @@ const buildDeck = () => {
   return deck;
 };
 
-const shuffleArray = (array) => {
+// Fisher–Yates shuffle used throughout tests and the app
+export const fisherYates = (array) => {
   for (let i = array.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]];
   }
+  return array;
 };
 
 export class Shoe {
@@ -33,7 +35,7 @@ export class Shoe {
     for (let i = 0; i < this.decks; i += 1) {
       this.cards.push(...buildDeck());
     }
-    shuffleArray(this.cards);
+    fisherYates(this.cards);
     this.shufflePoint = Math.floor(this.cards.length * this.penetration);
     this.dealt = 0;
     this.shuffleCount += 1;


### PR DESCRIPTION
## Summary
- add Fisher–Yates shuffle and uniformity test
- support multi-deck play, soft-17 rules, surrender, undo, and strategy hints
- simulate house edge under basic strategy

## Testing
- `yarn test`
- `yarn test __tests__/shuffle.test.ts __tests__/house-edge.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aabcf1c7748328a48e2a7dd105b315