### PR TITLE
feat: improve badge list accessibility

### DIFF
--- a/__tests__/BadgeList.accessibility.test.tsx
+++ b/__tests__/BadgeList.accessibility.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import BadgeList from '@components/BadgeList';
+
+describe('BadgeList accessibility', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: 'en',
+    });
+  });
+
+  it('opens modal with keyboard and closes with Escape', () => {
+    const badges = [
+      {
+        label: 'React',
+        src: '/react.png',
+        alt: 'React',
+        description: 'UI library',
+      },
+    ];
+    render(<BadgeList badges={badges} />);
+    const badgeButton = screen.getByRole('button', {
+      name: /view details for react/i,
+    });
+    badgeButton.focus();
+    fireEvent.keyDown(badgeButton, { key: 'Enter' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,8 +1,54 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
+
+const STRINGS = {
+  en: {
+    filterPlaceholder: 'Filter skills',
+    close: 'Close',
+    viewDetails: 'View details for',
+  },
+  es: {
+    filterPlaceholder: 'Filtrar habilidades',
+    close: 'Cerrar',
+    viewDetails: 'Ver detalles de',
+  },
+};
 
 const BadgeList = ({ badges, className = '' }) => {
+  const locale =
+    typeof navigator !== 'undefined'
+      ? navigator.language.slice(0, 2)
+      : 'en';
+  const strings = STRINGS[locale] || STRINGS.en;
+
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(null);
+  const closeRef = useRef(null);
+  const lastFocused = useRef(null);
+
+  useEffect(() => {
+    if (selected && closeRef.current) {
+      closeRef.current.focus();
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        setSelected(null);
+      }
+    };
+    if (selected) {
+      document.addEventListener('keydown', onKey);
+    }
+    return () => document.removeEventListener('keydown', onKey);
+  }, [selected]);
+
+  const openModal = (badge) => {
+    lastFocused.current = document.activeElement;
+    setSelected(badge);
+  };
+
+  const closeModal = () => {
+    setSelected(null);
+    lastFocused.current && lastFocused.current.focus();
+  };
 
   const filteredBadges = badges.filter((badge) =>
     badge.label.toLowerCase().includes(filter.toLowerCase())
@@ -12,39 +58,59 @@ const BadgeList = ({ badges, className = '' }) => {
     <div className={`flex flex-col items-center ${className}`}>
       <input
         type="text"
-        placeholder="Filter skills"
+        placeholder={strings.filterPlaceholder}
+        aria-label={strings.filterPlaceholder}
         className="mb-2 px-2 py-1 rounded text-black font-normal"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
       />
-      <div className="flex flex-wrap justify-center items-start w-full">
+      <div
+        className="flex flex-wrap justify-center items-start w-full"
+        role="list"
+      >
         {filteredBadges.map((badge, idx) => (
-          <img
+          <button
             key={idx}
+            type="button"
             className="m-1 hover:scale-110 transition-transform cursor-pointer"
-            src={badge.src}
-            alt={badge.alt}
-            title={badge.description || badge.label}
-            onClick={() => setSelected(badge)}
-          />
+            onClick={() => openModal(badge)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openModal(badge);
+              }
+            }}
+            aria-label={`${strings.viewDetails} ${badge.label}`}
+          >
+            <img src={badge.src} alt={badge.alt} />
+          </button>
         ))}
       </div>
       {selected && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-          onClick={() => setSelected(null)}
+          onClick={closeModal}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="badge-title"
+          aria-describedby="badge-description"
         >
           <div
             className="bg-white text-black p-4 rounded shadow max-w-sm"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="font-bold mb-2">{selected.label}</div>
-            <div className="text-sm">{selected.description}</div>
+            <div id="badge-title" className="font-bold mb-2">
+              {selected.label}
+            </div>
+            <div id="badge-description" className="text-sm">
+              {selected.description}
+            </div>
             <button
+              ref={closeRef}
               className="mt-4 px-2 py-1 bg-blue-600 text-white rounded"
-              onClick={() => setSelected(null)}
+              onClick={closeModal}
             >
-              Close
+              {strings.close}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add ARIA semantics and keyboard navigation to BadgeList modal
- localize BadgeList UI strings for English and Spanish
- test keyboard interactions for BadgeList

## Testing
- `yarn test __tests__/BadgeList.accessibility.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab7cba2dd08328bf4711bb09466a7e