### PR TITLE
Enhance nonogram solver with undo/redo and a11y

### DIFF
--- a/apps/nonogram/index.tsx
+++ b/apps/nonogram/index.tsx
@@ -90,8 +90,8 @@ const Nonogram: React.FC = () => {
       let ng = prev.map((row) => row.slice());
       const current = ng[r][c];
       ng[r][c] = mark ? (current === -1 ? 0 : -1) : current === 1 ? 0 : 1;
-      ng = propagate(ng, puzzle);
-      return ng;
+      const { grid: pg, contradiction } = propagate(ng, puzzle);
+      return contradiction ? prev : pg;
     });
   };
 
@@ -205,7 +205,12 @@ const Nonogram: React.FC = () => {
         {puzzle && (
           <button
             className="border px-2 py-1"
-            onClick={() => setGrid((g) => propagate(g, puzzle))}
+            onClick={() =>
+              setGrid((g) => {
+                const { grid: pg } = propagate(g, puzzle);
+                return pg;
+              })
+            }
           >
             Auto Fill
           </button>


### PR DESCRIPTION
## Summary
- add advanced line solver that supports pencil notes and contradiction detection
- expose propagate status and update nonogram app to handle it
- introduce undo/redo history, keyboard shortcuts, and accessible grid controls

## Testing
- `yarn test` *(fails: frogger mechanics – NUM_TILES_WIDE is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab015d3e4c832880df1d79017f86a0