### PR TITLE
Add Sokoban solver tests and pixel-perfect rendering

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -1,5 +1,6 @@
 import { defaultLevels } from '@apps/sokoban/levels';
 import { loadLevel, move, undo, isSolved } from '@apps/sokoban/engine';
+import { solve, SimpleState } from '@apps/sokoban/solverWorker';
 
 describe('sokoban engine', () => {
   test('simple level solvable', () => {
@@ -15,5 +16,26 @@ describe('sokoban engine', () => {
     expect(undone.player).toEqual(state.player);
     expect(Array.from(undone.boxes)).toEqual(Array.from(state.boxes));
     expect(undone.pushes).toBe(state.pushes);
+  });
+
+  test('cannot push two boxes into a wall', () => {
+    const level = ['#####', '#@$$#', '#####'];
+    const state = loadLevel(level);
+    const attempted = move(state, 'ArrowRight');
+    expect(attempted).toBe(state);
+  });
+
+  test('solver suggests first move for simple level', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const simple: SimpleState = {
+      width: state.width,
+      height: state.height,
+      walls: state.walls,
+      targets: state.targets,
+      boxes: state.boxes,
+      player: state.player,
+    };
+    const moves = solve(simple);
+    expect(moves[0]).toBe('ArrowRight');
   });
 });

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -354,7 +354,11 @@ const Sokoban: React.FC = () => {
       </div>
       <div
         className="relative bg-gray-700"
-        style={{ width: state.width * CELL, height: state.height * CELL }}
+        style={{
+          width: state.width * CELL,
+          height: state.height * CELL,
+          imageRendering: 'pixelated',
+        }}
       >
         {Array.from({ length: state.height }).map((_, y) =>
           Array.from({ length: state.width }).map((_, x) => {

--- a/apps/sokoban/solverWorker.ts
+++ b/apps/sokoban/solverWorker.ts
@@ -42,7 +42,7 @@ function isDeadlock(state: SimpleState, pos: Position): boolean {
   return (up && left) || (up && right) || (down && left) || (down && right);
 }
 
-interface SimpleState {
+export interface SimpleState {
   width: number;
   height: number;
   walls: Set<string>;
@@ -103,7 +103,7 @@ interface Node {
   path: string[];
 }
 
-function solve(start: SimpleState): string[] {
+export function solve(start: SimpleState): string[] {
   const open: Node[] = [{ state: start, g: 0, f: heuristic(start), path: [] }];
   const visited = new Map<string, number>();
   visited.set(stateKey(start), 0);
@@ -139,5 +139,3 @@ ctx.onmessage = (e: MessageEvent<SolveRequest>) => {
   const res: SolveResponse = { moves };
   ctx.postMessage(res);
 };
-
-export {};


### PR DESCRIPTION
## Summary
- ensure Sokoban tiles render crisp by enabling pixelated image rendering
- expose solver function for reuse and unit tests
- cover push rules and solver suggestions with new tests

## Testing
- `yarn test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab18ae98d48328a917629d88455c28