### PR TITLE
feat: enhance chess engine analysis and PGN tests

### DIFF
--- a/__tests__/chess.pgn.test.ts
+++ b/__tests__/chess.pgn.test.ts
@@ -1,0 +1,17 @@
+import { Chess } from 'chess.js';
+
+test('illegal moves are rejected', () => {
+  const game = new Chess();
+  expect(() => game.move({ from: 'e2', to: 'e5' })).toThrow();
+});
+
+test('PGN import and export roundtrip', () => {
+  const game = new Chess();
+  const pgn = '1. e4 e5 2. Nf3 Nc6 3. Bb5 a6';
+  game.loadPgn(pgn);
+  expect(game.history().join(' ')).toBe('e4 e5 Nf3 Nc6 Bb5 a6');
+  const exported = game.pgn();
+  const game2 = new Chess();
+  game2.loadPgn(exported);
+  expect(game2.history().join(' ')).toBe('e4 e5 Nf3 Nc6 Bb5 a6');
+});


### PR DESCRIPTION
## Summary
- display Stockfish evaluation and best move arrow on the chess board
- add unit tests for chess move legality and PGN import/export

## Testing
- `yarn test` *(fails: frogger.test.ts parse error, tictactoe.test.ts missing minimax)*
- `yarn test __tests__/chess.pgn.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab18a554dc83289b7aa5cebbfc97d8