### PR TITLE
chore: drop suspense option from dynamic imports

### DIFF
--- a/apps/report-viewer/index.tsx
+++ b/apps/report-viewer/index.tsx
@@ -1,12 +1,12 @@
 import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-const ReactMarkdown = dynamic(() => import('react-markdown'), { suspense: true });
+const ReactMarkdown = dynamic(() => import('react-markdown'));
 import { run } from '@mdx-js/mdx';
 import * as runtime from 'react/jsx-runtime';
 import rehypeSanitize from 'rehype-sanitize';
 const List = dynamic(
   () => import('react-window').then((mod) => mod.FixedSizeList),
-  { ssr: false, suspense: true }
+  { ssr: false }
 );
 import type { FixedSizeList as ListType } from 'react-window';
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import Meta from '../components/SEO/Meta';
 
 const Ubuntu = dynamic(() => import('../components/ubuntu'), {
   ssr: false,
-  suspense: true,
 });
 
 const App: React.FC = () => (


### PR DESCRIPTION
## Summary
- remove `suspense` option from dynamic `Ubuntu` import on homepage
- remove `suspense` option from report viewer dynamic imports

## Testing
- `yarn lint` *(fails: SyntaxError: Unexpected token '{')*

------
https://chatgpt.com/codex/tasks/task_e_68ab965f3d7c8328bc9c1ae07115e7ac