### PR TITLE
feat: add favicon hash utility

### DIFF
--- a/__tests__/favicon-hash.test.ts
+++ b/__tests__/favicon-hash.test.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { murmurhash3_32_gc } from '@apps/favicon-hash';
+
+function hashFile(rel: string): string {
+  const file = fs.readFileSync(path.join(__dirname, '..', rel));
+  const base64 = file.toString('base64');
+  return murmurhash3_32_gc(base64);
+}
+
+describe('favicon hash', () => {
+  test('hashes hash.svg correctly', () => {
+    expect(
+      hashFile('public/themes/Yaru/apps/hash.svg')
+    ).toBe('1635832192');
+  });
+
+  test('hashes calc.png correctly', () => {
+    expect(
+      hashFile('public/themes/Yaru/apps/calc.png')
+    ).toBe('-1557554903');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -605,7 +605,7 @@ const apps = [
   {
     id: 'favicon-hash',
     title: 'Favicon Hash',
-    icon: './themes/Yaru/apps/hash.svg',
+    icon: icon('favicon-hash.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/components/apps/favicon-hash.tsx
+++ b/components/apps/favicon-hash.tsx
@@ -1,0 +1,1 @@
+export { default, displayFaviconHash, murmurhash3_32_gc } from '../../apps/favicon-hash';

--- a/public/themes/Yaru/apps/favicon-hash.svg
+++ b/public/themes/Yaru/apps/favicon-hash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M22 16h4v32h-4zM38 16h4v32h-4zM16 24h32v4H16zM16 40h32v4H16z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Favicon Hash app for computing mmh3 from URLs or uploads
- add icon and register app in configuration
- test known favicon hashes

## Testing
- `yarn test __tests__/favicon-hash.test.ts`
- `yarn lint apps/favicon-hash/index.tsx components/apps/favicon-hash.tsx __tests__/favicon-hash.test.ts apps.config.js pages/apps/favicon-hash.tsx` *(fails: Couldn't find any `pages` or `app` directory)*
- `yarn validate:icons`


------
https://chatgpt.com/codex/tasks/task_e_68ab37668b1c8328947e23ebef6486e7