### PR TITLE
feat: add store abstraction for dev file persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 4. Update `.env.example` whenever new environment variables are added.
 5. Run `yarn validate:icons` to ensure all icon paths in `apps.config.js` exist under `public/themes/` before committing.
 
+## Local File Storage
+
+Some API routes persist data to the filesystem when running locally. This file-based storage is best effort and may be cleared between runs. Production deployments fall back to a no-op implementation or external storage via `lib/store`.
+
 ## Adding New Apps
 
 See [New App Checklist](./docs/new-app-checklist.md) to ensure all required steps are completed.

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,52 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type { Dirent, Stats } from 'fs';
+
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+export async function readJson<T>(file: string, defaultValue: T): Promise<T> {
+  if (IS_PROD) return defaultValue;
+  try {
+    const data = await fs.readFile(file, 'utf8');
+    return JSON.parse(data) as T;
+  } catch {
+    return defaultValue;
+  }
+}
+
+export async function writeJson(file: string, data: unknown): Promise<void> {
+  if (IS_PROD) return;
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+}
+
+export async function readDir(
+  dir: string,
+  options?: { withFileTypes?: boolean },
+): Promise<string[] | Dirent[]> {
+  if (IS_PROD) return [];
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    return await fs.readdir(dir, options);
+  } catch {
+    return [];
+  }
+}
+
+export async function readFile(file: string): Promise<string | undefined> {
+  if (IS_PROD) return undefined;
+  try {
+    return await fs.readFile(file, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+export async function stat(file: string): Promise<Stats | undefined> {
+  if (IS_PROD) return undefined;
+  try {
+    return await fs.stat(file);
+  } catch {
+    return undefined;
+  }
+}

--- a/pages/api/import-graph.ts
+++ b/pages/api/import-graph.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs/promises';
+import type { Dirent } from 'fs';
 import path from 'path';
 import { setupUrlGuard } from '../../lib/urlGuard';
+import { readDir, readFile } from '../../lib/store';
 
 setupUrlGuard();
 
@@ -17,10 +18,10 @@ export default async function handler(
   const files: Record<string, string> = {};
 
   async function walk(dir: string): Promise<void> {
-    let entries;
+    let entries: Dirent[];
     try {
       // eslint-disable-next-line security/detect-non-literal-fs-filename
-      entries = await fs.readdir(dir, { withFileTypes: true });
+      entries = (await readDir(dir, { withFileTypes: true })) as Dirent[];
     } catch {
       return;
     }
@@ -33,7 +34,7 @@ export default async function handler(
         try {
           const rel = path.relative(root, full).replace(/\\/g, '/');
           // eslint-disable-next-line security/detect-non-literal-fs-filename
-          files[rel] = await fs.readFile(full, 'utf8');
+          files[rel] = (await readFile(full)) ?? '';
         } catch {
           // ignore unreadable files
         }

--- a/pages/api/madge.ts
+++ b/pages/api/madge.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import madge from 'madge';
-import fs from 'fs/promises';
 import path from 'path';
 import { setupUrlGuard } from '../../lib/urlGuard';
+import { stat } from '../../lib/store';
 
 setupUrlGuard();
 
@@ -27,8 +27,8 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
       Object.keys(graph).map(async (file) => {
         try {
           // eslint-disable-next-line security/detect-non-literal-fs-filename
-          const stat = await fs.stat(path.join(root, file));
-          sizes[file] = stat.size;
+          const s = await stat(path.join(root, file));
+          sizes[file] = s?.size ?? 0;
         } catch {
           sizes[file] = 0;
         }

--- a/pages/api/pinball/scores.ts
+++ b/pages/api/pinball/scores.ts
@@ -1,29 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
 import path from 'path';
+import { readJson, writeJson } from '../../../lib/store';
 
 const filePath = path.join(process.cwd(), 'data', 'pinballScores.json');
 
-function readScores() {
-  try {
-    const data = fs.readFileSync(filePath, 'utf8');
-    return JSON.parse(data);
-  } catch {
-    return [];
-  }
-}
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    return res.status(200).json(readScores());
+    const scores = await readJson(filePath, [] as any[]);
+    return res.status(200).json(scores);
   }
 
   if (req.method === 'POST') {
     const { score, name = 'Anonymous', replay = [] } = req.body || {};
-    const scores = readScores();
+    const scores = await readJson(filePath, [] as any[]);
     scores.push({ name, score, replay, date: new Date().toISOString() });
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(scores, null, 2));
+    await writeJson(filePath, scores);
     return res.status(201).json({ ok: true });
   }
 

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -1,37 +1,29 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
 import path from 'path';
 import { setupUrlGuard } from '../../lib/urlGuard';
+import { readJson, writeJson } from '../../lib/store';
 
 setupUrlGuard();
 
 const filePath = path.join(process.cwd(), 'data', 'settings.json');
 
-function readSettings() {
-  try {
-    const data = fs.readFileSync(filePath, 'utf8');
-    const parsed = JSON.parse(data);
-    return {
-      theme: 'light',
-      language: 'en-US',
-      units: 'metric',
-      dataSaving: false,
-      ...parsed,
-    };
-  } catch {
-    return { theme: 'light', language: 'en-US', units: 'metric', dataSaving: false };
-  }
+async function readSettings() {
+  return readJson(filePath, {
+    theme: 'light',
+    language: 'en-US',
+    units: 'metric',
+    dataSaving: false,
+  });
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
-    return res.status(200).json(readSettings());
+    return res.status(200).json(await readSettings());
   }
 
   if (req.method === 'POST') {
     const settings = req.body;
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2));
+    await writeJson(filePath, settings);
     return res.status(200).json({ ok: true });
   }
 

--- a/pages/api/tetris/replay.ts
+++ b/pages/api/tetris/replay.ts
@@ -1,20 +1,15 @@
-import fs from 'fs';
 import path from 'path';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { readJson, writeJson } from '../../../lib/store';
 
 const file = path.join(process.cwd(), 'data', 'tetris-replays.json');
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     const body = req.body;
-    let arr: any[] = [];
-    try {
-      arr = JSON.parse(fs.readFileSync(file, 'utf8'));
-    } catch {
-      arr = [];
-    }
+    const arr = await readJson(file, [] as any[]);
     arr.push({ ...body, time: Date.now() });
-    fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+    await writeJson(file, arr);
     res.status(200).json({ ok: true });
   } else {
     res.status(405).end();

--- a/pages/api/tetris/stats.ts
+++ b/pages/api/tetris/stats.ts
@@ -1,20 +1,15 @@
-import fs from 'fs';
 import path from 'path';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { readJson, writeJson } from '../../../lib/store';
 
 const file = path.join(process.cwd(), 'data', 'tetris-stats.json');
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     const body = req.body;
-    let arr: any[] = [];
-    try {
-      arr = JSON.parse(fs.readFileSync(file, 'utf8'));
-    } catch {
-      arr = [];
-    }
+    const arr = await readJson(file, [] as any[]);
     arr.push({ ...body, time: Date.now() });
-    fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+    await writeJson(file, arr);
     res.status(200).json({ ok: true });
   } else {
     res.status(405).end();


### PR DESCRIPTION
## Summary
- add `lib/store.ts` to provide file-backed storage in development and a no-op in production
- update API routes to use the store instead of direct `fs` calls
- note that local file persistence is best-effort in README

## Testing
- `yarn lint` (fails: SyntaxError: Unexpected token '{')
- `yarn test` (fails: SyntaxError: Unexpected token '{')

------
https://chatgpt.com/codex/tasks/task_e_68ab9666d9e08328b26d25ffe3250641