### PR TITLE
feat(2048): expand board size, AI heuristics, and replay sharing

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -12,24 +12,41 @@ import {
 
 const dailySeed = Number(new Date().toISOString().slice(0, 10).replace(/-/g, ''));
 
-const size = 4;
-const positions = Array.from({ length: size * size }, (_, i) => ({
-  x: (i % size) * 100,
-  y: Math.floor(i / size) * 100,
-}));
-
-const Tile: React.FC<{ value: number; index: number }> = ({ value, index }) => {
-  const { x, y } = positions[index];
+const Tile: React.FC<{ value: number; index: number; size: number }> = ({ value, index, size }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const cell = 100;
+  const x = (index % size) * cell;
+  const y = Math.floor(index / size) * cell;
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const startX = parseFloat(el.dataset.x || String(x));
+    const startY = parseFloat(el.dataset.y || String(y));
+    const dx = x - startX;
+    const dy = y - startY;
+    let start: number | null = null;
+    const duration = 150;
+    const step = (t: number) => {
+      if (start === null) start = t;
+      const p = Math.min((t - start) / duration, 1);
+      const cx = startX + dx * p;
+      const cy = startY + dy * p;
+      el.style.transform = `translate(${cx + 5}px, ${cy + 5}px)`;
+      if (p < 1) requestAnimationFrame(step);
+      else {
+        el.dataset.x = String(x);
+        el.dataset.y = String(y);
+      }
+    };
+    requestAnimationFrame(step);
+  }, [x, y]);
   return (
     <div
-      className={`absolute flex items-center justify-center rounded bg-orange-200 text-xl font-bold transition-transform duration-150 ease-out ${
+      ref={ref}
+      className={`absolute flex items-center justify-center rounded bg-orange-200 text-xl font-bold ${
         value ? 'opacity-100' : 'opacity-0'
       }`}
-      style={{
-        width: 90,
-        height: 90,
-        transform: `translate(${x + 5}px, ${y + 5}px)`,
-      }}
+      style={{ width: 90, height: 90 }}
     >
       {value || ''}
     </div>
@@ -37,7 +54,19 @@ const Tile: React.FC<{ value: number; index: number }> = ({ value, index }) => {
 };
 
 const Game2048: React.FC = () => {
-  const rngRef = useRef(createRng(dailySeed));
+  const [size, setSize] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return parseInt(localStorage.getItem('2048_size') || '4', 10);
+    }
+    return 4;
+  });
+  const [seed, setSeed] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return parseInt(localStorage.getItem('2048_seed') || String(dailySeed), 10);
+    }
+    return dailySeed;
+  });
+  const rngRef = useRef(createRng(seed));
   const [state, setState] = useState<GameState>(() => {
     if (typeof window !== 'undefined') {
       try {
@@ -50,14 +79,23 @@ const Game2048: React.FC = () => {
         /* ignore */
       }
     }
-    return initialState(rngRef.current);
+    return initialState(rngRef.current, size);
   });
   const [best, setBest] = useState(() => {
     if (typeof window !== 'undefined') {
-      const b = parseInt(localStorage.getItem('2048_best') || '0', 10);
-      return b;
+      return parseInt(localStorage.getItem('2048_best') || '0', 10);
     }
     return 0;
+  });
+  const [achievements, setAchievements] = useState<number[]>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        return JSON.parse(localStorage.getItem('2048_achievements') || '[]');
+      } catch {
+        return [];
+      }
+    }
+    return [];
   });
   const workerRef = useRef<Worker>();
   const startRef = useRef<{ x: number; y: number } | null>(null);
@@ -75,12 +113,20 @@ const Game2048: React.FC = () => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('2048_board', JSON.stringify(state.board));
       localStorage.setItem('2048_score', String(state.score));
-      if (state.score > best) {
-        setBest(state.score);
-        localStorage.setItem('2048_best', String(state.score));
-      }
+      localStorage.setItem('2048_best', String(best));
+      localStorage.setItem('2048_size', String(size));
+      localStorage.setItem('2048_seed', String(seed));
+      localStorage.setItem('2048_achievements', JSON.stringify(achievements));
     }
-  }, [state, best]);
+  }, [state, best, size, seed, achievements]);
+
+  useEffect(() => {
+    if (state.score > best) setBest(state.score);
+    const maxTile = Math.max(...state.board);
+    const thresholds = [128, 256, 512, 1024, 2048, 4096];
+    const newAch = thresholds.filter((t) => maxTile >= t && !achievements.includes(t));
+    if (newAch.length) setAchievements((a) => [...a, ...newAch]);
+  }, [state, best, achievements]);
 
   const handleMove = (dir: Direction) => {
     setState((s) => move(s, dir, rngRef.current));
@@ -101,6 +147,10 @@ const Game2048: React.FC = () => {
   };
 
   useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', onKey);
+      return () => window.removeEventListener('keydown', onKey);
+    }
   }, []);
 
   const onPointerDown = (e: React.PointerEvent) => {
@@ -123,19 +173,58 @@ const Game2048: React.FC = () => {
     workerRef.current?.postMessage({ board: state.board, depth: 4, timeout: 200 });
   };
 
+  const reset = (n: number) => {
+    const newSeed = dailySeed;
+    setSeed(newSeed);
+    rngRef.current = createRng(newSeed);
+    setState(initialState(rngRef.current, n));
+  };
+
+  const changeSize = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const n = parseInt(e.target.value, 10);
+    setSize(n);
+    reset(n);
+  };
+
+  const share = () => {
+    const data = {
+      size,
+      seed,
+      moves: state.history.map((h) => h.move).filter(Boolean),
+    };
+    const encoded = btoa(JSON.stringify(data));
+    navigator.clipboard?.writeText(encoded);
+  };
+
   return (
     <div className="p-2 select-none">
       <div className="mb-2 flex justify-between">
         <div>Score: {state.score}</div>
         <div>Best: {best}</div>
       </div>
+      <div className="mb-2 flex gap-2">
+        <label>
+          Size
+          <select value={size} onChange={changeSize} className="ml-2 border p-1">
+            {[3, 4, 5, 6].map((n) => (
+              <option key={n} value={n}>
+                {n}x{n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button className="rounded bg-green-500 px-2 py-1 text-white" onClick={share}>
+          Share
+        </button>
+      </div>
       <div
-        className="relative h-[400px] w-[400px] bg-gray-300"
+        className="relative bg-gray-300"
+        style={{ width: size * 100, height: size * 100 }}
         onPointerDown={onPointerDown}
         onPointerUp={onPointerUp}
       >
         {state.board.map((v, i) => (
-          <Tile key={i} value={v} index={i} />
+          <Tile key={i} value={v} index={i} size={size} />
         ))}
       </div>
       <div className="mt-2 flex gap-2">
@@ -149,6 +238,9 @@ const Game2048: React.FC = () => {
           Solver
         </button>
       </div>
+      {achievements.length > 0 && (
+        <div className="mt-2 text-sm">Achieved: {achievements.join(', ')}</div>
+      )}
       {isGameOver(state.board) && <div className="mt-2 text-red-500">Game Over</div>}
     </div>
   );

--- a/apps/2048/solver.worker.ts
+++ b/apps/2048/solver.worker.ts
@@ -3,28 +3,29 @@ import { moveBoard, isGameOver, Direction } from './engine';
 const dirs: Direction[] = ['up', 'down', 'left', 'right'];
 
 const heuristic = (board: number[]): number => {
+  const size = Math.sqrt(board.length);
   let empty = 0;
   let smooth = 0;
   let mono = 0;
   let max = 0;
-  for (let r = 0; r < 4; r++) {
-    for (let c = 0; c < 4; c++) {
-      const v = board[r * 4 + c];
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      const v = board[r * size + c];
       if (v === 0) empty++;
       if (v > max) max = v;
-      if (c < 3) smooth -= Math.abs(v - board[r * 4 + c + 1]);
-      if (r < 3) smooth -= Math.abs(v - board[(r + 1) * 4 + c]);
+      if (c < size - 1) smooth -= Math.abs(v - board[r * size + c + 1]);
+      if (r < size - 1) smooth -= Math.abs(v - board[(r + 1) * size + c]);
     }
   }
   // monotonicity
-  for (let r = 0; r < 4; r++) {
-    for (let c = 0; c < 3; c++) {
-      if (board[r * 4 + c] >= board[r * 4 + c + 1]) mono += 1;
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size - 1; c++) {
+      if (board[r * size + c] >= board[r * size + c + 1]) mono += 1;
     }
   }
-  for (let c = 0; c < 4; c++) {
-    for (let r = 0; r < 3; r++) {
-      if (board[r * 4 + c] >= board[(r + 1) * 4 + c]) mono += 1;
+  for (let c = 0; c < size; c++) {
+    for (let r = 0; r < size - 1; r++) {
+      if (board[r * size + c] >= board[(r + 1) * size + c]) mono += 1;
     }
   }
   return empty * 100 + mono * 1 + smooth * 0.1 + Math.log2(max) * 10;


### PR DESCRIPTION
## Summary
- generalize 2048 engine for arbitrary board sizes
- add Expectimax AI heuristics and shareable replay serialization
- implement rAF-based tile animation, achievements, and size selector

## Testing
- `yarn test apps/2048`


------
https://chatgpt.com/codex/tasks/task_e_68aac909d0488328b8bbe50605ab222d