### PR TITLE
feat: add ascii art tool

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -1,0 +1,447 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+// Preset character sets and color palettes
+const presetCharSets = {
+  standard: '@#S%?*+;:,.',
+  blocks: '█▓▒░ ',
+  binary: '01',
+};
+
+const palettes = {
+  grayscale: [
+    [0, 0, 0],
+    [85, 85, 85],
+    [170, 170, 170],
+    [255, 255, 255],
+  ],
+  ansi16: [
+    [0, 0, 0],
+    [128, 0, 0],
+    [0, 128, 0],
+    [128, 128, 0],
+    [0, 0, 128],
+    [128, 0, 128],
+    [0, 128, 128],
+    [192, 192, 192],
+    [128, 128, 128],
+    [255, 0, 0],
+    [0, 255, 0],
+    [255, 255, 0],
+    [0, 0, 255],
+    [255, 0, 255],
+    [0, 255, 255],
+    [255, 255, 255],
+  ],
+};
+
+export default function AsciiArt() {
+  const [asciiHtml, setAsciiHtml] = useState('');
+  const [plainAscii, setPlainAscii] = useState('');
+  const [ansiAscii, setAnsiAscii] = useState('');
+  const [charSet, setCharSet] = useState('');
+  const [paletteName, setPaletteName] = useState('grayscale');
+  const [fontSize, setFontSize] = useState(8);
+  const [fontFamily, setFontFamily] = useState('monospace');
+  const [charWidth, setCharWidth] = useState(8);
+  const [isMono, setIsMono] = useState(true);
+  const [useColor, setUseColor] = useState(true);
+  const [altText, setAltText] = useState('');
+  const [typingMode, setTypingMode] = useState(false);
+  const undoStack = useRef([]);
+  const [colors, setColors] = useState(null);
+  const workerRef = useRef(null);
+  const canvasRef = useRef(null);
+  const editorRef = useRef(null);
+  const [imgSrc, setImgSrc] = useState(null);
+
+  // Load saved preferences
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedSet = window.localStorage.getItem('ascii_char_set');
+    const savedPalette = window.localStorage.getItem('ascii_palette');
+    const savedFont = window.localStorage.getItem('ascii_font_family');
+    setCharSet(savedSet || presetCharSets.standard);
+    setPaletteName(savedPalette || 'grayscale');
+    setFontFamily(savedFont || 'monospace');
+  }, []);
+
+  // Persist preferences
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('ascii_char_set', charSet);
+      window.localStorage.setItem('ascii_palette', paletteName);
+      window.localStorage.setItem('ascii_font_family', fontFamily);
+    }
+  }, [charSet, paletteName, fontFamily]);
+
+  // Measure character width and verify monospaced font
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.font = `${fontSize}px ${fontFamily}, monospace`;
+    const w = ctx.measureText('W').width;
+    const i = ctx.measureText('i').width;
+    setCharWidth(w);
+    setIsMono(Math.abs(w - i) < 0.01);
+  }, [fontFamily, fontSize]);
+
+  // Cleanup image preview
+  useEffect(
+    () => () => {
+      if (imgSrc) URL.revokeObjectURL(imgSrc);
+    },
+    [imgSrc]
+  );
+
+  // Setup worker
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
+    workerRef.current.onmessage = (e) => {
+      const { plain, html, ansi, colors: colorArr, width, height } = e.data;
+      setPlainAscii(plain);
+      setAsciiHtml(html);
+      setAnsiAscii(ansi);
+      setColors({ data: colorArr, width, height });
+      setAltText(`ASCII art ${width}x${height}`);
+    };
+    return () => {
+      workerRef.current.terminate();
+    };
+  }, []);
+
+  const handleFile = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (imgSrc) URL.revokeObjectURL(imgSrc);
+    const previewUrl = URL.createObjectURL(file);
+    setImgSrc(previewUrl);
+    const bitmap = await createImageBitmap(file);
+    if (workerRef.current && typeof OffscreenCanvas !== 'undefined') {
+      workerRef.current.postMessage(
+        {
+          bitmap,
+          charSet,
+          fontSize,
+          charWidth,
+          useColor,
+          palette: palettes[paletteName],
+        },
+        [bitmap]
+      );
+    } else {
+      // Fallback to processing on main thread
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        const maxDim = 1000;
+        const width = Math.max(1, Math.min(Math.floor(img.width / charWidth), maxDim));
+        const height = Math.max(1, Math.min(Math.floor(img.height / fontSize), maxDim));
+        canvas.width = width;
+        canvas.height = height;
+        ctx.drawImage(img, 0, 0, width, height);
+        const { data } = ctx.getImageData(0, 0, width, height);
+        let plain = '';
+        let html = '';
+        const chars = charSet.split('');
+        const colorArr = new Uint8ClampedArray(width * height * 3);
+        for (let y = 0; y < height; y += 1) {
+          let row = '';
+          let htmlRow = '';
+          for (let x = 0; x < width; x += 1) {
+            const idx = (y * width + x) * 4;
+            const r = data[idx];
+            const g = data[idx + 1];
+            const b = data[idx + 2];
+            const avg = (r + g + b) / 3;
+            const charIndex = Math.floor((avg / 255) * (chars.length - 1));
+            const ch = chars[chars.length - 1 - charIndex];
+            row += ch;
+            htmlRow += useColor
+              ? `<span style=\"color: rgb(${r},${g},${b})\">${ch}</span>`
+              : ch;
+            const cIdx = (y * width + x) * 3;
+            colorArr[cIdx] = r;
+            colorArr[cIdx + 1] = g;
+            colorArr[cIdx + 2] = b;
+          }
+          plain += `${row}\n`;
+          html += `${htmlRow}<br/>`;
+        }
+        setPlainAscii(plain);
+        setAsciiHtml(html);
+        setAnsiAscii(plain);
+        setColors({ data: colorArr, width, height });
+      };
+      img.src = previewUrl;
+    }
+  };
+
+  const copyAscii = () => {
+    const text = useColor ? ansiAscii : plainAscii;
+    if (text) navigator.clipboard.writeText(text);
+  };
+
+  const downloadAscii = () => {
+    const text = useColor ? ansiAscii : plainAscii;
+    if (!text) return;
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'ascii-art.txt';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadHtml = () => {
+    if (!asciiHtml) return;
+    const html = `<pre style="font-family:${fontFamily},monospace;font-size:${fontSize}px;line-height:${fontSize}px;background:#000;color:#fff;">${asciiHtml}</pre>`;
+    const blob = new Blob([html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'ascii-art.html';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadPng = () => {
+    if (!plainAscii || !colors) return;
+    const lines = plainAscii.trimEnd().split('\n');
+    const width = colors.width;
+    const height = colors.height;
+    const canvas = canvasRef.current;
+    canvas.width = width * charWidth;
+    canvas.height = height * fontSize;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.font = `${fontSize}px ${fontFamily}, monospace`;
+    ctx.textBaseline = 'top';
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const cIdx = (y * width + x) * 3;
+        const r = colors.data[cIdx];
+        const g = colors.data[cIdx + 1];
+        const b = colors.data[cIdx + 2];
+        ctx.fillStyle = useColor ? `rgb(${r},${g},${b})` : '#FFFFFF';
+        const ch = lines[y][x];
+        ctx.fillText(ch, x * charWidth, y * fontSize);
+      }
+    }
+    canvas.toBlob((blob) => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'ascii-art.png';
+      link.click();
+      URL.revokeObjectURL(url);
+    });
+  };
+
+  // Typing mode handlers
+  const toggleTypingMode = () => {
+    setTypingMode(!typingMode);
+    setAltText('Custom ASCII art typing mode');
+  };
+
+  const handleEditorChange = (e) => {
+    undoStack.current.push(plainAscii);
+    setPlainAscii(e.target.value);
+    setAsciiHtml(e.target.value.replace(/\n/g, '<br/>'));
+  };
+
+  const undo = () => {
+    if (!undoStack.current.length) return;
+    const prev = undoStack.current.pop();
+    setPlainAscii(prev);
+    setAsciiHtml(prev.replace(/\n/g, '<br/>'));
+  };
+
+  const playAltText = () => {
+    if (!altText) return;
+    const utter = new SpeechSynthesisUtterance(altText);
+    window.speechSynthesis.speak(utter);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col p-4 bg-panel text-white overflow-auto">
+      <div className="mb-2 flex flex-wrap gap-2">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFile}
+          className="mb-2"
+        />
+        <label className="flex items-center gap-2">
+          Charset:
+          <input
+            type="text"
+            value={charSet}
+            onChange={(e) => setCharSet(e.target.value)}
+            className="px-1 bg-gray-700"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Ramp:
+          <select
+            onChange={(e) => setCharSet(presetCharSets[e.target.value])}
+            className="bg-gray-700"
+            defaultValue="standard"
+          >
+            {Object.keys(presetCharSets).map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          Font:
+          <input
+            type="number"
+            min="4"
+            max="32"
+            value={fontSize}
+            onChange={(e) => setFontSize(Number(e.target.value))}
+            className="w-16 px-1 bg-gray-700"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Family:
+          <input
+            type="text"
+            value={fontFamily}
+            onChange={(e) => setFontFamily(e.target.value)}
+            className="px-1 bg-gray-700"
+          />
+        </label>
+        <span className="px-2 py-1 bg-gray-700 rounded">
+          <span
+            style={{ fontFamily, fontSize: `${fontSize}px`, lineHeight: `${fontSize}px` }}
+          >
+            AaBbCc123
+          </span>
+        </span>
+        {!isMono && <span className="text-red-400 text-xs">not mono</span>}
+        <label className="flex items-center gap-2">
+          Palette:
+          <select
+            value={paletteName}
+            onChange={(e) => setPaletteName(e.target.value)}
+            className="bg-gray-700"
+          >
+            {Object.keys(palettes).map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          Color
+          <input
+            type="checkbox"
+            checked={useColor}
+            onChange={(e) => setUseColor(e.target.checked)}
+          />
+        </label>
+        <button
+          type="button"
+          onClick={downloadAscii}
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+        >
+          TXT
+        </button>
+        <button
+          type="button"
+          onClick={downloadHtml}
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+        >
+          HTML
+        </button>
+        <button
+          type="button"
+          onClick={downloadPng}
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+        >
+          PNG
+        </button>
+        <button
+          type="button"
+          onClick={toggleTypingMode}
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+        >
+          {typingMode ? 'Image Mode' : 'Typing Mode'}
+        </button>
+        {typingMode && (
+          <button
+            type="button"
+            onClick={undo}
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          >
+            Undo
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={playAltText}
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+        >
+          Alt
+        </button>
+      </div>
+      <div className="flex flex-1 overflow-auto gap-4">
+        {imgSrc && (
+          <img
+            src={imgSrc}
+            alt="original"
+            className="max-h-full object-contain flex-1"
+          />
+        )}
+        <div className="relative flex-1 flex">
+          {typingMode ? (
+            <textarea
+              ref={editorRef}
+              value={plainAscii}
+              onChange={handleEditorChange}
+              className="flex-1 font-mono bg-gray-800 text-white resize-none"
+              style={{
+                lineHeight: `${fontSize}px`,
+                fontSize: `${fontSize}px`,
+                fontFamily,
+                backgroundSize: `${fontSize}px ${fontSize}px`,
+                backgroundImage:
+                  'linear-gradient(0deg, transparent calc(100% - 1px), rgba(255,255,255,0.1) calc(100% - 1px)), linear-gradient(90deg, transparent calc(100% - 1px), rgba(255,255,255,0.1) calc(100% - 1px))',
+              }}
+            />
+          ) : (
+            <pre
+              className="font-mono whitespace-pre overflow-auto flex-1"
+              style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize}px`, fontFamily }}
+              dangerouslySetInnerHTML={{ __html: asciiHtml }}
+            />
+          )}
+          {!typingMode && (
+            <button
+              type="button"
+              onClick={copyAscii}
+              className="absolute top-2 right-2 px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+            >
+              Copy
+            </button>
+          )}
+        </div>
+      </div>
+      <canvas ref={canvasRef} className="hidden" />
+      <div className="sr-only" aria-live="polite">
+        {altText}
+      </div>
+    </div>
+  );
+}
+
+export const displayAsciiArt = () => <AsciiArt />;
+

--- a/apps/ascii-art/worker.js
+++ b/apps/ascii-art/worker.js
@@ -1,0 +1,94 @@
+self.onmessage = async (e) => {
+  const { bitmap, charSet, fontSize, charWidth, useColor, palette } = e.data;
+  const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+  const safeFont = clamp(fontSize || 8, 1, 100);
+  const safeChar = clamp(charWidth || safeFont, 1, 1000);
+  const rawWidth = Math.floor(bitmap.width / safeChar);
+  const rawHeight = Math.floor(bitmap.height / safeFont);
+  const MAX_DIM = 1000;
+  const width = clamp(rawWidth, 1, MAX_DIM);
+  const height = clamp(rawHeight, 1, MAX_DIM);
+  const chars = charSet.split('');
+  let canvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(width, height);
+  } else {
+    canvas = new OffscreenCanvas(width, height); // rely on polyfill? fallback
+  }
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, width, height);
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  const colors = new Uint8ClampedArray(width * height * 3);
+  const gray = new Float32Array(width * height);
+  // Prepare grayscale array for dithering
+  for (let i = 0; i < width * height; i += 1) {
+    const idx = i * 4;
+    const r = data[idx];
+    const g = data[idx + 1];
+    const b = data[idx + 2];
+    gray[i] = 0.299 * r + 0.587 * g + 0.114 * b;
+  }
+  let plain = '';
+  let html = '';
+  let ansi = '';
+  const paletteArr = palette || [];
+  const mapToPalette = (r, g, b) => {
+    if (!paletteArr.length) return [r, g, b];
+    let best = paletteArr[0];
+    let bestDist = Infinity;
+    for (let i = 0; i < paletteArr.length; i += 1) {
+      const p = paletteArr[i];
+      const dr = r - p[0];
+      const dg = g - p[1];
+      const db = b - p[2];
+      const dist = dr * dr + dg * dg + db * db;
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = p;
+      }
+    }
+    return best;
+  };
+  for (let y = 0; y < height; y += 1) {
+    let plainRow = '';
+    let htmlRow = '';
+    let ansiRow = '';
+    for (let x = 0; x < width; x += 1) {
+      const idx = y * width + x;
+      const gx = gray[idx];
+      const charIndex = Math.floor((gx / 255) * (chars.length - 1));
+      const newPixel = (charIndex / (chars.length - 1)) * 255;
+      const error = gx - newPixel;
+      // Floyd-Steinberg dithering
+      if (x + 1 < width) gray[idx + 1] += error * (7 / 16);
+      if (y + 1 < height) {
+        if (x > 0) gray[idx + width - 1] += error * (3 / 16);
+        gray[idx + width] += error * (5 / 16);
+        if (x + 1 < width) gray[idx + width + 1] += error * (1 / 16);
+      }
+      const pixelIndex = idx * 4;
+      let r = data[pixelIndex];
+      let g = data[pixelIndex + 1];
+      let b = data[pixelIndex + 2];
+      [r, g, b] = mapToPalette(r, g, b);
+      const cIdx = idx * 3;
+      colors[cIdx] = r;
+      colors[cIdx + 1] = g;
+      colors[cIdx + 2] = b;
+      const ch = chars[chars.length - 1 - charIndex];
+      plainRow += ch;
+      if (useColor) {
+        htmlRow += `<span style="color: rgb(${r},${g},${b})">${ch}</span>`;
+        ansiRow += `\u001b[38;2;${r};${g};${b}m${ch}`;
+      } else {
+        htmlRow += ch;
+        ansiRow += ch;
+      }
+    }
+    plain += `${plainRow}\n`;
+    html += `${htmlRow}<br/>`;
+    ansi += `${ansiRow}\u001b[0m\n`;
+  }
+  self.postMessage({ plain, html, ansi, width, height, colors }, [colors.buffer]);
+};


### PR DESCRIPTION
## Summary
- add standalone ascii art app
- support glyph palettes, palette selection, and copy/export

## Testing
- `yarn test` *(fails: request.cache.test.ts, pinball-pixi.test.ts)*
- `yarn test:unit` *(fails: cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26ce8f60832887857cdcbb8e7a8f