### PR TITLE
feat: enhance qr tool with customization

### DIFF
--- a/__tests__/qr-tool.test.tsx
+++ b/__tests__/qr-tool.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import QRTool from '@components/apps/qr_tool';
+import QRCode from 'qrcode';
+import QrScanner from 'qr-scanner';
+
+jest.mock('qrcode', () => ({
+  toCanvas: jest.fn().mockResolvedValue(undefined),
+  toString: jest.fn().mockResolvedValue('<svg></svg>'),
+}));
+
+jest.mock('qr-scanner', () => ({
+  scanImage: jest.fn().mockResolvedValue({ data: 'scanned data' }),
+  default: function () {
+    return { start: jest.fn(), stop: jest.fn() } as any;
+  },
+}));
+
+describe('QR Tool', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+    (global as any).URL.createObjectURL = jest.fn(() => 'blob:mock');
+    // force decode to fail so fallback path is used
+    // @ts-ignore
+    global.Image.prototype.decode = jest
+      .fn()
+      .mockRejectedValue(new Error('fail'));
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('applies custom colors when generating', async () => {
+    render(<QRTool />);
+    fireEvent.change(screen.getByPlaceholderText('Enter text'), {
+      target: { value: 'hello' },
+    });
+    fireEvent.change(screen.getByLabelText('Foreground'), {
+      target: { value: '#ff0000' },
+    });
+    fireEvent.change(screen.getByLabelText('Background'), {
+      target: { value: '#00ff00' },
+    });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => {
+      expect(QRCode.toCanvas).toHaveBeenCalledWith(
+        expect.anything(),
+        'hello',
+        expect.objectContaining({
+          color: { dark: '#ff0000', light: '#00ff00' },
+        })
+      );
+    });
+  });
+
+  it('copies decoded text to clipboard', async () => {
+    render(<QRTool />);
+    const file = new File(['data'], 'qr.png', { type: 'image/png' });
+    const input = screen.getByLabelText('QR file');
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() =>
+      expect(screen.getByText(/Decoded:/)).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText('Copy'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('scanned data');
+  });
+});

--- a/apps/qr-tool/index.tsx
+++ b/apps/qr-tool/index.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'QR Tool',
+  description:
+    'Generate and scan QR codes with custom colors, logo overlays, and clipboard support.',
+};
+
+export { default, displayQrTool } from '../../components/apps/qr_tool';

--- a/pages/apps/qr-tool.tsx
+++ b/pages/apps/qr-tool.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const QrToolApp = dynamic(() => import('../../apps/qr-tool'), { ssr: false });
+
+export default function QrToolPage() {
+  return <QrToolApp />;
+}


### PR DESCRIPTION
## Summary
- allow QR code color selection, logo overlay, and clipboard copy
- add QR Tool page with metadata
- test color options and clipboard copying

## Testing
- `yarn test __tests__/qr-tool.test.tsx`
- `npx eslint components/apps/qr_tool/index.js apps/qr-tool/index.tsx pages/apps/qr-tool.tsx __tests__/qr-tool.test.tsx` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3788b9448328a79b02d99cdd594f