### PR TITLE
feat: enhance timeline builder with log support

### DIFF
--- a/__tests__/timeline-builder.log.test.ts
+++ b/__tests__/timeline-builder.log.test.ts
@@ -1,0 +1,22 @@
+import { parseLogText, filterEvents } from '@components/apps/timeline-builder';
+import fs from 'fs';
+import path from 'path';
+
+describe('timeline builder log parsing', () => {
+  const logPath = path.join(__dirname, '..', 'data', 'sample-logs.log');
+  const sample = fs.readFileSync(logPath, 'utf-8');
+
+  it('parses logs into events with tags', () => {
+    const events = parseLogText(sample);
+    expect(events).toHaveLength(3);
+    expect(events[0].tags).toEqual(['start']);
+    expect(events[2].tags).toEqual(['error', 'system']);
+  });
+
+  it('filters events by search term', () => {
+    const events = parseLogText(sample);
+    const filtered = filterEvents(events, 'error');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].event).toMatch(/Failure/);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -542,7 +542,7 @@ const apps = [
   {
     id: 'timeline-builder',
     title: 'Timeline Builder',
-    icon: icon('project-gallery.svg'),
+    icon: icon('timeline-builder.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/timeline-builder/index.tsx
+++ b/apps/timeline-builder/index.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Timeline Builder',
+  description: 'Build and explore event timelines from logs, CSV, or JSON files.',
+};
+
+export { default } from '../../components/apps/timeline-builder';

--- a/components/apps/timeline-builder.worker.ts
+++ b/components/apps/timeline-builder.worker.ts
@@ -6,17 +6,19 @@ self.onmessage = (e: MessageEvent<TimelineEvent[]>) => {
   const groupIds = new Map<string, number>();
   const items = events.map((evt, idx) => {
     let group: number | undefined;
-    if (evt.group) {
-      if (!groupIds.has(evt.group)) {
+    const label = evt.group || evt.tags?.[0];
+    if (label) {
+      if (!groupIds.has(label)) {
         const id = groupIds.size + 1;
-        groupIds.set(evt.group, id);
-        groups.push({ id, content: evt.group });
+        groupIds.set(label, id);
+        groups.push({ id, content: label });
       }
-      group = groupIds.get(evt.group);
+      group = groupIds.get(label);
     }
     return {
       id: idx,
-      content: evt.event,
+      content:
+        evt.event + (evt.tags && evt.tags.length ? ` [${evt.tags.join(',')}]` : ''),
       start: evt.time,
       end: evt.end,
       group,

--- a/data/sample-logs.log
+++ b/data/sample-logs.log
@@ -1,0 +1,3 @@
+2024-01-01T00:00:00Z [start] System boot
+2024-01-01T00:05:00Z [auth] User login
+2024-01-01T00:10:00Z [error,system] Failure detected

--- a/pages/apps/timeline-builder.tsx
+++ b/pages/apps/timeline-builder.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const TimelineBuilder = dynamic(() => import('../../components/apps/timeline-builder'), { ssr: false });
+const TimelineBuilder = dynamic(() => import('../../apps/timeline-builder'), { ssr: false });
 
 export default function TimelineBuilderPage() {
   return <TimelineBuilder />;

--- a/public/themes/Yaru/apps/timeline-builder.svg
+++ b/public/themes/Yaru/apps/timeline-builder.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#4b5563"/>
+  <line x1="8" y1="32" x2="56" y2="32" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="16" cy="32" r="6" fill="#2563eb"/>
+  <circle cx="32" cy="32" r="6" fill="#10b981"/>
+  <circle cx="48" cy="32" r="6" fill="#ef4444"/>
+</svg>


### PR DESCRIPTION
## Summary
- parse log/CSV/JSON data into tagged timeline events
- add search, CSV export, and virtualized event list
- wire metadata, page import, icon, and tests

## Testing
- `yarn lint`
- `yarn validate:icons`
- `yarn test __tests__/timeline-builder.log.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab377dc28c8328a4f84762729d163e