### PR TITLE
Add Playwright test for desktop window persistence

### DIFF
--- a/e2e/desktop-open.spec.ts
+++ b/e2e/desktop-open.spec.ts
@@ -34,3 +34,57 @@ test('open, minimize, restore, and focus windows', async ({ page }) => {
   await expect(chromeWindow).toHaveClass(/z-30/);
   await expect(aboutWindow).toHaveClass(/notFocused/);
 });
+
+test('window resize persists through minimize and restore with no console errors', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+
+  await page.goto('/');
+
+  const chromeIcon = page.getByTestId('ubuntu-app-chrome');
+  await expect(chromeIcon).toBeVisible();
+
+  const aboutWindow = page.getByTestId('window-about-alex');
+  if (await aboutWindow.isVisible().catch(() => false)) {
+    await aboutWindow.getByRole('button', { name: 'Close window' }).click();
+    await expect(aboutWindow).toBeHidden();
+  }
+
+  await chromeIcon.dblclick();
+  const chromeWindow = page.getByTestId('window-chrome');
+  await expect(chromeWindow).toBeVisible();
+
+  await page.evaluate(() => {
+    const win = document.querySelector('[data-testid="window-chrome"]') as HTMLElement | null;
+    if (win) {
+      win.style.width = '420px';
+      win.style.height = '320px';
+    }
+  });
+
+  const before = await chromeWindow.boundingBox();
+  if (!before) throw new Error('Failed to obtain window bounds');
+
+  await chromeWindow.getByRole('button', { name: 'Minimize window' }).click();
+  await expect(chromeWindow).toBeHidden();
+
+  await chromeIcon.dblclick();
+  await expect(chromeWindow).toBeVisible();
+
+  const after = await chromeWindow.boundingBox();
+  if (!after) throw new Error('Failed to obtain window bounds after restore');
+
+  expect(after.width).toBeCloseTo(before.width, 1);
+  expect(after.height).toBeCloseTo(before.height, 1);
+  expect(after.x).toBeCloseTo(before.x, 1);
+  expect(after.y).toBeCloseTo(before.y, 1);
+
+  await chromeWindow.getByRole('button', { name: 'Close window' }).click();
+  await expect(chromeWindow).toBeHidden();
+
+  expect(consoleErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- test window resize persistence through minimize and restore
- ensure no console errors when interacting with desktop windows

## Testing
- `yarn test:e2e` *(fails: /usr/local/bin/yarn: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7ca780ec832896c4936a30787f6c