### PR TITLE
feat: enhance CVE dashboard

### DIFF
--- a/apps/cve-dashboard/index.tsx
+++ b/apps/cve-dashboard/index.tsx
@@ -1,144 +1,193 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import Papa from 'papaparse';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import { useRouter } from 'next/router';
 
-type ExploitInfo = {
+interface ExploitInfo {
   id: string;
   file: string;
   description: string;
   source_url: string;
-};
+}
 
-type Vulnerability = {
+interface Vulnerability {
   cve: {
     id: string;
     published?: string;
     descriptions?: { lang: string; value: string }[];
     metrics?: any;
   };
+  kev: boolean;
+  epss: number | null;
+  severity?: string;
   exploits: ExploitInfo[];
-};
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+function riskColor(v: Vulnerability): string {
+  if (v.kev) return 'bg-red-900';
+  if ((v.epss ?? 0) > 0.5) return 'bg-orange-900';
+  switch (v.severity) {
+    case 'critical':
+      return 'bg-red-800';
+    case 'high':
+      return 'bg-red-700';
+    case 'medium':
+      return 'bg-yellow-700';
+    case 'low':
+      return 'bg-green-700';
+    default:
+      return '';
+  }
+}
 
 const CveDashboard: React.FC = () => {
+  const router = useRouter();
   const [keyword, setKeyword] = useState('');
+  const [cpe, setCpe] = useState('');
+  const [cwe, setCwe] = useState('');
   const [recent, setRecent] = useState(30);
-  const [page, setPage] = useState(1);
-  const [total, setTotal] = useState(0);
-  const [vulns, setVulns] = useState<Vulnerability[]>([]);
-  const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<Vulnerability | null>(null);
+  const [views, setViews] = useState<Record<string, any>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('cve_views') || '') || {};
+    } catch {
+      return {};
+    }
+  });
 
-  const fetchData = () => {
-    setLoading(true);
-    fetch(`/api/cve?keyword=${encodeURIComponent(keyword)}&recent=${recent}&page=${page}`)
-      .then((r) => r.json())
-      .then((d) => {
-        setVulns(d.vulnerabilities || []);
-        setTotal(d.totalResults || 0);
-      })
-      .catch(() => {
-        setVulns([]);
-        setTotal(0);
-      })
-      .finally(() => setLoading(false));
-  };
-
+  // Load from query for deep links
   useEffect(() => {
-    fetchData();
+    if (!router.isReady) return;
+    setKeyword((router.query.keyword as string) || '');
+    setCpe((router.query.cpe as string) || '');
+    setCwe((router.query.cwe as string) || '');
+    if (router.query.recent) setRecent(parseInt(router.query.recent as string, 10));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page]);
+  }, [router.isReady]);
 
