### PR TITLE
feat: expand mail auth checklist

### DIFF
--- a/__tests__/mail-auth.api.test.ts
+++ b/__tests__/mail-auth.api.test.ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../pages/api/mail-auth';
+
+function createRes() {
+  return {
+    statusCode: 0,
+    data: null as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(d: any) {
+      this.data = d;
+      return this;
+    },
+  } as unknown as NextApiResponse;
+}
+
+describe('mail auth api', () => {
+  test('returns records with spf and dane', async () => {
+    const bigKey = Buffer.alloc(128).toString('base64');
+    (global as any).fetch = jest.fn((url: string) => {
+      if (url.startsWith('https://cloudflare-dns.com')) {
+        const u = new URL(url);
+        const name = u.searchParams.get('name');
+        const type = u.searchParams.get('type');
+        let Answer: any[] = [];
+        switch (name) {
+          case 'example.com':
+            Answer = [{ data: '"v=spf1 -all"' }];
+            break;
+          case '_dmarc.example.com':
+            Answer = [{ data: '"v=DMARC1; p=reject"' }];
+            break;
+          case '_mta-sts.example.com':
+            Answer = [{ data: '"v=STSv1; id=1"' }];
+            break;
+          case '_smtp._tls.example.com':
+            Answer = [{ data: '"v=TLSRPTv1; rua=mailto:postmaster@example.com"' }];
+            break;
+          case 'default._bimi.example.com':
+            Answer = [{ data: '"v=BIMI1; l=https://example.com/logo.svg"' }];
+            break;
+          case 'default._domainkey.example.com':
+            Answer = [{ data: `"v=DKIM1; p=${bigKey}"` }];
+            break;
+          case '_25._tcp.example.com':
+            return Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ Answer: [{ data: '3 1 1 ABCDEF' }] }),
+            });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ Answer }) });
+      }
+      if (url === 'https://mta-sts.example.com/.well-known/mta-sts.txt') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === 'https://example.com/logo.svg') {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    });
+
+    const req = {
+      query: { domain: 'example.com' },
+      headers: {},
+      socket: { remoteAddress: '1.1.1.1' },
+    } as unknown as NextApiRequest;
+    const res: any = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.spf.pass).toBe(true);
+    expect(res.data.dane.pass).toBe(true);
+  });
+});

--- a/apps/mail-auth/index.tsx
+++ b/apps/mail-auth/index.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import Papa from 'papaparse';
 import jsPDF from 'jspdf';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Mail Auth',
+  description:
+    'Checklist for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, DANE and BIMI with exportable reports',
+};
 
 type Result = {
   pass: boolean;
@@ -16,19 +23,24 @@ type Result = {
 };
 
 type Response = {
+  spf: Result;
   dkim: Result;
   dmarc: Result;
   mtaSts: Result;
   tlsRpt: Result;
+  dane: Result;
   bimi: Result;
   error?: string;
 };
 
 const CONTROLS = [
-  { id: 'dkim', label: 'DKIM' },
   { id: 'dmarc', label: 'DMARC' },
+  { id: 'spf', label: 'SPF' },
+  { id: 'dkim', label: 'DKIM' },
   { id: 'mtaSts', label: 'MTA-STS' },
   { id: 'tlsRpt', label: 'TLS-RPT' },
+  { id: 'dane', label: 'DANE' },
+  { id: 'bimi', label: 'BIMI' },
 ] as const;
 
 type ControlId = typeof CONTROLS[number]['id'];
@@ -168,11 +180,13 @@ const MailAuth: React.FC = () => {
                       }
                       const r = (res as any)[id as ControlId] as Result;
                       const badgeColor = r.pass ? 'bg-green-600' : 'bg-red-600';
+                      const tip = [r.record, r.message].filter(Boolean).join('\n');
                       return (
                         <td key={domain} className="py-2">
                           <div className="flex flex-col">
                             <span
                               className={`px-2 py-0.5 rounded text-white text-xs ${badgeColor}`}
+                              title={tip}
                             >
                               {r.pass ? 'PASS' : 'FAIL'}
                             </span>


### PR DESCRIPTION
## Summary
- include SPF and DANE in mail auth checklist
- add caching, rate limiting, and HTTP validations for mail controls
- document tooltips and metadata, add mocked API test

## Testing
- `yarn lint`
- `yarn test __tests__/mail-auth.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab37720d0883289d64d7ab3f089986