### PR TITLE
feat: add shared tokens and accessibility updates

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import Modal from '../util-components/Modal';
 
 const SIZE = 4;
 
@@ -79,6 +80,7 @@ const Game2048 = () => {
   const [board, setBoard] = useState(() => initBoard());
   const [won, setWon] = useState(false);
   const [lost, setLost] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
 
   const handleKey = useCallback(
     (e) => {
@@ -119,7 +121,7 @@ const Game2048 = () => {
   };
 
   return (
-    <div className="h-full w-full p-4 flex flex-col items-center justify-center bg-panel text-white select-none">
+    <div className="h-full w-full p-4 flex flex-col items-center justify-center bg-[var(--color-surface)] text-[var(--color-text)] select-none">
       <div className="grid grid-cols-4 gap-2">
         {board.map((row, rIdx) =>
           row.map((cell, cIdx) => (
@@ -139,18 +141,27 @@ const Game2048 = () => {
       )}
       <div className="mt-4 space-x-2">
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
           onClick={reset}
         >
           Reset
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
+          onClick={() => setShowHelp(true)}
+        >
+          Help
+        </button>
+        <button
+          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
           onClick={close}
         >
           Close
         </button>
       </div>
+      <Modal isOpen={showHelp} onClose={() => setShowHelp(false)} title="How to play">
+        <p>Use arrow keys to combine tiles and reach 2048.</p>
+      </Modal>
     </div>
   );
 };

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -20,7 +20,14 @@ export class UbuntuApp extends Component {
                 className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 focus:ring-2 focus:ring-yellow-500 focus:ring-offset-1 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                tabIndex={0}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.openApp();
+                    }
+                }}
+                tabIndex={this.props.tabIndex ?? 0}
+                role="button"
                 aria-label={`Open ${this.props.name}`}
                 data-testid={`ubuntu-app-${this.props.id}`}
             >

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
+import ResponsiveGrid from '../util-components/ResponsiveGrid';
 
 class AllApplications extends React.Component {
     constructor() {
@@ -65,7 +66,7 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-overlay pointer-events-auto flex flex-col items-center overflow-y-auto bg-surface bg-opacity-95 all-apps-anim">
+            <div className="fixed inset-0 z-overlay pointer-events-auto flex flex-col items-center overflow-y-auto bg-[var(--color-bg)] bg-opacity-95 all-apps-anim">
                 <button
                     onClick={this.props.closeAllApps}
                     className="absolute top-4 right-4 p-1 rounded hover:bg-white hover:bg-opacity-10 focus:outline-none"
@@ -86,9 +87,7 @@ class AllApplications extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
-                </div>
+                <ResponsiveGrid>{this.renderApps()}</ResponsiveGrid>
             </div>
         );
     }

--- a/components/util-components/Modal.tsx
+++ b/components/util-components/Modal.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const focusableSelector =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialog = dialogRef.current;
+    const toFocus = dialog?.querySelector<HTMLElement>('[data-autofocus]');
+    toFocus?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab') {
+        const focusable = dialog?.querySelectorAll<HTMLElement>(focusableSelector);
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          last.focus();
+          e.preventDefault();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          first.focus();
+          e.preventDefault();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        ref={dialogRef}
+        className="bg-[var(--color-surface)] text-[var(--color-text)] p-4 rounded shadow-lg w-11/12 max-w-md"
+      >
+        {title && <h2 className="text-lg font-bold mb-2">{title}</h2>}
+        <div>{children}</div>
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-[var(--color-accent)] text-black rounded"
+            data-autofocus
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/components/util-components/ResponsiveGrid.tsx
+++ b/components/util-components/ResponsiveGrid.tsx
@@ -1,0 +1,56 @@
+import React, { useRef } from 'react';
+
+interface ResponsiveGridProps {
+  children: React.ReactNode;
+}
+
+const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const items = container.querySelectorAll<HTMLElement>('[data-grid-item]');
+    if (items.length === 0) return;
+    const currentIndex = Array.from(items).indexOf(document.activeElement as HTMLElement);
+    const columns = getComputedStyle(container).gridTemplateColumns.split(' ').length;
+    let nextIndex = currentIndex;
+    switch (e.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % items.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + items.length) % items.length;
+        break;
+      case 'ArrowDown':
+        nextIndex = (currentIndex + columns) % items.length;
+        break;
+      case 'ArrowUp':
+        nextIndex = (currentIndex - columns + items.length) % items.length;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    items[nextIndex].focus();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center"
+      onKeyDown={handleKeyDown}
+    >
+      {React.Children.map(children, (child, index) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child as React.ReactElement, {
+              tabIndex: index === 0 ? 0 : -1,
+              'data-grid-item': true,
+            })
+          : child
+      )}
+    </div>
+  );
+};
+
+export default ResponsiveGrid;

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,3 +1,4 @@
+@import "./tokens.css";
 body{
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,10 @@
+:root {
+  --color-bg: #0d1117;
+  --color-surface: #1e2329;
+  --color-accent: #62dafc;
+  --color-text: #e6edf3;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+}


### PR DESCRIPTION
## Summary
- add central design tokens and wire them into global styles
- provide responsive grid with keyboard navigation for app launcher
- introduce accessible modal and example usage in 2048 app

## Testing
- `yarn lint` *(fails: Parsing error in pages/api/request.ts)*
- `yarn test apps/2048/__tests__/engine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab26d322008328b32bcb6373781797