### PR TITLE
feat: improve ascii art rendering

### DIFF
--- a/components/apps/ascii_art/worker.js
+++ b/components/apps/ascii_art/worker.js
@@ -1,8 +1,9 @@
 self.onmessage = async (e) => {
-  const { bitmap, charSet, fontSize, useColor, palette } = e.data;
+  const { bitmap, charSet, fontSize, charWidth, useColor, palette } = e.data;
   const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
   const safeFont = clamp(fontSize || 8, 1, 100);
-  const rawWidth = Math.floor(bitmap.width / safeFont);
+  const safeChar = clamp(charWidth || safeFont, 1, 1000);
+  const rawWidth = Math.floor(bitmap.width / safeChar);
   const rawHeight = Math.floor(bitmap.height / safeFont);
   const MAX_DIM = 1000;
   const width = clamp(rawWidth, 1, MAX_DIM);


### PR DESCRIPTION
## Summary
- add customizable font family with monospaced preview
- allow exporting ASCII art to HTML alongside PNG and text
- pass character width to worker for more accurate rendering with palettes

## Testing
- `yarn lint` (fails: Identifier 'lastTime' has already been declared)
- `yarn test` (fails: ReferenceError: NUM_TILES_WIDE is not defined)

------
https://chatgpt.com/codex/tasks/task_e_68aac8daf17c8328b085dddbf03de0cd