### PR TITLE
Add analytics tracking and error reporting

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import LazyGitHubButton from '../LazyGitHubButton';
 import Certs from './certs';
+import { trackEvent } from '../../lib/analytics';
 
 export class AboutAlex extends Component {
 
@@ -183,7 +184,9 @@ function About() {
             <ul className=" mt-4 leading-tight tracking-tight text-sm md:text-base w-5/6 md:w-3/4 emoji-list">
                  <li className=" list-pc">I&apos;m a <span className=" font-medium"> Technology Enthusiast </span> who thrives on the thrill of learning and mastering the rapidly evolving world of tech. I&apos;ve completed 4 years of a degree in <u className=' cursor-pointer '><a href="https://shared.ontariotechu.ca/shared/faculty/fesns/documents/FESNS%20Program%20Maps/2018_nuclear_engineering_map_2017_entry.pdf" target={"_blank"}>Nuclear Engineering </a></u> at OntarioTech University before, I decided to my change my career goals to and pursue my passion of <u className=' cursor-pointer '> <a href="https://businessandit.ontariotechu.ca/undergraduate/bachelor-of-information-technology/networking-and-information-technology-security/networking-and-i.t-security-bit-2023-2024_.pdf" target={"_blank"}> Networking and I.T. Security</a> </u>.</li>
                  <li className=" mt-3 list-building">  If you&apos;re looking for the type of person that always wants to help others. That&apos;ll be there putting in the work 24/7. Please feel free to send an email <a className='text-underline'
-                               href='mailto:alex.unnippillil@hotmail.com'><u>@alex.unnippillil@hotmail.com</u></a></li>
+                               href='mailto:alex.unnippillil@hotmail.com'
+                               onClick={() => trackEvent('cta_contact_email', { email: 'alex.unnippillil@hotmail.com' })}
+                               ><u>@alex.unnippillil@hotmail.com</u></a></li>
                 <li className=" mt-3 list-time"> When I am not learning my next technical skill, I like to spend my time reading books, rock climbing or watching <u className=' cursor-pointer '><a href="https://www.youtube.com/@Alex-Unnippillil/playlists" target={"_blank"}>Youtube Videos</a></u> and <u className=' cursor-pointer '><a href="https://myanimelist.net/animelist/alex_u" target={"_blank"}>Anime</a></u></li> 
                 <li className=" mt-3 list-star"> And I also have interests in Deep Learning, Software Development & Animation!</li>
             </ul>
@@ -694,6 +697,7 @@ function Resume() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline text-blue"
+                    onClick={() => trackEvent('cta_download_resume')}
                 >
                     Download the resume
                 </a>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -3,6 +3,7 @@ import NextImage from 'next/image';
 import { DndContext, useDraggable } from '@dnd-kit/core';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
+import { trackEvent } from '../../lib/analytics';
 
 function DraggableContainer({ id, defaultPosition, bounds, onDrag, onStart, onStop, children, position: controlledPosition, onPositionChange }) {
     const [internalPosition, setInternalPosition] = React.useState(defaultPosition);
@@ -82,6 +83,7 @@ export class Window extends Component {
 
         // google analytics
         ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
+        trackEvent('window_open', { id: this.id, title: this.props.title });
 
         // on window resize, resize boundary
         window.addEventListener('resize', this.resizeBoundries);
@@ -89,7 +91,6 @@ export class Window extends Component {
 
     componentWillUnmount() {
         ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
-
         window.removeEventListener('resize', this.resizeBoundries);
     }
 
@@ -258,6 +259,7 @@ export class Window extends Component {
     }
 
     closeWindow = () => {
+        trackEvent('window_close', { id: this.id, title: this.props.title });
         this.setWinowsPosition();
         this.setState({ closed: true }, () => {
             this.props.hideSideBar(this.id, false);

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,33 @@
+import { logEvent } from './axiom';
+
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+const PHONE_REGEX = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g;
+
+export const maskPII = (value: any): any => {
+  if (typeof value === 'string') {
+    return value.replace(EMAIL_REGEX, '[email]').replace(PHONE_REGEX, '[phone]');
+  }
+  if (Array.isArray(value)) {
+    return value.map(maskPII);
+  }
+  if (value && typeof value === 'object') {
+    const masked: Record<string, any> = {};
+    for (const [key, val] of Object.entries(value)) {
+      masked[key] = maskPII(val);
+    }
+    return masked;
+  }
+  return value;
+};
+
+export const trackEvent = async (
+  type: string,
+  params: Record<string, any> = {}
+): Promise<void> => {
+  try {
+    await logEvent({ type, ...maskPII(params) });
+  } catch {
+    // ignore logging errors
+  }
+};
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '../lib/dev-ssr-logger';
 import type { AppProps, NextWebVitalsMetric } from 'next/app';
 import { useEffect, useState } from 'react';
 import { initAxiom, logEvent } from '../lib/axiom';
+import { maskPII } from '../lib/analytics';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import { Inter } from 'next/font/google';
@@ -27,7 +28,7 @@ const schedule = (cb: () => void) => {
 const sanitize = (params: any) => {
   if (!params || typeof params !== 'object') return params;
   const { payload, body, data, ...rest } = params;
-  return rest;
+  return maskPII(rest);
 };
 
 if (typeof window !== 'undefined') {
@@ -78,6 +79,36 @@ function MyApp({ Component, pageProps }: AppProps) {
     ) {
       navigator.serviceWorker.register('/sw.js').catch(() => {});
     }
+
+    const errorHandler = (
+      message: string | Event,
+      source?: string,
+      lineno?: number,
+      colno?: number,
+      error?: Error
+    ): void => {
+      const payload = maskPII({
+        message: String(message),
+        source,
+        lineno,
+        colno,
+        stack: error?.stack,
+      });
+      try {
+        fetch('/api/reportException', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } catch {
+        // ignore network errors
+      }
+    };
+
+    window.onerror = errorHandler;
+    return () => {
+      window.onerror = null;
+    };
   }, []);
 
   return (

--- a/pages/api/reportException.ts
+++ b/pages/api/reportException.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { logEvent } from '../../lib/axiom';
+import { maskPII } from '../../lib/analytics';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    const body = maskPII(req.body);
+    await logEvent({ type: 'runtime-error', ...body });
+  } catch {
+    // ignore logging errors
+  }
+
+  res.status(200).json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- instrument window open/close and key CTAs to analytics with PII masking
- capture runtime errors via window.onerror and POST to new reportException endpoint
- mask emails and phone numbers before logging

## Testing
- `yarn test` *(fails: missing fixtures and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ca6f1f083289e800850c6080158