### PR TITLE
feat(pacman): add mode controller and ghost tests

### DIFF
--- a/__tests__/pacman-ghost.test.ts
+++ b/__tests__/pacman-ghost.test.ts
@@ -1,0 +1,114 @@
+import Ghost, { GhostMode } from '@apps/pacman/Ghost';
+import Player from '@apps/pacman/Player';
+import Maze from '@apps/pacman/Maze';
+
+describe('ghost targeting', () => {
+  const maze = new Maze({
+    width: 20,
+    height: 20,
+    walls: [],
+    pellets: [],
+    powerUps: [],
+    player: { x: 0, y: 0 },
+    ghosts: [],
+  });
+  const ts = maze.tileSize;
+
+  test('blinky targets player tile', () => {
+    const player = new Player(5 * ts + ts / 2, 5 * ts + ts / 2);
+    player.dir = { x: 1, y: 0 };
+    const blinky = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'blinky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    const target = blinky.getTargetTile('chase', player, maze, blinky);
+    expect(target).toEqual({ x: 5, y: 5 });
+  });
+
+  test('pinky targets four tiles ahead', () => {
+    const player = new Player(2 * ts + ts / 2, 2 * ts + ts / 2);
+    player.dir = { x: 1, y: 0 };
+    const pinky = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'pinky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    const target = pinky.getTargetTile('chase', player, maze);
+    expect(target).toEqual({ x: 6, y: 2 });
+  });
+
+  test('inky uses vector from blinky', () => {
+    const player = new Player(5 * ts + ts / 2, 5 * ts + ts / 2);
+    player.dir = { x: 1, y: 0 };
+    const blinky = new Ghost({
+      x: 4 * ts + ts / 2,
+      y: 5 * ts + ts / 2,
+      type: 'blinky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    const inky = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'inky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    const target = inky.getTargetTile('chase', player, maze, blinky);
+    expect(target).toEqual({ x: 10, y: 5 });
+  });
+
+  test('clyde targets player when far and scatter when near', () => {
+    const farPlayer = new Player(10 * ts + ts / 2, ts / 2);
+    farPlayer.dir = { x: 0, y: 0 };
+    const clydeFar = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'clyde',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    expect(clydeFar.getTargetTile('chase', farPlayer, maze)).toEqual({ x: 10, y: 0 });
+
+    const nearPlayer = new Player(ts + ts / 2, ts / 2);
+    nearPlayer.dir = { x: 0, y: 0 };
+    const clydeNear = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'clyde',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    expect(clydeNear.getTargetTile('chase', nearPlayer, maze)).toEqual(clydeNear.scatter);
+  });
+
+  test('scatter mode uses scatter corner', () => {
+    const player = new Player(ts / 2, ts / 2);
+    const ghost = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'pinky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    expect(ghost.getTargetTile('scatter', player, maze)).toEqual(ghost.scatter);
+  });
+
+  test('frightened mode has no target', () => {
+    const player = new Player(ts / 2, ts / 2);
+    const ghost = new Ghost({
+      x: ts / 2,
+      y: ts / 2,
+      type: 'blinky',
+      mazeWidth: maze.width,
+      mazeHeight: maze.height,
+    });
+    expect(ghost.getTargetTile('frightened', player, maze)).toBeNull();
+  });
+});
+

--- a/__tests__/pacman-mode.test.ts
+++ b/__tests__/pacman-mode.test.ts
@@ -1,0 +1,18 @@
+import { ModeController, DEFAULT_MODE_SCHEDULE } from '@apps/pacman/modes';
+
+describe('ghost mode transitions', () => {
+  test('follows default schedule', () => {
+    const mc = new ModeController();
+    // initial scatter for 7 seconds
+    for (let i = 0; i < 7 * 60; i++) mc.tick();
+    expect(mc.currentMode()).toBe('scatter');
+    mc.tick();
+    expect(mc.currentMode()).toBe('chase');
+    // next chase lasts 20s
+    for (let i = 0; i < 20 * 60; i++) mc.tick();
+    expect(mc.currentMode()).toBe('chase');
+    mc.tick();
+    expect(mc.currentMode()).toBe('scatter');
+  });
+});
+

--- a/apps/pacman/modes.ts
+++ b/apps/pacman/modes.ts
@@ -1,0 +1,52 @@
+import { GhostMode } from "./Ghost";
+
+export interface ModeStep {
+  mode: GhostMode;
+  /** duration in seconds */
+  duration: number;
+}
+
+export const DEFAULT_MODE_SCHEDULE: ModeStep[] = [
+  { mode: "scatter", duration: 7 },
+  { mode: "chase", duration: 20 },
+  { mode: "scatter", duration: 7 },
+  { mode: "chase", duration: 20 },
+  { mode: "scatter", duration: 5 },
+  { mode: "chase", duration: 20 },
+  { mode: "scatter", duration: 5 },
+  { mode: "chase", duration: Infinity },
+];
+
+export class ModeController {
+  private schedule: ModeStep[];
+  private index = 0;
+  private timer = 0; // in frames
+
+  constructor(schedule: ModeStep[] = DEFAULT_MODE_SCHEDULE) {
+    this.schedule = schedule;
+  }
+
+  /** advance one frame and return current mode */
+  tick(): GhostMode {
+    this.timer++;
+    const current = this.schedule[this.index];
+    if (
+      this.index < this.schedule.length - 1 &&
+      this.timer > current.duration * 60
+    ) {
+      this.index++;
+      this.timer = 0;
+    }
+    return this.schedule[this.index].mode;
+  }
+
+  currentMode(): GhostMode {
+    return this.schedule[this.index].mode;
+  }
+
+  reset() {
+    this.index = 0;
+    this.timer = 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add mode controller and integrate into Pac-Man game
- expose ghost targeting and improve pathfinding
- test ghost targeting and mode transitions

## Testing
- `yarn test __tests__/pacman-ghost.test.ts --runInBand --verbose`
- `yarn test __tests__/pacman-mode.test.ts --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68ab18a995308328bc4f4d506729de25