### PR TITLE
feat: enhance CT search

### DIFF
--- a/components/apps/ct-search.tsx
+++ b/components/apps/ct-search.tsx
@@ -1,4 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+type Sct = { timestamp: string };
 
 type Result = {
   certId: number;
@@ -6,6 +20,17 @@ type Result = {
   issuer: string;
   notBefore: string;
   notAfter: string;
+  scts: Sct[];
+};
+
+type IssuerStat = { issuer: string; count: number };
+type SeriesPoint = { date: string; count: number };
+
+type ApiResponse = {
+  results: Result[];
+  issuerStats: IssuerStat[];
+  timeSeries: SeriesPoint[];
+  suspicious: string[];
 };
 
 const CtSearch: React.FC = () => {
@@ -13,9 +38,12 @@ const CtSearch: React.FC = () => {
   const [excludeExpired, setExcludeExpired] = useState(true);
   const [uniqueOnly, setUniqueOnly] = useState(true);
   const [results, setResults] = useState<Result[]>([]);
+  const [issuerStats, setIssuerStats] = useState<IssuerStat[]>([]);
+  const [timeSeries, setTimeSeries] = useState<SeriesPoint[]>([]);
+  const [suspicious, setSuspicious] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const cacheRef = useRef<Map<string, Result[]>>(new Map());
+  const cacheRef = useRef<Map<string, ApiResponse>>(new Map());
   const timerRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
@@ -27,7 +55,11 @@ const CtSearch: React.FC = () => {
     timerRef.current = setTimeout(async () => {
       const key = `${domain}|${excludeExpired}|${uniqueOnly}`;
       if (cacheRef.current.has(key)) {
-        setResults(cacheRef.current.get(key)!);
+        const cached = cacheRef.current.get(key)!;
+        setResults(cached.results);
+        setIssuerStats(cached.issuerStats);
+        setTimeSeries(cached.timeSeries);
+        setSuspicious(cached.suspicious);
         return;
       }
       setLoading(true);
@@ -39,19 +71,31 @@ const CtSearch: React.FC = () => {
         if (res.status === 429) {
           setError('Rate limit exceeded');
           setResults([]);
+          setIssuerStats([]);
+          setTimeSeries([]);
+          setSuspicious([]);
         } else {
-          const data = await res.json();
-          if (!res.ok) {
-            setError(data.error || 'Request failed');
+          const data: ApiResponse | { error: string } = await res.json();
+          if (!res.ok || 'error' in data) {
+            setError((data as any).error || 'Request failed');
             setResults([]);
+            setIssuerStats([]);
+            setTimeSeries([]);
+            setSuspicious([]);
           } else {
-            setResults(data);
+            setResults(data.results);
+            setIssuerStats(data.issuerStats);
+            setTimeSeries(data.timeSeries);
+            setSuspicious(data.suspicious);
             cacheRef.current.set(key, data);
           }
         }
       } catch (e: any) {
         setError(e.message || 'Request failed');
         setResults([]);
+        setIssuerStats([]);
+        setTimeSeries([]);
+        setSuspicious([]);
       } finally {
         setLoading(false);
       }
@@ -92,6 +136,49 @@ const CtSearch: React.FC = () => {
       </div>
       {loading && <div className="text-sm text-gray-400">Searching...</div>}
       {error && <div className="text-red-400 text-sm">{error}</div>}
+      {suspicious.length > 0 && (
+        <div className="p-2 bg-yellow-900 text-yellow-200 rounded text-sm space-y-1">
+          <div className="font-semibold">Warnings</div>
+          <ul className="list-disc pl-4">
+            {suspicious.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {timeSeries.length > 0 && (
+        <div className="bg-gray-800 p-2 rounded">
+          <Line
+            data={{
+              labels: timeSeries.map((t) => t.date),
+              datasets: [
+                {
+                  label: 'Issuance',
+                  data: timeSeries.map((t) => t.count),
+                  borderColor: 'rgb(59,130,246)',
+                  backgroundColor: 'rgba(59,130,246,0.5)',
+                },
+              ],
+            }}
+            options={{
+              responsive: true,
+              plugins: { legend: { display: false } },
+              scales: { x: { ticks: { color: 'white' } }, y: { ticks: { color: 'white' } } },
+            }}
+          />
+        </div>
+      )}
+      {issuerStats.length > 0 && (
+        <div className="bg-gray-800 p-2 rounded text-sm space-y-1">
+          <div className="font-semibold">Issuers</div>
+          {issuerStats.map((i) => (
+            <div key={i.issuer} className="flex justify-between">
+              <span className="break-words pr-2">{i.issuer}</span>
+              <span>{i.count}</span>
+            </div>
+          ))}
+        </div>
+      )}
       <div className="overflow-auto h-full space-y-2 pr-1">
         {results.map((r) => (
           <div key={r.certId} className="p-2 bg-gray-800 rounded space-y-1">
@@ -105,6 +192,13 @@ const CtSearch: React.FC = () => {
               {new Date(r.notBefore).toLocaleString()} -{' '}
               {new Date(r.notAfter).toLocaleString()}
             </div>
+            {r.scts.length > 0 && (
+              <div className="text-xs text-gray-500">
+                {r.scts.map((s) => (
+                  <div key={s.timestamp}>SCT: {new Date(s.timestamp).toLocaleString()}</div>
+                ))}
+              </div>
+            )}
             <a
               href={`https://crt.sh/?id=${r.certId}`}
               target="_blank"

--- a/pages/api/ct-search.ts
+++ b/pages/api/ct-search.ts
@@ -2,12 +2,24 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 
+type CtSct = {
+  timestamp: string;
+};
+
 type CtResult = {
   certId: number;
   sans: string[];
   issuer: string;
   notBefore: string;
   notAfter: string;
+  scts: CtSct[];
+};
+
+type CtResponse = {
+  results: CtResult[];
+  issuerStats: { issuer: string; count: number }[];
+  timeSeries: { date: string; count: number }[];
+  suspicious: string[];
 };
 
 export default async function handler(
@@ -42,31 +54,87 @@ export default async function handler(
     }
 
     const data = await response.json();
-    const results: CtResult[] = [];
+    const resultsMap = new Map<number, CtResult>();
+    const issuerCounts = new Map<string, number>();
+    const timeSeries = new Map<string, number>();
     const seen = new Set<string>();
     const now = new Date();
+    let wildcardCount = 0;
+    let deepWildcard = false;
 
     for (const item of data) {
       const certId = Number(item.id || item.min_cert_id || item.cert_id);
       const sans = String(item.name_value || '').split('\n');
       const notBefore = item.not_before as string;
       const notAfter = item.not_after as string;
+      const issuer = item.issuer_name as string;
+      const entryTimestamp = item.entry_timestamp as string;
 
       if (excludeExpired === 'true' && new Date(notAfter) < now) {
         continue;
       }
 
+      let finalSans = sans;
       if (unique === 'true') {
-        const unseen = sans.filter((s) => !seen.has(s));
-        if (unseen.length === 0) continue;
-        unseen.forEach((s) => seen.add(s));
-        results.push({ certId, sans: unseen, issuer: item.issuer_name, notBefore, notAfter });
+        finalSans = sans.filter((s) => !seen.has(s));
+        if (finalSans.length === 0) continue;
+        finalSans.forEach((s) => seen.add(s));
+      }
+
+      for (const s of finalSans) {
+        if (s.startsWith('*')) wildcardCount++;
+        if (s.includes('*.*')) deepWildcard = true;
+      }
+
+      if (!resultsMap.has(certId)) {
+        resultsMap.set(certId, {
+          certId,
+          sans: [...finalSans],
+          issuer,
+          notBefore,
+          notAfter,
+          scts: [{ timestamp: entryTimestamp }],
+        });
+
+        issuerCounts.set(issuer, (issuerCounts.get(issuer) || 0) + 1);
+        const dateKey = entryTimestamp?.slice(0, 10);
+        if (dateKey) {
+          timeSeries.set(dateKey, (timeSeries.get(dateKey) || 0) + 1);
+        }
       } else {
-        results.push({ certId, sans, issuer: item.issuer_name, notBefore, notAfter });
+        const existing = resultsMap.get(certId)!;
+        for (const s of finalSans) {
+          if (!existing.sans.includes(s)) existing.sans.push(s);
+        }
+        if (entryTimestamp && !existing.scts.find((s) => s.timestamp === entryTimestamp)) {
+          existing.scts.push({ timestamp: entryTimestamp });
+        }
       }
     }
 
-    return res.status(200).json(results);
+    const results = Array.from(resultsMap.values());
+    const issuerStats = Array.from(issuerCounts.entries())
+      .map(([issuer, count]) => ({ issuer, count }))
+      .sort((a, b) => b.count - a.count);
+    const timeSeriesArr = Array.from(timeSeries.entries())
+      .map(([date, count]) => ({ date, count }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    const suspicious: string[] = [];
+    if (issuerStats.length > 3) suspicious.push('Multiple issuers detected');
+    if (wildcardCount > 5) suspicious.push('High number of wildcard certificates');
+    if (deepWildcard) suspicious.push('Multi-level wildcard detected');
+    const maxDay = Math.max(0, ...timeSeriesArr.map((t) => t.count));
+    if (maxDay > 5) suspicious.push('Spike in certificate issuance');
+
+    const payload: CtResponse = {
+      results,
+      issuerStats,
+      timeSeries: timeSeriesArr,
+      suspicious,
+    };
+
+    return res.status(200).json(payload);
   } catch (e: any) {
     return res.status(500).json({ error: e.message || 'Request failed' });
   }


### PR DESCRIPTION
## Summary
- enrich CT search API with SCTs, issuer stats, issuance timeline, and basic anomaly detection
- display time-series chart, issuer breakdown, warnings, and SCTs in CT search app

## Testing
- `yarn lint --file components/apps/ct-search.tsx --file pages/api/ct-search.ts`
- `yarn test __tests__/frogger.test.ts` *(fails: NUM_TILES_WIDE is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8cc1ce88328bbe0739f6ed684c3