### PR TITLE
feat: add Prefetch and LNK parsing

### DIFF
--- a/__tests__/prefetchJumplist.test.tsx
+++ b/__tests__/prefetchJumplist.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import PrefetchJumpList from '@apps/prefetch-jumplist';
 
 describe('PrefetchJumpList', () => {
-  beforeEach(() => {
+  it('shows error for unsupported format', async () => {
     class MockWorker {
       onmessage: any;
       postMessage() {
@@ -13,14 +13,39 @@ describe('PrefetchJumpList', () => {
     }
     // @ts-ignore
     global.Worker = MockWorker;
-  });
 
-  it('shows error for unsupported format', async () => {
     const { getByTestId, findByTestId } = render(<PrefetchJumpList />);
     const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
     const input = getByTestId('file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
     const error = await findByTestId('error');
     expect(error.textContent).toMatch(/Unsupported/);
+  });
+
+  it('highlights anomalies', async () => {
+    const anomalyEvent = {
+      time: Date.now() + 1000,
+      source: 'Prefetch',
+      file: 'test',
+      runCount: 0,
+      anomaly: true,
+    };
+    class MockWorker {
+      onmessage: any;
+      postMessage() {
+        if (this.onmessage) this.onmessage({ data: { events: [anomalyEvent] } });
+      }
+      terminate() {}
+    }
+    // @ts-ignore
+    global.Worker = MockWorker;
+
+    const { getByTestId, findByTestId } = render(<PrefetchJumpList />);
+    const file = new File([''], 'a.pf');
+    const input = getByTestId('file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    const table = await findByTestId('timeline');
+    const row = table.querySelector('tbody tr');
+    expect(row).toHaveClass('bg-red-900');
   });
 });

--- a/apps/prefetch-jumplist/index.tsx
+++ b/apps/prefetch-jumplist/index.tsx
@@ -11,6 +11,7 @@ interface TimelineEvent {
     target?: string;
     created?: number;
   };
+  anomaly?: boolean;
   selected?: boolean;
 }
 
@@ -25,7 +26,10 @@ const PrefetchJumpList: React.FC = () => {
     const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' });
     workerRef.current = worker;
     worker.onmessage = (e) => {
-      const { events: evts, error: err } = e.data as { events?: Omit<TimelineEvent, 'id' | 'selected'>[]; error?: string };
+      const { events: evts, error: err } = e.data as {
+        events?: Omit<TimelineEvent, 'id' | 'selected'>[];
+        error?: string;
+      };
       if (err) {
         setError(`${err}. See docs/forensics-samples.md for sample files.`);
       } else if (evts) {
@@ -63,6 +67,7 @@ const PrefetchJumpList: React.FC = () => {
         runCount: ev.runCount ?? '',
         lnkTarget: ev.lnk?.target ?? '',
         lnkCreated: ev.lnk?.created ? new Date(ev.lnk.created).toISOString() : '',
+        anomaly: ev.anomaly ? 'yes' : '',
       }));
     const csv = Papa.unparse(rows);
     const blob = new Blob([csv], { type: 'text/csv' });
@@ -100,7 +105,10 @@ const PrefetchJumpList: React.FC = () => {
             </thead>
             <tbody>
               {sorted.map((ev) => (
-                <tr key={ev.id} className="border-b border-gray-700">
+                <tr
+                  key={ev.id}
+                  className={`border-b border-gray-700 ${ev.anomaly ? 'bg-red-900 bg-opacity-40' : ''}`}
+                >
                   <td>
                     <input
                       type="checkbox"


### PR DESCRIPTION
## Summary
- parse Prefetch, JumpList, and standalone LNK files
- surface run counts, carve timestamps, and flag anomalies
- support CSV export of selected timeline entries

## Testing
- `yarn test __tests__/prefetchJumplist.test.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab18cf1d9483288e6ceb0a39d4a020