### PR TITLE
feat: expand favicon hash tool

### DIFF
--- a/pages/api/favicon.ts
+++ b/pages/api/favicon.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withErrorHandler, UserInputError, UpstreamError } from '../../lib/errors';
+import { setupUrlGuard } from '../../lib/urlGuard';
+
+setupUrlGuard();
+
+export default withErrorHandler(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    throw new UserInputError('Method not allowed');
+  }
+
+  const { url } = req.query;
+  if (!url || typeof url !== 'string') {
+    throw new UserInputError('Missing url');
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new UpstreamError(`HTTP ${response.status}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const base64 = buffer.toString('base64');
+  const mime = response.headers.get('content-type') || 'application/octet-stream';
+
+  res.status(200).json({
+    ok: true,
+    base64,
+    size: buffer.length,
+    mime,
+  });
+});


### PR DESCRIPTION
## Summary
- allow favicon hashing from URL, file or data URI inputs
- add `/api/favicon` proxy returning base64 data, size and mime
- show mmh3 hash details with Censys and VirusTotal search links

## Testing
- `yarn test apps/favicon-hash/index.tsx pages/api/favicon.ts --passWithNoTests`
- `yarn lint` *(fails: Parsing error in components/apps/breakout.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aac1e7f474832894fa39abc790bd92