### PR TITLE
feat: persist scores and export shareable image

### DIFF
--- a/__tests__/score.test.ts
+++ b/__tests__/score.test.ts
@@ -1,12 +1,37 @@
-import { getHighScore, setHighScore } from '../components/game/score';
+import 'fake-indexeddb/auto';
+import { saveScore, getScores, getHighScore, resetScores, generateShareImage } from '../components/game/score';
+
+// polyfill structuredClone for fake-indexeddb
+if (!(global as any).structuredClone) {
+  (global as any).structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
 
 describe('score api', () => {
-  beforeEach(() => {
-    window.localStorage.clear();
+  beforeEach(async () => {
+    await resetScores();
   });
 
-  it('stores and retrieves high score', () => {
-    setHighScore(42);
-    expect(getHighScore()).toBe(42);
+  it('stores scores with date and session', async () => {
+    await saveScore(42);
+    const scores = await getScores();
+    expect(scores).toHaveLength(1);
+    expect(scores[0].score).toBe(42);
+    expect(typeof scores[0].date).toBe('string');
+    expect(typeof scores[0].session).toBe('string');
+  });
+
+  it('retrieves high score', async () => {
+    await saveScore(10);
+    await saveScore(50);
+    expect(await getHighScore()).toBe(50);
+  });
+
+  it('generates shareable image quickly', async () => {
+    await saveScore(1);
+    const start = performance.now();
+    const url = await generateShareImage();
+    const elapsed = performance.now() - start;
+    expect(typeof url).toBe('string');
+    expect(elapsed).toBeLessThan(300);
   });
 });

--- a/components/game/score.ts
+++ b/components/game/score.ts
@@ -1,29 +1,128 @@
 'use client';
 import { useEffect, useState } from 'react';
 
-const KEY = 'game-score';
+// IndexedDB helpers
+const DB_NAME = 'game-scores';
+const STORE_NAME = 'scores';
 
-export function getHighScore(): number {
-  if (typeof window === 'undefined') return 0;
-  return Number(window.localStorage.getItem(KEY) || 0);
+interface ScoreEntry {
+  score: number;
+  date: string; // ISO string
+  session: string;
 }
 
-export function setHighScore(score: number) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(KEY, String(score));
+let sessionId: string | null = null;
+
+function getSessionId(): string {
+  if (!sessionId) {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      sessionId = crypto.randomUUID();
+    } else {
+      sessionId = String(Date.now());
+    }
+  }
+  return sessionId;
+}
+
+function openDB(): Promise<IDBDatabase | null> {
+  return new Promise((resolve) => {
+    if (typeof window === 'undefined' || !('indexedDB' in window)) {
+      resolve(null);
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+  });
+}
+
+export async function saveScore(value: number): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const entry: ScoreEntry = {
+    score: value,
+    date: new Date().toISOString(),
+    session: getSessionId(),
+  };
+  store.add(entry);
+}
+
+export async function getScores(): Promise<ScoreEntry[]> {
+  const db = await openDB();
+  if (!db) return [];
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.getAll();
+    req.onsuccess = () => {
+      const data = (req.result as ScoreEntry[]) || [];
+      resolve(data);
+    };
+    req.onerror = () => resolve([]);
+  });
+}
+
+export async function resetScores(): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).clear();
+}
+
+export async function getHighScore(): Promise<number> {
+  const scores = await getScores();
+  return scores.reduce((max, s) => (s.score > max ? s.score : max), 0);
+}
+
+export async function generateShareImage(): Promise<string> {
+  if (typeof document === 'undefined') return '';
+  const scores = await getScores();
+  const start = performance.now();
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+  canvas.width = 400;
+  canvas.height = 40 + scores.length * 20;
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#000';
+  ctx.font = '16px sans-serif';
+  ctx.fillText('Scores', 10, 20);
+  scores.forEach((s, i) => {
+    ctx.fillText(`${s.score} - ${s.date} (${s.session})`, 10, 40 + i * 20);
+  });
+  const url = canvas.toDataURL('image/png');
+  const elapsed = performance.now() - start;
+  if (elapsed > 300) {
+    console.warn(`share image generation took ${elapsed}ms`);
+  }
+  return url;
 }
 
 export function useScore() {
   const [score, setScore] = useState(0);
 
   useEffect(() => {
-    setScore(getHighScore());
+    getHighScore().then(setScore);
   }, []);
 
-  const update = (value: number) => {
-    setScore(value);
-    if (value > getHighScore()) setHighScore(value);
+  const update = async (value: number) => {
+    await saveScore(value);
+    const high = await getHighScore();
+    setScore(high);
   };
 
-  return { score, update };
+  const reset = async () => {
+    await resetScores();
+    setScore(0);
+  };
+
+  return { score, update, reset };
 }
+
+export type { ScoreEntry };

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "eslint-config-next": "^15.5.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "fake-indexeddb": "^6.1.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "prettier": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7416,6 +7416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-indexeddb@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "fake-indexeddb@npm:6.1.0"
+  checksum: 10c0/f2bae6cf3ed38619ccc536ee1c0d72a1ba721da24d840e9c0993800c031a5c1d8e61adc00ea31f0c2a2380447c57bc953bd4128b08dabf559c7cdf03c8893239
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -15308,6 +15315,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.0.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     expr-eval: "npm:^2.0.2"
+    fake-indexeddb: "npm:^6.1.0"
     fast-xml-parser: "npm:^5.2.5"
     fuse.js: "npm:^6.6.2"
     howler: "npm:^2.2.4"


### PR DESCRIPTION
## Summary
- persist game scores in IndexedDB with timestamp and session id
- add reset and canvas image export helpers
- cover score storage and sharing with tests

## Testing
- `yarn test __tests__/score.test.ts`
- `yarn test` *(fails: missing fixtures and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cdd6140832898df1f472eeabb96