### PR TITLE
feat: compute flow field with worker

### DIFF
--- a/__tests__/tower-defense.test.ts
+++ b/__tests__/tower-defense.test.ts
@@ -6,6 +6,8 @@ import {
   fireProjectile,
   deactivateProjectile,
   getTowerDPS,
+  computeFlowField,
+  START,
 } from '@components/apps/tower-defense-core';
 
 describe('tower defense core', () => {
@@ -34,5 +36,12 @@ describe('tower defense core', () => {
     const d1 = getTowerDPS('single', 1);
     const d2 = getTowerDPS('single', 2);
     expect(d2).toBeGreaterThan(d1);
+  });
+
+  test('flow field respects obstacles', () => {
+    const { field } = computeFlowField([]);
+    expect(field[START.y][START.x]).toEqual({ dx: 1, dy: 0 });
+    const { field: field2 } = computeFlowField([{ x: START.x + 1, y: START.y }]);
+    expect(field2[START.y][START.x]).toEqual({ dx: 0, dy: -1 });
   });
 });

--- a/components/apps/tower-defense-flow-worker.js
+++ b/components/apps/tower-defense-flow-worker.js
@@ -1,0 +1,7 @@
+import { computeFlowField } from './tower-defense-core';
+
+self.onmessage = (e) => {
+  const { towers } = e.data;
+  const result = computeFlowField(towers || []);
+  (self).postMessage(result);
+};


### PR DESCRIPTION
## Summary
- compute flow field from Dijkstra map and expose helper
- recompute flow field in web worker on tower changes and draw debug arrows
- cover flow field behavior with tests

## Testing
- `yarn test __tests__/tower-defense.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab01584b18832881bfe2f428399a2d