### PR TITLE
feat: add regex redactor app page

### DIFF
--- a/apps/regex-redactor/index.js
+++ b/apps/regex-redactor/index.js
@@ -1,5 +1,0 @@
-export {
-  default,
-  displayRegexRedactor,
-  SAFE_PATTERNS,
-} from '../../components/apps/regex-redactor';

--- a/apps/regex-redactor/index.tsx
+++ b/apps/regex-redactor/index.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = {
+  title: 'Regex Redactor',
+  description:
+    'Redact sensitive data using vetted patterns with masking preview and export options',
+};
+export {
+  default,
+  displayRegexRedactor,
+  SAFE_PATTERNS,
+} from '../../components/apps/regex-redactor';

--- a/pages/apps/regex-redactor.tsx
+++ b/pages/apps/regex-redactor.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const RegexRedactor = dynamic(() => import('../../apps/regex-redactor'), { ssr: false });
+
+export default function RegexRedactorPage() {
+  return <RegexRedactor />;
+}

--- a/public/themes/Yaru/apps/regex-redactor.svg
+++ b/public/themes/Yaru/apps/regex-redactor.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#4c566a"/>
-  <text x="32" y="38" font-size="32" text-anchor="middle" fill="#eceff4">.*</text>
+  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
+  <rect x="12" y="16" width="40" height="8" fill="#ffffff"/>
+  <rect x="12" y="28" width="40" height="8" fill="#2d3748"/>
+  <rect x="12" y="40" width="40" height="8" fill="#ffffff"/>
 </svg>


### PR DESCRIPTION
## Summary
- wire regex redactor app with page metadata and icon
- test preset masking to ensure redaction accuracy

## Testing
- `yarn test __tests__/regex-redactor.test.ts`
- `yarn test` *(fails: TypeError: (0 , _frogger.initLane) is not a function)*
- `yarn validate:icons`
- `yarn lint` *(warn)*

------
https://chatgpt.com/codex/tasks/task_e_68ab378a17b483288d16073316f3901b