### PR TITLE
chore: replace any types

### DIFF
--- a/components/apps/ct-search.tsx
+++ b/components/apps/ct-search.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -72,38 +72,38 @@ const CtSearch: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(
-          `/api/ct-search?query=${encodeURIComponent(query)}&type=${searchType}&excludeExpired=${excludeExpired}&unique=${uniqueOnly}`
-        );
-        if (res.status === 429) {
-          setError('Rate limit exceeded');
-          setResults([]);
-          setIssuerStats([]);
-          setTimeSeries([]);
-          setSuspicious([]);
-        } else {
-          const data: ApiResponse | { error: string } = await res.json();
-          if (!res.ok || 'error' in data) {
-            setError((data as any).error || 'Request failed');
+          const res = await fetch(
+            `/api/ct-search?query=${encodeURIComponent(query)}&type=${searchType}&excludeExpired=${excludeExpired}&unique=${uniqueOnly}`
+          );
+          if (res.status === 429) {
+            setError('Rate limit exceeded');
             setResults([]);
             setIssuerStats([]);
             setTimeSeries([]);
             setSuspicious([]);
           } else {
-            setResults(data.results);
-            setIssuerStats(data.issuerStats);
-            setTimeSeries(data.timeSeries);
-            setSuspicious(data.suspicious);
-            cacheRef.current.set(key, data);
+            const data: ApiResponse | { error: string } = await res.json();
+            if (!res.ok || 'error' in data) {
+              setError('error' in data ? data.error : 'Request failed');
+              setResults([]);
+              setIssuerStats([]);
+              setTimeSeries([]);
+              setSuspicious([]);
+            } else {
+              setResults(data.results);
+              setIssuerStats(data.issuerStats);
+              setTimeSeries(data.timeSeries);
+              setSuspicious(data.suspicious);
+              cacheRef.current.set(key, data);
+            }
           }
-        }
-      } catch (e: any) {
-        setError(e.message || 'Request failed');
-        setResults([]);
-        setIssuerStats([]);
-        setTimeSeries([]);
-        setSuspicious([]);
-      } finally {
+        } catch (e: unknown) {
+          setError(e instanceof Error ? e.message : 'Request failed');
+          setResults([]);
+          setIssuerStats([]);
+          setTimeSeries([]);
+          setSuspicious([]);
+        } finally {
         setLoading(false);
       }
     }, 500);

--- a/pages/api/dns.ts
+++ b/pages/api/dns.ts
@@ -54,8 +54,10 @@ export default async function handler(
     }
     const data = await response.json();
     return res.status(200).json(data);
-  } catch (e: any) {
-    return res.status(500).json({ error: e.message || 'Request failed' });
+  } catch (e: unknown) {
+    return res.status(500).json({
+      error: e instanceof Error ? e.message : 'Request failed',
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- remove unused React import in CT search component
- narrow error handling types in CT search and DNS API

## Testing
- `yarn lint`
- `yarn typecheck` *(fails: Couldn't find a script named "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68ab89e4a8588328be0402502c5e8b5c