### PR TITLE
feat: add HTTP/3 probe app

### DIFF
--- a/__tests__/http3-probe.test.ts
+++ b/__tests__/http3-probe.test.ts
@@ -1,0 +1,46 @@
+function mockReqRes({ method, query }: { method: string; query: any }) {
+  const req: any = { method, query };
+  const res: any = { statusCode: 200 };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (data: any) => {
+    res.data = data;
+    return res;
+  };
+  res.end = () => res;
+  return { req, res };
+}
+
+describe('http3 probe api', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('returns hints and probe result', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      headers: { get: (h: string) => (h.toLowerCase() === 'alt-svc' ? 'h3=":443"' : null) },
+    });
+    const execFileMock = jest
+      .spyOn(require('child_process'), 'execFile')
+      .mockImplementation((cmd: any, _args: any, _opts: any, cb: any) => {
+        if (cmd === 'openssl') cb(null, { stdout: 'ALPN protocol: h2\n', stderr: '' });
+        else cb(null, { stdout: 'HTTP/3 200\n', stderr: '' });
+      });
+
+    const { default: handler } = await import('../pages/api/http3-probe');
+    const { req, res } = mockReqRes({
+      method: 'GET',
+      query: { url: 'https://example.com', probe: '1' },
+    });
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.data.altSvc).toBe('h3=":443"');
+    expect(res.data.alpn).toBe('h2');
+    expect(res.data.h3Probe.ok).toBe(true);
+
+    execFileMock.mockRestore();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -821,7 +821,7 @@ const apps = [
   {
     id: 'http3-probe',
     title: 'HTTP/3 Probe',
-    icon: './themes/Yaru/apps/resource-monitor.svg',
+    icon: './themes/Yaru/apps/http3-probe.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/http3-probe/index.tsx
+++ b/apps/http3-probe/index.tsx
@@ -1,0 +1,6 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = {
+  title: 'HTTP/3 Probe',
+  description: 'Inspect Alt-Svc and ALPN hints and optionally probe HTTP/3 support.',
+};
+export { default } from '../../components/apps/http3-probe';

--- a/components/apps/http3-probe.tsx
+++ b/components/apps/http3-probe.tsx
@@ -1,77 +1,113 @@
 import React, { useState } from 'react';
 
-interface ProbeResult {
-  ok: boolean;
+type Result = {
   altSvc: string | null;
-  alpnHints: string[];
-  negotiatedProtocol: string;
-  quicVersions: string[];
-  zeroRtt: boolean;
-  fallbackOk: boolean;
-}
+  alpn: string | null;
+  h3Probe?: { ok: boolean; output: string };
+};
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const Http3Probe: React.FC = () => {
   const [url, setUrl] = useState('');
-  const [result, setResult] = useState<ProbeResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [probe, setProbe] = useState(false);
+  const [result, setResult] = useState<Result | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const probe = async () => {
-    if (!url) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
+  const fetchWithRetry = async (attempt = 0): Promise<void> => {
     try {
-      const res = await fetch(`/api/http3-probe?url=${encodeURIComponent(url)}`);
-      const data = (await res.json()) as ProbeResult;
-      setResult(data);
-    } catch {
-      setError('Request failed');
+      const res = await fetch(
+        `/api/http3-probe?url=${encodeURIComponent(url)}${probe ? '&probe=1' : ''}`,
+      );
+      if (!res.ok) throw new Error('Request failed');
+      setResult(await res.json());
+      setError(null);
+    } catch (e: any) {
+      if (attempt < 2) {
+        await delay(500 * 2 ** attempt);
+        return fetchWithRetry(attempt + 1);
+      }
+      setError(e.message || 'Request failed');
     } finally {
       setLoading(false);
     }
   };
 
+  const onCheck = () => {
+    if (!url) return;
+    setLoading(true);
+    setResult(null);
+    fetchWithRetry();
+  };
+
+  const copy = () => {
+    if (!result) return;
+    navigator.clipboard.writeText(JSON.stringify(result, null, 2));
+  };
+
+  const renderExplanation = () => {
+    if (!result) return null;
+    const lines: string[] = [];
+    if (result.altSvc && /h3/i.test(result.altSvc)) {
+      lines.push('Alt-Svc advertises HTTP/3.');
+    } else {
+      lines.push('No Alt-Svc HTTP/3 hint detected.');
+    }
+    if (result.alpn) {
+      lines.push(`ALPN negotiated: ${result.alpn}.`);
+    } else {
+      lines.push('ALPN negotiation not determined.');
+    }
+    if (result.h3Probe) {
+      lines.push(result.h3Probe.ok ? 'curl --http3 succeeded.' : 'curl --http3 failed.');
+    }
+    return lines.map((l, i) => (
+      <div key={i}>{l}</div>
+    ));
+  };
+
   return (
-    <div className="p-2 text-sm text-gray-900 dark:text-gray-100">
-      <div className="flex gap-2 mb-2">
+    <div className="h-full w-full p-4 bg-gray-900 text-white space-y-4 overflow-auto">
+      <div className="flex space-x-2 items-center">
         <input
-          type="text"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          placeholder="example.com"
-          className="border px-2 py-1 flex-grow"
+          placeholder="https://example.com"
+          className="px-2 py-1 text-black flex-1"
         />
-        <button onClick={probe} className="px-2 py-1 border" disabled={loading}>
-          Probe
+        <label className="text-xs flex items-center space-x-1">
+          <input
+            type="checkbox"
+            checked={probe}
+            onChange={(e) => setProbe(e.target.checked)}
+          />
+          <span>Probe</span>
+        </label>
+        <button
+          onClick={onCheck}
+          disabled={loading}
+          className="px-3 py-1 bg-blue-600 rounded disabled:opacity-50"
+        >
+          {loading ? 'Loading...' : 'Check'}
         </button>
       </div>
-      {error && <div className="text-red-500">{error}</div>}
+      {error && <div className="text-red-400 text-sm">{error}</div>}
       {result && (
-        <div>
-          <div className="font-bold mb-1">
-            {result.ok ? 'HTTP/3 advertised' : 'No HTTP/3 hint'}
-          </div>
-          {result.altSvc && (
-            <div className="break-all">Alt-Svc: {result.altSvc}</div>
+        <div className="text-sm space-y-2">
+          <div>Alt-Svc: {result.altSvc || 'None'}</div>
+          <div>ALPN: {result.alpn || 'Unknown'}</div>
+          {result.h3Probe && (
+            <div>curl --http3: {result.h3Probe.ok ? 'success' : 'failed'}</div>
           )}
-          <div className="mt-1">
-            Fallback via: {result.negotiatedProtocol || 'unknown'}
-          </div>
-          {result.alpnHints.length > 0 && (
-            <div className="mt-1">Protocols: {result.alpnHints.join(', ')}</div>
-          )}
-          {result.quicVersions.length > 0 && (
-            <div className="mt-1">
-              QUIC Versions: {result.quicVersions.join(', ')}
-            </div>
-          )}
-          <div className="mt-1">
-            0-RTT: {result.zeroRtt ? 'supported' : 'not supported'}
-          </div>
-          {!result.fallbackOk && (
-            <div className="mt-1 text-red-500">No HTTP/1.1/2 fallback</div>
-          )}
+          <div>{renderExplanation()}</div>
+          <button
+            type="button"
+            onClick={copy}
+            className="px-2 py-0.5 bg-green-600 rounded text-xs"
+          >
+            Copy
+          </button>
         </div>
       )}
     </div>
@@ -79,3 +115,4 @@ const Http3Probe: React.FC = () => {
 };
 
 export default Http3Probe;
+export const displayHttp3Probe = () => <Http3Probe />;

--- a/pages/apps/http3-probe.tsx
+++ b/pages/apps/http3-probe.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const Http3Probe = dynamic(() => import('../../apps/http3-probe'), {
+  ssr: false,
+});
+
+export default function Http3ProbePage() {
+  return <Http3Probe />;
+}

--- a/public/themes/Yaru/apps/http3-probe.svg
+++ b/public/themes/Yaru/apps/http3-probe.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="20" width="48" height="24" rx="3" ry="3" fill="#222" stroke="#000" stroke-width="2"/>
+  <rect x="10" y="22" width="40" height="20" fill="#4ade80"/>
+  <rect x="56" y="26" width="4" height="12" fill="#000"/>
+</svg>


### PR DESCRIPTION
## Summary
- add HTTP/3 Probe app with Alt-Svc and ALPN checks and optional curl probe
- wire metadata, page, icon, and retry/backoff + clipboard features
- cover API with integration test

## Testing
- `yarn lint`
- `yarn test __tests__/http3-probe.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab3777138c8328aedeed1bb7fadf23