### PR TITLE
Add worker-based nonogram solver and interaction tests

### DIFF
--- a/__tests__/nonogram.interaction.test.tsx
+++ b/__tests__/nonogram.interaction.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import Nonogram from '@apps/nonogram';
+
+jest.mock('react-ga4', () => ({ event: jest.fn() }));
+
+describe('nonogram interactions', () => {
+  beforeEach(() => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            width: 2,
+            height: 1,
+            rows: [[1]],
+            cols: [[1], [1]],
+            id: 'test',
+          }),
+      })
+    );
+    localStorage.clear();
+  });
+
+  test('supports pencil marks and highlights contradictions', async () => {
+    render(<Nonogram />);
+    let cells = await screen.findAllByRole('gridcell');
+    fireEvent.click(screen.getByText('Pencil'));
+    fireEvent.click(cells[0]);
+    await waitFor(() => expect(cells[0]).toHaveTextContent('·'));
+
+    fireEvent.click(screen.getByText('Fill'));
+    cells = screen.getAllByRole('gridcell');
+    fireEvent.click(cells[0]);
+    fireEvent.click(cells[1]);
+
+    await waitFor(() => expect(cells[0]).toHaveClass('bg-red-200'));
+    await waitFor(() => expect(cells[1]).toHaveClass('bg-red-200'));
+  });
+});

--- a/__tests__/nonogram.test.ts
+++ b/__tests__/nonogram.test.ts
@@ -1,4 +1,5 @@
 import { validateSolution, findHint, getPuzzleBySeed, generateLinePatterns, lineToClues } from '@components/apps/nonogramUtils';
+import { solve, type Cell } from '@apps/nonogram/solver';
 
 describe('nonogram utilities', () => {
   test('validateSolution confirms grid matches clues', () => {
@@ -51,5 +52,16 @@ describe('nonogram utilities', () => {
     const a = getPuzzleBySeed('2024-01-01');
     const b = getPuzzleBySeed('2024-01-01');
     expect(a).toEqual(b);
+  });
+
+  test('solver completes puzzle', () => {
+    const { rows, cols } = getPuzzleBySeed('0');
+    const puzzle = { width: cols.length, height: rows.length, rows, cols };
+    const grid: Cell[][] = Array.from({ length: puzzle.height }, () =>
+      Array(puzzle.width).fill(0)
+    );
+    const { grid: solved, contradiction } = solve(grid, puzzle);
+    expect(contradiction).toBe(false);
+    expect(validateSolution(solved, rows, cols)).toBe(true);
   });
 });

--- a/apps/nonogram/solver.ts
+++ b/apps/nonogram/solver.ts
@@ -107,3 +107,37 @@ export function propagate(
   return { grid: ng, contradiction };
 }
 
+function backtrack(grid: Cell[][], puzzle: NonogramPuzzle): Cell[][] | null {
+  for (let r = 0; r < puzzle.height; r += 1) {
+    for (let c = 0; c < puzzle.width; c += 1) {
+      if (grid[r][c] === 0) {
+        for (const val of [1, -1] as Cell[]) {
+          const g = grid.map((row) => row.slice() as Cell[]);
+          g[r][c] = val;
+          const { grid: pg, contradiction } = propagate(g, puzzle);
+          if (!contradiction) {
+            const solved = backtrack(pg, puzzle);
+            if (solved) return solved;
+          }
+        }
+        return null;
+      }
+    }
+  }
+  return grid;
+}
+
+export function solve(
+  grid: Cell[][],
+  puzzle: NonogramPuzzle
+): { grid: Cell[][]; contradiction: boolean } {
+  const { grid: pg, contradiction } = propagate(grid, puzzle);
+  if (contradiction) return { grid: pg, contradiction: true };
+  const normalized = pg.map((row) =>
+    row.map((v) => (v === 2 ? 0 : v)) as Cell[]
+  );
+  const result = backtrack(normalized, puzzle);
+  if (!result) return { grid: pg, contradiction: true };
+  return { grid: result, contradiction: false };
+}
+

--- a/apps/nonogram/solver.worker.ts
+++ b/apps/nonogram/solver.worker.ts
@@ -1,0 +1,9 @@
+import { solve, type Cell } from './solver';
+import type { NonogramPuzzle } from './parser';
+
+self.onmessage = (e: MessageEvent) => {
+  const { grid, puzzle } = e.data as { grid: Cell[][]; puzzle: NonogramPuzzle };
+  const result = solve(grid, puzzle);
+  // result already has shape { grid, contradiction }
+  (self as any).postMessage(result);
+};


### PR DESCRIPTION
## Summary
- Add backtracking nonogram solver with worker fallback
- Support pencil marks and expose grid cells for accessibility
- Test solver correctness and user interactions

## Testing
- `yarn test __tests__/nonogram.test.ts __tests__/nonogram.interaction.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab18b3bff483289e7c788cbe771797