### PR TITLE
Add Pixi renderer and expand platformer physics tests

### DIFF
--- a/__tests__/platformer.test.js
+++ b/__tests__/platformer.test.js
@@ -1,4 +1,14 @@
-import { Player, updatePhysics, collectCoin, COYOTE_TIME, JUMP_BUFFER_TIME } from '@public/apps/platformer/engine.js';
+import {
+  Player,
+  updatePhysics,
+  collectCoin,
+  COYOTE_TIME,
+  JUMP_BUFFER_TIME,
+  hitHazard,
+} from '@public/apps/platformer/engine.js';
+import { Player as TerrainPlayer } from '@apps/platformer/Player.js';
+import { Terrain } from '@apps/platformer/Terrain.js';
+import { updatePhysics as updatePhysicsTerrain } from '@apps/platformer/physics.js';
 
 describe('platformer mechanics', () => {
   test('coyote time allows late jump', () => {
@@ -27,5 +37,34 @@ describe('platformer mechanics', () => {
     if (collectCoin(tiles, 0, 0)) score++;
     if (collectCoin(tiles, 0, 0)) score++;
     expect(score).toBe(1);
+  });
+
+  test('releasing jump early reduces upward velocity', () => {
+    const p = new Player();
+    p.onGround = true;
+    updatePhysics(p, { left: false, right: false, jump: true }, 0);
+    updatePhysics(p, { left: false, right: false, jump: true }, 0.016);
+    const vyHeld = p.vy;
+    updatePhysics(p, { left: false, right: false, jump: false }, 0.016);
+    expect(p.vy).toBeGreaterThan(vyHeld);
+  });
+
+  test('hazard tiles are detected', () => {
+    const tiles = [[4]];
+    expect(hitHazard(tiles, 0, 0)).toBe(true);
+    expect(hitHazard(tiles, 1, 0)).toBe(false);
+  });
+
+  test('player lands on slope tiles', () => {
+    const terrain = new Terrain(16, [
+      [0, 0],
+      [2, 0],
+    ]);
+    const p = new TerrainPlayer(2, 0);
+    for (let i = 0; i < 60; i++) {
+      updatePhysicsTerrain(p, { left: false, right: false, jump: false }, 1 / 60, terrain);
+    }
+    expect(p.onGround).toBe(true);
+    expect(p.y).toBeCloseTo(9, 1);
   });
 });

--- a/apps/platformer/pixiRenderer.js
+++ b/apps/platformer/pixiRenderer.js
@@ -1,0 +1,38 @@
+import * as PIXI from 'pixi.js';
+
+export function createPixiApp(width = 320, height = 180) {
+  const app = new PIXI.Application({ width, height, backgroundAlpha: 0 });
+  const world = new PIXI.Container();
+  app.stage.addChild(world);
+  const camera = { x: 0, y: 0, targetX: 0, targetY: 0 };
+  return { app, world, camera };
+}
+
+export function updateCamera(camera, targetX, targetY, lerp = 0.1) {
+  camera.targetX = targetX;
+  camera.targetY = targetY;
+  camera.x += (camera.targetX - camera.x) * lerp;
+  camera.y += (camera.targetY - camera.y) * lerp;
+}
+
+export function renderWorld(world, camera) {
+  world.position.set(-camera.x, -camera.y);
+}
+
+export function addCollectible(world, texture, x, y) {
+  const sprite = new PIXI.Sprite(texture);
+  sprite.x = x;
+  sprite.y = y;
+  sprite.name = 'collectible';
+  world.addChild(sprite);
+  return sprite;
+}
+
+export function addHazard(world, texture, x, y) {
+  const sprite = new PIXI.Sprite(texture);
+  sprite.x = x;
+  sprite.y = y;
+  sprite.name = 'hazard';
+  world.addChild(sprite);
+  return sprite;
+}

--- a/public/apps/platformer/engine.js
+++ b/public/apps/platformer/engine.js
@@ -66,3 +66,7 @@ export function collectCoin(tiles, x, y) {
   }
   return false;
 }
+
+export function hitHazard(tiles, x, y) {
+  return !!(tiles[y] && tiles[y][x] === 4);
+}


### PR DESCRIPTION
## Summary
- add hazard detection and variable jump tests for platformer engine
- create PixiJS renderer with interpolated camera and entity helpers
- cover slope collisions and input buffering mechanics

## Testing
- `npx jest __tests__/platformer.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab18aa8024832889e09b9ab54a6b96