### PR TITLE
Replace placeholder comments and enforce lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: no-placeholder-tokens
+        name: "No placeholder tokens"
+        entry: "(//\\s*\\.{3,}|['\"]\\.{3}['\"]|<!--\\s*\\.{3,}\\s*-->)"
+        language: pygrep
+        types: [text]

--- a/apps/dns-toolkit/index.tsx
+++ b/apps/dns-toolkit/index.tsx
@@ -64,7 +64,7 @@ const DnsToolkit: React.FC = () => {
           disabled={loading}
           className="px-3 py-1 bg-blue-600 rounded"
         >
-          {loading ? '...' : 'Lookup'}
+          {loading ? 'Looking up...' : 'Lookup'}
         </button>
       </form>
       {error && <div className="text-red-500">{error}</div>}

--- a/components/apps/caa-checker.tsx
+++ b/components/apps/caa-checker.tsx
@@ -60,7 +60,7 @@ const CaaChecker: React.FC = () => {
           className="text-black px-2 py-1 flex-1"
         />
         <button type="submit" disabled={loading} className="px-3 py-1 bg-blue-600 rounded">
-          {loading ? '...' : 'Check'}
+          {loading ? 'Checking...' : 'Check'}
         </button>
       </form>
       {error && <div className="text-red-500">{error}</div>}

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -209,7 +209,7 @@ const Sokoban = () => {
   };
 
   const getHint = () => {
-    setHint('...');
+    setHint('Calculating...');
     const dirs = [
       { dx: 0, dy: -1, key: 'Up' },
       { dx: 0, dy: 1, key: 'Down' },

--- a/components/apps/tls-inspector.tsx
+++ b/components/apps/tls-inspector.tsx
@@ -68,7 +68,7 @@ const TLSInspector: React.FC = () => {
           className="text-black px-2 py-1 flex-1"
         />
         <button type="submit" disabled={loading} className="px-3 py-1 bg-blue-600 rounded">
-          {loading ? '...' : 'Fetch'}
+          {loading ? 'Fetching...' : 'Fetch'}
         </button>
       </form>
       {error && <div className="text-red-500">{error}</div>}

--- a/docs/dynamic-app-loading.md
+++ b/docs/dynamic-app-loading.md
@@ -19,10 +19,10 @@ export default MyTool;
 1. Create your app under `components/apps/<id>` and export a default component.
 2. Add an entry to `dynamicAppEntries` in `apps.config.js`:
    ```js
-   const dynamicAppEntries = [
-     ['my-tool', 'My Tool'],
-     // ...existing entries
-   ];
+const dynamicAppEntries = [
+  ['terminal', 'Terminal'],
+  ['my-tool', 'My Tool'],
+];
    ```
    The configuration will call `createDynamicApp('my-tool', 'My Tool')` for you.
 3. Run `yarn lint` to ensure there are no direct imports from `components/apps`.

--- a/public/nmap.xsl
+++ b/public/nmap.xsl
@@ -40,14 +40,11 @@
 />
 
 <!-- global variables      -->
-<!-- ............................................................ -->
 <xsl:variable name="nmap_xsl_version">0.9c</xsl:variable>
-<!-- ............................................................ -->
 <xsl:variable name="start"><xsl:value-of select="/nmaprun/@startstr" /></xsl:variable>
 <xsl:variable name="end"><xsl:value-of select="/nmaprun/runstats/finished/@timestr" /> </xsl:variable>
 <xsl:variable name="totaltime"><xsl:value-of select="/nmaprun/runstats/finished/@time -/nmaprun/@start" /></xsl:variable>
 <xsl:key name="portstatus" match="@state" use="."/>
-<!-- ............................................................ -->
 
 
 <xsl:template match="/">
@@ -56,7 +53,6 @@
 
 
 <!-- root -->
-<!-- ............................................................ -->
 <xsl:template match="/nmaprun">
 <html>
 <head>
@@ -495,10 +491,8 @@
 </body>
 </html>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- host -->
-<!-- ............................................................ -->
 <xsl:template match="host">
 
   <hr class="print_only" />
@@ -645,26 +639,20 @@
   </xsl:element>
 	
 </xsl:template>
-<!-- ............................................................ -->
 
 
 
 <!-- hostnames -->
-<!-- ............................................................ -->
 <xsl:template match="hostnames">
   <xsl:if test="hostname/@name != ''"><h3>Hostnames</h3><ul>	<xsl:apply-templates/></ul></xsl:if>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- hostname -->
-<!-- ............................................................ -->
 <xsl:template match="hostname">
   <li><xsl:value-of select="@name"/> (<xsl:value-of select="@type"/>)</li>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- ports -->
-<!-- ............................................................ -->
 <xsl:template match="ports">
   <xsl:variable name="var_address" select="../address/@addr" />
   <h3>Ports</h3>
@@ -717,10 +705,8 @@
     </xsl:element>
   </xsl:if>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- port -->
-<!-- ............................................................ -->
 <xsl:template match="port">
 
   <xsl:choose>
@@ -809,10 +795,8 @@
 
   </xsl:choose>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- os -->
-<!-- ............................................................ -->
 <xsl:template match="os">
   <h3>Remote Operating System Detection</h3>
 		
@@ -831,11 +815,9 @@
   <xsl:apply-templates select="osfingerprint"/>
 
 </xsl:template>
-<!-- ............................................................ -->
 
 
 <!-- osfingerprint -->
-<!-- ............................................................ -->
 <xsl:template match="osfingerprint">
 
   <xsl:variable name="var_address" select="../../address/@addr" /> 
@@ -889,10 +871,8 @@
   </xsl:choose>
 
   </xsl:template>
-<!-- ............................................................ -->
 
 <!-- Pre-Scan script -->
-<!-- ............................................................ -->
 <xsl:template match="prescript">
 
   <hr class="print_only" />
@@ -924,10 +904,8 @@
   </xsl:for-each>
   </table>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- Post-Scan script -->
-<!-- ............................................................ -->
 <xsl:template match="postscript">
 
   <hr class="print_only" />
@@ -959,11 +937,9 @@
   </xsl:for-each>
   </table>
 </xsl:template>
-<!-- ............................................................ -->
 
 
 <!-- Host Script Scan -->
-<!-- ............................................................ -->
 <xsl:template match="hostscript">
   <h3>Host Script Output</h3>
 
@@ -988,10 +964,8 @@
 
     </table>
 </xsl:template>
-<!-- ............................................................ -->
 
 <!-- smurf -->
-<!-- ............................................................ -->
 <xsl:template match="smurf">
   <xsl:if test="@responses != ''"><h3>Smurf Responses</h3>
     <ul>
@@ -999,11 +973,9 @@
     </ul>
   </xsl:if>
 </xsl:template>
-<!-- ............................................................ -->
 
 
 <!-- traceroute -->
-<!-- ............................................................ -->
 
 <xsl:template match="trace">
   <xsl:if test="@port">
@@ -1067,5 +1039,4 @@
 
   </xsl:if>
 </xsl:template>
-<!-- ............................................................ -->
 </xsl:stylesheet>


### PR DESCRIPTION
## Summary
- replace placeholder ellipses with meaningful text in several components
- document dynamicAppEntries without placeholder comments
- remove dotted comments from nmap.xsl and add pre-commit rule to prevent them

## Testing
- `pre-commit run --files docs/dynamic-app-loading.md components/apps/caa-checker.tsx components/apps/sokoban.js apps/dns-toolkit/index.tsx components/apps/tls-inspector.tsx public/nmap.xsl .pre-commit-config.yaml`
- `yarn typecheck && yarn build` *(fails: Found 345 errors in 90 files)*

------
https://chatgpt.com/codex/tasks/task_e_68ab966a0c448328b9af6ff2ce8ca469