### PR TITLE
refactor: guard browser apis after mount

### DIFF
--- a/components/vulnerability-search.tsx
+++ b/components/vulnerability-search.tsx
@@ -73,27 +73,23 @@ export default function VulnerabilitySearch() {
   const [epss, setEpss] = useState('');
   const [kev, setKev] = useState(false);
   const [severity, setSeverity] = useState<string[]>([]);
-  const [columns, setColumns] = useState<string[]>(() => {
+  const [columns, setColumns] = useState<string[]>(['id', 'description', 'epss', 'kev']);
+  const [views, setViews] = useState<Record<string, any>>({});
+
+  useEffect(() => {
     try {
-      return (
-        JSON.parse(localStorage.getItem('vuln_columns') || '') || [
-          'id',
-          'description',
-          'epss',
-          'kev',
-        ]
-      );
+      const storedCols = localStorage.getItem('vuln_columns');
+      if (storedCols) {
+        setColumns(JSON.parse(storedCols) || ['id', 'description', 'epss', 'kev']);
+      }
+      const storedViews = localStorage.getItem('vuln_views');
+      if (storedViews) {
+        setViews(JSON.parse(storedViews) || {});
+      }
     } catch {
-      return ['id', 'description', 'epss', 'kev'];
+      // ignore invalid JSON
     }
-  });
-  const [views, setViews] = useState<Record<string, any>>(() => {
-    try {
-      return JSON.parse(localStorage.getItem('vuln_views') || '') || {};
-    } catch {
-      return {};
-    }
-  });
+  }, []);
 
   useEffect(() => {
     if (!router.isReady) return;


### PR DESCRIPTION
## Summary
- avoid top-level localStorage usage in solitaire app
- defer vulnerability-search preferences to client-side useEffect

## Testing
- `yarn lint` *(fails: Unexpected token '{' in validate.ts)*
- `yarn test` *(fails: Unexpected token '{')*


------
https://chatgpt.com/codex/tasks/task_e_68ab965fff108328bebba6893f3cf70d