### PR TITLE
feat: add ADSR audio and calibration to Simon game

### DIFF
--- a/__tests__/simonSequence.test.ts
+++ b/__tests__/simonSequence.test.ts
@@ -1,0 +1,13 @@
+import { generateSequence } from '@components/apps/simon';
+
+describe('generateSequence', () => {
+  test('adds a random pad without mutating the original sequence', () => {
+    const original = [0, 1];
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0.75);
+    const next = generateSequence(original);
+    expect(next).toEqual([0, 1, 3]);
+    expect(original).toEqual([0, 1]);
+    spy.mockRestore();
+  });
+});
+

--- a/__tests__/simonTiming.test.ts
+++ b/__tests__/simonTiming.test.ts
@@ -1,0 +1,14 @@
+import { isInputOnBeat } from '@components/apps/simon';
+
+describe('isInputOnBeat', () => {
+  test('returns true when input matches expected within window after calibration', () => {
+    const expected = 1; // seconds
+    const input = 1.04; // seconds
+    expect(isInputOnBeat(expected, input, 50, 0.05)).toBe(true);
+  });
+
+  test('returns false when input is outside tolerance', () => {
+    expect(isInputOnBeat(1, 1.2, 0, 0.05)).toBe(false);
+  });
+});
+

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -3,18 +3,22 @@ import React, { useState, useRef, useEffect } from 'react';
 const padStyles = [
   {
     color: { base: 'bg-green-700', active: 'bg-green-500' },
+    colorblind: { base: 'bg-emerald-700', active: 'bg-emerald-500' },
     symbol: '▲',
   },
   {
     color: { base: 'bg-red-700', active: 'bg-red-500' },
+    colorblind: { base: 'bg-orange-700', active: 'bg-orange-500' },
     symbol: '■',
   },
   {
     color: { base: 'bg-yellow-500', active: 'bg-yellow-300' },
+    colorblind: { base: 'bg-fuchsia-700', active: 'bg-fuchsia-500' },
     symbol: '●',
   },
   {
     color: { base: 'bg-blue-700', active: 'bg-blue-500' },
+    colorblind: { base: 'bg-cyan-700', active: 'bg-cyan-500' },
     symbol: '◆',
   },
 ];
@@ -23,6 +27,11 @@ const tones = [329.63, 261.63, 220, 164.81];
 
 export const createToneSchedule = (length, start, step) =>
   Array.from({ length }, (_, i) => start + i * step);
