### PR TITLE
feat: enhance flappy bird gameplay and accessibility

### DIFF
--- a/apps/flappy-bird/background.js
+++ b/apps/flappy-bird/background.js
@@ -2,19 +2,23 @@ export default class Background {
   constructor(width, height, theme = 'day') {
     this.width = width;
     this.height = height;
+    this.reducedMotion = false;
+    this.colorBlind = false;
     this.themes = {
       day: {
         sky: '#87CEEB',
         layers: [
-          { speed: 0.5, offset: 0, height: 40, color: '#7ec850' },
-          { speed: 1, offset: 0, height: 20, color: '#4caf50' },
+          { baseSpeed: 0.25, speed: 0.25, offset: 0, height: 60, color: '#a7c957' },
+          { baseSpeed: 0.5, speed: 0.5, offset: 0, height: 40, color: '#7ec850' },
+          { baseSpeed: 1, speed: 1, offset: 0, height: 20, color: '#4caf50' },
         ],
       },
       night: {
         sky: '#0d1b2a',
         layers: [
-          { speed: 0.5, offset: 0, height: 40, color: '#264653' },
-          { speed: 1, offset: 0, height: 20, color: '#2a9d8f' },
+          { baseSpeed: 0.25, speed: 0.25, offset: 0, height: 60, color: '#1b263b' },
+          { baseSpeed: 0.5, speed: 0.5, offset: 0, height: 40, color: '#264653' },
+          { baseSpeed: 1, speed: 1, offset: 0, height: 20, color: '#2a9d8f' },
         ],
       },
     };
@@ -24,6 +28,18 @@ export default class Background {
   setTheme(theme) {
     this.theme = this.themes[theme] ? theme : 'day';
     this.layers = this.themes[this.theme].layers.map((l) => ({ ...l }));
+    this.setReducedMotion(this.reducedMotion);
+  }
+
+  setReducedMotion(flag) {
+    this.reducedMotion = flag;
+    this.layers.forEach((layer) => {
+      layer.speed = flag ? 0 : layer.baseSpeed;
+    });
+  }
+
+  setColorBlind(flag) {
+    this.colorBlind = flag;
   }
 
   update(dt = 1) {
@@ -36,10 +52,12 @@ export default class Background {
   }
 
   draw(ctx) {
-    ctx.fillStyle = this.themes[this.theme].sky;
+    const sky = this.colorBlind ? '#000' : this.themes[this.theme].sky;
+    ctx.fillStyle = sky;
     ctx.fillRect(0, 0, this.width, this.height);
     this.layers.forEach((layer) => {
-      ctx.fillStyle = layer.color;
+      const color = this.colorBlind ? '#888' : layer.color;
+      ctx.fillStyle = color;
       ctx.fillRect(
         layer.offset,
         this.height - layer.height,

--- a/apps/flappy-bird/index.html
+++ b/apps/flappy-bird/index.html
@@ -18,10 +18,15 @@
     </select>
     <select id="skinSelect"></select>
     <span id="points"></span>
+    <button id="flapBtn">Flap</button>
+    <label><input type="checkbox" id="shakeToggle" checked /> Shake</label>
+    <label><input type="checkbox" id="motionToggle" /> Reduce Motion</label>
+    <label><input type="checkbox" id="colorToggle" /> Color Blind</label>
   </div>
   <canvas id="game" width="400" height="300"></canvas>
   <div id="overlay">
     <div>Game Over</div>
+    <div id="bestScore"></div>
     <button id="restart">Restart</button>
     <div id="leaderboards">
       <h4>Global</h4>

--- a/apps/flappy-bird/main.js
+++ b/apps/flappy-bird/main.js
@@ -12,14 +12,20 @@ const overlay = document.getElementById('overlay');
 const restartBtn = document.getElementById('restart');
 const globalBoard = document.getElementById('globalBoard');
 const friendsBoard = document.getElementById('friendsBoard');
+const flapBtn = document.getElementById('flapBtn');
+const shakeToggle = document.getElementById('shakeToggle');
+const motionToggle = document.getElementById('motionToggle');
+const colorToggle = document.getElementById('colorToggle');
+const bestScoreEl = document.getElementById('bestScore');
 
-const GRAVITY = 0.5;
-const FLAP_FORCE = -8;
-const PIPE_GAP = 80;
+const GRAVITY = 1.8;
+const FLAP_FORCE = -15; // tuned for ~0.28s airtime
+const PIPE_GAP = 100;
 const PIPE_WIDTH = 40;
 const PIPE_SPEED = 2;
 const PIPE_SPACING = 200;
 const PIPE_COUNT = 3;
+const HIT_PAUSE = 200; // ms
 
 const SKINS = [
   { name: 'Yellow', color: 'yellow', cost: 0 },
@@ -29,6 +35,16 @@ const SKINS = [
 
 let points = parseInt(localStorage.getItem('fb_points') || '0');
 let unlocked = JSON.parse(localStorage.getItem('fb_unlocked') || '["yellow"]');
+let highScore = parseInt(localStorage.getItem('fb_highScore') || '0');
+let settings = JSON.parse(
+  localStorage.getItem('fb_settings') ||
+    '{"shake":true,"reduced":false,"colorBlind":false}'
+);
+
+shakeToggle.checked = settings.shake;
+motionToggle.checked = settings.reduced;
+colorToggle.checked = settings.colorBlind;
+bestScoreEl.textContent = `Best: ${highScore}`;
 
 function updateSkinOptions() {
   skinSelect.innerHTML = '';
@@ -48,6 +64,10 @@ function saveProgress() {
   localStorage.setItem('fb_unlocked', JSON.stringify(unlocked));
 }
 
+function saveSettings() {
+  localStorage.setItem('fb_settings', JSON.stringify(settings));
+}
+
 pointsEl.textContent = `Points: ${points}`;
 updateSkinOptions();
 
@@ -65,6 +85,27 @@ skinSelect.addEventListener('change', () => {
   }
 });
 
+shakeToggle.addEventListener('change', () => {
+  settings.shake = shakeToggle.checked;
+  saveSettings();
+});
+
+motionToggle.addEventListener('change', () => {
+  settings.reduced = motionToggle.checked;
+  background?.setReducedMotion(settings.reduced);
+  saveSettings();
+});
+
+colorToggle.addEventListener('change', () => {
+  settings.colorBlind = colorToggle.checked;
+  background?.setColorBlind(settings.colorBlind);
+  pipes?.forEach((p) =>
+    p.setColor(settings.colorBlind ? '#555555' : '#228B22')
+  );
+  bird?.setSkin(settings.colorBlind ? 'orange' : skinSelect.value);
+  saveSettings();
+});
+
 let bird;
 let pipes;
 let background;
@@ -72,9 +113,19 @@ let score;
 let running;
 let timeLeft;
 let lastTime;
+let hitPause = 0;
+let ghostData = JSON.parse(localStorage.getItem('fb_ghost') || '[]');
+let ghostIndex = 0;
+let currentRun = [];
+let ghost;
 
 function startGame() {
-  bird = new Bird(50, canvas.height / 2, GRAVITY, skinSelect.value);
+  bird = new Bird(
+    50,
+    canvas.height / 2,
+    GRAVITY,
+    settings.colorBlind ? 'orange' : skinSelect.value
+  );
   pipes = [];
   for (let i = 0; i < PIPE_COUNT; i++) {
     pipes.push(
@@ -83,7 +134,8 @@ function startGame() {
         PIPE_GAP,
         PIPE_WIDTH,
         canvas.height,
-        PIPE_SPEED
+        PIPE_SPEED,
+        settings.colorBlind ? '#555555' : '#228B22'
       )
     );
   }
@@ -92,6 +144,13 @@ function startGame() {
     canvas.height,
     Math.random() < 0.5 ? 'day' : 'night'
   );
+  background.setReducedMotion(settings.reduced);
+  background.setColorBlind(settings.colorBlind);
+  ghost = ghostData.length
+    ? new Bird(50, ghostData[0], GRAVITY, 'rgba(255,255,255,0.3)')
+    : null;
+  ghostIndex = 0;
+  currentRun = [];
   score = 0;
   running = true;
   timeLeft = modeSelect.value === 'time' ? 30000 : null;
@@ -105,14 +164,40 @@ function flap() {
   bird.flap(force);
 }
 
+function screenShake() {
+  if (!settings.shake || settings.reduced) return;
+  const intensity = 5;
+  const duration = 100;
+  const start = performance.now();
+  function shake() {
+    const elapsed = performance.now() - start;
+    if (elapsed < duration) {
+      const x = (Math.random() - 0.5) * intensity;
+      const y = (Math.random() - 0.5) * intensity;
+      canvas.style.transform = `translate(${x}px, ${y}px)`;
+      requestAnimationFrame(shake);
+    } else {
+      canvas.style.transform = '';
+    }
+  }
+  shake();
+}
+
 function gameOver() {
   running = false;
   points += score;
   saveProgress();
   pointsEl.textContent = `Points: ${points}`;
+  if (score > highScore) {
+    highScore = score;
+    localStorage.setItem('fb_highScore', highScore);
+  }
+  bestScoreEl.textContent = `Best: ${highScore}`;
   submitScore(score);
   loadLeaderboards();
   overlay.style.display = 'flex';
+  localStorage.setItem('fb_ghost', JSON.stringify(currentRun));
+  ghostData = currentRun.slice();
 }
 
 async function loadLeaderboards() {
@@ -137,32 +222,57 @@ function loop(timestamp) {
   lastTime = timestamp;
   const dt = delta / 16.6667;
 
-  background.update(dt);
+  if (hitPause > 0) {
+    hitPause -= delta;
+    if (hitPause <= 0) {
+      gameOver();
+    } else {
+      requestAnimationFrame(loop);
+    }
+    return;
+  }
+  if (!settings.reduced) background.update(dt);
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   background.draw(ctx);
+
+  if (ghost) {
+    if (ghostIndex < ghostData.length) {
+      ghost.y = ghostData[ghostIndex++];
+    }
+    ghost.draw(ctx);
+  }
 
   for (const p of pipes) {
     p.update(dt);
     p.draw(ctx);
     if (p.isOffscreen()) {
-      p.reset(canvas.width + PIPE_SPACING);
+      p.reset(canvas.width + PIPE_SPACING, score);
+      p.setColor(settings.colorBlind ? '#555555' : '#228B22');
     }
     if (!p.passed && bird.x > p.x + p.width / 2) {
       score++;
       p.passed = true;
     }
     if (p.collides(bird)) {
-      gameOver();
-      return;
+      screenShake();
+      hitPause = HIT_PAUSE;
+      break;
     }
+  }
+  if (hitPause > 0) {
+    requestAnimationFrame(loop);
+    return;
   }
 
   bird.update(modeSelect.value === 'reverse', dt);
   bird.draw(ctx);
+  currentRun.push(bird.y);
 
   const b = bird.bounds;
   if (b.top < 0 || b.bottom > canvas.height) {
-    gameOver();
+    screenShake();
+    hitPause = HIT_PAUSE;
+    requestAnimationFrame(loop);
     return;
   }
 
@@ -192,13 +302,16 @@ function handleInput(e) {
 }
 
 document.addEventListener('keydown', (e) => {
-  if (e.code === 'Space') {
+  if (['Space', 'ArrowUp', 'KeyW'].includes(e.code)) {
     handleInput(e);
   }
 });
 ['mousedown', 'touchstart'].forEach((ev) => {
   document.addEventListener(ev, handleInput, { passive: false });
 });
+
+flapBtn.addEventListener('click', handleInput);
+flapBtn.addEventListener('touchstart', handleInput, { passive: false });
 
 restartBtn.addEventListener('click', startGame);
 loadLeaderboards();

--- a/apps/flappy-bird/pipe.js
+++ b/apps/flappy-bird/pipe.js
@@ -1,15 +1,18 @@
 export default class Pipe {
-  constructor(x, gap, width, canvasHeight, speed = 2) {
+  constructor(x, gap, width, canvasHeight, speed = 2, color = '#228B22') {
     this.width = width;
     this.canvasHeight = canvasHeight;
     this.speed = speed;
     this.baseGap = gap;
+    this.color = color;
     this.reset(x);
   }
 
-  reset(x) {
+  reset(x, score = 0) {
     this.x = x;
-    const gap = this.baseGap + Math.random() * 40 - 20;
+    const difficulty = Math.min(score * 2, 30);
+    const gap =
+      Math.max(this.baseGap - difficulty, 50) + Math.random() * 40 - 20;
     const top = Math.random() * (this.canvasHeight - gap - 40) + 20;
     this.top = top;
     this.bottom = top + gap;
@@ -21,7 +24,7 @@ export default class Pipe {
   }
 
   draw(ctx) {
-    ctx.fillStyle = '#228B22';
+    ctx.fillStyle = this.color;
     ctx.fillRect(this.x, 0, this.width, this.top);
     ctx.fillRect(
       this.x,
@@ -39,5 +42,9 @@ export default class Pipe {
     const b = bird.bounds;
     if (b.right < this.x || b.left > this.x + this.width) return false;
     return b.top < this.top || b.bottom > this.bottom;
+  }
+
+  setColor(color) {
+    this.color = color;
   }
 }


### PR DESCRIPTION
## Summary
- tune physics for ~0.28s airtime and add hit-pause with optional screen shake
- scale pipe gaps by score and add parallax background with reduced-motion/color-blind settings
- add ghost replay, high score persistence, and mobile/desktop controls

## Testing
- `yarn test apps/flappy-bird --passWithNoTests`
- `yarn lint --dir apps/flappy-bird`

------
https://chatgpt.com/codex/tasks/task_e_68ab016271ec8328b99f518fabe46cb4