### PR TITLE
feat: improve accessibility and localization

### DIFF
--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import dynamicImport from 'next/dynamic';
+import messages from '../../../messages/en.json';
 
 export const dynamic = 'force-static';
 export const revalidate = 60;
@@ -15,16 +16,17 @@ const Reversi = dynamicImport(() => import('../../../apps/reversi'), {
 
 export default function GamePage({ params }: GamePageProps) {
   const { slug } = params;
+  const heading = messages.gamePage.title.replace('{slug}', slug);
   if (slug === 'reversi') {
     return (
-      <main>
+      <main role="main" aria-labelledby="game-heading">
         <Reversi />
       </main>
     );
   }
   return (
-    <main>
-      <h1>Game: {slug}</h1>
+    <main role="main" aria-labelledby="game-heading">
+      <h1 id="game-heading">{heading}</h1>
     </main>
   );
 }

--- a/components/util-components/Modal.tsx
+++ b/components/util-components/Modal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useId } from 'react';
+import messages from '../../messages/en.json';
 
 interface ModalProps {
   isOpen: boolean;
@@ -12,6 +13,7 @@ const focusableSelector =
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
   useEffect(() => {
     if (!isOpen) return;
@@ -48,20 +50,26 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
       role="dialog"
       aria-modal="true"
+      aria-labelledby={title ? titleId : undefined}
     >
       <div
         ref={dialogRef}
         className="bg-[var(--color-surface)] text-[var(--color-text)] p-4 rounded shadow-lg w-11/12 max-w-md"
       >
-        {title && <h2 className="text-lg font-bold mb-2">{title}</h2>}
+        {title && (
+          <h2 id={titleId} className="text-lg font-bold mb-2">
+            {title}
+          </h2>
+        )}
         <div>{children}</div>
         <div className="mt-4 text-right">
           <button
             onClick={onClose}
-            className="px-4 py-2 bg-[var(--color-accent)] text-black rounded"
+            className="px-4 py-2 bg-[var(--color-accent)] text-black rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-text)]"
             data-autofocus
+            aria-label={messages.modal.close}
           >
-            Close
+            {messages.modal.close}
           </button>
         </div>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,8 @@
+{
+  "modal": {
+    "close": "Close"
+  },
+  "gamePage": {
+    "title": "Game: {slug}"
+  }
+}


### PR DESCRIPTION
## Summary
- add translation messages for modals and game pages
- provide ARIA labelling and focus styles in Modal
- localize game page heading and add ARIA attributes

## Testing
- `yarn lint`
- `yarn test` *(fails: ENOENT for fixture files, SyntaxError in mail-auth, missing functions, etc.)*
- `yarn test:unit` *(fails: transform errors, unresolved imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cad20a883288eccdedef0210339