### PR TITLE
feat: add project gallery app

### DIFF
--- a/apps/project-gallery/index.tsx
+++ b/apps/project-gallery/index.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo, useState } from 'react';
+import Image from 'next/image';
+import projects from '../../data/projects.json';
+
+interface Project {
+  title: string;
+  description: string;
+  image: string;
+  tech: string[];
+  tags: string[];
+  live?: string;
+  repo?: string;
+}
+
+const ProjectGallery: React.FC = () => {
+  const [tag, setTag] = useState('All');
+
+  const tags = useMemo(() => {
+    return ['All', ...Array.from(new Set((projects as Project[]).flatMap(p => p.tags)))];
+  }, []);
+
+  const filtered = useMemo(() => {
+    return tag === 'All'
+      ? (projects as Project[])
+      : (projects as Project[]).filter(p => p.tags.includes(tag));
+  }, [tag]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {tags.map(t => (
+          <button
+            key={t}
+            onClick={() => setTag(t)}
+            className={`px-3 py-1 rounded ${t === tag ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {filtered.map((p, i) => (
+          <div key={i} className="border rounded overflow-hidden">
+            <Image
+              src={p.image}
+              alt={p.title}
+              width={400}
+              height={300}
+              className="w-full h-48 object-cover"
+              loading="lazy"
+            />
+            <div className="p-2">
+              <h3 className="font-semibold">{p.title}</h3>
+              <p className="text-sm text-gray-700 dark:text-gray-300">{p.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProjectGallery;

--- a/pages/apps/project-gallery.tsx
+++ b/pages/apps/project-gallery.tsx
@@ -1,0 +1,20 @@
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+const ProjectGallery = dynamic(() => import('../../apps/project-gallery'), {
+  ssr: false,
+});
+
+export default function ProjectGalleryPage() {
+  const ogImage = '/images/logos/logo_1200.png';
+  return (
+    <>
+      <Head>
+        <title>Project Gallery</title>
+        <meta property="og:title" content="Project Gallery" />
+        <meta property="og:image" content={ogImage} />
+      </Head>
+      <ProjectGallery />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add project gallery component with tag filters and lazy-loaded images
- expose project gallery route with OpenGraph metadata

## Testing
- `yarn test apps/project-gallery/index.tsx` *(fails: @types/emscripten missing in lockfile)*
- `yarn install --immutable` *(fails: lockfile would be modified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26c89ff483289edcf11d0e85c91c