### PR TITLE
Add metadata and tests for CAA checker

### DIFF
--- a/__tests__/caa-checker.api.test.ts
+++ b/__tests__/caa-checker.api.test.ts
@@ -1,0 +1,70 @@
+import type { NextApiHandler } from 'next';
+
+function mockReqRes({ method, query }: { method: string; query: any }) {
+  const req: any = { method, query };
+  const res: any = { statusCode: 200 };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (data: any) => {
+    res.data = data;
+    return res;
+  };
+  return { req, res };
+}
+
+describe('caa-checker api', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('parses records and caches responses', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        Answer: [
+          { data: '0 issue "letsencrypt.org"' },
+          { data: '0 iodef "mailto:security@example.com"' },
+        ],
+      }),
+    });
+    (global as any).fetch = fetchMock;
+
+    const { default: handler } = await import('../pages/api/caa-checker');
+
+    const { req, res } = mockReqRes({
+      method: 'GET',
+      query: { domain: 'sub.example.com' },
+    });
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.data.effective.issue).toEqual(['letsencrypt.org']);
+    expect(res.data.effective.iodef).toBe('mailto:security@example.com');
+
+    const { req: req2, res: res2 } = mockReqRes({
+      method: 'GET',
+      query: { domain: 'sub.example.com' },
+    });
+    await handler(req2, res2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('handles upstream errors', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false });
+    (global as any).fetch = fetchMock;
+    const { default: handler } = await import('../pages/api/caa-checker');
+    const { req, res } = mockReqRes({ method: 'GET', query: { domain: 'example.com' } });
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  test('validates domain input', async () => {
+    const { default: handler } = await import('../pages/api/caa-checker');
+    const { req, res } = mockReqRes({ method: 'GET', query: { domain: 'bad_domain!' } });
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+});
+

--- a/__tests__/caa-checker.test.tsx
+++ b/__tests__/caa-checker.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import CaaChecker from '@apps/caa-checker';
+
+describe('CaaChecker component', () => {
+  const realClipboard = navigator.clipboard;
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    // @ts-ignore
+    navigator.clipboard = realClipboard;
+    global.fetch = realFetch;
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('renders results and copies examples', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    // @ts-ignore
+    navigator.clipboard = { writeText };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        records: [
+          { flags: 0, tag: 'issue', value: 'letsencrypt.org' },
+          { flags: 0, tag: 'iodef', value: 'mailto:security@example.com' },
+        ],
+        issues: [],
+        policyDomain: 'example.com',
+        examples: '0 issue "letsencrypt.org"\n0 iodef "mailto:security@example.com"\n',
+        notes: [],
+        effective: {
+          issue: ['letsencrypt.org'],
+          issuewild: ['letsencrypt.org'],
+          iodef: 'mailto:security@example.com',
+        },
+      }),
+    });
+
+    render(<CaaChecker />);
+    fireEvent.change(screen.getByPlaceholderText('example.com'), {
+      target: { value: 'example.com' },
+    });
+    fireEvent.click(screen.getByText('Check'));
+
+    await waitFor(() => expect(screen.getAllByText('letsencrypt.org').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByText('Copy'));
+    expect(writeText).toHaveBeenCalledWith(
+      '0 issue "letsencrypt.org"\n0 iodef "mailto:security@example.com"\n',
+    );
+  });
+
+  test('shows error message on failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+    render(<CaaChecker />);
+    fireEvent.change(screen.getByPlaceholderText('example.com'), {
+      target: { value: 'example.com' },
+    });
+    fireEvent.click(screen.getByText('Check'));
+    await waitFor(() => expect(screen.getByText('network')).toBeInTheDocument());
+  });
+});
+

--- a/apps/caa-checker/index.tsx
+++ b/apps/caa-checker/index.tsx
@@ -1,1 +1,8 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'CAA Checker',
+  description: 'Inspect Certificate Authority Authorization records for a domain',
+};
+
 export { default, displayCaaChecker } from '../../components/apps/caa-checker';


### PR DESCRIPTION
## Summary
- add metadata for the CAA Checker app
- cover CAA Checker API caching and error handling with tests
- test CAA Checker UI rendering and copy behavior with mocked DNS data

## Testing
- `yarn test __tests__/caa-checker.api.test.ts __tests__/caa-checker.test.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab377ba81483289c94f1505d12135b