### PR TITLE
feat: add crt.sh certificate lookup tool

### DIFF
--- a/__tests__/crtsh.api.test.ts
+++ b/__tests__/crtsh.api.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+function createReqRes(query: any = {}) {
+  const req = {
+    method: 'GET',
+    query,
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+
+  const res: Partial<NextApiResponse> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn();
+
+  return { req, res: res as NextApiResponse };
+}
+
+describe('crtsh api', () => {
+  let handler: any;
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    handler = (await import('../pages/api/crtsh')).default;
+  });
+
+  it('returns parsed results and caches responses', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          issuer_name: 'Test CA',
+          not_before: '2024-01-01T00:00:00',
+          not_after: '2024-06-01T00:00:00',
+          name_value: 'example.com\nwww.example.com',
+          id: 1,
+        },
+      ],
+    });
+    (global as any).fetch = mockFetch;
+
+    const first = createReqRes({ domain: 'example.com' });
+    await handler(first.req, first.res);
+    expect(first.res.status).toHaveBeenCalledWith(200);
+    const data = (first.res.json as jest.Mock).mock.calls[0][0];
+    expect(data.results[0].issuer).toBe('Test CA');
+    expect(data.results[0].sans).toEqual(['example.com', 'www.example.com']);
+
+    const second = createReqRes({ domain: 'example.com' });
+    await handler(second.req, second.res);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces rate limits', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+    (global as any).fetch = mockFetch;
+
+    for (let i = 0; i < 10; i++) {
+      const { req, res } = createReqRes({ domain: 'a.com' });
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    }
+
+    const { req, res } = createReqRes({ domain: 'a.com' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenLastCalledWith(429);
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -169,6 +169,7 @@ const dynamicAppEntries = [
   ['candy-crush', 'Candy Crush'],
   ['match3', 'Match 3'],
   ['ct-search', 'CT Search'],
+  ['crtsh-lookup', 'crt.sh Lookup'],
   ['mail-auth', 'Mail Auth'],
   ['mail-security-matrix', 'Mail Security Matrix'],
   ['dnssec-validator', 'DNSSEC Validator'],
@@ -556,6 +557,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: getScreen('ct-search'),
+  },
+  {
+    id: 'crtsh-lookup',
+    title: 'crt.sh Lookup',
+    icon: icon('crtsh.svg'),
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: getScreen('crtsh-lookup'),
   },
   {
     id: 'evidence-notebook',

--- a/components/apps/crtsh-lookup.tsx
+++ b/components/apps/crtsh-lookup.tsx
@@ -1,0 +1,177 @@
+import React, { useRef, useState } from 'react';
+
+interface Result {
+  certId: number;
+  issuer: string;
+  notBefore: string;
+  notAfter: string;
+  sans: string[];
+}
+
+const CrtshLookup: React.FC = () => {
+  const [domain, setDomain] = useState('');
+  const [includeSubdomains, setIncludeSubdomains] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [results, setResults] = useState<Result[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cacheRef = useRef<Map<string, Result[]>>(new Map());
+
+  const search = async () => {
+    if (!domain) return;
+    const key = `${domain}|${includeSubdomains}`;
+    if (cacheRef.current.has(key)) {
+      setResults(cacheRef.current.get(key)!);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/crtsh?domain=${encodeURIComponent(domain)}&subdomains=${includeSubdomains}`
+      );
+      if (res.status === 429) {
+        const retry = res.headers.get('Retry-After');
+        setError(
+          retry ? `Rate limit exceeded. Retry after ${retry}s` : 'Rate limit exceeded'
+        );
+        setResults([]);
+      } else if (!res.ok) {
+        const data = await res.json();
+        setError((data as any).error || 'Request failed');
+        setResults([]);
+      } else {
+        const data: { results: Result[] } = await res.json();
+        setResults(data.results);
+        cacheRef.current.set(key, data.results);
+      }
+    } catch (e: any) {
+      setError(e.message || 'Request failed');
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify(results, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${domain || 'certs'}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCSV = () => {
+    const header = 'issuer,not_before,not_after,sans\n';
+    const rows = results
+      .map((r) => {
+        const sans = r.sans.join(';');
+        return `"${r.issuer.replace(/"/g, '""')}",${r.notBefore},${r.notAfter},"${sans.replace(/"/g, '""')}"`;
+      })
+      .join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${domain || 'certs'}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const filtered = results.filter((r) => {
+    if (!filter) return true;
+    const target = `${r.issuer} ${r.sans.join(' ')}`.toLowerCase();
+    return target.includes(filter.toLowerCase());
+  });
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 space-y-4 overflow-hidden">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          className="flex-1 px-2 py-1 rounded bg-gray-800 text-white"
+          placeholder="example.com"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+        />
+        <button
+          onClick={search}
+          className="px-2 py-1 bg-blue-600 rounded text-white"
+        >
+          Search
+        </button>
+      </div>
+      <div className="flex gap-4 text-sm items-center flex-wrap">
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={includeSubdomains}
+            onChange={(e) => setIncludeSubdomains(e.target.checked)}
+          />
+          Include subdomains
+        </label>
+        <input
+          type="text"
+          className="px-2 py-1 rounded bg-gray-800 text-white"
+          placeholder="Filter results"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <button
+          onClick={exportJSON}
+          className="px-2 py-1 bg-green-600 rounded text-white"
+          disabled={results.length === 0}
+        >
+          JSON
+        </button>
+        <button
+          onClick={exportCSV}
+          className="px-2 py-1 bg-green-600 rounded text-white"
+          disabled={results.length === 0}
+        >
+          CSV
+        </button>
+      </div>
+      {loading && <div className="text-sm text-gray-400">Searching...</div>}
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+      <div className="overflow-auto h-full space-y-2 pr-1">
+        {filtered.map((r) => (
+          <div key={r.certId} className="p-2 bg-gray-800 rounded space-y-1">
+            <div className="font-mono break-words text-sm">
+              {r.sans.map((s) => (
+                <div key={s}>{s}</div>
+              ))}
+            </div>
+            <div className="text-xs text-gray-300 break-words">{r.issuer}</div>
+            <div className="text-xs text-gray-400">
+              {new Date(r.notBefore).toLocaleString()} -{' '}
+              {new Date(r.notAfter).toLocaleString()}
+            </div>
+            <div className="flex gap-2 text-xs">
+              <a
+                href={`https://crt.sh/?id=${r.certId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline"
+              >
+                View
+              </a>
+            </div>
+          </div>
+        ))}
+        {!loading && filtered.length === 0 && !error && (
+          <div className="text-sm text-gray-400">No results</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CrtshLookup;
+
+export const displayCrtshLookup = () => <CrtshLookup />;
+

--- a/components/apps/index.ts
+++ b/components/apps/index.ts
@@ -1,1 +1,2 @@
 export { displayCaaChecker } from './caa-checker';
+export { displayCrtshLookup } from './crtsh-lookup';

--- a/pages/api/crtsh.ts
+++ b/pages/api/crtsh.ts
@@ -1,0 +1,103 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { LRUCache } from 'lru-cache';
+import { setupUrlGuard } from '../../lib/urlGuard';
+
+setupUrlGuard();
+
+interface CertResult {
+  certId: number;
+  issuer: string;
+  notBefore: string;
+  notAfter: string;
+  sans: string[];
+}
+
+interface CacheEntry {
+  results: CertResult[];
+}
+
+const cache = new LRUCache<string, CacheEntry>({ max: 100, ttl: 10 * 60 * 1000 });
+const RATE_LIMIT_WINDOW = 60 * 1000;
+const RATE_LIMIT_MAX = 10;
+const rateLimit = new Map<string, { count: number; reset: number }>();
+
+function checkRateLimit(ip: string): number | null {
+  const now = Date.now();
+  const record = rateLimit.get(ip);
+  if (!record || now > record.reset) {
+    rateLimit.set(ip, { count: 1, reset: now + RATE_LIMIT_WINDOW });
+    return null;
+  }
+  if (record.count >= RATE_LIMIT_MAX) {
+    return record.reset - now;
+  }
+  record.count++;
+  return null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { domain, subdomains = 'true' } = req.query;
+  if (!domain || typeof domain !== 'string') {
+    return res.status(400).json({ error: 'Missing domain' });
+  }
+
+  const ip =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0] ||
+    req.socket.remoteAddress ||
+    'unknown';
+  const retry = checkRateLimit(ip);
+  if (retry !== null) {
+    res.setHeader('Retry-After', Math.ceil(retry / 1000).toString());
+    return res.status(429).json({ error: 'Rate limit exceeded' });
+  }
+
+  const key = `${domain}|${subdomains}`;
+  const cached = cache.get(key);
+  if (cached) {
+    return res.status(200).json(cached);
+  }
+
+  const search = subdomains === 'true' ? `%25.${domain}` : domain;
+  try {
+    const response = await fetch(
+      `https://crt.sh/?q=${encodeURIComponent(search)}&output=json`,
+      { headers: { 'User-Agent': 'Mozilla/5.0' } }
+    );
+
+    if (response.status === 429) {
+      return res.status(429).json({ error: 'Upstream rate limit exceeded' });
+    }
+
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: 'Upstream server error' });
+    }
+
+    const data = await response.json();
+    const results: CertResult[] = data.map((item: any) => ({
+      certId: Number(item.id || item.min_cert_id || item.cert_id),
+      issuer: item.issuer_name as string,
+      notBefore: item.not_before as string,
+      notAfter: item.not_after as string,
+      sans: String(item.name_value || '')
+        .split('\n')
+        .filter(Boolean),
+    }));
+
+    const payload: CacheEntry = { results };
+    cache.set(key, payload);
+    return res.status(200).json(payload);
+  } catch (e: any) {
+    return res.status(500).json({ error: e.message || 'Request failed' });
+  }
+}
+

--- a/pages/apps/crtsh-lookup.tsx
+++ b/pages/apps/crtsh-lookup.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const CrtshLookup = dynamic(() => import('../../components/apps/crtsh-lookup'), {
+  ssr: false,
+});
+
+export default function CrtshLookupPage() {
+  return <CrtshLookup />;
+}
+

--- a/public/themes/Yaru/apps/crtsh.svg
+++ b/public/themes/Yaru/apps/crtsh.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="8" width="48" height="48" rx="4" ry="4" fill="#f9fafb" stroke="#1f2937" stroke-width="2"/>
+  <path d="M16 24h32M16 32h32M16 40h20" stroke="#1f2937" stroke-width="2" stroke-linecap="round"/>
+  <path d="M32 40l8 8-4 8-4-8-4 8-4-8 8-8z" fill="#eab308"/>
+</svg>


### PR DESCRIPTION
## Summary
- add API with caching and rate limiting to retrieve crt.sh certificate data
- create crt.sh lookup app with filtering and CSV/JSON export
- register tool in app config with icon and tests

## Testing
- `yarn test __tests__/crtsh.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab377ea5408328880be2ab25d3cc48