### PR TITLE
feat: rate limit external API endpoints

### DIFF
--- a/pages/api/cve.ts
+++ b/pages/api/cve.ts
@@ -4,6 +4,10 @@ import { fetchEpssScores } from '../../lib/epss';
 import { rateLimitEdge } from '../../lib/rateLimiter';
 import { kv } from '../../lib/kv';
 
+/**
+ * CVE aggregation using NVD and other sources.
+ * Rate limited to 60 requests per minute.
+ */
 setupUrlGuard();
 
 export const config = {

--- a/pages/api/dns.ts
+++ b/pages/api/dns.ts
@@ -1,7 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { validateRequest } from '../../lib/validate';
+import { rateLimit } from '../../lib/rateLimiter';
 import { setupUrlGuard } from '../../lib/urlGuard';
+
+/**
+ * DNS lookup using Google's resolver.
+ * Rate limited to 60 requests per minute.
+ */
 setupUrlGuard();
 
 const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'NS'];
@@ -30,6 +36,8 @@ export default async function handler(
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  if (!(await rateLimit(req, res))) return;
 
   const parsed = validateRequest(req, res, {
     querySchema,

--- a/pages/api/dnssec-validator.ts
+++ b/pages/api/dnssec-validator.ts
@@ -1,5 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { rateLimit } from '../../lib/rateLimiter';
 import { setupUrlGuard } from '../../lib/urlGuard';
+
+/**
+ * DNSSEC validation using Google's resolver.
+ * Rate limited to 60 requests per minute.
+ */
 setupUrlGuard();
 
 const ALLOWED_TYPES = ['A', 'AAAA', 'CNAME', 'TXT', 'MX', 'NS', 'SOA', 'DNSKEY', 'DS', 'CAA'];
@@ -21,6 +27,8 @@ export default async function handler(
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  if (!(await rateLimit(req, res))) return;
 
   const { domain, type } = req.query;
 

--- a/pages/api/hibp-check.ts
+++ b/pages/api/hibp-check.ts
@@ -2,6 +2,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { createHash } from 'crypto';
 import { rateLimit } from '../../lib/rateLimiter';
 import { setupUrlGuard } from '../../lib/urlGuard';
+
+/**
+ * Check a password against the Have I Been Pwned API.
+ * Rate limited to 60 requests per minute.
+ */
 setupUrlGuard();
 
 export default async function handler(

--- a/pages/api/rdap.ts
+++ b/pages/api/rdap.ts
@@ -1,5 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { rateLimit } from '../../lib/rateLimiter';
 import { setupUrlGuard } from '../../lib/urlGuard';
+
+/**
+ * RDAP domain lookup using rdap.org.
+ * Rate limited to 60 requests per minute.
+ */
 setupUrlGuard();
 
 let tldCache: Set<string> | null = null;
@@ -37,6 +43,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  if (!(await rateLimit(req, res))) return;
   const { domain } = req.query;
   if (typeof domain !== 'string') {
     res.status(400).json({ error: 'domain query parameter required' });


### PR DESCRIPTION
## Summary
- document 60 req/min limit for CVE and HIBP APIs
- protect DNS-related and RDAP endpoints with rateLimit helper

## Testing
- `yarn test` *(fails: ENOENT fixtures, jest parsing errors, vitest import errors, other suite failures)*
- `yarn lint` *(fails: parsing errors in components, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89e07d1c832886cf1e9b2525aee7