### PR TITLE
refactor: add shared game loop

### DIFF
--- a/lib/game/loop.ts
+++ b/lib/game/loop.ts
@@ -4,25 +4,76 @@ export interface LoopOptions {
   fps?: number;
 }
 
-export function startFixedLoop({ update, render, fps = 60 }: LoopOptions): () => void {
-  const timestep = 1000 / fps;
+/**
+ * Shared game loop utility using `requestAnimationFrame` with a fixed timestep.
+ * The loop automatically pauses when the tab is hidden or when the user
+ * prefers reduced motion. Returns a cleanup function that stops the loop and
+ * removes listeners.
+ */
+export function startGameLoop({
+  update,
+  render,
+  fps = 60,
+}: LoopOptions): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const step = 1000 / fps;
   let last = performance.now();
   let acc = 0;
-  let raf: number;
+  let raf = 0;
+  let running = true;
 
-  function frame(now: number) {
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const frame = (now: number) => {
+    if (!running || media.matches) return;
+
     acc += now - last;
     last = now;
 
-    while (acc >= timestep) {
-      update(timestep / 1000);
-      acc -= timestep;
+    while (acc >= step) {
+      update(step / 1000);
+      acc -= step;
     }
 
-    render?.(acc / timestep);
+    render?.(acc / step);
     raf = requestAnimationFrame(frame);
+  };
+
+  const pause = () => {
+    running = false;
+    cancelAnimationFrame(raf);
+  };
+
+  const resume = () => {
+    if (running || media.matches || document.hidden) return;
+    running = true;
+    last = performance.now();
+    raf = requestAnimationFrame(frame);
+  };
+
+  const onVisibility = () => {
+    if (document.hidden) pause();
+    else resume();
+  };
+
+  const onMotionChange = () => {
+    if (media.matches) pause();
+    else resume();
+  };
+
+  document.addEventListener('visibilitychange', onVisibility);
+  media.addEventListener('change', onMotionChange);
+
+  if (!media.matches && !document.hidden) {
+    raf = requestAnimationFrame(frame);
+  } else {
+    running = false;
   }
 
-  raf = requestAnimationFrame(frame);
-  return () => cancelAnimationFrame(raf);
+  return () => {
+    pause();
+    document.removeEventListener('visibilitychange', onVisibility);
+    media.removeEventListener('change', onMotionChange);
+  };
 }


### PR DESCRIPTION
## Summary
- add reusable requestAnimationFrame game loop with fixed timestep
- pause game loop on tab blur and reduced-motion preference
- use shared loop in main GameClient

## Testing
- `yarn lint`
- `yarn test` *(fails: jwks-fetcher.api, mail-auth.api, gitSecretsTester.api, theme-fallback, tictactoe, madge api)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cdc291c8328b04da7d2ab0dbda1