### PR TITLE
feat: add otp tool with totp and hotp support

### DIFF
--- a/__tests__/otp.test.ts
+++ b/__tests__/otp.test.ts
@@ -1,0 +1,36 @@
+import { hotp } from 'otplib';
+
+describe('OTP vectors', () => {
+  const secrets = {
+    sha1: Buffer.from('12345678901234567890').toString('hex'),
+    sha256: Buffer.from('12345678901234567890123456789012').toString('hex'),
+    sha512: Buffer.from(
+      '1234567890123456789012345678901234567890123456789012345678901234'
+    ).toString('hex'),
+  } as const;
+
+  test('HOTP RFC4226 test values', () => {
+    hotp.options = { digits: 6, algorithm: 'sha1' as any, encoding: 'hex' };
+    const counters = [0,1,2,3,4,5,6,7,8,9];
+    const expected = ['755224','287082','359152','969429','338314','254676','287922','162583','399871','520489'];
+    counters.forEach((c, idx) => {
+      expect((hotp as any).generate(secrets.sha1, c)).toBe(expected[idx]);
+    });
+  });
+
+  test('TOTP RFC6238 test values', () => {
+    const vectors = [
+      { time: 59, sha1: '94287082', sha256: '46119246', sha512: '90693936' },
+      { time: 1111111109, sha1: '07081804', sha256: '68084774', sha512: '25091201' },
+      { time: 1234567890, sha1: '89005924', sha256: '91819424', sha512: '93441116' },
+    ];
+    vectors.forEach(v => {
+      hotp.options = { digits: 8, algorithm: 'sha1' as any, encoding: 'hex' };
+      expect((hotp as any).generate(secrets.sha1, Math.floor(v.time / 30))).toBe(v.sha1);
+      hotp.options = { digits: 8, algorithm: 'sha256' as any, encoding: 'hex' };
+      expect((hotp as any).generate(secrets.sha256, Math.floor(v.time / 30))).toBe(v.sha256);
+      hotp.options = { digits: 8, algorithm: 'sha512' as any, encoding: 'hex' };
+      expect((hotp as any).generate(secrets.sha512, Math.floor(v.time / 30))).toBe(v.sha512);
+    });
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -17,7 +17,7 @@ import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
 import { displayKeyConverter } from './components/apps/key-converter';
 import { displayQrTool } from './components/apps/qr_tool';
-import { displayTotp } from './components/apps/totp';
+import { displayOtp } from './components/apps/otp';
 import { displayRegexRedactor } from './components/apps/regex-redactor';
 import { displayRegexLab } from './components/apps/regex-lab';
 import { displayAsciiArt } from './components/apps/ascii_art';
@@ -450,13 +450,13 @@ const apps = [
     screen: displayQrTool,
   },
   {
-    id: 'totp',
-    title: 'TOTP',
-    icon: icon('calc.png'),
+    id: 'otp',
+    title: 'OTP',
+    icon: icon('otp.svg'),
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
-    screen: displayTotp,
+    screen: displayOtp,
   },
   {
     id: 'regex-redactor',

--- a/pages/apps/otp.tsx
+++ b/pages/apps/otp.tsx
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic';
+
+const OTPApp = dynamic(() => import('../../components/apps/otp'), { ssr: false });
+
+export default OTPApp;

--- a/public/themes/Yaru/apps/otp.svg
+++ b/public/themes/Yaru/apps/otp.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#353535"/>
+  <circle cx="32" cy="32" r="20" fill="#ffffff"/>
+  <text x="32" y="37" font-size="20" text-anchor="middle" fill="#000000">OTP</text>
+</svg>


### PR DESCRIPTION
## Summary
- add combined OTP app for TOTP/HOTP secrets with URI import/export
- allow algorithm, digit, period/counter and drift settings with copy buttons and remaining time
- wire new OTP app into desktop config with icon and route; add RFC test vectors

## Testing
- `yarn lint`
- `yarn test __tests__/otp.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab37898e308328a7a9302f620768a5