### PR TITLE
feat: add JWS/JWE workbench app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -46,7 +46,7 @@ import { displaySpfFlattener } from './components/apps/spf-flattener';
 
 import { displayHibpCheck } from './components/apps/hibp-check';
 
-import { displayJwsJweWorkbench } from './components/apps/jws-jwe-workbench';
+import { displayJwsJweWorkbench } from './apps/jws-jwe-workbench';
 
 import { displayCaaChecker } from './components/apps/caa-checker';
 

--- a/pages/apps/jws-jwe-workbench.tsx
+++ b/pages/apps/jws-jwe-workbench.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const JwsJweWorkbench = dynamic(() => import('../../components/apps/jws-jwe-workbench'), { ssr: false });
+const JwsJweWorkbench = dynamic(() => import('../../apps/jws-jwe-workbench'), { ssr: false });
 
 export default function JwsJweWorkbenchPage() {
   return <JwsJweWorkbench />;


### PR DESCRIPTION
## Summary
- move JWS/JWE workbench into apps
- support critical header and detached payload handling

## Testing
- `yarn lint` *(fails: Parsing error: Identifier expected. 'import' is a reserved word that cannot be used here.)*
- `yarn test` *(fails: expected ident in pages/api/request.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26be6c308328be8f2f3ae575dbb1