### PR TITLE
feat: enhance touch controls accessibility

### DIFF
--- a/components/game/HUD.tsx
+++ b/components/game/HUD.tsx
@@ -6,8 +6,13 @@ import { useScore } from './score';
 export default function HUD() {
   const { score } = useScore();
   return (
-    <div className="absolute top-2 left-2 text-white" aria-label="game heads up display">
-      <span className="mr-4">Score: {score}</span>
+    <div
+      className="absolute top-2 left-2 bg-black/60 text-white p-2 rounded text-sm sm:text-base md:text-lg"
+      aria-label="game heads up display"
+    >
+      <span className="mr-4" aria-live="polite">
+        Score: {score}
+      </span>
       <PauseMenu />
     </div>
   );

--- a/components/game/TouchControls.tsx
+++ b/components/game/TouchControls.tsx
@@ -1,19 +1,47 @@
 'use client';
 import React from 'react';
 
+// Simple hook to trigger a short vibration when supported by the browser.
+function useHaptics() {
+  return React.useCallback(() => {
+    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+      navigator.vibrate(50);
+    }
+  }, []);
+}
+
 export default function TouchControls() {
+  const haptic = useHaptics();
+  const commonClasses =
+    'w-14 h-14 bg-black/80 text-white rounded flex items-center justify-center text-2xl sm:text-3xl focus:outline-none focus:ring-2 focus:ring-offset-2';
   return (
     <div
       className="absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-4"
+      role="group"
       aria-label="touch controls"
     >
-      <button className="w-12 h-12 bg-gray-500/50 text-white rounded" aria-label="left">
+      <button
+        className={commonClasses}
+        aria-label="move left"
+        onTouchStart={haptic}
+        onClick={haptic}
+      >
         ◀
       </button>
-      <button className="w-12 h-12 bg-gray-500/50 text-white rounded" aria-label="jump">
+      <button
+        className={commonClasses}
+        aria-label="jump"
+        onTouchStart={haptic}
+        onClick={haptic}
+      >
         ▲
       </button>
-      <button className="w-12 h-12 bg-gray-500/50 text-white rounded" aria-label="right">
+      <button
+        className={commonClasses}
+        aria-label="move right"
+        onTouchStart={haptic}
+        onClick={haptic}
+      >
         ▶
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add reusable haptic feedback hook and apply to touch controls
- style touch controls and HUD with high-contrast, scalable text and aria labels

## Testing
- `yarn test` *(fails: ENOENT fixtures, SyntaxError, timeouts)*
- `yarn lint` *(warnings: react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7cdc2ac48328ac9ba0bb3480479b