### PR TITLE
feat: refresh hangman with frequency word list and scoring hints

### DIFF
--- a/public/wordlists/frequency.json
+++ b/public/wordlists/frequency.json
@@ -1,0 +1,38 @@
+{
+  "easy": [
+    {"word": "apple"},
+    {"word": "house"},
+    {"word": "water"},
+    {"word": "music"},
+    {"word": "chair"},
+    {"word": "green"},
+    {"word": "light"},
+    {"word": "phone"},
+    {"word": "train"},
+    {"word": "pizza"}
+  ],
+  "medium": [
+    {"word": "puzzle"},
+    {"word": "gadget"},
+    {"word": "forest"},
+    {"word": "rocket"},
+    {"word": "camera"},
+    {"word": "silver"},
+    {"word": "planet"},
+    {"word": "whisper"},
+    {"word": "jungle"},
+    {"word": "castle"}
+  ],
+  "hard": [
+    {"word": "xylophone"},
+    {"word": "quizzical"},
+    {"word": "zephyr"},
+    {"word": "mnemonic"},
+    {"word": "labyrinth"},
+    {"word": "sphinx"},
+    {"word": "paradox"},
+    {"word": "obfuscate"},
+    {"word": "axiom"},
+    {"word": "cryptic"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add general frequency-based word list free of offensive terms
- streamline Hangman to use difficulty-only selection
- keep keyboard controls and deduct score when using hints, cycling words without repeats

## Testing
- `CI=1 yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aabcf7f1088328b1b45a96325af88c