-  const onSearch = () => {
-    setPage(1);
-    fetchData();
+  // Update URL when filters change
+  useEffect(() => {
+    const query: any = { keyword, cpe, cwe, recent };
+    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
+  }, [keyword, cpe, cwe, recent, router]);
+
+  const params = useMemo(() => {
+    const p = new URLSearchParams({ keyword, cpe, cwe, recent: String(recent), pageSize: '200', sort: 'epss' });
+    return p.toString();
+  }, [keyword, cpe, cwe, recent]);
+
+  const { data } = useSWR(`/api/cve?${params}`, fetcher, { revalidateOnFocus: false });
+  const vulns: Vulnerability[] = data?.vulnerabilities || [];
+
+  const exportCsv = () => {
+    const rows = vulns.map((v) => ({
+      id: v.cve.id,
+      description: v.cve.descriptions?.[0]?.value || '',
+      severity: v.severity || '',
+      epss: v.epss ?? '',
+      kev: v.kev ? 'yes' : 'no',
+    }));
+    const csv = Papa.unparse(rows);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'vulnerabilities.csv';
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
-  const totalPages = Math.ceil(total / 20);
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(vulns, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'vulnerabilities.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const saveView = () => {
+    const name = prompt('View name?');
+    if (!name) return;
+    const newViews = { ...views, [name]: { keyword, cpe, cwe, recent } };
+    setViews(newViews);
+    localStorage.setItem('cve_views', JSON.stringify(newViews));
+  };
+
+  const loadView = (name: string) => {
+    const v = views[name];
+    if (!v) return;
+    setKeyword(v.keyword);
+    setCpe(v.cpe);
+    setCwe(v.cwe);
+    setRecent(v.recent);
+  };
+
+  const Row = ({ index, style }: ListChildComponentProps) => {
+    const v = vulns[index];
+    return (
+      <div
+        style={style}
+        className={`grid grid-cols-4 gap-2 px-2 py-1 border-b border-gray-700 text-sm cursor-pointer ${riskColor(v)}`}
+        onClick={() => setSelected(v)}
+      >
+        <div className="truncate">{v.cve.id}</div>
+        <div className="truncate">{v.cve.descriptions?.[0]?.value}</div>
+        <div>{v.epss ?? ''}</div>
+        <div>{v.kev ? '✔' : ''}</div>
+      </div>
+    );
+  };
 
   return (
     <div className="p-4 text-white space-y-4">
-      <div className="flex space-x-2">
-        <input
-          value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
-          placeholder="Keyword"
-          className="px-2 py-1 bg-gray-800 rounded"
-        />
-        <input
-          type="number"
-          value={recent}
-          onChange={(e) => setRecent(parseInt(e.target.value))}
-          className="px-2 py-1 bg-gray-800 rounded w-24"
-        />
-        <button onClick={onSearch} className="px-3 py-1 bg-blue-600 rounded">
-          Search
-        </button>
+      <div className="flex flex-wrap gap-2 items-center">
+        <input value={keyword} onChange={(e) => setKeyword(e.target.value)} placeholder="Keyword" className="px-2 py-1 bg-gray-800 rounded" />
+        <input value={cpe} onChange={(e) => setCpe(e.target.value)} placeholder="CPE" className="px-2 py-1 bg-gray-800 rounded" />
+        <input value={cwe} onChange={(e) => setCwe(e.target.value)} placeholder="CWE" className="px-2 py-1 bg-gray-800 rounded" />
+        <input type="number" value={recent} onChange={(e) => setRecent(parseInt(e.target.value, 10))} className="px-2 py-1 bg-gray-800 rounded w-24" />
+        <button onClick={exportCsv} className="px-3 py-1 bg-blue-600 rounded">CSV</button>
+        <button onClick={exportJson} className="px-3 py-1 bg-blue-600 rounded">JSON</button>
+        <button onClick={saveView} className="px-3 py-1 bg-gray-700 rounded">Save View</button>
+        <select onChange={(e) => loadView(e.target.value)} className="bg-gray-800 px-2 py-1 rounded">
+          <option value="">Load View</option>
+          {Object.keys(views).map((n) => (
+            <option key={n}>{n}</option>
+          ))}
+        </select>
       </div>
-      {loading ? (
-        <div>Loading...</div>
-      ) : (
-        <div className="overflow-auto">
-          <table className="min-w-full text-left text-sm">
-            <thead>
-              <tr className="bg-gray-800">
-                <th className="p-2">CVE</th>
-                <th className="p-2">Description</th>
-                <th className="p-2">Published</th>
-              </tr>
-            </thead>
-            <tbody>
-              {vulns.map((v) => (
-                <tr
-                  key={v.cve.id}
-                  className="hover:bg-gray-700 cursor-pointer"
-                  onClick={() => setSelected(v)}
-                >
-                  <td className="p-2 whitespace-nowrap">{v.cve.id}</td>
-                  <td className="p-2">{v.cve.descriptions?.[0]?.value}</td>
-                  <td className="p-2 whitespace-nowrap">
-                    {v.cve.published ? new Date(v.cve.published).toISOString().split('T')[0] : ''}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-      <div className="flex justify-between items-center">
-        <button
-          className="px-3 py-1 bg-gray-800 rounded disabled:opacity-50"
-          disabled={page <= 1}
-          onClick={() => setPage((p) => Math.max(1, p - 1))}
-        >
-          Prev
-        </button>
-        <span>
-          Page {page} / {totalPages || 1}
-        </span>
-        <button
-          className="px-3 py-1 bg-gray-800 rounded disabled:opacity-50"
-          disabled={page >= totalPages}
-          onClick={() => setPage((p) => p + 1)}
-        >
-          Next
-        </button>
+      <div className="grid grid-cols-4 gap-2 font-bold bg-gray-800 px-2 py-1 text-sm">
+        <div>CVE</div>
+        <div>Description</div>
+        <div>EPSS</div>
+        <div>KEV</div>
+      </div>
+      <div style={{ height: '60vh' }} className="bg-gray-900 overflow-hidden">
+        <List height={350} itemCount={vulns.length} itemSize={40} width={'100%'}>
+          {Row}
+        </List>
       </div>
       {selected && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-gray-900 p-4 rounded w-11/12 md:w-2/3 lg:w-1/2 space-y-2 max-h-[80vh] overflow-y-auto">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-end">
+          <div className="bg-gray-900 w-full md:w-1/2 lg:w-1/3 p-4 space-y-2 overflow-y-auto">
             <h2 className="text-xl font-bold">{selected.cve.id}</h2>
             <p>{selected.cve.descriptions?.[0]?.value}</p>
             <p>Published: {selected.cve.published}</p>
+            <p>CVSS v3.1: {selected.cve.metrics?.cvssMetricV31?.[0]?.cvssData?.baseScore ?? 'N/A'}</p>
+            <p>CVSS v4: {selected.cve.metrics?.cvssMetricV40?.[0]?.cvssData?.baseScore ?? 'N/A'}</p>
+            <p>EPSS: {selected.epss ?? 'N/A'}</p>
+            <p>KEV: {selected.kev ? 'Yes' : 'No'}</p>
             {selected.exploits.length > 0 ? (
               <div>
                 <h3 className="font-semibold">Exploits</h3>
-                <ul className="list-disc list-inside">
+                <ul className="list-disc list-inside space-y-1">
                   {selected.exploits.map((e) => (
                     <li key={e.id}>
-                      <a
-                        href={e.source_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-400 underline"
-                      >
+                      <a href={e.source_url} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">
                         {e.description}
                       </a>
                     </li>
@@ -159,4 +208,3 @@ const CveDashboard: React.FC = () => {
 };
 
 export default CveDashboard;
-


### PR DESCRIPTION
## Summary
- support CPE and CWE filters in CVE API and dashboard
- add risk visualization, virtualized list, exports, and saved views
- show CVSS v3.1/v4 details in right-hand drawer

## Testing
- `yarn lint --file apps/cve-dashboard/index.tsx`
- `yarn test apps/cve-dashboard --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aac1e88c788328be0f34755c7c6bfe