### PR TITLE
feat: add cookie visualizer app

### DIFF
--- a/__tests__/cookie-visualizer.test.ts
+++ b/__tests__/cookie-visualizer.test.ts
@@ -1,0 +1,19 @@
+import { parseSetCookies } from '../lib/cookie-visualizer';
+
+describe('cookie visualizer parser', () => {
+  it('identifies secure attributes and ratings', () => {
+    const cookies = parseSetCookies([
+      'session=abc; Secure; HttpOnly; SameSite=Strict; Path=/; Expires=Wed, 09 Jun 2099 10:18:14 GMT',
+    ]);
+    expect(cookies[0].secure).toBe(true);
+    expect(cookies[0].httpOnly).toBe(true);
+    expect(cookies[0].sameSite).toBe('Strict');
+    expect(cookies[0].rating).toBe('A');
+  });
+
+  it('flags missing attributes', () => {
+    const cookies = parseSetCookies(['id=1']);
+    expect(cookies[0].issues.length).toBeGreaterThan(0);
+    expect(cookies[0].rating).toBe('F');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -192,6 +192,7 @@ const dynamicAppEntries = [
   ['hsts-preload', 'HSTS Preload'],
   ['cookie-jar', 'Cookie Jar'],
   ['cookie-simulator', 'Cookie Simulator'],
+  ['cookie-visualizer', 'Cookie Visualizer'],
   ['mixed-content', 'Mixed Content'],
   ['tls-explainer', 'TLS Explainer'],
   ['cache-policy', 'Cache Policy'],
@@ -700,6 +701,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: getScreen('cookie-simulator'),
+  },
+  {
+    id: 'cookie-visualizer',
+    title: 'Cookie Visualizer',
+    icon: './themes/Yaru/apps/cookie-jar.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: getScreen('cookie-visualizer'),
   },
   {
     id: 'content-fingerprint',

--- a/apps/cookie-visualizer/index.tsx
+++ b/apps/cookie-visualizer/index.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { CookieInfo, parseSetCookies, buildRecipe } from '../../lib/cookie-visualizer';
+
+const ratingClass = (rating: string) => {
+  switch (rating) {
+    case 'A':
+      return 'bg-green-600';
+    case 'B':
+      return 'bg-green-500';
+    case 'C':
+      return 'bg-yellow-500';
+    case 'D':
+      return 'bg-orange-500';
+    default:
+      return 'bg-red-600';
+  }
+};
+
+function expiryProgress(c: CookieInfo): number {
+  if (c.expired) return 0;
+  if (c.maxAge && c.expires) {
+    const ageMs = parseInt(c.maxAge, 10) * 1000;
+    const remaining = new Date(c.expires).getTime() - Date.now();
+    return Math.max(0, Math.min(100, (remaining / ageMs) * 100));
+  }
+  if (c.expires) {
+    const remaining = new Date(c.expires).getTime() - Date.now();
+    const oneYear = 365 * 24 * 60 * 60 * 1000;
+    return Math.max(0, Math.min(100, (remaining / oneYear) * 100));
+  }
+  return 100;
+}
+
+const CookieVisualizer: React.FC = () => {
+  const [url, setUrl] = useState('https://example.com');
+  const [cookies, setCookies] = useState<CookieInfo[]>([]);
+  const [filter, setFilter] = useState('all');
+
+  const fetchCookies = async () => {
+    try {
+      const res = await fetch('/api/cookie-visualizer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      const data = await res.json();
+      if (Array.isArray(data.cookies)) {
+        setCookies(parseSetCookies(data.cookies));
+      } else {
+        setCookies([]);
+      }
+    } catch {
+      setCookies([]);
+    }
+  };
+
+  const exportReport = () => {
+    const blob = new Blob([JSON.stringify(cookies, null, 2)], { type: 'application/json' });
+    const urlObj = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = urlObj;
+    a.download = 'cookie-visualizer-report.json';
+    a.click();
+    URL.revokeObjectURL(urlObj);
+  };
+
+  const filtered = cookies.filter((c) => filter === 'all' || c.rating === filter);
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4">
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 text-black p-1"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+        />
+        <button type="button" onClick={fetchCookies} className="px-4 py-1 bg-blue-600 rounded">
+          Fetch
+        </button>
+        {cookies.length > 0 && (
+          <button type="button" onClick={exportReport} className="px-4 py-1 bg-green-600 rounded">
+            Export
+          </button>
+        )}
+      </div>
+      {cookies.length > 0 && (
+        <>
+          <div>
+            <label className="mr-2">Filter:</label>
+            <select className="text-black p-1" value={filter} onChange={(e) => setFilter(e.target.value)}>
+              <option value="all">All</option>
+              <option value="A">A</option>
+              <option value="B">B</option>
+              <option value="C">C</option>
+              <option value="D">D</option>
+              <option value="F">F</option>
+            </select>
+          </div>
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1">Rating</th>
+                  <th className="px-2 py-1 text-left">Cookie</th>
+                  <th className="px-2 py-1">Domain</th>
+                  <th className="px-2 py-1">Path</th>
+                  <th className="px-2 py-1">Secure</th>
+                  <th className="px-2 py-1">HttpOnly</th>
+                  <th className="px-2 py-1">SameSite</th>
+                  <th className="px-2 py-1">Expires</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((c) => (
+                  <tr key={c.name} className="odd:bg-gray-800">
+                    <td className="px-2 py-1 text-center">
+                      <span className={`px-2 py-0.5 rounded text-black ${ratingClass(c.rating)}`}>{c.rating}</span>
+                    </td>
+                    <td className="px-2 py-1 text-left break-all">{c.name}</td>
+                    <td className="px-2 py-1 break-all">{c.domain || 'Host-only'}</td>
+                    <td className="px-2 py-1 break-all">{c.path || 'Default'}</td>
+                    <td className={`px-2 py-1 ${c.secure ? 'text-green-500' : 'text-red-500'}`}>{c.secure ? 'Yes' : 'No'}</td>
+                    <td className={`px-2 py-1 ${c.httpOnly ? 'text-green-500' : 'text-red-500'}`}>{c.httpOnly ? 'Yes' : 'No'}</td>
+                    <td className={`px-2 py-1 ${c.sameSite && c.sameSite.toLowerCase() !== 'none' ? 'text-green-500' : 'text-red-500'}`}>{c.sameSite || 'Missing'}</td>
+                    <td className={`px-2 py-1 ${c.expires ? (c.expired ? 'text-red-500' : 'text-green-500') : 'text-yellow-500'}`}>{c.expires || 'Session'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 space-y-2">
+              {filtered.map((c) => (
+                <div key={c.name}>
+                  <div className="font-bold flex items-center space-x-2">
+                    <span>{c.name}</span>
+                    <span className={`px-2 py-0.5 rounded text-black ${ratingClass(c.rating)}`}>{c.rating}</span>
+                  </div>
+                  <div className="text-xs">Scope: {(c.domain || 'host-only') + (c.path || '/')}</div>
+                  <div className="flex items-center space-x-2 mt-1">
+                    <div className="flex-1 bg-gray-700 h-2">
+                      <div className="bg-green-500 h-2" style={{ width: `${expiryProgress(c)}%` }} />
+                    </div>
+                    <div className="text-xs">{c.expires || 'Session'}</div>
+                  </div>
+                  {c.issues.length > 0 ? (
+                    <ul className="list-disc list-inside text-sm">
+                      {c.issues.map((issue) => (
+                        <li key={issue}>{issue}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-green-500 text-sm">No issues detected.</div>
+                  )}
+                  <code className="block text-xs mt-1 break-all">{buildRecipe(c)}</code>
+                  <button
+                    type="button"
+                    onClick={() => navigator.clipboard.writeText(buildRecipe(c))}
+                    className="mt-1 px-2 py-1 bg-blue-600 rounded"
+                  >
+                    Copy recipe
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CookieVisualizer;

--- a/components/apps/cookie-visualizer.tsx
+++ b/components/apps/cookie-visualizer.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../apps/cookie-visualizer';

--- a/lib/cookie-visualizer.ts
+++ b/lib/cookie-visualizer.ts
@@ -1,0 +1,147 @@
+export interface CookieInfo {
+  name: string;
+  value: string;
+  domain: string | null;
+  path: string | null;
+  secure: boolean;
+  httpOnly: boolean;
+  sameSite: string | null;
+  expires: string | null;
+  maxAge: string | null;
+  expired: boolean;
+  partitioned: boolean;
+  issues: string[];
+  rating: string;
+}
+
+function normalizeSameSite(v: string | null): string | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  if (lower === 'lax') return 'Lax';
+  if (lower === 'strict') return 'Strict';
+  if (lower === 'none') return 'None';
+  return null;
+}
+
+function rateCookie(c: Omit<CookieInfo, 'rating'>): string {
+  let score = 0;
+  if (c.secure) score += 1;
+  if (c.httpOnly) score += 1;
+  if (c.sameSite && c.sameSite.toLowerCase() !== 'none') score += 1;
+  if (c.expires && !c.expired) score += 1;
+  if (c.path === '/') score += 1;
+  if (score === 5) return 'A';
+  if (score === 4) return 'B';
+  if (score === 3) return 'C';
+  if (score === 2) return 'D';
+  return 'F';
+}
+
+export function parseSetCookies(headers: string[]): CookieInfo[] {
+  const results: CookieInfo[] = [];
+  headers.forEach((cookieStr) => {
+    const parts = cookieStr.split(';').map((p) => p.trim());
+    if (parts.length === 0) return;
+    const [nameValue, ...attrs] = parts;
+    const eqIndex = nameValue.indexOf('=');
+    const name = eqIndex >= 0 ? nameValue.slice(0, eqIndex) : nameValue;
+    const value = eqIndex >= 0 ? nameValue.slice(eqIndex + 1) : '';
+
+    const attrsLower = attrs.map((a) => a.toLowerCase());
+    const secure = attrsLower.includes('secure');
+    const httpOnly = attrsLower.includes('httponly');
+    const partitioned = attrsLower.includes('partitioned');
+    const sameSiteAttr = attrs.find((a) => /^samesite=/i.test(a));
+    const sameSite = normalizeSameSite(sameSiteAttr ? sameSiteAttr.split('=')[1] : null);
+    const domainAttr = attrs.find((a) => /^domain=/i.test(a));
+    const domain = domainAttr ? domainAttr.split('=')[1] : null;
+    const pathAttr = attrs.find((a) => /^path=/i.test(a));
+    const path = pathAttr ? pathAttr.split('=')[1] : null;
+    const expiresAttr = attrs.find((a) => /^expires=/i.test(a));
+    const maxAgeAttr = attrs.find((a) => /^max-age=/i.test(a));
+    const maxAge = maxAgeAttr ? maxAgeAttr.split('=')[1] : null;
+
+    let expires: string | null = null;
+    let expired = false;
+    if (expiresAttr) {
+      const dateStr = expiresAttr.split('=')[1];
+      expires = dateStr;
+      const date = new Date(dateStr);
+      if (!Number.isNaN(date.getTime())) {
+        expired = date.getTime() <= Date.now();
+      }
+    } else if (maxAge) {
+      const age = parseInt(maxAge, 10);
+      const date = new Date(Date.now() + age * 1000);
+      expires = date.toUTCString();
+      expired = age <= 0;
+    }
+
+    const issues: string[] = [];
+    if (!secure) issues.push('Add Secure attribute to transmit cookie only over HTTPS.');
+    if (!httpOnly) issues.push('Add HttpOnly to prevent access via JavaScript.');
+    if (!sameSite) {
+      issues.push('Add SameSite=Lax or Strict to mitigate CSRF.');
+    } else if (sameSite.toLowerCase() === 'none') {
+      issues.push('Avoid SameSite=None unless necessary.');
+    }
+    if (!expiresAttr && !maxAgeAttr) {
+      issues.push('No expiry set; cookie will be a session cookie.');
+    } else if (expired) {
+      issues.push('Cookie is already expired.');
+    }
+    if (sameSite && sameSite.toLowerCase() === 'none' && !secure) {
+      issues.push('SameSite=None requires the Secure attribute.');
+    }
+    if (expiresAttr && maxAgeAttr) {
+      issues.push('Avoid using both Expires and Max-Age.');
+    }
+    if (!path) {
+      issues.push('No Path attribute; cookie defaults to request path.');
+    }
+    if (domain && domain.startsWith('.')) {
+      issues.push('Domain with leading dot is deprecated.');
+    }
+    if (partitioned) {
+      if (!secure) issues.push('Partitioned cookies require the Secure attribute.');
+      if (!sameSite || sameSite.toLowerCase() !== 'none') {
+        issues.push('Partitioned cookies require SameSite=None.');
+      }
+      if (path !== '/') {
+        issues.push('Partitioned cookies require Path=/');
+      }
+    }
+
+    const base: Omit<CookieInfo, 'rating'> = {
+      name,
+      value,
+      domain,
+      path,
+      secure,
+      httpOnly,
+      sameSite,
+      expires,
+      maxAge,
+      expired,
+      partitioned,
+      issues,
+    };
+
+    const rating = rateCookie(base);
+    results.push({ ...base, rating });
+  });
+  return results;
+}
+
+export function buildRecipe(c: CookieInfo): string {
+  const attrs = [] as string[];
+  if (c.domain) attrs.push(`Domain=${c.domain}`);
+  if (c.path) attrs.push(`Path=${c.path}`);
+  if (c.secure) attrs.push('Secure');
+  if (c.httpOnly) attrs.push('HttpOnly');
+  if (c.sameSite) attrs.push(`SameSite=${c.sameSite}`);
+  if (c.expires) attrs.push(`Expires=${c.expires}`);
+  if (c.maxAge) attrs.push(`Max-Age=${c.maxAge}`);
+  if (c.partitioned) attrs.push('Partitioned');
+  return `${c.name}=${c.value}; ${attrs.join('; ')}`;
+}

--- a/pages/api/cookie-visualizer.ts
+++ b/pages/api/cookie-visualizer.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Agent } from 'undici';
+import { setupUrlGuard } from '../../lib/urlGuard';
+setupUrlGuard();
+
+const agents: Record<string, Agent> = {
+  'http:': new Agent({ keepAliveTimeout: 10_000 }),
+  'https:': new Agent({ keepAliveTimeout: 10_000 }),
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ cookies: [] });
+  }
+
+  const { url } = req.body || {};
+  if (typeof url !== 'string' || !url) {
+    return res.status(400).json({ cookies: [] });
+  }
+
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch {
+    return res.status(400).json({ cookies: [] });
+  }
+
+  try {
+    const urlObj = new URL(url);
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'manual',
+      // @ts-ignore - dispatcher is undici-specific
+      dispatcher: agents[urlObj.protocol],
+    } as any);
+    const cookies = response.headers.getSetCookie ? response.headers.getSetCookie() : [];
+    return res.status(200).json({ cookies });
+  } catch {
+    return res.status(500).json({ cookies: [] });
+  }
+}

--- a/pages/apps/cookie-visualizer.tsx
+++ b/pages/apps/cookie-visualizer.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const CookieVisualizer = dynamic(() => import('../../apps/cookie-visualizer'), { ssr: false });
+
+export default function CookieVisualizerPage() {
+  return <CookieVisualizer />;
+}


### PR DESCRIPTION
## Summary
- add domain cookie visualizer app with rating badges, filtering, copy/export
- parse Set-Cookie headers with security checks and guidance
- expose API endpoint and tests using mock cookies

## Testing
- `yarn test __tests__/cookie-visualizer.test.ts __tests__/iconAssets.test.ts`
- `yarn lint apps/cookie-visualizer/index.tsx lib/cookie-visualizer.ts pages/api/cookie-visualizer.ts components/apps/cookie-visualizer.tsx pages/apps/cookie-visualizer.tsx apps.config.js` *(fails: > Couldn't find any `pages` or `app` directory)*
- `npx eslint apps/cookie-visualizer/index.tsx lib/cookie-visualizer.ts pages/api/cookie-visualizer.ts components/apps/cookie-visualizer.tsx pages/apps/cookie-visualizer.tsx apps.config.js` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab376b2db08328ba031ea7c506edb3