### PR TITLE
Add seeded Vegas-scoring solitaire with undo and stats

### DIFF
--- a/__tests__/solitaireEngine.test.ts
+++ b/__tests__/solitaireEngine.test.ts
@@ -10,6 +10,7 @@ import {
   suits,
   Card,
   GameState,
+  createDeck,
 } from '@components/apps/solitaire/engine';
 
 const card = (s: any, v: number, faceUp = true): Card => ({
@@ -27,6 +28,7 @@ const emptyState = (): GameState => ({
   draw: 1,
   score: 0,
   redeals: 3,
+  scoring: 'standard',
 });
 
 describe('Solitaire engine', () => {
@@ -51,6 +53,24 @@ describe('Solitaire engine', () => {
     expect(recycled.waste.length).toBe(0);
     expect(recycled.stock.every((c) => !c.faceUp)).toBe(true);
     expect(recycled.redeals).toBe(2);
+  });
+
+  test('createDeck is deterministic with seed', () => {
+    const d1 = createDeck(42);
+    const d2 = createDeck(42);
+    expect(d1).toEqual(d2);
+  });
+
+  test('vegas scoring applies bonuses and penalties', () => {
+    let game = initializeGame(1, undefined, { scoring: 'vegas', seed: 1 });
+    const afterDraw = drawFromStock(game);
+    expect(afterDraw.score).toBe(-53); // -52 start -1 draw
+    const state = emptyState();
+    state.scoring = 'vegas';
+    state.score = -52;
+    state.waste = [card('♠', 1, true)];
+    const moved = moveToFoundation(state, 'waste', null);
+    expect(moved.score).toBe(-47); // +5 for foundation move
   });
 
   test('moveTableauToTableau obeys rules and flips card', () => {

--- a/components/apps/solitaire/engine.ts
+++ b/components/apps/solitaire/engine.ts
@@ -6,6 +6,8 @@ export type Card = {
   faceUp: boolean;
 };
 
+export type Scoring = 'standard' | 'vegas';
+
 export type GameState = {
   tableau: Card[][];
   stock: Card[];
@@ -13,7 +15,8 @@ export type GameState = {
   foundations: Card[][];
   draw: 1 | 3;
   score: number;
-  redeals: number; // remaining times waste can be recycled into stock
+  redeals: number | null; // null means unlimited redeals
+  scoring: Scoring;
 };
 
 export const suits: Suit[] = ['♠', '♥', '♦', '♣'];
@@ -24,27 +27,42 @@ const colors: Record<Suit, 'red' | 'black'> = {
   '♦': 'red',
 };
 
-export const createDeck = (): Card[] => {
+// simple seeded RNG (mulberry32)
+const mulberry32 = (a: number) => () => {
+  let t = (a += 0x6d2b79f5);
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+export const createDeck = (seed?: number): Card[] => {
   const deck: Card[] = [];
   suits.forEach((suit) => {
     for (let value = 1; value <= 13; value += 1) {
       deck.push({ suit, value, color: colors[suit], faceUp: false });
     }
   });
+  const rand = seed !== undefined ? mulberry32(seed) : Math.random;
   // Shuffle using Fisher-Yates
   for (let i = deck.length - 1; i > 0; i -= 1) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(rand() * (i + 1));
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
   return deck;
 };
 
-export const initializeGame = (draw: 1 | 3 = 1, deck: Card[] = createDeck()): GameState => {
+export const initializeGame = (
+  draw: 1 | 3 = 1,
+  deck?: Card[],
+  options: { redeals?: number | null; scoring?: Scoring; seed?: number } = {},
+): GameState => {
+  const { redeals = 3, scoring = 'standard', seed } = options;
+  const useDeck = deck || createDeck(seed);
   const tableau: Card[][] = Array.from({ length: 7 }, () => []);
   // Deal tableau
   for (let i = 0; i < 7; i += 1) {
     for (let j = 0; j <= i; j += 1) {
-      const card = deck.pop();
+      const card = useDeck.pop();
       if (!card) break;
       tableau[i].push(card);
     }
@@ -54,18 +72,19 @@ export const initializeGame = (draw: 1 | 3 = 1, deck: Card[] = createDeck()): Ga
 
   return {
     tableau,
-    stock: deck,
+    stock: useDeck,
     waste: [],
     foundations: Array.from({ length: 4 }, () => []),
     draw,
-    score: 0,
-    redeals: 3,
+    score: scoring === 'vegas' ? -52 : 0,
+    redeals,
+    scoring,
   };
 };
 
 export const drawFromStock = (state: GameState): GameState => {
   if (state.stock.length === 0) {
-    if (state.waste.length === 0 || state.redeals === 0) return state;
+    if (state.waste.length === 0 || (state.redeals !== null && state.redeals === 0)) return state;
     const newStock = state.waste
       .slice()
       .reverse()
@@ -74,14 +93,16 @@ export const drawFromStock = (state: GameState): GameState => {
       ...state,
       stock: newStock,
       waste: [],
-      redeals: state.redeals - 1,
-      score: state.score - 100,
+      redeals: state.redeals === null ? null : state.redeals - 1,
+      score: state.scoring === 'vegas' ? state.score : state.score - 100,
     };
   }
   const drawCount = Math.min(state.draw, state.stock.length);
   const newStock = state.stock.slice(0, state.stock.length - drawCount);
   const drawn = state.stock.slice(-drawCount).map((c) => ({ ...c, faceUp: true }));
-  return { ...state, stock: newStock, waste: [...state.waste, ...drawn] };
+  const score =
+    state.scoring === 'vegas' ? state.score - drawCount : state.score;
+  return { ...state, stock: newStock, waste: [...state.waste, ...drawn], score };
 };
 
 const canPlaceOnTableau = (card: Card, dest: Card[]): boolean => {
@@ -148,7 +169,8 @@ export const moveToFoundation = (
     if (dest.length > 0 && dest[dest.length - 1].value + 1 !== card.value) return state;
     const newWaste = state.waste.slice(0, -1);
     dest.push(card);
-    return { ...state, waste: newWaste, foundations, score: state.score + 10 };
+    const scoreAdd = state.scoring === 'vegas' ? 5 : 10;
+    return { ...state, waste: newWaste, foundations, score: state.score + scoreAdd };
   }
   const pile = state.tableau[fromIndex!];
   card = pile[pile.length - 1];
@@ -170,7 +192,8 @@ export const moveToFoundation = (
     return p;
   });
   dest.push(card);
-  return { ...state, tableau: newTableau, foundations, score: state.score + 10 };
+  const scoreAdd = state.scoring === 'vegas' ? 5 : 10;
+  return { ...state, tableau: newTableau, foundations, score: state.score + scoreAdd };
 };
 
 export const autoMove = (


### PR DESCRIPTION
## Summary
- support seeded deck generation, Vegas scoring, and unlimited redeals in solitaire engine
- add undo history, scoring/passes toggles, daily challenge seed, and export/importable stats
- include deterministic deck and Vegas scoring tests

## Testing
- `yarn test __tests__/solitaireEngine.test.ts`
- `yarn lint components/apps/solitaire/engine.ts components/apps/solitaire/index.tsx __tests__/solitaireEngine.test.ts` *(fails: Couldn't find any `pages` or `app` directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ab014ac72c83288501c02f2091d275