### PR TITLE
feat: enhance tic tac toe AI and gameplay

### DIFF
--- a/apps/tic-tac-toe/index.tsx
+++ b/apps/tic-tac-toe/index.tsx
@@ -1,41 +1,33 @@
 import React, { useState, useEffect, useRef } from 'react';
 import confetti from 'canvas-confetti';
 
-/**
- * All possible winning line combinations on the board. Each array contains the
- * indexes of squares that form a line. The board is represented as a flat array
- * of nine cells:
- *
- * [0,1,2,
- *  3,4,5,
- *  6,7,8]
- */
-const winningLines: number[][] = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-];
+/** Generate all possible winning line combinations for a given board size. */
+const generateWinningLines = (size: number): number[][] => {
+  const lines: number[][] = [];
+  // rows
+  for (let r = 0; r < size; r += 1) {
+    lines.push(Array.from({ length: size }, (_, c) => r * size + c));
+  }
+  // columns
+  for (let c = 0; c < size; c += 1) {
+    lines.push(Array.from({ length: size }, (_, r) => r * size + c));
+  }
+  // diagonals
+  lines.push(Array.from({ length: size }, (_, i) => i * size + i));
+  lines.push(Array.from({ length: size }, (_, i) => (i + 1) * size - i - 1));
+  return lines;
+};
 
