### PR TITLE
feat: add git-secrets scan panel

### DIFF
--- a/__tests__/gitSecretsTester.api.test.ts
+++ b/__tests__/gitSecretsTester.api.test.ts
@@ -1,0 +1,34 @@
+import JSZip from 'jszip';
+import { describe, test, expect } from 'vitest';
+
+function mockReqRes(method: string, body: any) {
+  const req: any = { method, body };
+  const res: any = { statusCode: 200 };
+  res.status = (c: number) => { res.statusCode = c; return res; };
+  res.json = (d: any) => { res.data = d; return res; };
+  res.end = () => res;
+  return { req, res };
+}
+
+describe('git-secrets api', () => {
+  test('detects secrets in patch', async () => {
+    const patch = 'AKIA1234567890ABCDE1';
+    const { req, res } = mockReqRes('POST', { patch });
+    const handler = (await import('../pages/api/git-secrets-tester')).default;
+    await handler(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.results.some((r: any) => r.pattern.includes('AWS'))).toBe(true);
+  });
+
+  test('detects secrets in archive', async () => {
+    const zip = new JSZip();
+    zip.file('test.txt', 'xoxb-1234567890ABCDEF');
+    const archive = await zip.generateAsync({ type: 'base64' });
+    const { req, res } = mockReqRes('POST', { archive });
+    const handler = (await import('../pages/api/git-secrets-tester')).default;
+    await handler(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.results.some((r: any) => r.pattern.includes('Slack'))).toBe(true);
+  });
+});
+

--- a/components/apps/git-secrets-tester.worker.ts
+++ b/components/apps/git-secrets-tester.worker.ts
@@ -5,6 +5,7 @@ interface Pattern {
   regex: string;
   severity: string;
   remediation: string;
+  whitelist: string;
   tool: string;
 }
 
@@ -17,6 +18,7 @@ interface WorkerResult {
   match: string;
   severity: string;
   remediation: string;
+  whitelist: string;
 }
 
 const gitleaksPatterns: Omit<Pattern, 'tool'>[] = [
@@ -25,12 +27,14 @@ const gitleaksPatterns: Omit<Pattern, 'tool'>[] = [
     regex: 'AKIA[0-9A-Z]{16}',
     severity: 'high',
     remediation: 'Rotate the key and remove from history.',
+    whitelist: 'git secrets --add "AKIA[0-9A-Z]{16}"',
   },
   {
     name: 'Generic API Key',
     regex: '[A-Za-z0-9-_]{32,45}',
     severity: 'medium',
     remediation: 'Rotate the key and remove from the repository.',
+    whitelist: 'git secrets --add "[A-Za-z0-9-_]{32,45}"',
   },
 ];
 
@@ -40,12 +44,14 @@ const trufflehogPatterns: Omit<Pattern, 'tool'>[] = [
     regex: 'xox[baprs]-[0-9a-zA-Z]{10,48}',
     severity: 'high',
     remediation: 'Revoke the token and generate a new one.',
+    whitelist: 'git secrets --add "xox[baprs]-[0-9a-zA-Z]{10,48}"',
   },
   {
     name: 'RSA Private Key',
     regex: '-----BEGIN(?: RSA)? PRIVATE KEY-----',
     severity: 'critical',
     remediation: 'Remove private keys and generate new ones.',
+    whitelist: 'git secrets --add "-----BEGIN(?: RSA)? PRIVATE KEY-----"',
   },
 ];
 
@@ -87,6 +93,7 @@ self.onmessage = async (e: MessageEvent<ScanMessage>) => {
             severity: pat.severity,
             confidence: 'high',
             remediation: pat.remediation,
+            whitelist: pat.whitelist,
           });
         }
       });

--- a/pages/api/git-secrets-tester.ts
+++ b/pages/api/git-secrets-tester.ts
@@ -1,16 +1,75 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import JSZip from 'jszip';
+import { spawn, spawnSync } from 'child_process';
+import { defaultPatterns, redactSecret } from '../../components/apps/git-secrets-tester';
 
-const { GITLEAKS_URL, TRUFFLEHOG_URL } = process.env;
+interface ApiResult {
+  file: string;
+  pattern: string;
+  match: string;
+  index: number;
+  line: number;
+  severity: string;
+  confidence: string;
+  remediation: string;
+  whitelist: string;
+}
 
