### PR TITLE
feat: enhance solitaire hints and accessibility

### DIFF
--- a/__tests__/solitaireEngine.test.ts
+++ b/__tests__/solitaireEngine.test.ts
@@ -5,6 +5,7 @@ import {
   moveWasteToTableau,
   moveToFoundation,
   autoMove,
+  autoMoveHint,
   autoComplete,
   isWin,
   suits,
@@ -117,6 +118,16 @@ describe('Solitaire engine', () => {
     state.waste = [card('♦', 1, true)];
     const r = autoMove(state, 'waste', null);
     expect(r.foundations[suits.indexOf('♦')].length).toBe(1);
+  });
+
+  test('autoMoveHint suggests movable cards', () => {
+    const state = emptyState();
+    state.waste = [card('♣', 1, true)];
+    expect(autoMoveHint(state)).toEqual({ source: 'waste' });
+    const state2 = emptyState();
+    state2.tableau[0] = [card('♠', 1, true)];
+    expect(autoMoveHint(state2)).toEqual({ source: 'tableau', index: 0 });
+    expect(autoMoveHint(emptyState())).toBeNull();
   });
 
   test('autoComplete moves all possible cards to foundation', () => {

--- a/components/apps/solitaire/engine.ts
+++ b/components/apps/solitaire/engine.ts
@@ -207,6 +207,22 @@ export const autoMove = (
   return moveToFoundation(state, 'tableau', index);
 };
 
+export type AutoMoveHint =
+  | { source: 'waste' }
+  | { source: 'tableau'; index: number };
+
+export const autoMoveHint = (state: GameState): AutoMoveHint | null => {
+  if (state.waste.length) {
+    const moved = moveToFoundation(state, 'waste', null);
+    if (moved !== state) return { source: 'waste' };
+  }
+  for (let i = 0; i < state.tableau.length; i += 1) {
+    const moved = moveToFoundation(state, 'tableau', i);
+    if (moved !== state) return { source: 'tableau', index: i };
+  }
+  return null;
+};
+
 export const autoComplete = (state: GameState): GameState => {
   let current = state;
   let moved = true;


### PR DESCRIPTION
## Summary
- add auto-move hint detection in solitaire engine
- highlight movable cards and label piles for screen readers
- expand solitaire engine tests

## Testing
- `yarn test __tests__/solitaireEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab18aef8688328b9df93d5a629e64a