### PR TITLE
chore(test): clean ubuntu test imports

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,9 +1,8 @@
+/** @jest-environment jsdom */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
-import { render, screen, act } from '@testing-library/react';
- 
 import Ubuntu from '@components/ubuntu';
 
 jest.mock('@components/screen/desktop', () => () => <div data-testid="desktop" />);


### PR DESCRIPTION
## Summary
- remove duplicate import block in Ubuntu test
- import act from react-dom/test-utils and declare jsdom environment

## Testing
- `JWT_SECRET=secret yarn test __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aba192a6b8832884a4d2e970b488aa