-async function callTool(url: string | undefined, patch: string) {
-  if (!url) return [];
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ patch }),
+function scanFile(name: string, content: string): ApiResult[] {
+  const res: ApiResult[] = [];
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    defaultPatterns.forEach((p) => {
+      try {
+        const re = new RegExp(p.regex, 'g');
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(line)) !== null) {
+          res.push({
+            file: name,
+            pattern: p.name,
+            match: redactSecret(m[0]),
+            index: m.index,
+            line: idx + 1,
+            severity: p.severity,
+            confidence: 'high',
+            remediation: p.remediation,
+            whitelist: p.whitelist,
+          });
+        }
+      } catch {
+        // ignore bad regex
+      }
+    });
   });
-  if (!res.ok) throw new Error(`Server responded ${res.status}`);
-  return res.json();
+  return res;
+}
+
+async function runGitSecrets(input: string, logs: string[]): Promise<void> {
+  try {
+    spawnSync('git', ['secrets', '--register-aws']);
+    await new Promise<void>((resolve) => {
+      const proc = spawn('git', ['secrets', '--scan', '-']);
+      let out = '';
+      proc.stdout.on('data', (d) => {
+        out += d.toString();
+      });
+      proc.stderr.on('data', (d) => {
+        out += d.toString();
+      });
+      proc.on('close', () => {
+        if (out.trim()) logs.push(out.trim());
+        resolve();
+      });
+      proc.on('error', (e) => {
+        logs.push(`git secrets failed: ${e.message}`);
+        resolve();
+      });
+      proc.stdin.write(input);
+      proc.stdin.end();
+    });
+  } catch (e: any) {
+    logs.push(`git secrets error: ${e.message}`);
+  }
 }
 
 export default async function handler(
@@ -22,20 +81,41 @@ export default async function handler(
     return;
   }
 
-  const { patch } = req.body as { patch?: string };
-  if (!patch) {
-    res.status(400).json({ error: 'Missing patch' });
+  const { patch, archive } = req.body as {
+    patch?: string;
+    archive?: string;
+  };
+  if (!patch && !archive) {
+    res.status(400).json({ error: 'Missing patch or archive' });
     return;
   }
 
-  try {
-    const [gitleaks, trufflehog] = await Promise.all([
-      callTool(GITLEAKS_URL, patch).catch((e) => ({ error: e.message })),
-      callTool(TRUFFLEHOG_URL, patch).catch((e) => ({ error: e.message })),
-    ]);
-    res.status(200).json({ gitleaks, trufflehog });
-  } catch (e: any) {
-    res.status(500).json({ error: e.message || 'Error' });
+  const logs: string[] = [];
+  let combined = '';
+  let results: ApiResult[] = [];
+
+  if (archive) {
+    try {
+      const zip = await JSZip.loadAsync(Buffer.from(archive, 'base64'));
+      const entries = Object.values(zip.files);
+      for (const entry of entries) {
+        if (entry.dir) continue;
+        const txt = await entry.async('string');
+        results = results.concat(scanFile(entry.name, txt));
+        combined += `${txt}\n`;
+      }
+    } catch (e: any) {
+      logs.push(`archive error: ${e.message}`);
+    }
   }
+
+  if (patch) {
+    results = results.concat(scanFile('input', patch));
+    combined += patch;
+  }
+
+  await runGitSecrets(combined, logs);
+
+  res.status(200).json({ results, logs });
 }
 

--- a/pages/apps/git-secrets-tester.tsx
+++ b/pages/apps/git-secrets-tester.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const GitSecretsTester = dynamic(() => import('../../apps/git-secrets-tester'), { ssr: false });
+
+export default function GitSecretsTesterPage() {
+  return <GitSecretsTester />;
+}
+


### PR DESCRIPTION
## Summary
- build git-secrets tester page with worker-based archive scan, server-side git-secrets route, and log download
- enrich secret patterns with whitelist suggestions and expose copyable remediation actions
- cover git-secrets API with unit tests for diff and zip archives

## Testing
- `yarn test:unit __tests__/gitSecretsTester.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab376a49e883288a8eae09c459aeaa