### PR TITLE
feat: improve vulnerability search accessibility

### DIFF
--- a/components/vulnerability-search.tsx
+++ b/components/vulnerability-search.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import useSWR from 'swr';
 import Papa from 'papaparse';
+import strings from '../locales/en/vulnerability-search.json';
 
 interface Vuln {
   cve: { id: string; descriptions?: { value: string }[] };
@@ -11,21 +12,20 @@ interface Vuln {
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-const allColumns = [
-  { key: 'id', label: 'CVE' },
-  { key: 'description', label: 'Description' },
-  { key: 'severity', label: 'Severity' },
-  { key: 'epss', label: 'EPSS' },
-  { key: 'kev', label: 'CISA KEV' },
-];
-
 export default function VulnerabilitySearch() {
   const [keyword, setKeyword] = useState('');
   const [domain, setDomain] = useState('');
   const [severity, setSeverity] = useState<string[]>([]);
   const [columns, setColumns] = useState<string[]>(() => {
     try {
-      return JSON.parse(localStorage.getItem('vuln_columns') || '') || ['id', 'description', 'epss', 'kev'];
+      return (
+        JSON.parse(localStorage.getItem('vuln_columns') || '') || [
+          'id',
+          'description',
+          'epss',
+          'kev',
+        ]
+      );
     } catch {
       return ['id', 'description', 'epss', 'kev'];
     }
@@ -38,19 +38,37 @@ export default function VulnerabilitySearch() {
     }
   });
 
-  const params = new URLSearchParams({ keyword, domain, severity: severity.join(','), sort: 'epss' });
+  const params = new URLSearchParams({
+    keyword,
+    domain,
+    severity: severity.join(','),
+    sort: 'epss',
+  });
   const { data } = useSWR(`/api/cve?${params.toString()}`, fetcher, {
     revalidateOnFocus: false,
   });
+
+  const allColumns = [
+    { key: 'id', label: strings.columns.id },
+    { key: 'description', label: strings.columns.description },
+    { key: 'severity', label: strings.columns.severity },
+    { key: 'epss', label: strings.columns.epss },
+    { key: 'kev', label: strings.columns.kev },
+  ];
+
+  const severityOptions = ['critical', 'high', 'medium', 'low'] as const;
 
   useEffect(() => {
     localStorage.setItem('vuln_columns', JSON.stringify(columns));
   }, [columns]);
 
   const saveView = () => {
-    const name = prompt('View name?');
+    const name = prompt(strings.viewNamePrompt);
     if (!name) return;
-    const newViews = { ...views, [name]: { keyword, domain, severity, columns } };
+    const newViews = {
+      ...views,
+      [name]: { keyword, domain, severity, columns },
+    };
     setViews(newViews);
     localStorage.setItem('vuln_views', JSON.stringify(newViews));
   };
@@ -71,7 +89,7 @@ export default function VulnerabilitySearch() {
       description: v.cve.descriptions?.[0]?.value || '',
       severity: v.severity || '',
       epss: v.epss ?? '',
-      kev: v.kev ? 'yes' : 'no',
+      kev: v.kev ? strings.yes : strings.no,
     }));
     const csv = Papa.unparse(rows);
     const blob = new Blob([csv], { type: 'text/csv' });
@@ -103,33 +121,52 @@ export default function VulnerabilitySearch() {
         <input
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
-          placeholder="Keyword"
-          className="border p-1"
+          placeholder={strings.keyword}
+          aria-label={strings.keyword}
+          className="border p-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         />
         <input
           value={domain}
           onChange={(e) => setDomain(e.target.value)}
-          placeholder="Domain"
-          className="border p-1"
+          placeholder={strings.domain}
+          aria-label={strings.domain}
+          className="border p-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         />
-        {['critical', 'high', 'medium', 'low'].map((sev) => (
+        {severityOptions.map((sev) => (
           <label key={sev} className="flex items-center gap-1">
             <input
               type="checkbox"
               checked={severity.includes(sev)}
               onChange={() => toggleSeverity(sev)}
+              className="focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             />
-            {sev}
+            {strings.severities[sev]}
           </label>
         ))}
-        <button onClick={saveView} className="border px-2">Save View</button>
-        <select onChange={(e) => loadView(e.target.value)} className="border">
-          <option value="">Load View</option>
+        <button
+          onClick={saveView}
+          className="border px-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label={strings.saveView}
+        >
+          {strings.saveView}
+        </button>
+        <select
+          onChange={(e) => loadView(e.target.value)}
+          className="border focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label={strings.loadView}
+        >
+          <option value="">{strings.loadViewOption}</option>
           {Object.keys(views).map((n) => (
             <option key={n}>{n}</option>
           ))}
         </select>
-        <button onClick={exportCsv} className="border px-2">CSV</button>
+        <button
+          onClick={exportCsv}
+          className="border px-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label={strings.csv}
+        >
+          {strings.csv}
+        </button>
       </div>
       <div className="flex gap-2 flex-wrap">
         {allColumns.map((col) => (
@@ -138,6 +175,7 @@ export default function VulnerabilitySearch() {
               type="checkbox"
               checked={columns.includes(col.key)}
               onChange={() => toggleColumn(col.key)}
+              className="focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             />
             {col.label}
           </label>
@@ -146,21 +184,29 @@ export default function VulnerabilitySearch() {
       <table className="min-w-full border">
         <thead>
           <tr>
-            {columns.includes('id') && <th className="border px-2">CVE</th>}
+            {columns.includes('id') && (
+              <th className="border px-2">{strings.columns.id}</th>
+            )}
             {columns.includes('description') && (
-              <th className="border px-2">Description</th>
+              <th className="border px-2">{strings.columns.description}</th>
             )}
             {columns.includes('severity') && (
-              <th className="border px-2">Severity</th>
+              <th className="border px-2">{strings.columns.severity}</th>
             )}
-            {columns.includes('epss') && <th className="border px-2">EPSS</th>}
-            {columns.includes('kev') && <th className="border px-2">KEV</th>}
+            {columns.includes('epss') && (
+              <th className="border px-2">{strings.columns.epss}</th>
+            )}
+            {columns.includes('kev') && (
+              <th className="border px-2">{strings.columns.kev}</th>
+            )}
           </tr>
         </thead>
         <tbody>
           {vulns.map((v) => (
             <tr key={v.cve.id} className="border-t">
-              {columns.includes('id') && <td className="border px-2">{v.cve.id}</td>}
+              {columns.includes('id') && (
+                <td className="border px-2">{v.cve.id}</td>
+              )}
               {columns.includes('description') && (
                 <td className="border px-2">
                   {v.cve.descriptions?.[0]?.value || ''}

--- a/locales/en/vulnerability-search.json
+++ b/locales/en/vulnerability-search.json
@@ -1,0 +1,25 @@
+{
+  "keyword": "Keyword",
+  "domain": "Domain",
+  "severityLabel": "Severity",
+  "severities": {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low"
+  },
+  "saveView": "Save View",
+  "loadView": "Load View",
+  "csv": "CSV",
+  "viewNamePrompt": "View name?",
+  "columns": {
+    "id": "CVE",
+    "description": "Description",
+    "severity": "Severity",
+    "epss": "EPSS",
+    "kev": "CISA KEV"
+  },
+  "yes": "yes",
+  "no": "no",
+  "loadViewOption": "Load View"
+}


### PR DESCRIPTION
## Summary
- localize vulnerability search UI strings
- add ARIA labels and focus styles to vulnerability search form controls

## Testing
- `yarn test` *(fails: ENOENT: no such file or directory, open '__tests__/fixtures/rsa-private.pem'; Jest encountered an unexpected token in mail-auth API; Vitest cannot be imported in a CommonJS module using require(); ReferenceError: displayImportGraph is not defined; x Expected ',', got 'jsx')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cb1285083289d4477fd040b1221