### PR TITLE
Add Base Encoders page with tests and Base36 support

### DIFF
--- a/__tests__/baseEncoders.test.ts
+++ b/__tests__/baseEncoders.test.ts
@@ -1,0 +1,96 @@
+import { base16, base32, base64, base64url } from 'rfc4648';
+import { bech32 } from 'bech32';
+import { TextEncoder, TextDecoder } from 'util';
+import { webcrypto } from 'crypto';
+
+(global as any).crypto = webcrypto;
+const {
+  encodeAscii85,
+  decodeAscii85,
+  encodeZ85,
+  decodeZ85,
+  encodeBase36,
+  decodeBase36,
+  decodeBase64Stream,
+} = require('@components/apps/base-encoders.worker');
+const { detectCodec } = require('@components/apps/base-encoders');
+const bs58 = require('bs58').default;
+
+describe('base algorithm roundtrips', () => {
+  const text = 'hello world';
+
+  it('base16', () => {
+    const encoded = base16.stringify(new TextEncoder().encode(text));
+    const decoded = new TextDecoder().decode(base16.parse(encoded));
+    expect(decoded).toBe(text);
+  });
+
+  it('base32', () => {
+    const encoded = base32.stringify(new TextEncoder().encode(text));
+    const decoded = new TextDecoder().decode(base32.parse(encoded));
+    expect(decoded).toBe(text);
+  });
+
+  it('base36', () => {
+    const encoded = encodeBase36(text);
+    const decoded = decodeBase36(encoded);
+    expect(decoded).toBe(text);
+  });
+
+  it('base64', () => {
+    const encoded = base64.stringify(new TextEncoder().encode(text));
+    const { result } = decodeBase64Stream(encoded, true);
+    expect(result).toBe(text);
+  });
+
+  it('base64url', () => {
+    const encoded = base64url.stringify(new TextEncoder().encode(text));
+    const decoded = new TextDecoder().decode(base64url.parse(encoded));
+    expect(decoded).toBe(text);
+  });
+
+  it('ascii85', () => {
+    const encoded = encodeAscii85(text);
+    const decoded = decodeAscii85(encoded);
+    expect(decoded).toBe(text);
+  });
+
+  it('z85', () => {
+    const encoded = encodeZ85(text);
+    const decoded = decodeZ85(encoded);
+    expect(decoded).toBe(text);
+  });
+
+  it('base58', () => {
+    const encoded = bs58.encode(new TextEncoder().encode(text));
+    const decoded = new TextDecoder().decode(bs58.decode(encoded));
+    expect(decoded).toBe(text);
+  });
+
+  it('bech32', () => {
+    const words = bech32.toWords(new TextEncoder().encode(text));
+    const encoded = bech32.encode('text', words);
+    const { words: decWords } = bech32.decode(encoded);
+    const decoded = new TextDecoder().decode(
+      Uint8Array.from(bech32.fromWords(decWords))
+    );
+    expect(decoded).toBe(text);
+  });
+});
+
+describe('codec detection', () => {
+  it('detects base64', () => {
+    expect(detectCodec('SGVsbG8=')).toBe('base64');
+  });
+});
+
+describe('base64 streaming decode', () => {
+  it('limits preview size', () => {
+    const size = 256 * 1024 + 10;
+    const bytes = new Uint8Array(size).fill(65); // 'A'
+    const encoded = base64.stringify(bytes);
+    const res = decodeBase64Stream(encoded, false);
+    expect(res.overLimit).toBe(true);
+    expect(res.result.length).toBe(256 * 1024);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -596,7 +596,7 @@ const apps = [
   {
     id: 'base-encoders',
     title: 'Base Encoders',
-    icon: icon('hash.svg'),
+    icon: icon('base-encoders.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/components/apps/base-encoders.tsx
+++ b/components/apps/base-encoders.tsx
@@ -10,6 +10,7 @@ const BASE64URL_ALPHABET =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const BASE16_ALPHABET = '0123456789abcdefABCDEF';
+const BASE36_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const BASE58_ALPHABET =
   '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 const ASCII85_ALPHABET = (() => {
@@ -23,6 +24,7 @@ type Mode = 'encode' | 'decode';
 type Codec =
   | 'base16'
   | 'base32'
+  | 'base36'
   | 'base64'
   | 'base64url'
   | 'ascii85'
@@ -151,6 +153,8 @@ function validate(codec: Codec, mode: Mode, data: string): ValidationError {
       return validateBase64url(data);
     case 'base32':
       return validateBase32(data);
+    case 'base36':
+      return validateAlphabet(data.toLowerCase(), BASE36_ALPHABET);
     case 'base16':
       return validateBase16(data);
     case 'base58check':
@@ -177,6 +181,7 @@ function detectCodec(data: string): Codec | null {
     return 'base58check';
   if (/^[^\s]+1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+$/.test(str)) return 'bech32';
   if (/^[0-9A-Fa-f]+$/.test(str) && str.length % 2 === 0) return 'base16';
+  if (/^[0-9A-Za-z]+$/.test(str)) return 'base36';
   return null;
 }
 
@@ -188,6 +193,12 @@ const docs: Record<
     alphabet: BASE16_ALPHABET,
     padding: 'none',
     tooltip: 'Hexadecimal encoding',
+    checksum: 'none',
+  },
+  base36: {
+    alphabet: BASE36_ALPHABET,
+    padding: 'none',
+    tooltip: 'Base36 encoding',
     checksum: 'none',
   },
   base32: {
@@ -237,6 +248,7 @@ const docs: Record<
 const codecOptions: { value: Codec; label: string }[] = [
   { value: 'base16', label: 'Base16' },
   { value: 'base32', label: 'Base32' },
+  { value: 'base36', label: 'Base36' },
   { value: 'base64', label: 'Base64 MIME' },
   { value: 'base64url', label: 'Base64 URL' },
   { value: 'base58check', label: 'Base58Check' },
@@ -533,3 +545,4 @@ const BaseEncoders = () => {
 
 export default BaseEncoders;
 export const displayBaseEncoders = () => <BaseEncoders />;
+export { detectCodec };

--- a/pages/apps/base-encoders.tsx
+++ b/pages/apps/base-encoders.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const BaseEncoders = dynamic(() => import('../../apps/base-encoders'), {
+  ssr: false,
+});
+
+export default function BaseEncodersPage() {
+  return <BaseEncoders />;
+}

--- a/public/themes/Yaru/apps/base-encoders.svg
+++ b/public/themes/Yaru/apps/base-encoders.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M22 16h4v32h-4zM38 16h4v32h-4zM16 24h32v4H16zM16 40h32v4H16z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated page and icon for Base Encoders
- extend base encoder utilities with Base36 support and node-friendly worker
- cover base algorithms and streaming parsing in unit tests

## Testing
- `yarn test __tests__/baseEncoders.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab3765e44883289d2609010c527154