### PR TITLE
Run SBOM parsing in worker with progress and cancel

### DIFF
--- a/__tests__/sbom-viewer.test.tsx
+++ b/__tests__/sbom-viewer.test.tsx
@@ -4,13 +4,24 @@ jest.mock('@lib/sbom', () => {
   const actual = jest.requireActual('@lib/sbom');
   return {
     ...actual,
-    readFileChunks: jest.fn(async () => JSON.stringify(cyclonedxSample)),
     fetchOsv: jest.fn(),
   };
 });
 
+import { parseSbomObject } from '@lib/sbom';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import SbomViewer from '@components/apps/sbom-viewer';
+
+class MockWorker {
+  onmessage: ((e: any) => void) | null = null;
+  postMessage() {
+    const parsed = parseSbomObject(cyclonedxSample);
+    this.onmessage?.({ data: { type: 'done', sbom: parsed } });
+  }
+  terminate() {}
+}
+
+(global as any).Worker = MockWorker as any;
 
 describe('SBOM Viewer', () => {
   it('loads SBOM and displays components', async () => {

--- a/components/apps/sbom-viewer.worker.ts
+++ b/components/apps/sbom-viewer.worker.ts
@@ -1,0 +1,44 @@
+import { parseSbomObject, fetchOsv, ParsedSbom } from '@lib/sbom';
+
+let cancelled = false;
+let controller: AbortController | null = null;
+
+self.onmessage = async (e: MessageEvent<any>) => {
+  const { type } = e.data;
+  if (type === 'parse') {
+    cancelled = false;
+    controller = new AbortController();
+    try {
+      const file: File = e.data.file;
+      const text = await file.text();
+      if (cancelled) return;
+      const data = JSON.parse(text);
+      const parsed: ParsedSbom = parseSbomObject(data);
+      const total = parsed.components.length;
+      for (let i = 0; i < total; i += 1) {
+        if (cancelled) break;
+        await fetchOsv(parsed.components[i], controller.signal);
+        (self as any).postMessage({
+          type: 'progress',
+          progress: (i + 1) / total,
+        });
+      }
+      if (!cancelled) {
+        (self as any).postMessage({ type: 'done', sbom: parsed });
+      }
+    } catch (err: any) {
+      if (!cancelled) {
+        (self as any).postMessage({
+          type: 'error',
+          error: err.message || String(err),
+        });
+      }
+    }
+  } else if (type === 'cancel') {
+    cancelled = true;
+    controller?.abort();
+    (self as any).postMessage({ type: 'cancelled' });
+  }
+};
+
+export {};

--- a/lib/sbom.ts
+++ b/lib/sbom.ts
@@ -117,7 +117,10 @@ function parseSpdx(data: any): ParsedSbom {
   return { components, graph };
 }
 
-export async function fetchOsv(component: SbomComponent): Promise<void> {
+export async function fetchOsv(
+  component: SbomComponent,
+  signal?: AbortSignal,
+): Promise<void> {
   if (!component.version) {
     component.vulns = [];
     return;
@@ -130,6 +133,7 @@ export async function fetchOsv(component: SbomComponent): Promise<void> {
         version: component.version,
         package: { name: component.name },
       }),
+      signal,
     });
     if (!res.ok) return;
     const json = await res.json();


### PR DESCRIPTION
## Summary
- Offload SBOM parsing and OSV lookup to a web worker, providing progress updates and cancellation support
- Allow SBOM OSV fetch helper to accept an abort signal
- Update SBOM viewer tests to mock the worker environment

## Testing
- `yarn test` *(fails: jwks-fetcher.api.test.ts, mail-auth.api.test.ts, gitSecretsTester.api.test.ts, tictactoe.test.ts)*
- `yarn test __tests__/sbom-viewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab7cb9d07083288bccc73f74c50794