### PR TITLE
chore: type components and add tests

### DIFF
--- a/__tests__/BadgeList.test.tsx
+++ b/__tests__/BadgeList.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import BadgeList from '../components/BadgeList';
+import type { Badge } from '../lib/types';
+
+describe('BadgeList', () => {
+  const badges: Badge[] = [
+    { src: '/a.png', alt: 'A', label: 'Alpha', description: 'Alpha badge' },
+    { src: '/b.png', alt: 'B', label: 'Beta', description: 'Beta badge' },
+  ];
+
+  it('filters badges and toggles modal', () => {
+    render(<BadgeList badges={badges} />);
+
+    expect(screen.getAllByRole('img')).toHaveLength(2);
+
+    fireEvent.change(screen.getByPlaceholderText(/filter skills/i), {
+      target: { value: 'alpha' },
+    });
+    expect(screen.getAllByRole('img')).toHaveLength(1);
+
+    fireEvent.click(screen.getAllByRole('img')[0]);
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/close/i));
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/LazyGitHubButton.test.tsx
+++ b/__tests__/LazyGitHubButton.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import LazyGitHubButton from '../components/LazyGitHubButton';
+
+class MockIntersectionObserver {
+  private callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe() {
+    this.callback([{ isIntersecting: true } as IntersectionObserverEntry], this as any);
+  }
+  disconnect() {}
+}
+
+// @ts-ignore
+global.IntersectionObserver = MockIntersectionObserver;
+
+describe('LazyGitHubButton', () => {
+  it('renders GitHub iframe on intersection', async () => {
+    render(<LazyGitHubButton user="alex" repo="repo" />);
+    const iframe = await screen.findByTitle('repo-star');
+    expect(iframe).toBeInTheDocument();
+  });
+});

--- a/apps/project-gallery/index.tsx
+++ b/apps/project-gallery/index.tsx
@@ -1,16 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import Image from 'next/image';
 import projects from '../../data/projects.json';
-
-interface Project {
-  title: string;
-  description: string;
-  image: string;
-  tech: string[];
-  tags: string[];
-  live?: string;
-  repo?: string;
-}
+import type { Project } from '../../lib/types';
 
 const ProjectGallery: React.FC = () => {
   const [tag, setTag] = useState('All');

--- a/components/BadgeList.tsx
+++ b/components/BadgeList.tsx
@@ -1,8 +1,14 @@
 import React, { useState } from 'react';
+import type { Badge } from '../lib/types';
 
-const BadgeList = ({ badges, className = '' }) => {
+interface BadgeListProps {
+  badges: Badge[];
+  className?: string;
+}
+
+const BadgeList: React.FC<BadgeListProps> = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<Badge | null>(null);
 
   const filteredBadges = badges.filter((badge) =>
     badge.label.toLowerCase().includes(filter.toLowerCase())

--- a/components/LazyGitHubButton.tsx
+++ b/components/LazyGitHubButton.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-const LazyGitHubButton = ({ user, repo }) => {
-  const ref = useRef(null);
+interface LazyGitHubButtonProps {
+  user: string;
+  repo: string;
+}
+
+const LazyGitHubButton: React.FC<LazyGitHubButtonProps> = ({ user, repo }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -2,21 +2,22 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import projectsData from '../../data/projects.json';
+import type { Project } from '../../lib/types';
 
 export default function ProjectGallery() {
-  const [projects, setProjects] = useState([]);
-  const [search, setSearch] = useState('');
-  const [tag, setTag] = useState('All');
-  const [pinned, setPinned] = useState([]);
-  const [columns, setColumns] = useState(1);
-  const cardRefs = useRef([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [search, setSearch] = useState<string>('');
+  const [tag, setTag] = useState<string>('All');
+  const [pinned, setPinned] = useState<string[]>([]);
+  const [columns, setColumns] = useState<number>(1);
+  const cardRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   useEffect(() => {
     ReactGA.event({ category: 'Application', action: 'Loaded Project Gallery' });
   }, []);
 
   useEffect(() => {
-    setProjects(projectsData);
+    setProjects(projectsData as Project[]);
   }, []);
 
   useEffect(() => {
@@ -40,12 +41,12 @@ export default function ProjectGallery() {
     return () => window.removeEventListener('resize', updateColumns);
   }, []);
 
-  const tags = useMemo(
+  const tags = useMemo<string[]>(
     () => ['All', ...Array.from(new Set(projects.flatMap((p) => p.tags)))],
     [projects]
   );
 
-  const filtered = useMemo(() => {
+  const filtered = useMemo<Project[]>(() => {
     const term = search.toLowerCase();
     return projects.filter(
       (p) =>
@@ -57,7 +58,7 @@ export default function ProjectGallery() {
     );
   }, [projects, search, tag]);
 
-  const sorted = useMemo(() => {
+  const sorted = useMemo<Project[]>(() => {
     const pinnedProjects = filtered.filter((p) => pinned.includes(p.title));
     const otherProjects = filtered.filter((p) => !pinned.includes(p.title));
     return [...pinnedProjects, ...otherProjects];
@@ -67,7 +68,7 @@ export default function ProjectGallery() {
     cardRefs.current = cardRefs.current.slice(0, sorted.length);
   }, [sorted]);
 
-  const togglePinned = (title) => {
+  const togglePinned = (title: string) => {
     setPinned((prev) => {
       const next = prev.includes(title)
         ? prev.filter((t) => t !== title)
@@ -79,7 +80,10 @@ export default function ProjectGallery() {
     });
   };
 
-  const handleKeyDown = (e, index) => {
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    index: number
+  ) => {
     if (e.key === 'ArrowRight') {
       const next = index + 1;
       if (next < sorted.length) {
@@ -135,7 +139,7 @@ export default function ProjectGallery() {
         <p className="text-center">No projects found.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {sorted.map((project, index) => (
+          {sorted.map((project: Project, index: number) => (
             <div
               key={index}
               ref={(el) => (cardRefs.current[index] = el)}
@@ -159,8 +163,9 @@ export default function ProjectGallery() {
                   sizes="100%"
                   loading="lazy"
                   onError={(e) => {
-                    e.currentTarget.onerror = null;
-                    e.currentTarget.src = '/images/logos/logo.png';
+                    const target = e.currentTarget as HTMLImageElement;
+                    target.onerror = null;
+                    target.src = '/images/logos/logo.png';
                   }}
                 />
               </div>

--- a/e2e/project-gallery.spec.ts
+++ b/e2e/project-gallery.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('filters projects by tag', async ({ page }) => {
+  await page.goto('/apps/project-gallery');
+  await page.click('button:has-text("game")');
+  const titles = page.locator('h3');
+  await expect(titles).toContainText(['Tower Defense Game', 'Checkers']);
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,16 @@
+export interface Badge {
+  src: string;
+  alt: string;
+  label: string;
+  description?: string;
+}
+
+export interface Project {
+  title: string;
+  description: string;
+  image: string;
+  tech: string[];
+  tags: string[];
+  live?: string;
+  repo?: string;
+}


### PR DESCRIPTION
## Summary
- type BadgeList, LazyGitHubButton, and ProjectGallery components
- define shared Badge and Project models
- add unit and e2e tests for project gallery and GitHub button

## Testing
- `yarn test:unit` *(fails: Failed to resolve import `@components/apps/calc`)*
- `yarn test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cb88ca48328860a1c8c82a8bbab