### PR TITLE
feat(breakout): add advanced power-ups and replay support

### DIFF
--- a/apps/breakout/Ball.ts
+++ b/apps/breakout/Ball.ts
@@ -7,6 +7,7 @@ export default class Ball {
   canvasWidth: number;
   canvasHeight: number;
   maxSpeed = 600;
+  stuck = false;
 
   constructor(canvasWidth: number, canvasHeight: number) {
     this.canvasWidth = canvasWidth;
@@ -19,9 +20,11 @@ export default class Ball {
     this.y = this.canvasHeight / 2;
     this.vx = 150 * (Math.random() > 0.5 ? 1 : -1);
     this.vy = -150;
+    this.stuck = false;
   }
 
   update(dt: number) {
+    if (this.stuck) return;
     let remaining = dt;
     const step = 1 / 60; // base fixed step
     while (remaining > 0) {

--- a/apps/breakout/Brick.ts
+++ b/apps/breakout/Brick.ts
@@ -4,7 +4,7 @@ export default class Brick {
   w: number;
   h: number;
   destroyed = false;
-  powerUp: 'multiball' | 'laser' | null;
+  powerUp: 'multiball' | 'laser' | 'expand' | 'sticky' | 'slow' | null;
   hp: number;
 
   constructor(
@@ -12,7 +12,7 @@ export default class Brick {
     y: number,
     w: number,
     h: number,
-    powerUp: 'multiball' | 'laser' | null = null,
+    powerUp: 'multiball' | 'laser' | 'expand' | 'sticky' | 'slow' | null = null,
     hp = 1,
   ) {
     this.x = x;

--- a/apps/breakout/Paddle.ts
+++ b/apps/breakout/Paddle.ts
@@ -7,9 +7,13 @@ export default class Paddle {
   canvasWidth: number;
   lasers: { x: number; y: number }[] = [];
   laserActive = false;
+  vx = 0;
+  baseWidth: number;
+  sticky = false;
 
   constructor(canvasWidth: number, canvasHeight: number) {
-    this.width = 80;
+    this.baseWidth = 80;
+    this.width = this.baseWidth;
     this.height = 10;
     this.x = canvasWidth / 2 - this.width / 2;
     this.y = canvasHeight - this.height * 2;
@@ -18,7 +22,8 @@ export default class Paddle {
   }
 
   move(dir: number, dt: number) {
-    this.x += dir * this.speed * dt;
+    this.vx = dir * this.speed;
+    this.x += this.vx * dt;
     if (this.x < 0) this.x = 0;
     if (this.x + this.width > this.canvasWidth) this.x = this.canvasWidth - this.width;
   }
@@ -32,6 +37,14 @@ export default class Paddle {
     this.lasers = this.lasers
       .map((l) => ({ ...l, y: l.y - 400 * dt }))
       .filter((l) => l.y > 0);
+  }
+
+  expand() {
+    this.width = Math.min(this.canvasWidth, this.width * 1.5);
+  }
+
+  resetWidth() {
+    this.width = this.baseWidth;
   }
 
   draw(ctx: CanvasRenderingContext2D) {

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -12,6 +12,7 @@ const LevelEditor = ({ onSave, onCancel }) => {
   const [grid, setGrid] = useState(
     Array.from({ length: rows }, () => Array(cols).fill(0))
   );
+  const [link, setLink] = useState('');
   const toggle = (r, c) => {
     setGrid((g) => {
       const ng = g.map((row) => row.slice());
@@ -25,6 +26,9 @@ const LevelEditor = ({ onSave, onCancel }) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(grid),
     });
+    const encoded = btoa(JSON.stringify(grid));
+    const url = `${window.location.origin}${window.location.pathname}?layout=${encoded}`;
+    setLink(url);
     onSave(grid);
   };
   return (
@@ -59,6 +63,16 @@ const LevelEditor = ({ onSave, onCancel }) => {
           Back
         </button>
       </div>
+      {link && (
+        <div>
+          <input
+            type="text"
+            readOnly
+            value={link}
+            className="w-full text-black px-1"
+          />
+        </div>
+      )}
     </div>
   );
 };
@@ -70,6 +84,22 @@ const Breakout = () => {
   const [editing, setEditing] = useState(false);
   const [customLayout, setCustomLayout] = useState(null);
   const [levels, setLevels] = useState([]);
+  const replayRef = useRef([]);
+  const elapsedRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const layoutParam = params.get('layout');
+    if (layoutParam) {
+      try {
+        const parsed = JSON.parse(atob(layoutParam));
+        setCustomLayout(parsed);
+      } catch (e) {
+        // ignore
+      }
+    }
+  }, []);
 
   useEffect(() => {
     fetch('/api/breakout/levels')
@@ -107,7 +137,11 @@ const Breakout = () => {
     const balls = [new Ball(width, height)];
     const bricks = [];
     const powerUps = [];
+    const powerUpPool = [];
     let particles = [];
+    let speedFactor = 1;
+    replayRef.current = [];
+    elapsedRef.current = 0;
 
     const layout = customLayout || levels[0] || null;
     const rows = layout ? layout.length : rowsByDifficulty[difficulty];
@@ -117,7 +151,8 @@ const Breakout = () => {
     for (let r = 0; r < rows; r += 1) {
       for (let c = 0; c < cols; c += 1) {
         if (layout && !layout[r][c]) continue;
-        const powerUp = Math.random() < 0.1 ? (Math.random() < 0.5 ? 'multiball' : 'laser') : null;
+        const types = ['multiball', 'laser', 'expand', 'sticky', 'slow'];
+        const powerUp = Math.random() < 0.1 ? types[Math.floor(Math.random() * types.length)] : null;
         const hp = Math.random() < 0.05 ? 3 : 1;
         bricks.push(new Brick(c * bw, r * bh + 40, bw - 2, bh - 2, powerUp, hp));
       }
@@ -126,10 +161,22 @@ const Breakout = () => {
     balls[0].vy *= speedByDifficulty[difficulty] / 150;
 
     const keys = { left: false, right: false };
+    const releaseBalls = () => {
+      balls.forEach((b) => {
+        if (b.stuck) {
+          b.stuck = false;
+          b.vx = 150 * (Math.random() > 0.5 ? 1 : -1);
+          b.vy = -150;
+        }
+      });
+    };
     const keyDown = (e) => {
       if (e.key === 'ArrowLeft') keys.left = true;
       if (e.key === 'ArrowRight') keys.right = true;
-      if (e.key === ' ') paddle.shoot();
+      if (e.key === ' ') {
+        releaseBalls();
+        paddle.shoot();
+      }
     };
     const keyUp = (e) => {
       if (e.key === 'ArrowLeft') keys.left = false;
@@ -144,7 +191,10 @@ const Breakout = () => {
       if (paddle.x < 0) paddle.x = 0;
       if (paddle.x + paddle.width > width) paddle.x = width - paddle.width;
     };
-    const pointerDown = () => paddle.shoot();
+    const pointerDown = () => {
+      releaseBalls();
+      paddle.shoot();
+    };
     canvas.addEventListener('pointermove', pointerMove);
     canvas.addEventListener('pointerdown', pointerDown);
 
@@ -177,6 +227,47 @@ const Breakout = () => {
       }
       return arr;
     };
+    const sweptAABB = (ball, rect, dt) => {
+      const dx = ball.vx * dt;
+      const dy = ball.vy * dt;
+      const invEntry = { x: 0, y: 0 };
+      const invExit = { x: 0, y: 0 };
+      if (dx > 0) {
+        invEntry.x = rect.x - (ball.x + ball.r);
+        invExit.x = rect.x + rect.w - (ball.x - ball.r);
+      } else {
+        invEntry.x = rect.x + rect.w - (ball.x - ball.r);
+        invExit.x = rect.x - (ball.x + ball.r);
+      }
+      if (dy > 0) {
+        invEntry.y = rect.y - (ball.y + ball.r);
+        invExit.y = rect.y + rect.h - (ball.y - ball.r);
+      } else {
+        invEntry.y = rect.y + rect.h - (ball.y - ball.r);
+        invExit.y = rect.y - (ball.y + ball.r);
+      }
+      const entry = {
+        x: dx === 0 ? -Infinity : invEntry.x / dx,
+        y: dy === 0 ? -Infinity : invEntry.y / dy,
+      };
+      const exit = {
+        x: dx === 0 ? Infinity : invExit.x / dx,
+        y: dy === 0 ? Infinity : invExit.y / dy,
+      };
+      const entryTime = Math.max(entry.x, entry.y);
+      const exitTime = Math.min(exit.x, exit.y);
+      if (entryTime > exitTime || entry.x < 0 && entry.y < 0 || entryTime > 1 || entryTime < 0) {
+        return null;
+      }
+      let nx = 0;
+      let ny = 0;
+      if (entry.x > entry.y) {
+        nx = invEntry.x < 0 ? 1 : -1;
+      } else {
+        ny = invEntry.y < 0 ? 1 : -1;
+      }
+      return { time: entryTime, nx, ny };
+    };
     const drawBricks = () => {
       const groups = { normal: [], power: [], boss: [] };
       bricks.forEach((br) => {
@@ -202,23 +293,51 @@ const Breakout = () => {
     let acc = 0;
     const step = 1 / 60;
 
-    const update = (dt) => {
-      paddle.move((keys.right ? 1 : 0) - (keys.left ? 1 : 0), dt);
-      paddle.updateLasers(dt);
+    const spawnPowerUp = (x, y, type) => {
+      const p = powerUpPool.pop() || { x: 0, y: 0, vy: 50, type: null };
+      p.x = x;
+      p.y = y;
+      p.vy = 50;
+      p.type = type;
+      powerUps.push(p);
+    };
 
-      balls.forEach((b) => b.update(dt));
+    const update = (dt) => {
+      const dtAdj = dt * speedFactor;
+      paddle.move((keys.right ? 1 : 0) - (keys.left ? 1 : 0), dtAdj);
+      paddle.updateLasers(dtAdj);
 
       balls.forEach((b) => {
-        if (b.y + b.r > paddle.y && b.x > paddle.x && b.x < paddle.x + paddle.width && b.vy > 0) {
-          const relative = (b.x - (paddle.x + paddle.width / 2)) / (paddle.width / 2);
-          const angle = relative * (Math.PI / 3);
-          const speed = Math.sqrt(b.vx * b.vx + b.vy * b.vy);
-          b.vx = speed * Math.sin(angle);
-          b.vy = -Math.abs(speed * Math.cos(angle));
+        if (b.stuck) {
+          b.x = paddle.x + paddle.width / 2;
           b.y = paddle.y - b.r;
+        } else {
+          b.update(dtAdj);
+        }
+      });
+
+      balls.forEach((b) => {
+        const res = sweptAABB(b, { x: paddle.x, y: paddle.y, w: paddle.width, h: paddle.height }, dtAdj);
+        if (res && b.vy > 0) {
+          b.x += b.vx * res.time;
+          b.y += b.vy * res.time;
+          if (paddle.sticky) {
+            b.stuck = true;
+            b.vx = 0;
+            b.vy = 0;
+          } else {
+            const speed = Math.sqrt(b.vx * b.vx + b.vy * b.vy);
+            const relative = (b.x - (paddle.x + paddle.width / 2)) / (paddle.width / 2);
+            const angle = relative * (Math.PI / 3);
+            b.vx = speed * Math.sin(angle) + paddle.vx * 0.1;
+            b.vy = -Math.abs(speed * Math.cos(angle));
+          }
           playSound(200);
         }
-        if (b.y > height + b.r) b.reset();
+        if (b.y > height + b.r) {
+          const idx = balls.indexOf(b);
+          if (idx >= 0) balls.splice(idx, 1);
+        }
       });
 
       paddle.lasers.forEach((l) => {
@@ -227,8 +346,7 @@ const Breakout = () => {
             br.hit();
             if (br.destroyed) {
               particles.push(...spawnParticles(br.x + br.w / 2, br.y + br.h / 2));
-              if (br.powerUp)
-                powerUps.push({ x: br.x + br.w / 2, y: br.y + br.h / 2, type: br.powerUp, vy: 50 });
+              if (br.powerUp) spawnPowerUp(br.x + br.w / 2, br.y + br.h / 2, br.powerUp);
             }
           }
         });
@@ -237,20 +355,17 @@ const Breakout = () => {
       balls.forEach((b) => {
         bricks.forEach((br) => {
           if (br.destroyed) return;
-          if (b.x + b.r > br.x && b.x - b.r < br.x + br.w && b.y + b.r > br.y && b.y - b.r < br.y + br.h) {
-            const overlapX = Math.min(b.x + b.r - br.x, br.x + br.w - (b.x - b.r));
-            const overlapY = Math.min(b.y + b.r - br.y, br.y + br.h - (b.y - b.r));
-            if (overlapX < overlapY) {
-              b.vx *= -1;
-            } else {
-              b.vy *= -1;
-            }
+          const res = sweptAABB(b, br, dtAdj);
+          if (res) {
+            b.x += b.vx * res.time;
+            b.y += b.vy * res.time;
+            if (res.nx) b.vx *= -1;
+            if (res.ny) b.vy *= -1;
             br.hit();
             if (br.destroyed) {
               playSound(400);
               particles.push(...spawnParticles(br.x + br.w / 2, br.y + br.h / 2));
-              if (br.powerUp)
-                powerUps.push({ x: br.x + br.w / 2, y: br.y + br.h / 2, type: br.powerUp, vy: 50 });
+              if (br.powerUp) spawnPowerUp(br.x + br.w / 2, br.y + br.h / 2, br.powerUp);
             }
           }
         });
@@ -258,42 +373,75 @@ const Breakout = () => {
 
       for (let i = powerUps.length - 1; i >= 0; i -= 1) {
         const p = powerUps[i];
-        p.y += p.vy * dt;
+        p.y += p.vy * dtAdj;
         if (p.y > paddle.y && p.x > paddle.x && p.x < paddle.x + paddle.width) {
           if (p.type === 'multiball') {
             const nb = new Ball(width, height);
-            nb.x = balls[0].x;
-            nb.y = balls[0].y;
-            nb.vx = -balls[0].vx;
-            nb.vy = balls[0].vy;
+            nb.x = balls[0] ? balls[0].x : width / 2;
+            nb.y = balls[0] ? balls[0].y : height / 2;
+            nb.vx = balls[0] ? -balls[0].vx : 150;
+            nb.vy = balls[0] ? balls[0].vy : -150;
             balls.push(nb);
           } else if (p.type === 'laser') {
             paddle.laserActive = true;
             setTimeout(() => {
               paddle.laserActive = false;
             }, 5000);
+          } else if (p.type === 'expand') {
+            paddle.expand();
+            setTimeout(() => paddle.resetWidth(), 5000);
+          } else if (p.type === 'sticky') {
+            paddle.sticky = true;
+            setTimeout(() => {
+              paddle.sticky = false;
+            }, 5000);
+          } else if (p.type === 'slow') {
+            speedFactor = 0.5;
+            setTimeout(() => {
+              speedFactor = 1;
+            }, 5000);
           }
           playSound(600);
+          powerUpPool.push(p);
           powerUps.splice(i, 1);
         } else if (p.y > height) {
+          powerUpPool.push(p);
           powerUps.splice(i, 1);
         }
       }
 
       particles = particles
-        .map((pt) => ({ ...pt, x: pt.x + pt.vx * dt, y: pt.y + pt.vy * dt, life: pt.life - dt }))
+        .map((pt) => ({ ...pt, x: pt.x + pt.vx * dtAdj, y: pt.y + pt.vy * dtAdj, life: pt.life - dtAdj }))
         .filter((pt) => pt.life > 0);
+
+      elapsedRef.current += dtAdj;
+      replayRef.current.push({
+        t: elapsedRef.current,
+        balls: balls.map((b) => ({ x: b.x, y: b.y, vx: b.vx, vy: b.vy })),
+        paddle: { x: paddle.x },
+      });
+
+      if (balls.length === 0) {
+        balls.push(new Ball(width, height));
+      }
     };
 
     const render = () => {
       ctx.clearRect(0, 0, width, height);
-      drawBricks();
-      balls.forEach((b) => b.draw(ctx));
-      paddle.draw(ctx);
-      powerUps.forEach((p) => {
-        ctx.fillStyle = p.type === 'multiball' ? 'yellow' : 'red';
-        ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
-      });
+        drawBricks();
+        balls.forEach((b) => b.draw(ctx));
+        paddle.draw(ctx);
+        powerUps.forEach((p) => {
+          const colors = {
+            multiball: 'yellow',
+            laser: 'red',
+            expand: 'green',
+            sticky: 'purple',
+            slow: 'cyan',
+          };
+          ctx.fillStyle = colors[p.type] || 'white';
+          ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
+        });
       particles.forEach((pt) => {
         ctx.fillStyle = `rgba(255,255,255,${pt.life})`;
         ctx.fillRect(pt.x, pt.y, 2, 2);
@@ -323,6 +471,18 @@ const Breakout = () => {
     };
   }, [difficulty, editing, customLayout, levels]);
 
+  const saveReplay = () => {
+    const blob = new Blob([JSON.stringify(replayRef.current)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'breakout-replay.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div ref={containerRef} className="h-full w-full bg-black relative overflow-hidden">
       {editing ? (
@@ -351,28 +511,35 @@ const Breakout = () => {
       ) : (
         <>
           <canvas ref={canvasRef} className="touch-none" />
-          <div className="absolute top-2 left-2 space-x-2 text-white">
-            <select
-              value={difficulty}
-              onChange={(e) => setDifficulty(e.target.value)}
-              className="text-black px-1"
-            >
-              <option value="easy">Easy</option>
-              <option value="medium">Medium</option>
-              <option value="hard">Hard</option>
-            </select>
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="px-2 py-1 bg-blue-600"
-            >
-              Edit Level
-            </button>
-          </div>
-        </>
-      )}
-    </div>
-  );
+            <div className="absolute top-2 left-2 space-x-2 text-white">
+              <select
+                value={difficulty}
+                onChange={(e) => setDifficulty(e.target.value)}
+                className="text-black px-1"
+              >
+                <option value="easy">Easy</option>
+                <option value="medium">Medium</option>
+                <option value="hard">Hard</option>
+              </select>
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="px-2 py-1 bg-blue-600"
+              >
+                Edit Level
+              </button>
+              <button
+                type="button"
+                onClick={saveReplay}
+                className="px-2 py-1 bg-green-700"
+              >
+                Save Replay
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    );
 };
 
 export default Breakout;


### PR DESCRIPTION
## Summary
- implement swept AABB collisions and paddle spin for richer ball physics
- add expand, sticky and slow-mo power-ups with object pooling and multiball management
- expose JSON level sharing and replay saving from the Breakout interface

## Testing
- `yarn test __tests__/breakout.engine.test.ts __tests__/breakout.api.test.ts`
- `yarn lint apps/breakout/Ball.ts apps/breakout/Paddle.ts apps/breakout/Brick.ts components/apps/breakout.js` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac90d43e08328bb4e72fe6e551fa2