### PR TITLE
feat: enhance YARA tester

### DIFF
--- a/__tests__/fixtures/yara/rule.yar
+++ b/__tests__/fixtures/yara/rule.yar
@@ -1,0 +1,9 @@
+rule SampleRule {
+  meta:
+    description = "Detects sample string"
+  strings:
+    $a = "MALWARE"
+    $b = { 31 32 33 }
+  condition:
+    $a and $b
+}

--- a/__tests__/fixtures/yara/sample.txt
+++ b/__tests__/fixtures/yara/sample.txt
@@ -1,0 +1,1 @@
+This sample MALWARE file contains digits 123 and should trigger.

--- a/__tests__/yara-api.test.ts
+++ b/__tests__/yara-api.test.ts
@@ -1,0 +1,19 @@
+import handler from '../pages/api/yara-scan';
+
+const rule = `rule T {
+  strings:
+    $a = "MALWARE"
+  condition:
+    $a
+}`;
+
+test('api route scans samples', async () => {
+  const req: any = { method: 'POST', body: { input: 'MALWARE', rules: { 'test.yar': rule } } };
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const res: any = { status };
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(200);
+  const body = json.mock.calls[0][0];
+  expect(body.matches.length).toBe(1);
+});

--- a/__tests__/yara-fixtures.test.ts
+++ b/__tests__/yara-fixtures.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import yaraFactory from 'libyara-wasm';
+
+test('fixture rule detects sample and exposes meta and strings', async () => {
+  const yara = await (yaraFactory.default ? yaraFactory.default() : (yaraFactory as any)());
+  const rule = fs.readFileSync(path.join(__dirname, 'fixtures/yara/rule.yar'), 'utf8');
+  const sample = fs.readFileSync(path.join(__dirname, 'fixtures/yara/sample.txt'), 'utf8');
+  const res = yara.run(sample, rule);
+  const matches = res.matchedRules;
+  expect(matches.size()).toBe(1);
+  const m = matches.get(0);
+  expect(m.ruleName).toBe('SampleRule');
+  const meta = (m as any).metadata;
+  expect(meta.get(0).identifier).toBe('description');
+  expect(meta.get(0).data).toBe('Detects sample string');
+  const rm = m.resolvedMatches;
+  expect(rm.size()).toBe(2);
+  const ids = [rm.get(0).stringIdentifier, rm.get(1).stringIdentifier];
+  expect(ids.sort()).toEqual(['$a', '$b']);
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -641,7 +641,7 @@ const apps = [
   {
     id: 'yara-tester',
     title: 'YARA Tester',
-    icon: './themes/Yaru/apps/bash.png',
+    icon: './themes/Yaru/apps/yara.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/pages/api/yara-scan.ts
+++ b/pages/api/yara-scan.ts
@@ -1,0 +1,116 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import yaraFactory from 'libyara-wasm';
+
+interface MatchDetail {
+  rule: string;
+  tags?: string[];
+  meta?: Record<string, string>;
+  matches: { identifier: string; data: string; offset: number; length: number }[];
+}
+
+interface CompileError {
+  message: string;
+  line?: number;
+  column?: number;
+  warning?: boolean;
+}
+
+let yara: any;
+
+async function getYara() {
+  if (!yara) {
+    const mod = await ((yaraFactory as any).default?.() ?? (yaraFactory as any)());
+    yara = mod;
+  }
+  return yara;
+}
+
+const resolveIncludes = (files: Record<string, string>): { code: string; missing: string[] } => {
+  const cache: Record<string, string> = {};
+  const missing: string[] = [];
+  const resolve = (name: string, stack: string[] = []): string => {
+    if (cache[name]) return cache[name];
+    const src = files[name];
+    if (src === undefined) {
+      missing.push(name);
+      return '';
+    }
+    if (stack.includes(name)) return '';
+    const out = src.replace(/include\s+"([^"]+)"/g, (_m, inc) => resolve(inc, [...stack, name]));
+    cache[name] = out;
+    return out;
+  };
+  const code = Object.keys(files)
+    .map((k) => resolve(k))
+    .join('\n');
+  return { code, missing };
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const { input = '', rules = {} } = req.body || {};
+  if (typeof input !== 'string' || typeof rules !== 'object') {
+    res.status(400).json({ error: 'Invalid payload' });
+    return;
+  }
+  if (input.length > 1024 * 1024) {
+    res.status(400).json({ error: 'Sample too large' });
+    return;
+  }
+  const totalRuleSize = Object.values(rules).reduce((n: number, r: any) => n + (typeof r === 'string' ? r.length : 0), 0);
+  if (totalRuleSize > 1024 * 1024) {
+    res.status(400).json({ error: 'Rules too large' });
+    return;
+  }
+  const yaraMod = await getYara();
+  const { code, missing } = resolveIncludes(rules as Record<string, string>);
+  const result = yaraMod.run(input, code);
+  const ruleVec = result.matchedRules;
+  const found: MatchDetail[] = [];
+  for (let i = 0; i < ruleVec.size(); i += 1) {
+    const r = ruleVec.get(i);
+    const det: MatchDetail['matches'] = [];
+    const rm = r.resolvedMatches;
+    for (let j = 0; j < rm.size(); j += 1) {
+      const m = rm.get(j);
+      det.push({
+        identifier: m.stringIdentifier,
+        data: m.data,
+        offset: m.location,
+        length: m.matchLength,
+      });
+    }
+    const meta: Record<string, string> = {};
+    const metas = (r as any).metas || (r as any).metadata;
+    if (metas) {
+      for (let k = 0; k < metas.size(); k += 1) {
+        const m = metas.get(k);
+        const id = (m as any).id ?? (m as any).identifier;
+        const val = (m as any).value ?? (m as any).data;
+        meta[id] = val;
+      }
+    }
+    const tags: string[] = [];
+    const tagVec = r.ruleTags;
+    if (tagVec) {
+      for (let k = 0; k < tagVec.size(); k += 1) tags.push(tagVec.get(k));
+    }
+    found.push({ rule: r.ruleName, matches: det, meta, tags });
+  }
+  const errVec = result.compileErrors;
+  const errArr: CompileError[] = [];
+  for (let i = 0; i < errVec.size(); i += 1) {
+    const e = errVec.get(i);
+    errArr.push({
+      message: e.message,
+      line: e.lineNumber,
+      column: (e as any).columnNumber,
+      warning: e.warning,
+    });
+  }
+  missing.forEach((m) => errArr.push({ message: `missing include: ${m}` }));
+  res.status(200).json({ matches: found, compileErrors: errArr });
+}

--- a/pages/apps/yara-tester.tsx
+++ b/pages/apps/yara-tester.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import dynamic from 'next/dynamic';
+
+const YaraTester = dynamic(() => import('../../apps/yara-tester'), { ssr: false });
+
+export default function YaraTesterPage() {
+  return (
+    <>
+      <Head>
+        <title>YARA Tester</title>
+        <meta name="description" content="Test YARA rules against sample data" />
+      </Head>
+      <YaraTester />
+    </>
+  );
+}

--- a/public/themes/Yaru/apps/yara.svg
+++ b/public/themes/Yaru/apps/yara.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#2d2d2d"/>
+  <text x="32" y="40" font-size="32" text-anchor="middle" fill="#f9c74f" font-family="Arial, Helvetica, sans-serif">Y</text>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated YARA tester page and icon
- persist rules, add copy/export, and show lint line/column info
- provide server scan route with file-size guards and match metadata

## Testing
- `yarn lint`
- `yarn validate:icons`
- `yarn test __tests__/yara-*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab3767dc0c83289b7c6cf97ab4bbb6