### PR TITLE
feat: add tls inspector

### DIFF
--- a/__tests__/tls-chain.api.test.ts
+++ b/__tests__/tls-chain.api.test.ts
@@ -1,0 +1,65 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../pages/api/tls-chain';
+import tls from 'tls';
+
+describe('tls-chain api', () => {
+  function createReqRes(host = 'example.com') {
+    const req = { query: { host } } as unknown as NextApiRequest;
+    const res: Partial<NextApiResponse> = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return { req, res: res as NextApiResponse };
+  }
+
+  const rootCert: any = {
+    subject: { CN: 'Root CA' },
+    issuer: { CN: 'Root CA' },
+    subjectaltname: 'DNS:root',
+    valid_from: 'Jan 1 00:00:00 2020 GMT',
+    valid_to: 'Jan 1 00:00:00 2030 GMT',
+    fingerprint256: 'root',
+  };
+  rootCert.issuerCertificate = rootCert;
+
+  const leafCert: any = {
+    subject: { CN: 'example.com' },
+    issuer: { CN: 'Root CA' },
+    subjectaltname: 'DNS:example.com,DNS:www.example.com',
+    valid_from: 'Jan 1 00:00:00 2024 GMT',
+    valid_to: 'Jan 1 00:00:00 2025 GMT',
+    fingerprint256: 'leaf',
+    issuerCertificate: rootCert,
+  };
+
+  const mockSocket: any = {
+    getPeerCertificate: jest.fn(() => leafCert),
+    getCipher: jest.fn(() => ({ name: 'TLS_AES_128_GCM_SHA256', version: 'TLSv1.3' })),
+    getProtocol: jest.fn(() => 'TLSv1.3'),
+    end: jest.fn(),
+    on: jest.fn(),
+    ocspResponse: Buffer.from('00', 'hex'),
+  };
+
+  beforeAll(() => {
+    (tls.connect as any) = jest.fn((_opts: any, cb: () => void) => {
+      setTimeout(cb, 0);
+      return mockSocket;
+    });
+  });
+
+  it('returns tls details and caches result', async () => {
+    const first = createReqRes();
+    await handler(first.req, first.res);
+    expect(first.res.status).toHaveBeenCalledWith(200);
+    expect(first.res.json).toHaveBeenCalled();
+
+    const second = createReqRes();
+    await handler(second.req, second.res);
+
+    expect((tls.connect as any)).toHaveBeenCalledTimes(1);
+    const data = (first.res.json as jest.Mock).mock.calls[0][0];
+    expect(data.chain.length).toBeGreaterThan(0);
+    expect(data.cipher.name).toBe('TLS_AES_128_GCM_SHA256');
+    expect(data.ocspStapled).toBe(true);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -194,6 +194,7 @@ const dynamicAppEntries = [
   ['cookie-simulator', 'Cookie Simulator'],
   ['mixed-content', 'Mixed Content'],
   ['tls-explainer', 'TLS Explainer'],
+  ['tls-inspector', 'TLS Inspector'],
   ['cache-policy', 'Cache Policy'],
   ['tor-exit-check', 'Tor Exit Check'],
   ['wayback-viewer', 'Wayback Viewer'],
@@ -574,6 +575,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: getScreen('tls-explainer'),
+  },
+  {
+    id: 'tls-inspector',
+    title: 'TLS Inspector',
+    icon: './themes/Yaru/apps/tls-inspector.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: getScreen('tls-inspector'),
   },
   {
     id: 'import-graph',

--- a/apps/tls-inspector/index.tsx
+++ b/apps/tls-inspector/index.tsx
@@ -1,0 +1,1 @@
+export { default, displayTlsInspector } from '../../components/apps/tls-inspector';

--- a/components/apps/tls-inspector.tsx
+++ b/components/apps/tls-inspector.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+
+interface CertInfo {
+  subject: Record<string, string>;
+  issuer: Record<string, string>;
+  san: string[];
+  validFrom: string;
+  validTo: string;
+  daysRemaining: number;
+}
+
+interface ApiResult {
+  host: string;
+  port: number;
+  protocol?: string;
+  cipher?: { name: string; version?: string };
+  ocspStapled: boolean;
+  chain: CertInfo[];
+  sslLabsUrl: string;
+  explanations: Record<string, string>;
+}
+
+const TLSInspector: React.FC = () => {
+  const [host, setHost] = useState('');
+  const [result, setResult] = useState<ApiResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchInfo = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!host) return;
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tls-chain?host=${encodeURIComponent(host)}`);
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || 'Request failed');
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || 'Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyReport = () => {
+    if (!result) return;
+    navigator.clipboard.writeText(JSON.stringify(result, null, 2));
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+      <form onSubmit={fetchInfo} className="flex space-x-2 items-center">
+        <input
+          type="text"
+          value={host}
+          onChange={(e) => setHost(e.target.value)}
+          placeholder="example.com"
+          className="text-black px-2 py-1 flex-1"
+        />
+        <button type="submit" disabled={loading} className="px-3 py-1 bg-blue-600 rounded">
+          {loading ? '...' : 'Fetch'}
+        </button>
+      </form>
+      {error && <div className="text-red-500">{error}</div>}
+      {result && (
+        <>
+          <div className="text-sm space-y-1">
+            <div><strong>Protocol:</strong> {result.protocol || 'Unknown'}</div>
+            <div><strong>Cipher:</strong> {result.cipher?.name || 'Unknown'}</div>
+            <div><strong>OCSP Stapled:</strong> {result.ocspStapled ? 'Yes' : 'No'}</div>
+            <div>
+              <a href={result.sslLabsUrl} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">
+                SSL Labs Report
+              </a>
+            </div>
+          </div>
+          <div className="text-sm space-y-2 overflow-auto">
+            {result.chain.map((c, i) => (
+              <div key={i} className="border border-gray-700 p-2 rounded">
+                <div><strong>Subject:</strong> {c.subject.CN || JSON.stringify(c.subject)}</div>
+                <div><strong>Issuer:</strong> {c.issuer.CN || JSON.stringify(c.issuer)}</div>
+                <div><strong>SAN:</strong> {c.san.join(', ') || 'None'}</div>
+                <div><strong>Valid From:</strong> {new Date(c.validFrom).toUTCString()}</div>
+                <div><strong>Valid To:</strong> {new Date(c.validTo).toUTCString()}</div>
+                <div><strong>Days Remaining:</strong> {c.daysRemaining}</div>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={copyReport}
+            className="self-start px-3 py-1 bg-blue-600 rounded text-sm"
+          >
+            Copy Report
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TLSInspector;
+export const displayTlsInspector = () => <TLSInspector />;

--- a/pages/apps/tls-inspector.tsx
+++ b/pages/apps/tls-inspector.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const TLSInspector = dynamic(() => import('../../apps/tls-inspector'), {
+  ssr: false,
+});
+
+export default function TLSInspectorPage() {
+  return <TLSInspector />;
+}

--- a/public/themes/Yaru/apps/tls-inspector.svg
+++ b/public/themes/Yaru/apps/tls-inspector.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <path d="M32 18a6 6 0 0 0-6 6v6h-4v16h20V30h-4v-6a6 6 0 0 0-6-6zm0 4a2 2 0 0 1 2 2v6h-4v-6a2 2 0 0 1 2-2z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add API caching and cipher/SSL Labs details
- introduce TLS Inspector app with copyable report
- document TLS inspector in app registry and add tests

## Testing
- `yarn test __tests__/tls-chain.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab377fe4f08328a0be7c17638168f6