### PR TITLE
feat: gate analytics behind consent

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
-import ReactGA from 'react-ga4';
 import LazyGitHubButton from '../LazyGitHubButton';
 import Certs from './certs';
-import { trackEvent } from '../../lib/analytics';
+import { trackEvent, trackPageview } from '../../lib/analytics';
 
 export class AboutAlex extends Component {
 
@@ -43,7 +42,7 @@ export class AboutAlex extends Component {
         localStorage.setItem("about-section", screen);
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${screen}`, title: "Custom Title" });
+        trackPageview(`/${screen}`, "Custom Title");
 
 
         this.setState({

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import NextImage from 'next/image';
 import { DndContext, useDraggable } from '@dnd-kit/core';
 import Settings from '../apps/settings';
-import ReactGA from 'react-ga4';
-import { trackEvent } from '../../lib/analytics';
+import { trackEvent, trackPageview } from '../../lib/analytics';
 
 function DraggableContainer({ id, defaultPosition, bounds, onDrag, onStart, onStop, children, position: controlledPosition, onPositionChange }) {
     const [internalPosition, setInternalPosition] = React.useState(defaultPosition);
@@ -82,7 +81,7 @@ export class Window extends Component {
         this.setDefaultWindowDimenstion();
 
         // google analytics
-        ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
+        trackPageview(`/${this.id}`, "Custom Title");
         trackEvent('window_open', { id: this.id, title: this.props.title });
 
         // on window resize, resize boundary
@@ -90,7 +89,7 @@ export class Window extends Component {
     }
 
     componentWillUnmount() {
-        ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        trackPageview('/desktop', 'Custom Title');
         window.removeEventListener('resize', this.resizeBoundries);
     }
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,6 +8,7 @@ import AllApplications from '../screen/all-applications';
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import ReactGA from 'react-ga4';
+import { trackPageview } from '../../lib/analytics';
 
 export class Desktop extends Component {
   constructor() {
@@ -37,11 +38,7 @@ export class Desktop extends Component {
 
   componentDidMount() {
     // google analytics
-    ReactGA.send({
-      hitType: 'pageview',
-      page: '/desktop',
-      title: 'Custom Title',
-    });
+    trackPageview('/desktop', 'Custom Title');
 
     this.fetchAppsData();
     this.setContextListeners();

--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -4,6 +4,7 @@ import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
+import { trackPageview } from '../lib/analytics';
 
 interface UbuntuProps {}
 
@@ -70,7 +71,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   lockScreen = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/lock-screen', title: 'Lock Screen' });
+    trackPageview('/lock-screen', 'Lock Screen');
     ReactGA.event({
       category: `Screen Change`,
       action: `Set Screen to Locked`,
@@ -90,7 +91,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   unLockScreen = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/desktop', title: 'Custom Title' });
+    trackPageview('/desktop', 'Custom Title');
 
     if (typeof window !== 'undefined') {
       try {
@@ -123,7 +124,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   shutDown = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/switch-off', title: 'Custom Title' });
+    trackPageview('/switch-off', 'Custom Title');
 
     ReactGA.event({
       category: `Screen Change`,
@@ -142,7 +143,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   turnOn = (): void => {
-    ReactGA.send({ hitType: 'pageview', page: '/desktop', title: 'Custom Title' });
+    trackPageview('/desktop', 'Custom Title');
 
     this.setState({ shutDownScreen: false, booting_screen: true });
     this.setTimeOutBootScreen();

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,5 +1,6 @@
 import { logEvent } from './axiom';
 import type { NextWebVitalsMetric } from 'next/app';
+import ReactGA from 'react-ga4';
 
 const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 const PHONE_REGEX = /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g;
@@ -36,5 +37,15 @@ export const trackWebVital = async (
   metric: NextWebVitalsMetric,
 ): Promise<void> => {
   await trackEvent('web-vital', metric);
+};
+
+export const trackPageview = (page: string, title?: string): void => {
+  if (
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true' &&
+    typeof window !== 'undefined' &&
+    window.localStorage.getItem('analytics-consent') === 'granted'
+  ) {
+    ReactGA.send({ hitType: 'pageview', page, title });
+  }
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -38,9 +38,10 @@ const sanitize = (params: any) => {
 ReactGA.event = () => {};
 ReactGA.send = () => {};
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }: AppProps & { pageProps: any }) {
   const [enableAnalytics, setEnableAnalytics] = useState(false);
   const [consent, setConsent] = useState<'granted' | 'denied' | null>(null);
+  const nonce = pageProps?.nonce;
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -114,7 +115,8 @@ function MyApp({ Component, pageProps }: AppProps) {
             });
           };
 
-          ReactGA.initialize(trackingId);
+          const options = nonce ? { nonce } : undefined;
+          ReactGA.initialize(trackingId, options);
           setEnableAnalytics(true);
         });
       }
@@ -122,12 +124,14 @@ function MyApp({ Component, pageProps }: AppProps) {
       ReactGA.event = () => {};
       ReactGA.send = () => {};
     }
-  }, [consent]);
+  }, [consent, nonce]);
 
   return (
     <main className={inter.className} suppressHydrationWarning data-app-root>
       <Component {...pageProps} />
-      {analyticsEnabled && enableAnalytics && shouldTrack && <Analytics />}
+      {analyticsEnabled && enableAnalytics && shouldTrack && (
+        <Analytics nonce={nonce} />
+      )}
       {consent === null && (
         <ConsentBanner
           onConsent={(granted) => setConsent(granted ? 'granted' : 'denied')}


### PR DESCRIPTION
## Summary
- add trackPageview helper to respect env flag and consent
- gate pageview calls behind new helper to avoid double tracking
- forward CSP nonce to Vercel Analytics and GA initialization

## Testing
- `yarn test` (fails: SyntaxError: Unexpected token '{')
- `yarn lint` (fails: SyntaxError: Unexpected token '{')

------
https://chatgpt.com/codex/tasks/task_e_68ab966c33a08328b9d4c08e6e192b47