+
+export const generateSequence = (seq) => [...seq, Math.floor(Math.random() * 4)];
+
+export const isInputOnBeat = (expected, input, calibration = 0, window = 0.1) =>
+  Math.abs(input - (expected + calibration / 1000)) <= window;
 
 const Simon = () => {
   const [sequence, setSequence] = useState([]);
@@ -37,6 +46,8 @@ const Simon = () => {
   const [customPattern, setCustomPattern] = useState([]);
   const [sharedPatterns, setSharedPatterns] = useState([]);
   const [strictMode, setStrictMode] = useState(false);
+  const [calibration, setCalibration] = useState(0);
+  const [expectedTimes, setExpectedTimes] = useState([]);
   const audioCtx = useRef(null);
 
   useEffect(() => {
@@ -48,6 +59,8 @@ const Simon = () => {
     if (settings.difficulty) setDifficulty(settings.difficulty);
     if (settings.accessibility) setAccessibility(settings.accessibility);
     if (settings.strictMode) setStrictMode(settings.strictMode);
+    if (typeof settings.calibration === 'number')
+      setCalibration(settings.calibration);
     const storedScore =
       typeof window !== 'undefined'
         ? Number(localStorage.getItem('simon-highScore')) || 0
@@ -65,10 +78,10 @@ const Simon = () => {
     if (typeof window !== 'undefined') {
       localStorage.setItem(
         'simon-settings',
-        JSON.stringify({ difficulty, accessibility, strictMode })
+        JSON.stringify({ difficulty, accessibility, strictMode, calibration })
       );
     }
-  }, [difficulty, accessibility, strictMode]);
+  }, [difficulty, accessibility, strictMode, calibration]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -113,21 +126,40 @@ const Simon = () => {
     }
   };
 
-  const scheduleTone = (freq, startTime, type = 'sine') => {
+  const scheduleTone = (
+    freq,
+    startTime,
+    type = 'sine',
+    adsr = { attack: 0.01, decay: 0.1, sustain: 0.2, release: 0.2, gain: 0.5 }
+  ) => {
     const ctx =
-      audioCtx.current || new (window.AudioContext || window.webkitAudioContext)();
+      audioCtx.current ||
+      new (window.AudioContext || window.webkitAudioContext)({
+        latencyHint: 'interactive',
+      });
     audioCtx.current = ctx;
     const oscillator = ctx.createOscillator();
-    const gain = ctx.createGain();
+    const gainNode = ctx.createGain();
     oscillator.type = type;
     oscillator.frequency.value = freq;
-    oscillator.connect(gain);
-    gain.connect(ctx.destination);
-    gain.gain.setValueAtTime(0.0001, startTime);
-    gain.gain.exponentialRampToValueAtTime(0.5, startTime + 0.01);
-    gain.gain.exponentialRampToValueAtTime(0.0001, startTime + 0.4);
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    const { attack, decay, sustain, release, gain } = adsr;
+    const sustainLevel = gain * 0.7;
+    const peak = startTime + attack;
+    const decayTime = peak + decay;
+    const sustainTime = decayTime + sustain;
+    const end = sustainTime + release;
+
+    gainNode.gain.setValueAtTime(0.0001, startTime);
+    gainNode.gain.linearRampToValueAtTime(gain, peak);
+    gainNode.gain.linearRampToValueAtTime(sustainLevel, decayTime);
+    gainNode.gain.setValueAtTime(sustainLevel, sustainTime);
+    gainNode.gain.linearRampToValueAtTime(0.0001, end);
+
     oscillator.start(startTime);
-    oscillator.stop(startTime + 0.5);
+    oscillator.stop(end);
   };
 
   const playError = (time) => {
@@ -147,18 +179,25 @@ const Simon = () => {
 
   const playPattern = (pattern, { onComplete } = {}) => {
     const ctx =
-      audioCtx.current || new (window.AudioContext || window.webkitAudioContext)();
+      audioCtx.current ||
+      new (window.AudioContext || window.webkitAudioContext)({
+        latencyHint: 'interactive',
+      });
     audioCtx.current = ctx;
     const start = ctx.currentTime + 0.1;
     const delta = stepDuration(pattern.length);
-    const schedule = createToneSchedule(pattern.length, start, delta);
+    const audioStart = start - calibration / 1000;
+    const schedule = createToneSchedule(pattern.length, audioStart, delta);
+    const visualSchedule = schedule.map((t) => t + calibration / 1000);
+    setExpectedTimes(visualSchedule);
     schedule.forEach((time, i) => {
       const idx = pattern[i];
       scheduleTone(tones[idx], time);
-      const delay = (time - ctx.currentTime) * 1000;
+      const delay = (visualSchedule[i] - ctx.currentTime) * 1000;
       setTimeout(() => flashPad(idx), delay);
     });
-    const totalDelay = (schedule[schedule.length - 1] - ctx.currentTime + delta) * 1000;
+    const totalDelay =
+      (visualSchedule[visualSchedule.length - 1] - ctx.currentTime + delta) * 1000;
     if (onComplete) setTimeout(onComplete, totalDelay);
     return totalDelay;
   };
@@ -186,7 +225,7 @@ const Simon = () => {
   const startGame = () => {
     const initial = customPattern.length
       ? [...customPattern]
-      : [Math.floor(Math.random() * 4)];
+      : generateSequence([]);
     setSequence(initial);
     setStatus('Listen...');
     setCustomPattern([]);
@@ -196,7 +235,9 @@ const Simon = () => {
   const handlePadClick = (idx) => {
     if (editing) {
       if (!audioCtx.current) {
-        audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
+        audioCtx.current = new (window.AudioContext || window.webkitAudioContext)({
+          latencyHint: 'interactive',
+        });
       }
       flashPad(idx);
       scheduleTone(tones[idx], audioCtx.current.currentTime);
@@ -205,21 +246,26 @@ const Simon = () => {
     }
     if (!isPlayerTurn) return;
     if (!audioCtx.current) {
-      audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
+      audioCtx.current = new (window.AudioContext || window.webkitAudioContext)({
+        latencyHint: 'interactive',
+      });
     }
     flashPad(idx);
-    scheduleTone(tones[idx], audioCtx.current.currentTime);
-    if (sequence[step] === idx) {
+    const now = audioCtx.current.currentTime;
+    scheduleTone(tones[idx], now);
+    const expected = expectedTimes[step];
+    const timingOk = expected ? isInputOnBeat(expected, now, 0, 0.3) : true;
+    if (sequence[step] === idx && timingOk) {
       if (step + 1 === sequence.length) {
         setIsPlayerTurn(false);
         setTimeout(() => {
-          setSequence((seq) => [...seq, Math.floor(Math.random() * 4)]);
+          setSequence((seq) => generateSequence(seq));
         }, 1000);
       } else {
         setStep(step + 1);
       }
     } else {
-      playError(audioCtx.current.currentTime);
+      playError(now);
       if (strictMode) {
         submitScore(sequence.length - 1);
         setStatus('Wrong! Press Start');
@@ -238,13 +284,11 @@ const Simon = () => {
   };
 
   const padClass = (pad, idx) => {
-    let colors = accessibility === 'colorblind'
-      ? { base: 'bg-gray-700', active: 'bg-gray-500' }
-      : pad.color;
+    let colors = accessibility === 'colorblind' ? pad.colorblind : pad.color;
     if (difficulty === 'inverted') {
       colors = { base: colors.active, active: colors.base };
     }
-    return `h-32 w-32 rounded flex items-center justify-center text-3xl ${
+    return `h-40 w-40 rounded flex items-center justify-center text-5xl ${
       activePad === idx ? colors.active : colors.base
     }`;
   };
@@ -293,6 +337,21 @@ const Simon = () => {
           <option value="normal">Normal</option>
           <option value="strict">Strict</option>
         </select>
+        <div className="flex items-center gap-2">
+          <label htmlFor="calibration" className="text-xs">
+            Calibrate
+          </label>
+          <input
+            id="calibration"
+            type="range"
+            min="-200"
+            max="200"
+            value={calibration}
+            onChange={(e) => setCalibration(Number(e.target.value))}
+            className="w-32"
+          />
+          <span className="text-xs">{calibration}ms</span>
+        </div>
         <button
           className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
           onClick={startGame}


### PR DESCRIPTION
## Summary
- use ADSR envelopes for Simon tones and keep scheduling low-latency
- add large colorblind-friendly pads with calibration slider
- test sequence generation and input timing utilities

## Testing
- `yarn test` *(fails: frogger and tictactoe suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18ad1c88832884184371b9e670d3