### PR TITLE
Add All Apps E2E test with network-stubbed Playwright config

### DIFF
--- a/e2e/2048-game.spec.ts
+++ b/e2e/2048-game.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('2048 game state updates after moves', async ({ page }) => {
   test.setTimeout(20_000);

--- a/e2e/all-apps-grid.spec.ts
+++ b/e2e/all-apps-grid.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '../playwright.config';
+
+test('All Apps grid tiles display a heading when opened', async ({ page }) => {
+  await page.goto('/apps');
+  const tiles = page.locator('a[href^="/apps/"]');
+  const count = await tiles.count();
+
+  for (let i = 0; i < count; i++) {
+    const tile = tiles.nth(i);
+    await Promise.all([
+      page.waitForNavigation(),
+      tile.click(),
+    ]);
+    await expect(page.getByRole('heading').first()).toBeVisible();
+    await page.goto('/apps');
+  }
+});

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('renders CVE dashboard app', async ({ page }) => {
   await page.goto('/apps/cve-dashboard');

--- a/e2e/desktop-open.spec.ts
+++ b/e2e/desktop-open.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('open, minimize, restore, and focus windows', async ({ page }) => {
   await page.goto('/');

--- a/e2e/desktop.spec.ts
+++ b/e2e/desktop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 // Helper to close an app window by title if it is open
 async function closeWindowByTitle(page, title) {

--- a/e2e/http-diff.spec.ts
+++ b/e2e/http-diff.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('renders HTTP diff app', async ({ page }) => {
   await page.goto('/apps/http-diff');

--- a/e2e/open-apps.spec.ts
+++ b/e2e/open-apps.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('open Firefox app from desktop', async ({ page }) => {
   await page.goto('/');

--- a/e2e/request-builder.smoke.spec.ts
+++ b/e2e/request-builder.smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../playwright.config';
 
 test('request builder page loads', async ({ page }) => {
   await page.goto('/apps/request-builder');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,40 @@
 // @ts-ignore
-import { defineConfig } from '@playwright/test';
+import { defineConfig, test as base, expect } from '@playwright/test';
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/*', route => {
+      const url = route.request().url();
+      if (
+        url.startsWith('http://localhost') ||
+        url.startsWith('https://localhost') ||
+        url.startsWith('http://127.0.0.1') ||
+        url.startsWith('https://127.0.0.1')
+      ) {
+        return route.continue();
+      }
+      return route.fulfill({ status: 204, body: '' });
+    });
+    await use(page);
+  },
+});
+
+export { expect };
 
 export default defineConfig({
   testDir: './',
   testMatch: ['e2e/**/*.spec.ts', '__tests__/e2e/**/*.spec.ts'],
+  retries: 2,
+  reporter: [['html', { open: 'never' }]],
   webServer: {
     command: 'yarn dev',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    env: {
+      JWT_SECRET: 'test-secret',
+      NODE_ENV: 'test',
+    },
   },
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- run Playwright tests with retries and HTML report, stubbing external network requests
- cover All Apps grid by opening each tile and asserting a heading is visible
- unify existing e2e specs to use shared Playwright fixtures

## Testing
- `yarn test:e2e` *(fails: __tests__/e2e/apps.spec.ts loads /apps/chrome without errors; e2e/2048-game.spec.ts; e2e/all-apps-grid.spec.ts; app.spec.ts cve API returns json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1a1a90083288aa9b53a7a999bf8