### PR TITLE
test: add e2e coverage for app slugs

### DIFF
--- a/__tests__/e2e/apps.spec.ts
+++ b/__tests__/e2e/apps.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const configPath = path.join(process.cwd(), 'apps.config.js');
+const content = fs.readFileSync(configPath, 'utf8');
+const appsSection = content.match(/const apps = \[([\s\S]*?)\];/);
+const appsArray = appsSection ? appsSection[1] : '';
+const slugs = Array.from(appsArray.matchAll(/id:\s*'([^']+)'/g)).map((m) => m[1]);
+
+test.describe('apps pages', () => {
+  for (const slug of slugs) {
+    test(`loads /apps/${slug} without errors`, async ({ page }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: Error[] = [];
+
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      page.on('pageerror', (err) => {
+        pageErrors.push(err);
+      });
+
+      const response = await page.goto(`/apps/${slug}`);
+      expect(response?.status()).toBe(200);
+      expect(consoleErrors).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    });
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: './',
+  testMatch: ['e2e/**/*.spec.ts', '__tests__/e2e/**/*.spec.ts'],
   webServer: {
     command: 'yarn dev',
     port: 3000,


### PR DESCRIPTION
## Summary
- add Playwright test that loads each app slug and checks for console and page errors
- configure Playwright to look for tests in `e2e` and `__tests__/e2e`

## Testing
- `yarn test:e2e __tests__/e2e/apps.spec.ts` *(fails: Host system is missing dependencies to run browsers)*


------
https://chatgpt.com/codex/tasks/task_e_68ab89e73904832893aee4632dbf9f74