### PR TITLE
feat(reversi): add alpha-beta worker and dynamic import

### DIFF
--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dynamicImport from 'next/dynamic';
 
 export const dynamic = 'force-static';
 export const revalidate = 60;
@@ -8,8 +9,19 @@ interface GamePageProps {
   params: { slug: string };
 }
 
+const Reversi = dynamicImport(() => import('../../../apps/reversi'), {
+  ssr: false,
+});
+
 export default function GamePage({ params }: GamePageProps) {
   const { slug } = params;
+  if (slug === 'reversi') {
+    return (
+      <main>
+        <Reversi />
+      </main>
+    );
+  }
   return (
     <main>
       <h1>Game: {slug}</h1>

--- a/apps/reversi/index.tsx
+++ b/apps/reversi/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 import {
   initialBoard,


### PR DESCRIPTION
## Summary
- enhance Reversi engine with corner, stability, parity heuristics and ordered iterative deepening search
- expose Reversi as client component and dynamically load it on the game page

## Testing
- `yarn lint` *(fails: Parsing error in pages/api/request.ts)*
- `yarn test apps/reversi --passWithNoTests`
- `yarn test:unit apps/reversi --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ce601ac8328b7643e7c34b7f406