### PR TITLE
feat: add app scaffolding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,26 +34,39 @@ Heavy applications should be loaded with [`next/dynamic`](https://nextjs.org/doc
 import dynamic from 'next/dynamic';
 import ReactGA from 'react-ga4';
 
-const MyApp = dynamic(() =>
-    import('./components/apps/my-app').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded My App' });
-        return mod.default;
-    }), {
-        ssr: false,
-        loading: () => (
-            <div className="h-full w-full flex items-center justify-center bg-panel text-white">
-                Loading My App...
-            </div>
-        ),
-    }
+const MyApp = dynamic(
+  () =>
+    import('./components/apps/my-app').then((mod) => {
+      ReactGA.event({ category: 'Application', action: 'Loaded My App' });
+      return mod.default;
+    }),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-panel text-white">
+        Loading My App...
+      </div>
+    ),
+  }
 );
 
 const displayMyApp = (addFolder, openApp) => (
-    <MyApp addFolder={addFolder} openApp={openApp} />
+  <MyApp addFolder={addFolder} openApp={openApp} />
 );
 ```
 
 Add the `displayMyApp` function to `apps.config.js` and reference it in the `apps` array to make the app available to the desktop.
+
+### Scripted Setup
+
+Run `yarn scaffold:app <id> "App Title"` to scaffold a new application. The script:
+
+1. Appends entries to `apps.config.js`.
+2. Creates a placeholder component in `components/apps/`.
+3. Adds an empty icon under `public/themes/Yaru/apps/`.
+4. Executes `yarn validate:icons` to verify icon paths.
+
+Use this as a starting point and replace the generated component and icon with real implementations.
 
 ### Minimal Example
 
@@ -70,7 +83,9 @@ export default function Hello() {
 ```js
 import dynamic from 'next/dynamic';
 
