### PR TITLE
feat: add wayback capture heatmap and filters

### DIFF
--- a/pages/api/wayback-viewer.ts
+++ b/pages/api/wayback-viewer.ts
@@ -5,13 +5,16 @@ setupUrlGuard();
 interface Snapshot {
   timestamp: string;
   original: string;
+  statuscode: string;
+  mimetype: string;
+  robotflags?: string | null;
 }
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const { url, page = '0', limit = '50' } = req.query;
+  const { url, page = '0', limit = '50', status, mime, noRobot } = req.query;
   if (!url || typeof url !== 'string') {
     res.status(400).json({ error: 'Missing url' });
     return;
@@ -26,23 +29,38 @@ export default async function handler(
     );
     const availability = await availabilityRes.json();
 
+    const filters: string[] = [];
+    if (status && typeof status === 'string') filters.push(`statuscode:${status}`);
+    if (mime && typeof mime === 'string') filters.push(`mimetype:${mime}`);
+    if (noRobot === '1' || noRobot === 'true') filters.push('!robotflags:.*');
+    const filterParam = filters.map((f) => `&filter=${encodeURIComponent(f)}`).join('');
+
     const listRes = await fetch(
       `https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(
         url,
-      )}&output=json&fl=timestamp,original&page=${Number.isNaN(pageNum) ? 0 : pageNum}&limit=${
-        Number.isNaN(limitNum) ? 50 : limitNum
-      }`,
+      )}&output=json&fl=timestamp,original,statuscode,mimetype,robotflags${filterParam}&page=${
+        Number.isNaN(pageNum) ? 0 : pageNum
+      }&limit=${Number.isNaN(limitNum) ? 50 : limitNum}`,
     );
     if (!listRes.ok) {
       throw new Error('Failed to fetch snapshots');
     }
     const listJson = await listRes.json();
-    const rows = Array.isArray(listJson) ? listJson.slice(1) : [];
-    const snapshots: Snapshot[] = rows.map((row: [string, string]) => ({
-      timestamp: row[0],
-      original: row[1],
-    }));
-    const hasMore = rows.length === (Number.isNaN(limitNum) ? 50 : limitNum);
+    const rawRows: any[] = Array.isArray(listJson) ? listJson.slice(1) : [];
+    let rows = rawRows;
+    if (status && typeof status === 'string') rows = rows.filter((r) => r[2] === status);
+    if (mime && typeof mime === 'string') rows = rows.filter((r) => r[3] === mime);
+    if (noRobot === '1' || noRobot === 'true') rows = rows.filter((r) => !r[4]);
+    const snapshots: Snapshot[] = rows.map(
+      (row: [string, string, string, string, string | null]) => ({
+        timestamp: row[0],
+        original: row[1],
+        statuscode: row[2],
+        mimetype: row[3],
+        robotflags: row[4] ?? null,
+      }),
+    );
+    const hasMore = rawRows.length === (Number.isNaN(limitNum) ? 50 : limitNum);
 
     res.status(200).json({ availability, snapshots, hasMore });
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- extend wayback viewer API to filter by status code, MIME type and robots flag
- show capture calendar heatmap with filter controls on Wayback viewer

## Testing
- `npm test` *(fails: ReferenceError: NUM_TILES_WIDE is not defined in frogger.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8c7cd0c8328aaa8431b0d58743c