### PR TITLE
ci: cache browsers and extend matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,39 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    env:
+      JWT_SECRET: ${{ secrets.JWT_SECRET || 'test-secret' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+          cache-dependency-path: yarn.lock
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
       - run: corepack enable
       - run: yarn install --immutable
+      - run: yarn dedupe --check
       - run: yarn lint:ci
       - run: yarn typecheck
       - run: yarn build:ci
@@ -50,7 +75,7 @@ jobs:
             playwright-report
           if-no-files-found: ignore
 
-      - name: Lighthouse
+      - name: Lighthouse CI
         run: yarn lighthouse --collect.startServerCommand="yarn start" --collect.startServerReadyPattern="ready on"
       - name: Upload Lighthouse results
         if: always()


### PR DESCRIPTION
## Summary
- add Node 20 to matrix and cache yarn dependencies & Playwright browsers
- run `yarn dedupe --check` and rename Lighthouse step
- set `JWT_SECRET` with default fallback

## Testing
- `yarn install --immutable` *(fails: lockfile would have been modified)*
- `JWT_SECRET=test-secret yarn lint:ci` *(fails: Plugin "plugin:@next" not found.)*
- `JWT_SECRET=test-secret yarn test:unit --run` *(fails: HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1a90ec48328896aa8025966e8eb