### PR TITLE
feat: improve plist inspector

### DIFF
--- a/components/apps/plist-inspector.worker.ts
+++ b/components/apps/plist-inspector.worker.ts
@@ -1,5 +1,5 @@
 import plist from 'plist';
-import bplist from 'bplist-parser';
+import { UID } from 'bplist-parser';
 import { Buffer } from 'buffer';
 
 const detectFormat = (bytes: Uint8Array): string => {
@@ -25,9 +25,11 @@ self.onmessage = (e: MessageEvent) => {
   const format = detectFormat(bytes);
   try {
     let obj: any;
+    let offsets: Record<string, number> = {};
     if (format === 'binary') {
-      const parsed = bplist.parseBuffer(Buffer.from(bytes));
-      obj = parsed.length === 1 ? parsed[0] : parsed;
+      const parsed = parseBinaryWithOffsets(Buffer.from(bytes));
+      obj = parsed.root;
+      offsets = parsed.offsets;
     } else if (format === 'xml') {
       const text = new TextDecoder().decode(bytes);
       obj = plist.parse(text);
@@ -37,7 +39,12 @@ self.onmessage = (e: MessageEvent) => {
     } else {
       throw new Error('Unknown plist format');
     }
-    (self as any).postMessage({ type: 'result', root: obj, format });
+    (self as any).postMessage({
+      type: 'result',
+      root: obj,
+      format,
+      offsets,
+    });
   } catch (err: any) {
     const corruption =
       format === 'binary'
@@ -50,4 +57,210 @@ self.onmessage = (e: MessageEvent) => {
       format,
     });
   }
+};
+
+const EPOCH = 978307200000;
+
+const parseBinaryWithOffsets = (buffer: Buffer) => {
+  const header = buffer.slice(0, 6).toString('utf8');
+  if (header !== 'bplist') {
+    throw new Error("Invalid binary plist. Expected 'bplist' at offset 0.");
+  }
+  const trailer = buffer.slice(buffer.length - 32);
+  const offsetSize = trailer.readUInt8(6);
+  const objectRefSize = trailer.readUInt8(7);
+  const numObjects = readUInt64BE(trailer, 8);
+  const topObject = readUInt64BE(trailer, 16);
+  const offsetTableOffset = readUInt64BE(trailer, 24);
+
+  const offsetTable: number[] = [];
+  for (let i = 0; i < numObjects; i++) {
+    const offsetBytes = buffer.slice(
+      offsetTableOffset + i * offsetSize,
+      offsetTableOffset + (i + 1) * offsetSize,
+    );
+    offsetTable[i] = readUInt(offsetBytes, 0);
+  }
+
+  const offsets: Record<string, number> = {};
+
+  const parseObject = (objRef: number, path: string, record = true): any => {
+    const offset = offsetTable[objRef];
+    if (record) offsets[path] = offset;
+    const type = buffer[offset];
+    const objType = (type & 0xf0) >> 4;
+    const objInfo = type & 0x0f;
+    switch (objType) {
+      case 0x0:
+        return parseSimple(objInfo);
+      case 0x1:
+        return parseInteger(objInfo, offset);
+      case 0x8:
+        return parseUID(objInfo, offset);
+      case 0x2:
+        return parseReal(objInfo, offset);
+      case 0x3:
+        return parseDate(objInfo, offset);
+      case 0x4:
+        return parseData(objInfo, offset);
+      case 0x5:
+        return parseAscii(objInfo, offset);
+      case 0x6:
+        return parseUtf16(objInfo, offset);
+      case 0xa:
+        return parseArray(objInfo, offset, path);
+      case 0xd:
+        return parseDict(objInfo, offset, path);
+      default:
+        throw new Error('Unhandled type 0x' + objType.toString(16));
+    }
+  };
+
+  const parseLength = (offset: number, objInfo: number) => {
+    let length = objInfo;
+    let newOffset = offset + 1;
+    if (objInfo === 0xf) {
+      const intType = buffer[newOffset];
+      const intInfo = intType & 0x0f;
+      const intLength = Math.pow(2, intInfo);
+      newOffset += 1;
+      length = readUInt(buffer.slice(newOffset, newOffset + intLength));
+      newOffset += intLength;
+    }
+    return { length, offset: newOffset };
+  };
+
+  const parseSimple = (objInfo: number) => {
+    switch (objInfo) {
+      case 0x0:
+        return null;
+      case 0x8:
+        return false;
+      case 0x9:
+        return true;
+      case 0xf:
+        return null;
+      default:
+        throw new Error('Unhandled simple type 0x' + objInfo.toString(16));
+    }
+  };
+
+  const parseInteger = (objInfo: number, offset: number) => {
+    const length = Math.pow(2, objInfo);
+    const data = buffer.slice(offset + 1, offset + 1 + length);
+    let value = 0n;
+    for (const byte of data) {
+      value = (value << 8n) | BigInt(byte);
+    }
+    return length <= 6 ? Number(value) : value;
+  };
+
+  const parseUID = (objInfo: number, offset: number) => {
+    const length = objInfo + 1;
+    const data = buffer.slice(offset + 1, offset + 1 + length);
+    const value = readUInt(data, 0);
+    return new UID(value);
+  };
+
+  const parseReal = (objInfo: number, offset: number) => {
+    const length = Math.pow(2, objInfo);
+    const realBuffer = buffer.slice(offset + 1, offset + 1 + length);
+    if (length === 4) return realBuffer.readFloatBE(0);
+    if (length === 8) return realBuffer.readDoubleBE(0);
+    throw new Error('Unhandled float size ' + length);
+  };
+
+  const parseDate = (objInfo: number, offset: number) => {
+    if (objInfo !== 0x3) {
+      // fallthrough
+    }
+    const dateBuffer = buffer.slice(offset + 1, offset + 9);
+    const seconds = dateBuffer.readDoubleBE(0);
+    return new Date(EPOCH + seconds * 1000);
+  };
+
+  const parseData = (objInfo: number, offset: number) => {
+    const { length, offset: dataOffset } = parseLength(offset, objInfo);
+    return buffer.slice(dataOffset, dataOffset + length);
+  };
+
+  const parseAscii = (objInfo: number, offset: number) => {
+    const { length, offset: strOffset } = parseLength(offset, objInfo);
+    return buffer.slice(strOffset, strOffset + length).toString('utf8');
+  };
+
+  const parseUtf16 = (objInfo: number, offset: number) => {
+    const { length, offset: strOffset } = parseLength(offset, objInfo);
+    const byteLength = length * 2;
+    let plistString = Buffer.from(
+      buffer.slice(strOffset, strOffset + byteLength),
+    );
+    plistString = swapBytes(plistString);
+    return plistString.toString('ucs2');
+  };
+
+  const parseArray = (objInfo: number, offset: number, path: string) => {
+    const { length, offset: arrayOffset } = parseLength(offset, objInfo);
+    const arr: any[] = [];
+    for (let i = 0; i < length; i++) {
+      const objRef = readUInt(
+        buffer.slice(
+          arrayOffset + i * objectRefSize,
+          arrayOffset + (i + 1) * objectRefSize,
+        ),
+      );
+      arr[i] = parseObject(objRef, `${path}[${i}]`);
+    }
+    return arr;
+  };
+
+  const parseDict = (objInfo: number, offset: number, path: string) => {
+    const { length, offset: dictOffset } = parseLength(offset, objInfo);
+    const dict: Record<string, any> = {};
+    for (let i = 0; i < length; i++) {
+      const keyRef = readUInt(
+        buffer.slice(
+          dictOffset + i * objectRefSize,
+          dictOffset + (i + 1) * objectRefSize,
+        ),
+      );
+      const valRef = readUInt(
+        buffer.slice(
+          dictOffset + length * objectRefSize + i * objectRefSize,
+          dictOffset + length * objectRefSize + (i + 1) * objectRefSize,
+        ),
+      );
+      const key = parseObject(keyRef, '', false);
+      const childPath = path === '$' ? `$.${key}` : `${path}.${key}`;
+      dict[key] = parseObject(valRef, childPath);
+    }
+    return dict;
+  };
+
+  const root = parseObject(topObject, '$');
+  return { root, offsets };
+};
+
+const readUInt = (buffer: Buffer, start: number) => {
+  let l = 0;
+  for (let i = start; i < buffer.length; i++) {
+    l <<= 8;
+    l |= buffer[i] & 0xff;
+  }
+  return l;
+};
+
+const readUInt64BE = (buffer: Buffer, start: number) => {
+  const data = buffer.slice(start, start + 8);
+  return data.readUInt32BE(4);
+};
+
+const swapBytes = (buffer: Buffer) => {
+  const len = buffer.length;
+  for (let i = 0; i < len; i += 2) {
+    const a = buffer[i];
+    buffer[i] = buffer[i + 1];
+    buffer[i + 1] = a;
+  }
+  return buffer;
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
     "@emailjs/browser": "^3.10.0",
+    "@iarna/toml": "^3.0.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@stephen-riley/pcre2-wasm": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@iarna/toml@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@iarna/toml@npm:3.0.0"
+  checksum: 10c0/419506f8d8183eb34e3d8d632dacbaf40790d20d56290acf3ad90765e20111140335e682b02e9fe76713fbf35dc652b2b482dbfd752c0aa890e6ef39b8f1c421
+  languageName: node
+  linkType: hard
+
 "@iconify/types@npm:^2.0.0":
   version: 2.0.0
   resolution: "@iconify/types@npm:2.0.0"
@@ -1555,6 +1562,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@leichtgewicht/ip-codec@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
+  checksum: 10c0/14a0112bd59615eef9e3446fea018045720cd3da85a98f801a685a818b0d96ef2a1f7227e8d271def546b2e2a0fe91ef915ba9dc912ab7967d2317b1a051d66b
+  languageName: node
+  linkType: hard
+
 "@lhci/cli@npm:^0.13.0":
   version: 0.13.0
   resolution: "@lhci/cli@npm:0.13.0"
@@ -1591,7 +1605,50 @@ __metadata:
     tree-kill: "npm:^1.2.1"
   checksum: 10c0/661c61895188a4e7a9af069c50731df89ed13e84c106ed3e3ab6328f55a9bcd43abbe4030d7a64796deb6b144f3fae37b70dd9b85c582fe23c33746eb429490d
   languageName: node
+  linkType: hard
 
+"@mdx-js/mdx@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@mdx-js/mdx@npm:3.1.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdx": "npm:^2.0.0"
+    collapse-white-space: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    estree-util-scope: "npm:^1.0.0"
+    estree-walker: "npm:^3.0.0"
+    hast-util-to-jsx-runtime: "npm:^2.0.0"
+    markdown-extensions: "npm:^2.0.0"
+    recma-build-jsx: "npm:^1.0.0"
+    recma-jsx: "npm:^1.0.0"
+    recma-stringify: "npm:^1.0.0"
+    rehype-recma: "npm:^1.0.0"
+    remark-mdx: "npm:^3.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.0.0"
+    source-map: "npm:^0.7.0"
+    unified: "npm:^11.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/e586ab772dcfee2bab334d5aac54c711e6d6d550085271c38a49c629b3e3954b5f41f488060761284a5e00649d0638d6aba6c0a7c66f91db80dee0ccc304ab32
+  languageName: node
+  linkType: hard
+
+"@mdx-js/react@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@mdx-js/react@npm:3.1.0"
+  dependencies:
+    "@types/mdx": "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 10c0/381ed1211ba2b8491bf0ad9ef0d8d1badcdd114e1931d55d44019d4b827cc2752586708f9c7d2f9c3244150ed81f1f671a6ca95fae0edd5797fb47a22e06ceca
+  languageName: node
   linkType: hard
 
 "@mermaid-js/parser@npm:^0.6.2":
@@ -3292,8 +3349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.15.0":
-
+"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -3651,7 +3707,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.1"
   checksum: 10c0/3a1a409764faa1471601a0ad01b3aa699292991aa9c8a30c7717002cabdf5d98008e7b53ae61f6e058f757fc6ba965e147967a93c13e62692c907d79cfb245f8
+  languageName: node
+  linkType: hard
 
+"astring@npm:^1.8.0":
+  version: 1.9.0
+  resolution: "astring@npm:1.9.0"
+  bin:
+    astring: bin/astring
+  checksum: 10c0/e7519544d9824494e80ef0e722bb3a0c543a31440d59691c13aeaceb75b14502af536b23f08db50aa6c632dafaade54caa25f0788aa7550b6b2d6e2df89e0830
   languageName: node
   linkType: hard
 
@@ -6063,6 +6127,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esast-util-from-estree@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "esast-util-from-estree@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-visit: "npm:^2.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+  checksum: 10c0/6c619bc6963314f8f64b32e3b101b321bf121f659e62b11e70f425619c2db6f1d25f4c594a57fd00908da96c67d9bfbf876eb5172abf9e13f47a71796f6630ff
+  languageName: node
+  linkType: hard
+
+"esast-util-from-js@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "esast-util-from-js@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    acorn: "npm:^8.0.0"
+    esast-util-from-estree: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/3a446fb0b0d7bcd7e0157aa44b3b692802a08c93edbea81cc0f7fe4437bfdfb4b72e4563fe63b4e36d390086b71185dba4ac921f4180cc6349985c263cc74421
+  languageName: node
+  linkType: hard
+
 "esbuild@npm:^0.21.3":
   version: 0.21.5
   resolution: "esbuild@npm:0.21.5"
@@ -6140,7 +6228,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
-
   languageName: node
   linkType: hard
 
@@ -6538,8 +6625,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^3.0.3":
+"estree-util-scope@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "estree-util-scope@npm:1.0.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+  checksum: 10c0/ef8a573cc899277c613623a1722f630e2163abbc6e9e2f49e758c59b81b484e248b585df6df09a38c00fbfb6390117997cc80c1347b7a86bc1525d9e462b60d5
+  languageName: node
+  linkType: hard
 
+"estree-util-to-js@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "estree-util-to-js@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    astring: "npm:^1.8.0"
+    source-map: "npm:^0.7.0"
+  checksum: 10c0/ac88cb831401ef99e365f92f4af903755d56ae1ce0e0f0fb8ff66e678141f3d529194f0fb15f6c78cd7554c16fda36854df851d58f9e05cfab15bddf7a97cea0
+  languageName: node
+  linkType: hard
+
+"estree-util-visit@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "estree-util-visit@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/acda8b03cc8f890d79c7c7361f6c95331ba84b7ccc0c32b49f447fc30206b20002b37ffdfc97b6ad16e6fe065c63ecbae1622492e2b6b4775c15966606217f39
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3":
   version: 3.0.3
   resolution: "estree-walker@npm:3.0.3"
   dependencies:
@@ -12601,8 +12718,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.0, source-map@npm:~0.6.1":
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: 10c0/beb2c5974bb58954d75e86249953d47ae16f7df1a8531abb9fcae0cd262d9fa09c2db3a134e20e99358b1adba42b6b054a32c8e16b571b3efcf6af644c329f0d
+  languageName: node
+  linkType: hard
 
+"source-map@npm:^0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
@@ -12731,6 +12854,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: 10c0/18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "stacktrace-gps@npm:3.1.2"
+  dependencies:
+    source-map: "npm:0.5.6"
+    stackframe: "npm:^1.3.4"
+  checksum: 10c0/0dcc1aa46e364a2b4d1eabce4777fecf337576a11ee3cfc92f07b9ec79ccb76810752431eeb9771289d250d0bb58dbe19a178b96bf7b2e9f773334d03aa96bb9
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: "npm:^2.0.6"
+    stack-generator: "npm:^2.0.5"
+    stacktrace-gps: "npm:^3.0.4"
+  checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
@@ -12742,7 +12893,6 @@ __metadata:
   version: 3.9.0
   resolution: "std-env@npm:3.9.0"
   checksum: 10c0/4a6f9218aef3f41046c3c7ecf1f98df00b30a07f4f35c6d47b28329bc2531eef820828951c7d7b39a1c5eb19ad8a46e3ddfc7deb28f0a2f3ceebee11bab7ba50
-
   languageName: node
   linkType: hard
 
@@ -13783,8 +13933,10 @@ __metadata:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@emailjs/browser": "npm:^3.10.0"
+    "@iarna/toml": "npm:^3.0.0"
     "@lhci/cli": "npm:^0.13.0"
-
+    "@mdx-js/mdx": "npm:^3.1.0"
+    "@mdx-js/react": "npm:^3.1.0"
     "@playwright/test": "npm:^1.51.1"
     "@stephen-riley/pcre2-wasm": "npm:^1.2.4"
     "@testing-library/dom": "npm:^10.4.1"


### PR DESCRIPTION
## Summary
- detect plist format and parse binary plists with offset tracking
- support UID/data export and add TOML output option
- surface offsets in inspector UI for binary nodes

## Testing
- `yarn test` *(fails: frogger.test.ts, tictactoe.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18cad3e083288f0366b0cafc68a9