### PR TITLE
Sanitize DOM output with isomorphic-dompurify

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
 
 // Preset character sets and color palettes
 const presetCharSets = {
@@ -421,7 +422,7 @@ export default function AsciiArt() {
             <pre
               className="font-mono whitespace-pre overflow-auto flex-1"
               style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize}px`, fontFamily }}
-              dangerouslySetInnerHTML={{ __html: asciiHtml }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(asciiHtml) }}
             />
           )}
           {!typingMode && (

--- a/apps/http-diff/index.tsx
+++ b/apps/http-diff/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { ApiResult, DiffPart } from '@/types/http-diff';
+import DOMPurify from 'isomorphic-dompurify';
 
 function escapeHtml(str: string): string {
   return str.replace(/[&<>"']/g, (c) => ({
@@ -37,11 +38,11 @@ function renderSideBySide(diff: DiffPart[]) {
     <div className="grid grid-cols-2 gap-4">
       <pre
         className="bg-gray-800 text-white p-2 overflow-auto"
-        dangerouslySetInnerHTML={{ __html: left.join('\n') }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(left.join('\n')) }}
       />
       <pre
         className="bg-gray-800 text-white p-2 overflow-auto"
-        dangerouslySetInnerHTML={{ __html: right.join('\n') }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(right.join('\n')) }}
       />
     </div>
   );

--- a/apps/wayback-viewer/index.tsx
+++ b/apps/wayback-viewer/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
 
 interface Snapshot {
   timestamp: string;
@@ -63,13 +64,11 @@ function renderSideBySide(diff: DiffPart[]) {
     <div className="grid grid-cols-2 gap-4">
       <pre
         className="bg-gray-800 text-white p-2 overflow-auto"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: left.join('\n') }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(left.join('\n')) }}
       />
       <pre
         className="bg-gray-800 text-white p-2 overflow-auto"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: right.join('\n') }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(right.join('\n')) }}
       />
     </div>
   );

--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
 
 // Preset character sets and color palettes
 const presetCharSets = {
@@ -421,7 +422,7 @@ export default function AsciiArt() {
             <pre
               className="font-mono whitespace-pre overflow-auto flex-1"
               style={{ fontSize: `${fontSize}px`, lineHeight: `${fontSize}px`, fontFamily }}
-              dangerouslySetInnerHTML={{ __html: asciiHtml }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(asciiHtml) }}
             />
           )}
           {!typingMode && (

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "fuse.js": "^6.6.2",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
+    "isomorphic-dompurify": "^2.26.0",
     "jose": "^6.0.13",
     "jsonwebtoken": "^9.0.2",
     "jspdf": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,6 +9184,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-dompurify@npm:^2.26.0":
+  version: 2.26.0
+  resolution: "isomorphic-dompurify@npm:2.26.0"
+  dependencies:
+    dompurify: "npm:^3.2.6"
+    jsdom: "npm:^26.1.0"
+  checksum: 10c0/d6d4f7850180a77d9c8966feb27df46bd8f719c656320936d134ee25f939f15d90c901561251853047d7df240625318656f0f8ba7ac9a75b32a844b103a2178e
+  languageName: node
+  linkType: hard
+
 "isomorphic-fetch@npm:^3.0.0":
   version: 3.0.0
   resolution: "isomorphic-fetch@npm:3.0.0"
@@ -15652,6 +15662,7 @@ __metadata:
     fuse.js: "npm:^6.6.2"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
+    isomorphic-dompurify: "npm:^2.26.0"
     jest: "npm:^30.0.5"
     jest-environment-jsdom: "npm:^30.0.5"
     jose: "npm:^6.0.13"


### PR DESCRIPTION
## Summary
- add isomorphic-dompurify dependency
- sanitize ASCII art and HTTP diff outputs before using `dangerouslySetInnerHTML`
- ensure wayback viewer diff view also sanitizes rendered HTML

## Testing
- `yarn lint --dir apps/http-diff`
- `yarn lint --dir apps/ascii-art`
- `yarn lint --dir apps/wayback-viewer`
- `yarn lint --file components/apps/ascii_art/index.js`
- `yarn test __tests__/http-diff.api.test.ts` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89e5d9f48328bdde7000e1b198eb