### PR TITLE
Type components and snake scores API with tests

### DIFF
--- a/__tests__/badgeList.test.tsx
+++ b/__tests__/badgeList.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BadgeList from '../components/BadgeList';
+
+describe('BadgeList component', () => {
+  const badges = [
+    { label: 'TypeScript', src: '/ts', alt: 'ts', description: 'TS' },
+    { label: 'JavaScript', src: '/js', alt: 'js', description: 'JS' },
+  ];
+
+  test('filters badges and displays details', () => {
+    render(<BadgeList badges={badges} />);
+
+    const input = screen.getByPlaceholderText('Filter skills');
+    fireEvent.change(input, { target: { value: 'type' } });
+
+    expect(screen.getByAltText('ts')).toBeInTheDocument();
+    expect(screen.queryByAltText('js')).toBeNull();
+
+    fireEvent.click(screen.getByAltText('ts'));
+    expect(screen.getByText('TS')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Close'));
+    expect(screen.queryByText('TS')).toBeNull();
+  });
+});

--- a/__tests__/snakeScores.api.test.ts
+++ b/__tests__/snakeScores.api.test.ts
@@ -1,0 +1,35 @@
+import handler from '../pages/api/snake/scores';
+
+function createRes() {
+  return {
+    statusCode: 0,
+    data: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(d) {
+      this.data = d;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  };
+}
+
+describe('snake scores api', () => {
+  test('stores and returns scores', () => {
+    const postReq = { method: 'POST', body: { score: 42 } };
+    const postRes = createRes();
+    handler(postReq, postRes);
+    expect(postRes.statusCode).toBe(201);
+    expect(postRes.data.scores[0]).toBe(42);
+
+    const getReq = { method: 'GET' };
+    const getRes = createRes();
+    handler(getReq, getRes);
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.data.scores[0]).toBe(42);
+  });
+});

--- a/components/BadgeList.tsx
+++ b/components/BadgeList.tsx
@@ -1,11 +1,23 @@
 import React, { useState } from 'react';
 
-const BadgeList = ({ badges, className = '' }) => {
+export interface Badge {
+  label: string;
+  src: string;
+  alt: string;
+  description?: string;
+}
+
+interface BadgeListProps {
+  badges: Badge[];
+  className?: string;
+}
+
+const BadgeList: React.FC<BadgeListProps> = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<Badge | null>(null);
 
   const filteredBadges = badges.filter((badge) =>
-    badge.label.toLowerCase().includes(filter.toLowerCase())
+    badge.label.toLowerCase().includes(filter.toLowerCase()),
   );
 
   return (

--- a/components/LazyGitHubButton.tsx
+++ b/components/LazyGitHubButton.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-const LazyGitHubButton = ({ user, repo }) => {
-  const ref = useRef(null);
+interface LazyGitHubButtonProps {
+  user: string;
+  repo: string;
+}
+
+const LazyGitHubButton: React.FC<LazyGitHubButtonProps> = ({ user, repo }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -13,8 +18,9 @@ const LazyGitHubButton = ({ user, repo }) => {
         }
       });
     });
-    if (ref.current) {
-      observer.observe(ref.current);
+    const current = ref.current;
+    if (current) {
+      observer.observe(current);
     }
     return () => observer.disconnect();
   }, []);

--- a/e2e/snake-scores.spec.ts
+++ b/e2e/snake-scores.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('snake scores api works', async ({ request }) => {
+  const post = await request.post('/api/snake/scores', {
+    data: { score: 7 },
+  });
+  expect(post.ok()).toBeTruthy();
+  const postJson = await post.json();
+  expect(Array.isArray(postJson.scores)).toBe(true);
+
+  const get = await request.get('/api/snake/scores');
+  expect(get.ok()).toBeTruthy();
+  const getJson = await get.json();
+  expect(getJson.scores[0]).toBe(7);
+});

--- a/pages/api/snake/scores.ts
+++ b/pages/api/snake/scores.ts
@@ -1,21 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+export interface ScoresResponse {
+  scores: number[];
+}
+
+interface PostBody {
+  score?: number;
+}
+
 let scores: number[] = [];
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ScoresResponse | { error: string }>,
+) {
   if (req.method === 'GET') {
-    res.status(200).json({ scores });
-    return;
+    return res.status(200).json({ scores });
   }
   if (req.method === 'POST') {
-    const { score } = req.body || {};
+    const { score }: PostBody = req.body || {};
     if (typeof score === 'number' && !Number.isNaN(score)) {
       scores.push(score);
       scores.sort((a, b) => b - a);
       scores = scores.slice(0, 10);
     }
-    res.status(201).json({ scores });
-    return;
+    return res.status(201).json({ scores });
   }
-  res.status(405).end();
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).json({ error: 'Method not allowed' });
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
   },
   esbuild: {
-    loader: 'jsx',
+    loader: 'tsx',
   },
 });


### PR DESCRIPTION
## Summary
- migrate BadgeList and LazyGitHubButton to TypeScript and add strong props typing
- type snake scores API responses and adjust vitest config for TSX
- add unit and e2e coverage for badge filtering and snake score API

## Testing
- `yarn test:unit __tests__/badgeList.test.tsx __tests__/snakeScores.api.test.ts`
- `yarn test:e2e e2e/snake-scores.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab7cd9faec8328a7f9158fa8cd99c7