### PR TITLE
feat: add jwks rotation warnings

### DIFF
--- a/components/apps/jwks-fetcher.tsx
+++ b/components/apps/jwks-fetcher.tsx
@@ -7,6 +7,8 @@ const JwksFetcher: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [jwt, setJwt] = useState('');
   const [verifyResult, setVerifyResult] = useState<string | null>(null);
+  const [collisions, setCollisions] = useState<string[]>([]);
+  const [rotations, setRotations] = useState<string[]>([]);
 
   const fetchKeys = async () => {
     if (!jwksUrl) return;
@@ -14,6 +16,8 @@ const JwksFetcher: React.FC = () => {
     setError(null);
     setVerifyResult(null);
     setKeys([]);
+    setCollisions([]);
+    setRotations([]);
     try {
       const res = await fetch('/api/jwks-fetcher', {
         method: 'POST',
@@ -29,6 +33,8 @@ const JwksFetcher: React.FC = () => {
         setError(msg);
       } else {
         setKeys(data.keys || []);
+        setCollisions(data.collisions || []);
+        setRotations(data.rotations || []);
         if (data.payload) {
           setVerifyResult(
             JSON.stringify({ payload: data.payload, header: data.header }, null, 2)
@@ -84,6 +90,16 @@ const JwksFetcher: React.FC = () => {
           <pre className="text-xs overflow-auto bg-gray-800 p-2 rounded">{verifyResult}</pre>
         </div>
       )}
+      {collisions.length > 0 && (
+        <div className="text-yellow-400 text-xs">
+          Duplicate kids: {collisions.join(', ')}
+        </div>
+      )}
+      {rotations.length > 0 && (
+        <div className="text-yellow-400 text-xs">
+          Key rotation detected for: {rotations.join(', ')}
+        </div>
+      )}
       <div className="space-y-2 overflow-auto">
         {keys.map((k, idx) => (
           <div key={k.kid || idx} className="bg-gray-800 p-2 rounded">
@@ -109,6 +125,11 @@ const JwksFetcher: React.FC = () => {
               </div>
             </div>
             <pre className="text-xs overflow-auto">{JSON.stringify(k, null, 2)}</pre>
+            {k.jwkThumbprint && (
+              <div className="text-xs mt-1">
+                thumbprint: {k.jwkThumbprint}
+              </div>
+            )}
             {k.x5t !== undefined && (
               <div className="text-xs mt-1">x5t valid: {String(k.x5tValid)}</div>
             )}


### PR DESCRIPTION
## Summary
- compute JWK thumbprints on the server
- track duplicate `kid`s and key rotations
- surface collision and rotation warnings in JWKS Fetcher UI

## Testing
- `yarn lint` *(fails: Parsing error: Identifier 'lastTime' has already been declared)*
- `yarn test` *(fails: ReferenceError: NUM_TILES_WIDE is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8c1cbb48328af8984df768c2cd1