### PR TITLE
feat: enhance prefetch jumplist parsing and export

### DIFF
--- a/apps/prefetch-jumplist/index.tsx
+++ b/apps/prefetch-jumplist/index.tsx
@@ -2,14 +2,22 @@ import React, { useEffect, useRef, useState } from 'react';
 import Papa from 'papaparse';
 
 interface TimelineEvent {
+  id: number;
   time: number;
   source: string;
-  detail: string;
+  file: string;
+  runCount?: number;
+  lnk?: {
+    target?: string;
+    created?: number;
+  };
+  selected?: boolean;
 }
 
 const PrefetchJumpList: React.FC = () => {
   const workerRef = useRef<Worker | null>(null);
-  const idRef = useRef(0);
+  const fileIdRef = useRef(0);
+  const eventIdRef = useRef(0);
   const [events, setEvents] = useState<TimelineEvent[]>([]);
   const [error, setError] = useState('');
 
@@ -17,11 +25,14 @@ const PrefetchJumpList: React.FC = () => {
     const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' });
     workerRef.current = worker;
     worker.onmessage = (e) => {
-      const { events: evts, error: err } = e.data as { events?: TimelineEvent[]; error?: string };
+      const { events: evts, error: err } = e.data as { events?: Omit<TimelineEvent, 'id' | 'selected'>[]; error?: string };
       if (err) {
         setError(`${err}. See docs/forensics-samples.md for sample files.`);
       } else if (evts) {
-        setEvents((prev) => [...prev, ...evts]);
+        setEvents((prev) => [
+          ...prev,
+          ...evts.map((ev) => ({ ...ev, id: ++eventIdRef.current, selected: false })),
+        ]);
       }
     };
     return () => worker.terminate();
@@ -32,18 +43,27 @@ const PrefetchJumpList: React.FC = () => {
     setError('');
     for (const file of files) {
       const buf = await (file.arrayBuffer?.() || fileToArrayBuffer(file));
-      workerRef.current?.postMessage({ id: ++idRef.current, name: file.name, buffer: buf }, [buf]);
+      workerRef.current?.postMessage({ id: ++fileIdRef.current, name: file.name, buffer: buf }, [buf]);
     }
   };
 
+  const toggleSelect = (id: number) => {
+    setEvents((prev) => prev.map((ev) => (ev.id === id ? { ...ev, selected: !ev.selected } : ev)));
+  };
+
   const exportCsv = () => {
-    if (events.length === 0) return;
-    const sorted = [...events].sort((a, b) => a.time - b.time);
-    const rows = sorted.map((ev) => ({
-      time: new Date(ev.time).toISOString(),
-      source: ev.source,
-      detail: ev.detail,
-    }));
+    const selected = events.filter((ev) => ev.selected);
+    if (selected.length === 0) return;
+    const rows = selected
+      .sort((a, b) => a.time - b.time)
+      .map((ev) => ({
+        time: new Date(ev.time).toISOString(),
+        source: ev.source,
+        file: ev.file,
+        runCount: ev.runCount ?? '',
+        lnkTarget: ev.lnk?.target ?? '',
+        lnkCreated: ev.lnk?.created ? new Date(ev.lnk.created).toISOString() : '',
+      }));
     const csv = Papa.unparse(rows);
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
@@ -55,6 +75,7 @@ const PrefetchJumpList: React.FC = () => {
   };
 
   const sorted = [...events].sort((a, b) => a.time - b.time);
+  const anySelected = events.some((ev) => ev.selected);
 
   return (
     <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col space-y-4">
@@ -66,18 +87,42 @@ const PrefetchJumpList: React.FC = () => {
       )}
       {sorted.length > 0 && (
         <div className="flex-1 overflow-auto">
-          <ul className="space-y-1">
-            {sorted.map((ev, i) => (
-              <li key={i} className="text-sm">
-                {new Date(ev.time).toISOString()} - {ev.source}: {ev.detail}
-              </li>
-            ))}
-          </ul>
+          <table className="text-sm w-full" data-testid="timeline">
+            <thead>
+              <tr className="text-left">
+                <th></th>
+                <th>Time</th>
+                <th>Source</th>
+                <th>File</th>
+                <th>Run Count</th>
+                <th>LNK Target</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((ev) => (
+                <tr key={ev.id} className="border-b border-gray-700">
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={ev.selected}
+                      onChange={() => toggleSelect(ev.id)}
+                    />
+                  </td>
+                  <td>{new Date(ev.time).toISOString()}</td>
+                  <td>{ev.source}</td>
+                  <td>{ev.file}</td>
+                  <td>{ev.runCount ?? ''}</td>
+                  <td>{ev.lnk?.target || ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
           <button
             type="button"
             onClick={exportCsv}
             className="mt-2 px-2 py-1 bg-blue-600 rounded"
             data-testid="export"
+            disabled={!anySelected}
           >
             Export CSV
           </button>

--- a/apps/prefetch-jumplist/worker.ts
+++ b/apps/prefetch-jumplist/worker.ts
@@ -3,7 +3,12 @@ import { read, find } from 'cfb';
 interface ParseEvent {
   time: number;
   source: string;
-  detail: string;
+  file: string;
+  runCount?: number;
+  lnk?: {
+    target?: string;
+    created?: number;
+  };
 }
 
 const EPOCH_DIFF = 11644473600000; // ms between 1601 and 1970
@@ -28,7 +33,50 @@ function parsePrefetch(buffer: ArrayBuffer): ParseEvent[] {
   const low = dv.getUint32(128, true);
   const high = dv.getUint32(132, true);
   const lastRun = filetimeToDate(low, high);
-  return [{ time: lastRun.getTime(), source: 'Prefetch', detail: `${name} (run ${runCount} times)` }];
+  return [
+    {
+      time: lastRun.getTime(),
+      source: 'Prefetch',
+      file: name,
+      runCount,
+    },
+  ];
+}
+
+function readString(dv: DataView, offset: number, unicode = true): string {
+  let s = '';
+  for (let i = offset; i < dv.byteLength; i += unicode ? 2 : 1) {
+    const c = unicode ? dv.getUint16(i, true) : dv.getUint8(i);
+    if (c === 0) break;
+    s += String.fromCharCode(c);
+  }
+  return s;
+}
+
+function parseLnk(buf: Uint8Array): { target?: string; created?: number } {
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  const flags = dv.getUint32(0x14, true);
+  const created = filetimeToDate(dv.getUint32(0x1c, true), dv.getUint32(0x20, true));
+  let target = '';
+  let offset = 0x4c;
+  if (flags & 0x1) {
+    const idListSize = dv.getUint16(offset, true);
+    offset += 2 + idListSize;
+  }
+  if (flags & 0x2) {
+    const liSize = dv.getUint32(offset, true);
+    const liFlags = dv.getUint32(offset + 8, true);
+    if (liFlags & 1) {
+      const localBasePathOffset = dv.getUint32(offset + 16, true);
+      const localBasePathOffsetUnicode = dv.getUint32(offset + 28, true);
+      const ofs =
+        localBasePathOffsetUnicode && localBasePathOffsetUnicode < liSize
+          ? offset + localBasePathOffsetUnicode
+          : offset + localBasePathOffset;
+      target = readString(dv, ofs);
+    }
+  }
+  return { target, created: created.getTime() };
 }
 
 function parseJumpList(buffer: ArrayBuffer): ParseEvent[] {
@@ -46,16 +94,24 @@ function parseJumpList(buffer: ArrayBuffer): ParseEvent[] {
     const low = dv.getUint32(base + 8, true);
     const high = dv.getUint32(base + 12, true);
     const time = filetimeToDate(low, high);
+    const runCount = dv.getUint32(base + 0x18, true);
     let path = '';
     const ofs = dv.getUint16(base + 0x50, true);
     if (ofs > 0 && ofs < entrySize) {
-      for (let j = base + ofs; j < base + entrySize; j += 2) {
-        const c = dv.getUint16(j, true);
-        if (c === 0) break;
-        path += String.fromCharCode(c);
-      }
+      path = readString(dv, base + ofs);
     }
-    events.push({ time: time.getTime(), source: 'JumpList', detail: path || `entry ${i + 1}` });
+    let lnk;
+    const stream = find(cf, String(i + 1));
+    if (stream && stream.content) {
+      lnk = parseLnk(stream.content as Uint8Array);
+    }
+    events.push({
+      time: time.getTime(),
+      source: 'JumpList',
+      file: path || `entry ${i + 1}`,
+      runCount,
+      lnk,
+    });
   }
   return events;
 }


### PR DESCRIPTION
## Summary
- parse Prefetch artifacts for file names, run counts, and last run times
- extract JumpList entries with run counts and basic LNK fields
- display timeline with selectable rows and export selected entries to CSV

## Testing
- `npm test __tests__/prefetchJumplist.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aac8bc6adc8328ba6471422141e38d