### PR TITLE
feat: enhance wayback viewer with search and caching

### DIFF
--- a/__tests__/wayback-viewer.api.test.ts
+++ b/__tests__/wayback-viewer.api.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler, { __clearCache } from '../pages/api/wayback-viewer';
+
+function createReqRes(query: any) {
+  const req = { method: 'GET', query } as unknown as NextApiRequest;
+  const res: Partial<NextApiResponse> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockImplementation((d) => {
+    (res as any)._data = d;
+    return res;
+  });
+  return { req, res: res as NextApiResponse };
+}
+
+describe('wayback viewer api', () => {
+  beforeEach(() => {
+    __clearCache();
+  });
+
+  it('caches responses for identical queries', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          ['timestamp', 'original', 'statuscode', 'mimetype', 'robotflags'],
+          ['20200101000000', 'http://example.com', '200', 'text/html', null],
+        ],
+      });
+    (global as any).fetch = mockFetch;
+
+    const q = { url: 'http://example.com' };
+    const first = createReqRes(q);
+    await handler(first.req, first.res);
+    const second = createReqRes(q);
+    await handler(second.req, second.res);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((second.res as any)._data.snapshots).toHaveLength(1);
+  });
+
+  it('handles upstream errors', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: false });
+    (global as any).fetch = mockFetch;
+
+    const { req, res } = createReqRes({ url: 'http://example.com' });
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res as any)._data.error).toBe('Failed to fetch snapshots');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -866,7 +866,7 @@ const apps = [
   {
     id: 'wayback-viewer',
     title: 'Wayback Viewer',
-    icon: './themes/Yaru/apps/hash.svg',
+    icon: './themes/Yaru/apps/wayback.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/pages/apps/wayback-viewer.tsx
+++ b/pages/apps/wayback-viewer.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 
 const WaybackViewer = dynamic(
   () => import('../../components/apps/wayback-viewer'),
@@ -6,5 +7,16 @@ const WaybackViewer = dynamic(
 );
 
 export default function WaybackViewerPage() {
-  return <WaybackViewer />;
+  return (
+    <>
+      <Head>
+        <title>Wayback Viewer</title>
+        <meta
+          name="description"
+          content="Browse and diff Internet Archive snapshots"
+        />
+      </Head>
+      <WaybackViewer />
+    </>
+  );
 }

--- a/public/themes/Yaru/apps/wayback.svg
+++ b/public/themes/Yaru/apps/wayback.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#fff" stroke-width="4"/>
+  <path d="M32 18v16l12 6" stroke="#fff" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add caching to Wayback viewer API to reuse snapshot results
- support client-side search, pagination caching and metadata for Wayback viewer page
- provide new icon and tests with mocked API responses

## Testing
- `yarn test __tests__/wayback-viewer.api.test.ts`
- `yarn test __tests__/iconAssets.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab377b0e1c83288d7a333ef6932ade