### PR TITLE
Add robots.txt auditor report and caching

### DIFF
--- a/__tests__/fixtures/robots-sample.txt
+++ b/__tests__/fixtures/robots-sample.txt
@@ -1,0 +1,10 @@
+# Sample robots.txt
+User-agent: GoogleBot
+Allow: /public/
+Disallow: /private/
+
+User-agent: bingbot
+Disallow: /bing
+
+Sitemap: https://example.com/sitemap.xml
+Unknown: value

--- a/__tests__/robots-parser.test.ts
+++ b/__tests__/robots-parser.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import { parseRobots, testPath, fetchRobots, clearRobotsCache } from '../lib/robots';
+
+describe('robots parser', () => {
+  const sample = fs.readFileSync(__dirname + '/fixtures/robots-sample.txt', 'utf8');
+
+  test('parses robots file and identifies unknown directives', () => {
+    const data = parseRobots(sample);
+    expect(data.sitemaps).toEqual(['https://example.com/sitemap.xml']);
+    expect(data.unsupported).toEqual(['Unknown: value']);
+    expect(data.groups).toHaveLength(2);
+    const google = data.groups[0];
+    expect(google.userAgents).toEqual(['googlebot']);
+    expect(google.allows).toEqual(['/public/']);
+    expect(google.disallows).toEqual(['/private/']);
+    const decision = testPath(data, 'googlebot', '/private/secret');
+    expect(decision.allowed).toBe(false);
+  });
+
+  test('caches fetch results', async () => {
+    clearRobotsCache();
+    const text = sample;
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => text,
+      headers: { get: () => null },
+    });
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const data1 = await fetchRobots('https://example.com');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const data2 = await fetchRobots('https://example.com');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(data2).toEqual(data1);
+    global.fetch = originalFetch;
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -839,7 +839,7 @@ const apps = [
   {
     id: 'robots-auditor',
     title: 'Robots Auditor',
-    icon: './themes/Yaru/apps/resource-monitor.svg',
+    icon: icon('robots-auditor.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/docs/robots.md
+++ b/docs/robots.md
@@ -1,10 +1,10 @@
 # Robots Parser
 
-This project includes a simple `robots.txt` parser used by the Robots Auditor app. It fetches a site's `robots.txt`, caches the response by domain and uses the returned `ETag` to avoid re-downloading unchanged files.
+This project includes a simple `robots.txt` parser used by the Robots Auditor app. It fetches a site's `robots.txt`, caches the response by domain and uses the returned `ETag` to avoid re-downloading unchanged files. A one hour TTL allows offline reuse of the cached policy.
 
 ## Parsing quirks
 
-* Lines with unknown directives are ignored.
+* Lines with unknown directives are reported back to the UI.
 * `Disallow:` without a path is treated as `/`.
 * Rules appearing before any `User-agent` are grouped under `*`.
 * Longest matching rule wins; if an `Allow` and `Disallow` tie, the `Allow` takes precedence.

--- a/lib/robots.ts
+++ b/lib/robots.ts
@@ -14,11 +14,13 @@ export interface RobotsData {
 interface CacheEntry {
   etag?: string;
   data: RobotsData;
+  fetched: number;
 }
 
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour
 const cache = new Map<string, CacheEntry>();
 
-function parseRobots(text: string): RobotsData {
+export function parseRobots(text: string): RobotsData {
   const groups: RobotsRuleGroup[] = [];
   const sitemaps: string[] = [];
   const unsupported: string[] = [];
@@ -65,27 +67,36 @@ export async function fetchRobots(origin: string): Promise<RobotsData> {
   const base = origin.replace(/\/$/, '');
   const url = `${base}/robots.txt`;
   const cached = cache.get(url);
+
+  if (cached && Date.now() - cached.fetched < CACHE_TTL) {
+    return cached.data;
+  }
+
   const headers: Record<string, string> = {};
   if (cached?.etag) headers['If-None-Match'] = cached.etag;
 
   try {
     const res = await fetch(url, { headers });
     if (res.status === 304 && cached) {
+      cached.fetched = Date.now();
       return cached.data;
     }
     if (!res.ok) {
       const data: RobotsData = { groups: [], sitemaps: [], unsupported: [], missing: true };
-      cache.set(url, { etag: cached?.etag, data });
+      cache.set(url, { etag: cached?.etag, data, fetched: Date.now() });
       return data;
     }
     const text = await res.text();
     const data = parseRobots(text);
     const etag = res.headers.get('etag') || undefined;
-    cache.set(url, { etag, data });
+    cache.set(url, { etag, data, fetched: Date.now() });
     return data;
   } catch {
+    if (cached) {
+      return cached.data;
+    }
     const data: RobotsData = { groups: [], sitemaps: [], unsupported: [], missing: true };
-    cache.set(url, { etag: cached?.etag, data });
+    cache.set(url, { etag: cached?.etag, data, fetched: Date.now() });
     return data;
   }
 }

--- a/pages/apps/robots-auditor.tsx
+++ b/pages/apps/robots-auditor.tsx
@@ -1,9 +1,20 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const RobotsAuditor = dynamic(() => import('../../components/apps/robots-auditor'), {
   ssr: false,
 });
 
 export default function RobotsAuditorPage() {
-  return <RobotsAuditor />;
+  const ogImage = '/images/logos/logo_1200.png';
+  return (
+    <>
+      <Head>
+        <title>Robots Auditor</title>
+        <meta property="og:title" content="Robots Auditor" />
+        <meta property="og:image" content={ogImage} />
+      </Head>
+      <RobotsAuditor />
+    </>
+  );
 }

--- a/public/themes/Yaru/apps/robots-auditor.svg
+++ b/public/themes/Yaru/apps/robots-auditor.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#1f2937"/>
+  <circle cx="32" cy="20" r="6" fill="#9ca3af"/>
+  <rect x="16" y="28" width="32" height="20" rx="4" fill="#9ca3af"/>
+  <circle cx="24" cy="38" r="4" fill="#1f2937"/>
+  <circle cx="40" cy="38" r="4" fill="#1f2937"/>
+</svg>


### PR DESCRIPTION
## Summary
- cache robots.txt with TTL and surface unknown directives
- display per-user-agent allow/disallow rules with report export
- document robots parser and wire page metadata and icon

## Testing
- `yarn test __tests__/robots-parser.test.ts __tests__/iconAssets.test.ts`
- `yarn lint lib/robots.ts components/apps/robots-auditor.tsx pages/apps/robots-auditor.tsx __tests__/robots-parser.test.ts docs/robots.md apps.config.js` *(fails: Couldn't find any pages or app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3778f0648328b350b191ab263edd