### PR TITLE
Enable bundling of ESM deps in pages router

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,6 +74,7 @@ const securityHeaders = [
 ];
 
 module.exports = {
+  bundlePagesRouterDependencies: true,
   productionBrowserSourceMaps: true,
   images: {
     // Keep unoptimized if you serve static assets without the Next image optimizer.


### PR DESCRIPTION
## Summary
- enable bundling of pages router dependencies for better ESM compatibility

## Testing
- `yarn test` *(fails: SyntaxError: Unexpected token '{')*
- `yarn build` *(fails: Failed to load next.config.js - SyntaxError)*
- `yarn test:unit` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68ab952d6c788328b57f099146ef436e