### PR TITLE
feat: enhance regex redactor with RE2 patterns

### DIFF
--- a/__tests__/regex-redactor.test.ts
+++ b/__tests__/regex-redactor.test.ts
@@ -1,0 +1,54 @@
+import { PRESETS } from '@components/apps/regex-redactor/presets';
+
+const getPattern = (label: string): string => {
+  const preset = PRESETS.find((p) => p.label === label);
+  if (!preset) throw new Error(`Preset ${label} not found`);
+  return preset.pattern;
+};
+
+const highlightMatches = async (pattern: string, text: string) => {
+  const { RE2 } = await import('re2-wasm');
+  const regex = new RE2(pattern, 'gu');
+  const highlights: Array<{ start: number; end: number }> = [];
+  text.replace(regex, (match: string, offset: number) => {
+    highlights.push({ start: offset, end: offset + match.length });
+    return match;
+  });
+  return highlights;
+};
+
+describe('regex-redactor RE2 patterns', () => {
+  test('email pattern highlights address', async () => {
+    const text = 'Reach me at user.name@example.com for details.';
+    const pattern = getPattern('Email');
+    const highlights = await highlightMatches(pattern, text);
+    const match = 'user.name@example.com';
+    const start = text.indexOf(match);
+    expect(highlights).toEqual([{ start, end: start + match.length }]);
+  });
+
+  test('phone pattern highlights number', async () => {
+    const text = 'Call +1 234-567-8901 soon.';
+    const pattern = getPattern('Phone');
+    const highlights = await highlightMatches(pattern, text);
+    const match = '+1 234-567-8901';
+    const start = text.indexOf(match);
+    expect(highlights).toEqual([{ start, end: start + match.length }]);
+  });
+
+  test('IP pattern highlights addresses', async () => {
+    const text =
+      'Hosts 192.168.0.1 and 2001:0db8:85a3:0000:0000:8a2e:0370:7334 are reachable.';
+    const pattern = getPattern('IP');
+    const highlights = await highlightMatches(pattern, text);
+    const ipv4 = '192.168.0.1';
+    const ipv6 = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+    const start4 = text.indexOf(ipv4);
+    const start6 = text.indexOf(ipv6);
+    expect(highlights).toEqual([
+      { start: start4, end: start4 + ipv4.length },
+      { start: start6, end: start6 + ipv6.length },
+    ]);
+  });
+});
+

--- a/components/apps/regex-redactor/index.js
+++ b/components/apps/regex-redactor/index.js
@@ -141,7 +141,7 @@ const RegexRedactor = () => {
           patterns.
         </div>
       )}
-      {useRe2 && (
+      {engine === 're2' && (
         <div className="text-sm text-gray-300 mb-2">RE2 mode enabled.</div>
       )}
       <textarea

--- a/components/apps/regex-redactor/presets.js
+++ b/components/apps/regex-redactor/presets.js
@@ -12,7 +12,7 @@ export const PRESETS = [
   },
   {
     label: 'Phone',
-    pattern: '\\b(?:\\+?\\d{1,3}[ -]?)?(?:\\d{3}[ -]?){2}\\d{4}\\b',
+    pattern: '(?:\\+?\\d{1,3}[ -]?)?(?:\\d{3}[ -]?){2}\\d{4}\\b',
     mask(match, option) {
       if (option === 'partial') {
         return '***-***-' + match.slice(-4);

--- a/components/apps/regex-redactor/worker.js
+++ b/components/apps/regex-redactor/worker.js
@@ -1,6 +1,5 @@
 import { diffWords } from 'diff';
 import safeRegex from 'safe-regex';
-import { RE2 } from 're2-wasm';
 import { PRESETS } from './presets';
 
 self.onmessage = async (e) => {
@@ -19,7 +18,7 @@ self.onmessage = async (e) => {
     try {
       if (engine === 're2') {
         const mod = await import('re2-wasm');
-        regex = new mod.RE2(pattern, 'g');
+        regex = new mod.RE2(pattern, 'gu');
       } else {
         unsafe = !safeRegex(pattern);
         if (unsafe) {


### PR DESCRIPTION
## Summary
- use RE2 with unicode flag and highlight support
- expose RE2 mode indicator and update phone preset
- add tests covering email, phone and IP highlighting

## Testing
- `yarn test __tests__/regex-redactor.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab26cd4bcc83289af38d45d8888894