### PR TITLE
test: validate app icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: yarn lint:ci
       - run: yarn typecheck
       - run: yarn build:ci
+      - run: yarn validate:icons
       - name: Jest tests
         run: yarn test --ci | tee jest-report.txt
       - name: Upload Jest report

--- a/__tests__/theme-fallback.test.ts
+++ b/__tests__/theme-fallback.test.ts
@@ -17,9 +17,39 @@ describe('theme fallback helpers', () => {
       const modPath = `@components/apps/${file}`;
       jest.mock(modPath, () => ({}));
     });
+    (global as any).displayImportGraph = () => null;
     process.env.NEXT_PUBLIC_THEME = 'UnknownTheme';
     const mod = await import('@/apps.config.js');
     expect(mod.icon('calc.png')).toBe('./themes/Yaru/apps/calc.png');
     expect(mod.sys('folder.png')).toBe('./themes/Yaru/system/folder.png');
+  });
+
+  it('has Yaru app icons for every apps.config.js entry', async () => {
+    const appsDir = path.join(__dirname, '../components/apps');
+    fs.readdirSync(appsDir).forEach((file) => {
+      const modPath = `@components/apps/${file}`;
+      jest.mock(modPath, () => ({}));
+    });
+    (global as any).displayImportGraph = () => null;
+    const { default: apps, games } = await import('@/apps.config.js');
+    const icons = [...apps, ...games]
+      .map(({ icon }) => icon)
+      .filter((icon) => icon.includes('/apps/'));
+
+    const missing = icons
+      .map((iconPath) => {
+        const filePath = path.join(
+          process.cwd(),
+          'public',
+          'themes',
+          'Yaru',
+          'apps',
+          path.basename(iconPath),
+        );
+        return fs.existsSync(filePath) ? null : filePath;
+      })
+      .filter(Boolean);
+
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- verify apps.config.js entries reference existing Yaru icons
- run `yarn validate:icons` before test suite in CI

## Testing
- `yarn validate:icons`
- `JWT_SECRET=dummy yarn test __tests__/theme-fallback.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aba1953b1483288740c65d5c029984