### PR TITLE
feat: enhance threat modeler

### DIFF
--- a/__tests__/threat-modeler.test.tsx
+++ b/__tests__/threat-modeler.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ThreatModeler from '@apps/threat-modeler';
+
+describe('ThreatModeler', () => {
+  it('adds and moves nodes with keyboard', () => {
+    const { getByText } = render(<ThreatModeler />);
+    fireEvent.click(getByText('Add Node'));
+    const node = getByText('Node 1');
+    fireEvent.click(node);
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(node.style.transform).toContain('30px');
+  });
+});

--- a/pages/apps/threat-modeler.tsx
+++ b/pages/apps/threat-modeler.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const ThreatModeler = dynamic(() => import('../../apps/threat-modeler'), { ssr: false });
+
+export default function ThreatModelerPage() {
+  return <ThreatModeler />;
+}


### PR DESCRIPTION
## Summary
- add metadata export and keyboard navigation
- support importing, saving and loading threat diagrams
- expose threat modeler page and basic component test

## Testing
- `yarn test __tests__/threat-modeler.test.tsx`
- `yarn lint apps/threat-modeler/index.tsx pages/apps/threat-modeler.tsx __tests__/threat-modeler.test.tsx` *(fails: Couldn't find any `pages` or `app` directory)*
- `npx eslint apps/threat-modeler/index.tsx pages/apps/threat-modeler.tsx __tests__/threat-modeler.test.tsx` *(fails: missing eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37727b488328a9f6c9284e894456