### PR TITLE
feat: add detailed redirect tracing

### DIFF
--- a/__tests__/redirect-visualizer.api.test.ts
+++ b/__tests__/redirect-visualizer.api.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Response } from 'undici';
+import handler from '../pages/api/redirect-visualizer';
+
+jest.mock('../lib/headCache', () => ({
+  fetchHead: jest.fn(() => Promise.resolve({ alpn: 'h2' })),
+}));
+
+function createReqRes(body: any = {}) {
+  const req = {
+    method: 'POST',
+    body,
+    headers: {},
+  } as unknown as NextApiRequest;
+
+  const res: Partial<NextApiResponse> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return { req, res: res as NextApiResponse };
+}
+
+describe('redirect-visualizer api', () => {
+  it('captures redirect chain with method changes and cache headers', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('', {
+          status: 302,
+          headers: {
+            location: 'https://b.example',
+            'cache-control': 'no-store',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('', {
+          status: 200,
+          headers: {
+            'cache-control': 'max-age=60',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('', { status: 200, headers: {} })
+      );
+    (global as any).fetch = mockFetch;
+
+    const { req, res } = createReqRes({
+      url: 'https://a.example',
+      method: 'POST',
+    });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const data = (res.json as any).mock.calls[0][0];
+    expect(data.ok).toBe(true);
+    expect(data.chain).toHaveLength(2);
+    expect(data.chain[0].method).toBe('POST');
+    expect(data.chain[0].cacheControl).toBe('no-store');
+    expect(data.chain[1].method).toBe('GET');
+    expect(data.chain[1].cacheControl).toBe('max-age=60');
+  });
+});

--- a/apps/redirect-visualizer/index.tsx
+++ b/apps/redirect-visualizer/index.tsx
@@ -7,6 +7,10 @@ interface Hop {
   setCookie?: string;
   hsts?: string;
   altSvc?: string;
+  cacheControl?: string;
+  expires?: string;
+  age?: string;
+  method: string;
   protocol: string;
   crossSite: boolean;
   insecure: boolean;
@@ -17,6 +21,7 @@ interface ApiResponse {
   ok: boolean;
   chain: Hop[];
   mixedContent?: boolean;
+  error?: string;
 }
 
 function statusColor(status: number) {
@@ -28,6 +33,7 @@ function statusColor(status: number) {
 
 const RedirectVisualizer: React.FC = () => {
   const [url, setUrl] = useState('');
+  const [method, setMethod] = useState('GET');
   const [data, setData] = useState<Hop[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -43,11 +49,11 @@ const RedirectVisualizer: React.FC = () => {
       const res = await fetch('/api/redirect-visualizer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url, method: 'HEAD' }),
+        body: JSON.stringify({ url, method }),
       });
-      const json = (await res.json()) as ApiResponse;
+      const json = (await res.json()) as ApiResponse & { error?: string };
       if (!res.ok || !json.ok) {
-        setError('Trace failed');
+        setError(json.error || 'Trace failed');
       }
       setData(json.chain);
       setMixed(!!json.mixedContent);
@@ -67,6 +73,17 @@ const RedirectVisualizer: React.FC = () => {
           value={url}
           onChange={(e) => setUrl(e.target.value)}
         />
+        <select
+          className="text-black px-1"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+        >
+          {['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'].map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
         <button
           type="button"
           onClick={trace}
@@ -84,17 +101,52 @@ const RedirectVisualizer: React.FC = () => {
       {error && <div className="text-red-500">{error}</div>}
       {data.length > 0 && (
         <div className="space-y-2 overflow-auto">
+          <div className="flex space-x-2 mb-2">
+            <button
+              type="button"
+              className="px-2 py-1 bg-gray-700 rounded"
+              onClick={() =>
+                navigator.clipboard.writeText(
+                  JSON.stringify({ chain: data, mixedContent: mixed }, null, 2)
+                )
+              }
+            >
+              Copy JSON
+            </button>
+            <button
+              type="button"
+              className="px-2 py-1 bg-gray-700 rounded"
+              onClick={() => {
+                const blob = new Blob(
+                  [JSON.stringify({ chain: data, mixedContent: mixed }, null, 2)],
+                  { type: 'application/json' }
+                );
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = 'redirect-chain.json';
+                a.click();
+                URL.revokeObjectURL(a.href);
+              }}
+            >
+              Export JSON
+            </button>
+          </div>
           {data.map((hop, i) => (
             <div
               key={i}
               className={`border p-2 rounded ${
-                hop.insecure ? 'border-red-700' : hop.crossSite ? 'border-yellow-700' : 'border-gray-700'
+                hop.insecure
+                  ? 'border-red-700'
+                  : hop.crossSite
+                    ? 'border-yellow-700'
+                    : 'border-gray-700'
               }`}
             >
               <div className="flex justify-between">
                 <span className="break-all">{hop.url}</span>
                 <span className={statusColor(hop.status)}>{hop.status}</span>
               </div>
+              <div className="text-sm">Method: {hop.method}</div>
               <div className="text-sm">Protocol: {hop.protocol}</div>
               {hop.location && (
                 <div className="break-all text-sm">Location: {hop.location}</div>
@@ -104,6 +156,15 @@ const RedirectVisualizer: React.FC = () => {
               )}
               {hop.setCookie && (
                 <div className="break-all text-sm">Set-Cookie: {hop.setCookie}</div>
+              )}
+              {hop.cacheControl && (
+                <div className="break-all text-sm">Cache-Control: {hop.cacheControl}</div>
+              )}
+              {hop.expires && (
+                <div className="break-all text-sm">Expires: {hop.expires}</div>
+              )}
+              {hop.age && (
+                <div className="break-all text-sm">Age: {hop.age}</div>
               )}
               {hop.hsts && (
                 <div className="break-all text-sm">HSTS: {hop.hsts}</div>
@@ -121,9 +182,15 @@ const RedirectVisualizer: React.FC = () => {
               <button
                 type="button"
                 className="text-blue-400 text-sm underline"
-                onClick={() => navigator.clipboard.writeText(`curl -I ${hop.url}`)}
+                onClick={() => {
+                  const cmd =
+                    hop.method === 'HEAD'
+                      ? `curl -I ${hop.url}`
+                      : `curl -X ${hop.method} -i ${hop.url}`;
+                  navigator.clipboard.writeText(cmd);
+                }}
               >
-                Copy curl -I
+                Copy curl
               </button>
             </div>
           ))}

--- a/pages/apps/redirect-visualizer.tsx
+++ b/pages/apps/redirect-visualizer.tsx
@@ -1,10 +1,22 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const RedirectVisualizer = dynamic(() => import('../../apps/redirect-visualizer'), {
   ssr: false,
 });
 
 export default function RedirectVisualizerPage() {
-  return <RedirectVisualizer />;
+  return (
+    <>
+      <Head>
+        <title>Redirect Visualizer</title>
+        <meta
+          name="description"
+          content="Trace HTTP redirect chains with method and cache insights"
+        />
+      </Head>
+      <RedirectVisualizer />
+    </>
+  );
 }
 


### PR DESCRIPTION
## Summary
- show method, cache hints, and curl snippet for each redirect hop
- add copy/export options and better error messages
- document page with head metadata

## Testing
- `yarn test __tests__/redirect-visualizer.api.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab37767130832899f683a610d6bafe