### PR TITLE
test: add 2048 game e2e

### DIFF
--- a/e2e/2048-game.spec.ts
+++ b/e2e/2048-game.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('2048 game state updates after moves', async ({ page }) => {
+  test.setTimeout(20_000);
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto('/apps/2048');
+
+  const webgl = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
+    if (!canvas) return false;
+    return !!(canvas.getContext('webgl') || canvas.getContext('webgl2'));
+  });
+  expect(webgl).toBeTruthy();
+
+  await page.waitForFunction(() => localStorage.getItem('2048_board') !== null);
+  const before = await page.evaluate(() => localStorage.getItem('2048_board'));
+
+  await page.locator('canvas').click();
+  await page.keyboard.press('ArrowUp');
+  await page.keyboard.press('ArrowLeft');
+
+  await page.waitForFunction(
+    (b) => localStorage.getItem('2048_board') !== b,
+    before
+  );
+  const after = await page.evaluate(() => localStorage.getItem('2048_board'));
+  expect(after).not.toBe(before);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add Playwright test for 2048 game interactions
- ensure test fails on console errors or WebGL fallback and validates state change

## Testing
- `npx playwright test e2e/2048-game.spec.ts` *(fails: WebGL not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cdd5a08832881107c3086da91e5