### PR TITLE
fix(csp): correct external host tokens

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,9 +12,9 @@ const ContentSecurityPolicy = [
   // External script required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.googleapis.com https://stackblitz.com https://api64.ipify.org https://cloudflare-dns.com https://dns.google stun:stun.l.google.com:19302",
+  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.googleapis.com https://stackblitz.com https://api64.ipify.org https://cloudflare-dns.com https://dns.google https://ghbtns.com stun:stun.l.google.com:19302",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+  "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://open.spotify.com https://todoist.com https://ghbtns.com https://www.youtube.com https://www.youtube-nocookie.com",
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
   // Disallow plugins and limit base/submit targets


### PR DESCRIPTION
## Summary
- fix CSP host names for external embeds

## Testing
- `yarn test`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab89da8930832888ade5f08fe9b74c