### PR TITLE
feat(weather-widget): add provider adapter and demo mode

### DIFF
--- a/apps/weather_widget/index.html
+++ b/apps/weather_widget/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div id="weather" class="weather">
+  <div id="weather" class="weather" data-provider="openweather" data-city="London">
     <div class="temp">--°C</div>
     <img class="icon" src="" alt="Weather icon" />
     <div class="forecast">Loading...</div>

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -1,21 +1,76 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const apiKey = 'YOUR_API_KEY'; // Replace with your OpenWeather API key
-  const city = 'London';
   const widget = document.getElementById('weather');
   const tempEl = widget.querySelector('.temp');
   const iconEl = widget.querySelector('.icon');
   const forecastEl = widget.querySelector('.forecast');
 
-  async function fetchWeather() {
-    try {
+  const params = new URLSearchParams(location.search);
+  const demoMode = params.has('demo');
+  let providerName = widget.dataset.provider || 'openweather';
+  let city = widget.dataset.city || 'London';
+  const apiKey = widget.dataset.apiKey || 'YOUR_API_KEY'; // Replace with your provider API key
+
+  const providers = {
+    openweather: async (loc, key) => {
       const response = await fetch(
-        `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
+        `https://api.openweathermap.org/data/2.5/weather?q=${loc}&units=metric&appid=${key}`
       );
       if (!response.ok) throw new Error('Failed to fetch weather');
       const data = await response.json();
+      return {
+        temp: Math.round(data.main.temp),
+        icon: `https://openweathermap.org/img/wn/${data.weather[0].icon}@2x.png`,
+        description: data.weather[0].description
+      };
+    },
+    weatherapi: async (loc, key) => {
+      const response = await fetch(
+        `https://api.weatherapi.com/v1/current.json?key=${key}&q=${loc}`
+      );
+      if (!response.ok) throw new Error('Failed to fetch weather');
+      const data = await response.json();
+      return {
+        temp: Math.round(data.current.temp_c),
+        icon: `https:${data.current.condition.icon}`,
+        description: data.current.condition.text
+      };
+    },
+    demo: async () => ({
+      temp: 21,
+      icon: 'https://openweathermap.org/img/wn/01d@2x.png',
+      description: 'clear sky'
+    })
+  };
+
+  if (demoMode) {
+    providerName = 'demo';
+    city = 'Demo City';
+  }
+
+  const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+  const cacheKey = `weather:${providerName}:${city}`;
+
+  async function fetchWeather() {
+    try {
+      const data = await providers[providerName](city, apiKey);
       updateWeather(data);
+      localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data }));
     } catch (err) {
       console.error(err);
+    }
+  }
+
+  function loadWeather() {
+    const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+    const isStale = !cached || Date.now() - cached.timestamp > CACHE_TTL;
+    if (cached) {
+      updateWeather(cached.data);
+    }
+    if (isStale) {
+      fetchWeather();
+    } else {
+      // revalidate in background
+      fetchWeather().catch(() => {});
     }
   }
 
@@ -26,11 +81,10 @@ document.addEventListener('DOMContentLoaded', () => {
       'animationend',
       function handler() {
         widget.classList.remove('fade-out');
-        tempEl.textContent = `${Math.round(data.main.temp)}°C`;
-        const icon = data.weather[0].icon;
-        iconEl.src = `https://openweathermap.org/img/wn/${icon}@2x.png`;
-        iconEl.alt = data.weather[0].description;
-        forecastEl.textContent = data.weather[0].description;
+        tempEl.textContent = `${data.temp}°C`;
+        iconEl.src = data.icon;
+        iconEl.alt = data.description;
+        forecastEl.textContent = data.description;
         widget.classList.add('fade-in');
         widget.removeEventListener('animationend', handler);
       },
@@ -38,7 +92,6 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   }
 
-  fetchWeather();
-  // Refresh weather every 10 minutes
-  setInterval(fetchWeather, 10 * 60 * 1000);
+  loadWeather();
+  setInterval(loadWeather, CACHE_TTL);
 });


### PR DESCRIPTION
## Summary
- add provider adapter and demo location support to weather widget
- cache weather responses in local storage with background revalidation

## Testing
- `yarn test apps/weather_widget --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aac8d115308328a391e7ddd984ebb4