### PR TITLE
refactor: replace simhash package

### DIFF
--- a/apps/hash-toolkit/hashWorker.ts
+++ b/apps/hash-toolkit/hashWorker.ts
@@ -1,7 +1,7 @@
 import CryptoJS from 'crypto-js';
 import ssdeep from 'ssdeep.js';
 import tlsh from 'tlsh';
-import createSimhash from 'simhash';
+import createSimhash from '@lib/simhash';
 
 const simhash = createSimhash();
 

--- a/apps/hash-toolkit/index.tsx
+++ b/apps/hash-toolkit/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import CryptoJS from 'crypto-js';
 import ssdeep from 'ssdeep.js';
 import tlsh from 'tlsh';
-import createSimhash from 'simhash';
+import createSimhash from '@lib/simhash';
 import DigestHashBuilder from 'tlsh/lib/digests/digest-hash-builder';
 
 const simhash = createSimhash();

--- a/lib/simhash.ts
+++ b/lib/simhash.ts
@@ -1,0 +1,32 @@
+export default function createSimhash() {
+  return (tokens: string[]): number[] => {
+    const hashLength = 32;
+    const acc = new Array<number>(hashLength).fill(0);
+    for (const token of tokens) {
+      const h = crc32(token);
+      for (let j = 0; j < hashLength; j++) {
+        acc[j] += h & (1 << j) ? 1 : -1;
+      }
+    }
+    return acc.map((v) => (v > 0 ? 1 : 0));
+  };
+}
+
+const crcTable = new Uint32Array(256);
+for (let n = 0; n < 256; n++) {
+  let c = n;
+  for (let k = 0; k < 8; k++) {
+    c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  }
+  crcTable[n] = c >>> 0;
+}
+
+function crc32(str: string): number {
+  let crc = -1;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    crc = (crc >>> 8) ^ crcTable[(crc ^ code) & 0xff];
+  }
+  crc = crc ^ -1;
+  return crc >>> 0;
+}

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "rfc4648": "^1.5.4",
     "safe-regex": "^2.1.1",
     "sax": "^1.4.1",
-    "simhash": "^0.1.0",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "spdx-license-ids": "^3.0.17",

--- a/types/simhash.d.ts
+++ b/types/simhash.d.ts
@@ -1,3 +1,0 @@
-declare module 'simhash' {
-  export default function createSimhash(algo?: string): (tokens: string[]) => number[];
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,13 +4400,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:0.1.x":
-  version: 0.1.1
-  resolution: "buffer-crc32@npm:0.1.1"
-  checksum: 10c0/a68ad44357aeaaf477a0ebce5546d6ffe4ff44bcecbe69a8b21ba8236af609c049d812c4eed2256aec5fb7ee0925687fe43ea798dba9b6c0e09887b98f1f29c3
-  languageName: node
-  linkType: hard
-
 "buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -14039,15 +14032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simhash@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "simhash@npm:0.1.0"
-  dependencies:
-    buffer-crc32: "npm:0.1.x"
-  checksum: 10c0/1941bca3cd76ac09ff0f2b774c6ff595fad3c12e7aefedd5c6a40e21e02d05e021598255185e022c0bbd725c3135ae6c6914bd7200dbea34608311c2fa5f8c81
-  languageName: node
-  linkType: hard
-
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.2
   resolution: "simple-swizzle@npm:0.2.2"
@@ -15697,7 +15681,6 @@ __metadata:
     rfc4648: "npm:^1.5.4"
     safe-regex: "npm:^2.1.1"
     sax: "npm:^1.4.1"
-    simhash: "npm:^0.1.0"
     socket.io: "npm:^4.7.5"
     socket.io-client: "npm:^4.7.5"
     spdx-license-ids: "npm:^3.0.17"


### PR DESCRIPTION
## Summary
- replace external simhash dependency with internal implementation
- update hash toolkit components to use new simhash
- remove incompatible simhash package

## Testing
- `yarn test __tests__/hashToolkit.test.tsx`
- `yarn build` *(fails: Identifier 'SPF_SPEC' has already been declared; other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a1beda48328949905ab1a938ce9