### PR TITLE
feat: offload heavy work to worker with progress

### DIFF
--- a/components/apps/utilities.worker.ts
+++ b/components/apps/utilities.worker.ts
@@ -1,6 +1,29 @@
-self.onmessage = (e: MessageEvent<number>) => {
-  const n = e.data;
-  // simple demo: square the number
-  // @ts-ignore
-  self.postMessage(n * n);
+let cancelled = false;
+
+function heavySum(n: number) {
+  let total = 0;
+  for (let i = 0; i <= n; i++) {
+    total += i;
+    if (i % 10000 === 0) {
+      // @ts-ignore
+      self.postMessage({ progress: i / n });
+      if (cancelled) return null;
+    }
+  }
+  return total;
+}
+
+self.onmessage = (e: MessageEvent<any>) => {
+  const data = e.data;
+  if (data && data.type === 'cancel') {
+    cancelled = true;
+    return;
+  }
+  cancelled = false;
+  const result = heavySum(data.n ?? 0);
+  if (result !== null) {
+    // @ts-ignore
+    self.postMessage({ result });
+  }
 };
+

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -7,8 +7,8 @@ Common helper utilities for apps and libraries are centralized in `lib/utilities
 - **fileGuards.ts** – basic size and MIME type checks for uploaded files.
 - **streamingParser.ts** – parse newline-delimited JSON streams via async
   iteration.
-- **workerWrapper.ts** – promise-based wrapper around Web Workers or compatible
-  interfaces.
+- **workerWrapper.ts** – promise-based wrapper around Web Workers with
+  progress callbacks and cancellation support.
 - **fetchWithRetry.ts** – `fetch` with timeout and retry semantics.
 - **useToastLogger.ts** – React hook combining console logging with a simple
   toast message state.

--- a/lib/utilities/workerWrapper.ts
+++ b/lib/utilities/workerWrapper.ts
@@ -4,26 +4,66 @@ export interface WorkerLike {
   removeEventListener(type: 'message' | 'error', listener: (ev: any) => void): void;
 }
 
+export interface WorkerCallOptions<P = any> {
+  signal?: AbortSignal;
+  onProgress?: (progress: P) => void;
+}
+
 /**
- * Wrap a Worker-like object to return a promise-based call helper.
+ * Wrap a Worker-like object to return a promise-based call helper with support
+ * for progress events and cancellation via AbortController.
  */
-export function wrapWorker<T, R>(worker: WorkerLike) {
-  return (msg: T) =>
+export function wrapWorker<T, R, P = any>(
+  worker: WorkerLike,
+) {
+  return (msg: T, opts: WorkerCallOptions<P> = {}) =>
     new Promise<R>((resolve, reject) => {
+      const { signal, onProgress } = opts;
+      let settled = false;
+
       const onMessage = (e: any) => {
+        const data = e.data;
+        if (data && typeof data === 'object' && 'progress' in data) {
+          onProgress?.((data as any).progress as P);
+          return;
+        }
+        settled = true;
         cleanup();
-        resolve(e.data as R);
+        resolve(data as R);
       };
+
       const onError = (e: any) => {
+        settled = true;
         cleanup();
         reject(e.error ?? e);
       };
+
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        try {
+          worker.postMessage({ type: 'cancel' });
+        } catch {
+          // ignore
+        }
+        reject(new Error('aborted'));
+      };
+
       const cleanup = () => {
         worker.removeEventListener('message', onMessage);
         worker.removeEventListener('error', onError);
+        signal?.removeEventListener('abort', onAbort);
       };
+
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+
       worker.addEventListener('message', onMessage);
       worker.addEventListener('error', onError);
+      signal?.addEventListener('abort', onAbort);
       worker.postMessage(msg);
     });
 }


### PR DESCRIPTION
## Summary
- add progress and cancellation support to generic worker wrapper
- offload heavy utility demo task to dedicated worker with progress bar and cancel
- document worker utilities

## Testing
- `yarn test` *(fails: ENOENT rsa-private.pem in jwks-fetcher.api.test.ts; SyntaxError: Identifier 'SPF_SPEC' has already been declared in mail-auth.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cb71c5083288a94879fcc5b3fed