### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn lint:ci
+      - run: yarn typecheck
+      - run: yarn build:ci
+      - run: yarn test
+      - run: yarn test:e2e

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
+# Yarn configuration
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "validate:icons": "node scripts/validate-icons.js",
     "test:unit": "vitest",
     "format": "prettier --write .",
-    "lighthouse": "lhci autorun"
+    "lighthouse": "lhci autorun",
+    "typecheck": "tsc --noEmit",
+    "build:ci": "next build",
+    "lint:ci": "next lint --max-warnings=0",
+    "format:check": "prettier --check ."
   },
   "engines": {
     "node": "20.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16620,3 +16620,4 @@ __metadata:
   checksum: 10c0/862f101cc95247b30290bad67ade333e430a16763bb771ce4e4c5414396d987f9a64288225675c96bd6f8d3eba65da0dee119b2a4eaa2e249da3f540b036942e
   languageName: node
   linkType: hard
+


### PR DESCRIPTION
## Summary
- add typecheck, build:ci, lint:ci, and format:check scripts
- document yarn settings
- add continuous integration workflow

## Testing
- `yarn dlx @yarnpkg/sdks base` *(fails: This tool can only be used with projects using Yarn Plug'n'Play)*
- `yarn lint:ci` *(fails: Parsing error: Unexpected token)*
- `yarn typecheck` *(fails: Found 18 errors in 5 files)*
- `yarn build:ci` *(fails: Identifier 'SPF_SPEC' has already been declared)*
- `yarn test` *(fails: 11 failed, 115 passed)*
- `yarn test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89d9285883288e2d0fec50a40f70