### PR TITLE
feat(match3): refine gameplay and dynamic load

### DIFF
--- a/pages/apps/match3.tsx
+++ b/pages/apps/match3.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const Match3 = dynamic(() => import('../../apps/match3'), { ssr: false });
+
+export default function Match3Page() {
+  return <Match3 />;
+}


### PR DESCRIPTION
## Summary
- replace line-based matching with flood-fill search and propagate crush animations
- track moves and cascading chains with simple pooled animation overlay
- expose match3 page via dynamic import for client-only rendering

## Testing
- `yarn test __tests__/match3.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab441692308328a837ab94c8324cca