### PR TITLE
docs: add App Router migration guide and desktop layout skeleton

### DIFF
--- a/app/(desktop)/layout.tsx
+++ b/app/(desktop)/layout.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import '../../lib/dev-ssr-logger';
+import { useEffect, useState, type ReactNode } from 'react';
+import { initAxiom } from '../../lib/axiom';
+import { maskPII, trackWebVital } from '../../lib/analytics';
+import ReactGA from 'react-ga4';
+import { Analytics } from '@vercel/analytics/next';
+import { Inter } from 'next/font/google';
+import 'tailwindcss/tailwind.css';
+import '../../styles/index.css';
+import ConsentBanner from '../../components/ConsentBanner';
+import { validatePublicEnv } from '../../lib/validate';
+
+type Props = { children: ReactNode };
+
+const inter = Inter({ subsets: ['latin'] });
+
+validatePublicEnv(process.env);
+initAxiom();
+
+const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+const shouldTrack = Math.random() < 0.1;
+
+const schedule = (cb: () => void) => {
+  if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+    (window as any).requestIdleCallback(cb);
+  } else {
+    setTimeout(cb, 0);
+  }
+};
+
+const sanitize = (params: any) => {
+  if (!params || typeof params !== 'object') return params;
+  const { payload, body, data, ...rest } = params;
+  return maskPII(rest);
+};
+
+// Default to no-op analytics until consent is granted
+ReactGA.event = () => {};
+ReactGA.send = () => {};
+
+export default function DesktopLayout({ children }: Props) {
+  const [enableAnalytics, setEnableAnalytics] = useState(false);
+  const [consent, setConsent] = useState<'granted' | 'denied' | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('analytics-consent');
+      if (stored === 'granted' || stored === 'denied') {
+        setConsent(stored);
+      }
+    }
+
+    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+
+    const errorHandler = (
+      message: string | Event,
+      source?: string,
+      lineno?: number,
+      colno?: number,
+      error?: Error
+    ): void => {
+      const payload = maskPII({
+        message: String(message),
+        source,
+        lineno,
+        colno,
+        stack: error?.stack,
+      });
+      try {
+        fetch('/api/reportException', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } catch {
+        // ignore network errors
+      }
+    };
+
+    window.onerror = errorHandler;
+    return () => {
+      window.onerror = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (consent === 'granted' && shouldTrack && analyticsEnabled) {
+      const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
+      if (trackingId) {
+        schedule(() => {
+          const originalEvent = ReactGA.event.bind(ReactGA);
+          const originalSend = ReactGA.send.bind(ReactGA);
+
+          ReactGA.event = (...args: any[]) => {
+            if (!shouldTrack) return;
+            schedule(() => {
+              if (typeof args[0] === 'string') {
+                originalEvent(args[0], sanitize(args[1]));
+              } else {
+                originalEvent(sanitize(args[0]));
+              }
+            });
+          };
+
+          ReactGA.send = (...args: any[]) => {
+            if (!shouldTrack) return;
+            schedule(() => {
+              originalSend(sanitize(args[0]));
+            });
+          };
+
+          ReactGA.initialize(trackingId);
+          setEnableAnalytics(true);
+        });
+      }
+    } else {
+      ReactGA.event = () => {};
+      ReactGA.send = () => {};
+    }
+  }, [consent]);
+
+  useEffect(() => {
+    if (
+      analyticsEnabled &&
+      typeof window !== 'undefined' &&
+      window.localStorage.getItem('analytics-consent') === 'granted'
+    ) {
+      // Web Vitals reporting mirrors pages/_app.tsx
+      const handler = (metric: any) => trackWebVital(metric);
+      (window as any).__NEXT_REPORT_VITALS__ = handler;
+    }
+  }, []);
+
+  return (
+    <main className={inter.className} suppressHydrationWarning data-app-root>
+      {children}
+      {analyticsEnabled && enableAnalytics && shouldTrack && <Analytics />}
+      {consent === null && (
+        <ConsentBanner
+          onConsent={(granted) => setConsent(granted ? 'granted' : 'denied')}
+        />
+      )}
+    </main>
+  );
+}

--- a/docs/migration-app-router.md
+++ b/docs/migration-app-router.md
@@ -1,0 +1,20 @@
+# App Router Migration Steps
+
+This guide explains how to move entries from the legacy `pages/` directory into the `app/` directory while preserving layouts.
+
+## Steps
+
+1. **Create a route group**
+   - Under `app/`, add a directory like `(desktop)` and include a `layout.tsx` that mirrors the behaviour of `_app.tsx`.
+2. **Mirror the path structure**
+   - For each file in `pages/`, create a matching folder inside `app/(desktop)` and add a `page.tsx`.
+3. **Transfer component code**
+   - Move the React component from the old `pages` file into the new `page.tsx`.
+4. **Update data fetching**
+   - Convert `getStaticProps`/`getServerSideProps` to `fetch` requests or server components.
+5. **Remove legacy wrappers**
+   - Delete usage of `_app.tsx` or custom documents once all routes use the App Router.
+6. **Test the migration**
+   - Run `yarn lint`, `yarn typecheck`, and `yarn test` to ensure the new route works.
+
+Following these steps allows a gradual migration to the App Router while keeping equivalent layouts.


### PR DESCRIPTION
## Summary
- document steps for migrating legacy `pages/` routes into the `app/` directory
- add `(desktop)` layout skeleton mirroring existing `_app.tsx` behavior

## Testing
- `yarn lint` *(fails: Plugin "plugin:@next" not found)*
- `yarn typecheck` *(command hung with no output)*
- `yarn test` *(fails: missing fixture files)*
- `yarn test:unit` *(fails: missing browser APIs and test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68aba197fcb08328a033ced434aff4f8