### PR TITLE
feat: expand HTTP/3 probe details

### DIFF
--- a/components/apps/http3-probe.tsx
+++ b/components/apps/http3-probe.tsx
@@ -4,6 +4,10 @@ interface ProbeResult {
   ok: boolean;
   altSvc: string | null;
   alpnHints: string[];
+  negotiatedProtocol: string;
+  quicVersions: string[];
+  zeroRtt: boolean;
+  fallbackOk: boolean;
 }
 
 const Http3Probe: React.FC = () => {
@@ -51,11 +55,22 @@ const Http3Probe: React.FC = () => {
           {result.altSvc && (
             <div className="break-all">Alt-Svc: {result.altSvc}</div>
           )}
-          {!result.ok && (
-            <div className="mt-1">Fallback to HTTP/1.1/2</div>
-          )}
-          {result.ok && result.alpnHints.length > 0 && (
+          <div className="mt-1">
+            Fallback via: {result.negotiatedProtocol || 'unknown'}
+          </div>
+          {result.alpnHints.length > 0 && (
             <div className="mt-1">Protocols: {result.alpnHints.join(', ')}</div>
+          )}
+          {result.quicVersions.length > 0 && (
+            <div className="mt-1">
+              QUIC Versions: {result.quicVersions.join(', ')}
+            </div>
+          )}
+          <div className="mt-1">
+            0-RTT: {result.zeroRtt ? 'supported' : 'not supported'}
+          </div>
+          {!result.fallbackOk && (
+            <div className="mt-1 text-red-500">No HTTP/1.1/2 fallback</div>
           )}
         </div>
       )}

--- a/pages/api/http3-probe.ts
+++ b/pages/api/http3-probe.ts
@@ -1,11 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { setupUrlGuard } from '../../lib/urlGuard';
+import { fetchHead } from '../../lib/headCache';
 setupUrlGuard();
 
 interface ProbeResult {
   ok: boolean;
   altSvc: string | null;
   alpnHints: string[];
+  negotiatedProtocol: string;
+  quicVersions: string[];
+  zeroRtt: boolean;
+  fallbackOk: boolean;
 }
 
 export default async function handler(
@@ -14,7 +19,15 @@ export default async function handler(
 ) {
   const { url } = req.query;
   if (!url || typeof url !== 'string') {
-    res.status(400).json({ ok: false, altSvc: null, alpnHints: [] });
+    res.status(400).json({
+      ok: false,
+      altSvc: null,
+      alpnHints: [],
+      negotiatedProtocol: '',
+      quicVersions: [],
+      zeroRtt: false,
+      fallbackOk: false,
+    });
     return;
   }
 
@@ -22,22 +35,70 @@ export default async function handler(
   try {
     target = new URL(`https://${url}`);
   } catch {
-    res.status(400).json({ ok: false, altSvc: null, alpnHints: [] });
+    res.status(400).json({
+      ok: false,
+      altSvc: null,
+      alpnHints: [],
+      negotiatedProtocol: '',
+      quicVersions: [],
+      zeroRtt: false,
+      fallbackOk: false,
+    });
     return;
   }
 
   try {
-    const response = await fetch(target.toString(), { method: 'HEAD' });
-    const altSvc = response.headers.get('alt-svc');
-    const alpnHints = altSvc
-      ? altSvc
-          .split(',')
-          .map((s) => s.trim())
-          .filter((s) => /^h3(-\d+)?/.test(s))
-          .map((s) => s.split('=')[0])
-      : [];
-    res.status(200).json({ ok: alpnHints.length > 0, altSvc, alpnHints });
+    const { headers, alpn } = await fetchHead(target.toString());
+    const altSvc = (headers['alt-svc'] as string | undefined) ?? null;
+
+    const alpnHints: string[] = [];
+    const quicVersions: string[] = [];
+    let zeroRtt = false;
+
+    if (altSvc) {
+      const entries = altSvc.split(',').map((s) => s.trim());
+      for (const entry of entries) {
+        const [protoPart, ...paramParts] = entry.split(';').map((p) => p.trim());
+        const proto = protoPart.split('=')[0];
+        if (proto) {
+          alpnHints.push(proto);
+          const m = proto.match(/^h3-(\d+)/i);
+          if (m) {
+            quicVersions.push(m[1]);
+          }
+        }
+        for (const param of paramParts) {
+          const [k, v = ''] = param.split('=').map((p) => p.trim());
+          if (k.toLowerCase() === 'v') {
+            const versions = v.replace(/"/g, '').split(/\s*,\s*/);
+            quicVersions.push(...versions);
+          }
+          if (k.toLowerCase() === '0rtt') {
+            zeroRtt = true;
+          }
+        }
+      }
+    }
+
+    const uniqueVersions = Array.from(new Set(quicVersions));
+    res.status(200).json({
+      ok: alpnHints.some((p) => p.toLowerCase().startsWith('h3')),
+      altSvc,
+      alpnHints,
+      negotiatedProtocol: alpn,
+      quicVersions: uniqueVersions,
+      zeroRtt,
+      fallbackOk: ['h2', 'http/1.1', 'unknown'].includes(alpn),
+    });
   } catch {
-    res.status(500).json({ ok: false, altSvc: null, alpnHints: [] });
+    res.status(500).json({
+      ok: false,
+      altSvc: null,
+      alpnHints: [],
+      negotiatedProtocol: '',
+      quicVersions: [],
+      zeroRtt: false,
+      fallbackOk: false,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- report negotiated ALPN protocol, QUIC versions, 0-RTT support, and fallback status
- display extended HTTP/3 probing results in the UI

## Testing
- `yarn test` *(fails: frogger mechanics › lane spawn variance via lane-local RNG)*
- `yarn lint` *(fails: Parsing error in components/apps/breakout.js, and missing pages/app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8c3df588328a0fadf3e7d8c16a0