### PR TITLE
Add CAA checker app

### DIFF
--- a/apps/caa-checker/index.tsx
+++ b/apps/caa-checker/index.tsx
@@ -1,0 +1,1 @@
+export { default, displayCaaChecker } from '../../components/apps/caa-checker';

--- a/pages/api/caa-checker.ts
+++ b/pages/api/caa-checker.ts
@@ -140,6 +140,11 @@ export default async function handler(
         'Critical flag set: unrecognized tags must be understood by CAs or issuance is forbidden.'
       );
     }
+    if (!records.some((r) => r.tag === 'issuewild') && issueValues.length > 0) {
+      notes.push(
+        'Wildcard policy inherits non-wildcard issue tags when issuewild is absent.'
+      );
+    }
     notes.push(
       `Records at ${policyDomain} apply to ${domain}. More specific subdomains override parent policies.`
     );

--- a/pages/apps/caa-checker.tsx
+++ b/pages/apps/caa-checker.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const CaaChecker = dynamic(() => import('../../apps/caa-checker'), {
+  ssr: false,
+});
+
+export default function CaaCheckerPage() {
+  return <CaaChecker />;
+}


### PR DESCRIPTION
## Summary
- Expose the CAA checker app through a new index and dynamic page
- Note wildcard inheritance when no `issuewild` tag is present

## Testing
- `yarn test pages/api/caa-checker.ts components/apps/caa-checker.tsx --passWithNoTests`
- `yarn lint --file components/apps/caa-checker.tsx --file pages/api/caa-checker.ts --file pages/apps/caa-checker.tsx --file apps/caa-checker/index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab26bdb4808328b10c0e5bf2510908