### PR TITLE
fix: guard browser globals for SSR safety

### DIFF
--- a/__tests__/ubuntu.server.test.ts
+++ b/__tests__/ubuntu.server.test.ts
@@ -15,6 +15,8 @@ describe('Ubuntu component server-side', () => {
       ubuntu.getLocalData();
       ubuntu.unLockScreen();
       ubuntu.changeBackgroundImage('wall-1');
+      ubuntu.lockScreen();
+      ubuntu.shutDown();
       ubuntu.turnOn();
     }).not.toThrow();
     errorSpy.mockRestore();

--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -77,7 +77,9 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
       action: `Set Screen to Locked`,
     });
 
-    document.getElementById('status-bar')?.blur();
+    if (typeof document !== 'undefined') {
+      document.getElementById('status-bar')?.blur();
+    }
     setTimeout(() => {
       this.setState({ screen_locked: true });
     }, 100);
@@ -131,7 +133,9 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
       action: `Switched off the Ubuntu`,
     });
 
-    document.getElementById('status-bar')?.blur();
+    if (typeof document !== 'undefined') {
+      document.getElementById('status-bar')?.blur();
+    }
     this.setState({ shutDownScreen: true });
     if (typeof window !== 'undefined') {
       try {


### PR DESCRIPTION
## Summary
- wrap document access in Ubuntu component with browser checks
- expand Ubuntu server-side test to cover more methods

## Testing
- `JWT_SECRET=dummy yarn test __tests__/ubuntu.server.test.ts`
- `pre-commit run --files components/ubuntu.tsx __tests__/ubuntu.server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aba1a705448328b6d435a1970b0e7e