### PR TITLE
feat(tower-defense): add flow fields and wave editor

### DIFF
--- a/apps/tower-defense/engine.ts
+++ b/apps/tower-defense/engine.ts
@@ -88,6 +88,7 @@ export interface Enemy {
   index: number;
   x: number;
   y: number;
+  health?: number;
 }
 
 export const spawnWave = (count: number, paths: Point[][]): Enemy[] =>
@@ -113,3 +114,192 @@ export const createEmptyMap = (size: number): MapData => ({
   goal: { x: size - 1, y: Math.floor(size / 2) },
   walls: new Set(),
 });
+
+// ---- Flow field utilities ----
+
+export let flowRecomputeCount = 0;
+
+export const computeDistanceField = (map: MapData): number[][] => {
+  const { width, height, goal, walls } = map;
+  const dist = Array.from({ length: height }, () => Array(width).fill(Infinity));
+  const queue: Point[] = [{ x: goal.x, y: goal.y }];
+  dist[goal.y][goal.x] = 0;
+  while (queue.length) {
+    const { x, y } = queue.shift()!;
+    const d = dist[y][x];
+    const dirs = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 },
+    ];
+    for (const dir of dirs) {
+      const nx = x + dir.x;
+      const ny = y + dir.y;
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+      if (walls.has(`${nx},${ny}`)) continue;
+      if (dist[ny][nx] > d + 1) {
+        dist[ny][nx] = d + 1;
+        queue.push({ x: nx, y: ny });
+      }
+    }
+  }
+  return dist;
+};
+
+export const computeFlowField = (map: MapData) => {
+  const dist = computeDistanceField(map);
+  const field = Array.from({ length: map.height }, () =>
+    Array.from({ length: map.width }, () => ({ dx: 0, dy: 0 }))
+  );
+  for (let y = 0; y < map.height; y += 1) {
+    for (let x = 0; x < map.width; x += 1) {
+      if (dist[y][x] === Infinity) continue;
+      const dirs = [
+        { dx: 1, dy: 0 },
+        { dx: -1, dy: 0 },
+        { dx: 0, dy: 1 },
+        { dx: 0, dy: -1 },
+      ];
+      let best = dist[y][x];
+      let bestDir = { dx: 0, dy: 0 };
+      for (const d of dirs) {
+        const nx = x + d.dx;
+        const ny = y + d.dy;
+        if (nx < 0 || ny < 0 || nx >= map.width || ny >= map.height) continue;
+        if (dist[ny][nx] < best) {
+          best = dist[ny][nx];
+          bestDir = d;
+        }
+      }
+      field[y][x] = bestDir;
+    }
+  }
+  flowRecomputeCount += 1;
+  return { dist, field };
+};
+
+export const pathsFromDistance = (map: MapData, dist: number[][]): Point[][] => {
+  const { start, goal } = map;
+  const paths: Point[][] = [];
+  const dfs = (p: Point, path: Point[]) => {
+    path.push(p);
+    if (p.x === goal.x && p.y === goal.y) {
+      paths.push([...path]);
+      path.pop();
+      return;
+    }
+    const d = dist[p.y][p.x];
+    const dirs = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 },
+    ];
+    for (const dir of dirs) {
+      const nx = p.x + dir.x;
+      const ny = p.y + dir.y;
+      if (nx < 0 || ny < 0 || nx >= map.width || ny >= map.height) continue;
+      if (dist[ny][nx] === d - 1) dfs({ x: nx, y: ny }, path);
+    }
+    path.pop();
+  };
+  if (dist[start.y][start.x] !== Infinity) dfs(start, []);
+  return paths;
+};
+
+// ---- Targeting priorities ----
+
+export type TargetPriority = 'first' | 'last' | 'closest' | 'strongest';
+
+export interface Tower extends Point {
+  range: number;
+  priority: TargetPriority;
+}
+
+export const selectTarget = (
+  tower: Tower,
+  enemies: Enemy[],
+): Enemy | null => {
+  const inRange = enemies.filter(
+    (e) => Math.hypot(e.x - tower.x, e.y - tower.y) <= tower.range,
+  );
+  if (!inRange.length) return null;
+  switch (tower.priority) {
+    case 'last':
+      return inRange[inRange.length - 1];
+    case 'closest':
+      return inRange.reduce((a, b) =>
+        Math.hypot(a.x - tower.x, a.y - tower.y) <
+        Math.hypot(b.x - tower.x, b.y - tower.y)
+          ? a
+          : b,
+      );
+    case 'strongest':
+      return inRange.reduce((a, b) => (a.health || 0) > (b.health || 0) ? a : b);
+    case 'first':
+    default:
+      return inRange[0];
+  }
+};
+
+// ---- Projectile pooling ----
+
+export interface Projectile {
+  active: boolean;
+  x: number;
+  y: number;
+  targetId: number | null;
+  damage: number;
+  speed: number;
+  radius?: number;
+}
+
+export const createProjectilePool = (size: number): Projectile[] =>
+  Array.from({ length: size }, () => ({
+    active: false,
+    x: 0,
+    y: 0,
+    targetId: null,
+    damage: 0,
+    speed: 1,
+    radius: 0,
+  }));
+
+export const fireProjectile = (
+  pool: Projectile[],
+  props: Omit<Projectile, 'active'>,
+): Projectile | null => {
+  const idx = pool.findIndex((p) => !p.active);
+  if (idx === -1) return null;
+  Object.assign(pool[idx], props, { active: true });
+  return pool[idx];
+};
+
+export const deactivateProjectile = (p: Projectile) => {
+  p.active = false;
+};
+
+// ---- AoE using Matter collisions ----
+
+import { Bodies, Query } from 'matter-js';
+
+export const applyAOE = (
+  projectile: Projectile,
+  enemies: Enemy[],
+): Enemy[] => {
+  if (!projectile.radius) return enemies;
+  const projBody = Bodies.circle(projectile.x, projectile.y, projectile.radius);
+  const bodies = enemies.map((e) => ({ body: Bodies.circle(e.x, e.y, 0.5), enemy: e }));
+  const collisions = Query.collides(
+    projBody,
+    bodies.map((b) => b.body),
+  );
+  collisions.forEach((c) => {
+    const hit = bodies.find((b) => b.body === c.bodyB || b.body === c.bodyA);
+    if (hit && hit.enemy.health !== undefined)
+      hit.enemy.health = Math.max(0, hit.enemy.health - projectile.damage);
+  });
+  return enemies;
+};
+

