### PR TITLE
docs: add quick start guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## Quick Start
+
+1. **Install dependencies** – ensure [Node.js 20](https://nodejs.org/) and Yarn 4 are available. `nvm install 20 && nvm use 20` sets the correct Node version, and `corepack enable` activates Yarn 4.
+2. **Install packages** – run `yarn` to install project dependencies.
+3. **Environment** – copy `.env.example` to `.env.local` and fill in required variables like `JWT_SECRET`.
+4. **Run the app** – start the development server with `yarn dev`.
+
+### Common Install Issues
+
+- **Node version mismatch** – run `nvm use 20` or upgrade Node to version 20.
+- **Yarn not found** – execute `corepack enable` to install Yarn 4.
+- **Slow or failed installs** – retry with `yarn install --network-timeout 100000` and ensure network connectivity.
+
 ## Setup
 
 1. Copy `.env.example` to `.env.local`.
@@ -169,7 +182,6 @@ defaults:
 - **Scaling limits** – serverless WebSockets have connection limits per region
   and may recycle instances under load. For heavy usage, monitor connection
   counts and consider a dedicated WebSocket host or external state store.
-=======
 ## E2E Testing
 
 The project uses [Playwright](https://playwright.dev/) for end-to-end tests.

--- a/apps/pkce-helper/index.tsx
+++ b/apps/pkce-helper/index.tsx
@@ -159,7 +159,7 @@ const PkceHelper: React.FC = () => {
             value={callback}
             onChange={(e) => setCallback(e.target.value)}
             className="w-full p-2 rounded text-black"
-            placeholder="https://example.com/callback?code=...&state=..."
+            placeholder="https://example.com/callback?code=AUTH_CODE&state=STATE"
           />
         </div>
         <button


### PR DESCRIPTION
## Summary
- document how to set up Node 20 and Yarn 4 and run `yarn dev`
- provide tips for common install issues
- clarify callback URL placeholder in PKCE helper

## Testing
- `yarn lint` *(fails: Parsing error: Expression expected in components/apps/license-classifier.tsx and others)*
- `yarn test` *(fails: ENOENT: no such file or directory, open '__tests__/fixtures/rsa-private.pem'; SyntaxError: Identifier 'SPF_SPEC' has already been declared; and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89e933848328be5f14faaf601a53