### PR TITLE
feat: add strict types and tests

### DIFF
--- a/apps/request-builder/index.tsx
+++ b/apps/request-builder/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import type { RequestResponse } from '@/types/request';
 
 interface HistoryEntry {
   method: string;
@@ -7,14 +8,16 @@ interface HistoryEntry {
   body: string;
 }
 
+interface RequestBuilderProps {}
+
 const STORAGE_KEY = 'request-builder-history';
 
-const RequestBuilder: React.FC = () => {
+const RequestBuilder: React.FC<RequestBuilderProps> = () => {
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
   const [headers, setHeaders] = useState('{}');
   const [body, setBody] = useState('');
-  const [response, setResponse] = useState<any>(null);
+  const [response, setResponse] = useState<RequestResponse | null>(null);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
 
   useEffect(() => {
@@ -46,7 +49,7 @@ const RequestBuilder: React.FC = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ method, url, headers: parsedHeaders, body }),
     });
-    const data = await res.json();
+    const data = (await res.json()) as RequestResponse;
     setResponse(data);
   };
 

--- a/e2e/request-builder.smoke.spec.ts
+++ b/e2e/request-builder.smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('request builder page loads', async ({ page }) => {
+  await page.goto('/apps/request-builder');
+  await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
+});
+

--- a/lib/rateLimitedFetch.test.ts
+++ b/lib/rateLimitedFetch.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { rateLimitedFetch } from './rateLimitedFetch';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (typeof window !== 'undefined') {
+    localStorage.clear();
+  }
+});
+
+describe('rateLimitedFetch', () => {
+  it('returns data on success', async () => {
+    const mockData = { ok: true };
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(mockData), { status: 200 })));
+    const result = await rateLimitedFetch('https://example.com');
+    expect(result).toEqual(mockData);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('fail');
+    }));
+    await expect(rateLimitedFetch('https://example.com', { retries: 0 })).rejects.toThrow('fail');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/lib/rateLimitedFetch.ts
+++ b/lib/rateLimitedFetch.ts
@@ -2,10 +2,10 @@ let lastReq = 0;
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
-export async function rateLimitedFetch(
+export async function rateLimitedFetch<T>(
   url: string,
-  options: { ttl?: number; retries?: number } = {}
-): Promise<any> {
+  options: { ttl?: number; retries?: number } = {},
+): Promise<T> {
   const { ttl = 60_000, retries = 2 } = options;
   const key = `rlf:${url}`;
   const now = Date.now();
@@ -13,7 +13,7 @@ export async function rateLimitedFetch(
     const raw = localStorage.getItem(key);
     if (raw) {
       try {
-        const entry = JSON.parse(raw);
+        const entry = JSON.parse(raw) as { ts: number; data: T };
         if (now - entry.ts < ttl) {
           return entry.data;
         }
@@ -30,7 +30,7 @@ export async function rateLimitedFetch(
     try {
       const res = await fetch(url);
       if (!res.ok) throw new Error(`Request failed: ${res.status}`);
-      const data = await res.json();
+      const data = (await res.json()) as T;
       if (typeof window !== 'undefined') {
         try {
           localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data }));
@@ -40,9 +40,12 @@ export async function rateLimitedFetch(
       }
       lastReq = Date.now();
       return data;
-    } catch (e) {
+    } catch (e: unknown) {
       if (i === retries) throw e;
       await sleep(500 * (i + 1));
     }
   }
+
+  throw new Error('Unreachable');
 }
+

--- a/types/request.ts
+++ b/types/request.ts
@@ -1,0 +1,9 @@
+export interface RequestResponse {
+  duration: number;
+  status: number;
+  statusText?: string;
+  headers: Record<string, string>;
+  body: string;
+  error?: string;
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
   },
   esbuild: {
-    loader: 'jsx',
+    loader: 'tsx',
   },
 });


### PR DESCRIPTION
## Summary
- add type-safe `rateLimitedFetch` with generic return type
- strongly type Request Builder state and API response
- cover rateLimitedFetch with Vitest and add Playwright smoke test

## Testing
- `yarn test:unit lib/rateLimitedFetch.test.ts`
- `yarn test:e2e e2e/request-builder.smoke.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cabb4ec8328b380060e12b42f83