### PR TITLE
guard analytics calls behind env var

### DIFF
--- a/__tests__/analytics-noop.test.ts
+++ b/__tests__/analytics-noop.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('react-ga4', () => ({
+  default: {
+    send: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/axiom', () => ({
+  logEvent: vi.fn(),
+}));
+
+vi.mock('next/font/google', () => ({
+  Inter: () => ({ className: '' }),
+}));
+
+vi.mock('../lib/validate', () => ({
+  validatePublicEnv: () => {},
+}));
+
+describe('analytics disabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_ENABLE_ANALYTICS;
+    localStorage.clear();
+    localStorage.setItem('analytics-consent', 'granted');
+  });
+
+  it.each([undefined, 'false'])('trackEvent no-ops when env is %s', async (value) => {
+    if (value !== undefined) {
+      process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = value;
+    }
+    const { trackEvent } = await import('../lib/analytics');
+    const { logEvent } = await import('../lib/axiom');
+    await trackEvent('test');
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 'false'])('trackPageview no-ops when env is %s', async (value) => {
+    if (value !== undefined) {
+      process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = value;
+    }
+    const { trackPageview } = await import('../lib/analytics');
+    const ReactGA = (await import('react-ga4')).default;
+    trackPageview('/page');
+    expect(ReactGA.send).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 'false'])('reportWebVitals no-ops when env is %s', async (value) => {
+    vi.resetModules();
+    if (value !== undefined) {
+      process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = value;
+    }
+    const analytics = await import('../lib/analytics');
+    const trackWebVitalSpy = vi.spyOn(analytics, 'trackWebVital').mockResolvedValue();
+    const { reportWebVitals } = await import('../pages/_app');
+    reportWebVitals({ id: '1', name: 'CLS', value: 0, label: 'web-vital', startTime: 0 });
+    expect(trackWebVitalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -26,6 +26,7 @@ export const trackEvent = async (
   type: string,
   params: Record<string, any> = {}
 ): Promise<void> => {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
   try {
     await logEvent({ type, ...maskPII(params) });
   } catch {
@@ -36,6 +37,7 @@ export const trackEvent = async (
 export const trackWebVital = async (
   metric: NextWebVitalsMetric,
 ): Promise<void> => {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
   await trackEvent('web-vital', metric);
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,10 +13,12 @@ import { validatePublicEnv } from '../lib/validate';
 
 const inter = Inter({ subsets: ['latin'] });
 
-validatePublicEnv(process.env);
-initAxiom();
-
 const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+
+validatePublicEnv(process.env);
+if (analyticsEnabled) {
+  initAxiom();
+}
 
 const shouldTrack = Math.random() < 0.1;
 


### PR DESCRIPTION
## Summary
- prevent analytics events from firing unless `NEXT_PUBLIC_ENABLE_ANALYTICS` is set to "true"
- skip Axiom initialization when analytics disabled
- add tests to ensure analytics functions and `reportWebVitals` no-op when analytics are disabled

## Testing
- `yarn test:unit __tests__/analytics-noop.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68aba1a7bf708328a988984312405210