### PR TITLE
Add health check API endpoint

### DIFF
--- a/__tests__/healthz.api.test.ts
+++ b/__tests__/healthz.api.test.ts
@@ -1,0 +1,38 @@
+import { execSync } from 'child_process';
+import pkg from '../package.json';
+
+function mockReqRes({ method }: { method: string }) {
+  const req: any = { method };
+  const res: any = { statusCode: 200 };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (data: any) => {
+    res.data = data;
+    return res;
+  };
+  return { req, res };
+}
+
+describe('healthz api', () => {
+  test('returns build info and git sha without sensitive data', async () => {
+    const { default: handler } = await import('../pages/api/healthz');
+    const { req, res } = mockReqRes({ method: 'GET' });
+    await handler(req, res);
+
+    const expectedSha = execSync('git rev-parse HEAD').toString().trim();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.data.name).toBe(pkg.name);
+    expect(res.data.version).toBe(pkg.version);
+    expect(res.data.gitSha).toBe(expectedSha);
+    expect(typeof res.data.buildTime).toBe('string');
+    expect(Object.keys(res.data).sort()).toEqual([
+      'buildTime',
+      'gitSha',
+      'name',
+      'version',
+    ]);
+  });
+});

--- a/pages/api/healthz.ts
+++ b/pages/api/healthz.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import pkg from '../../package.json';
+import { execSync } from 'child_process';
+
+function getGitSha(): string {
+  if (process.env.VERCEL_GIT_COMMIT_SHA)
+    return process.env.VERCEL_GIT_COMMIT_SHA;
+  if (process.env.GIT_SHA) return process.env.GIT_SHA;
+  try {
+    return execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const data = {
+    name: pkg.name,
+    version: pkg.version,
+    buildTime: new Date().toISOString(),
+    gitSha: getGitSha(),
+  };
+  res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- add `/api/healthz` endpoint returning version, build time and git SHA
- ensure only non-sensitive fields are exposed
- add unit test for health endpoint

## Testing
- `yarn test __tests__/healthz.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab89ebb0d483288538412c7c3f7e6a