### PR TITLE
chore: run Lighthouse CI and add Vercel Speed Insights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,13 @@ jobs:
       - run: yarn lint:ci
       - run: yarn typecheck
       - run: yarn build:ci
+      - name: Run Lighthouse CI
+        run: yarn lighthouse
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci
       - run: yarn test
       - run: yarn test:e2e

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,12 @@
+import { SpeedInsights } from '@vercel/speed-insights/next';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <SpeedInsights />
+      </body>
     </html>
   );
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/zxcvbn": "^4.4.5",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "apache-arrow": "^21.0.0",
     "argon2-browser": "^1.18.0",
     "ascii85": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,6 +3582,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/speed-insights@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@vercel/speed-insights@npm:1.2.0"
+  peerDependencies:
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10c0/2fb4c4a46330949182d6f63691c51310b636fc3cc464bde3c0f24f100b712c3c4ec57a9fedcd6dc3cc75951064b3295b3cb616c80ff7179fbe310cd4314fffaa
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:1.6.1":
   version: 1.6.1
   resolution: "@vitest/expect@npm:1.6.1"
@@ -15824,6 +15851,7 @@ __metadata:
     "@types/three": "npm:^0.179.0"
     "@types/zxcvbn": "npm:^4.4.5"
     "@vercel/analytics": "npm:^1.5.0"
+    "@vercel/speed-insights": "npm:^1.2.0"
     apache-arrow: "npm:^21.0.0"
     argon2-browser: "npm:^1.18.0"
     ascii85: "npm:^1.0.2"
@@ -16832,4 +16860,3 @@ __metadata:
   checksum: 10c0/862f101cc95247b30290bad67ade333e430a16763bb771ce4e4c5414396d987f9a64288225675c96bd6f8d3eba65da0dee119b2a4eaa2e249da3f540b036942e
   languageName: node
   linkType: hard
-


### PR DESCRIPTION
## Summary
- run Lighthouse CI in workflow and upload reports
- instrument Next.js layout with Vercel Speed Insights
- add `@vercel/speed-insights` dependency

## Testing
- `yarn lint:ci` *(fails: Unexpected token '{')*
- `yarn typecheck` *(fails: multiple TS errors)*
- `yarn build:ci` *(fails: Unexpected token '{')*
- `yarn lighthouse` *(fails: run #1 failed)*
- `yarn test` *(fails: Unexpected token '{')*
- `yarn test:e2e` *(fails: Unexpected token '{')*

------
https://chatgpt.com/codex/tasks/task_e_68ab9668bd948328ac3ddff90641a101