### PR TITLE
Disable automatic prefetching for heavy app routes

### DIFF
--- a/__tests__/allAppsGrid.test.tsx
+++ b/__tests__/allAppsGrid.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import AllApps from '@apps/all-apps';
-import * as NextRouter from 'next/router';
 
 jest.mock('../apps.config', () => ({
   __esModule: true,
@@ -14,15 +13,7 @@ jest.mock('../apps.config', () => ({
   ],
 }));
 
-const push = jest.fn();
-const prefetch = jest.fn();
-jest.spyOn(NextRouter, 'useRouter').mockReturnValue({ push, prefetch } as any);
-
 describe('AllApps component', () => {
-  beforeEach(() => {
-    push.mockReset();
-    prefetch.mockReset();
-  });
 
   it('filters apps by search term', () => {
     const { getByPlaceholderText, queryByText } = render(<AllApps />);
@@ -32,10 +23,9 @@ describe('AllApps component', () => {
     expect(queryByText('Beta')).not.toBeInTheDocument();
   });
 
-  it('prefetches app on hover', () => {
+  it('links to app route without prefetch', () => {
     const { getByText } = render(<AllApps />);
-    const target = getByText('Alpha').closest('[data-grid-item]')!;
-    fireEvent.mouseEnter(target);
-    expect(prefetch).toHaveBeenCalledWith('/apps/alpha');
+    const link = getByText('Alpha').closest('a');
+    expect(link).toHaveAttribute('href', '/apps/alpha');
   });
 });

--- a/apps/evidence-notebook/index.tsx
+++ b/apps/evidence-notebook/index.tsx
@@ -79,6 +79,7 @@ const EvidenceNotebook: React.FC = () => {
         <Link
           href="/apps/evidence-notebook/verify"
           className="px-3 py-1 bg-purple-600 rounded"
+          prefetch={false}
         >
           Verify
         </Link>

--- a/components/apps/all-apps.tsx
+++ b/components/apps/all-apps.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import apps, { games } from '../../apps.config';
 import ResponsiveGrid from '../util-components/ResponsiveGrid';
 
@@ -19,7 +19,6 @@ const allEntries: AppEntry[] = [
 ];
 
 export default function AllApps() {
-  const router = useRouter();
   const [search, setSearch] = useState('');
   const [tag, setTag] = useState('All');
 
@@ -67,14 +66,11 @@ export default function AllApps() {
       ) : (
         <ResponsiveGrid>
           {filtered.map(app => (
-            <div
+            <Link
               key={app.id}
+              href={`/apps/${app.id}`}
               className="flex flex-col items-center p-2 rounded hover:bg-gray-700 focus:bg-gray-700 cursor-pointer"
-              onClick={() => router.push(`/apps/${app.id}`)}
-              onMouseEnter={() => router.prefetch(`/apps/${app.id}`)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') router.push(`/apps/${app.id}`);
-              }}
+              prefetch={false}
             >
               <Image
                 src={app.icon.replace('./', '/')}
@@ -85,7 +81,7 @@ export default function AllApps() {
                 loading="lazy"
               />
               <span className="text-xs text-center">{app.title}</span>
-            </div>
+            </Link>
           ))}
         </ResponsiveGrid>
       )}


### PR DESCRIPTION
## Summary
- avoid prefetching in the All Apps grid by using `<Link prefetch={false}>`
- disable prefetch on Evidence Notebook verify link
- update grid tests for new navigation behavior

## Testing
- `npm test __tests__/allAppsGrid.test.tsx`
- `npm test` *(fails: jwks-fetcher.api.test.ts missing fixtures, mail-auth.api.test.ts syntax errors, tls-chain.api.test.ts status 500, gitSecretsTester.api.test.ts import error, http-diff.api.test.ts import error, desktop.closeApp.test.ts syntax error)*
- `node -e "const { chromium } = require('playwright'); (async () => { const browser = await chromium.launch(); const page = await browser.newPage(); const requests = []; page.on('request', req => { const url = req.url(); if (url.includes('/apps/') && !url.endsWith('/apps') && !url.includes('/_next') && !url.includes('favicon')) { requests.push(url); } }); await page.goto('http://localhost:3000/apps', { waitUntil: 'load' }); await page.waitForTimeout(3000); console.log('prefetched:', requests); await browser.close(); })();"`

------
https://chatgpt.com/codex/tasks/task_e_68ab89e29428832894fb40c65e174856