### PR TITLE
feat(api): add input validation

### DIFF
--- a/__tests__/blackjack-api.test.ts
+++ b/__tests__/blackjack-api.test.ts
@@ -82,4 +82,23 @@ describe('blackjack api', () => {
     }
     expect(res.statusCode).toBe(429);
   });
+
+  test('validates request body', async () => {
+    process.env.JWT_SECRET = 'secret';
+    jest.resetModules();
+
+    const { setKVAdapter, MemoryKV } = await import('../lib/kv');
+    setKVAdapter(new MemoryKV());
+    const { default: handler } = await import('../pages/api/users/[id]/blackjack');
+
+    const token = jwt.sign({ sub: id }, process.env.JWT_SECRET!);
+    const { req, res } = mockReqRes({
+      method: 'POST',
+      query: { id },
+      body: { result: 'invalid' },
+      headers: { authorization: `Bearer ${token}` },
+    });
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/__tests__/breakout.api.test.ts
+++ b/__tests__/breakout.api.test.ts
@@ -38,4 +38,11 @@ describe('breakout levels api', () => {
     expect(Array.isArray(resGet.data)).toBe(true);
     expect(resGet.data.some((l: any) => JSON.stringify(l) === JSON.stringify(level))).toBe(true);
   });
+
+  test('rejects invalid level data', () => {
+    const req = { method: 'POST', body: 'bad' } as unknown as NextApiRequest;
+    const res: any = createRes();
+    handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/__tests__/crtsh.api.test.ts
+++ b/__tests__/crtsh.api.test.ts
@@ -71,5 +71,11 @@ describe('crtsh api', () => {
     await handler(req, res);
     expect(res.status).toHaveBeenLastCalledWith(429);
   });
+
+  it('validates query parameters', async () => {
+    const { req, res } = createReqRes({});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });
 

--- a/__tests__/gitSecretsTester.api.test.ts
+++ b/__tests__/gitSecretsTester.api.test.ts
@@ -1,5 +1,4 @@
 import JSZip from 'jszip';
-import { describe, test, expect } from 'vitest';
 
 function mockReqRes(method: string, body: any) {
   const req: any = { method, body };
@@ -29,6 +28,13 @@ describe('git-secrets api', () => {
     await handler(req as any, res as any);
     expect(res.statusCode).toBe(200);
     expect(res.data.results.some((r: any) => r.pattern.includes('Slack'))).toBe(true);
+  });
+
+  test('validates input body', async () => {
+    const { req, res } = mockReqRes('POST', {});
+    const handler = (await import('../pages/api/git-secrets-tester')).default;
+    await handler(req as any, res as any);
+    expect(res.statusCode).toBe(400);
   });
 });
 

--- a/__tests__/mail-auth.api.test.ts
+++ b/__tests__/mail-auth.api.test.ts
@@ -41,7 +41,11 @@ describe('mail-auth api', () => {
         new Response(JSON.stringify({ Answer: answer }), { status: 200 })
       );
     });
-    const req = { query: { domain: 'example.com' } } as unknown as NextApiRequest;
+    const req = {
+      query: { domain: 'example.com' },
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest;
     const res = createRes();
     await handler(req, res);
     expect(res.statusCode).toBe(200);
@@ -53,7 +57,11 @@ describe('mail-auth api', () => {
   test('handles network errors', async () => {
     const { default: handler } = await import('../pages/api/mail-auth');
     (global as any).fetch = jest.fn(() => Promise.reject(new Error('network')));
-    const req = { query: { domain: 'example.com' } } as unknown as NextApiRequest;
+    const req = {
+      query: { domain: 'example.com' },
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest;
     const res = createRes();
     await handler(req, res);
     expect(res.statusCode).toBe(200);
@@ -71,12 +79,28 @@ describe('mail-auth api', () => {
       );
     });
     (global as any).fetch = fetchMock;
-    const req = { query: { domain: 'cache.com' } } as unknown as NextApiRequest;
+    const req = {
+      query: { domain: 'cache.com' },
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest;
     const res1 = createRes();
     await handler(req, res1);
     const res2 = createRes();
     await handler(req, res2);
     expect(fetchMock).toHaveBeenCalledTimes(6);
 
+  });
+
+  test('validates input', async () => {
+    const { default: handler } = await import('../pages/api/mail-auth');
+    const req = {
+      query: {},
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest;
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/__tests__/redirect-visualizer.api.test.ts
+++ b/__tests__/redirect-visualizer.api.test.ts
@@ -61,4 +61,10 @@ describe('redirect-visualizer api', () => {
     expect(data.chain[1].method).toBe('GET');
     expect(data.chain[1].cacheControl).toBe('max-age=60');
   });
+
+  it('validates request body', async () => {
+    const { req, res } = createReqRes({});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });

--- a/__tests__/spf-flattener.api.test.ts
+++ b/__tests__/spf-flattener.api.test.ts
@@ -124,4 +124,11 @@ describe('spf flattener api', () => {
     expect(data.flattenedSpfRecord).not.toContain('10.0.0.10');
     expect(data.flattenedSpfRecord).not.toContain('10.0.0.11');
   });
+
+  test('validates input', async () => {
+    const req = { method: 'GET', query: {} } as unknown as NextApiRequest;
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/__tests__/wayback-viewer.api.test.ts
+++ b/__tests__/wayback-viewer.api.test.ts
@@ -55,4 +55,10 @@ describe('wayback viewer api', () => {
     expect(res.status).toHaveBeenCalledWith(500);
     expect((res as any)._data.error).toBe('Failed to fetch snapshots');
   });
+
+  it('validates input', async () => {
+    const { req, res } = createReqRes({});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });

--- a/__tests__/yara-api.test.ts
+++ b/__tests__/yara-api.test.ts
@@ -17,3 +17,12 @@ test('api route scans samples', async () => {
   const body = json.mock.calls[0][0];
   expect(body.matches.length).toBe(1);
 });
+
+test('rejects invalid payload', async () => {
+  const req: any = { method: 'POST', body: { input: 123 } };
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const res: any = { status };
+  await handler(req, res);
+  expect(status).toHaveBeenCalledWith(400);
+});

--- a/pages/api/breakout/levels.ts
+++ b/pages/api/breakout/levels.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
+import { z } from 'zod';
+import { validateRequest } from '../../../lib/validate';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const dir = path.join(process.cwd(), 'apps', 'breakout', 'levels');
@@ -23,9 +25,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (req.method === 'POST') {
+    const bodySchema = z.array(z.array(z.number()));
+    const parsed = validateRequest(req, res, { bodySchema });
+    if (!parsed) return;
     try {
       const file = path.join(dir, `level-${Date.now()}.json`);
-      fs.writeFileSync(file, JSON.stringify(req.body));
+      fs.writeFileSync(file, JSON.stringify(parsed.body));
       res.status(200).json({ saved: true });
     } catch (e) {
       res.status(500).json({ error: 'Failed to save' });

--- a/pages/api/git-secrets-tester.ts
+++ b/pages/api/git-secrets-tester.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import JSZip from 'jszip';
 import { spawn, spawnSync } from 'child_process';
+import { z } from 'zod';
+import { validateRequest } from '../../lib/validate';
 import { defaultPatterns, redactSecret } from '../../components/apps/git-secrets-tester';
 
 interface ApiResult {
@@ -81,14 +83,15 @@ export default async function handler(
     return;
   }
 
-  const { patch, archive } = req.body as {
+  const bodySchema = z
+    .object({ patch: z.string().optional(), archive: z.string().optional() })
+    .refine((d) => d.patch || d.archive, { message: 'Missing patch or archive' });
+  const parsed = validateRequest(req, res, { bodySchema });
+  if (!parsed) return;
+  const { patch, archive } = parsed.body as {
     patch?: string;
     archive?: string;
   };
-  if (!patch && !archive) {
-    res.status(400).json({ error: 'Missing patch or archive' });
-    return;
-  }
 
   const logs: string[] = [];
   let combined = '';

--- a/pages/api/tls-chain.ts
+++ b/pages/api/tls-chain.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import tls, { PeerCertificate } from 'tls';
 import { LRUCache } from 'lru-cache';
+import { z } from 'zod';
+import { validateRequest } from '../../lib/validate';
 
 interface FormattedCert {
   subject: Record<string, string>;
@@ -143,13 +145,11 @@ const cache = new LRUCache<string, any>({
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { host, port } = req.query;
-  if (!host || typeof host !== 'string') {
-    res.status(400).json({ error: 'host query parameter required' });
-    return;
-  }
-
-  const portNum = typeof port === 'string' ? parseInt(port, 10) || 443 : 443;
+  const querySchema = z.object({ host: z.string().min(1), port: z.string().optional() });
+  const parsed = validateRequest(req, res, { querySchema });
+  if (!parsed) return;
+  const { host, port } = parsed.query as { host: string; port?: string };
+  const portNum = port ? parseInt(port, 10) || 443 : 443;
 
   const key = `${host}:${portNum}`;
   try {

--- a/pages/api/wayback-viewer.ts
+++ b/pages/api/wayback-viewer.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { validateRequest } from '../../lib/validate';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 
@@ -17,11 +19,17 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const { url, page = '0', limit = '50', status, mime, noRobot } = req.query;
-  if (!url || typeof url !== 'string') {
-    res.status(400).json({ error: 'Missing url' });
-    return;
-  }
+  const querySchema = z.object({
+    url: z.string().url(),
+    page: z.string().optional(),
+    limit: z.string().optional(),
+    status: z.string().optional(),
+    mime: z.string().optional(),
+    noRobot: z.string().optional(),
+  });
+  const parsed = validateRequest(req, res, { querySchema });
+  if (!parsed) return;
+  const { url, page = '0', limit = '50', status, mime, noRobot } = parsed.query as any;
 
   const pageNum = Array.isArray(page) ? parseInt(page[0], 10) : parseInt(page, 10);
   const limitNum = Array.isArray(limit) ? parseInt(limit[0], 10) : parseInt(limit, 10);


### PR DESCRIPTION
## Summary
- validate API inputs with zod schemas
- handle invalid requests with HTTP 400
- add tests for valid and invalid cases

## Testing
- `yarn test __tests__/blackjack-api.test.ts __tests__/breakout.api.test.ts __tests__/caa-checker.api.test.ts __tests__/crtsh.api.test.ts __tests__/gitSecretsTester.api.test.ts __tests__/http-diff.api.test.ts __tests__/mail-auth.api.test.ts __tests__/redirect-visualizer.api.test.ts __tests__/spf-flattener.api.test.ts __tests__/tls-chain.api.test.ts __tests__/wayback-viewer.api.test.ts __tests__/yara-api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab89df36a08328918cd9d021aaec9b