### PR TITLE
refactor: split validate utilities for server and client

### DIFF
--- a/lib/validate-env.node.cjs
+++ b/lib/validate-env.node.cjs
@@ -1,0 +1,16 @@
+const { z } = require('zod');
+
+const EnvSchema = z.object({
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+});
+
+function validateEnv(env) {
+  const result = EnvSchema.safeParse(env);
+  if (!result.success) {
+    const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+    throw new Error(`Missing required environment variables: ${missing}`);
+  }
+  return result.data;
+}
+
+module.exports = { validateEnv };

--- a/lib/validate-public.ts
+++ b/lib/validate-public.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  NEXT_PUBLIC_ENABLE_ANALYTICS: z.enum(['true', 'false']).optional(),
+  NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
+});
+
+export function validateEnv(env: Record<string, string | undefined>) {
+  const result = EnvSchema.safeParse(env);
+  if (!result.success) {
+    const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+    throw new Error(`Missing required environment variables: ${missing}`);
+  }
+  return result.data;
+}

--- a/lib/validate-server.ts
+++ b/lib/validate-server.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import type { ZodTypeAny } from 'zod';
 import crypto from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -73,19 +72,4 @@ export function validateRequest(
   }
 
   return { query: parsedQuery, body: parsedBody };
-}
-
-const EnvSchema = z.object({
-  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
-  NEXT_PUBLIC_ENABLE_ANALYTICS: z.enum(['true', 'false']).optional(),
-  NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
-});
-
-export function validateEnv(env: NodeJS.ProcessEnv) {
-  const result = EnvSchema.safeParse(env);
-  if (!result.success) {
-    const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
-    throw new Error(`Missing required environment variables: ${missing}`);
-  }
-  return result.data;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 // Security headers configuration for Next.js.
 // Allows external badges, inline styles, and same-origin PDF embedding.
 
-const { validateEnv } = require('./lib/validate.ts');
+const { validateEnv } = require('./lib/validate-env.node.cjs');
 validateEnv(process.env);
 
 const ContentSecurityPolicy = [

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,7 +9,7 @@ import { Inter } from 'next/font/google';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
 import ConsentBanner from '../components/ConsentBanner';
-import { validateEnv } from '../lib/validate';
+import { validateEnv } from '../lib/validate-public';
 
 const inter = Inter({ subsets: ['latin'] });
 

--- a/pages/api/breakout/levels.ts
+++ b/pages/api/breakout/levels.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
-import { validateRequest } from '../../../lib/validate';
+import { validateRequest } from '../../../lib/validate-server';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const dir = path.join(process.cwd(), 'apps', 'breakout', 'levels');

--- a/pages/api/caa-checker.ts
+++ b/pages/api/caa-checker.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 

--- a/pages/api/crtsh.ts
+++ b/pages/api/crtsh.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 
 setupUrlGuard();

--- a/pages/api/dns.ts
+++ b/pages/api/dns.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { rateLimit } from '../../lib/rateLimiter';
 import { setupUrlGuard } from '../../lib/urlGuard';
 

--- a/pages/api/git-secrets-tester.ts
+++ b/pages/api/git-secrets-tester.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import JSZip from 'jszip';
 import { spawn, spawnSync } from 'child_process';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { defaultPatterns, redactSecret } from '../../components/apps/git-secrets-tester';
 import { setupUrlGuard } from '../../lib/urlGuard';
 

--- a/pages/api/http-diff.ts
+++ b/pages/api/http-diff.ts
@@ -3,7 +3,7 @@ import { diffLines } from 'diff';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import type { ApiResult, DiffPart, FetchMeta, HttpDiffResponse } from '@/types/http-diff';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();

--- a/pages/api/jwks-fetcher.ts
+++ b/pages/api/jwks-fetcher.ts
@@ -10,7 +10,7 @@ import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 
 interface CacheEntry {
   jwk: any;

--- a/pages/api/mail-auth.ts
+++ b/pages/api/mail-auth.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 

--- a/pages/api/redirect-visualizer.ts
+++ b/pages/api/redirect-visualizer.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Agent } from 'undici';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 import { fetchHead } from '../../lib/headCache';
 setupUrlGuard();

--- a/pages/api/robots.ts
+++ b/pages/api/robots.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { UserInputError, withErrorHandler } from '../../lib/errors';
 import { fetchRobots, RobotsData } from '../../lib/robots';
 import { setupUrlGuard } from '../../lib/urlGuard';

--- a/pages/api/spf-flattener.ts
+++ b/pages/api/spf-flattener.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 

--- a/pages/api/tls-chain.ts
+++ b/pages/api/tls-chain.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import tls, { PeerCertificate } from 'tls';
 import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 
 
 interface FormattedCert {

--- a/pages/api/users/[id]/blackjack.ts
+++ b/pages/api/users/[id]/blackjack.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
-import { validateRequest } from '../../../../lib/validate';
+import { validateRequest } from '../../../../lib/validate-server';
 import { getStats, setStats, type Stats } from '../../../../lib/user-store';
 
 if (!process.env.JWT_SECRET && process.env.NODE_ENV !== 'test') {

--- a/pages/api/wayback-viewer.ts
+++ b/pages/api/wayback-viewer.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import { setupUrlGuard } from '../../lib/urlGuard';
 setupUrlGuard();
 

--- a/pages/api/yara-scan.ts
+++ b/pages/api/yara-scan.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
-import { validateRequest } from '../../lib/validate';
+import { validateRequest } from '../../lib/validate-server';
 import yaraFactory from 'libyara-wasm';
 import { setupUrlGuard } from '../../lib/urlGuard';
 

--- a/scripts/validate-env.mjs
+++ b/scripts/validate-env.mjs
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+  NEXT_PUBLIC_ENABLE_ANALYTICS: z.enum(['true', 'false']).optional(),
+  NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
+});
+
+const result = EnvSchema.safeParse(process.env);
+if (!result.success) {
+  const missing = result.error.issues.map((i) => i.path.join('.')).join(', ');
+  throw new Error(`Missing required environment variables: ${missing}`);
+}


### PR DESCRIPTION
## Summary
- split lib/validate into server and public modules
- add server-side env checks and validation script
- update Next.js config and app to use new validators

## Testing
- `JWT_SECRET=test node scripts/validate-env.mjs`
- `JWT_SECRET=test yarn test` (fails: missing fixtures, ReferenceError, timeout)
- `JWT_SECRET=test yarn test:unit` (fails: missing modules, jest not defined)


------
https://chatgpt.com/codex/tasks/task_e_68ab965e40788328887f21601fe88269