### PR TITLE
Ensure playable seeded Match-3 boards

### DIFF
--- a/__tests__/match3.test.ts
+++ b/__tests__/match3.test.ts
@@ -1,4 +1,10 @@
-import { findMatches, swapPieces, rngFactory } from '@components/apps/match3';
+import {
+  findMatches,
+  swapPieces,
+  rngFactory,
+  initializeBoard,
+  hasValidMove,
+} from '@components/apps/match3';
 import type { Board, Piece } from '@components/apps/match3';
 
 const make = (color: string): Piece => ({ color, type: 'normal', id: Math.random() });
@@ -38,4 +44,10 @@ test('swap with fixed seed is deterministic', () => {
   const res1 = swapPieces(board, { x: 0, y: 0 }, { x: 1, y: 0 }, rngFactory(seed));
   const res2 = swapPieces(board2, { x: 0, y: 0 }, { x: 1, y: 0 }, rngFactory(seed));
   expect(simplify(res1.board)).toEqual(simplify(res2.board));
+});
+
+test('initialized board has no matches and at least one move', () => {
+  const { board } = initializeBoard(8, 123);
+  expect(findMatches(board).size).toBe(0);
+  expect(hasValidMove(board)).toBe(true);
 });

--- a/components/apps/match3.js
+++ b/components/apps/match3.js
@@ -1,4 +1,20 @@
-import Match3, { createBoard, swapPieces, findMatches, resolveBoard, rngFactory } from '../../apps/match3';
+import Match3, {
+  createBoard,
+  swapPieces,
+  findMatches,
+  resolveBoard,
+  rngFactory,
+  initializeBoard,
+  hasValidMove,
+} from '../../apps/match3';
 
 export default Match3;
-export { createBoard, swapPieces, findMatches, resolveBoard, rngFactory };
+export {
+  createBoard,
+  swapPieces,
+  findMatches,
+  resolveBoard,
+  rngFactory,
+  initializeBoard,
+  hasValidMove,
+};


### PR DESCRIPTION
## Summary
- guarantee Match-3 board is initialized without pre-matches and with at least one valid move
- allow boards to be seeded via URL and expose utility to verify available moves
- add tests covering seeded initialization

## Testing
- `yarn test __tests__/match3.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab016401c4832892cb4eb2d8708ea0