### PR TITLE
feat: add CVE dashboard app

### DIFF
--- a/__tests__/cve-dashboard.test.tsx
+++ b/__tests__/cve-dashboard.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CveDashboard from '@components/apps/cve-dashboard';
+
+const fixture = require('./fixtures/cves.json');
+
+describe('CveDashboard', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => fixture,
+    });
+  });
+
+  it('renders CVE results from API', async () => {
+    const { getByPlaceholderText, getByText, findByText } = render(<CveDashboard />);
+    fireEvent.change(getByPlaceholderText('CVE-2024-1234'), {
+      target: { value: 'CVE-2024-0001' },
+    });
+    fireEvent.click(getByText('Search'));
+    expect(await findByText('CVE-2024-0001')).toBeInTheDocument();
+  });
+});

--- a/__tests__/fixtures/cves.json
+++ b/__tests__/fixtures/cves.json
@@ -1,0 +1,20 @@
+{
+  "totalResults": 1,
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2024-0001",
+        "descriptions": [{ "lang": "en", "value": "Example vulnerability" }],
+        "metrics": {
+          "cvssMetricV31": [
+            {"cvssData": {"vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8, "baseSeverity": "CRITICAL"}}
+          ],
+          "cvssMetricV40": [
+            {"cvssData": {"vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/S:U/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H", "baseScore": 10.0, "baseSeverity": "CRITICAL"}}
+          ]
+        },
+        "references": {"reference_data": [{"url": "https://example.com"}]}
+      }
+    }
+  ]
+}

