### PR TITLE
feat: add SLAAC analyzer

### DIFF
--- a/__tests__/slaac.test.ts
+++ b/__tests__/slaac.test.ts
@@ -1,0 +1,27 @@
+import { parseSlaac, hasPrivacyExtensions } from '../lib/slaac';
+
+describe('SLAAC parser', () => {
+  const sample = `
+00:00:01 Router Advertisement from fe80::1
+00:00:02 Neighbor Solicitation for fe80::abcd:ff:fe00:1234
+00:00:03 interface eth0 ipv6 address autoconfig
+`;
+
+  it('detects events and EUI-64 addresses', () => {
+    const result = parseSlaac(sample);
+    expect(result.events).toHaveLength(3);
+    expect(result.eui64Addresses[0]).toBe('fe80::abcd:ff:fe00:1234');
+    expect(hasPrivacyExtensions(result)).toBe(false);
+  });
+
+  it('reports privacy extensions when no EUI-64 is present', () => {
+    const sample2 = `
+12:00:00 Router Advertisement from fe80::1
+12:00:01 Neighbor Solicitation for 2001:db8::1a2b:3c4d:5e6f:7a8b
+`;
+    const result = parseSlaac(sample2);
+    expect(result.events).toHaveLength(2);
+    expect(result.eui64Addresses).toHaveLength(0);
+    expect(hasPrivacyExtensions(result)).toBe(true);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -857,7 +857,7 @@ const apps = [
   {
     id: 'ipv6-slaac',
     title: 'IPv6 SLAAC',
-    icon: icon('calc.png'),
+    icon: icon('ipv6-slaac.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/lib/slaac.ts
+++ b/lib/slaac.ts
@@ -1,0 +1,49 @@
+export interface SlaacEvent {
+  time: string;
+  type: string;
+  line: string;
+}
+
+export interface SlaacResult {
+  events: SlaacEvent[];
+  eui64Addresses: string[];
+}
+
+function extractTime(line: string): string {
+  const match = line.match(/(\d{2}:\d{2}:\d{2})/);
+  return match ? match[1] : '';
+}
+
+export function parseSlaac(input: string): SlaacResult {
+  const events: SlaacEvent[] = [];
+  const eui64Addresses: string[] = [];
+  const lines = input.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const time = extractTime(trimmed);
+    if (/Router Advertisement/i.test(trimmed)) {
+      events.push({ time, type: 'Router Advertisement', line: trimmed });
+    } else if (/Neighbor Solicitation/i.test(trimmed)) {
+      events.push({ time, type: 'Neighbor Solicitation', line: trimmed });
+    } else if (/Neighbor Advertisement/i.test(trimmed)) {
+      events.push({ time, type: 'Neighbor Advertisement', line: trimmed });
+    } else if (/autoconfig/i.test(trimmed)) {
+      events.push({ time, type: 'Autoconfig', line: trimmed });
+    }
+
+    const withoutTime = trimmed.replace(/\d{2}:\d{2}:\d{2}/, '');
+    const addrMatch = withoutTime.match(/[0-9a-f]{1,4}:[0-9a-f:]+/i);
+    if (addrMatch) {
+      const addr = addrMatch[0];
+      if (/ff:fe|fffe/i.test(addr)) {
+        eui64Addresses.push(addr);
+      }
+    }
+  }
+  return { events, eui64Addresses };
+}
+
+export function hasPrivacyExtensions(result: SlaacResult): boolean {
+  return result.eui64Addresses.length === 0;
+}

--- a/pages/slaac.tsx
+++ b/pages/slaac.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import { parseSlaac, hasPrivacyExtensions, SlaacResult } from '../lib/slaac';
+import { z } from 'zod';
+
+const inputSchema = z.string().min(1, 'Input is required');
+
+export default function SlaacPage() {
+  const [input, setInput] = useState('');
+  const [result, setResult] = useState<SlaacResult | null>(null);
+  const [error, setError] = useState('');
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setInput(String(reader.result));
+    reader.readAsText(file);
+  };
+
+  const analyze = () => {
+    const check = inputSchema.safeParse(input);
+    if (!check.success) {
+      setError(check.error.issues[0].message);
+      setResult(null);
+      return;
+    }
+    setError('');
+    const res = parseSlaac(input);
+    setResult(res);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>SLAAC Analyzer</title>
+        <meta
+          name="description"
+          content="Detect SLAAC patterns and privacy extensions from neighbor discovery logs."
+        />
+      </Head>
+      <div className="p-4">
+        <h1 className="text-2xl mb-2 flex items-center gap-2">
+          <img src="/images/slaac.svg" alt="" className="h-6 w-6" /> SLAAC Analyzer
+        </h1>
+        <input
+          type="file"
+          accept=".txt,.log"
+          onChange={handleFile}
+          className="mb-2"
+        />
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="w-full border p-2 h-40"
+          placeholder="Paste neighbor discovery capture or config sample"
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button
+          onClick={analyze}
+          className="mt-2 px-4 py-1 bg-blue-600 text-white rounded"
+        >
+          Analyze
+        </button>
+        {result && (
+          <div className="mt-4">
+            <h2 className="text-xl mb-2">Timeline</h2>
+            <ul className="border-l border-gray-400 pl-4">
+              {result.events.map((ev, i) => (
+                <li key={i} className="mb-2">
+                  <span className="font-mono">{ev.time}</span> - {ev.type}
+                </li>
+              ))}
+            </ul>
+            <h2 className="text-xl mt-4">Privacy Extension</h2>
+            {hasPrivacyExtensions(result) ? (
+              <p>
+                Temporary addresses detected; privacy extensions appear enabled.
+              </p>
+            ) : (
+              <p>
+                Found EUI-64 addresses. Enable IPv6 privacy extensions to avoid
+                tracking.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/public/images/slaac.svg
+++ b/public/images/slaac.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M2 12h20M12 2v20"/>
+</svg>

--- a/public/themes/Yaru/apps/ipv6-slaac.svg
+++ b/public/themes/Yaru/apps/ipv6-slaac.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M2 12h20M12 2v20"/>
+</svg>


### PR DESCRIPTION
## Summary
- add SLAAC analyzer page supporting file upload or manual input with timeline display and privacy-extension guidance
- implement SLAAC pattern detection utilities and wire icon/metadata
- cover detection logic with unit tests and add themed icon reference

## Testing
- `yarn lint`
- `yarn test __tests__/slaac.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab377a8a94832891c986c945f5420e