### PR TITLE
feat: add shared utilities and demo

### DIFF
--- a/__tests__/utilities.test.ts
+++ b/__tests__/utilities.test.ts
@@ -1,0 +1,77 @@
+import { guardFile, parseNdjsonStream, wrapWorker, fetchWithRetry } from '@lib/utilities';
+import { useToastLogger } from '@lib/utilities/useToastLogger';
+import { renderHook, act } from '@testing-library/react';
+import { ReadableStream } from 'stream/web';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Polyfill encoding APIs for the test environment
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder as any;
+
+describe('guardFile', () => {
+  it('validates size and type', () => {
+    const file = { size: 10, type: 'text/plain' } as File;
+    expect(guardFile(file, { maxSize: 20, mimeTypes: ['text/plain'] })).toBe(true);
+    expect(() => guardFile(file, { maxSize: 5 })).toThrow('File too large');
+    expect(() => guardFile(file, { mimeTypes: ['image/png'] })).toThrow('Invalid file type');
+  });
+});
+
+describe('parseNdjsonStream', () => {
+  it('parses streamed objects', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"a":1}\n{"b":2}\n'));
+        controller.close();
+      },
+    });
+    const out: any[] = [];
+    for await (const obj of parseNdjsonStream(stream)) out.push(obj);
+    expect(out).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});
+
+describe('fetchWithRetry', () => {
+  it('retries on failure', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue({ ok: true } as Response);
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const res = await fetchWithRetry('https://example.com', {}, 10, 1);
+    expect(res.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('wrapWorker', () => {
+  it('wraps worker communication', async () => {
+    class MockWorker {
+      listeners: Record<string, any> = {};
+      postMessage(msg: any) {
+        this.listeners['message']({ data: msg * 2 });
+      }
+      addEventListener(type: 'message' | 'error', cb: any) {
+        this.listeners[type] = cb;
+      }
+      removeEventListener() {}
+    }
+    const worker = new MockWorker();
+    const call = wrapWorker<number, number>(worker as any);
+    await expect(call(2)).resolves.toBe(4);
+  });
+});
+
+describe('useToastLogger', () => {
+  jest.useFakeTimers();
+  it('sets and clears message', () => {
+    const { result } = renderHook(() => useToastLogger(100));
+    act(() => result.current.toast('hi'));
+    expect(result.current.message).toBe('hi');
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(result.current.message).toBeNull();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -51,6 +51,7 @@ import { displayJwsJweWorkbench } from './apps/jws-jwe-workbench';
 import { displayCaaChecker } from './components/apps/caa-checker';
 
 
+
 export const THEME = process.env.NEXT_PUBLIC_THEME || 'Yaru';
 
 const FALLBACK_THEME = 'Yaru';
@@ -215,6 +216,7 @@ const dynamicAppEntries = [
   ['redirect-visualizer', 'Redirect Visualizer'],
   ['http3-probe', 'HTTP/3 Probe'],
   ['sbom-viewer', 'SBOM Viewer'],
+  ['utilities-demo', 'Utilities Demo'],
 ];
 
 const dynamicScreens = Object.fromEntries(
@@ -871,6 +873,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: getScreen('wayback-viewer'),
+  },
+  {
+    id: 'utilities-demo',
+    title: 'Utilities Demo',
+    icon: './themes/Yaru/apps/utilities.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: getScreen('utilities-demo'),
   },
 ];
  

--- a/components/apps/utilities-demo.tsx
+++ b/components/apps/utilities-demo.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { guardFile, fetchWithRetry, wrapWorker, useToastLogger } from '@lib/utilities';
+
+const UtilitiesDemo: React.FC = () => {
+  const { message, toast } = useToastLogger();
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      guardFile(file, { maxSize: 1024 * 1024, mimeTypes: ['text/plain'] });
+      toast('File accepted');
+    } catch (err) {
+      toast((err as Error).message);
+    }
+  };
+
+  const doFetch = async () => {
+    try {
+      const res = await fetchWithRetry('https://httpbin.org/status/200');
+      toast(`Fetch ${res.ok ? 'succeeded' : 'failed'}`);
+    } catch (err) {
+      toast('Fetch failed');
+    }
+  };
+
+  const workerDemo = async () => {
+    const worker = new Worker(new URL('./utilities.worker.ts', import.meta.url));
+    const call = wrapWorker<number, number>(worker);
+    const result = await call(4);
+    worker.terminate();
+    toast(`Worker result ${result}`);
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <input type="file" onChange={handleFile} />
+      <div className="space-x-2">
+        <button className="px-2 py-1 bg-blue-600 text-white" onClick={doFetch}>
+          Fetch with retry
+        </button>
+        <button className="px-2 py-1 bg-green-600 text-white" onClick={workerDemo}>
+          Worker demo
+        </button>
+      </div>
+      {message && (
+        <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-2 py-1" role="alert">
+          {message}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const displayUtilitiesDemo = () => <UtilitiesDemo />;
+export default UtilitiesDemo;

--- a/components/apps/utilities.worker.ts
+++ b/components/apps/utilities.worker.ts
@@ -1,0 +1,6 @@
+self.onmessage = (e: MessageEvent<number>) => {
+  const n = e.data;
+  // simple demo: square the number
+  // @ts-ignore
+  self.postMessage(n * n);
+};

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,0 +1,17 @@
+# Utilities
+
+Common helper utilities for apps and libraries are centralized in `lib/utilities`.
+
+## Modules
+
+- **fileGuards.ts** – basic size and MIME type checks for uploaded files.
+- **streamingParser.ts** – parse newline-delimited JSON streams via async
+  iteration.
+- **workerWrapper.ts** – promise-based wrapper around Web Workers or compatible
+  interfaces.
+- **fetchWithRetry.ts** – `fetch` with timeout and retry semantics.
+- **useToastLogger.ts** – React hook combining console logging with a simple
+  toast message state.
+
+These helpers aim to reduce duplicated code across apps. Refer to
+`components/apps/utilities-demo.tsx` for example usage.

--- a/lib/utilities/fetchWithRetry.ts
+++ b/lib/utilities/fetchWithRetry.ts
@@ -1,0 +1,24 @@
+/**
+ * Fetch with timeout and retry logic.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  timeout = 5000,
+  retries = 2
+): Promise<Response> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal });
+      clearTimeout(timer);
+      if (!res.ok && attempt < retries) continue;
+      return res;
+    } catch (err) {
+      clearTimeout(timer);
+      if (attempt === retries) throw err;
+    }
+  }
+  throw new Error('unreachable');
+}

--- a/lib/utilities/fileGuards.ts
+++ b/lib/utilities/fileGuards.ts
@@ -1,0 +1,24 @@
+export interface FileGuardOptions {
+  maxSize?: number;
+  mimeTypes?: string[];
+}
+
+/**
+ * Guard a file's size and MIME type.
+ * Throws an error if the file violates provided constraints.
+ */
+export function guardFile(
+  file: { size: number; type: string },
+  { maxSize, mimeTypes }: FileGuardOptions = {}
+): true {
+  if (typeof file.size !== 'number' || typeof file.type !== 'string') {
+    throw new Error('Invalid file');
+  }
+  if (maxSize && file.size > maxSize) {
+    throw new Error('File too large');
+  }
+  if (mimeTypes && mimeTypes.length && !mimeTypes.includes(file.type)) {
+    throw new Error('Invalid file type');
+  }
+  return true;
+}

--- a/lib/utilities/index.ts
+++ b/lib/utilities/index.ts
@@ -1,0 +1,5 @@
+export * from './fileGuards';
+export * from './streamingParser';
+export * from './workerWrapper';
+export * from './fetchWithRetry';
+export * from './useToastLogger';

--- a/lib/utilities/streamingParser.ts
+++ b/lib/utilities/streamingParser.ts
@@ -1,0 +1,20 @@
+/**
+ * Parse a newline-delimited JSON ReadableStream.
+ * Returns an async generator yielding parsed objects.
+ */
+export async function* parseNdjsonStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (line.trim()) yield JSON.parse(line);
+    }
+  }
+  if (buffer.trim()) yield JSON.parse(buffer);
+}

--- a/lib/utilities/useToastLogger.ts
+++ b/lib/utilities/useToastLogger.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+/**
+ * Simple toast/logger hook. Logs messages to console and exposes
+ * a transient message state for UI display.
+ */
+export function useToastLogger(duration = 3000) {
+  const [message, setMessage] = useState<string | null>(null);
+
+  const toast = (msg: string) => {
+    console.log(msg);
+    setMessage(msg);
+    setTimeout(() => setMessage(null), duration);
+  };
+
+  return { message, toast };
+}

--- a/lib/utilities/workerWrapper.ts
+++ b/lib/utilities/workerWrapper.ts
@@ -1,0 +1,29 @@
+export interface WorkerLike {
+  postMessage(msg: any): void;
+  addEventListener(type: 'message' | 'error', listener: (ev: any) => void): void;
+  removeEventListener(type: 'message' | 'error', listener: (ev: any) => void): void;
+}
+
+/**
+ * Wrap a Worker-like object to return a promise-based call helper.
+ */
+export function wrapWorker<T, R>(worker: WorkerLike) {
+  return (msg: T) =>
+    new Promise<R>((resolve, reject) => {
+      const onMessage = (e: any) => {
+        cleanup();
+        resolve(e.data as R);
+      };
+      const onError = (e: any) => {
+        cleanup();
+        reject(e.error ?? e);
+      };
+      const cleanup = () => {
+        worker.removeEventListener('message', onMessage);
+        worker.removeEventListener('error', onError);
+      };
+      worker.addEventListener('message', onMessage);
+      worker.addEventListener('error', onError);
+      worker.postMessage(msg);
+    });
+}

--- a/public/themes/Yaru/apps/utilities.svg
+++ b/public/themes/Yaru/apps/utilities.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <circle cx="32" cy="32" r="30" stroke="#333" stroke-width="4" fill="#eee"/>
+  <path d="M32 20l4 0 2-4 6 6-4 2 0 4 4 2-6 6-2-4-4 0-2 4-6-6 4-2 0-4-4-2 6-6 2 4z" fill="#333"/>
+</svg>


### PR DESCRIPTION
## Summary
- centralize common helpers in lib/utilities (file guards, streaming parser, worker wrapper, fetch with retry, toast logger)
- document utilities and add demo app with icon and metadata
- add unit tests for new helpers

## Testing
- `yarn test __tests__/utilities.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab3781f2f88328a0be7317a4baec3e