### PR TITLE
feat(memory): rewrite with pixijs

### DIFF
--- a/pages/apps/memory.tsx
+++ b/pages/apps/memory.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Memory = dynamic(() => import('../../apps/memory'), { ssr: false });
+
+export default function MemoryPage() {
+  return <Memory />;
+}
+


### PR DESCRIPTION
## Summary
- rebuild memory game with PixiJS canvas and Fisher-Yates shuffle
- add difficulty presets, turn/time counters, and optional assist to highlight mismatches
- load memory client component dynamically

## Testing
- `yarn test __tests__/memory.test.tsx`
- `yarn lint --file apps/memory/index.tsx --file pages/apps/memory.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ce0a2ac8328ae82ed1d5ce044a1