### PR TITLE
feat: add retryable error fallback for dynamic apps

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -99,6 +99,7 @@ class DynamicAppErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
+    this.handleRetry = this.handleRetry.bind(this);
   }
 
   static getDerivedStateFromError() {
@@ -117,12 +118,17 @@ class DynamicAppErrorBoundary extends React.Component {
       return (
         <ErrorPane
           code="render_error"
-          message={`An error occurred while rendering ${this.props.name}.`}
+          message={`An error occurred while rendering ${this.props.name}. Please try again.`}
+          onRetry={this.handleRetry}
         />
       );
     }
 
     return this.props.children;
+  }
+
+  handleRetry() {
+    this.setState({ hasError: false });
   }
 }
 

--- a/components/ErrorPane.tsx
+++ b/components/ErrorPane.tsx
@@ -3,12 +3,21 @@ import React from 'react';
 interface ErrorPaneProps {
   code: string;
   message: string;
+  onRetry?: () => void;
 }
 
-const ErrorPane: React.FC<ErrorPaneProps> = ({ code, message }) => (
+const ErrorPane: React.FC<ErrorPaneProps> = ({ code, message, onRetry }) => (
   <div className="h-full w-full flex flex-col items-center justify-center bg-panel text-white space-y-2 p-4 text-center">
     <div className="text-lg font-bold">{code}</div>
     <div>{message}</div>
+    {onRetry && (
+      <button
+        onClick={onRetry}
+        className="bg-gray-700 px-3 py-1 rounded hover:bg-gray-600"
+      >
+        Retry
+      </button>
+    )}
   </div>
 );
 

--- a/lib/createDynamicApp.tsx
+++ b/lib/createDynamicApp.tsx
@@ -19,7 +19,13 @@ const createDynamicApp = (path: string, name: string) =>
           });
           ReactGA.event('exception', { description: error.message });
           return function DynamicAppError() {
-            return <ErrorPane code="load_error" message={`Failed to load ${name}.`} />;
+            return (
+              <ErrorPane
+                code="load_error"
+                message={`Failed to load ${name}. Please try again.`}
+                onRetry={() => window.location.reload()}
+              />
+            );
           };
         }),
       {


### PR DESCRIPTION
## Summary
- wrap dynamically loaded apps in a retryable error boundary
- allow ErrorPane to offer retry button and descriptive error messages
- surface load failures from createDynamicApp via ErrorPane with retry

## Testing
- `yarn test` *(fails: ENOENT for fixtures, syntax errors, and other issues)*
- `yarn test:unit` *(fails: module resolution errors and missing jest in vitest tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89dda6f4832896d27f5cd05f6229