### PR TITLE
Add audit bundle export and hash-chain tests for Evidence Notebook

### DIFF
--- a/__tests__/evidence-notebook.test.ts
+++ b/__tests__/evidence-notebook.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+// @vitest-environment node
+import { hashEntry, verifyChain } from '../apps/evidence-notebook/utils';
+
+describe('evidence notebook hash chaining', () => {
+  it('detects tampering in chain', async () => {
+    const t1 = '2024-01-01T00:00:00Z';
+    const h1 = await hashEntry('first note', '', t1);
+    const t2 = '2024-01-01T00:01:00Z';
+    const h2 = await hashEntry('second note', h1, t2);
+    const entries = [
+      { data: 'first note', timestamp: t1, hash: h1 },
+      { data: 'second note', timestamp: t2, hash: h2 },
+    ];
+    expect(await verifyChain(entries)).toBe(true);
+    const tampered = [...entries];
+    tampered[1] = { ...tampered[1], data: 'evil' };
+    expect(await verifyChain(tampered)).toBe(false);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -560,7 +560,7 @@ const apps = [
   {
     id: 'evidence-notebook',
     title: 'Evidence Notebook',
-    icon: './themes/Yaru/apps/gedit.png',
+    icon: icon('hash.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/pages/apps/evidence-notebook/index.tsx
+++ b/pages/apps/evidence-notebook/index.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
 const EvidenceNotebook = dynamic(
-  () => import('../../../apps/evidence-notebook'),
+  () => import('../../../components/apps/evidence-notebook'),
   { ssr: false }
 );
 


### PR DESCRIPTION
## Summary
- export signed audit bundles with embedded manifest JSON for Evidence Notebook
- support entry copy/delete actions and manual verification
- add dedicated hash chaining unit test and wire app page/icon metadata

## Testing
- `yarn test __tests__/evidence-notebook.test.ts`
- `yarn test:unit __tests__/evidence-notebook.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab377f14208328b08d08d9b927d94a