### PR TITLE
Parse CVSS vectors and surface impact details

### DIFF
--- a/__tests__/cvssParser.test.ts
+++ b/__tests__/cvssParser.test.ts
@@ -1,0 +1,17 @@
+import { parseCvss } from '@lib/cvss';
+
+describe('parseCvss', () => {
+  test('parses CVSS v3.1 vector', () => {
+    const info = parseCvss('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    expect(info?.score).toBeCloseTo(9.8, 1);
+    expect(info?.impact).toBeCloseTo(5.9, 1);
+    expect(info?.exploitability).toBeCloseTo(3.9, 1);
+  });
+
+  test('parses CVSS v4.0 vector', () => {
+    const info = parseCvss('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H');
+    expect(info?.score).toBeCloseTo(10, 1);
+    expect(info?.impact).toBeNull();
+    expect(info?.exploitability).toBeNull();
+  });
+});

--- a/components/apps/cve-dashboard.tsx
+++ b/components/apps/cve-dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Papa from 'papaparse';
 import { rateLimitedFetch } from '@lib/rateLimitedFetch';
+import { parseCvss } from '@lib/cvss';
 
 interface CvssMetric {
   cvssData: { vectorString: string; baseScore: number; baseSeverity?: string };
@@ -83,6 +84,21 @@ export default function CveDashboard() {
     URL.revokeObjectURL(url);
   };
 
+  const renderCvss = (vector?: string) => {
+    if (!vector) return '';
+    const info = parseCvss(vector);
+    if (!info) return '';
+    const parts = [`Vector: ${vector}`, `Score: ${info.score.toFixed(1)}`];
+    if (info.impact !== null && info.exploitability !== null) {
+      parts.push(`Impact: ${info.impact.toFixed(1)}`, `Exploitability: ${info.exploitability.toFixed(1)}`);
+    }
+    return (
+      <span title={parts.join('\n')}>
+        {info.score.toFixed(1)}
+      </span>
+    );
+  };
+
   return (
     <div className="p-4 space-y-4 text-sm">
       <div className="flex flex-wrap gap-2">
@@ -155,24 +171,8 @@ export default function CveDashboard() {
                 <td className="border px-1">
                   {v.cve.descriptions?.[0]?.value || ''}
                 </td>
-                <td className="border px-1">
-                  {v31 ? (
-                    <span title={`Score: ${v31.cvssData.baseScore}`}>
-                      {v31.cvssData.vectorString}
-                    </span>
-                  ) : (
-                    ''
-                  )}
-                </td>
-                <td className="border px-1">
-                  {v40 ? (
-                    <span title={`Score: ${v40.cvssData.baseScore}`}>
-                      {v40.cvssData.vectorString}
-                    </span>
-                  ) : (
-                    ''
-                  )}
-                </td>
+                <td className="border px-1">{renderCvss(v31?.cvssData.vectorString)}</td>
+                <td className="border px-1">{renderCvss(v40?.cvssData.vectorString)}</td>
                 <td className="border px-1" title="EPSS score placeholder">--</td>
                 <td className="border px-1">
                   {v.cve.references?.reference_data?.map((r, i) => (

--- a/lib/cvss.ts
+++ b/lib/cvss.ts
@@ -1,0 +1,21 @@
+import { calculateBaseResult, calculateBaseScore } from 'cvss4';
+
+export interface CvssInfo {
+  score: number;
+  impact: number | null;
+  exploitability: number | null;
+}
+
+export function parseCvss(vector?: string): CvssInfo | null {
+  if (!vector) return null;
+  try {
+    const score = calculateBaseScore(vector);
+    if (vector.startsWith('CVSS:3.1') || vector.startsWith('CVSS:3.0')) {
+      const res = calculateBaseResult(vector);
+      return { score, impact: res.impact, exploitability: res.exploitability };
+    }
+    return { score, impact: null, exploitability: null };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- compute CVSS scores from vector strings
- show impact and exploitability details via tooltips
- add cvss parser utility with tests

## Testing
- `yarn test __tests__/cvssParser.test.ts`
- `yarn test` *(fails: ENOENT: no such file or directory, open '__tests__/fixtures/rsa-private.pem')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7cb4c99883289cfdda2b321d5278