### PR TITLE
Add clipboard support to converter plugins

### DIFF
--- a/components/apps/converter/EncodingConverter.js
+++ b/components/apps/converter/EncodingConverter.js
@@ -56,12 +56,21 @@ const EncodingConverter = ({ onConvert }) => {
         placeholder="Input"
       />
       {error && <div className="text-red-400 text-sm">{error}</div>}
-      <textarea
-        className="text-black p-1 rounded"
-        value={output}
-        readOnly
-        placeholder="Result"
-      />
+      <div className="flex flex-col gap-2">
+        <textarea
+          className="text-black p-1 rounded"
+          value={output}
+          readOnly
+          placeholder="Result"
+        />
+        <button
+          onClick={() => navigator.clipboard.writeText(output)}
+          disabled={!output}
+          className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+        >
+          Copy
+        </button>
+      </div>
     </div>
   );
 };

--- a/components/apps/converter/TextTransform.js
+++ b/components/apps/converter/TextTransform.js
@@ -50,12 +50,21 @@ const TextTransform = ({ onConvert }) => {
         placeholder="Input"
       />
       {error && <div className="text-red-400 text-sm">{error}</div>}
-      <textarea
-        className="text-black p-1 rounded"
-        value={output}
-        readOnly
-        placeholder="Result"
-      />
+      <div className="flex flex-col gap-2">
+        <textarea
+          className="text-black p-1 rounded"
+          value={output}
+          readOnly
+          placeholder="Result"
+        />
+        <button
+          onClick={() => navigator.clipboard.writeText(output)}
+          disabled={!output}
+          className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+        >
+          Copy
+        </button>
+      </div>
     </div>
   );
 };

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -118,8 +118,23 @@ const UnitConverter = ({ onConvert }) => {
           </select>
         </label>
       </div>
-      <div data-testid="unit-result" className="mt-2">
-        {result && `${value} ${fromUnit} = ${result} ${toUnit}`}
+      <div
+        data-testid="unit-result"
+        className="mt-2 flex items-center gap-2"
+      >
+        {result && (
+          <>
+            <span>{`${value} ${fromUnit} = ${result} ${toUnit}`}</span>
+            <button
+              onClick={() =>
+                navigator.clipboard.writeText(`${result} ${toUnit}`)
+              }
+              className="bg-blue-600 text-white px-2 py-1 rounded"
+            >
+              Copy
+            </button>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow Encoding converter results to be copied to clipboard
- add copy button for text transforms
- include copy helper for unit conversions

## Testing
- `yarn test __tests__/converter.test.tsx`
- `yarn lint` *(fails: Parsing error: Identifier 'lastTime' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8d5fe848328b2afaa9bd2b49bf0