### PR TITLE
feat: strengthen CSP and monitor violations

### DIFF
--- a/components/apps/csp-reporter.tsx
+++ b/components/apps/csp-reporter.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { sendTelemetry } from '@lib/game';
 
 interface Report {
   [key: string]: any;
@@ -49,6 +50,13 @@ const CspReporter: React.FC = () => {
     const handler = (e: MessageEvent) => {
       if (e.data && e.data.type === 'csp-violation') {
         setTimeline((t) => [...t, e.data]);
+        sendTelemetry({
+          name: 'csp-violation',
+          data: {
+            directive: e.data.directive,
+            blocked: e.data.blockedURI,
+          },
+        });
       }
     };
     window.addEventListener('message', handler);

--- a/next.config.js
+++ b/next.config.js
@@ -17,13 +17,26 @@ const ContentSecurityPolicy = [
   "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
+  // Disallow plugins and limit base/submit targets
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  // Enable Reporting API endpoint for violations
+  "report-to csp-endpoint",
 ].join('; ');
 
 // Omit the CSP in development to prevent dev tooling from breaking.
 const securityHeaders = [
   ...(process.env.NODE_ENV === 'development'
     ? []
-    : [{ key: 'Content-Security-Policy', value: ContentSecurityPolicy }]),
+    : [
+        { key: 'Content-Security-Policy', value: ContentSecurityPolicy },
+        {
+          key: 'Report-To',
+          value:
+            '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/csp-reporter"}]}'
+        }
+      ]),
   {
     key: 'X-Content-Type-Options',
     value: 'nosniff',


### PR DESCRIPTION
## Summary
- tighten Content-Security-Policy and wire up Reporting API endpoint
- send telemetry for CSP violations in reporter app

## Testing
- `yarn test` *(fails: @types/emscripten missing in lockfile)*
- `yarn lint` *(fails: @types/emscripten missing in lockfile)*
- `npx jest __tests__/request.cache.test.ts __tests__/pinball-pixi.test.ts apps/word_search/generator.test.ts`
- `npx vitest run apps/word_search/generator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab26d551108328b9c7b0a0e54d2a11