### PR TITLE
feat: add pkce auth flow demo

### DIFF
--- a/components/apps/pkce-helper.tsx
+++ b/components/apps/pkce-helper.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 
 const PKCEHelper: React.FC = () => {
   const [length, setLength] = useState(64);
-  const [method, setMethod] = useState<'S256' | 'plain'>('S256');
   const [codeVerifier, setCodeVerifier] = useState('');
-  const [codeChallenge, setCodeChallenge] = useState('');
-  const [authUrl, setAuthUrl] = useState('');
+  const [challengeS256, setChallengeS256] = useState('');
+  const [challengePlain, setChallengePlain] = useState('');
+  const [authUrlS256, setAuthUrlS256] = useState('');
+  const [authUrlPlain, setAuthUrlPlain] = useState('');
   const [lengthWarning, setLengthWarning] = useState('');
   const [counter, setCounter] = useState(60);
+  const [flowStep, setFlowStep] = useState(0);
 
   const generate = async () => {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
@@ -25,25 +27,27 @@ const PKCEHelper: React.FC = () => {
     }
     setCodeVerifier(verifier);
 
-    if (method === 'S256') {
-      const encoder = new TextEncoder();
-      const hash = await crypto.subtle.digest('SHA-256', encoder.encode(verifier));
-      const bytes = Array.from(new Uint8Array(hash));
-      const base64 = btoa(String.fromCharCode(...bytes))
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/, '');
-      setCodeChallenge(base64);
-    } else {
-      setCodeChallenge(verifier);
-    }
+    // plain challenge
+    setChallengePlain(verifier);
+
+    // S256 challenge
+    const encoder = new TextEncoder();
+    const hash = await crypto.subtle.digest('SHA-256', encoder.encode(verifier));
+    const bytes = Array.from(new Uint8Array(hash));
+    const base64 = btoa(String.fromCharCode(...bytes))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    setChallengeS256(base64);
+
     setCounter(60);
+    setFlowStep(0);
   };
 
   useEffect(() => {
     generate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [length, method]);
+  }, [length]);
 
   useEffect(() => {
     if (counter <= 0) {
@@ -56,17 +60,28 @@ const PKCEHelper: React.FC = () => {
   }, [counter]);
 
   useEffect(() => {
-    const params = new URLSearchParams({
+    const baseParams = {
       response_type: 'code',
       client_id: 'CLIENT_ID',
       redirect_uri: 'https://client.example.com/callback',
       scope: 'SCOPE',
       state: 'STATE',
-      code_challenge: codeChallenge,
-      code_challenge_method: method,
+    } as const;
+
+    const paramsS256 = new URLSearchParams({
+      ...baseParams,
+      code_challenge: challengeS256,
+      code_challenge_method: 'S256',
     });
-    setAuthUrl(`https://auth.example.com/authorize?${params.toString()}`);
-  }, [codeChallenge, method]);
+    setAuthUrlS256(`https://auth.example.com/authorize?${paramsS256.toString()}`);
+
+    const paramsPlain = new URLSearchParams({
+      ...baseParams,
+      code_challenge: challengePlain,
+      code_challenge_method: 'plain',
+    });
+    setAuthUrlPlain(`https://auth.example.com/authorize?${paramsPlain.toString()}`);
+  }, [challengeS256, challengePlain]);
 
   const copy = async (text: string) => {
     try {
@@ -98,6 +113,19 @@ const PKCEHelper: React.FC = () => {
 
   const callbackSnippet = `const params = new URLSearchParams(window.location.search);\nconst code = params.get('code');\nconst state = params.get('state');`;
 
+  const steps = [
+    { title: 'Authorization Request', content: authUrlS256 },
+    {
+      title: 'Authorization Response',
+      content: 'https://client.example.com/callback?code=AUTH_CODE&state=STATE',
+    },
+    { title: 'Token Request', content: tokenRequest },
+    { title: 'Token Response', content: '{"access_token":"FAKE_ACCESS_TOKEN"}' },
+  ];
+
+  const resetFlow = () => setFlowStep(0);
+  const nextFlow = () => setFlowStep((s) => Math.min(s + 1, steps.length));
+
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
       <div className="flex flex-col sm:flex-row gap-2">
@@ -112,17 +140,6 @@ const PKCEHelper: React.FC = () => {
             className="text-black px-2 py-1 w-24"
           />
         </label>
-        <label className="flex items-center gap-2">
-          Method:
-          <select
-            value={method}
-            onChange={(e) => setMethod(e.target.value as 'S256' | 'plain')}
-            className="text-black px-2 py-1"
-          >
-            <option value="S256">S256</option>
-            <option value="plain">plain</option>
-          </select>
-        </label>
         <button
           type="button"
           onClick={generate}
@@ -133,11 +150,6 @@ const PKCEHelper: React.FC = () => {
         <span className="self-center text-sm">Refresh in {counter}s</span>
       </div>
       {lengthWarning && <div className="text-yellow-300 text-sm">{lengthWarning}</div>}
-      {method === 'plain' && (
-        <div className="text-yellow-300 text-sm">
-          Warning: plain method is less secure. Prefer S256.
-        </div>
-      )}
       <div className="flex items-center space-x-2">
         <input
           type="text"
@@ -153,35 +165,73 @@ const PKCEHelper: React.FC = () => {
           Copy
         </button>
       </div>
-      <div className="flex items-center space-x-2">
-        <input
-          type="text"
-          readOnly
-          value={codeChallenge}
-          className="flex-1 text-black px-2 py-1"
-        />
-        <button
-          type="button"
-          onClick={() => copy(codeChallenge)}
-          className="px-3 py-1 bg-blue-600 rounded"
-        >
-          Copy
-        </button>
+      <div>
+        <div className="mb-1 text-sm">S256 Challenge</div>
+        <div className="flex items-center space-x-2 mb-2">
+          <input
+            type="text"
+            readOnly
+            value={challengeS256}
+            className="flex-1 text-black px-2 py-1"
+          />
+          <button
+            type="button"
+            onClick={() => copy(challengeS256)}
+            className="px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
+        <div className="mb-1 text-sm">plain Challenge</div>
+        <div className="flex items-center space-x-2">
+          <input
+            type="text"
+            readOnly
+            value={challengePlain}
+            className="flex-1 text-black px-2 py-1"
+          />
+          <button
+            type="button"
+            onClick={() => copy(challengePlain)}
+            className="px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
       </div>
-      <div className="flex items-center space-x-2">
-        <input
-          type="text"
-          readOnly
-          value={authUrl}
-          className="flex-1 text-black px-2 py-1"
-        />
-        <button
-          type="button"
-          onClick={() => copy(authUrl)}
-          className="px-3 py-1 bg-blue-600 rounded"
-        >
-          Copy
-        </button>
+      <div>
+        <div className="mb-1 text-sm">Authorization URL (S256)</div>
+        <div className="flex items-center space-x-2 mb-2">
+          <input
+            type="text"
+            readOnly
+            value={authUrlS256}
+            className="flex-1 text-black px-2 py-1"
+          />
+          <button
+            type="button"
+            onClick={() => copy(authUrlS256)}
+            className="px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
+        <div className="mb-1 text-sm">Authorization URL (plain)</div>
+        <div className="flex items-center space-x-2">
+          <input
+            type="text"
+            readOnly
+            value={authUrlPlain}
+            className="flex-1 text-black px-2 py-1"
+          />
+          <button
+            type="button"
+            onClick={() => copy(authUrlPlain)}
+            className="px-3 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
       </div>
       <div className="space-y-2 text-sm">
         <div>
@@ -192,6 +242,35 @@ const PKCEHelper: React.FC = () => {
           Callback handling:
           <pre className="bg-gray-800 p-2 mt-1 overflow-auto text-xs">{callbackSnippet}</pre>
         </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex space-x-2">
+          <button
+            type="button"
+            onClick={resetFlow}
+            className="px-3 py-1 bg-purple-600 rounded"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={nextFlow}
+            className="px-3 py-1 bg-purple-600 rounded"
+            disabled={flowStep >= steps.length}
+          >
+            Next
+          </button>
+        </div>
+        <ol className="space-y-2">
+          {steps.slice(0, flowStep).map((s, idx) => (
+            <li key={s.title} className="bg-gray-800 p-2">
+              <div className="font-bold">
+                {idx + 1}. {s.title}
+              </div>
+              <pre className="mt-1 overflow-auto text-xs">{s.content}</pre>
+            </li>
+          ))}
+        </ol>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- generate PKCE code verifier
- display S256 and plain code challenges with example authorization URLs
- demo authorization flow without real tokens

## Testing
- `CI=1 yarn test` (fails: frogger mechanics)
- `yarn lint --file components/apps/pkce-helper.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aac8ca5944832895c9995039c76204