### PR TITLE
Add settings app with server-side persistence and JSON import/export

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect, ChangeEvent } from 'react';
+
+interface Settings {
+  theme: string;
+  dataSaving: boolean;
+  locale: string;
+}
+
+const defaultSettings: Settings = {
+  theme: 'light',
+  dataSaving: false,
+  locale: 'en-US',
+};
+
+const SettingsApp: React.FC = () => {
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((res) => res.json())
+      .then((data) => setSettings({ ...defaultSettings, ...data }))
+      .catch(() => setSettings(defaultSettings));
+  }, []);
+
+  const save = async () => {
+    setStatus('');
+    try {
+      await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      setStatus('Saved!');
+    } catch {
+      setStatus('Save failed');
+    }
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(settings, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'settings.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importJson = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async (ev) => {
+      try {
+        const imported = JSON.parse(ev.target?.result as string);
+        const newSettings = { ...defaultSettings, ...imported };
+        setSettings(newSettings);
+        await fetch('/api/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(newSettings),
+        });
+      } catch {
+        // ignore invalid JSON
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col space-y-4">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      <label className="flex items-center space-x-2">
+        <span>Theme</span>
+        <select
+          value={settings.theme}
+          onChange={(e) => setSettings({ ...settings, theme: e.target.value })}
+          className="text-black p-1"
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+
+      <label className="flex items-center space-x-2">
+        <span>Data Saving</span>
+        <input
+          type="checkbox"
+          checked={settings.dataSaving}
+          onChange={(e) =>
+            setSettings({ ...settings, dataSaving: e.target.checked })
+          }
+        />
+      </label>
+
+      <label className="flex items-center space-x-2">
+        <span>Locale</span>
+        <select
+          value={settings.locale}
+          onChange={(e) => setSettings({ ...settings, locale: e.target.value })}
+          className="text-black p-1"
+        >
+          <option value="en-US">English</option>
+          <option value="es-ES">Español</option>
+          <option value="fr-FR">Français</option>
+        </select>
+      </label>
+
+      <div className="flex space-x-2">
+        <button onClick={save} className="px-3 py-1 bg-blue-600 rounded">
+          Save
+        </button>
+        <button onClick={exportJson} className="px-3 py-1 bg-green-600 rounded">
+          Export
+        </button>
+        <label className="px-3 py-1 bg-gray-700 rounded cursor-pointer">
+          Import
+          <input
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={importJson}
+          />
+        </label>
+      </div>
+      {status && <div>{status}</div>}
+    </div>
+  );
+};
+
+export default SettingsApp;

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,0 +1,5 @@
+{
+  "theme": "light",
+  "dataSaving": false,
+  "locale": "en-US"
+}

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+const filePath = path.join(process.cwd(), 'data', 'settings.json');
+
+function readSettings() {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return { theme: 'light', dataSaving: false, locale: 'en-US' };
+  }
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json(readSettings());
+  }
+
+  if (req.method === 'POST') {
+    const settings = req.body;
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2));
+    return res.status(200).json({ ok: true });
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/apps/settings.tsx
+++ b/pages/apps/settings.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+
+export default function SettingsPage() {
+  return <SettingsApp />;
+}


### PR DESCRIPTION
## Summary
- add settings app to manage theme, data-saving mode, and locale
- persist settings via new `/api/settings` endpoint using data/settings.json
- enable importing and exporting settings as JSON

## Testing
- `yarn lint` *(fails: @types/emscripten not in lockfile)*
- `yarn test` *(fails: @types/emscripten not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26c61554832888d185e519c35a42