### PR TITLE
feat: validate env vars

### DIFF
--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -1,4 +1,5 @@
-import { ZodTypeAny } from 'zod';
+import { z } from 'zod';
+import type { ZodTypeAny } from 'zod';
 import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -72,4 +73,19 @@ export function validateRequest(
   }
 
   return { query: parsedQuery, body: parsedBody };
+}
+
+const EnvSchema = z.object({
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+  NEXT_PUBLIC_ENABLE_ANALYTICS: z.enum(['true', 'false']).optional(),
+  NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
+});
+
+export function validateEnv(env: NodeJS.ProcessEnv) {
+  const result = EnvSchema.safeParse(env);
+  if (!result.success) {
+    const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+    throw new Error(`Missing required environment variables: ${missing}`);
+  }
+  return result.data;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 // Security headers configuration for Next.js.
 // Allows external badges, inline styles, and same-origin PDF embedding.
 
+const { validateEnv } = require('./lib/validate.ts');
+validateEnv(process.env);
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Allow external images and data URIs for badges/icons

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,9 +9,11 @@ import { Inter } from 'next/font/google';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
 import ConsentBanner from '../components/ConsentBanner';
+import { validateEnv } from '../lib/validate';
 
 const inter = Inter({ subsets: ['latin'] });
 
+validateEnv(process.env);
 initAxiom();
 
 const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';


### PR DESCRIPTION
## Summary
- validate required env variables with Zod
- invoke env validation during app start and build config

## Testing
- `JWT_SECRET=test yarn test --bail` *(fails: ENOENT: no such file or directory, open '/workspace/kali-linux-portfolio/__tests__/fixtures/rsa-private.pem')*


------
https://chatgpt.com/codex/tasks/task_e_68ab89d9a7fc83288b42017318318c9c