### PR TITLE
feat(reversi): add transposition search and UI heatmap

### DIFF
--- a/apps/reversi/engine.ts
+++ b/apps/reversi/engine.ts
@@ -10,65 +10,95 @@ export const enum Player {
 
 const FULL = 0xffffffffffffffffn;
 
-const DIRS: Array<[number, number]> = [
-  [1, 0],
-  [-1, 0],
-  [0, 1],
-  [0, -1],
-  [1, 1],
-  [1, -1],
-  [-1, 1],
-  [-1, -1],
-];
+const MASK_E = 0xfefefefefefefefen;
+const MASK_W = 0x7f7f7f7f7f7f7f7fn;
+const MASK_N = 0xffffffffffffff00n;
+const MASK_S = 0x00ffffffffffffffn;
+const MASK_NE = MASK_N & MASK_E;
+const MASK_NW = MASK_N & MASK_W;
+const MASK_SE = MASK_S & MASK_E;
+const MASK_SW = MASK_S & MASK_W;
+
+const shift = (bb: bigint, dir: number): bigint =>
+  dir > 0 ? ((bb << BigInt(dir)) & FULL) : ((bb >> BigInt(-dir)) & FULL);
 
 export const initialBoard = (): Board => ({
   black: (1n << 28n) | (1n << 35n),
   white: (1n << 27n) | (1n << 36n),
 });
 
-const bit = (index: number) => 1n << BigInt(index);
-
-const inBounds = (x: number, y: number) => x >= 0 && x < 8 && y >= 0 && y < 8;
-
 export const countBits = (bb: bigint): number => {
   let c = 0;
   let b = bb & FULL;
   while (b) {
     b &= b - 1n;
-    c++;
+    c += 1;
   }
   return c;
+};
+
+const movesDir = (
+  p: bigint,
+  o: bigint,
+  empty: bigint,
+  mask: bigint,
+  dir: number
+): bigint => {
+  const oMask = o & mask;
+  let m = oMask & shift(p, dir);
+  m |= oMask & shift(m, dir);
+  m |= oMask & shift(m, dir);
+  m |= oMask & shift(m, dir);
+  m |= oMask & shift(m, dir);
+  m |= oMask & shift(m, dir);
+  return empty & mask & shift(m, dir);
 };
 
 export const getMoves = (player: bigint, opponent: bigint): bigint => {
   const empty = ~(player | opponent) & FULL;
   let moves = 0n;
-  for (let i = 0; i < 64; i += 1) {
-    const m = bit(i);
-    if ((empty & m) === 0n) continue;
-    const x = i % 8;
-    const y = Math.floor(i / 8);
-    for (const [dx, dy] of DIRS) {
-      let cx = x + dx;
-      let cy = y + dy;
-      let seen = false;
-      while (inBounds(cx, cy)) {
-        const b = bit(cy * 8 + cx);
-        if ((opponent & b) !== 0n) {
-          seen = true;
-          cx += dx;
-          cy += dy;
-          continue;
-        }
-        if (seen && (player & b) !== 0n) {
-          moves |= m;
-        }
-        break;
-      }
-      if ((moves & m) !== 0n) break;
-    }
-  }
+  moves |= movesDir(player, opponent, empty, MASK_E, 1);
+  moves |= movesDir(player, opponent, empty, MASK_W, -1);
+  moves |= movesDir(player, opponent, empty, MASK_N, 8);
+  moves |= movesDir(player, opponent, empty, MASK_S, -8);
+  moves |= movesDir(player, opponent, empty, MASK_NE, 9);
+  moves |= movesDir(player, opponent, empty, MASK_NW, 7);
+  moves |= movesDir(player, opponent, empty, MASK_SE, -7);
+  moves |= movesDir(player, opponent, empty, MASK_SW, -9);
   return moves;
+};
+
+const flipDir = (
+  move: bigint,
+  p: bigint,
+  o: bigint,
+  mask: bigint,
+  dir: number
+): bigint => {
+  let flips = 0n;
+  let m = shift(move, dir) & mask;
+  while (m && (m & o)) {
+    flips |= m;
+    m = shift(m, dir) & mask;
+  }
+  return m & p ? flips : 0n;
+};
+
+export const flipsForMove = (
+  player: bigint,
+  opponent: bigint,
+  move: bigint
+): bigint => {
+  let flips = 0n;
+  flips |= flipDir(move, player, opponent, MASK_E, 1);
+  flips |= flipDir(move, player, opponent, MASK_W, -1);
+  flips |= flipDir(move, player, opponent, MASK_N, 8);
+  flips |= flipDir(move, player, opponent, MASK_S, -8);
+  flips |= flipDir(move, player, opponent, MASK_NE, 9);
+  flips |= flipDir(move, player, opponent, MASK_NW, 7);
+  flips |= flipDir(move, player, opponent, MASK_SE, -7);
+  flips |= flipDir(move, player, opponent, MASK_SW, -9);
+  return flips;
 };
 
 export const makeMove = (
@@ -76,82 +106,85 @@ export const makeMove = (
   opponent: bigint,
   move: bigint
 ): { player: bigint; opponent: bigint } => {
-  const idx = (() => {
-    for (let i = 0; i < 64; i += 1) {
-      if (move === bit(i)) return i;
-    }
-    return 0;
-  })();
-  const x = idx % 8;
-  const y = Math.floor(idx / 8);
-  let flips = 0n;
-  for (const [dx, dy] of DIRS) {
-    let cx = x + dx;
-    let cy = y + dy;
-    let path = 0n;
-    while (inBounds(cx, cy)) {
-      const b = bit(cy * 8 + cx);
-      if ((opponent & b) !== 0n) {
-        path |= b;
-        cx += dx;
-        cy += dy;
-        continue;
-      }
-      if ((player & b) !== 0n) {
-        flips |= path;
-      }
-      break;
-    }
-  }
-  const newPlayer = player | move | flips;
-  const newOpponent = opponent & ~flips;
-  return { player: newPlayer, opponent: newOpponent };
+  const flips = flipsForMove(player, opponent, move);
+  return { player: player | move | flips, opponent: opponent & ~flips };
 };
 
-const mobility = (player: bigint, opponent: bigint) =>
-  countBits(getMoves(player, opponent)) - countBits(getMoves(opponent, player));
+const mobility = (p: bigint, o: bigint) =>
+  countBits(getMoves(p, o)) - countBits(getMoves(o, p));
 
-const stability = (player: bigint, opponent: bigint) => {
-  const corners = [0, 7, 56, 63].map(bit);
+const stability = (p: bigint, o: bigint) => {
+  const corners = [0, 7, 56, 63].map((i) => 1n << BigInt(i));
   let score = 0;
   corners.forEach((c) => {
-    if (player & c) score += 1;
-    else if (opponent & c) score -= 1;
+    if (p & c) score += 1;
+    else if (o & c) score -= 1;
   });
   return score;
 };
 
-const parity = (player: bigint, opponent: bigint) => {
-  const empty = 64 - countBits(player | opponent);
+const parity = (p: bigint, o: bigint) => {
+  const empty = 64 - countBits(p | o);
   return empty % 2 === 0 ? 1 : -1;
 };
 
-const evaluate = (player: bigint, opponent: bigint) =>
-  10 * mobility(player, opponent) + 5 * stability(player, opponent) + parity(player, opponent);
+const evaluate = (p: bigint, o: bigint) =>
+  10 * mobility(p, o) + 25 * stability(p, o) + parity(p, o);
 
-export const negamax = (
-  player: bigint,
-  opponent: bigint,
+const enum TTFlag {
+  Exact,
+  Lower,
+  Upper,
+}
+
+interface TTEntry {
+  depth: number;
+  score: number;
+  flag: TTFlag;
+  move: bigint;
+}
+
+const tt = new Map<bigint, TTEntry>();
+
+const keyFor = (p: bigint, o: bigint) => ((p & FULL) << 64n) | (o & FULL);
+
+const negamaxSearch = (
+  p: bigint,
+  o: bigint,
   depth: number,
-  alpha = -Infinity,
-  beta = Infinity
+  alpha: number,
+  beta: number
 ): { score: number; move: bigint } => {
-  const moves = getMoves(player, opponent);
+  const key = keyFor(p, o);
+  const entry = tt.get(key);
+  if (entry && entry.depth >= depth) {
+    if (entry.flag === TTFlag.Exact) {
+      return { score: entry.score, move: entry.move };
+    }
+    if (entry.flag === TTFlag.Lower) {
+      alpha = Math.max(alpha, entry.score);
+    } else if (entry.flag === TTFlag.Upper) {
+      beta = Math.min(beta, entry.score);
+    }
+    if (alpha >= beta) {
+      return { score: entry.score, move: entry.move };
+    }
+  }
+
+  const moves = getMoves(p, o);
   if (depth === 0 || moves === 0n) {
-    const score = evaluate(player, opponent);
+    const score = evaluate(p, o);
     return { score, move: 0n };
   }
+
   let bestMove = 0n;
   let bestScore = -Infinity;
+  const alphaOrig = alpha;
   let m = moves;
   while (m) {
     const move = m & -m;
-    const { player: newPlayer, opponent: newOpponent } = makeMove(
-      player,
-      opponent,
-      move
-    );
-    const { score } = negamax(newOpponent, newPlayer, depth - 1, -beta, -alpha);
+    const { player: np, opponent: no } = makeMove(p, o, move);
+    const { score } = negamaxSearch(no, np, depth - 1, -beta, -alpha);
     const val = -score;
     if (val > bestScore) {
       bestScore = val;
@@ -161,5 +194,33 @@ export const negamax = (
     if (alpha >= beta) break;
     m ^= move;
   }
+
+  let flag: TTFlag;
+  if (bestScore <= alphaOrig) flag = TTFlag.Upper;
+  else if (bestScore >= beta) flag = TTFlag.Lower;
+  else flag = TTFlag.Exact;
+  tt.set(key, { depth, score: bestScore, flag, move: bestMove });
   return { score: bestScore, move: bestMove };
+};
+
+export const negamax = (
+  player: bigint,
+  opponent: bigint,
+  depth: number
+): { score: number; move: bigint } => {
+  let result = { score: 0, move: 0n };
+  for (let d = 1; d <= depth; d += 1) {
+    result = negamaxSearch(player, opponent, d, -Infinity, Infinity);
+  }
+  return result;
+};
+
+export const bitIndex = (bb: bigint): number => {
+  let idx = 0;
+  let b = bb;
+  while (b > 1n) {
+    b >>= 1n;
+    idx += 1;
+  }
+  return idx;
 };

--- a/apps/reversi/index.tsx
+++ b/apps/reversi/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   initialBoard,
   getMoves,
@@ -6,16 +6,34 @@ import {
   negamax,
   Player,
   countBits,
+  flipsForMove,
+  bitIndex,
 } from './engine';
 
 const Reversi: React.FC = () => {
   const [board, setBoard] = useState(initialBoard());
   const [turn, setTurn] = useState<Player>(Player.Black);
   const [hint, setHint] = useState<bigint | null>(null);
+  const [hoverFlips, setHoverFlips] = useState<bigint>(0n);
+  const [heatmap, setHeatmap] = useState<Record<number, number>>({});
 
   const playerBits = turn === Player.Black ? board.black : board.white;
   const oppBits = turn === Player.Black ? board.white : board.black;
   const moves = getMoves(playerBits, oppBits);
+
+  useEffect(() => {
+    const h: Record<number, number> = {};
+    let m = moves;
+    while (m) {
+      const move = m & -m;
+      const idx = bitIndex(move);
+      const { player, opponent } = makeMove(playerBits, oppBits, move);
+      const { score } = negamax(opponent, player, 4);
+      h[idx] = -score;
+      m ^= move;
+    }
+    setHeatmap(h);
+  }, [board, turn]);
 
   const handleClick = (idx: number) => {
     const m = 1n << BigInt(idx);
@@ -31,9 +49,17 @@ const Reversi: React.FC = () => {
   };
 
   const showHint = () => {
-    const { move } = negamax(playerBits, oppBits, 3);
+    const { move } = negamax(playerBits, oppBits, 8);
     setHint(move === 0n ? null : move);
   };
+
+  const handleHover = (idx: number) => {
+    const m = 1n << BigInt(idx);
+    if ((moves & m) === 0n) return;
+    setHoverFlips(flipsForMove(playerBits, oppBits, m));
+  };
+
+  const clearHover = () => setHoverFlips(0n);
 
   const renderSquare = (idx: number) => {
     const b = 1n << BigInt(idx);
@@ -41,14 +67,29 @@ const Reversi: React.FC = () => {
     const hasWhite = (board.white & b) !== 0n;
     const isHint = hint === b;
     const isMove = (moves & b) !== 0n;
+    const isFlip = (hoverFlips & b) !== 0n;
+    const score = heatmap[idx];
+    const color =
+      score !== undefined
+        ? `rgba(${score < 0 ? 255 : 0}, ${score > 0 ? 255 : 0}, 0, ${Math.min(
+            Math.abs(score) / 100,
+            1
+          )})`
+        : undefined;
     return (
       <div
         key={idx}
         onClick={() => handleClick(idx)}
-        className={`w-10 h-10 flex items-center justify-center bg-green-700 border border-green-800 ${
+        onMouseEnter={() => handleHover(idx)}
+        onMouseLeave={clearHover}
+        className={`relative w-10 h-10 flex items-center justify-center bg-green-700 border border-green-800 ${
           isHint ? 'ring-4 ring-yellow-400' : ''
         }`}
       >
+        {color && !hasBlack && !hasWhite && (
+          <div className="absolute inset-0" style={{ backgroundColor: color }} />
+        )}
+        {isFlip && <div className="absolute inset-0 bg-yellow-300 opacity-50" />}
         {hasBlack && <div className="w-8 h-8 rounded-full bg-black" />}
         {hasWhite && <div className="w-8 h-8 rounded-full bg-white" />}
         {!hasBlack && !hasWhite && isMove && (


### PR DESCRIPTION
## Summary
- implement bitboard-based move/flip logic with transposition table and iterative deepening search
- expose mobility & corner heuristics and depth-8 hinting
- highlight flip previews and move evaluation heatmap in Reversi UI

## Testing
- `yarn test apps/reversi --passWithNoTests`
- `node - <<'NODE'
const {initialBoard, negamax} = require('/tmp/reversi/engine.js');
const b = initialBoard();
negamax(b.black, b.white, 8);
console.time('depth8');
negamax(b.black, b.white, 8);
console.timeEnd('depth8');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68aabcfbd69883288fdeb23dbd7e6833