### PR TITLE
feat(memory): expand packs and improve accessibility

### DIFF
--- a/__tests__/memory.test.tsx
+++ b/__tests__/memory.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import Memory from '@components/apps/memory';
+import { FLIP_BACK_DELAY } from '@components/apps/memory_utils';
+
+jest.mock('@components/apps/memory_utils', () => ({
+  THEME_PACKS: { fruits: ['A', 'B'] },
+  createDeck: () => [
+    { id: 0, value: 'A' },
+    { id: 1, value: 'B' },
+    { id: 2, value: 'A' },
+    { id: 3, value: 'B' },
+  ],
+  MATCH_PAUSE: 600,
+  FLIP_BACK_DELAY: 200,
+}));
+
+describe('Memory game', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('detects matches and updates score', () => {
+    const { getAllByRole, getByText } = render(<Memory />);
+    const cards = getAllByRole('button');
+    fireEvent.click(cards[0]);
+    fireEvent.click(cards[2]);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(getByText(/Score: 10/)).toBeInTheDocument();
+  });
+
+  it('flips unmatched cards back after delay', () => {
+    const { getAllByRole } = render(<Memory />);
+    const cards = getAllByRole('button');
+    fireEvent.click(cards[0]);
+    fireEvent.click(cards[1]);
+    const firstInner = cards[0].firstChild as HTMLElement;
+    expect(firstInner).toHaveStyle('transform: rotateY(180deg)');
+    act(() => {
+      jest.advanceTimersByTime(FLIP_BACK_DELAY);
+    });
+    expect(firstInner).toHaveStyle('transform: rotateY(0deg)');
+  });
+});

--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -67,8 +67,16 @@ export const THEME_PACKS = {
     '\u{1F989}', // owl
     '\u{1F98B}', // butterfly
   ],
+  photos: Array.from(
+    { length: 30 },
+    (_, i) => `https://picsum.photos/seed/memory${i}/100`
+  ),
   'high-contrast': Array.from({ length: 30 }, (_, i) => String(i + 1)),
 };
+
+// Delays used by the game. Exported for tests and component reuse.
+export const MATCH_PAUSE = 600;
+export const FLIP_BACK_DELAY = 200;
 
 // Fisher–Yates shuffle implementation.
 export function fisherYatesShuffle(array) {


### PR DESCRIPTION
## Summary
- add optional picture pack and expose timing constants
- render cards as focusable buttons with keyboard navigation and ARIA match announcements
- add unit tests for match detection and flip timing

## Testing
- `yarn test __tests__/memory.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab18a823d08328866700aeaee6b515