### PR TITLE
feat: add light and dark design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@
 4. Update `.env.example` whenever new environment variables are added.
 5. Run `yarn validate:icons` to ensure all icon paths in `apps.config.js` exist under `public/themes/` before committing.
 
+## Design Tokens
+
+Color variables and spacing are centralized in `styles/tokens.css`. The file defines light and dark palettes, and the `--accent` color blends Ubuntu Orange (`#E95420`) with Aubergine (`#77216F`). Semantic tokens map to the active palette via `prefers-color-scheme`:
+
+| Semantic token | Light | Dark |
+| -------------- | ----- | ---- |
+| `--color-bg` | `--color-light-bg` | `--color-dark-bg` |
+| `--color-surface` | `--color-light-surface` | `--color-dark-surface` |
+| `--color-text` | `--color-light-text` | `--color-dark-text` |
+
+These pairings meet or exceed WCAG contrast guidelines:
+
+| Pair | Contrast | Rating |
+| ---- | -------- | ------ |
+| Light `--color-bg` / `--color-text` | 18.88:1 | AAA |
+| Light `--color-surface` / `--color-text` | 16.87:1 | AAA |
+| Dark `--color-bg` / `--color-text` | 16.02:1 | AAA |
+| Dark `--color-surface` / `--color-text` | 13.39:1 | AAA |
+
 ## Local File Storage
 
 Some API routes persist data to the filesystem when running locally. This file-based storage is best effort and may be cleared between runs. Production deployments fall back to a no-op implementation or external storage via `lib/store`.

--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -141,19 +141,19 @@ const Game2048 = () => {
       )}
       <div className="mt-4 space-x-2">
         <button
-          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
+          className="px-4 py-2 bg-[var(--accent)] text-black rounded hover:opacity-90"
           onClick={reset}
         >
           Reset
         </button>
         <button
-          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
+          className="px-4 py-2 bg-[var(--accent)] text-black rounded hover:opacity-90"
           onClick={() => setShowHelp(true)}
         >
           Help
         </button>
         <button
-          className="px-4 py-2 bg-[var(--color-accent)] text-black rounded hover:opacity-90"
+          className="px-4 py-2 bg-[var(--accent)] text-black rounded hover:opacity-90"
           onClick={close}
         >
           Close

--- a/components/util-components/Modal.tsx
+++ b/components/util-components/Modal.tsx
@@ -74,7 +74,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
         <div className="mt-4 text-right">
           <button
             onClick={onClose}
-            className="px-4 py-2 bg-[var(--color-accent)] text-black rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-text)]"
+            className="px-4 py-2 bg-[var(--accent)] text-black rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-text)]"
             data-autofocus
             aria-label={messages.modal.close}
           >

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,10 +1,35 @@
 :root {
-  --color-bg: #0d1117;
-  --color-surface: #1e2329;
-  --color-accent: #62dafc;
-  --color-text: #e6edf3;
+  /* Ubuntu brand colors */
+  --ubuntu-orange: #e95420;
+  --ubuntu-aubergine: #77216f;
+  --accent: color-mix(in srgb, var(--ubuntu-orange) 50%, var(--ubuntu-aubergine));
+
+  /* Light palette */
+  --color-light-bg: #ffffff;
+  --color-light-surface: #f2f2f2;
+  --color-light-text: #111111;
+
+  /* Dark palette */
+  --color-dark-bg: #0d1117;
+  --color-dark-surface: #1e2329;
+  --color-dark-text: #e6edf3;
+
+  /* Semantic tokens default to dark mode */
+  --color-bg: var(--color-dark-bg);
+  --color-surface: var(--color-dark-surface);
+  --color-text: var(--color-dark-text);
+
+  /* Spacing scale */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
   --space-lg: 2rem;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: var(--color-light-bg);
+    --color-surface: var(--color-light-surface);
+    --color-text: var(--color-light-text);
+  }
 }


### PR DESCRIPTION
## Summary
- add Ubuntu-derived accent and light/dark palette tokens
- map semantic colors to new tokens and update components
- document color contrast ratios in README

## Testing
- `yarn lint` *(fails: Plugin "plugin:@next" not found)*
- `yarn test` *(fails: missing test fixtures)*
- `yarn test:unit` *(fails: various test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aba190c7c88328b4183bc5375efee8