### PR TITLE
feat: add error pane and tests

### DIFF
--- a/__tests__/dynamicAppLoadError.test.tsx
+++ b/__tests__/dynamicAppLoadError.test.tsx
@@ -32,7 +32,9 @@ describe('createDynamicApp', () => {
     const FailingApp = createDynamicApp('non-existent', 'FailApp');
     render(<FailingApp />);
     await waitFor(() =>
-      expect(screen.getByText('Failed to load FailApp.')).toBeInTheDocument()
+      expect(
+        screen.getByText('Failed to load FailApp. Please try again.')
+      ).toBeInTheDocument()
     );
     expect(ReactGA.event).toHaveBeenCalledWith('exception', expect.any(Object));
     expect(ReactGA.event).toHaveBeenCalledWith(

--- a/__tests__/error-boundary.test.tsx
+++ b/__tests__/error-boundary.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import Window from '@components/base/window';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+describe('Error boundaries', () => {
+  it('catches errors in window content', () => {
+    jest.useFakeTimers();
+    const failingScreen = () => {
+      throw new Error('boom');
+    };
+    render(
+      <Window
+        id="test-err"
+        title="Error Window"
+        screen={failingScreen}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />,
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(screen.getByText('render_error')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /reload app/i }),
+    ).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -95,11 +95,11 @@ export const sys = (name) => resolveAsset('system', name);
 
 import createDynamicApp from './lib/createDynamicApp';
 
-class DynamicAppErrorBoundary extends React.Component {
+export class DynamicAppErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
-    this.handleRetry = this.handleRetry.bind(this);
+    this.handleReload = this.handleReload.bind(this);
   }
 
   static getDerivedStateFromError() {
@@ -119,7 +119,7 @@ class DynamicAppErrorBoundary extends React.Component {
         <ErrorPane
           code="render_error"
           message={`An error occurred while rendering ${this.props.name}. Please try again.`}
-          onRetry={this.handleRetry}
+          onReload={this.handleReload}
         />
       );
     }
@@ -127,7 +127,7 @@ class DynamicAppErrorBoundary extends React.Component {
     return this.props.children;
   }
 
-  handleRetry() {
+  handleReload() {
     this.setState({ hasError: false });
   }
 }

--- a/components/ErrorPane.tsx
+++ b/components/ErrorPane.tsx
@@ -3,19 +3,19 @@ import React from 'react';
 interface ErrorPaneProps {
   code: string;
   message: string;
-  onRetry?: () => void;
+  onReload?: () => void;
 }
 
-const ErrorPane: React.FC<ErrorPaneProps> = ({ code, message, onRetry }) => (
+const ErrorPane: React.FC<ErrorPaneProps> = ({ code, message, onReload }) => (
   <div className="h-full w-full flex flex-col items-center justify-center bg-panel text-white space-y-2 p-4 text-center">
     <div className="text-lg font-bold">{code}</div>
     <div>{message}</div>
-    {onRetry && (
+    {onReload && (
       <button
-        onClick={onRetry}
+        onClick={onReload}
         className="bg-gray-700 px-3 py-1 rounded hover:bg-gray-600"
       >
-        Retry
+        Reload app
       </button>
     )}
   </div>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -3,6 +3,7 @@ import NextImage from 'next/image';
 import { DndContext, useDraggable } from '@dnd-kit/core';
 import Settings from '../apps/settings';
 import { trackEvent, trackPageview } from '../../lib/analytics';
+import ErrorPane from '../ErrorPane';
 
 function DraggableContainer({ id, defaultPosition, bounds, onDrag, onStart, onStop, children, position: controlledPosition, onPositionChange }) {
     const [internalPosition, setInternalPosition] = React.useState(defaultPosition);
@@ -436,23 +437,46 @@ export function WindowEditButtons(props) {
     )
 }
 
+function ScreenRenderer(props) {
+    return props.screen(props.addFolder, props.openApp);
+}
+
 // Window's Main Screen
 export class WindowMainScreen extends Component {
     constructor() {
         super();
         this.state = {
             setDarkBg: false,
-        }
+            hasError: false,
+        };
+        this.handleReload = this.handleReload.bind(this);
+    }
+    static getDerivedStateFromError() {
+        return { hasError: true };
     }
     componentDidMount() {
         setTimeout(() => {
             this.setState({ setDarkBg: true });
         }, 3000);
     }
+    handleReload() {
+        if (typeof window !== 'undefined') {
+            window.location.reload();
+        }
+    }
     render() {
+        if (this.state.hasError) {
+            return (
+                <ErrorPane
+                    code="render_error"
+                    message={`An error occurred while rendering ${this.props.title}. Please try again.`}
+                    onReload={this.handleReload}
+                />
+            );
+        }
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-brand-dark " : " bg-panel")}>
-                {this.props.screen(this.props.addFolder, this.props.openApp)}
+            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-brand-dark " : " bg-panel")}> 
+                <ScreenRenderer screen={this.props.screen} addFolder={this.props.addFolder} openApp={this.props.openApp} />
             </div>
         )
     }

--- a/lib/createDynamicApp.tsx
+++ b/lib/createDynamicApp.tsx
@@ -23,7 +23,7 @@ const createDynamicApp = (path: string, name: string) =>
               <ErrorPane
                 code="load_error"
                 message={`Failed to load ${name}. Please try again.`}
-                onRetry={() => window.location.reload()}
+                onReload={() => window.location.reload()}
               />
             );
           };


### PR DESCRIPTION
## Summary
- add reusable ErrorPane with reload action
- wrap window content with error boundary using ErrorPane
- cover window error handling with unit tests

## Testing
- `yarn test __tests__/error-boundary.test.tsx __tests__/dynamicAppLoadError.test.tsx __tests__/window.test.tsx`
- `yarn test` *(fails: Missing required environment variables and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1a5cb50832887df9dd1580c9f09