### PR TITLE
feat(pcap-viewer): stream packets in wasm worker and add analysis tools

### DIFF
--- a/apps/pcap-viewer/index.tsx
+++ b/apps/pcap-viewer/index.tsx
@@ -1,38 +1,68 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { FixedSizeList as List } from 'react-window';
+import { Bar } from 'react-chartjs-2';
+import 'chart.js/auto';
 
 const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
-type FlowInfo = { flow: string; start: number; end: number };
-type PacketInfo = { flow: string; proto: string; data: Uint8Array };
-type ParseResult = { flows: FlowInfo[]; protocols: Record<string, number>; packets: PacketInfo[] };
+export type PacketInfo = {
+  index: number;
+  ts: number;
+  proto: string;
+  src: string;
+  dst: string;
+  src_port: number;
+  dst_port: number;
+  data: number[];
+};
+
+type Summary = {
+  protocols: Record<string, number>;
+  malformed: number;
+};
+
+const protocolsList = ['TCP', 'UDP', 'DNS', 'HTTP', 'OTHER'];
 
 const PcapViewer: React.FC = () => {
   const [worker, setWorker] = useState<Worker | null>(null);
-  const [flows, setFlows] = useState<FlowInfo[]>([]);
-  const [protocols, setProtocols] = useState<Record<string, number>>({});
   const [packets, setPackets] = useState<PacketInfo[]>([]);
-  const [filter, setFilter] = useState('');
+  const [summary, setSummary] = useState<Summary>({ protocols: {}, malformed: 0 });
+  const [filters, setFilters] = useState<Record<string, boolean>>({
+    TCP: true,
+    UDP: true,
+    DNS: true,
+    HTTP: true,
+    OTHER: true,
+  });
   const [error, setError] = useState('');
-  const [selected, setSelected] = useState<PacketInfo | null>(null);
+  const [sliceStart, setSliceStart] = useState(0);
+  const [sliceEnd, setSliceEnd] = useState(0);
+  const [timeRange, setTimeRange] = useState<[number, number]>([0, 0]);
 
   useEffect(() => {
     const w = new Worker(new URL('./parserWorker.ts', import.meta.url));
     w.onmessage = (e) => {
-      const { type, result, error } = e.data;
-      if (type === 'result') {
-        const r: ParseResult = result;
-        setFlows(r.flows);
-        setProtocols(r.protocols);
-        setPackets(r.packets);
-        setSelected(null);
-        setError('');
+      const { type } = e.data;
+      if (type === 'summary') {
+        setSummary({ protocols: e.data.protocols, malformed: e.data.malformed });
+      } else if (type === 'packet') {
+        setPackets((prev) => [...prev, ...e.data.packets]);
       } else if (type === 'error') {
-        setError(error);
+        setError(e.data.error);
       }
     };
     setWorker(w);
     return () => w.terminate();
   }, []);
+
+  useEffect(() => {
+    if (packets.length > 0 && timeRange[1] === 0) {
+      const times = packets.map((p) => p.ts);
+      const min = Math.min(...times);
+      const max = Math.max(...times);
+      setTimeRange([min, max]);
+    }
+  }, [packets, timeRange]);
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -41,28 +71,64 @@ const PcapViewer: React.FC = () => {
       setError('File too large');
       return;
     }
+    setPackets([]);
+    setSummary({ protocols: {}, malformed: 0 });
     const buffer = new Uint8Array(await file.arrayBuffer());
     worker.postMessage({ type: 'parse', buffer }, { transfer: [buffer.buffer] });
   };
 
-  const matchesFilter = (p: PacketInfo) => {
-    const q = filter.toLowerCase();
-    if (q.startsWith('proto:')) return p.proto.toLowerCase() === q.slice(6);
-    if (q.startsWith('flow:')) return p.flow.toLowerCase().includes(q.slice(5));
-    return p.flow.toLowerCase().includes(q) || p.proto.toLowerCase().includes(q);
+  const toggleFilter = (proto: string) => {
+    setFilters((f) => ({ ...f, [proto]: !f[proto] }));
   };
 
-  const filteredPackets = packets.filter(matchesFilter);
+  const filteredPackets = useMemo(
+    () =>
+      packets.filter(
+        (p) =>
+          filters[p.proto] &&
+          p.ts >= timeRange[0] &&
+          (timeRange[1] === 0 || p.ts <= timeRange[1])
+      ),
+    [packets, filters, timeRange]
+  );
 
-  const downloadFiltered = () => {
-    const data = JSON.stringify(
-      filteredPackets.map((p) => ({ flow: p.flow, proto: p.proto, data: Array.from(p.data) }))
-    );
-    const blob = new Blob([data], { type: 'application/json' });
+  const times = useMemo(() => filteredPackets.map((p) => p.ts), [filteredPackets]);
+  const histData = useMemo(() => {
+    if (times.length === 0) return { labels: [], datasets: [] };
+    const min = Math.min(...times);
+    const max = Math.max(...times);
+    const bins = 20;
+    const step = (max - min) / bins || 1;
+    const counts = new Array(bins).fill(0);
+    times.forEach((t) => {
+      const idx = Math.min(Math.floor((t - min) / step), bins - 1);
+      counts[idx]++;
+    });
+    const labels = new Array(bins)
+      .fill(0)
+      .map((_, i) => ((min + i * step) / 1_000_000).toFixed(2));
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Packets',
+          data: counts,
+          backgroundColor: 'rgba(54,162,235,0.5)',
+        },
+      ],
+    };
+  }, [times]);
+
+  const exportSlice = () => {
+    const start = Math.max(0, sliceStart);
+    const end = Math.min(packets.length, sliceEnd);
+    if (end <= start) return;
+    const slice = packets.slice(start, end);
+    const blob = new Blob([JSON.stringify(slice)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'filtered.json';
+    a.download = 'packets.json';
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -71,41 +137,68 @@ const PcapViewer: React.FC = () => {
     <div className="p-2 text-white bg-ub-cool-grey h-full overflow-auto text-xs">
       <input type="file" accept=".pcap,.pcapng" onChange={handleFile} disabled={!worker} className="mb-2" />
       {error && <div className="text-red-500 mb-2">{error}</div>}
-      <input
-        type="text"
-        placeholder="Filter (proto:tcp or flow:1.2.3.4)"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        className="mb-2 w-full text-black px-1"
-      />
-      <button onClick={downloadFiltered} className="mb-2 px-2 py-1 bg-ub-blue text-white">
-        Download Filtered
-      </button>
       <div className="mb-2">
-        {Object.entries(protocols).map(([p, c]) => (
-          <span key={p} className="mr-2">{p}: {c}</span>
+        {protocolsList.map((p) => (
+          <label key={p} className="mr-2">
+            <input type="checkbox" checked={filters[p]} onChange={() => toggleFilter(p)} /> {p}
+          </label>
         ))}
       </div>
-      <ul>
-        {filteredPackets.map((p, i) => (
-          <li key={i} className="mb-1 cursor-pointer" onClick={() => setSelected(p)}>
-            {p.flow} [{p.proto}]
-          </li>
-        ))}
-      </ul>
-      {selected && (
-        <div className="mt-2">
-          <div className="mb-1">Hex:</div>
-          <pre className="overflow-x-auto">
-            {Array.from(selected.data)
-              .map((b) => b.toString(16).padStart(2, '0'))
-              .join(' ')}
-          </pre>
-        </div>
-      )}
+      <div className="mb-2">
+        Malformed packets: {summary.malformed}
+      </div>
+      <div className="mb-2">
+        <Bar data={histData} options={{ responsive: true, plugins: { legend: { display: false } } }} />
+        {timeRange[1] > timeRange[0] && (
+          <div className="flex mt-1">
+            <input
+              type="range"
+              min={timeRange[0]}
+              max={timeRange[1]}
+              value={timeRange[0]}
+              onChange={(e) => setTimeRange([Number(e.target.value), timeRange[1]])}
+              className="flex-1 mr-1"
+            />
+            <input
+              type="range"
+              min={timeRange[0]}
+              max={timeRange[1]}
+              value={timeRange[1]}
+              onChange={(e) => setTimeRange([timeRange[0], Number(e.target.value)])}
+              className="flex-1"
+            />
+          </div>
+        )}
+      </div>
+      <List height={300} itemCount={filteredPackets.length} itemSize={20} width={'100%'} className="border mb-2">
+        {({ index, style }) => {
+          const p = filteredPackets[index];
+          return (
+            <div style={style} className="whitespace-nowrap overflow-hidden px-1">
+              #{p.index} {p.src}:{p.src_port} -> {p.dst}:{p.dst_port} [{p.proto}]
+            </div>
+          );
+        }}
+      </List>
+      <div className="flex items-center mb-2">
+        <input
+          type="number"
+          value={sliceStart}
+          onChange={(e) => setSliceStart(Number(e.target.value))}
+          className="text-black mr-1 px-1 w-20"
+        />
+        <input
+          type="number"
+          value={sliceEnd}
+          onChange={(e) => setSliceEnd(Number(e.target.value))}
+          className="text-black mr-1 px-1 w-20"
+        />
+        <button onClick={exportSlice} className="px-2 py-1 bg-ub-blue text-white">
+          Export Slice
+        </button>
+      </div>
     </div>
   );
 };
 
 export default PcapViewer;
-

--- a/apps/pcap-viewer/parserWorker.ts
+++ b/apps/pcap-viewer/parserWorker.ts
@@ -1,13 +1,20 @@
 // Web Worker for parsing pcap/pcapng files using WASM parser
 
+const BATCH_SIZE = 200;
+
 self.onmessage = async (e: MessageEvent) => {
   if (e.data.type === 'parse') {
     try {
       // @ts-ignore - generated at build time
       const mod = await import(/* webpackIgnore: true */ './pcap-wasm/pkg/pcap_wasm.js');
       await mod.default();
-      const result = mod.parse_pcap(new Uint8Array(e.data.buffer));
-      (self as any).postMessage({ type: 'result', result });
+      const { packets, protocols, malformed } = mod.parse_pcap(new Uint8Array(e.data.buffer));
+      (self as any).postMessage({ type: 'summary', protocols, malformed });
+      for (let i = 0; i < packets.length; i += BATCH_SIZE) {
+        const batch = packets.slice(i, i + BATCH_SIZE);
+        (self as any).postMessage({ type: 'packet', packets: batch });
+      }
+      (self as any).postMessage({ type: 'done' });
     } catch (err: any) {
       (self as any).postMessage({ type: 'error', error: err.toString() });
     }

--- a/apps/pcap-viewer/pcap-wasm/src/lib.rs
+++ b/apps/pcap-viewer/pcap-wasm/src/lib.rs
@@ -2,107 +2,117 @@ use wasm_bindgen::prelude::*;
 use pcap_parser::{create_reader, PcapBlockOwned};
 use pcap_parser::pcapng::Block;
 use pcap_parser::traits::PcapNGPacketBlock;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Cursor;
-use serde::Serialize;
-
-#[derive(Serialize)]
-pub struct FlowInfo {
-    flow: String,
-    start: u32,
-    end: u32,
-}
 
 #[derive(Serialize)]
 pub struct PacketInfo {
-    flow: String,
+    index: u32,
+    ts: u64,
     proto: String,
+    src: String,
+    dst: String,
+    src_port: u16,
+    dst_port: u16,
     data: Vec<u8>,
 }
 
 #[derive(Serialize)]
 pub struct ParseResult {
-    flows: Vec<FlowInfo>,
-    protocols: HashMap<String, u32>,
     packets: Vec<PacketInfo>,
+    protocols: HashMap<String, u32>,
+    malformed: u32,
+}
+
+fn classify_packet(packet: &[u8], index: u32, ts: u64) -> Option<PacketInfo> {
+    if packet.len() < 34 || packet[12] != 0x08 || packet[13] != 0x00 {
+        return None;
+    }
+    let proto = packet[23];
+    if packet.len() < 38 {
+        return None;
+    }
+    let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
+    let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
+    let src_port = u16::from_be_bytes([packet[34], packet[35]]);
+    let dst_port = u16::from_be_bytes([packet[36], packet[37]]);
+    let proto_name = match proto {
+        6 => {
+            if src_port == 80 || dst_port == 80 || src_port == 8080 || dst_port == 8080 {
+                "HTTP"
+            } else {
+                "TCP"
+            }
+        }
+        17 => {
+            if src_port == 53 || dst_port == 53 {
+                "DNS"
+            } else {
+                "UDP"
+            }
+        }
+        _ => "OTHER",
+    };
+    Some(PacketInfo {
+        index,
+        ts,
+        proto: proto_name.to_string(),
+        src,
+        dst,
+        src_port,
+        dst_port,
+        data: packet.to_vec(),
+    })
 }
 
 #[wasm_bindgen]
 pub fn parse_pcap(data: &[u8]) -> Result<JsValue, JsValue> {
-    let mut flows: HashMap<String, (u32, u32)> = HashMap::new();
-    let mut protocols: HashMap<String, u32> = HashMap::new();
     let mut packets: Vec<PacketInfo> = Vec::new();
+    let mut protocols: HashMap<String, u32> = HashMap::new();
+    let mut malformed: u32 = 0;
 
     let cursor = Cursor::new(data);
     let mut reader = create_reader(65536, cursor)
         .map_err(|e| JsValue::from_str(&format!("failed to parse header: {:?}", e)))?;
 
+    let mut index: u32 = 0;
     loop {
         match reader.next() {
             Ok((offset, block)) => {
+                let mut handled = false;
                 if let PcapBlockOwned::Legacy(b) = &block {
-                    let packet = b.data;
-                    if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
-                        let proto = packet[23];
-                        let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
-                        let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
-                        let flow_key = format!("{src} -> {dst}");
-                        let ts = b.ts_sec;
-                        let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
-                        entry.1 = ts;
-                        let proto_name = match proto {
-                            6 => "TCP",
-                            17 => "UDP",
-                            1 => "ICMP",
-                            _ => "OTHER",
-                        };
-                        *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
-                        packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                    if let Some(info) = classify_packet(b.data, index, (b.ts_sec as u64) * 1_000_000 + b.ts_usec as u64) {
+                        *protocols.entry(info.proto.clone()).or_insert(0) += 1;
+                        packets.push(info);
+                        handled = true;
                     }
                 } else if let PcapBlockOwned::NG(b) = &block {
                     match b {
                         Block::EnhancedPacket(epb) => {
                             let packet = epb.packet_data();
-                            if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
-                                let proto = packet[23];
-                                let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
-                                let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
-                                let flow_key = format!("{src} -> {dst}");
-                                let ts = epb.decode_ts(0, 1).0;
-                                let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
-                                entry.1 = ts;
-                                let proto_name = match proto {
-                                    6 => "TCP",
-                                    17 => "UDP",
-                                    1 => "ICMP",
-                                    _ => "OTHER",
-                                };
-                                *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
-                                packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                            let (sec, nsec) = epb.decode_ts(0, 1);
+                            if let Some(info) = classify_packet(packet, index, sec * 1_000_000 + nsec / 1000) {
+                                *protocols.entry(info.proto.clone()).or_insert(0) += 1;
+                                packets.push(info);
+                                handled = true;
                             }
                         }
                         Block::SimplePacket(spb) => {
                             let packet = spb.packet_data();
-                            if packet.len() >= 34 && packet[12] == 0x08 && packet[13] == 0x00 {
-                                let proto = packet[23];
-                                let src = format!("{}.{}.{}.{}", packet[26], packet[27], packet[28], packet[29]);
-                                let dst = format!("{}.{}.{}.{}", packet[30], packet[31], packet[32], packet[33]);
-                                let flow_key = format!("{src} -> {dst}");
-                                let ts = 0;
-                                let entry = flows.entry(flow_key.clone()).or_insert((ts, ts));
-                                entry.1 = ts;
-                                let proto_name = match proto {
-                                    6 => "TCP",
-                                    17 => "UDP",
-                                    1 => "ICMP",
-                                    _ => "OTHER",
-                                };
-                                *protocols.entry(proto_name.to_string()).or_insert(0) += 1;
-                                packets.push(PacketInfo { flow: flow_key, proto: proto_name.to_string(), data: packet.to_vec() });
+                            if let Some(info) = classify_packet(packet, index, 0) {
+                                *protocols.entry(info.proto.clone()).or_insert(0) += 1;
+                                packets.push(info);
+                                handled = true;
                             }
                         }
                         _ => {}
                     }
+                }
+                if handled {
+                    index += 1;
+                } else {
+                    malformed += 1;
                 }
                 reader.consume(offset);
             }
@@ -121,10 +131,10 @@ pub fn parse_pcap(data: &[u8]) -> Result<JsValue, JsValue> {
         }
     }
 
-    let flows_vec: Vec<FlowInfo> = flows
-        .into_iter()
-        .map(|(flow, (start, end))| FlowInfo { flow, start, end })
-        .collect();
-    let result = ParseResult { flows: flows_vec, protocols, packets };
+    let result = ParseResult {
+        packets,
+        protocols,
+        malformed,
+    };
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsValue::from_str(&e.to_string()))
 }


### PR DESCRIPTION
## Summary
- parse pcap/pcapng in Rust→WASM and classify TCP/UDP/DNS/HTTP packets while tracking malformed frames
- stream packets from worker to a virtualized grid with protocol filters and zoomable time histogram
- support packet slice export and display malformed packet statistics

## Testing
- `yarn test apps/pcap-viewer --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aac1e953608328a9104df388a53cdd