### PR TITLE
Offload license matching to worker with progress

### DIFF
--- a/lib/licenseMatcher.worker-client.ts
+++ b/lib/licenseMatcher.worker-client.ts
@@ -1,0 +1,54 @@
+import { LicenseMatchResult } from './licenseMatcher';
+
+interface WorkerClientOptions {
+  signal?: AbortSignal;
+  onProgress?: (progress: number) => void;
+}
+
+export function matchLicenseWorker(
+  text: string,
+  options: WorkerClientOptions = {}
+): Promise<LicenseMatchResult> {
+  const { signal, onProgress } = options;
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./licenseMatcher.worker.ts', import.meta.url));
+    const id = Math.random().toString(36).slice(2);
+
+    const cleanup = () => {
+      worker.terminate();
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    worker.onmessage = (e: MessageEvent<any>) => {
+      if (e.data.id !== id) return;
+      if (typeof e.data.progress === 'number') {
+        onProgress?.(e.data.progress);
+        return;
+      }
+      cleanup();
+      if (e.data.error) {
+        if (e.data.error === 'aborted') {
+          reject(new DOMException('Aborted', 'AbortError'));
+        } else {
+          reject(new Error(e.data.error));
+        }
+      } else {
+        resolve(e.data.result as LicenseMatchResult);
+      }
+    };
+
+    const onAbort = () => {
+      worker.postMessage({ id, type: 'cancel' });
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener('abort', onAbort);
+      }
+    }
+
+    worker.postMessage({ id, text });
+  });
+}

--- a/lib/licenseMatcher.worker.ts
+++ b/lib/licenseMatcher.worker.ts
@@ -1,0 +1,65 @@
+const ctx: Worker = self as any;
+
+import { matchLicense, LicenseMatchResult } from './licenseMatcher';
+
+interface RequestMessage {
+  id: string;
+  text: string;
+}
+
+interface CancelMessage {
+  id: string;
+  type: 'cancel';
+}
+
+interface ResponseMessage {
+  id: string;
+  result?: LicenseMatchResult;
+  error?: string;
+  progress?: number;
+  duration?: number;
+}
+
+const controllers = new Map<string, AbortController>();
+
+ctx.onmessage = (e: MessageEvent<RequestMessage | CancelMessage>) => {
+  const data = e.data as any;
+  if (data.type === 'cancel') {
+    const ctrl = controllers.get(data.id);
+    if (ctrl) {
+      ctrl.abort();
+      controllers.delete(data.id);
+    }
+    return;
+  }
+
+  const { id, text } = data;
+  const controller = new AbortController();
+  controllers.set(id, controller);
+  const start = performance.now();
+  try {
+    const result = matchLicense(text, {
+      signal: controller.signal,
+      onProgress(completed, total) {
+        const progress = completed / total;
+        const msg: ResponseMessage = { id, progress };
+        ctx.postMessage(msg);
+      },
+    });
+    const duration = performance.now() - start;
+    const msg: ResponseMessage = { id, result, duration };
+    ctx.postMessage(msg);
+  } catch (err: any) {
+    const duration = performance.now() - start;
+    const msg: ResponseMessage = {
+      id,
+      error: err && err.name === 'AbortError' ? 'aborted' : err.message || String(err),
+      duration,
+    };
+    ctx.postMessage(msg);
+  } finally {
+    controllers.delete(id);
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- Measure license matching with Performance API and accept cancellation/progress hooks
- Run license matching in a dedicated worker and expose client helper
- Add progress indicator and cancel support to license classifier app

## Testing
- `yarn lint`
- `yarn test` *(fails: missing fixtures and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cac778c8328b646e13d16d2a3bd