### PR TITLE
feat: add perceptual hash visualizations

### DIFF
--- a/apps/content-fingerprint/hashWorker.ts
+++ b/apps/content-fingerprint/hashWorker.ts
@@ -83,6 +83,15 @@ function hamming(a: string, b: string): number {
   return dist;
 }
 
+function diffBits(a: string, b: string): number[] {
+  const x = BigInt('0x' + a) ^ BigInt('0x' + b);
+  const bits: number[] = [];
+  for (let i = 63; i >= 0; i -= 1) {
+    bits.push(Number((x >> BigInt(i)) & 1n));
+  }
+  return bits;
+}
+
 async function diffOverlay(fileA: File, fileB: File) {
   const size = 256;
   const a = await getImageData(fileA, size, size);
@@ -126,8 +135,14 @@ self.onmessage = async (e: MessageEvent<{ fileA: File; fileB: File }>) => {
       pHash: hamming(hashesA.pHash, hashesB.pHash),
       simHash: hamming(hashesA.simHash, hashesB.simHash),
     };
+    const heatmaps = {
+      aHash: diffBits(hashesA.aHash, hashesB.aHash),
+      dHash: diffBits(hashesA.dHash, hashesB.dHash),
+      pHash: diffBits(hashesA.pHash, hashesB.pHash),
+      simHash: diffBits(hashesA.simHash, hashesB.simHash),
+    };
     // @ts-ignore
-    self.postMessage({ hashesA, hashesB, distances, diff }, [diff.data]);
+    self.postMessage({ hashesA, hashesB, distances, diff, heatmaps }, [diff.data]);
   } catch (err) {
     // @ts-ignore
     self.postMessage({ error: (err as Error).message });

--- a/apps/content-fingerprint/index.tsx
+++ b/apps/content-fingerprint/index.tsx
@@ -12,12 +12,14 @@ interface WorkerResult {
   hashesB: HashResult;
   distances: Record<string, number>;
   diff: { width: number; height: number; data: ArrayBuffer };
+  heatmaps: Record<string, number[]>;
   error?: string;
 }
 
 const guidance = (d: number) => {
+  if (d === 0) return 'identical';
   if (d <= 5) return 'almost identical';
-  if (d <= 10) return 'similar';
+  if (d <= 10) return 'similar – review for false positives';
   return 'different';
 };
 
@@ -31,6 +33,27 @@ const ContentFingerprint: React.FC = () => {
   const [result, setResult] = useState<WorkerResult | null>(null);
   const diffCanvas = useRef<HTMLCanvasElement>(null);
   const [error, setError] = useState('');
+
+  const downloadCSV = () => {
+    if (!result) return;
+    const rows = [
+      ['algorithm', 'hashA', 'hashB', 'hamming'],
+      ...Object.keys(result.hashesA).map((key) => [
+        key,
+        (result.hashesA as any)[key],
+        (result.hashesB as any)[key],
+        result.distances[key].toString(),
+      ]),
+    ];
+    const csv = rows.map((r) => r.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'hashes.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
   useEffect(() => {
     if (typeof Worker !== 'undefined') {
@@ -120,6 +143,17 @@ const ContentFingerprint: React.FC = () => {
     </div>
   );
 
+  const renderHeatmap = (bits: number[]) => (
+    <div className="grid grid-cols-8 gap-0.5">
+      {bits.map((b, i) => (
+        <div
+          key={i}
+          className={`w-4 h-4 ${b ? 'bg-red-500' : 'bg-green-600'}`}
+        />
+      ))}
+    </div>
+  );
+
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
       <div className="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
@@ -128,33 +162,52 @@ const ContentFingerprint: React.FC = () => {
       </div>
       {error && <div className="text-red-400 text-sm">{error}</div>}
       {result && (
-        <div className="overflow-auto">
-          <table className="w-full text-sm text-left">
-            <thead>
-              <tr>
-                <th className="p-2">Algorithm</th>
-                <th className="p-2">Image A</th>
-                <th className="p-2">Image B</th>
-                <th className="p-2">Hamming</th>
-                <th className="p-2">Guidance</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Object.keys(result.hashesA).map((key) => (
-                <tr key={key} className="border-t border-gray-700">
-                  <td className="p-2">{key}</td>
-                  <td className="p-2 break-all">{(result.hashesA as any)[key]}</td>
-                  <td className="p-2 break-all">{(result.hashesB as any)[key]}</td>
-                  <td className="p-2">{result.distances[key]}</td>
-                  <td className="p-2">{guidance(result.distances[key])}</td>
+        <>
+          <div className="overflow-auto">
+            <table className="w-full text-sm text-left">
+              <thead>
+                <tr>
+                  <th className="p-2">Algorithm</th>
+                  <th className="p-2">Image A</th>
+                  <th className="p-2">Image B</th>
+                  <th className="p-2">Hamming</th>
+                  <th className="p-2">Guidance</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {Object.keys(result.hashesA).map((key) => (
+                  <tr key={key} className="border-t border-gray-700">
+                    <td className="p-2">{key}</td>
+                    <td className="p-2 break-all">{(result.hashesA as any)[key]}</td>
+                    <td className="p-2 break-all">{(result.hashesB as any)[key]}</td>
+                    <td className="p-2">{result.distances[key]}</td>
+                    <td className="p-2">{guidance(result.distances[key])}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex justify-end mt-2">
+            <button
+              onClick={downloadCSV}
+              className="px-2 py-1 bg-blue-600 rounded text-xs"
+            >
+              Download CSV
+            </button>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+            {Object.keys(result.heatmaps).map((key) => (
+              <div key={key} className="flex flex-col items-center">
+                <div className="mb-1 text-xs">{key}</div>
+                {renderHeatmap(result.heatmaps[key])}
+              </div>
+            ))}
+          </div>
+        </>
       )}
       <div className="text-xs text-gray-400">
         Hash differences &lt;=5 are typically nearly identical, 6-10 similar, &gt;10 different.
+        Low distances may still collide, so inspect the heatmap and diff overlay to avoid false positives.
         WebAssembly-optimized pHash runs in a worker to keep the UI responsive.
       </div>
     </div>


### PR DESCRIPTION
## Summary
- compute per-bit diff heatmaps in hashing worker
- visualize hash differences and export digest CSV in content fingerprint UI
- add guidance on interpreting low Hamming distances to avoid false positives

## Testing
- `yarn test apps/content-fingerprint --passWithNoTests`
- `yarn lint --file apps/content-fingerprint/index.tsx --file apps/content-fingerprint/hashWorker.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab18ccb7b8832890d6a1d8f5f1e405