### PR TITLE
Document typecheck usage and align Vitest aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 2. **Install packages** – run `yarn` to install project dependencies.
 3. **Environment** – copy `.env.example` to `.env.local` and fill in required variables like `JWT_SECRET`.
 4. **Run the app** – start the development server with `yarn dev`.
+5. **Type-check** – run `yarn typecheck` to verify TypeScript types. This command also runs in CI.
 
 ### Common Install Issues
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@apps': path.resolve(__dirname, './apps'),
+      '@components': path.resolve(__dirname, './components'),
+      '@lib': path.resolve(__dirname, './lib'),
+      '@pages': path.resolve(__dirname, './pages'),
+      '@public': path.resolve(__dirname, './public'),
+      '@': path.resolve(__dirname, './'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- add path aliases to Vitest config matching tsconfig and Jest
- document `yarn typecheck` in Quick Start instructions

## Testing
- `yarn lint` *(fails: SyntaxError in `lib/validate.ts`)*
- `yarn typecheck` *(fails: multiple TypeScript errors)*
- `yarn test` *(fails: SyntaxError during setup)*
- `yarn test:unit` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab966b49888328ae04edf17f542e9d