-const HelloApp = dynamic(() => import('./components/apps/hello'), { ssr: false });
+const HelloApp = dynamic(() => import('./components/apps/hello'), {
+  ssr: false,
+});
 
 const displayHello = (addFolder, openApp) => (
   <HelloApp addFolder={addFolder} openApp={openApp} />
@@ -95,36 +110,38 @@ To introduce a new game:
 1. **Icon** – Add the game's icon to `public/themes/Yaru/apps/` and reference it with the helper `icon('my-game.png')`.
 2. **Dynamic import** – Create the game component in `components/apps/` and load it with `next/dynamic` to keep the initial bundle small:
 
-    ```js
-    const MyGame = dynamic(() =>
-      import('./components/apps/my-game').then(mod => {
-        ReactGA.event({ category: 'Application', action: 'Loaded My Game' });
-        return mod.default;
-      }), {
-        ssr: false,
-        loading: () => (
-          <div className="h-full w-full flex items-center justify-center bg-panel text-white">
-            Loading My Game...
-          </div>
-        ),
-      }
-    );
+   ```js
+   const MyGame = dynamic(
+     () =>
+       import('./components/apps/my-game').then((mod) => {
+         ReactGA.event({ category: 'Application', action: 'Loaded My Game' });
+         return mod.default;
+       }),
+     {
+       ssr: false,
+       loading: () => (
+         <div className="h-full w-full flex items-center justify-center bg-panel text-white">
+           Loading My Game...
+         </div>
+       ),
+     }
+   );
 
-    const displayMyGame = (addFolder, openApp) => (
-      <MyGame addFolder={addFolder} openApp={openApp} />
-    );
-    ```
+   const displayMyGame = (addFolder, openApp) => (
+     <MyGame addFolder={addFolder} openApp={openApp} />
+   );
+   ```
 
 3. **Register** – Append the game's configuration object to the `games` array:
 
-    ```js
-    games.push({
-      id: 'my-game',
-      title: 'My Game',
-      icon: icon('my-game.png'),
-      screen: displayMyGame,
-    });
-    ```
+   ```js
+   games.push({
+     id: 'my-game',
+     title: 'My Game',
+     icon: icon('my-game.png'),
+     screen: displayMyGame,
+   });
+   ```
 
 The new game will then appear alongside the other games on the desktop.
 
@@ -187,6 +204,7 @@ defaults:
 - **Scaling limits** – serverless WebSockets have connection limits per region
   and may recycle instances under load. For heavy usage, monitor connection
   counts and consider a dedicated WebSocket host or external state store.
+
 ## E2E Testing
 
 The project uses [Playwright](https://playwright.dev/) for end-to-end tests.
@@ -215,4 +233,3 @@ yarn start
 ```
 
 Deploy to any platform that can run a Next.js server; static export is not supported.
-

--- a/__tests__/add-app-script.test.ts
+++ b/__tests__/add-app-script.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { addApp } from '../scripts/add-app';
+
+describe('add-app script', () => {
+  it('scaffolds files and updates config', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'app-test-'));
+    // create minimal apps.config.js
+    fs.writeFileSync(
+      path.join(tmp, 'apps.config.js'),
+      `const dynamicAppEntries = [\n];\n\nconst apps = [\n];\n`
+    );
+
+    const spawn = jest.fn();
+
+    addApp('demo-app', 'Demo App', tmp, spawn);
+
+    const cfg = fs.readFileSync(path.join(tmp, 'apps.config.js'), 'utf8');
+    expect(cfg).toContain("['demo-app', 'Demo App']");
+    expect(cfg).toContain("id: 'demo-app'");
+    expect(
+      fs.existsSync(path.join(tmp, 'components', 'apps', 'demo-app.tsx'))
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmp, 'public', 'themes', 'Yaru', 'apps', 'demo-app.svg')
+      )
+    ).toBe(true);
+    expect(spawn).toHaveBeenCalledWith('yarn', ['validate:icons'], {
+      stdio: 'inherit',
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "check:node-core": "node scripts/check-node-core-modules.js",
     "check:edge-node": "node scripts/check-edge-node-modules.js",
     "validate:icons": "node scripts/validate-icons.js",
+    "scaffold:app": "node scripts/add-app.js",
     "test:unit": "vitest",
     "format": "prettier --write .",
     "lighthouse": "lhci autorun",
     "typecheck": "tsc --noEmit",
     "build:ci": "next build",
     "lint:ci": "next lint --max-warnings=0 && yarn check:edge-node",
-
     "format:check": "prettier --check ."
   },
   "engines": {
@@ -104,7 +104,6 @@
     "react-activity-calendar": "^2.7.13",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.1",
-
     "react-force-graph": "^1.48.0",
     "react-force-graph-2d": "^1.28.0",
     "react-ga4": "^2.1.0",
@@ -177,6 +176,5 @@
     "prettier": "^3.2.5",
     "typescript": "^5.9.2",
     "vitest": "^1.6.0"
-
   }
 }

--- a/scripts/add-app.js
+++ b/scripts/add-app.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+
+const toPascal = (str) =>
+  str
+    .split(/[-_]/)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+
+const injectApp = (configPath, id, title) => {
+  let content = fs.readFileSync(configPath, 'utf8');
+
+  const dynamicRegex = /(const dynamicAppEntries = \[[^]*?)(\n\];)/;
+  const dynamicEntry = `  ['${id}', '${title}'],\n`;
+  if (dynamicRegex.test(content)) {
+    content = content.replace(dynamicRegex, `$1${dynamicEntry}$2`);
+  } else {
+    throw new Error('dynamicAppEntries not found');
+  }
+
+  const appsRegex = /(const apps = \[[^]*?)(\n\];)/;
+  const appsEntry = `  {\n    id: '${id}',\n    title: '${title}',\n    icon: icon('${id}.svg'),\n    disabled: false,\n    favourite: false,\n    desktop_shortcut: false,\n    screen: getScreen('${id}'),\n  },\n`;
+  if (appsRegex.test(content)) {
+    content = content.replace(appsRegex, `$1${appsEntry}$2`);
+  } else {
+    throw new Error('apps array not found');
+  }
+
+  fs.writeFileSync(configPath, content);
+};
+
+const scaffoldComponent = (componentsDir, id, title) => {
+  if (!fs.existsSync(componentsDir))
+    fs.mkdirSync(componentsDir, { recursive: true });
+  const pascal = toPascal(id);
+  const file = path.join(componentsDir, `${id}.tsx`);
+  const component = `import React from 'react';\n\nconst ${pascal} = () => (\n  <div data-testid='${id}-app'>New app: ${title}</div>\n);\n\nexport const display${pascal} = () => <${pascal} />;\n\nexport default display${pascal};\n`;
+  fs.writeFileSync(file, component);
+};
+
+const createIcon = (iconDir, id) => {
+  if (!fs.existsSync(iconDir)) fs.mkdirSync(iconDir, { recursive: true });
+  const iconPath = path.join(iconDir, `${id}.svg`);
+  if (!fs.existsSync(iconPath)) {
+    fs.writeFileSync(
+      iconPath,
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>\n'
+    );
+  }
+};
+
+const runValidateIcons = (spawn = child_process.spawnSync) => {
+  spawn('yarn', ['validate:icons'], { stdio: 'inherit' });
+};
+
+const addApp = (
+  id,
+  title,
+  root = path.join(__dirname, '..'),
+  spawn = child_process.spawnSync
+) => {
+  const configPath = path.join(root, 'apps.config.js');
+  const componentsDir = path.join(root, 'components', 'apps');
+  const iconDir = path.join(root, 'public', 'themes', 'Yaru', 'apps');
+  injectApp(configPath, id, title);
+  scaffoldComponent(componentsDir, id, title);
+  createIcon(iconDir, id);
+  runValidateIcons(spawn);
+};
+
+if (require.main === module) {
+  const [id, ...rest] = process.argv.slice(2);
+  const title = rest.join(' ');
+  if (!id || !title) {
+    console.error('Usage: node scripts/add-app.js <id> "App Title"');
+    process.exit(1);
+  }
+  addApp(id, title);
+}
+
+module.exports = {
+  addApp,
+  injectApp,
+  scaffoldComponent,
+  createIcon,
+  runValidateIcons,
+  toPascal,
+};


### PR DESCRIPTION
## Summary
- add script to scaffold new apps and run icon validation
- document script usage in README
- add test for app scaffolder

## Testing
- `JWT_SECRET=test yarn test __tests__/add-app-script.test.ts`
- `yarn validate:icons`


------
https://chatgpt.com/codex/tasks/task_e_68aba1a48df48328b96451f7a2866363