### PR TITLE
Enhance mail authentication tooling with SPF and DMARC templates

### DIFF
--- a/__tests__/mail-auth.api.test.ts
+++ b/__tests__/mail-auth.api.test.ts
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Response } from 'undici';
+
+function createRes() {
+  return {
+    statusCode: 0,
+    data: null as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(d: any) {
+      this.data = d;
+      return this;
+    },
+  } as unknown as NextApiResponse;
+}
+
+describe('mail-auth api', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+  test('returns records for SPF, DKIM and DMARC', async () => {
+    const { default: handler } = await import('../pages/api/mail-auth');
+    (global as any).fetch = jest.fn((url: string) => {
+      const name = new URL(url).searchParams.get('name');
+      let answer: any[] = [];
+      if (name === 'example.com') {
+        answer = [{ data: '"v=spf1 -all"' }];
+      } else if (name === '_dmarc.example.com') {
+        answer = [{ data: '"v=DMARC1; p=reject"' }];
+      } else if (name === 'default._domainkey.example.com') {
+        const key = 'A'.repeat(172);
+        answer = [{ data: `"v=DKIM1; p=${key}"` }];
+      } else {
+        answer = [];
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ Answer: answer }), { status: 200 })
+      );
+    });
+    const req = { query: { domain: 'example.com' } } as unknown as NextApiRequest;
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.spf.record).toContain('v=spf1');
+    expect(res.data.dmarc.policy).toBe('reject');
+    expect(res.data.dkim.pass).toBe(true);
+  });
+
+  test('handles network errors', async () => {
+    const { default: handler } = await import('../pages/api/mail-auth');
+    (global as any).fetch = jest.fn(() => Promise.reject(new Error('network')));
+    const req = { query: { domain: 'example.com' } } as unknown as NextApiRequest;
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.spf.pass).toBe(false);
+    expect(res.data.spf.message).toMatch(/network/);
+  });
+
+  test('caches DNS lookups', async () => {
+    const { default: handler } = await import('../pages/api/mail-auth');
+    const fetchMock = jest.fn((url: string) => {
+      const name = new URL(url).searchParams.get('name');
+      const answer = [{ data: `"record for ${name}"` }];
+      return Promise.resolve(
+        new Response(JSON.stringify({ Answer: answer }), { status: 200 })
+      );
+    });
+    (global as any).fetch = fetchMock;
+    const req = { query: { domain: 'cache.com' } } as unknown as NextApiRequest;
+    const res1 = createRes();
+    await handler(req, res1);
+    const res2 = createRes();
+    await handler(req, res2);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+});

--- a/pages/api/mail-auth.ts
+++ b/pages/api/mail-auth.ts
@@ -44,6 +44,60 @@ async function lookupTxt(name: string): Promise<string[]> {
   return promise;
 }
 
