### PR TITLE
Enhance Wordle with difficulty tiers and persistent progress

### DIFF
--- a/apps/frogger/index.ts
+++ b/apps/frogger/index.ts
@@ -1,4 +1,5 @@
 export const TILE = 40;
+export const NUM_TILES_WIDE = 10;
 export const PAD_POSITIONS = [TILE, TILE * 3, TILE * 5, TILE * 7, TILE * 9];
 
 // linear congruential generator for deterministic lane RNG

--- a/apps/wordle/words.ts
+++ b/apps/wordle/words.ts
@@ -1,58 +1,36 @@
-export const ANSWERS = [
-  'apple',
-  'brave',
-  'crane',
-  'dodge',
-  'eagle',
-  'flair',
-  'grape',
-  'honey',
-  'ivory',
-  'jumpy',
-  'karma',
-  'lemon',
-  'mango',
-  'nifty',
-  'ocean',
-  'proxy',
-  'quart',
-  'risky',
-  'solar',
-  'tiger',
-  'ultra',
-  'vivid',
-  'whale',
-  'xenon',
-  'yacht',
-  'zebra',
-];
+import BadWords from 'bad-words';
+import curated from '../../public/wordlists/curated.json';
 
-export const GUESSES = Array.from(new Set([
-  ...ANSWERS,
-  'about',
-  'other',
-  'which',
-  'their',
-  'there',
-  'candy',
-  'fuzzy',
-  'gamer',
-  'house',
-  'input',
-  'jolly',
-  'knack',
-  'linen',
-  'might',
-  'novel',
-  'oxide',
-  'piano',
-  'quake',
-  'rival',
-  'smile',
-  'table',
-  'unzip',
-  'vigor',
-  'woven',
-  'yield',
-  'zesty',
-]));
+const medicalAllow = ['heart', 'ulcer', 'nerve', 'tumor', 'virus'];
+const filter = new BadWords();
+filter.removeWords(...medicalAllow);
+
+const levels = ['easy', 'medium', 'hard'] as const;
+export type Difficulty = typeof levels[number];
+
+type Curated = Record<Difficulty, string[]>;
+const data = curated as Curated;
+
+const filtered = levels.reduce((acc, level) => {
+  acc[level] = data[level].filter((w) => !filter.isProfane(w));
+  return acc;
+}, {} as Record<Difficulty, string[]>);
+
+export const WORDS_BY_DIFFICULTY = filtered;
+export const ALL_GUESSES = Array.from(
+  new Set([...filtered.easy, ...filtered.medium, ...filtered.hard]),
+);
+
+export const seedIndex = () => {
+  const epoch = new Date('2024-01-01T00:00:00Z');
+  const today = new Date();
+  const diff = Math.floor(
+    (today.setUTCHours(0, 0, 0, 0) - epoch.getTime()) / 86400000,
+  );
+  return diff;
+};
+
+export const getAnswer = (difficulty: Difficulty, seed = seedIndex()) => {
+  const list = filtered[difficulty];
+  return list[seed % list.length];
+};

--- a/components/apps/wordle.tsx
+++ b/components/apps/wordle.tsx
@@ -1,17 +1,14 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { ANSWERS, GUESSES } from '../../apps/wordle/words';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  WORDS_BY_DIFFICULTY,
+  ALL_GUESSES,
+  getAnswer,
+  Difficulty,
+} from '../../apps/wordle/words';
+import { loadState, saveState } from '../../lib/idb';
 
 const ROWS = 6;
 const COLS = 5;