-/**
- * Determine the winner of the current board.
- *
- * @param board - Current board state represented as an array of nine cells. Each
- * cell contains 'X', 'O', or `null`.
- * @returns Object containing the winning player ('X', 'O', or 'draw') and the
- * indices forming the winning line. If the game is not finished, `winner` is
- * `null`.
- */
+/** Determine the winner of the current board of arbitrary size. */
 export const checkWinner = (
   board: (string | null)[],
+  size: number,
 ): { winner: string | null; line: number[] } => {
-  for (const [a, b, c] of winningLines) {
-    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-      return { winner: board[a], line: [a, b, c] };
+  const lines = generateWinningLines(size);
+  for (const line of lines) {
+    const [a, ...rest] = line;
+    if (board[a] && rest.every((i) => board[i] === board[a])) {
+      return { winner: board[a], line };
     }
   }
   if (board.every(Boolean)) return { winner: 'draw', line: [] };
@@ -43,51 +35,43 @@ export const checkWinner = (
 };
 
 /**
- * Recursive minimax implementation used by the AI to evaluate moves.
- *
- * The algorithm always scores the board from O's perspective:
- *   - `1`  : O wins
- *   - `-1` : X wins
- *   - `0`  : Draw
- *
- * @param board - Current board state.
- * @param player - The player whose turn it is at this depth.
- * @returns Best move index and the associated score.
+ * Negamax with alpha-beta pruning for optimal play on variable-sized boards.
  */
-export const minimax = (
+export const negamax = (
   board: (string | null)[],
   player: 'X' | 'O',
+  size: number,
+  alpha = -Infinity,
+  beta = Infinity,
 ): { index?: number; score: number } => {
-  const { winner } = checkWinner(board);
-  if (winner === 'O') return { score: 1 };
-  if (winner === 'X') return { score: -1 };
+  const opponent = player === 'X' ? 'O' : 'X';
+  const { winner } = checkWinner(board, size);
+  if (winner === player) return { score: 1 };
+  if (winner === opponent) return { score: -1 };
   if (winner === 'draw') return { score: 0 };
 
-  const moves: { index: number; score: number }[] = [];
-  board.forEach((cell, idx) => {
-    if (!cell) {
-      const newBoard = board.slice();
-      newBoard[idx] = player;
-      const result = minimax(newBoard, player === 'O' ? 'X' : 'O');
-      moves.push({ index: idx, score: result.score });
+  let best = { index: -1, score: -Infinity };
+  for (let i = 0; i < board.length; i += 1) {
+    if (board[i]) continue;
+    board[i] = player;
+    const result = negamax(board, opponent, size, -beta, -alpha);
+    const score = -result.score;
+    board[i] = null;
+    if (score > best.score) {
+      best = { index: i, score };
     }
-  });
-
-  if (player === 'O') {
-    // O tries to maximise the score
-    return moves.reduce((best, move) => (move.score > best.score ? move : best), {
-      score: -Infinity,
-    });
+    if (score > alpha) alpha = score;
+    if (alpha >= beta) break;
   }
-  // X tries to minimise the score
-  return moves.reduce((best, move) => (move.score < best.score ? move : best), {
-    score: Infinity,
-  });
+  return best;
 };
 
 const TicTacToe: React.FC = () => {
   // Game state
-  const [history, setHistory] = useState<(string | null)[][]>([Array(9).fill(null)]);
+  const [size, setSize] = useState(3);
+  const [history, setHistory] = useState<(string | null)[][]>([
+    Array(3 * 3).fill(null),
+  ]);
   const [step, setStep] = useState(0);
   const board = history[step];
   const [status, setStatus] = useState('Choose X or O');
@@ -98,10 +82,13 @@ const TicTacToe: React.FC = () => {
   const [aiMoves, setAiMoves] = useState(0);
   // Scores for each available move – used for visualisation
   const [moveEvals, setMoveEvals] = useState<Record<number, number>>({});
+  const [hintMove, setHintMove] = useState<number | null>(null);
   const [winningLine, setWinningLine] = useState<number[]>([]);
   const [leaderboard, setLeaderboard] = useState<{ X: number; O: number; draw: number }>(
     { X: 0, O: 0, draw: 0 },
   );
+  const [selected, setSelected] = useState(0);
+  const [stats, setStats] = useState({ wins: 0, losses: 0, draws: 0, streak: 0 });
 
   // WebSocket ref for multiplayer support
   const wsRef = useRef<WebSocket | null>(null);
@@ -134,7 +121,7 @@ const TicTacToe: React.FC = () => {
   const applyMove = (idx: number, p: string) => {
     const current = history.slice(0, step + 1);
     const newBoard = current[current.length - 1].slice();
-    if (newBoard[idx] || checkWinner(newBoard).winner) return;
+    if (newBoard[idx] || checkWinner(newBoard, size).winner) return;
     newBoard[idx] = p;
     setHistory([...current, newBoard]);
     setStep(current.length);
@@ -155,17 +142,19 @@ const TicTacToe: React.FC = () => {
     setPlayer(p);
     setAi(a);
     setStatus(p === 'X' ? 'Your turn' : "AI's turn");
-    setHistory([Array(9).fill(null)]);
+    setHistory([Array(size * size).fill(null)]);
     setStep(0);
     setAiMoves(0);
     setMoveEvals({});
+    setHintMove(null);
     setWinningLine([]);
+    setSelected(0);
   };
 
   // Handle local board click
   const handleClick = (idx: number) => {
     if (player === null) return;
-    if (board[idx] || checkWinner(board).winner) return;
+    if (board[idx] || checkWinner(board, size).winner) return;
     const filled = board.filter(Boolean).length;
     const isXTurn = filled % 2 === 0;
     const currentTurn = isXTurn ? 'X' : 'O';
@@ -173,6 +162,8 @@ const TicTacToe: React.FC = () => {
     applyMove(idx, player);
     sendMove(idx, player);
     setMoveEvals({});
+    setHintMove(null);
+    setSelected(idx);
   };
 
   // Fetch leaderboard on mount
@@ -199,10 +190,42 @@ const TicTacToe: React.FC = () => {
       });
   };
 
+  // Load stats from localStorage
+  useEffect(() => {
+    try {
+      const s = localStorage.getItem('ttt-stats');
+      if (s) setStats(JSON.parse(s));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const updateStats = (result: 'win' | 'loss' | 'draw') => {
+    setStats((prev) => {
+      const next = { ...prev };
+      if (result === 'win') {
+        next.wins += 1;
+        next.streak = prev.streak >= 0 ? prev.streak + 1 : 1;
+      } else if (result === 'loss') {
+        next.losses += 1;
+        next.streak = prev.streak <= 0 ? prev.streak - 1 : -1;
+      } else {
+        next.draws += 1;
+        next.streak = 0;
+      }
+      try {
+        localStorage.setItem('ttt-stats', JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
   // React to board changes – AI moves and game over logic
   useEffect(() => {
     if (player === null || ai === null) return;
-    const { winner, line } = checkWinner(board);
+    const { winner, line } = checkWinner(board, size);
     if (winner) {
       if (winner !== 'draw') {
         setWinningLine(line);
@@ -212,6 +235,7 @@ const TicTacToe: React.FC = () => {
         winner === 'draw' ? "It's a draw" : winner === player ? 'You win!' : 'You lose!',
       );
       saveResult(winner);
+      updateStats(winner === 'draw' ? 'draw' : winner === player ? 'win' : 'loss');
       return;
     }
 
@@ -226,8 +250,8 @@ const TicTacToe: React.FC = () => {
       const evaluations = available.map((idx) => {
         const newBoard = board.slice();
         newBoard[idx] = ai;
-        const result = minimax(newBoard, ai === 'X' ? 'O' : 'X');
-        const score = ai === 'X' ? -result.score : result.score;
+        const result = negamax(newBoard, ai === 'X' ? 'O' : 'X', size);
+        const score = -result.score;
         return { index: idx, score };
       });
 
@@ -251,10 +275,27 @@ const TicTacToe: React.FC = () => {
         }, 200);
       }
     } else {
-      setMoveEvals({});
+      const available = board
+        .map((v, i) => (v ? null : i))
+        .filter((v) => v !== null) as number[];
+
+      const evaluations = available.map((idx) => {
+        const newBoard = board.slice();
+        newBoard[idx] = player;
+        const result = negamax(newBoard, player === 'X' ? 'O' : 'X', size);
+        const score = -result.score;
+        return { index: idx, score };
+      });
+
+      setMoveEvals(Object.fromEntries(evaluations.map((e) => [e.index, e.score])));
+      const best = evaluations.reduce(
+        (a, b) => (b.score > a.score ? b : a),
+        { index: -1, score: -Infinity },
+      );
+      setHintMove(best.index);
       setStatus('Your turn');
     }
-  }, [board, player, ai, difficulty]);
+  }, [board, player, ai, difficulty, size]);
 
   // Jump to a specific move in history
   const jumpTo = (move: number) => {
@@ -262,7 +303,9 @@ const TicTacToe: React.FC = () => {
     setStep(move);
     setAiMoves(Math.floor(move / 2));
     setMoveEvals({});
+    setHintMove(null);
     setWinningLine([]);
+    setSelected(0);
   };
 
   // Reset entire game
@@ -270,12 +313,45 @@ const TicTacToe: React.FC = () => {
     setPlayer(null);
     setAi(null);
     setStatus('Choose X or O');
-    setHistory([Array(9).fill(null)]);
+    setHistory([Array(size * size).fill(null)]);
     setStep(0);
     setAiMoves(0);
     setMoveEvals({});
+    setHintMove(null);
     setWinningLine([]);
+    setSelected(0);
   };
+
+  const moveUp = () => setSelected((s) => (s - size + size * size) % (size * size));
+  const moveDown = () => setSelected((s) => (s + size) % (size * size));
+  const moveLeft = () =>
+    setSelected((s) => (s % size === 0 ? s + size - 1 : s - 1));
+  const moveRight = () =>
+    setSelected((s) => ((s + 1) % size === 0 ? s - size + 1 : s + 1));
+
+  const exportReplay = () => {
+    const data = JSON.stringify({ size, history });
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'tictactoe-replay.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (player === null) return;
+      if (e.key === 'ArrowUp') moveUp();
+      else if (e.key === 'ArrowDown') moveDown();
+      else if (e.key === 'ArrowLeft') moveLeft();
+      else if (e.key === 'ArrowRight') moveRight();
+      else if (e.key === 'Enter' || e.key === ' ') handleClick(selected);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [player, selected, size]);
 
   const difficultySlider = (
     <div className="w-40 mb-4">
@@ -299,6 +375,17 @@ const TicTacToe: React.FC = () => {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center bg-panel text-white p-4">
         {difficultySlider}
+        <div className="mb-4 flex flex-col items-center">
+          <label className="mb-1">Board Size</label>
+          <select
+            value={size}
+            onChange={(e) => setSize(parseInt(e.target.value, 10))}
+            className="bg-gray-700 p-1 rounded"
+          >
+            <option value={3}>3×3</option>
+            <option value={4}>4×4</option>
+          </select>
+        </div>
         <div className="mb-4">Choose X or O</div>
         <div className="flex space-x-4">
           <button
@@ -314,6 +401,12 @@ const TicTacToe: React.FC = () => {
             O
           </button>
         </div>
+        <div className="mt-4 text-sm text-center">
+          <div>
+            Wins: {stats.wins} Losses: {stats.losses} Draws: {stats.draws}
+          </div>
+          <div>Streak: {stats.streak}</div>
+        </div>
       </div>
     );
   }
@@ -322,13 +415,16 @@ const TicTacToe: React.FC = () => {
     <div className="h-full w-full flex flex-col md:flex-row items-center justify-center bg-panel text-white p-4 space-y-4 md:space-y-0 md:space-x-4">
       <div className="flex flex-col items-center">
         {difficultySlider}
-        <div className="grid grid-cols-3 gap-1 w-60 mb-4">
+        <div
+          className={`grid gap-1 ${size === 3 ? 'w-60' : 'w-80'} mb-2`}
+          style={{ gridTemplateColumns: `repeat(${size}, 1fr)` }}
+        >
           {board.map((cell, idx) => (
             <button
               key={idx}
-              className={`h-20 w-20 text-4xl flex items-center justify-center bg-gray-700 hover:bg-gray-600 ${
+              className={`relative h-20 w-20 text-4xl flex items-center justify-center bg-gray-700 hover:bg-gray-600 ${
                 winningLine.includes(idx) ? 'bg-green-600 animate-pulse' : ''
-              }`}
+              } ${selected === idx ? 'ring-2 ring-yellow-400' : ''}`}
               onClick={() => handleClick(idx)}
             >
               {cell || (
@@ -336,16 +432,51 @@ const TicTacToe: React.FC = () => {
                   {moveEvals[idx]?.toFixed(2)}
                 </span>
               )}
+              {hintMove === idx && !cell && (
+                <span className="absolute -top-3 left-1/2 transform -translate-x-1/2 text-green-400">↑</span>
+              )}
             </button>
           ))}
         </div>
-        <div className="mb-4">{status}</div>
-        <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-          onClick={reset}
-        >
-          Reset
-        </button>
+        <div className="mb-2">{status}</div>
+        <div className="hidden md:block text-xs mb-2">Use arrow keys + Enter</div>
+        <div className="md:hidden flex flex-col items-center mb-2">
+          <div>
+            <button className="px-2 py-1 bg-gray-700" onClick={moveUp}>
+              ↑
+            </button>
+          </div>
+          <div className="flex space-x-2 mt-2">
+            <button className="px-2 py-1 bg-gray-700" onClick={moveLeft}>
+              ←
+            </button>
+            <button className="px-2 py-1 bg-gray-700" onClick={() => handleClick(selected)}>
+              OK
+            </button>
+            <button className="px-2 py-1 bg-gray-700" onClick={moveRight}>
+              →
+            </button>
+          </div>
+          <div className="mt-2">
+            <button className="px-2 py-1 bg-gray-700" onClick={moveDown}>
+              ↓
+            </button>
+          </div>
+        </div>
+        <div className="flex space-x-2">
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={reset}
+          >
+            Reset
+          </button>
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={exportReplay}
+          >
+            Export
+          </button>
+        </div>
       </div>
       <div className="text-sm">
         <div className="mb-2 font-bold">Move history</div>
@@ -366,6 +497,13 @@ const TicTacToe: React.FC = () => {
           <div>X wins: {leaderboard.X}</div>
           <div>O wins: {leaderboard.O}</div>
           <div>Draws: {leaderboard.draw}</div>
+        </div>
+        <div className="mt-4">
+          <div className="font-bold mb-1">Your Stats</div>
+          <div>Wins: {stats.wins}</div>
+          <div>Losses: {stats.losses}</div>
+          <div>Draws: {stats.draws}</div>
+          <div>Streak: {stats.streak}</div>
         </div>
       </div>
     </div>

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,5 +1,5 @@
-import TicTacToe, { checkWinner, minimax } from '../../apps/tic-tac-toe';
+import TicTacToe, { checkWinner, negamax } from '../../apps/tic-tac-toe';
 
 export default TicTacToe;
-export { checkWinner, minimax };
+export { checkWinner, negamax };
 


### PR DESCRIPTION
## Summary
- support 3x3 and 4x4 boards with alpha-beta negamax AI
- add hint arrows, keyboard/touch controls and replay export
- track local streaks and stats for players

## Testing
- `yarn test apps/tic-tac-toe --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab014de914832895966132b235f5e8