+const SPF_SPEC = 'https://www.rfc-editor.org/rfc/rfc7208';
+
+function parseSpf(records: string[]) {
+  const spfRecords = records.filter((r) => r.toLowerCase().startsWith('v=spf1'));
+  if (spfRecords.length === 0) {
+    return {
+      pass: false,
+      message: 'No SPF record found',
+      recommendation: 'Add a TXT record with v=spf1 and authorized senders',
+      example: 'v=spf1 include:_spf.example.com -all',
+      spec: SPF_SPEC,
+    };
+  }
+  if (spfRecords.length > 1) {
+    return {
+      pass: false,
+      record: spfRecords.join(' | '),
+      message: 'Multiple SPF records found',
+      recommendation: 'Only one SPF record should exist',
+      example: 'v=spf1 include:_spf.example.com -all',
+      spec: SPF_SPEC,
+    };
+  }
+  const record = spfRecords[0];
+  const qualifier = record.match(/([~+?\-])all/i)?.[1];
+  let pass = true;
+  let message: string | undefined;
+  let recommendation = '';
+  if (!qualifier) {
+    pass = false;
+    message = 'SPF record missing all mechanism';
+    recommendation = 'End the record with -all';
+  } else if (qualifier === '?') {
+    pass = false;
+    message = 'Neutral SPF policy';
+    recommendation = 'Use -all or ~all to specify a policy';
+  } else if (qualifier === '+') {
+    pass = false;
+    message = 'SPF record allows all hosts (+all)';
+    recommendation = 'Use -all or ~all to restrict senders';
+  } else if (qualifier === '~') {
+    recommendation = 'Consider using -all for stricter enforcement';
+  }
+  return {
+    pass,
+    record,
+    policy: qualifier ? `${qualifier}all` : undefined,
+    message,
+    recommendation,
+    example: pass ? undefined : 'v=spf1 include:_spf.example.com -all',
+    spec: SPF_SPEC,
+  };
+}
+
 const DKIM_SPEC = 'https://datatracker.ietf.org/doc/html/rfc6376';
 
 function parseDkim(records: string[]) {
@@ -235,34 +289,94 @@ export default async function handler(
     res.status(400).json({ error: 'domain parameter required' });
     return;
   }
+
+  const response: any = {};
+
+  try {
+    const spfRecords = await lookupTxt(domain);
+    response.spf = parseSpf(spfRecords);
+  } catch (e: any) {
+    response.spf = {
+      pass: false,
+      message: e.message || 'SPF lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: SPF_SPEC,
+    };
+  }
+
   try {
     const dmarcRecords = await lookupTxt(`_dmarc.${domain}`);
+    response.dmarc = parseDmarc(dmarcRecords);
+  } catch (e: any) {
+    response.dmarc = {
+      pass: false,
+      message: e.message || 'DMARC lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: DMARC_SPEC,
+    };
+  }
+
+  try {
     const mtaStsRecords = await lookupTxt(`_mta-sts.${domain}`);
+    response.mtaSts = parseMtaSts(mtaStsRecords);
+  } catch (e: any) {
+    response.mtaSts = {
+      pass: false,
+      message: e.message || 'MTA-STS lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: MTA_STS_SPEC,
+    };
+  }
+
+  try {
     const tlsRptRecords = await lookupTxt(`_smtp._tls.${domain}`);
+    response.tlsRpt = parseTlsRpt(tlsRptRecords);
+  } catch (e: any) {
+    response.tlsRpt = {
+      pass: false,
+      message: e.message || 'TLS-RPT lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: TLS_RPT_SPEC,
+    };
+  }
+
+  try {
     const bimiRecords = await lookupTxt(`default._bimi.${domain}`);
+    response.bimi = parseBimi(bimiRecords);
+  } catch (e: any) {
+    response.bimi = {
+      pass: false,
+      message: e.message || 'BIMI lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: BIMI_SPEC,
+    };
+  }
+
+  try {
     let dkimRecords: string[] = [];
     if (typeof selector === 'string' && selector) {
       dkimRecords = await lookupTxt(`${selector}._domainkey.${domain}`);
     } else {
-      dkimRecords = await lookupTxt(`default._domainkey.${domain}`).catch(() => []);
+      dkimRecords = await lookupTxt(`default._domainkey.${domain}`);
     }
-    res.status(200).json({
-      dkim:
-        dkimRecords.length > 0
-          ? parseDkim(dkimRecords)
-          : {
-              pass: false,
-              message: 'No DKIM record found',
-              recommendation: 'Publish a DKIM record or specify a selector',
-              example: 'v=DKIM1; k=rsa; p=base64publickey',
-              spec: DKIM_SPEC,
-            },
-      dmarc: parseDmarc(dmarcRecords),
-      mtaSts: parseMtaSts(mtaStsRecords),
-      tlsRpt: parseTlsRpt(tlsRptRecords),
-      bimi: parseBimi(bimiRecords),
-    });
+    response.dkim =
+      dkimRecords.length > 0
+        ? parseDkim(dkimRecords)
+        : {
+            pass: false,
+            message: 'No DKIM record found',
+            recommendation: 'Publish a DKIM record or specify a selector',
+            example: 'v=DKIM1; k=rsa; p=base64publickey',
+            spec: DKIM_SPEC,
+          };
   } catch (e: any) {
-    res.status(500).json({ error: e.message || 'Lookup failed' });
+    response.dkim = {
+      pass: false,
+      message: e.message || 'DKIM lookup failed',
+      recommendation: 'Check DNS and try again',
+      spec: DKIM_SPEC,
+    };
   }
+
+  res.status(200).json(response);
 }

--- a/pages/apps/mail-auth.tsx
+++ b/pages/apps/mail-auth.tsx
@@ -1,7 +1,18 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const MailAuth = dynamic(() => import('../../apps/mail-auth'), { ssr: false });
 
 export default function MailAuthPage() {
-  return <MailAuth />;
+  const ogImage = '/themes/Yaru/apps/mail-auth.svg';
+  return (
+    <>
+      <Head>
+        <title>Mail Auth</title>
+        <meta property="og:title" content="Mail Auth" />
+        <meta property="og:image" content={ogImage} />
+      </Head>
+      <MailAuth />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- extend mail auth API with SPF lookup, policy evaluation, and robust per-record error handling
- show SPF results, DMARC templates, and copy-to-clipboard buttons in the mail auth UI
- document page metadata and add unit tests with mocked DNS ensuring caching and error behavior

## Testing
- `yarn test __tests__/mail-auth.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab37715a248328b2dabaceb578910e