-
-const seedIndex = () => {
-  const epoch = new Date('2024-01-01T00:00:00Z');
-  const today = new Date();
-  const diff = Math.floor(
-    (today.setUTCHours(0, 0, 0, 0) - epoch.getTime()) / 86400000,
-  );
-  return diff % ANSWERS.length;
-};
 
 const evaluateGuess = (guess: string, answer: string) => {
   const res: ('correct' | 'present' | 'absent')[] = Array(COLS).fill('absent');
@@ -38,15 +35,17 @@ const evaluateGuess = (guess: string, answer: string) => {
 const Keyboard = ({
   onKey,
   keyStatuses,
+  colorBlind,
 }: {
   onKey: (k: string) => void;
   keyStatuses: Record<string, string>;
+  colorBlind: boolean;
 }) => {
   const rows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
   const getKeyClass = (k: string) => {
     const status = keyStatuses[k];
-    if (status === 'correct') return 'bg-green-600';
-    if (status === 'present') return 'bg-yellow-500';
+    if (status === 'correct') return colorBlind ? 'bg-blue-600' : 'bg-green-600';
+    if (status === 'present') return colorBlind ? 'bg-orange-500' : 'bg-yellow-500';
     if (status === 'absent') return 'bg-gray-700';
     return 'bg-gray-500';
   };
@@ -58,6 +57,7 @@ const Keyboard = ({
             <button
               className="px-3 py-2 bg-gray-500 rounded text-sm"
               onClick={() => onKey('ENTER')}
+              aria-label="enter"
             >
               Enter
             </button>
@@ -67,6 +67,7 @@ const Keyboard = ({
               key={ch}
               className={`w-8 h-10 rounded text-sm ${getKeyClass(ch)}`}
               onClick={() => onKey(ch)}
+              aria-label={`letter ${ch}`}
             >
               {ch}
             </button>
@@ -75,6 +76,7 @@ const Keyboard = ({
             <button
               className="px-3 py-2 bg-gray-500 rounded text-sm"
               onClick={() => onKey('BACKSPACE')}
+              aria-label="backspace"
             >
               ⌫
             </button>
@@ -85,8 +87,11 @@ const Keyboard = ({
   );
 };
 
+const difficulties = Object.keys(WORDS_BY_DIFFICULTY) as Difficulty[];
+
 const Wordle = () => {
-  const answer = useMemo(() => ANSWERS[seedIndex()], []);
+  const [difficulty, setDifficulty] = useState<Difficulty>('easy');
+  const [answer, setAnswer] = useState('');
   const [guesses, setGuesses] = useState<string[]>([]);
   const [statuses, setStatuses] = useState<string[][]>([]);
   const [current, setCurrent] = useState('');
@@ -94,6 +99,58 @@ const Wordle = () => {
   const [message, setMessage] = useState('');
   const [gameOver, setGameOver] = useState(false);
   const [keyStatuses, setKeyStatuses] = useState<Record<string, string>>({});
+  const [hints, setHints] = useState(3);
+  const [streak, setStreak] = useState(0);
+  const [colorBlind, setColorBlind] = useState(false);
+
+  useEffect(() => {
+    loadState('wordle').then((data) => {
+      if (!data) return;
+      setGuesses(data.guesses || []);
+      setStatuses(data.statuses || []);
+      setCurrent(data.current || '');
+      setHardMode(data.hardMode || false);
+      setMessage(data.message || '');
+      setGameOver(data.gameOver || false);
+      setKeyStatuses(data.keyStatuses || {});
+      setHints(data.hints ?? 3);
+      setStreak(data.streak ?? 0);
+      setColorBlind(data.colorBlind || false);
+      setDifficulty(data.difficulty || 'easy');
+    });
+  }, []);
+
+  useEffect(() => {
+    setAnswer(getAnswer(difficulty));
+  }, [difficulty]);
+
+  useEffect(() => {
+    saveState('wordle', {
+      guesses,
+      statuses,
+      current,
+      hardMode,
+      message,
+      gameOver,
+      keyStatuses,
+      hints,
+      streak,
+      colorBlind,
+      difficulty,
+    });
+  }, [
+    guesses,
+    statuses,
+    current,
+    hardMode,
+    message,
+    gameOver,
+    keyStatuses,
+    hints,
+    streak,
+    colorBlind,
+    difficulty,
+  ]);
 
   const checkHardMode = useCallback(
     (g: string) => {
@@ -114,7 +171,7 @@ const Wordle = () => {
   const submitGuess = useCallback(() => {
     if (current.length !== COLS) return setMessage('Word must be 5 letters');
     const lower = current.toLowerCase();
-    if (!GUESSES.includes(lower)) return setMessage('Word not in list');
+    if (!ALL_GUESSES.includes(lower)) return setMessage('Word not in list');
     if (!checkHardMode(lower)) return setMessage('Use revealed hints');
 
     const evals = evaluateGuess(lower, answer);
@@ -124,7 +181,7 @@ const Wordle = () => {
     setMessage('');
 
     setKeyStatuses((prev) => {
-      const next = { ...prev };
+      const next = { ...prev } as Record<string, string>;
       lower.split('').forEach((ch, i) => {
         const st = evals[i];
         const prevSt = next[ch.toUpperCase()];
@@ -138,9 +195,11 @@ const Wordle = () => {
     if (lower === answer) {
       setGameOver(true);
       setMessage('You solved it!');
+      setStreak((s) => s + 1);
     } else if (guesses.length + 1 === ROWS) {
       setGameOver(true);
       setMessage(`Word was ${answer.toUpperCase()}`);
+      setStreak(0);
     }
   }, [current, guesses, statuses, answer, checkHardMode]);
 
@@ -167,11 +226,53 @@ const Wordle = () => {
     return () => window.removeEventListener('keydown', onKey);
   }, [handleKey]);
 
+  const useHint = () => {
+    if (hints <= 0 || gameOver) return;
+    const unrevealed: number[] = [];
+    for (let i = 0; i < COLS; i++) {
+      if (!guesses.some((g) => g[i] === answer[i])) unrevealed.push(i);
+    }
+    if (!unrevealed.length) return;
+    const idx = unrevealed[Math.floor(Math.random() * unrevealed.length)];
+    setCurrent((c) => {
+      const arr = c.toUpperCase().padEnd(COLS).split('');
+      arr[idx] = answer[idx].toUpperCase();
+      return arr.join('').trimEnd();
+    });
+    setHints(hints - 1);
+  };
+
+  const getCellClass = (status?: string) => {
+    let cls =
+      'w-12 h-12 border-2 flex items-center justify-center text-xl font-bold';
+    if (status === 'correct')
+      cls += colorBlind
+        ? ' bg-blue-600 border-blue-600'
+        : ' bg-green-600 border-green-600';
+    else if (status === 'present')
+      cls += colorBlind
+        ? ' bg-orange-500 border-orange-500'
+        : ' bg-yellow-500 border-yellow-500';
+    else if (status === 'absent') cls += ' bg-gray-700 border-gray-700';
+    else cls += ' border-gray-500';
+    return cls;
+  };
+
   const share = () => {
     const grid = statuses
       .map((row) =>
         row
-          .map((s) => (s === 'correct' ? '🟩' : s === 'present' ? '🟨' : '⬛'))
+          .map((s) =>
+            s === 'correct'
+              ? colorBlind
+                ? '\uD83D\uDFE6'
+                : '\uD83D\uDFE9'
+              : s === 'present'
+              ? colorBlind
+                ? '\uD83D\uDFE7'
+                : '\uD83D\uDFE8'
+              : '\u2B1B',
+          )
           .join(''),
       )
       .join('\n');
@@ -187,7 +288,18 @@ const Wordle = () => {
   return (
     <div className="h-full w-full flex flex-col items-center bg-panel text-white p-4">
       <div className="flex justify-between items-center w-full max-w-sm mb-2">
-        <h1 className="text-lg font-bold">Daily Puzzle</h1>
+        <select
+          value={difficulty}
+          onChange={(e) => setDifficulty(e.target.value as Difficulty)}
+          className="text-black text-sm"
+          aria-label="difficulty"
+        >
+          {difficulties.map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
         <label className="text-sm flex items-center space-x-1">
           <input
             type="checkbox"
@@ -197,7 +309,28 @@ const Wordle = () => {
           <span>Hard</span>
         </label>
       </div>
-      <div className="grid gap-1 mb-2" style={{ gridTemplateColumns: `repeat(${COLS},3rem)` }}>
+      <div className="flex justify-between items-center w-full max-w-sm mb-2">
+        <button
+          onClick={useHint}
+          disabled={hints === 0}
+          className="px-3 py-1 bg-gray-600 rounded text-sm"
+        >
+          Hint ({hints})
+        </button>
+        <div className="text-sm">Streak: {streak}</div>
+        <label className="text-sm flex items-center space-x-1">
+          <input
+            type="checkbox"
+            checked={colorBlind}
+            onChange={() => setColorBlind(!colorBlind)}
+          />
+          <span>Color blind</span>
+        </label>
+      </div>
+      <div
+        className="grid gap-1 mb-2"
+        style={{ gridTemplateColumns: `repeat(${COLS},3rem)` }}
+      >
         {Array.from({ length: ROWS }).map((_, r) => (
           <div key={r} className="flex space-x-1">
             {Array.from({ length: COLS }).map((__, c) => {
@@ -206,14 +339,12 @@ const Wordle = () => {
                 (r === guesses.length ? current[c] : '') ||
                 '';
               const status = statuses[r]?.[c];
-              let cls =
-                'w-12 h-12 border-2 flex items-center justify-center text-xl font-bold';
-              if (status === 'correct') cls += ' bg-green-600 border-green-600';
-              else if (status === 'present') cls += ' bg-yellow-500 border-yellow-500';
-              else if (status === 'absent') cls += ' bg-gray-700 border-gray-700';
-              else cls += ' border-gray-500';
               return (
-                <div key={c} className={cls}>
+                <div
+                  key={c}
+                  className={getCellClass(status)}
+                  aria-label={`${letter || 'blank'} ${status || 'empty'}`}
+                >
                   {letter}
                 </div>
               );
@@ -221,7 +352,11 @@ const Wordle = () => {
           </div>
         ))}
       </div>
-      {message && <div className="mb-2 text-sm">{message}</div>}
+      {message && (
+        <div className="mb-2 text-sm" role="status" aria-live="polite">
+          {message}
+        </div>
+      )}
       {gameOver && (
         <button
           onClick={share}
@@ -230,7 +365,7 @@ const Wordle = () => {
           Share
         </button>
       )}
-      <Keyboard onKey={handleKey} keyStatuses={keyStatuses} />
+      <Keyboard onKey={handleKey} keyStatuses={keyStatuses} colorBlind={colorBlind} />
     </div>
   );
 };

--- a/lib/idb.ts
+++ b/lib/idb.ts
@@ -1,0 +1,32 @@
+export const getDB = (): Promise<IDBDatabase> => {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('wordle', 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore('state');
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const loadState = async <T = any>(key: string): Promise<T | undefined> => {
+  const db = await getDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('state', 'readonly');
+    const store = tx.objectStore('state');
+    const req = store.get(key);
+    req.onsuccess = () => resolve(req.result as T | undefined);
+    req.onerror = () => reject(req.error);
+  });
+};
+
+export const saveState = async (key: string, value: any): Promise<void> => {
+  const db = await getDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction('state', 'readwrite');
+    const store = tx.objectStore('state');
+    const req = store.put(value, key);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+};

--- a/public/wordlists/curated.json
+++ b/public/wordlists/curated.json
@@ -1,0 +1,5 @@
+{
+  "easy": ["apple", "train", "chair", "light", "candy"],
+  "medium": ["heart", "ulcer", "nerve", "tumor", "virus"],
+  "hard": ["xenon", "quart", "glyph", "oxide", "nadir"]
+}


### PR DESCRIPTION
## Summary
- add curated word list with profanity filter and medical allow list
- add IndexedDB helpers and persist Wordle state
- add color-blind mode, hint system, streak tracking, and difficulty selection
- fix frogger NUM_TILES_WIDE constant for test stability

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aac912f61c832883229594c87e119b