### PR TITLE
feat(minesweeper): add solver and board presets

### DIFF
--- a/apps/minesweeper/engine.ts
+++ b/apps/minesweeper/engine.ts
@@ -15,6 +15,14 @@ export const enum CellBits {
 
 const index = (g: MinesweeperGame, x: number, y: number) => x * g.width + y;
 
+export const PRESETS = {
+  beginner: { width: 9, height: 9, mines: 10 },
+  intermediate: { width: 16, height: 16, mines: 40 },
+  expert: { width: 30, height: 16, mines: 99 },
+} as const;
+
+export type PresetName = keyof typeof PRESETS;
+
 export const createGame = (
   width: number,
   height: number,
@@ -66,6 +74,15 @@ export const createGame = (
   return { width, height, mines, cells, revealedCount: 0 };
 };
 
+export const createPresetGame = (
+  preset: PresetName,
+  safeX: number,
+  safeY: number,
+): MinesweeperGame => {
+  const p = PRESETS[preset];
+  return createGame(p.width, p.height, p.mines, safeX, safeY);
+};
+
 export const adjacent = (g: MinesweeperGame, x: number, y: number) =>
   g.cells[index(g, x, y)] >> CellBits.AdjShift;
 
@@ -84,7 +101,72 @@ export const toggleFlag = (g: MinesweeperGame, x: number, y: number) => {
   g.cells[i] ^= CellBits.Flagged;
 };
 
-export const reveal = (
+export interface SolverAction {
+  x: number;
+  y: number;
+  flag: boolean;
+}
+
+const solveConstraints = (g: MinesweeperGame): SolverAction[] => {
+  const actions: Map<number, SolverAction> = new Map();
+  for (let x = 0; x < g.width; x++) {
+    for (let y = 0; y < g.height; y++) {
+      if (!isRevealed(g, x, y)) continue;
+      const adj = adjacent(g, x, y);
+      let flagged = 0;
+      const hidden: { x: number; y: number }[] = [];
+      for (let dx = -1; dx <= 1; dx++) {
+        for (let dy = -1; dy <= 1; dy++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < g.width && ny >= 0 && ny < g.height) {
+            if (isFlagged(g, nx, ny)) flagged++;
+            else if (!isRevealed(g, nx, ny)) hidden.push({ x: nx, y: ny });
+          }
+        }
+      }
+      if (!hidden.length) continue;
+      if (flagged === adj) {
+        for (const h of hidden) {
+          const id = index(g, h.x, h.y);
+          actions.set(id, { x: h.x, y: h.y, flag: false });
+        }
+      } else if (flagged + hidden.length === adj) {
+        for (const h of hidden) {
+          const id = index(g, h.x, h.y);
+          actions.set(id, { x: h.x, y: h.y, flag: true });
+        }
+      }
+    }
+  }
+  return Array.from(actions.values());
+};
+
+export function applySolver(g: MinesweeperGame): boolean {
+  let changed = false;
+  while (true) {
+    const actions = solveConstraints(g);
+    if (actions.length === 0) break;
+    changed = true;
+    for (const a of actions) {
+      if (a.flag) {
+        const i = index(g, a.x, a.y);
+        if (!(g.cells[i] & CellBits.Flagged)) g.cells[i] |= CellBits.Flagged;
+      } else {
+        revealCell(g, a.x, a.y);
+      }
+    }
+  }
+  return changed;
+}
+
+export const getHint = (g: MinesweeperGame): SolverAction | null => {
+  const actions = solveConstraints(g);
+  return actions.length > 0 ? actions[0] : null;
+};
+
+const revealCell = (
   g: MinesweeperGame,
   x: number,
   y: number,
@@ -102,12 +184,51 @@ export const reveal = (
         const nx = x + dx;
         const ny = y + dy;
         if (nx >= 0 && nx < g.width && ny >= 0 && ny < g.height) {
-          reveal(g, nx, ny);
+          revealCell(g, nx, ny);
         }
       }
     }
   }
   return false;
+};
+
+export const reveal = (
+  g: MinesweeperGame,
+  x: number,
+  y: number,
+): boolean => {
+  const hitMine = revealCell(g, x, y);
+  if (!hitMine) applySolver(g);
+  return hitMine;
+};
+
+export const chord = (
+  g: MinesweeperGame,
+  x: number,
+  y: number,
+): boolean => {
+  if (!isRevealed(g, x, y)) return false;
+  const adj = adjacent(g, x, y);
+  let flagged = 0;
+  const hidden: { x: number; y: number }[] = [];
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dy = -1; dy <= 1; dy++) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx >= 0 && nx < g.width && ny >= 0 && ny < g.height) {
+        if (isFlagged(g, nx, ny)) flagged++;
+        else if (!isRevealed(g, nx, ny)) hidden.push({ x: nx, y: ny });
+      }
+    }
+  }
+  if (flagged !== adj) return false;
+  let hit = false;
+  for (const h of hidden) {
+    hit = revealCell(g, h.x, h.y) || hit;
+  }
+  if (!hit) applySolver(g);
+  return hit;
 };
 
 export const isComplete = (g: MinesweeperGame) =>


### PR DESCRIPTION
## Summary
- support standard board presets for beginner/intermediate/expert games
- add constraint-based solver with hint generation and auto pattern clearing
- implement chord-click reveal for atomic neighbor expansion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabcf9374883288513f5c337fc497c