### PR TITLE
feat: add SBOM viewer with search and export

### DIFF
--- a/__tests__/sbom-parser.test.ts
+++ b/__tests__/sbom-parser.test.ts
@@ -1,4 +1,6 @@
 import { parseSbomObject } from '@lib/sbom';
+import cyclonedxSample from './sbom-samples/cyclonedx.json';
+import spdxSample from './sbom-samples/spdx.json';
 
 describe('SBOM parsing', () => {
   it('parses CycloneDX components and dependencies', () => {
@@ -17,6 +19,13 @@ describe('SBOM parsing', () => {
     const parsed = parseSbomObject(data);
     expect(parsed.components[0].licenses).toEqual(['MIT']);
     expect(parsed.graph.comp1).toEqual(['comp2']);
+  });
+
+  it('parses CycloneDX sample file', () => {
+    const parsed = parseSbomObject(cyclonedxSample);
+    expect(parsed.components.length).toBe(2);
+    expect(parsed.graph.pkg1).toEqual(['pkg2']);
+    expect(parsed.components[1].licenses).toEqual(['Apache-2.0']);
   });
 
   it('parses SPDX packages and relationships', () => {
@@ -41,6 +50,14 @@ describe('SBOM parsing', () => {
     const parsed = parseSbomObject(data);
     expect(parsed.components[0].name).toBe('pkg');
     expect(parsed.graph['pkg:1']).toEqual(['pkg:2']);
+  });
+
+  it('parses SPDX sample file', () => {
+    const parsed = parseSbomObject(spdxSample);
+    expect(parsed.components.length).toBe(2);
+    expect(parsed.graph['SPDXRef-Package-pkg1']).toEqual([
+      'SPDXRef-Package-pkg2',
+    ]);
   });
 
   it('throws with path on invalid schema', () => {

--- a/__tests__/sbom-samples/cyclonedx.json
+++ b/__tests__/sbom-samples/cyclonedx.json
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bomRef": "pkg1",
+      "name": "pkg1",
+      "version": "1.0.0",
+      "licenses": [{ "license": { "id": "MIT" } }]
+    },
+    {
+      "bomRef": "pkg2",
+      "name": "pkg2",
+      "version": "2.0.0",
+      "licenses": [{ "license": { "id": "Apache-2.0" } }],
+      "vulnerabilities": [{ "id": "CVE-2024-0001" }]
+    }
+  ],
+  "dependencies": [
+    { "ref": "pkg1", "dependsOn": ["pkg2"] }
+  ]
+}

--- a/__tests__/sbom-samples/spdx.json
+++ b/__tests__/sbom-samples/spdx.json
@@ -1,0 +1,24 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-pkg1",
+      "name": "pkg1",
+      "versionInfo": "1.0.0",
+      "licenseDeclared": "MIT"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-pkg2",
+      "name": "pkg2",
+      "versionInfo": "2.0.0",
+      "licenseDeclared": "Apache-2.0"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-pkg1",
+      "relatedSpdxElement": "SPDXRef-Package-pkg2",
+      "relationshipType": "DEPENDS_ON"
+    }
+  ]
+}

--- a/__tests__/sbom-viewer.test.tsx
+++ b/__tests__/sbom-viewer.test.tsx
@@ -1,0 +1,24 @@
+import cyclonedxSample from './sbom-samples/cyclonedx.json';
+
+jest.mock('@lib/sbom', () => {
+  const actual = jest.requireActual('@lib/sbom');
+  return {
+    ...actual,
+    readFileChunks: jest.fn(async () => JSON.stringify(cyclonedxSample)),
+    fetchOsv: jest.fn(),
+  };
+});
+
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import SbomViewer from '@components/apps/sbom-viewer';
+
+describe('SBOM Viewer', () => {
+  it('loads SBOM and displays components', async () => {
+    render(<SbomViewer />);
+    const file = new File(['dummy'], 'sbom.json', { type: 'application/json' });
+    const input = screen.getByTestId('file-input');
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(screen.getByText('pkg1')).toBeInTheDocument());
+    expect(screen.getByText('License Map')).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -803,7 +803,7 @@ const apps = [
   {
     id: 'sbom-viewer',
     title: 'SBOM Viewer',
-    icon: './themes/Yaru/apps/gedit.png',
+    icon: './themes/Yaru/apps/sbom.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/pages/sbom.tsx
+++ b/pages/sbom.tsx
@@ -1,0 +1,20 @@
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+const SbomViewer = dynamic(() => import('../components/apps/sbom-viewer'), { ssr: false });
+
+export default function SbomPage() {
+  return (
+    <>
+      <Head>
+        <title>SBOM Viewer</title>
+        <meta
+          name="description"
+          content="Explore software bills of materials for dependencies, licenses and vulnerabilities."
+        />
+        <link rel="icon" href="/themes/Yaru/apps/sbom.svg" />
+      </Head>
+      <SbomViewer />
+    </>
+  );
+}

--- a/public/themes/Yaru/apps/sbom.svg
+++ b/public/themes/Yaru/apps/sbom.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <circle cx="20" cy="20" r="6" fill="#fff"/>
+  <circle cx="44" cy="20" r="6" fill="#fff"/>
+  <circle cx="32" cy="44" r="6" fill="#fff"/>
+  <path d="M20 20 L44 20 M20 20 L32 44 M44 20 L32 44" stroke="#fff" stroke-width="4" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- stream SBOM files and parse CycloneDX/SPDX JSON
- explore components with search, dependency tree, license map, CVE links and CSV export
- add SBOM page, icon, and tests with sample SBOMs

## Testing
- `yarn test sbom`
- `yarn lint pages/sbom.tsx components/apps/sbom-viewer.tsx __tests__/sbom-parser.test.ts __tests__/sbom-viewer.test.tsx` *(fails: Could not complete linting due to repository-wide ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab377480d08328b0b516de926e14de