--- a/apps.config.js
+++ b/apps.config.js
@@ -614,7 +614,7 @@ const apps = [
   {
     id: 'cve-dashboard',
     title: 'CVE Dashboard',
-    icon: './themes/Yaru/apps/calc.png',
+    icon: icon('hash.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/components/apps/cve-dashboard.tsx
+++ b/components/apps/cve-dashboard.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import Papa from 'papaparse';
+import { rateLimitedFetch } from '@lib/rateLimitedFetch';
+
+interface CvssMetric {
+  cvssData: { vectorString: string; baseScore: number; baseSeverity?: string };
+}
+
+interface Vulnerability {
+  cve: {
+    id: string;
+    descriptions?: { value: string }[];
+    metrics?: {
+      cvssMetricV31?: CvssMetric[];
+      cvssMetricV40?: CvssMetric[];
+    };
+    references?: { reference_data?: { url: string }[] };
+  };
+}
+
+const perPage = 20;
+
+export default function CveDashboard() {
+  const [cveId, setCveId] = useState('');
+  const [cpe, setCpe] = useState('');
+  const [vendor, setVendor] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [severity, setSeverity] = useState('');
+  const [page, setPage] = useState(0);
+  const [vulns, setVulns] = useState<Vulnerability[]>([]);
+  const [total, setTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildUrl = () => {
+    const url = new URL('https://services.nvd.nist.gov/rest/json/cves/2.0');
+    if (cveId) url.searchParams.set('cveId', cveId);
+    if (cpe) url.searchParams.set('cpeName', cpe);
+    if (vendor) url.searchParams.set('vendor', vendor);
+    if (startDate) url.searchParams.set('pubStartDate', `${startDate}T00:00:00.000`);
+    if (endDate) url.searchParams.set('pubEndDate', `${endDate}T00:00:00.000`);
+    if (severity) url.searchParams.set('cvssV3Severity', severity.toUpperCase());
+    url.searchParams.set('startIndex', String(page * perPage));
+    url.searchParams.set('resultsPerPage', String(perPage));
+    return url.toString();
+  };
+
+  const search = async () => {
+    try {
+      setError(null);
+      const data = await rateLimitedFetch(buildUrl());
+      setVulns(data.vulnerabilities || []);
+      setTotal(data.totalResults || 0);
+    } catch (e: any) {
+      setError(e.message || 'Request failed');
+      setVulns([]);
+      setTotal(0);
+    }
+  };
+
+  const exportCsv = () => {
+    const rows = vulns.map((v) => ({
+      id: v.cve.id,
+      description: v.cve.descriptions?.[0]?.value || '',
+    }));
+    const csv = Papa.unparse(rows);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'cves.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(vulns, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'cves.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-sm">
+      <div className="flex flex-wrap gap-2">
+        <input
+          value={cveId}
+          onChange={(e) => setCveId(e.target.value)}
+          placeholder="CVE-2024-1234"
+          className="border p-1"
+        />
+        <input
+          value={cpe}
+          onChange={(e) => setCpe(e.target.value)}
+          placeholder="cpe:2.3:a:vendor:product:*"
+          className="border p-1"
+        />
+        <input
+          value={vendor}
+          onChange={(e) => setVendor(e.target.value)}
+          placeholder="Vendor"
+          className="border p-1"
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="border p-1"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="border p-1"
+        />
+        <select
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+          className="border p-1"
+        >
+          <option value="">Severity</option>
+          <option value="LOW">Low</option>
+          <option value="MEDIUM">Medium</option>
+          <option value="HIGH">High</option>
+          <option value="CRITICAL">Critical</option>
+        </select>
+        <button onClick={() => { setPage(0); search(); }} className="border px-2">
+          Search
+        </button>
+        <button onClick={exportCsv} className="border px-2">CSV</button>
+        <button onClick={exportJson} className="border px-2">JSON</button>
+      </div>
+      {error && <div className="text-red-500">{error}</div>}
+      <table className="w-full text-xs border">
+        <thead>
+          <tr>
+            <th className="border px-1">CVE</th>
+            <th className="border px-1">Description</th>
+            <th className="border px-1" title="CVSS v3.1 vector and score">CVSS v3.1</th>
+            <th className="border px-1" title="CVSS v4.0 vector and score">CVSS v4.0</th>
+            <th className="border px-1" title="Exploit Prediction Scoring System">EPSS</th>
+            <th className="border px-1">Refs</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vulns.map((v) => {
+            const v31 = v.cve.metrics?.cvssMetricV31?.[0];
+            const v40 = v.cve.metrics?.cvssMetricV40?.[0];
+            return (
+              <tr key={v.cve.id} className="border-t">
+                <td className="border px-1">{v.cve.id}</td>
+                <td className="border px-1">
+                  {v.cve.descriptions?.[0]?.value || ''}
+                </td>
+                <td className="border px-1">
+                  {v31 ? (
+                    <span title={`Score: ${v31.cvssData.baseScore}`}>
+                      {v31.cvssData.vectorString}
+                    </span>
+                  ) : (
+                    ''
+                  )}
+                </td>
+                <td className="border px-1">
+                  {v40 ? (
+                    <span title={`Score: ${v40.cvssData.baseScore}`}>
+                      {v40.cvssData.vectorString}
+                    </span>
+                  ) : (
+                    ''
+                  )}
+                </td>
+                <td className="border px-1" title="EPSS score placeholder">--</td>
+                <td className="border px-1">
+                  {v.cve.references?.reference_data?.map((r, i) => (
+                    <a
+                      key={i}
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline mr-1"
+                    >
+                      [{i + 1}]
+                    </a>
+                  ))}
+                </td>
+              </tr>
+            );
+          })}
+          {vulns.length === 0 && (
+            <tr>
+              <td colSpan={6} className="text-center p-2">
+                No results
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="flex gap-2">
+        <button
+          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          disabled={page === 0}
+          className="border px-2"
+        >
+          Prev
+        </button>
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          disabled={(page + 1) * perPage >= total}
+          className="border px-2"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const displayCveDashboard = () => <CveDashboard />;

--- a/components/apps/index.ts
+++ b/components/apps/index.ts
@@ -1,1 +1,2 @@
 export { displayCaaChecker } from './caa-checker';
+export { displayCveDashboard } from './cve-dashboard';

--- a/lib/rateLimitedFetch.ts
+++ b/lib/rateLimitedFetch.ts
@@ -1,0 +1,48 @@
+let lastReq = 0;
+
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export async function rateLimitedFetch(
+  url: string,
+  options: { ttl?: number; retries?: number } = {}
+): Promise<any> {
+  const { ttl = 60_000, retries = 2 } = options;
+  const key = `rlf:${url}`;
+  const now = Date.now();
+  if (typeof window !== 'undefined') {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      try {
+        const entry = JSON.parse(raw);
+        if (now - entry.ts < ttl) {
+          return entry.data;
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  const wait = 1100 - (now - lastReq);
+  if (wait > 0) await sleep(wait);
+
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = await res.json();
+      if (typeof window !== 'undefined') {
+        try {
+          localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data }));
+        } catch {
+          // ignore
+        }
+      }
+      lastReq = Date.now();
+      return data;
+    } catch (e) {
+      if (i === retries) throw e;
+      await sleep(500 * (i + 1));
+    }
+  }
+}

--- a/pages/apps/cve-dashboard.tsx
+++ b/pages/apps/cve-dashboard.tsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const CveDashboard = dynamic(() => import('../../apps/cve-dashboard'), { ssr: false });
+const CveDashboard = dynamic(() => import('../../components/apps/cve-dashboard'), {
+  ssr: false,
+});
 
 export default function CveDashboardPage() {
   return <CveDashboard />;
 }
-


### PR DESCRIPTION
## Summary
- add CVE Dashboard app with CVE, CPE, vendor, date, and severity search
- implement rate-limited fetch with local caching
- wire page, metadata, and tests

## Testing
- `yarn test __tests__/cve-dashboard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab3766eb048328aacb28929dbe377a