### PR TITLE
feat: add quadtree collision and accessibility options

### DIFF
--- a/apps/asteroids/renderer.ts
+++ b/apps/asteroids/renderer.ts
@@ -20,21 +20,23 @@ self.onmessage = (e: MessageEvent) => {
   if (type === 'init') {
     ctx = (e.data.canvas as OffscreenCanvas).getContext('2d');
   } else if (type === 'render' && ctx) {
-    const { ship, bullets, saucerBullets, asteroids, saucer, score, level } = e.data.state as {
-      ship: { x: number; y: number; angle: number; r: number };
-      bullets: Bullet[];
-      saucerBullets: Bullet[];
-      asteroids: Asteroid[];
-      saucer: Saucer;
-      score: number;
-      level: number;
-    };
+    const { ship, bullets, saucerBullets, asteroids, saucer, score, level, safeMode } =
+      e.data.state as {
+        ship: { x: number; y: number; angle: number; r: number };
+        bullets: Bullet[];
+        saucerBullets: Bullet[];
+        asteroids: Asteroid[];
+        saucer: Saucer;
+        score: number;
+        level: number;
+        safeMode: boolean;
+      };
     const width = (ctx.canvas as OffscreenCanvas).width;
     const height = (ctx.canvas as OffscreenCanvas).height;
     ctx.clearRect(0, 0, width, height);
     ctx.lineWidth = 1.5;
     ctx.strokeStyle = '#ffffff';
-    ctx.shadowBlur = 4;
+    ctx.shadowBlur = safeMode ? 0 : 4;
     ctx.shadowColor = '#0ff';
     ctx.beginPath();
     ctx.moveTo(ship.x + Math.cos(ship.angle) * ship.r, ship.y + Math.sin(ship.angle) * ship.r);

--- a/apps/asteroids/utils.ts
+++ b/apps/asteroids/utils.ts
@@ -59,3 +59,99 @@ export function splitAsteroidTree(size: number, min = 20) {
   }
   return node;
 }
+
+// Simple quadtree for broadphase collision detection
+export interface QuadItem<T = any> {
+  x: number;
+  y: number;
+  r: number;
+  data: T;
+}
+
+const MAX_OBJECTS = 4;
+const MAX_LEVELS = 5;
+
+export class Quadtree<T = any> {
+  private objects: QuadItem<T>[] = [];
+  private nodes: Quadtree<T>[] = [];
+
+  constructor(
+    private bounds: { x: number; y: number; w: number; h: number },
+    private level = 0,
+  ) {}
+
+  private split() {
+    const { x, y, w, h } = this.bounds;
+    const halfW = w / 2;
+    const halfH = h / 2;
+    const next = this.level + 1;
+    this.nodes[0] = new Quadtree({ x: x + halfW, y, w: halfW, h: halfH }, next);
+    this.nodes[1] = new Quadtree({ x, y, w: halfW, h: halfH }, next);
+    this.nodes[2] = new Quadtree({ x, y: y + halfH, w: halfW, h: halfH }, next);
+    this.nodes[3] = new Quadtree({ x: x + halfW, y: y + halfH, w: halfW, h: halfH }, next);
+  }
+
+  private getIndex(item: QuadItem): number {
+    const verticalMid = this.bounds.x + this.bounds.w / 2;
+    const horizontalMid = this.bounds.y + this.bounds.h / 2;
+    const top = item.y + item.r < horizontalMid;
+    const bottom = item.y - item.r > horizontalMid;
+    const left = item.x + item.r < verticalMid;
+    const right = item.x - item.r > verticalMid;
+
+    if (left) {
+      if (top) return 1;
+      if (bottom) return 2;
+    } else if (right) {
+      if (top) return 0;
+      if (bottom) return 3;
+    }
+    return -1;
+  }
+
+  insert(item: QuadItem<T>) {
+    if (this.nodes.length) {
+      const index = this.getIndex(item);
+      if (index !== -1) {
+        this.nodes[index].insert(item);
+        return;
+      }
+    }
+
+    this.objects.push(item);
+
+    if (
+      this.objects.length > MAX_OBJECTS &&
+      this.level < MAX_LEVELS &&
+      this.nodes.length === 0
+    ) {
+      this.split();
+      let i = 0;
+      while (i < this.objects.length) {
+        const index = this.getIndex(this.objects[i]);
+        if (index !== -1) {
+          this.nodes[index].insert(this.objects.splice(i, 1)[0]);
+        } else {
+          i++;
+        }
+      }
+    }
+  }
+
+  retrieve(range: { x: number; y: number; r: number }, result: QuadItem<T>[] = []): QuadItem<T>[] {
+    const index = this.getIndex(range as QuadItem);
+    if (index !== -1 && this.nodes.length) {
+      this.nodes[index].retrieve(range, result);
+    }
+    result.push(...this.objects);
+    return result;
+  }
+
+  clear() {
+    this.objects.length = 0;
+    for (const node of this.nodes) {
+      node.clear();
+    }
+    this.nodes.length = 0;
+  }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -279,3 +279,16 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
         transition: none !important;
     }
 }
+
+canvas.crt {
+    background-image: repeating-linear-gradient(
+        rgba(255, 255, 255, 0.05) 0px,
+        rgba(255, 255, 255, 0.05) 1px,
+        transparent 1px,
+        transparent 2px
+    );
+}
+
+canvas.safe-mode {
+    filter: brightness(0.8);
+}


### PR DESCRIPTION
## Summary
- add quadtree broadphase for asteroids
- introduce gamepad rumble, scanline shader toggle, and safe mode
- add touch controls and telemetry hooks

## Testing
- `npx eslint apps/asteroids/index.tsx apps/asteroids/renderer.ts apps/asteroids/utils.ts` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `yarn test apps/asteroids --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aac90ae6e4832895abef3ff9d94a8e