### PR TITLE
chore: guard browser globals and use dynamic tetris import

### DIFF
--- a/apps/favicon-hash/index.tsx
+++ b/apps/favicon-hash/index.tsx
@@ -107,7 +107,7 @@ const FaviconHash: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const copy = useCallback((text: string) => {
-    if (!text) return;
+    if (!text || typeof navigator === 'undefined') return;
     navigator.clipboard?.writeText(text).catch(() => {});
   }, []);
 

--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -357,17 +357,19 @@ export default function Pinball() {
   }
 
   function triggerHaptics() {
-    if (navigator.vibrate) {
-      navigator.vibrate(50);
-    }
-    const pads = navigator.getGamepads();
-    const pad = pads[0];
-    if (pad && pad.vibrationActuator) {
-      pad.vibrationActuator.playEffect('dual-rumble', {
-        duration: 50,
-        strongMagnitude: 1,
-        weakMagnitude: 1,
-      });
+    if (typeof navigator !== 'undefined') {
+      if (navigator.vibrate) {
+        navigator.vibrate(50);
+      }
+      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+      const pad = pads[0];
+      if (pad && pad.vibrationActuator) {
+        pad.vibrationActuator.playEffect('dual-rumble', {
+          duration: 50,
+          strongMagnitude: 1,
+          weakMagnitude: 1,
+        });
+      }
     }
   }
 

--- a/apps/pong/index.tsx
+++ b/apps/pong/index.tsx
@@ -85,6 +85,7 @@ const Pong: React.FC = () => {
     }
 
     function pollPads() {
+      if (typeof navigator === 'undefined') return;
       const pads = navigator.getGamepads ? navigator.getGamepads() : [];
       const p1 = pads[0];
       const p2 = pads[1];

--- a/pages/apps/tetris.tsx
+++ b/pages/apps/tetris.tsx
@@ -1,4 +1,6 @@
-import Tetris from '../../apps/tetris';
+import dynamic from 'next/dynamic';
+
+const Tetris = dynamic(() => import('../../apps/tetris'), { ssr: false });
 
 export default function TetrisPage() {
   return <Tetris />;


### PR DESCRIPTION
## Summary
- wrap Tetris page in dynamic import with SSR disabled
- guard navigator usage in Pinball and Pong apps
- check navigator availability before copying in Favicon Hash app

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ab89dcfe68832890ec4f65ceadd1ee