### PR TITLE
chore: upgrade react to 19

### DIFF
--- a/__tests__/serviceWorkerRegistration.test.tsx
+++ b/__tests__/serviceWorkerRegistration.test.tsx
@@ -11,12 +11,12 @@ describe('service worker registration', () => {
   const originalEnv = process.env.NODE_ENV;
 
   afterEach(() => {
-    process.env.NODE_ENV = originalEnv;
+    (process.env as any).NODE_ENV = originalEnv;
     delete (navigator as any).serviceWorker;
   });
 
   it('does not register service worker in development', async () => {
-    process.env.NODE_ENV = 'development';
+    (process.env as any).NODE_ENV = 'development';
     const register = jest.fn();
     Object.defineProperty(navigator, 'serviceWorker', {
       value: { register },
@@ -32,7 +32,7 @@ describe('service worker registration', () => {
   });
 
   it('registers service worker in production', async () => {
-    process.env.NODE_ENV = 'production';
+    (process.env as any).NODE_ENV = 'production';
     const register = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'serviceWorker', {
       value: { register },

--- a/package.json
+++ b/package.json
@@ -96,10 +96,10 @@
     "qrcode": "^1.5.4",
     "re2": "^1.22.1",
     "re2-wasm": "^1.0.2",
-    "react": "18.2.0",
+    "react": "^19.0.0",
     "react-activity-calendar": "^2.7.13",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "18.2.0",
+    "react-dom": "^19.0.0",
     "react-force-graph": "^1.48.0",
     "react-force-graph-2d": "^1.28.0",
     "react-ga4": "^2.1.0",
@@ -150,7 +150,8 @@
     "@types/mermaid": "^9.2.0",
     "@types/node": "^24.2.1",
     "@types/plist": "^3.0.2",
-    "@types/react": "^18.2.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@types/react-window": "^1",
     "@types/sax": "^1",
     "@types/sql.js": "^1",
@@ -170,7 +171,7 @@
     "vitest": "^1.6.0"
   },
   "resolutions": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import Meta from '../components/SEO/Meta';
 
 const Ubuntu = dynamic(() => import('../components/ubuntu'), {
   ssr: false,
-  suspense: true,
 });
 
 const App: React.FC = () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,6 +3062,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:^19.0.0":
+  version: 19.1.7
+  resolution: "@types/react-dom@npm:19.1.7"
+  peerDependencies:
+    "@types/react": ^19.0.0
+  checksum: 10c0/8db5751c1567552fe4e1ece9f5823b682f2994ec8d30ed34ba0ef984e3c8ace1435f8be93d02f55c350147e78ac8c4dbcd8ed2c3b6a60f575bc5374f588c51c9
+  languageName: node
+  linkType: hard
+
 "@types/react-window@npm:^1":
   version: 1.8.8
   resolution: "@types/react-window@npm:1.8.8"
@@ -3071,13 +3080,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^18.2.0":
+"@types/react@npm:*":
   version: 18.3.24
   resolution: "@types/react@npm:18.3.24"
   dependencies:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/9e188fa8e50f172cf647fc48fea2e04d88602afff47190b697de281a8ac88df9ee059864757a2a438ff599eaf9276d9a9e0e60585e88f7d57f01a2e4877d37ec
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^19.0.0":
+  version: 19.1.11
+  resolution: "@types/react@npm:19.1.11"
+  dependencies:
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/639b225c2bbcd4b8a30e1ea7a73aec81ae5b952a4c432460b48c9881c9d12e76645c9032d24f15eefae9985a12d5cb26557fe10e9850b2da0fabfb0a1e2d16bd
   languageName: node
   linkType: hard
 
@@ -10536,7 +10554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -13143,15 +13161,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^19.0.0":
+  version: 19.1.1
+  resolution: "react-dom@npm:19.1.1"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.0"
+    scheduler: "npm:^0.26.0"
   peerDependencies:
-    react: ^18.2.0
-  checksum: 10c0/66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+    react: ^19.1.1
+  checksum: 10c0/8c91198510521299c56e4e8d5e3a4508b2734fb5e52f29eeac33811de64e76fe586ad32c32182e2e84e070d98df67125da346c3360013357228172dbcd20bcdd
   languageName: node
   linkType: hard
 
@@ -13305,12 +13322,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10c0/b562d9b569b0cb315e44b48099f7712283d93df36b19a39a67c254c6686479d3980b7f013dc931f4a5a3ae7645eae6386b4aa5eea933baa54ecd0f9acb0902b8
+"react@npm:^19.0.0":
+  version: 19.1.1
+  resolution: "react@npm:19.1.1"
+  checksum: 10c0/8c9769a2dfd02e603af6445058325e6c8a24b47b185d0e461f66a6454765ddcaecb3f0a90184836c68bb509f3c38248359edbc42f0d07c23eb500a5c30c87b4e
   languageName: node
   linkType: hard
 
@@ -13958,12 +13973,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
+"scheduler@npm:^0.26.0":
+  version: 0.26.0
+  resolution: "scheduler@npm:0.26.0"
+  checksum: 10c0/5b8d5bfddaae3513410eda54f2268e98a376a429931921a81b5c3a2873aab7ca4d775a8caac5498f8cbc7d0daeab947cf923dbd8e215d61671f9f4e392d34356
   languageName: node
   linkType: hard
 
@@ -15816,7 +15829,8 @@ __metadata:
     "@types/mermaid": "npm:^9.2.0"
     "@types/node": "npm:^24.2.1"
     "@types/plist": "npm:^3.0.2"
-    "@types/react": "npm:^18.2.0"
+    "@types/react": "npm:^19.0.0"
+    "@types/react-dom": "npm:^19.0.0"
     "@types/react-window": "npm:^1"
     "@types/sax": "npm:^1"
     "@types/sql.js": "npm:^1"
@@ -15893,10 +15907,10 @@ __metadata:
     qrcode: "npm:^1.5.4"
     re2: "npm:^1.22.1"
     re2-wasm: "npm:^1.0.2"
-    react: "npm:18.2.0"
+    react: "npm:^19.0.0"
     react-activity-calendar: "npm:^2.7.13"
     react-chartjs-2: "npm:^5.3.0"
-    react-dom: "npm:18.2.0"
+    react-dom: "npm:^19.0.0"
     react-force-graph: "npm:^1.48.0"
     react-force-graph-2d: "npm:^1.28.0"
     react-ga4: "npm:^2.1.0"
@@ -16832,4 +16846,3 @@ __metadata:
   checksum: 10c0/862f101cc95247b30290bad67ade333e430a16763bb771ce4e4c5414396d987f9a64288225675c96bd6f8d3eba65da0dee119b2a4eaa2e249da3f540b036942e
   languageName: node
   linkType: hard
-


### PR DESCRIPTION
## Summary
- update react and react-dom to v19 along with type definitions
- drop deprecated `suspense` option from dynamic Ubuntu loader
- fix service worker tests to handle read-only `NODE_ENV`

## Testing
- `yarn test` *(fails: SyntaxError: Unexpected token '{')*
- `yarn test:unit --run` *(fails: jest is not defined in several tests)*
- `yarn typecheck` *(fails: many TS errors such as missing declarations and invalid types)*
- `yarn lint` *(fails: SyntaxError: Unexpected token '{')*


------
https://chatgpt.com/codex/tasks/task_e_68ab952bdb1483289b9481873ff1bf0d