### PR TITLE
feat: enhance memory game with themes and scoring

### DIFF
--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { createDeck } from './memory_utils';
+import { createDeck, THEME_PACKS } from './memory_utils';
 
-const modes = [2, 4, 6];
+const LEVELS = [8, 12, 18, 24, 30];
 
 const Memory = () => {
-  const [size, setSize] = useState(4);
+  const [pairs, setPairs] = useState(8);
+  const [theme, setTheme] = useState('fruits');
   const [timed, setTimed] = useState(false);
   const [assistive, setAssistive] = useState(false);
   const [cards, setCards] = useState([]);
@@ -12,15 +13,25 @@ const Memory = () => {
   const [matched, setMatched] = useState([]);
   const [moves, setMoves] = useState(0);
   const [time, setTime] = useState(0);
-  const [stats, setStats] = useState({ games: 0, bestTime: null, bestMoves: null });
+  const [streak, setStreak] = useState(0);
+  const [score, setScore] = useState(0);
+  const [lastDeck, setLastDeck] = useState([]);
+  const [stats, setStats] = useState({
+    games: 0,
+    bestTime: null,
+    bestMoves: null,
+    bestScore: null,
+  });
   const timerRef = useRef(null);
 
-    const key = useCallback(
-      (s = size, t = timed) => `memory_${s}_${t ? 'timed' : 'casual'}`,
-      [size, timed]
-    );
+  const key = useCallback(
+    (p = pairs, t = timed, th = theme) =>
+      `memory_${th}_${p}_${t ? 'timed' : 'casual'}`,
+    [pairs, timed, theme]
+  );
 
-    const reset = useCallback((newSize = size) => {
+  const reset = useCallback(
+    (newPairs = pairs, deck = null) => {
       if (timerRef.current) {
         clearInterval(timerRef.current);
         timerRef.current = null;
@@ -29,22 +40,31 @@ const Memory = () => {
       setMoves(0);
       setFlipped([]);
       setMatched([]);
-      setCards(createDeck(newSize));
-    }, [size]);
+      setStreak(0);
+      setScore(0);
+      const newDeck = deck || createDeck(newPairs, theme);
+      setCards(newDeck);
+      setLastDeck(newDeck);
+    },
+    [pairs, theme]
+  );
 
-    useEffect(() => {
-      reset(size);
-    }, [size, reset]);
+  const replay = () => reset(pairs, lastDeck);
 
-    useEffect(() => {
-      if (typeof window === 'undefined') return;
-      const stored = JSON.parse(localStorage.getItem(key()) || '{}');
-      setStats({
-        games: stored.games || 0,
-        bestTime: stored.bestTime ?? null,
-        bestMoves: stored.bestMoves ?? null,
-      });
-    }, [key]);
+  useEffect(() => {
+    reset(pairs);
+  }, [pairs, theme, reset]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = JSON.parse(localStorage.getItem(key()) || '{}');
+    setStats({
+      games: stored.games || 0,
+      bestTime: stored.bestTime ?? null,
+      bestMoves: stored.bestMoves ?? null,
+      bestScore: stored.bestScore ?? null,
+    });
+  }, [key]);
 
   const startTimer = () => {
     if (timed && !timerRef.current) {
@@ -52,35 +72,36 @@ const Memory = () => {
     }
   };
 
-    const saveStats = useCallback(() => {
-      if (typeof window === 'undefined') return;
-      const current = JSON.parse(localStorage.getItem(key()) || '{}');
-      const updated = {
-        games: (current.games || 0) + 1,
-        bestTime: timed
-          ? current.bestTime
-            ? Math.min(current.bestTime, time)
-            : time
-          : current.bestTime || null,
-        bestMoves: !timed
-          ? current.bestMoves
-            ? Math.min(current.bestMoves, moves)
-            : moves
-          : current.bestMoves || null,
-      };
-      localStorage.setItem(key(), JSON.stringify(updated));
-      setStats(updated);
-    }, [timed, time, moves, key]);
+  const saveStats = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const current = JSON.parse(localStorage.getItem(key()) || '{}');
+    const updated = {
+      games: (current.games || 0) + 1,
+      bestTime: timed
+        ? current.bestTime
+          ? Math.min(current.bestTime, time)
+          : time
+        : current.bestTime || null,
+      bestMoves: !timed
+        ? current.bestMoves
+          ? Math.min(current.bestMoves, moves)
+          : moves
+        : current.bestMoves || null,
+      bestScore: current.bestScore ? Math.max(current.bestScore, score) : score,
+    };
+    localStorage.setItem(key(), JSON.stringify(updated));
+    setStats(updated);
+  }, [timed, time, moves, score, key]);
 
-    useEffect(() => {
-      if (cards.length && matched.length === cards.length) {
-        if (timerRef.current) {
-          clearInterval(timerRef.current);
-          timerRef.current = null;
-        }
-        saveStats();
+  useEffect(() => {
+    if (cards.length && matched.length === cards.length) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
       }
-    }, [matched, cards, saveStats]);
+      saveStats();
+    }
+  }, [matched, cards, saveStats]);
 
   const handleFlip = (idx) => {
     if (flipped.includes(idx) || matched.includes(idx)) return;
@@ -96,28 +117,59 @@ const Memory = () => {
       setMoves((m) => m + 1);
 
       if (cards[first].value === cards[second].value) {
+        const newStreak = streak + 1;
+        setStreak(newStreak);
+        setScore((s) => s + 10 * newStreak);
         setMatched([...matched, first, second]);
         setTimeout(() => setFlipped([]), 600);
       } else {
+        setStreak(0);
         setTimeout(() => setFlipped([]), assistive ? 800 : 200);
       }
     }
   };
 
-  const gridStyle = { gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))` };
+  const totalCards = cards.length || pairs * 2;
+  const cols = Math.ceil(Math.sqrt(totalCards));
+  const gridStyle = { gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` };
+
+  const frontClasses =
+    theme === 'high-contrast'
+      ? 'absolute inset-0 bg-black text-yellow-300 rounded flex items-center justify-center text-xl'
+      : 'absolute inset-0 bg-gray-700 rounded flex items-center justify-center text-2xl';
+  const backClasses =
+    theme === 'high-contrast'
+      ? 'absolute inset-0 bg-white rounded'
+      : 'absolute inset-0 bg-gray-600 rounded';
 
   return (
     <div className="h-full w-full flex flex-col items-center justify-center bg-panel text-white p-4 select-none">
       <div className="mb-2 flex flex-wrap items-center justify-center space-x-4">
         <label className="flex items-center">
-          Size
+          Pairs
           <select
             className="ml-1 text-black"
-            value={size}
-            onChange={(e) => setSize(Number(e.target.value))}
+            value={pairs}
+            onChange={(e) => setPairs(Number(e.target.value))}
           >
-            {modes.map((m) => (
-              <option key={m} value={m}>{`${m}x${m}`}</option>
+            {LEVELS.map((lvl) => (
+              <option key={lvl} value={lvl}>
+                {lvl}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center">
+          Theme
+          <select
+            className="ml-1 text-black"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value)}
+          >
+            {Object.keys(THEME_PACKS).map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
             ))}
           </select>
         </label>
@@ -127,7 +179,7 @@ const Memory = () => {
             checked={timed}
             onChange={(e) => {
               setTimed(e.target.checked);
-              reset(size);
+              reset(pairs);
             }}
           />
           <span className="ml-1">Timed</span>
@@ -155,33 +207,42 @@ const Memory = () => {
                 }}
               >
                 <div
-                  className="absolute inset-0 bg-gray-700 rounded flex items-center justify-center text-2xl"
+                  className={frontClasses}
                   style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
                 >
                   {card.value}
                 </div>
-                <div
-                  className="absolute inset-0 bg-gray-600 rounded"
-                  style={{ backfaceVisibility: 'hidden' }}
-                />
+                <div className={backClasses} style={{ backfaceVisibility: 'hidden' }} />
               </div>
             </div>
           );
         })}
       </div>
