### PR TITLE
feat(flappy-bird): add pooled engine with tap control

### DIFF
--- a/apps/flappy-bird/background.js
+++ b/apps/flappy-bird/background.js
@@ -1,16 +1,34 @@
 export default class Background {
-  constructor(width, height) {
+  constructor(width, height, theme = 'day') {
     this.width = width;
     this.height = height;
-    this.layers = [
-      { speed: 0.5, offset: 0, height: 40, color: '#7ec850' },
-      { speed: 1, offset: 0, height: 20, color: '#4caf50' },
-    ];
+    this.themes = {
+      day: {
+        sky: '#87CEEB',
+        layers: [
+          { speed: 0.5, offset: 0, height: 40, color: '#7ec850' },
+          { speed: 1, offset: 0, height: 20, color: '#4caf50' },
+        ],
+      },
+      night: {
+        sky: '#0d1b2a',
+        layers: [
+          { speed: 0.5, offset: 0, height: 40, color: '#264653' },
+          { speed: 1, offset: 0, height: 20, color: '#2a9d8f' },
+        ],
+      },
+    };
+    this.setTheme(theme);
   }
 
-  update() {
+  setTheme(theme) {
+    this.theme = this.themes[theme] ? theme : 'day';
+    this.layers = this.themes[this.theme].layers.map((l) => ({ ...l }));
+  }
+
+  update(dt = 1) {
     this.layers.forEach((layer) => {
-      layer.offset -= layer.speed;
+      layer.offset -= layer.speed * dt;
       if (layer.offset <= -this.width) {
         layer.offset += this.width;
       }
@@ -18,7 +36,7 @@ export default class Background {
   }
 
   draw(ctx) {
-    ctx.fillStyle = '#87CEEB';
+    ctx.fillStyle = this.themes[this.theme].sky;
     ctx.fillRect(0, 0, this.width, this.height);
     this.layers.forEach((layer) => {
       ctx.fillStyle = layer.color;

--- a/apps/flappy-bird/bird.js
+++ b/apps/flappy-bird/bird.js
@@ -4,7 +4,8 @@ export default class Bird {
     this.y = y;
     this.vy = 0;
     this.gravity = gravity;
-    this.radius = 10;
+    this.width = 20;
+    this.height = 20;
     this.skin = skin;
   }
 
@@ -12,10 +13,19 @@ export default class Bird {
     this.vy = force;
   }
 
-  update(reverse = false) {
+  update(reverse = false, dt = 1) {
     const g = reverse ? -this.gravity : this.gravity;
-    this.vy += g;
-    this.y += this.vy;
+    this.vy += g * dt;
+    this.y += this.vy * dt;
+  }
+
+  get bounds() {
+    return {
+      left: this.x - this.width / 2,
+      right: this.x + this.width / 2,
+      top: this.y - this.height / 2,
+      bottom: this.y + this.height / 2,
+    };
   }
 
   setSkin(color) {
@@ -24,8 +34,11 @@ export default class Bird {
 
   draw(ctx) {
     ctx.fillStyle = this.skin;
-    ctx.beginPath();
-    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.fillRect(
+      this.x - this.width / 2,
+      this.y - this.height / 2,
+      this.width,
+      this.height
+    );
   }
 }

--- a/apps/flappy-bird/pipe.js
+++ b/apps/flappy-bird/pipe.js
@@ -1,23 +1,34 @@
 export default class Pipe {
   constructor(x, gap, width, canvasHeight, speed = 2) {
-    this.x = x;
-    this.gap = gap;
     this.width = width;
     this.canvasHeight = canvasHeight;
     this.speed = speed;
-    const top = Math.random() * (canvasHeight - gap - 40) + 20;
-    this.top = top;
-    this.bottom = top + gap;
+    this.baseGap = gap;
+    this.reset(x);
   }
 
-  update() {
-    this.x -= this.speed;
+  reset(x) {
+    this.x = x;
+    const gap = this.baseGap + Math.random() * 40 - 20;
+    const top = Math.random() * (this.canvasHeight - gap - 40) + 20;
+    this.top = top;
+    this.bottom = top + gap;
+    this.passed = false;
+  }
+
+  update(dt = 1) {
+    this.x -= this.speed * dt;
   }
 
   draw(ctx) {
     ctx.fillStyle = '#228B22';
     ctx.fillRect(this.x, 0, this.width, this.top);
-    ctx.fillRect(this.x, this.bottom, this.width, this.canvasHeight - this.bottom);
+    ctx.fillRect(
+      this.x,
+      this.bottom,
+      this.width,
+      this.canvasHeight - this.bottom
+    );
   }
 
   isOffscreen() {
@@ -25,9 +36,8 @@ export default class Pipe {
   }
 
   collides(bird) {
-    if (this.x > bird.x + bird.radius || this.x + this.width < bird.x - bird.radius) {
-      return false;
-    }
-    return bird.y - bird.radius < this.top || bird.y + bird.radius > this.bottom;
+    const b = bird.bounds;
+    if (b.right < this.x || b.left > this.x + this.width) return false;
+    return b.top < this.top || b.bottom > this.bottom;
   }
 }


### PR DESCRIPTION
## Summary
- improve flappy-bird engine with time-scaled physics and AABB collisions
- recycle pipes with procedural gaps and centerline scoring
- add tap controls and themed parallax backgrounds

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aabd081f248328a8e85d0d956365fb