--- a/apps/tower-defense/waveEditor.tsx
+++ b/apps/tower-defense/waveEditor.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onStart: (count: number) => void;
+  recomputeCount: number;
+}
+
+const WaveEditor: React.FC<Props> = ({ onStart, recomputeCount }) => {
+  const [count, setCount] = useState(5);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor="wave-count" className="text-xs">
+          Wave size
+        </label>
+        <input
+          id="wave-count"
+          type="number"
+          value={count}
+          min={1}
+          onChange={(e) => setCount(Number(e.target.value))}
+          className="w-16 text-black"
+        />
+        <button
+          className="bg-blue-600 px-2 py-1 text-xs"
+          onClick={() => onStart(count)}
+        >
+          Start
+        </button>
+      </div>
+      <div className="text-xs">Field recomputes: {recomputeCount}</div>
+    </div>
+  );
+};
+
+export default WaveEditor;

--- a/apps/tower-defense/waveWorker.ts
+++ b/apps/tower-defense/waveWorker.ts
@@ -1,7 +1,18 @@
-import { astarPaths, spawnWave, stepEnemies, MapData, Enemy, Point } from './engine';
+import {
+  computeFlowField,
+  pathsFromDistance,
+  spawnWave,
+  stepEnemies,
+  MapData,
+  Enemy,
+  flowRecomputeCount,
+} from './engine';
 
 let enemies: Enemy[] = [];
 let paths: Point[][] = [];
+let dist: number[][] = [];
+let field: { dx: number; dy: number }[][] = [];
+let recomputeCount = 0;
 
 self.onmessage = (e: MessageEvent) => {
   const { type } = e.data;
@@ -9,14 +20,47 @@ self.onmessage = (e: MessageEvent) => {
     case 'init': {
       const map: MapData = e.data.map;
       const count: number = e.data.count || 5;
-      paths = astarPaths(map);
+      const ff = computeFlowField(map);
+      dist = ff.dist;
+      field = ff.field;
+      paths = pathsFromDistance(map, dist);
+      recomputeCount = flowRecomputeCount;
       enemies = spawnWave(count, paths);
-      (self as any).postMessage({ type: 'state', enemies, paths });
+      (self as any).postMessage({
+        type: 'state',
+        enemies,
+        paths,
+        dist,
+        field,
+        recomputeCount,
+      });
+      break;
+    }
+    case 'updateMap': {
+      const map: MapData = e.data.map;
+      const ff = computeFlowField(map);
+      dist = ff.dist;
+      field = ff.field;
+      paths = pathsFromDistance(map, dist);
+      recomputeCount = flowRecomputeCount;
+      (self as any).postMessage({
+        type: 'field',
+        dist,
+        field,
+        paths,
+        recomputeCount,
+      });
+      break;
+    }
+    case 'spawn': {
+      const count: number = e.data.count || 5;
+      enemies = enemies.concat(spawnWave(count, paths));
+      (self as any).postMessage({ type: 'state', enemies, recomputeCount });
       break;
     }
     case 'tick': {
       enemies = stepEnemies(enemies, paths);
-      (self as any).postMessage({ type: 'state', enemies });
+      (self as any).postMessage({ type: 'state', enemies, recomputeCount });
       break;
     }
     default:


### PR DESCRIPTION
## Summary
- precompute flow-field distance map and expose targeting, projectile, and AoE helpers
- process map updates with flow-field recomputation and expose a new wave editor
- dynamically import level and wave editors on the client

## Testing
- `npm test __tests__/tower-defense.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab4414a8448328a325c9262cc26e92