-      <div className="flex space-x-4 mb-2">
+      <div className="flex flex-wrap space-x-4 mb-2 items-center justify-center">
         <div>Moves: {moves}</div>
+        <div>Score: {score}</div>
+        {streak > 1 && <div>Streak: {streak}</div>}
         {timed && stats.bestTime != null && <div>Best: {stats.bestTime}s</div>}
         {!timed && stats.bestMoves != null && <div>Best: {stats.bestMoves}</div>}
+        {stats.bestScore != null && <div>High Score: {stats.bestScore}</div>}
       </div>
-      <button
-        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-        onClick={() => reset(size)}
-      >
-        Reset
-      </button>
+      <div className="space-x-2">
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={() => reset(pairs)}
+        >
+          Reset
+        </button>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={replay}
+        >
+          Replay
+        </button>
+      </div>
     </div>
   );
 };
 
 export default Memory;
+

--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -1,24 +1,76 @@
-export const EMOJIS = [
-  '\u{1F34E}', // apple
-  '\u{1F34C}', // banana
-  '\u{1F347}', // grapes
-  '\u{1F353}', // strawberry
-  '\u{1F34D}', // pineapple
-  '\u{1F95D}', // kiwi
-  '\u{1F351}', // peach
-  '\u{1F951}', // avocado
-  '\u{1F346}', // eggplant
-  '\u{1F955}', // carrot
-  '\u{1F33D}', // ear of corn
-  '\u{1F954}', // potato
-  '\u{1F34A}', // tangerine
-  '\u{1F350}', // pear
-  '\u{1F965}', // coconut
-  '\u{1FAD0}', // blueberry
-  '\u{1F96D}', // mango
-  '\u{1F345}'  // tomato
-];
+// Utilities for the memory card game.
 
