### PR TITLE
Add theme asset fallback test and validate icons in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn lint:ci
       - run: yarn typecheck
+      - run: yarn validate:icons
       - run: yarn build:ci
       - name: Jest tests
         run: yarn test --ci | tee jest-report.txt

--- a/__tests__/theme-fallback.test.ts
+++ b/__tests__/theme-fallback.test.ts
@@ -1,13 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 describe('theme fallback helpers', () => {
   const originalTheme = process.env.NEXT_PUBLIC_THEME;
 
+  beforeEach(() => {
+    (global as any).displayImportGraph = jest.fn();
+  });
+
   afterEach(() => {
     process.env.NEXT_PUBLIC_THEME = originalTheme;
+    delete (global as any).displayImportGraph;
     jest.resetModules();
   });
 
@@ -21,5 +26,26 @@ describe('theme fallback helpers', () => {
     const mod = await import('@/apps.config.js');
     expect(mod.icon('calc.png')).toBe('./themes/Yaru/apps/calc.png');
     expect(mod.sys('folder.png')).toBe('./themes/Yaru/system/folder.png');
+  });
+
+  it('falls back to Yaru when individual assets are missing from a custom theme', async () => {
+    const appsDir = path.join(__dirname, '../components/apps');
+    fs.readdirSync(appsDir).forEach((file) => {
+      const modPath = `@components/apps/${file}`;
+      jest.mock(modPath, () => ({}));
+    });
+
+    const customThemeDir = path.join(__dirname, '../public/themes/Custom');
+    const customAppsDir = path.join(customThemeDir, 'apps');
+    const customSystemDir = path.join(customThemeDir, 'system');
+    fs.mkdirSync(customAppsDir, { recursive: true });
+    fs.mkdirSync(customSystemDir, { recursive: true });
+
+    process.env.NEXT_PUBLIC_THEME = 'Custom';
+    const mod = await import('@/apps.config.js');
+    expect(mod.icon('calc.png')).toBe('./themes/Yaru/apps/calc.png');
+    expect(mod.sys('folder.png')).toBe('./themes/Yaru/system/folder.png');
+
+    fs.rmSync(customThemeDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- test: verify Yaru fallback when custom theme assets are missing
- ci: run `yarn validate:icons` during workflow

## Testing
- `yarn validate:icons`
- `JWT_SECRET=test yarn test __tests__/theme-fallback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aba1a0307c8328a3856c8587cd8d2e