### PR TITLE
feat: add evidence notebook with signed hash chain

### DIFF
--- a/apps/evidence-notebook/index.tsx
+++ b/apps/evidence-notebook/index.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Link from 'next/link';
+import {
+  Entry,
+  hashEntry,
+  generateKeyPair,
+  signData,
+  exportPublicKey,
+} from './utils';
+
+const EvidenceNotebook: React.FC = () => {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [text, setText] = useState('');
+  const [keyPair, setKeyPair] = useState<CryptoKeyPair | null>(null);
+
+  const addEntry = async () => {
+    if (!text) return;
+    const timestamp = new Date().toISOString();
+    const prevHash = entries.length ? entries[entries.length - 1].hash : '';
+    const hash = await hashEntry(text, prevHash, timestamp);
+    setEntries([...entries, { data: text, timestamp, hash }]);
+    setText('');
+  };
+
+  const exportJson = async () => {
+    if (entries.length === 0) return;
+    const kp = keyPair ?? (await generateKeyPair());
+    if (!keyPair) setKeyPair(kp);
+    const dataStr = JSON.stringify(entries);
+    const signature = await signData(dataStr, kp.privateKey);
+    const publicKey = await exportPublicKey(kp.publicKey);
+    const signed = { entries, signature, publicKey };
+    const blob = new Blob([JSON.stringify(signed, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'evidence.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <div className="flex space-x-2">
+        <input
+          aria-label="Entry"
+          className="flex-1 text-black px-2 py-1"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={addEntry}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          onClick={() => alert('Transparency log upload coming soon')}
+          className="px-3 py-1 bg-gray-600 rounded"
+        >
+          Upload
+        </button>
+      </div>
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={exportJson}
+          className="px-3 py-1 bg-green-600 rounded disabled:bg-gray-600"
+          disabled={entries.length === 0}
+        >
+          Export Signed JSON
+        </button>
+        <Link
+          href="/apps/evidence-notebook/verify"
+          className="px-3 py-1 bg-purple-600 rounded"
+        >
+          Verify
+        </Link>
+      </div>
+      <div className="overflow-auto flex-1">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left p-2">Timestamp</th>
+              <th className="text-left p-2">Data</th>
+              <th className="text-left p-2">Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, i) => (
+              <tr key={i} className="border-t border-gray-700">
+                <td className="p-2">{e.timestamp}</td>
+                <td className="p-2 break-all">{e.data}</td>
+                <td className="p-2 break-all">{e.hash}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default EvidenceNotebook;

--- a/apps/evidence-notebook/utils.ts
+++ b/apps/evidence-notebook/utils.ts
@@ -1,0 +1,99 @@
+export interface Entry {
+  data: string;
+  timestamp: string;
+  hash: string;
+}
+
+const te = new TextEncoder();
+
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function bufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export async function hashEntry(
+  data: string,
+  prevHash: string,
+  timestamp: string
+): Promise<string> {
+  const input = prevHash + timestamp + data;
+  const buffer = await crypto.subtle.digest('SHA-256', te.encode(input));
+  return bufferToHex(buffer);
+}
+
+export async function generateKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify']
+  );
+}
+
+export async function signData(
+  data: string,
+  privateKey: CryptoKey
+): Promise<string> {
+  const sig = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    te.encode(data)
+  );
+  return bufferToBase64(sig);
+}
+
+export async function exportPublicKey(key: CryptoKey): Promise<string> {
+  const spki = await crypto.subtle.exportKey('spki', key);
+  return bufferToBase64(spki);
+}
+
+export async function verifySignature(
+  data: string,
+  sigB64: string,
+  publicKeyB64: string
+): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    'spki',
+    base64ToArrayBuffer(publicKeyB64),
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify']
+  );
+  const signature = base64ToArrayBuffer(sigB64);
+  return crypto.subtle.verify(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    key,
+    signature,
+    te.encode(data)
+  );
+}
+
+export async function verifyChain(entries: Entry[]): Promise<boolean> {
+  let prevHash = '';
+  for (const entry of entries) {
+    const expected = await hashEntry(entry.data, prevHash, entry.timestamp);
+    if (expected !== entry.hash) {
+      return false;
+    }
+    prevHash = entry.hash;
+  }
+  return true;
+}

--- a/apps/evidence-notebook/verify.tsx
+++ b/apps/evidence-notebook/verify.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Entry, verifyChain, verifySignature } from './utils';
+
+const VerifyEvidence: React.FC = () => {
+  const [valid, setValid] = useState<boolean | null>(null);
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const data = JSON.parse(text) as {
+        entries: Entry[];
+        signature: string;
+        publicKey: string;
+      };
+      const chainOk = await verifyChain(data.entries);
+      const sigOk = await verifySignature(
+        JSON.stringify(data.entries),
+        data.signature,
+        data.publicKey
+      );
+      setValid(chainOk && sigOk);
+      setEntries(data.entries);
+    } catch {
+      setValid(false);
+      setEntries([]);
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <input type="file" onChange={handleFile} className="text-sm" />
+      {valid !== null && (
+        <div className={valid ? 'text-green-400' : 'text-red-400'}>
+          {valid ? 'Signature and hash chain valid.' : 'Verification failed.'}
+        </div>
+      )}
+      <div className="overflow-auto flex-1">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left p-2">Timestamp</th>
+              <th className="text-left p-2">Data</th>
+              <th className="text-left p-2">Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, i) => (
+              <tr key={i} className="border-t border-gray-700">
+                <td className="p-2">{e.timestamp}</td>
+                <td className="p-2 break-all">{e.data}</td>
+                <td className="p-2 break-all">{e.hash}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyEvidence;

--- a/pages/apps/evidence-notebook/index.tsx
+++ b/pages/apps/evidence-notebook/index.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const EvidenceNotebook = dynamic(
+  () => import('../../../apps/evidence-notebook'),
+  { ssr: false }
+);
+
+export default function EvidenceNotebookPage() {
+  return <EvidenceNotebook />;
+}

--- a/pages/apps/evidence-notebook/verify.tsx
+++ b/pages/apps/evidence-notebook/verify.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const VerifyEvidence = dynamic(
+  () => import('../../../apps/evidence-notebook/verify'),
+  { ssr: false }
+);
+
+export default function EvidenceNotebookVerifyPage() {
+  return <VerifyEvidence />;
+}


### PR DESCRIPTION
## Summary
- add client-side notebook that builds a hash chain, timestamps entries, and exports signed JSON
- include verification page for read-only validation and placeholder transparency log upload

## Testing
- `yarn lint --dir apps/evidence-notebook --dir pages/apps/evidence-notebook`
- `yarn test apps/evidence-notebook --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab26c241108328a636d1a2d7b7095c