### PR TITLE
feat: enhance CVE dashboard

### DIFF
--- a/apps/cve-dashboard/index.tsx
+++ b/apps/cve-dashboard/index.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import Papa from 'papaparse';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useRouter } from 'next/router';
+import Fuse from 'fuse.js';
 
 interface ExploitInfo {
   id: string;
@@ -24,7 +25,11 @@ interface Vulnerability {
   exploits: ExploitInfo[];
 }
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const json = await res.json();
+  return { data: json, headers: Object.fromEntries(res.headers.entries()), status: res.status };
+};
 
 function riskColor(v: Vulnerability): string {
   if (v.kev) return 'bg-red-900';
@@ -43,12 +48,77 @@ function riskColor(v: Vulnerability): string {
   }
 }
 
+const parseVector = (vector: string): Record<string, string> => {
+  const parts = vector.split('/');
+  const start = parts[0].startsWith('CVSS') ? 1 : 0;
+  const obj: Record<string, string> = {};
+  parts.slice(start).forEach((p) => {
+    const [k, v] = p.split(':');
+    if (k && v) obj[k] = v;
+  });
+  return obj;
+};
+
+const metricExamplesV3: Record<string, Record<string, string>> = {
+  AV: { N: 'Network', A: 'Adjacent', L: 'Local', P: 'Physical' },
+  AC: { L: 'Low', H: 'High' },
+  PR: { N: 'None', L: 'Low', H: 'High' },
+  UI: { N: 'None', R: 'Required' },
+  S: { U: 'Unchanged', C: 'Changed' },
+  C: { H: 'High', L: 'Low', N: 'None' },
+  I: { H: 'High', L: 'Low', N: 'None' },
+  A: { H: 'High', L: 'Low', N: 'None' },
+};
+
+const metricWeights = {
+  AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
+  AC: { L: 0.77, H: 0.44 },
+  PR: {
+    N: { U: 0.85, C: 0.85 },
+    L: { U: 0.62, C: 0.68 },
+    H: { U: 0.27, C: 0.5 },
+  },
+  UI: { N: 0.85, R: 0.62 },
+  C: { H: 0.56, L: 0.22, N: 0 },
+  I: { H: 0.56, L: 0.22, N: 0 },
+  A: { H: 0.56, L: 0.22, N: 0 },
+};
+
+function computeCvss31(vector: string): number | null {
+  try {
+    const m = parseVector(vector);
+    const S = m.S as 'U' | 'C';
+    const AV = metricWeights.AV[m.AV as keyof typeof metricWeights.AV] ?? 0;
+    const AC = metricWeights.AC[m.AC as keyof typeof metricWeights.AC] ?? 0;
+    const PR = (metricWeights.PR as any)[m.PR]?.[S] ?? 0;
+    const UI = metricWeights.UI[m.UI as keyof typeof metricWeights.UI] ?? 0;
+    const C = metricWeights.C[m.C as keyof typeof metricWeights.C] ?? 0;
+    const I = metricWeights.I[m.I as keyof typeof metricWeights.I] ?? 0;
+    const A = metricWeights.A[m.A as keyof typeof metricWeights.A] ?? 0;
+    const exploitability = 8.22 * AV * AC * PR * UI;
+    const impactSub = 1 - (1 - C) * (1 - I) * (1 - A);
+    const impact =
+      S === 'U'
+        ? 6.42 * impactSub
+        : 7.52 * (impactSub - 0.029) - 3.25 * Math.pow(impactSub - 0.02, 15);
+    if (impact <= 0) return 0;
+    const base =
+      S === 'U'
+        ? Math.min(impact + exploitability, 10)
+        : Math.min(1.08 * (impact + exploitability), 10);
+    return Math.ceil(base * 10) / 10;
+  } catch {
+    return null;
+  }
+}
+
 const CveDashboard: React.FC = () => {
   const router = useRouter();
   const [keyword, setKeyword] = useState('');
   const [cpe, setCpe] = useState('');
   const [cwe, setCwe] = useState('');
   const [recent, setRecent] = useState(30);
+  const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<Vulnerability | null>(null);
   const [views, setViews] = useState<Record<string, any>>(() => {
     try {
@@ -57,6 +127,7 @@ const CveDashboard: React.FC = () => {
       return {};
     }
   });
+  const [rateInfo, setRateInfo] = useState<{ limit?: number; remaining?: number; retryAfter?: string }>({});
 
   // Load from query for deep links
   useEffect(() => {
@@ -80,10 +151,23 @@ const CveDashboard: React.FC = () => {
   }, [keyword, cpe, cwe, recent]);
 
   const { data } = useSWR(`/api/cve?${params}`, fetcher, { revalidateOnFocus: false });
-  const vulns: Vulnerability[] = data?.vulnerabilities || [];
+  const vulns: Vulnerability[] = data?.data?.vulnerabilities || [];
+
+  useEffect(() => {
+    if (data?.headers) {
+      setRateInfo({
+        limit: Number(data.headers['x-ratelimit-limit'] || 0),
+        remaining: Number(data.headers['x-ratelimit-remaining'] || 0),
+        retryAfter: data.status === 429 ? data.headers['retry-after'] : undefined,
+      });
+    }
+  }, [data]);
+
+  const fuse = useMemo(() => new Fuse(vulns, { keys: ['cve.id', 'cve.descriptions.0.value'], threshold: 0.3 }), [vulns]);
+  const filtered = useMemo(() => (search ? fuse.search(search).map((r) => r.item) : vulns), [fuse, search, vulns]);
 
   const exportCsv = () => {
-    const rows = vulns.map((v) => ({
+    const rows = filtered.map((v) => ({
       id: v.cve.id,
       description: v.cve.descriptions?.[0]?.value || '',
       severity: v.severity || '',
@@ -101,7 +185,7 @@ const CveDashboard: React.FC = () => {
   };
 
   const exportJson = () => {
-    const blob = new Blob([JSON.stringify(vulns, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(filtered, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -128,7 +212,7 @@ const CveDashboard: React.FC = () => {
   };
 
   const Row = ({ index, style }: ListChildComponentProps) => {
-    const v = vulns[index];
+    const v = filtered[index];
     return (
       <div
         style={style}
@@ -150,6 +234,7 @@ const CveDashboard: React.FC = () => {
         <input value={cpe} onChange={(e) => setCpe(e.target.value)} placeholder="CPE" className="px-2 py-1 bg-gray-800 rounded" />
         <input value={cwe} onChange={(e) => setCwe(e.target.value)} placeholder="CWE" className="px-2 py-1 bg-gray-800 rounded" />
         <input type="number" value={recent} onChange={(e) => setRecent(parseInt(e.target.value, 10))} className="px-2 py-1 bg-gray-800 rounded w-24" />
+        <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Fuzzy search" className="px-2 py-1 bg-gray-800 rounded" />
         <button onClick={exportCsv} className="px-3 py-1 bg-blue-600 rounded">CSV</button>
         <button onClick={exportJson} className="px-3 py-1 bg-blue-600 rounded">JSON</button>
         <button onClick={saveView} className="px-3 py-1 bg-gray-700 rounded">Save View</button>
@@ -160,6 +245,12 @@ const CveDashboard: React.FC = () => {
           ))}
         </select>
       </div>
+      {rateInfo.limit !== undefined && (
+        <div className="text-sm">Rate limit: {rateInfo.remaining}/{rateInfo.limit}</div>
+      )}
+      {rateInfo.retryAfter && (
+        <div className="text-sm text-red-400">Rate limited. Retry after {rateInfo.retryAfter}s</div>
+      )}
       <div className="grid grid-cols-4 gap-2 font-bold bg-gray-800 px-2 py-1 text-sm">
         <div>CVE</div>
         <div>Description</div>
@@ -167,7 +258,7 @@ const CveDashboard: React.FC = () => {
         <div>KEV</div>
       </div>
       <div style={{ height: '60vh' }} className="bg-gray-900 overflow-hidden">
-        <List height={350} itemCount={vulns.length} itemSize={40} width={'100%'}>
+        <List height={350} itemCount={filtered.length} itemSize={40} width={'100%'}>
           {Row}
         </List>
       </div>
@@ -177,10 +268,38 @@ const CveDashboard: React.FC = () => {
             <h2 className="text-xl font-bold">{selected.cve.id}</h2>
             <p>{selected.cve.descriptions?.[0]?.value}</p>
             <p>Published: {selected.cve.published}</p>
-            <p>CVSS v3.1: {selected.cve.metrics?.cvssMetricV31?.[0]?.cvssData?.baseScore ?? 'N/A'}</p>
-            <p>CVSS v4: {selected.cve.metrics?.cvssMetricV40?.[0]?.cvssData?.baseScore ?? 'N/A'}</p>
+            <p>
+              CVSS v3.1: {computeCvss31(selected.cve.metrics?.cvssMetricV31?.[0]?.cvssData?.vectorString || '') ?? 'N/A'}
+            </p>
+            {selected.cve.metrics?.cvssMetricV31?.[0]?.cvssData?.vectorString && (
+              <div>
+                <p className="font-semibold">Vector Breakdown</p>
+                <ul className="list-disc list-inside">
+                  {Object.entries(
+                    parseVector(selected.cve.metrics!.cvssMetricV31[0].cvssData.vectorString),
+                  ).map(([k, v]) => (
+                    <li key={k}>
+                      {k}:{v} - {metricExamplesV3[k]?.[v]}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <p>
+              CVSS v4: {selected.cve.metrics?.cvssMetricV40?.[0]?.cvssData?.baseScore ?? 'N/A'}
+            </p>
             <p>EPSS: {selected.epss ?? 'N/A'}</p>
             <p>KEV: {selected.kev ? 'Yes' : 'No'}</p>
+            <p>
+              <a
+                href={`https://osv.dev/vulnerability/${selected.cve.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline"
+              >
+                OSV Entry
+              </a>
+            </p>
             {selected.exploits.length > 0 ? (
               <div>
                 <h3 className="font-semibold">Exploits</h3>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "es-module-lexer": "^1.5.4",
     "expr-eval": "^2.0.2",
     "fast-xml-parser": "^5.2.5",
+    "fuse.js": "^6.6.2",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
     "jose": "^6.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,6 +1555,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@leichtgewicht/ip-codec@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
+  checksum: 10c0/14a0112bd59615eef9e3446fea018045720cd3da85a98f801a685a818b0d96ef2a1f7227e8d271def546b2e2a0fe91ef915ba9dc912ab7967d2317b1a051d66b
+  languageName: node
+  linkType: hard
+
 "@lhci/cli@npm:^0.13.0":
   version: 0.13.0
   resolution: "@lhci/cli@npm:0.13.0"
@@ -1591,7 +1598,50 @@ __metadata:
     tree-kill: "npm:^1.2.1"
   checksum: 10c0/661c61895188a4e7a9af069c50731df89ed13e84c106ed3e3ab6328f55a9bcd43abbe4030d7a64796deb6b144f3fae37b70dd9b85c582fe23c33746eb429490d
   languageName: node
+  linkType: hard
 
+"@mdx-js/mdx@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@mdx-js/mdx@npm:3.1.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdx": "npm:^2.0.0"
+    collapse-white-space: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    estree-util-scope: "npm:^1.0.0"
+    estree-walker: "npm:^3.0.0"
+    hast-util-to-jsx-runtime: "npm:^2.0.0"
+    markdown-extensions: "npm:^2.0.0"
+    recma-build-jsx: "npm:^1.0.0"
+    recma-jsx: "npm:^1.0.0"
+    recma-stringify: "npm:^1.0.0"
+    rehype-recma: "npm:^1.0.0"
+    remark-mdx: "npm:^3.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.0.0"
+    source-map: "npm:^0.7.0"
+    unified: "npm:^11.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/e586ab772dcfee2bab334d5aac54c711e6d6d550085271c38a49c629b3e3954b5f41f488060761284a5e00649d0638d6aba6c0a7c66f91db80dee0ccc304ab32
+  languageName: node
+  linkType: hard
+
+"@mdx-js/react@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@mdx-js/react@npm:3.1.0"
+  dependencies:
+    "@types/mdx": "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 10c0/381ed1211ba2b8491bf0ad9ef0d8d1badcdd114e1931d55d44019d4b827cc2752586708f9c7d2f9c3244150ed81f1f671a6ca95fae0edd5797fb47a22e06ceca
+  languageName: node
   linkType: hard
 
 "@mermaid-js/parser@npm:^0.6.2":
@@ -3292,8 +3342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.15.0":
-
+"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -3651,7 +3700,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.1"
   checksum: 10c0/3a1a409764faa1471601a0ad01b3aa699292991aa9c8a30c7717002cabdf5d98008e7b53ae61f6e058f757fc6ba965e147967a93c13e62692c907d79cfb245f8
+  languageName: node
+  linkType: hard
 
+"astring@npm:^1.8.0":
+  version: 1.9.0
+  resolution: "astring@npm:1.9.0"
+  bin:
+    astring: bin/astring
+  checksum: 10c0/e7519544d9824494e80ef0e722bb3a0c543a31440d59691c13aeaceb75b14502af536b23f08db50aa6c632dafaade54caa25f0788aa7550b6b2d6e2df89e0830
   languageName: node
   linkType: hard
 
@@ -6063,6 +6120,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esast-util-from-estree@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "esast-util-from-estree@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-visit: "npm:^2.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+  checksum: 10c0/6c619bc6963314f8f64b32e3b101b321bf121f659e62b11e70f425619c2db6f1d25f4c594a57fd00908da96c67d9bfbf876eb5172abf9e13f47a71796f6630ff
+  languageName: node
+  linkType: hard
+
+"esast-util-from-js@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "esast-util-from-js@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    acorn: "npm:^8.0.0"
+    esast-util-from-estree: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/3a446fb0b0d7bcd7e0157aa44b3b692802a08c93edbea81cc0f7fe4437bfdfb4b72e4563fe63b4e36d390086b71185dba4ac921f4180cc6349985c263cc74421
+  languageName: node
+  linkType: hard
+
 "esbuild@npm:^0.21.3":
   version: 0.21.5
   resolution: "esbuild@npm:0.21.5"
@@ -6140,7 +6221,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
-
   languageName: node
   linkType: hard
 
@@ -6538,8 +6618,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^3.0.3":
+"estree-util-scope@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "estree-util-scope@npm:1.0.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+  checksum: 10c0/ef8a573cc899277c613623a1722f630e2163abbc6e9e2f49e758c59b81b484e248b585df6df09a38c00fbfb6390117997cc80c1347b7a86bc1525d9e462b60d5
+  languageName: node
+  linkType: hard
 
+"estree-util-to-js@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "estree-util-to-js@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    astring: "npm:^1.8.0"
+    source-map: "npm:^0.7.0"
+  checksum: 10c0/ac88cb831401ef99e365f92f4af903755d56ae1ce0e0f0fb8ff66e678141f3d529194f0fb15f6c78cd7554c16fda36854df851d58f9e05cfab15bddf7a97cea0
+  languageName: node
+  linkType: hard
+
+"estree-util-visit@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "estree-util-visit@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/acda8b03cc8f890d79c7c7361f6c95331ba84b7ccc0c32b49f447fc30206b20002b37ffdfc97b6ad16e6fe065c63ecbae1622492e2b6b4775c15966606217f39
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3":
   version: 3.0.3
   resolution: "estree-walker@npm:3.0.3"
   dependencies:
@@ -7028,6 +7138,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 10c0/33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 10c0/c2fe4f234f516e9ea83b06f06f8f3c8b7117f51aa75bbccd052eed0c0423364bf1e360ffbf29cadae8ef6aa39476b7961eaf9d07bed779cea5c83d62b34e2df9
   languageName: node
   linkType: hard
 
@@ -12601,8 +12718,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.0, source-map@npm:~0.6.1":
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: 10c0/beb2c5974bb58954d75e86249953d47ae16f7df1a8531abb9fcae0cd262d9fa09c2db3a134e20e99358b1adba42b6b054a32c8e16b571b3efcf6af644c329f0d
+  languageName: node
+  linkType: hard
 
+"source-map@npm:^0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
@@ -12731,6 +12854,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: 10c0/18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "stacktrace-gps@npm:3.1.2"
+  dependencies:
+    source-map: "npm:0.5.6"
+    stackframe: "npm:^1.3.4"
+  checksum: 10c0/0dcc1aa46e364a2b4d1eabce4777fecf337576a11ee3cfc92f07b9ec79ccb76810752431eeb9771289d250d0bb58dbe19a178b96bf7b2e9f773334d03aa96bb9
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: "npm:^2.0.6"
+    stack-generator: "npm:^2.0.5"
+    stacktrace-gps: "npm:^3.0.4"
+  checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
@@ -12742,7 +12893,6 @@ __metadata:
   version: 3.9.0
   resolution: "std-env@npm:3.9.0"
   checksum: 10c0/4a6f9218aef3f41046c3c7ecf1f98df00b30a07f4f35c6d47b28329bc2531eef820828951c7d7b39a1c5eb19ad8a46e3ddfc7deb28f0a2f3ceebee11bab7ba50
-
   languageName: node
   linkType: hard
 
@@ -13784,7 +13934,8 @@ __metadata:
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@emailjs/browser": "npm:^3.10.0"
     "@lhci/cli": "npm:^0.13.0"
-
+    "@mdx-js/mdx": "npm:^3.1.0"
+    "@mdx-js/react": "npm:^3.1.0"
     "@playwright/test": "npm:^1.51.1"
     "@stephen-riley/pcre2-wasm": "npm:^1.2.4"
     "@testing-library/dom": "npm:^10.4.1"
@@ -13837,6 +13988,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.1.3"
     expr-eval: "npm:^2.0.2"
     fast-xml-parser: "npm:^5.2.5"
+    fuse.js: "npm:^6.6.2"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
     jest: "npm:^30.0.5"


### PR DESCRIPTION
## Summary
- cache CVE data with headers and expose rate-limit indicators
- add CVSS v3.1 vector parsing, scoring, and OSV links in details panel
- integrate Fuse.js fuzzy search with CSV/JSON export updates

## Testing
- `yarn test`
- `yarn lint apps/cve-dashboard/index.tsx` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18c5b4588328a0a6596d4a0677ea