### PR TITLE
refactor: remove suspense option from Ubuntu dynamic import

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,13 +4,14 @@ import Meta from '../components/SEO/Meta';
 
 const Ubuntu = dynamic(() => import('../components/ubuntu'), {
   ssr: false,
-  suspense: true,
 });
 
 const App: React.FC = () => (
   <>
     <Meta />
-    <Suspense fallback={<div className="w-screen h-screen bg-gray-900 animate-pulse" />}>
+    <Suspense
+      fallback={<div className="w-screen h-screen bg-gray-900 animate-pulse" />}
+    >
       <Ubuntu />
     </Suspense>
   </>


### PR DESCRIPTION
## Summary
- remove `suspense: true` option from Ubuntu dynamic import in `pages/index.tsx`
- keep existing `<Suspense>` wrapper unchanged

## Testing
- `JWT_SECRET=foo yarn lint`
- `JWT_SECRET=foo yarn test` *(fails: missing fixtures and environment mismatches, e.g., jwks-fetcher.api.test.ts, dynamicAppLoadError.test.tsx, desktop.openApp.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab952b473c8328a630f67a9bea701a