### PR TITLE
feat: track web vitals with consent

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { logEvent } from './axiom';
+import type { NextWebVitalsMetric } from 'next/app';
 
 const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 const PHONE_REGEX = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g;
@@ -29,5 +30,11 @@ export const trackEvent = async (
   } catch {
     // ignore logging errors
   }
+};
+
+export const trackWebVital = async (
+  metric: NextWebVitalsMetric,
+): Promise<void> => {
+  await trackEvent('web-vital', metric);
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,8 @@
 import '../lib/dev-ssr-logger';
 import type { AppProps, NextWebVitalsMetric } from 'next/app';
 import { useEffect, useState } from 'react';
-import { initAxiom, logEvent } from '../lib/axiom';
-import { maskPII } from '../lib/analytics';
+import { initAxiom } from '../lib/axiom';
+import { maskPII, trackWebVital } from '../lib/analytics';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import { Inter } from 'next/font/google';
@@ -138,5 +138,11 @@ function MyApp({ Component, pageProps }: AppProps) {
 export default MyApp;
 
 export function reportWebVitals(metric: NextWebVitalsMetric): void {
-  logEvent({ type: 'web-vital', ...metric });
+  if (
+    analyticsEnabled &&
+    typeof window !== 'undefined' &&
+    window.localStorage.getItem('analytics-consent') === 'granted'
+  ) {
+    trackWebVital(metric);
+  }
 }


### PR DESCRIPTION
## Summary
- add `trackWebVital` helper to analytics to mask PII in vitals
- only send web vitals to analytics when user consent is granted and analytics is enabled

## Testing
- `yarn lint`
- `yarn test lib/analytics.ts pages/_app.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab89e38d108328b7aa2910ffed8cc3