### PR TITLE
feat: add forecast route and unit toggle

### DIFF
--- a/apps/weather_widget/index.html
+++ b/apps/weather_widget/index.html
@@ -7,10 +7,13 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div id="weather" class="weather" data-provider="openweather" data-city="London">
-    <div class="temp">--°C</div>
-    <img class="icon" src="" alt="Weather icon" />
-    <div class="forecast">Loading...</div>
+  <div id="weather" class="weather" data-city="London">
+    <div class="controls">
+      <button class="unit-btn active" data-unit="metric">°C</button>
+      <button class="unit-btn" data-unit="imperial">°F</button>
+    </div>
+    <div class="temp skeleton"></div>
+    <ul class="forecast"></ul>
   </div>
   <script src="main.js"></script>
 </body>

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -16,20 +16,55 @@ body {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
-.temp {
-  font-size: 2rem;
+
+.controls {
+  display: flex;
+  justify-content: flex-end;
   margin-bottom: 10px;
 }
 
-.icon {
-  width: 80px;
-  height: 80px;
+.unit-btn {
+  background: #e0e0e0;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+  margin-left: 5px;
+}
+
+.unit-btn.active {
+  background: #d0d0d0;
+  font-weight: bold;
+}
+
+.temp {
+  font-size: 2rem;
+  margin-bottom: 10px;
+  min-width: 80px;
+  min-height: 32px;
 }
 
 .forecast {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0;
   font-size: 1rem;
-  margin-top: 10px;
-  text-transform: capitalize;
+}
+
+.forecast li {
+  margin: 4px 0;
+}
+
+.skeleton {
+  background: #e0e0e0;
+  color: transparent;
+  border-radius: 4px;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
 }
 
 .fade-in {


### PR DESCRIPTION
## Summary
- fetch forecast via `/api/weather`
- add unit toggle for metric and imperial
- display skeleton placeholders while loading

## Testing
- `yarn test apps/weather_widget` *(fails: @types/emscripten missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26c5b34c83288a6e2af7b6ee9d64