### PR TITLE
feat: enhance IP/DNS leak tool

### DIFF
--- a/__tests__/ip-dns-leak.test.tsx
+++ b/__tests__/ip-dns-leak.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import IpDnsLeak, { utils } from '@components/apps/ip-dns-leak';
+
+describe('IpDnsLeak', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('renders results and copies report', async () => {
+    const mockUtils = {
+      gatherIps: jest.fn().mockResolvedValue({
+        local: [],
+        public: ['203.0.113.10'],
+        mdns: false,
+      }),
+      testDns: jest.fn().mockResolvedValue([
+        { hostname: 'example.com', resolver: 'Cloudflare', addresses: ['93.184.216.34'] },
+      ]),
+      fetchPublicIps: jest.fn().mockResolvedValue({ ips: ['203.0.113.10'], errors: [] }),
+    } as typeof utils;
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resolvers: [] }),
+    });
+
+    const { getByText } = render(<IpDnsLeak utils={mockUtils} />);
+    fireEvent.click(getByText('Run'));
+
+    await waitFor(() => getByText(/Public Candidates/));
+
+    fireEvent.click(getByText('Copy Report'));
+    expect((navigator.clipboard.writeText as any)).toHaveBeenCalled();
+  });
+
+  it('shows errors and allows retry', async () => {
+    const mockUtils = {
+      gatherIps: jest.fn().mockRejectedValue(new Error('stun fail')),
+      testDns: jest.fn().mockResolvedValue([]),
+      fetchPublicIps: jest.fn().mockResolvedValue({ ips: [], errors: ['public ip failed'] }),
+    } as typeof utils;
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resolvers: [] }),
+    });
+
+    const { getByText, findByText } = render(<IpDnsLeak utils={mockUtils} />);
+    fireEvent.click(getByText('Run'));
+
+    await findByText(/public ip failed/i);
+    expect(getByText('Retry')).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -380,7 +380,7 @@ const apps = [
   {
     id: 'ip-dns-leak',
     title: 'IP/DNS Leak',
-    icon: icon('resource-monitor.svg'),
+    icon: icon('ip-dns-leak.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/ip-dns-leak/index.tsx
+++ b/apps/ip-dns-leak/index.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'IP/DNS Leak',
+  description: 'Detect public IP and DNS resolver exposure and generate a report.',
+};
+
+export { default, displayIpDnsLeak } from '../../components/apps/ip-dns-leak';

--- a/pages/apps/ip-dns-leak.tsx
+++ b/pages/apps/ip-dns-leak.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const IpDnsLeak = dynamic(() => import('../../components/apps/ip-dns-leak'), {
+const IpDnsLeak = dynamic(() => import('../../apps/ip-dns-leak'), {
   ssr: false,
 });
 

--- a/public/themes/Yaru/apps/ip-dns-leak.svg
+++ b/public/themes/Yaru/apps/ip-dns-leak.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#2e3436"/>
+  <circle cx="32" cy="32" r="20" fill="#4e9a06"/>
+  <circle cx="32" cy="32" r="8" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- query multiple endpoints for public IP data
- add retryable error feedback and a copyable report with browser limitation notice
- wire IP/DNS leak app metadata and icon

## Testing
- `yarn test __tests__/ip-dns-leak.test.tsx`
- `yarn validate:icons`


------
https://chatgpt.com/codex/tasks/task_e_68ab3786d734832892facc66d552e70e