### PR TITLE
feat: add blackjack presets and counting practice

### DIFF
--- a/apps/blackjack/CountingPractice.tsx
+++ b/apps/blackjack/CountingPractice.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from './types';
+import { fisherYates } from '@components/apps/blackjack/engine';
+
+const suits = ['\u2660', '\u2665', '\u2666', '\u2663'];
+const values = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+function createDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (const value of values) {
+      deck.push({ suit, value });
+    }
+  }
+  return deck;
+}
+
+function countValue(card: Card): number {
+  const v = card.value;
+  if (['2', '3', '4', '5', '6'].includes(v)) return 1;
+  if (['10', 'J', 'Q', 'K', 'A'].includes(v)) return -1;
+  return 0;
+}
+
+export default function CountingPractice() {
+  const [deck, setDeck] = useState<Card[]>([]);
+  const [current, setCurrent] = useState<Card | null>(null);
+  const [running, setRunning] = useState(0);
+  const [guess, setGuess] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  const deal = () => {
+    if (deck.length === 0) {
+      setDeck(fisherYates(createDeck()));
+      return;
+    }
+    const [card, ...rest] = deck;
+    setDeck(rest);
+    setCurrent(card);
+    setRunning((r) => r + countValue(card));
+  };
+
+  useEffect(() => {
+    setDeck(fisherYates(createDeck()));
+  }, []);
+
+  useEffect(() => {
+    if (!current && deck.length > 0) deal();
+  }, [deck, current]);
+
+  const check = () => {
+    if (guess.trim() === '') return;
+    const g = parseInt(guess, 10);
+    if (g === running) {
+      setFeedback('Correct!');
+    } else {
+      setFeedback(`Incorrect. Count is ${running}.`);
+    }
+  };
+
+  const next = () => {
+    setFeedback('');
+    setGuess('');
+    deal();
+  };
+
+  return (
+    <div className="p-4 border mt-4" aria-label="Card counting practice">
+      <div className="mb-2 text-lg">{current ? `${current.value}${current.suit}` : '?'}</div>
+      <input
+        className="border p-1 mr-2 w-20"
+        value={guess}
+        onChange={(e) => setGuess(e.target.value)}
+        aria-label="Your running count"
+      />
+      <button className="btn" onClick={check} aria-label="Check count">Check</button>
+      {feedback && <div className="mt-2">{feedback}</div>}
+      <button className="btn mt-2" onClick={next} aria-label="Next card">Next</button>
+    </div>
+  );
+}
+

--- a/apps/blackjack/index.tsx
+++ b/apps/blackjack/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import Dealer from './Dealer';
 import PlayerHand from './PlayerHand';
 import Controls from './Controls';
+import CountingPractice from './CountingPractice';
 import { Card, Hand } from './types';
 import { basicStrategy, fisherYates } from '@components/apps/blackjack/engine';
 
@@ -64,8 +65,10 @@ function isSoft(hand: Card[]): boolean {
 const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, token }) => {
   const [decks, setDecks] = useState(1);
   const [hitSoft17, setHitSoft17] = useState(true);
+  const [preset, setPreset] = useState<'custom' | 'vegas' | 'atlantic'>('custom');
   const [showCount, setShowCount] = useState(false);
   const [showStrategy, setShowStrategy] = useState(false);
+  const [showPractice, setShowPractice] = useState(false);
   const [deck, setDeck] = useState<Card[]>(() => shuffle(createDeck(1)));
   const [dealer, setDealer] = useState<Card[]>([]);
   const [playerHands, setPlayerHands] = useState<Hand[]>([]);
@@ -76,6 +79,16 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
   const [history, setHistory] = useState<any[]>([]);
   const [betting, setBetting] = useState(false);
   const trueCount = useMemo(() => runningCount / Math.max(1, deck.length / 52), [runningCount, deck.length]);
+
+  useEffect(() => {
+    if (preset === 'vegas') {
+      setDecks(6);
+      setHitSoft17(true);
+    } else if (preset === 'atlantic') {
+      setDecks(8);
+      setHitSoft17(false);
+    }
+  }, [preset]);
 
   useEffect(() => {
     setDeck(shuffle(createDeck(decks)));
@@ -268,13 +281,31 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
       </div>
       <div className="mb-2">
         <label>
+          Preset:
+          <select
+            value={preset}
+            onChange={(e) => setPreset(e.target.value as 'custom' | 'vegas' | 'atlantic')}
+            className="ml-1 border"
+            aria-label="Rule preset"
+          >
+            <option value="custom">Custom</option>
+            <option value="vegas">Las Vegas (H17)</option>
+            <option value="atlantic">Atlantic City (S17)</option>
+          </select>
+        </label>
+      </div>
+      <div className="mb-2">
+        <label>
           Decks:
           <input
             type="number"
             min={1}
             max={8}
             value={decks}
-            onChange={(e) => setDecks(parseInt(e.target.value, 10) || 1)}
+            onChange={(e) => {
+              setDecks(parseInt(e.target.value, 10) || 1);
+              setPreset('custom');
+            }}
             className="ml-1 w-16 border"
             aria-label="Number of decks"
           />
@@ -285,7 +316,10 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
           <input
             type="checkbox"
             checked={hitSoft17}
-            onChange={(e) => setHitSoft17(e.target.checked)}
+            onChange={(e) => {
+              setHitSoft17(e.target.checked);
+              setPreset('custom');
+            }}
             aria-label="Dealer hits soft 17"
           />{' '}
           Dealer hits soft 17
@@ -340,7 +374,15 @@ const Blackjack: React.FC<{ userId?: string; token?: string }> = ({ userId, toke
         canInsurance={canInsurance}
         disabled={playerHands.length === 0}
       />
-      <button className="btn mt-2" aria-label="Deal" onClick={startRound}>Deal</button>
+      <button className="btn mt-2 mr-2" aria-label="Deal" onClick={startRound}>Deal</button>
+      <button
+        className="btn mt-2"
+        aria-label="Toggle counting practice"
+        onClick={() => setShowPractice((s) => !s)}
+      >
+        {showPractice ? 'Hide Practice' : 'Counting Practice'}
+      </button>
+      {showPractice && <CountingPractice />}
     </div>
   );
 };

--- a/apps/frogger/index.ts
+++ b/apps/frogger/index.ts
@@ -1,5 +1,6 @@
 export const TILE = 40;
 export const PAD_POSITIONS = [TILE, TILE * 3, TILE * 5, TILE * 7, TILE * 9];
+export const NUM_TILES_WIDE = 13;
 
 // linear congruential generator for deterministic lane RNG
 const rng = (seed: number) => () => {


### PR DESCRIPTION
## Summary
- add rule presets for Las Vegas and Atlantic City blackjack variants
- include interactive card counting practice mode with feedback
- define Frogger board width constant used in tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aac90fa508832899c27d7bd1d7fc2e