### PR TITLE
test: verify sitemap and robots

### DIFF
--- a/__tests__/seo-files.test.ts
+++ b/__tests__/seo-files.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { parseSitemap } from '../lib/sitemap';
+import { parseRobots } from '../lib/robots';
+
+test('robots.txt references sitemap', () => {
+  const text = fs.readFileSync('public/robots.txt', 'utf8');
+  const data = parseRobots(text);
+  expect(data.sitemaps).toContain('https://unnippillil.com/sitemap.xml');
+});
+
+test('sitemap.xml contains home page URL', async () => {
+  const stream = fs.createReadStream('public/sitemap.xml');
+  const entries = await parseSitemap(stream);
+  const urls = entries.map((e) => e.loc);
+  expect(urls).toContain('https://unnippillil.com/');
+});
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://unnippillil.com/sitemap.xml


### PR DESCRIPTION
## Summary
- add sitemap URL to robots.txt
- add tests verifying sitemap and robots.txt contain expected URLs

## Testing
- `yarn test __tests__/seo-files.test.ts`
- `yarn test` *(fails: ENOENT errors, Vitest require() usage, syntax errors, timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89ec35e48328ae24c5e2780c78a9