### PR TITLE
feat: add all apps grid with search

### DIFF
--- a/__tests__/allAppsGrid.test.tsx
+++ b/__tests__/allAppsGrid.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import AllApps from '@apps/all-apps';
+import * as NextRouter from 'next/router';
+
+jest.mock('../apps.config', () => ({
+  __esModule: true,
+  default: [
+    { id: 'alpha', title: 'Alpha', icon: '/alpha.svg' },
+    { id: 'beta', title: 'Beta', icon: '/beta.svg' },
+  ],
+  games: [
+    { id: 'gamma', title: 'Gamma', icon: '/gamma.svg' },
+  ],
+}));
+
+const push = jest.fn();
+const prefetch = jest.fn();
+jest.spyOn(NextRouter, 'useRouter').mockReturnValue({ push, prefetch } as any);
+
+describe('AllApps component', () => {
+  beforeEach(() => {
+    push.mockReset();
+    prefetch.mockReset();
+  });
+
+  it('filters apps by search term', () => {
+    const { getByPlaceholderText, queryByText } = render(<AllApps />);
+    const input = getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'Alpha' } });
+    expect(queryByText('Alpha')).toBeInTheDocument();
+    expect(queryByText('Beta')).not.toBeInTheDocument();
+  });
+
+  it('prefetches app on hover', () => {
+    const { getByText } = render(<AllApps />);
+    const target = getByText('Alpha').closest('[data-grid-item]')!;
+    fireEvent.mouseEnter(target);
+    expect(prefetch).toHaveBeenCalledWith('/apps/alpha');
+  });
+});

--- a/__tests__/allAppsMeta.test.ts
+++ b/__tests__/allAppsMeta.test.ts
@@ -1,0 +1,19 @@
+jest.mock('../apps.config', () => ({
+  __esModule: true,
+  default: [],
+  games: [],
+}));
+
+jest.mock('../components/apps/all-apps', () => ({
+  __esModule: true,
+  default: () => null,
+  displayAllApps: () => null,
+}));
+
+import { metadata } from '@apps/all-apps';
+
+describe('all-apps metadata', () => {
+  it('sets title', () => {
+    expect(metadata.title).toBe('All Apps');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -30,6 +30,8 @@ import { displayCvssCalculator } from './components/apps/cvss-calculator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 import { displayBaseEncoders } from './components/apps/base-encoders';
 
+import { displayAllApps } from './components/apps/all-apps';
+
 import { displayDgaDemo } from './components/apps/dga-demo';
 
 import { displayEvidenceNotebook } from './components/apps/evidence-notebook';
@@ -394,6 +396,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'all-apps',
+    title: 'All Apps',
+    icon: icon('all-apps.svg'),
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayAllApps,
   },
   {
     id: 'todoist',

--- a/apps/all-apps/index.tsx
+++ b/apps/all-apps/index.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'All Apps',
+  description: 'Browse and launch available applications',
+};
+
+export { default, displayAllApps } from '../../components/apps/all-apps';

--- a/components/apps/all-apps.tsx
+++ b/components/apps/all-apps.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import apps, { games } from '../../apps.config';
+import ResponsiveGrid from '../util-components/ResponsiveGrid';
+
+interface AppEntry {
+  id: string;
+  title: string;
+  icon: string;
+  tags?: string[];
+}
+
+const allEntries: AppEntry[] = [
+  ...apps.map((a: AppEntry) => ({ ...a, tags: ['App', ...(a.tags || [])] })),
+  ...games.map((g: AppEntry) => ({ ...g, tags: ['Game', ...(g.tags || [])] })),
+];
+
+export default function AllApps() {
+  const router = useRouter();
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState('All');
+
+  const tags = useMemo(
+    () => ['All', ...Array.from(new Set(allEntries.flatMap(e => e.tags || [])))],
+    []
+  );
+
+  const filtered = useMemo(
+    () =>
+      allEntries.filter(
+        a =>
+          (tag === 'All' || (a.tags || []).includes(tag)) &&
+          a.title.toLowerCase().includes(search.toLowerCase())
+      ),
+    [tag, search]
+  );
+
+  return (
+    <div className="p-4 w-full h-full overflow-y-auto bg-panel text-white">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+        <input
+          type="text"
+          placeholder="Search..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="px-2 py-1 rounded bg-gray-800 text-white flex-grow"
+        />
+        <div className="flex flex-wrap gap-2">
+          {tags.map(t => (
+            <button
+              key={t}
+              onClick={() => setTag(t)}
+              className={`px-2 py-0.5 text-sm rounded ${
+                tag === t ? 'bg-blue-600' : 'bg-gray-700'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+      {filtered.length === 0 ? (
+        <p className="text-center">No apps found.</p>
+      ) : (
+        <ResponsiveGrid>
+          {filtered.map(app => (
+            <div
+              key={app.id}
+              className="flex flex-col items-center p-2 rounded hover:bg-gray-700 focus:bg-gray-700 cursor-pointer"
+              onClick={() => router.push(`/apps/${app.id}`)}
+              onMouseEnter={() => router.prefetch(`/apps/${app.id}`)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') router.push(`/apps/${app.id}`);
+              }}
+            >
+              <Image
+                src={app.icon.replace('./', '/')}
+                alt={app.title}
+                width={64}
+                height={64}
+                className="mb-1"
+                loading="lazy"
+              />
+              <span className="text-xs text-center">{app.title}</span>
+            </div>
+          ))}
+        </ResponsiveGrid>
+      )}
+    </div>
+  );
+}
+
+export const displayAllApps = () => <AllApps />;
+

--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -1,0 +1,20 @@
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+const AllApps = dynamic(() => import('../../components/apps/all-apps'), {
+  ssr: false,
+});
+
+export default function AllAppsPage() {
+  const ogImage = '/images/logos/logo_1200.png';
+  return (
+    <>
+      <Head>
+        <title>All Apps</title>
+        <meta property="og:title" content="All Apps" />
+        <meta property="og:image" content={ogImage} />
+      </Head>
+      <AllApps />
+    </>
+  );
+}

--- a/public/themes/Yaru/apps/all-apps.svg
+++ b/public/themes/Yaru/apps/all-apps.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect x="4" y="4" width="40" height="40" rx="3" ry="3" fill="#4A4A4A"/>
+  <circle cx="16" cy="16" r="5" fill="#FFFFFF"/>
+  <path d="M4 32l10-10 8 8 5-5 13 13H4V32z" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
## Summary
- add All Apps component showing app grid with search, tags, and hover prefetch
- expose grid via /apps page and app-router entry
- register All Apps in config with icon and tests

## Testing
- `yarn validate:icons`
- `yarn test __tests__/allAppsGrid.test.tsx __tests__/allAppsMeta.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab378614ec8328aa015dcbcb5545e8