### PR TITLE
feat: add mixed content scan report

### DIFF
--- a/__tests__/mixed-content.test.tsx
+++ b/__tests__/mixed-content.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { scan } from '@apps/mixed-content/worker';
+import MixedContent from '@apps/mixed-content';
+
+describe('Mixed Content', () => {
+  it('detects insecure subresources', () => {
+    const html = '<img src="http://example.com/a.png"><script src="http://example.com/a.js"></script>';
+    const results = scan(html);
+    expect(results).toHaveLength(2);
+    const script = results.find((r) => r.tag === 'script');
+    expect(script?.category).toBe('active');
+    const img = results.find((r) => r.tag === 'img');
+    expect(img?.category).toBe('passive');
+  });
+
+  it('copies report to clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    // @ts-ignore
+    Object.assign(navigator, { clipboard: { writeText } });
+    let workerInstance: any;
+    // @ts-ignore
+    global.Worker = class {
+      onmessage: ((e: any) => void) | null = null;
+      constructor() {
+        workerInstance = this;
+      }
+      postMessage() {}
+      terminate() {}
+    };
+    const { getByTestId } = render(<MixedContent />);
+    await waitFor(() => expect(workerInstance).toBeDefined());
+    const mockResults = [
+      {
+        tag: 'img',
+        attr: 'src',
+        url: 'http://example.com/a.png',
+        httpsUrl: 'https://example.com/a.png',
+        category: 'passive',
+        suggestion: 'Replace with https://example.com/a.png',
+      },
+    ];
+    act(() => {
+      workerInstance.onmessage({ data: mockResults });
+    });
+    fireEvent.click(getByTestId('copy-report'));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        JSON.stringify(mockResults, null, 2),
+      ),
+    );
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -785,7 +785,7 @@ const apps = [
   {
     id: 'mixed-content',
     title: 'Mixed Content',
-    icon: './themes/Yaru/apps/hash.svg',
+    icon: './themes/Yaru/apps/mixed-content.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/mixed-content/index.tsx
+++ b/apps/mixed-content/index.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
+import type { Metadata } from 'next';
 import type { ScanResult } from './worker';
+
+export const metadata: Metadata = {
+  title: 'Mixed Content',
+  description:
+    'Scan pages for insecure HTTP subresources and get upgrade-insecure-requests guidance',
+};
 
 const MixedContent: React.FC = () => {
   const [url, setUrl] = useState('');
@@ -57,6 +64,16 @@ const MixedContent: React.FC = () => {
     }
   };
 
+  const copyReport = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        JSON.stringify(results, null, 2),
+      );
+    } catch {
+      /* ignore */
+    }
+  };
+
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
       <div className="flex space-x-2">
@@ -103,9 +120,25 @@ const MixedContent: React.FC = () => {
       {error && <div className="text-red-400">{error}</div>}
       {results.length > 0 && (
         <div className="overflow-auto text-sm flex-1 space-y-4">
-          <div>
-            <p>Active mixed content: {results.filter((r) => r.category === 'active').length}</p>
-            <p>Passive mixed content: {results.filter((r) => r.category === 'passive').length}</p>
+          <div className="flex items-center justify-between">
+            <div>
+              <p>
+                Active mixed content:{' '}
+                {results.filter((r) => r.category === 'active').length}
+              </p>
+              <p>
+                Passive mixed content:{' '}
+                {results.filter((r) => r.category === 'passive').length}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={copyReport}
+              data-testid="copy-report"
+              className="bg-gray-700 px-2 py-1 rounded"
+            >
+              Copy Report
+            </button>
           </div>
           <table className="min-w-full">
             <thead>

--- a/apps/mixed-content/worker.ts
+++ b/apps/mixed-content/worker.ts
@@ -7,8 +7,7 @@ export interface ScanResult {
   suggestion: string;
 }
 
-self.onmessage = (e: MessageEvent<string>) => {
-  const html = e.data;
+export function scan(html: string): ScanResult[] {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
   const elements = Array.from(doc.querySelectorAll('[src],[href]'));
@@ -44,6 +43,11 @@ self.onmessage = (e: MessageEvent<string>) => {
     }
   });
 
+  return results;
+}
+
+self.onmessage = (e: MessageEvent<string>) => {
+  const results = scan(e.data);
   (self as any).postMessage(results);
 };
 

--- a/pages/api/mixed-content.ts
+++ b/pages/api/mixed-content.ts
@@ -46,9 +46,19 @@ export default async function handler(
   }
 
   try {
-    const response = await fetch(target.toString());
-    const body = await response.text();
-    res.status(200).json({ status: response.status, body });
+    let response: Response | null = null;
+    const attempts = 3;
+    for (let i = 0; i < attempts; i += 1) {
+      try {
+        response = await fetch(target.toString());
+        break;
+      } catch (err) {
+        if (i === attempts - 1) throw err;
+        await new Promise((r) => setTimeout(r, 2 ** i * 500));
+      }
+    }
+    const body = await response!.text();
+    res.status(200).json({ status: response!.status, body });
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
   }

--- a/pages/apps/mixed-content.tsx
+++ b/pages/apps/mixed-content.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const MixedContent = dynamic(() => import('../../apps/mixed-content'), {
+  ssr: false,
+});
+
+export default function MixedContentPage() {
+  return <MixedContent />;
+}

--- a/public/themes/Yaru/apps/mixed-content.svg
+++ b/public/themes/Yaru/apps/mixed-content.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M32 16a8 8 0 00-8 8v8h4v-8a4 4 0 018 0v4h4v-4a8 8 0 00-8-8zM20 28v20h24V28H20zm12 8a4 4 0 110 8 4 4 0 010-8z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- export reusable HTML scanner and add copyable report with metadata for Mixed Content tool
- retry mixed-content fetches with exponential backoff
- wire Mixed Content page and icon

## Testing
- `yarn test mixed-content`


------
https://chatgpt.com/codex/tasks/task_e_68ab3772d1708328b7cb65fee47d148d