+// Theme packs for the memory game. Each theme exposes at least 30 unique
+// symbols so that all difficulty levels (up to 30 pairs) are supported.
+export const THEME_PACKS = {
+  fruits: [
+    '\u{1F34E}', // apple
+    '\u{1F34C}', // banana
+    '\u{1F347}', // grapes
+    '\u{1F353}', // strawberry
+    '\u{1F34D}', // pineapple
+    '\u{1F95D}', // kiwi
+    '\u{1F351}', // peach
+    '\u{1F951}', // avocado
+    '\u{1F346}', // eggplant
+    '\u{1F955}', // carrot
+    '\u{1F33D}', // ear of corn
+    '\u{1F954}', // potato
+    '\u{1F34A}', // tangerine
+    '\u{1F350}', // pear
+    '\u{1F965}', // coconut
+    '\u{1FAD0}', // blueberry
+    '\u{1F96D}', // mango
+    '\u{1F345}', // tomato
+    '\u{1F349}', // watermelon
+    '\u{1F34B}', // lemon
+    '\u{1F352}', // cherries
+    '\u{1F34F}', // green apple
+    '\u{1F36D}', // lollipop
+    '\u{1F36E}', // custard
+    '\u{1F36F}', // honey pot
+    '\u{1F95C}', // peanuts
+    '\u{1F966}', // broccoli
+    '\u{1F968}', // canned food
+    '\u{1F9C4}', // garlic
+    '\u{1F9C5}', // onion
+  ],
+  animals: [
+    '\u{1F436}', // dog
+    '\u{1F431}', // cat
+    '\u{1F42D}', // mouse
+    '\u{1F98A}', // fox
+    '\u{1F43B}', // bear
+    '\u{1F43C}', // panda
+    '\u{1F438}', // frog
+    '\u{1F435}', // monkey
+    '\u{1F425}', // chick
+    '\u{1F419}', // octopus
+    '\u{1F984}', // unicorn
+    '\u{1F41D}', // bee
+    '\u{1F981}', // lion
+    '\u{1F42F}', // tiger
+    '\u{1F40E}', // horse
+    '\u{1F42E}', // cow
+    '\u{1F437}', // pig
+    '\u{1F430}', // rabbit
+    '\u{1F418}', // elephant
+    '\u{1F43A}', // wolf
+    '\u{1F414}', // rooster
+    '\u{1F427}', // penguin
+    '\u{1F422}', // turtle
+    '\u{1F41F}', // fish
+    '\u{1F40B}', // whale
+    '\u{1F42C}', // dolphin
+    '\u{1F980}', // crab
+    '\u{1F40C}', // snail
+    '\u{1F989}', // owl
+    '\u{1F98B}', // butterfly
+  ],
+  'high-contrast': Array.from({ length: 30 }, (_, i) => String(i + 1)),
+};
+
+// Fisher–Yates shuffle implementation.
 export function fisherYatesShuffle(array) {
   const arr = array.slice();
   for (let i = arr.length - 1; i > 0; i--) {
@@ -28,9 +80,11 @@ export function fisherYatesShuffle(array) {
   return arr;
 }
 
-export function createDeck(size) {
-  const pairs = (size * size) / 2;
-  const selected = EMOJIS.slice(0, pairs);
+// Create a shuffled deck for the given number of pairs and theme.
+export function createDeck(pairs, theme = 'fruits') {
+  const pack = THEME_PACKS[theme] || THEME_PACKS.fruits;
+  const selected = pack.slice(0, pairs);
   const doubled = [...selected, ...selected].map((value, index) => ({ id: index, value }));
   return fisherYatesShuffle(doubled);
 }
+


### PR DESCRIPTION
## Summary
- add theme packs with high-contrast option and Fisher–Yates shuffle
- support 8–30 pair difficulty, combo scoring, replay mode, and persistent stats

## Testing
- `yarn test` *(fails: ReferenceError: NUM_TILES_WIDE is not defined)*
- `yarn lint` *(fails: Identifier 'lastTime' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68aac913f91c83289aa5d642a764c340