### PR TITLE
docs: clarify env vars and set JWT secret in CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,23 @@
-NEXT_PUBLIC_AXIOM_TOKEN=
-NEXT_PUBLIC_AXIOM_DATASET=
-
-
-# Example environment variables
+### Example environment variables
 # Copy this file to ".env.local" and fill in the values.
 # Keep this file in sync when new environment variables are introduced.
 
-# Required
+# Required for production
 # Secret used to sign JWT tokens
 JWT_SECRET=
 
 # Analytics (optional)
 NEXT_PUBLIC_ENABLE_ANALYTICS=
 NEXT_PUBLIC_TRACKING_ID=
+NEXT_PUBLIC_AXIOM_TOKEN=
+NEXT_PUBLIC_AXIOM_DATASET=
 
-# Other optional variables
+# Email (optional)
 NEXT_PUBLIC_SERVICE_ID=
 NEXT_PUBLIC_TEMPLATE_ID=
 NEXT_PUBLIC_USER_ID=
+
+# Other optional variables
 NEXT_PUBLIC_YOUTUBE_API_KEY=
 NEXT_PUBLIC_THEME=Yaru
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
+      - name: Generate JWT secret
+        run: echo "JWT_SECRET=$(openssl rand -hex 32)" >> $GITHUB_ENV
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn lint:ci

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 1. **Install dependencies** – ensure [Node.js 20](https://nodejs.org/) and Yarn 4 are available. `nvm install 20 && nvm use 20` sets the correct Node version, and `corepack enable` activates Yarn 4.
 2. **Install packages** – run `yarn` to install project dependencies.
-3. **Environment** – copy `.env.example` to `.env.local` and fill in required variables like `JWT_SECRET`.
+3. **Environment** – copy `.env.example` to `.env.local` and set variables:
+
+   **Required for production**
+   - `JWT_SECRET` – secret used to sign JWT tokens.
+
+   **Optional**
+   - `NEXT_PUBLIC_ENABLE_ANALYTICS`, `NEXT_PUBLIC_TRACKING_ID`, `NEXT_PUBLIC_AXIOM_TOKEN`, `NEXT_PUBLIC_AXIOM_DATASET` – analytics.
+   - `NEXT_PUBLIC_SERVICE_ID`, `NEXT_PUBLIC_TEMPLATE_ID`, `NEXT_PUBLIC_USER_ID` – email configuration.
+   - `NEXT_PUBLIC_YOUTUBE_API_KEY` – YouTube data.
+   - `NEXT_PUBLIC_THEME` – UI theme (defaults to `Yaru`).
+   - `USER_STORE_FILE` – local path for development-only user stats.
 4. **Run the app** – start the development server with `yarn dev`.
 5. **Type-check** – run `yarn typecheck` to verify TypeScript types. This command also runs in CI.
 


### PR DESCRIPTION
## Summary
- detail production vs optional env vars in .env.example and README quick start
- generate ephemeral JWT_SECRET for CI jobs

## Testing
- `JWT_SECRET=test yarn lint` *(fails: Plugin "plugin:@next" not found)*
- `yarn test:unit --run` *(fails: jest is not defined in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aba19762608328af7ed611a8e1dca2