### PR TITLE
Improve accessibility and localization for vulnerability search

### DIFF
--- a/components/vulnerability-search.tsx
+++ b/components/vulnerability-search.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import useSWR from 'swr';
 import Papa from 'papaparse';
+import { vulnerabilitySearchStrings as strings } from '../lib/strings';
 
 interface Vuln {
   cve: { id: string; descriptions?: { value: string }[] };
@@ -12,11 +13,11 @@ interface Vuln {
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 const allColumns = [
-  { key: 'id', label: 'CVE' },
-  { key: 'description', label: 'Description' },
-  { key: 'severity', label: 'Severity' },
-  { key: 'epss', label: 'EPSS' },
-  { key: 'kev', label: 'CISA KEV' },
+  { key: 'id', label: strings.columns.id },
+  { key: 'description', label: strings.columns.description },
+  { key: 'severity', label: strings.columns.severity },
+  { key: 'epss', label: strings.columns.epss },
+  { key: 'kev', label: strings.columns.kev },
 ];
 
 export default function VulnerabilitySearch() {
@@ -48,7 +49,7 @@ export default function VulnerabilitySearch() {
   }, [columns]);
 
   const saveView = () => {
-    const name = prompt('View name?');
+    const name = prompt(strings.viewNamePrompt);
     if (!name) return;
     const newViews = { ...views, [name]: { keyword, domain, severity, columns } };
     setViews(newViews);
@@ -71,14 +72,14 @@ export default function VulnerabilitySearch() {
       description: v.cve.descriptions?.[0]?.value || '',
       severity: v.severity || '',
       epss: v.epss ?? '',
-      kev: v.kev ? 'yes' : 'no',
+      kev: v.kev ? strings.yes : strings.no,
     }));
     const csv = Papa.unparse(rows);
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'vulnerabilities.csv';
+    a.download = strings.csvFileName;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -103,33 +104,53 @@ export default function VulnerabilitySearch() {
         <input
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
-          placeholder="Keyword"
-          className="border p-1"
+          placeholder={strings.keyword}
+          aria-label={strings.keyword}
+          className="border p-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         />
         <input
           value={domain}
           onChange={(e) => setDomain(e.target.value)}
-          placeholder="Domain"
-          className="border p-1"
+          placeholder={strings.domain}
+          aria-label={strings.domain}
+          className="border p-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         />
-        {['critical', 'high', 'medium', 'low'].map((sev) => (
-          <label key={sev} className="flex items-center gap-1">
+        {strings.severityOptions.map((sev) => (
+          <label key={sev.key} className="flex items-center gap-1">
             <input
               type="checkbox"
-              checked={severity.includes(sev)}
-              onChange={() => toggleSeverity(sev)}
+              checked={severity.includes(sev.key)}
+              onChange={() => toggleSeverity(sev.key)}
+              aria-label={sev.label}
+              className="focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-            {sev}
+            {sev.label}
           </label>
         ))}
-        <button onClick={saveView} className="border px-2">Save View</button>
-        <select onChange={(e) => loadView(e.target.value)} className="border">
-          <option value="">Load View</option>
+        <button
+          onClick={saveView}
+          className="border px-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          aria-label={strings.saveView}
+        >
+          {strings.saveView}
+        </button>
+        <select
+          onChange={(e) => loadView(e.target.value)}
+          className="border focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          aria-label={strings.loadView}
+        >
+          <option value="">{strings.loadView}</option>
           {Object.keys(views).map((n) => (
             <option key={n}>{n}</option>
           ))}
         </select>
-        <button onClick={exportCsv} className="border px-2">CSV</button>
+        <button
+          onClick={exportCsv}
+          className="border px-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          aria-label={strings.exportCsv}
+        >
+          {strings.exportCsv}
+        </button>
       </div>
       <div className="flex gap-2 flex-wrap">
         {allColumns.map((col) => (
@@ -138,23 +159,45 @@ export default function VulnerabilitySearch() {
               type="checkbox"
               checked={columns.includes(col.key)}
               onChange={() => toggleColumn(col.key)}
+              aria-label={col.label}
+              className="focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             {col.label}
           </label>
         ))}
       </div>
-      <table className="min-w-full border">
+      <table
+        className="min-w-full border"
+        role="table"
+        aria-label={strings.tableLabel}
+      >
         <thead>
           <tr>
-            {columns.includes('id') && <th className="border px-2">CVE</th>}
+            {columns.includes('id') && (
+              <th className="border px-2" scope="col">
+                {strings.columns.id}
+              </th>
+            )}
             {columns.includes('description') && (
-              <th className="border px-2">Description</th>
+              <th className="border px-2" scope="col">
+                {strings.columns.description}
+              </th>
             )}
             {columns.includes('severity') && (
-              <th className="border px-2">Severity</th>
+              <th className="border px-2" scope="col">
+                {strings.columns.severity}
+              </th>
             )}
-            {columns.includes('epss') && <th className="border px-2">EPSS</th>}
-            {columns.includes('kev') && <th className="border px-2">KEV</th>}
+            {columns.includes('epss') && (
+              <th className="border px-2" scope="col">
+                {strings.columns.epss}
+              </th>
+            )}
+            {columns.includes('kev') && (
+              <th className="border px-2" scope="col">
+                {strings.columns.kev}
+              </th>
+            )}
           </tr>
         </thead>
         <tbody>

--- a/lib/strings.ts
+++ b/lib/strings.ts
@@ -1,0 +1,25 @@
+export const vulnerabilitySearchStrings = {
+  keyword: 'Keyword',
+  domain: 'Domain',
+  severityOptions: [
+    { key: 'critical', label: 'critical' },
+    { key: 'high', label: 'high' },
+    { key: 'medium', label: 'medium' },
+    { key: 'low', label: 'low' },
+  ],
+  saveView: 'Save View',
+  loadView: 'Load View',
+  exportCsv: 'Export CSV',
+  viewNamePrompt: 'View name?',
+  columns: {
+    id: 'CVE',
+    description: 'Description',
+    severity: 'Severity',
+    epss: 'EPSS',
+    kev: 'CISA KEV',
+  },
+  tableLabel: 'Vulnerability results',
+  yes: 'yes',
+  no: 'no',
+  csvFileName: 'vulnerabilities.csv',
+};


### PR DESCRIPTION
## Summary
- add centralized strings for vulnerability search
- add ARIA roles, labels, and focus styles for inputs, buttons, and table

## Testing
- `yarn lint --file components/vulnerability-search.tsx --file lib/strings.ts`
- `yarn test` *(fails: ENOENT for fixtures, various test suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cb3afa083288648c8f58b21dbe5