### PR TITLE
refactor: split env validation for client and server

### DIFF
--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -75,17 +75,28 @@ export function validateRequest(
   return { query: parsedQuery, body: parsedBody };
 }
 
-const EnvSchema = z.object({
-  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+const PublicEnvSchema = z.object({
   NEXT_PUBLIC_ENABLE_ANALYTICS: z.enum(['true', 'false']).optional(),
   NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
 });
 
-export function validateEnv(env: NodeJS.ProcessEnv) {
-  const result = EnvSchema.safeParse(env);
+const EnvSchema = z.object({
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+});
+
+function validate<T extends ZodTypeAny>(schema: T, env: NodeJS.ProcessEnv) {
+  const result = schema.safeParse(env);
   if (!result.success) {
     const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
     throw new Error(`Missing required environment variables: ${missing}`);
   }
-  return result.data;
+  return result.data as z.infer<T>;
+}
+
+export function validateEnv(env: NodeJS.ProcessEnv) {
+  return validate(EnvSchema, env);
+}
+
+export function validatePublicEnv(env: NodeJS.ProcessEnv) {
+  return validate(PublicEnvSchema, env);
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,11 +9,11 @@ import { Inter } from 'next/font/google';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
 import ConsentBanner from '../components/ConsentBanner';
-import { validateEnv } from '../lib/validate';
+import { validatePublicEnv } from '../lib/validate';
 
 const inter = Inter({ subsets: ['latin'] });
 
-validateEnv(process.env);
+validatePublicEnv(process.env);
 initAxiom();
 
 const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';


### PR DESCRIPTION
## Summary
- add `validatePublicEnv` for client-side checks of `NEXT_PUBLIC_*` variables
- call `validatePublicEnv` from `_app.tsx` and keep server `JWT_SECRET` validation via `next.config.js`

## Testing
- `yarn test` *(fails: SyntaxError: Unexpected token '{')*
- `yarn lint` *(fails: SyntaxError: Unexpected token '{')*

------
https://chatgpt.com/codex/tasks/task_e_68ab952ac70c83289c4011d33d17a49a