### PR TITLE
feat: enhance blackjack game

### DIFF
--- a/apps/blackjack/Controls.tsx
+++ b/apps/blackjack/Controls.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 interface ControlsProps {
@@ -14,6 +16,7 @@ interface ControlsProps {
   canSurrender: boolean;
   canUndo: boolean;
   disabled: boolean;
+  recommended?: string;
 }
 
 const Controls: React.FC<ControlsProps> = ({
@@ -30,15 +33,60 @@ const Controls: React.FC<ControlsProps> = ({
   canSurrender,
   canUndo,
   disabled,
+  recommended,
 }) => (
   <div className="space-x-2" aria-label="Controls">
-    <button aria-label="Hit" disabled={disabled} className="btn" onClick={onHit}>Hit</button>
-    <button aria-label="Stand" disabled={disabled} className="btn" onClick={onStand}>Stand</button>
-    <button aria-label="Split" disabled={disabled || !canSplit} className="btn" onClick={onSplit}>Split</button>
-    <button aria-label="Double down" disabled={disabled || !canDouble} className="btn" onClick={onDouble}>Double</button>
-    <button aria-label="Surrender" disabled={disabled || !canSurrender} className="btn" onClick={onSurrender}>Surrender</button>
-    <button aria-label="Undo" disabled={disabled || !canUndo} className="btn" onClick={onUndo}>Undo</button>
-    <button aria-label="Insurance" disabled={disabled || !canInsurance} className="btn" onClick={onInsurance}>Insurance</button>
+    <button
+      aria-label="Hit"
+      disabled={disabled}
+      className={`btn ${recommended === 'hit' ? 'ring-2 ring-green-500' : ''}`}
+      onClick={onHit}
+    >
+      Hit
+    </button>
+    <button
+      aria-label="Stand"
+      disabled={disabled}
+      className={`btn ${recommended === 'stand' ? 'ring-2 ring-green-500' : ''}`}
+      onClick={onStand}
+    >
+      Stand
+    </button>
+    <button
+      aria-label="Split"
+      disabled={disabled || !canSplit}
+      className={`btn ${recommended === 'split' ? 'ring-2 ring-green-500' : ''}`}
+      onClick={onSplit}
+    >
+      Split
+    </button>
+    <button
+      aria-label="Double down"
+      disabled={disabled || !canDouble}
+      className={`btn ${recommended === 'double' ? 'ring-2 ring-green-500' : ''}`}
+      onClick={onDouble}
+    >
+      Double
+    </button>
+    <button
+      aria-label="Surrender"
+      disabled={disabled || !canSurrender}
+      className={`btn ${recommended === 'surrender' ? 'ring-2 ring-green-500' : ''}`}
+      onClick={onSurrender}
+    >
+      Surrender
+    </button>
+    <button aria-label="Undo" disabled={disabled || !canUndo} className="btn" onClick={onUndo}>
+      Undo
+    </button>
+    <button
+      aria-label="Insurance"
+      disabled={disabled || !canInsurance}
+      className="btn"
+      onClick={onInsurance}
+    >
+      Insurance
+    </button>
   </div>
 );
 

--- a/apps/blackjack/CountingPractice.tsx
+++ b/apps/blackjack/CountingPractice.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { Card } from './types';
 import { fisherYates } from '@components/apps/blackjack/engine';

--- a/apps/blackjack/Dealer.tsx
+++ b/apps/blackjack/Dealer.tsx
@@ -1,22 +1,32 @@
+"use client";
+
 import React from 'react';
 import { Card } from './types';
 
 interface DealerProps {
   hand: Card[];
   hideHoleCard: boolean;
+  reduceMotion: boolean;
 }
 
 function cardValue(card: Card) {
   return card.value + card.suit;
 }
 
-const Dealer: React.FC<DealerProps> = ({ hand, hideHoleCard }) => {
+const Dealer: React.FC<DealerProps> = ({ hand, hideHoleCard, reduceMotion }) => {
   return (
     <div aria-label="Dealer" className="p-2">
       <h2 className="font-bold">Dealer</h2>
       <div className="flex space-x-2">
         {hand.map((card, idx) => (
-          <span key={idx} className="border p-1" aria-label={hideHoleCard && idx === 1 ? 'Hidden card' : cardValue(card)}>
+          <span
+            key={idx}
+            className={`border p-1 inline-block ${
+              reduceMotion ? '' : 'transform-gpu transition-transform duration-500'
+            }`}
+            style={{ transform: hideHoleCard && idx === 1 ? 'rotateY(180deg)' : 'rotateY(0deg)' }}
+            aria-label={hideHoleCard && idx === 1 ? 'Hidden card' : cardValue(card)}
+          >
             {hideHoleCard && idx === 1 ? '🂠' : cardValue(card)}
           </span>
         ))}

--- a/apps/blackjack/PlayerHand.tsx
+++ b/apps/blackjack/PlayerHand.tsx
@@ -1,20 +1,29 @@
+"use client";
+
 import React from 'react';
 import { Hand } from './types';
 
 interface PlayerHandProps {
   hand: Hand;
   active: boolean;
+  reduceMotion: boolean;
 }
 
 function cardValue(card: { value: string; suit: string }) {
   return card.value + card.suit;
 }
 
-const PlayerHand: React.FC<PlayerHandProps> = ({ hand, active }) => (
+const PlayerHand: React.FC<PlayerHandProps> = ({ hand, active, reduceMotion }) => (
   <div aria-label="Player hand" className={`p-2 ${active ? 'ring-2 ring-blue-500' : ''}`}>
     <div className="flex space-x-2">
       {hand.cards.map((card, idx) => (
-        <span key={idx} className="border p-1" aria-label={cardValue(card)}>
+        <span
+          key={idx}
+          className={`border p-1 inline-block ${
+            reduceMotion ? '' : 'transform-gpu transition-transform duration-500'
+          }`}
+          aria-label={cardValue(card)}
+        >
           {cardValue(card)}
         </span>
       ))}


### PR DESCRIPTION
## Summary
- implement multi-deck shoe with cut card and configurable H17/S17 rules
- add bankroll persistence, keyboard-friendly bet chips, and basic-strategy overlay
- respect reduced-motion with animated dealing and flip, include optional Hi-Lo practice

## Testing
- `npm test -- --passWithNoTests apps/blackjack`
- `npm run lint` *(fails: Couldn't find any `pages` or `app` directory / parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2cd621408328a06f4132ed6c4daf