### PR TITLE
feat: simulate CSP policies

### DIFF
--- a/__tests__/csp-reporter.test.ts
+++ b/__tests__/csp-reporter.test.ts
@@ -1,4 +1,9 @@
-import { normalizeReports, computeTop, validateReport } from '@pages/api/csp-reporter';
+import {
+  normalizeReports,
+  computeTop,
+  validateReport,
+  simulatePolicy,
+} from '@pages/api/csp-reporter';
 
 describe('csp-reporter utilities', () => {
   test('normalizes report-uri format', () => {
@@ -53,6 +58,30 @@ describe('csp-reporter utilities', () => {
   test('validate report returns helpful errors', () => {
     const errors = validateReport({ 'blocked-uri': '' } as any);
     expect(errors.length).toBeGreaterThan(0);
+  });
+
+  test('simulatePolicy flags violations', () => {
+    const list = [
+      {
+        'document-uri': 'https://example.com',
+        'violated-directive': 'img-src',
+        'blocked-uri': 'https://evil.com/img.png',
+      },
+    ];
+    const sim = simulatePolicy("img-src 'self'", list as any);
+    expect(sim.blocked.length).toBe(1);
+  });
+
+  test('simulatePolicy allows matching hosts', () => {
+    const list = [
+      {
+        'document-uri': 'https://example.com',
+        'violated-directive': 'img-src',
+        'blocked-uri': 'https://cdn.example.com/img.png',
+      },
+    ];
+    const sim = simulatePolicy('img-src https://cdn.example.com', list as any);
+    expect(sim.blocked.length).toBe(0);
   });
 });
 

--- a/apps/csp-reporter/index.tsx
+++ b/apps/csp-reporter/index.tsx
@@ -1,0 +1,4 @@
+import CspReporter, { displayCspReporter } from '@components/apps/csp-reporter';
+
+export default CspReporter;
+export { displayCspReporter };

--- a/pages/apps/csp-reporter.tsx
+++ b/pages/apps/csp-reporter.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const CspReporter = dynamic(() => import('../../components/apps/csp-reporter'), { ssr: false });
+const CspReporter = dynamic(() => import('@apps/csp-reporter'), { ssr: false });
 
 export default function CspReporterPage() {
   return <CspReporter />;


### PR DESCRIPTION
## Summary
- extend CSP reporter API to simulate candidate policies against stored reports
- expose simulation UI and hook up CSP reporter app
- cover new simulation logic with tests

## Testing
- `yarn test __tests__/csp-reporter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aac8c4aa688328a8541839c94947c7