### PR TITLE
feat(car-racer): add pixi outrun racer

### DIFF
--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -1,1 +1,3 @@
-export { default, CHECKPOINTS, advanceCheckpoints } from '../../apps/car-racer';
+import dynamic from 'next/dynamic';
+export { CHECKPOINTS, advanceCheckpoints } from '../../apps/car-racer';
+export default dynamic(() => import('../../apps/car-racer'), { ssr: false });


### PR DESCRIPTION
## Summary
- replace Matter.js version with PixiJS OutRun-style engine
- add parallax scenery, hills, curves and roadside sprites with culling
- support keyboard, touch and gamepad steering with fixed-timestep loop

## Testing
- `yarn test __tests__/carRacer.test.ts`
- `yarn lint` *(fails: Couldn't find any `pages` or `app` directory. Please create one under the project root)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2cd8a0988328855167892819f37a