### PR TITLE
chore: add jsx-a11y linting and improve focus outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ defaults:
 - **Scaling limits** – serverless WebSockets have connection limits per region
   and may recycle instances under load. For heavy usage, monitor connection
   counts and consider a dedicated WebSocket host or external state store.
+
+## Accessibility Test Plan
+
+1. Run `JWT_SECRET=dummy npx eslint components/screen/navbar.js components/screen/side_bar.js components/util-components/status_card.js components/apps/settings.js` to ensure interactive components satisfy accessibility lint rules.
+2. Start the development server with `yarn dev` and tab through interactive elements in both light and dark themes.
+3. Verify that focus outlines are clearly visible with a contrast ratio of at least 3:1 against adjacent colors.
+
 ## E2E Testing
 
 The project uses [Playwright](https://playwright.dev/) for end-to-end tests.

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -180,13 +180,14 @@ export function Settings(props) {
                 <legend className="font-bold">Wallpapers</legend>
                 <div className="flex flex-wrap justify-center items-center">
                     {Object.keys(wallpapers).map((name, index) => (
-                        <div
+                        <button
                             key={index}
-                            tabIndex={0}
+                            type="button"
                             onFocus={changeBackgroundImage}
                             onClick={changeBackgroundImage}
                             data-path={name}
-                            className={(name === bg ? ' border-yellow-700 ' : ' border-transparent ') + ' md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80'}
+                            aria-label={`Set wallpaper ${name}`}
+                            className={(name === bg ? ' border-yellow-700 ' : ' border-transparent ') + ' md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 border-4 border-opacity-80'}
                             style={{ backgroundImage: `url(${wallpapers[name]})`, backgroundSize: 'cover', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' }}
                         />
                     ))}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,44 +14,41 @@ export default class Navbar extends Component {
 	render() {
 		return (
 			<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-surface text-text text-sm select-none z-50">
-				<div
-					tabIndex="0"
-					className={
-						'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1 '
-					}
-				>
-					Activities
-				</div>
-				<div
-					tabIndex="0"
-					className={
-						'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1'
-					}
-				>
-					<Clock />
-				</div>
-				<div
-					id="status-bar"
-					tabIndex="0"
-					onFocus={() => {
-						this.setState({ status_card: true });
-					}}
-					// removed onBlur from here
-					className={
-						'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1 '
-					}
-				>
-					<Status />
-					<StatusCard
-						shutDown={this.props.shutDown}
-						lockScreen={this.props.lockScreen}
-						visible={this.state.status_card}
+                                <div
+                                        className={
+                                                'pl-3 pr-3 transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1 '
+                                        }
+                                >
+                                        Activities
+                                </div>
+                                <div
+                                        className={
+                                                'pl-2 pr-2 text-xs md:text-sm transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1'
+                                        }
+                                >
+                                        <Clock />
+                                </div>
+                                <button
+                                        id="status-bar"
+                                        type="button"
+                                        onFocus={() => {
+                                                this.setState({ status_card: true });
+                                        }}
+                                        className={
+                                                'relative pr-3 pl-3 transition duration-100 ease-in-out border-b-2 border-transparent focus:border-accent py-1 '
+                                        }
+                                >
+                                        <Status />
+                                        <StatusCard
+                                                shutDown={this.props.shutDown}
+                                                lockScreen={this.props.lockScreen}
+                                                visible={this.state.status_card}
                                                 toggleVisible={() => {
                                                         // StatusCard listens for outside clicks and calls this to hide itself
                                                         this.setState({ status_card: false });
                                                 }}
-					/>
-				</div>
+                                        />
+                                </button>
 			</div>
 		);
 	}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -47,7 +47,9 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
+        <button
+            type="button"
+            aria-label="Show Applications"
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
@@ -76,6 +78,6 @@ export function AllApps(props) {
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }

--- a/components/util-components/status_card.js
+++ b/components/util-components/status_card.js
@@ -181,11 +181,12 @@ export class StatusCard extends Component {
 						<span>Settings</span>
 					</div>
 				</div>
-				<div
-					onClick={this.props.lockScreen}
-					className="w-64 py-1.5 flex items-center justify-center bg-panel hover:bg-warm hover:bg-opacity-20"
-				>
-					<div className="w-8">
+                                <button
+                                        type="button"
+                                        onClick={this.props.lockScreen}
+                                        className="w-64 py-1.5 flex items-center justify-center bg-panel hover:bg-warm hover:bg-opacity-20"
+                                >
+                                        <div className="w-8">
                                                 <Image
                                                         width={16}
                                                         height={16}
@@ -193,16 +194,17 @@ export class StatusCard extends Component {
                                                         alt="ubuntu lock"
                                                         sizes="16px"
                                                 />
-					</div>
-					<div className="w-2/3 flex items-center justify-between">
-						<span>Lock</span>
-					</div>
-				</div>
-				<div
-					onClick={this.props.shutDown}
-					className="w-64 py-1.5 flex items-center justify-center bg-panel hover:bg-warm hover:bg-opacity-20"
-				>
-					<div className="w-8">
+                                        </div>
+                                        <div className="w-2/3 flex items-center justify-between">
+                                                <span>Lock</span>
+                                        </div>
+                                </button>
+                                <button
+                                        type="button"
+                                        onClick={this.props.shutDown}
+                                        className="w-64 py-1.5 flex items-center justify-center bg-panel hover:bg-warm hover:bg-opacity-20"
+                                >
+                                        <div className="w-8">
                                                 <Image
                                                         width={16}
                                                         height={16}
@@ -210,12 +212,12 @@ export class StatusCard extends Component {
                                                         alt="ubuntu power"
                                                         sizes="16px"
                                                 />
-					</div>
-					<div className="w-2/3 flex items-center justify-between">
-						<span>Power Off / Log Out</span>
-						<SmallArrow angle="right" />
-					</div>
-				</div>
+                                        </div>
+                                        <div className="w-2/3 flex items-center justify-between">
+                                                <span>Power Off / Log Out</span>
+                                                <SmallArrow angle="right" />
+                                        </div>
+                                </button>
 			</div>
 		);
 	}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextPlugin from "@next/eslint-plugin-next";
 import security from "eslint-plugin-security";
 import node from "eslint-plugin-node";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -16,16 +17,24 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-    nextPlugin.configs["core-web-vitals"],
     globalIgnores(["components/apps/breakout.js"]),
     {
-        extends: compat.extends("plugin:security/recommended-legacy", "prettier"),
+        extends: compat.extends(
+            "plugin:@next/next/recommended",
+            "plugin:jsx-a11y/recommended",
+            "plugin:security/recommended-legacy",
+            "prettier"
+        ),
 
         plugins: {
+            "@next/next": nextPlugin,
             security,
+            "jsx-a11y": jsxA11y,
         },
 
         rules: {
+            "@next/next/no-html-link-for-pages": "error",
+            "@next/next/no-sync-scripts": "error",
             "@next/next/no-page-custom-font": "off",
             "@next/next/no-img-element": "off",
             "security/detect-object-injection": "off",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "typecheck": "tsc --noEmit",
     "build:ci": "next build",
     "lint:ci": "next lint --max-warnings=0 && yarn check:edge-node",
-
     "format:check": "prettier --check ."
   },
   "engines": {
@@ -104,7 +103,6 @@
     "react-activity-calendar": "^2.7.13",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.1",
-
     "react-force-graph": "^1.48.0",
     "react-force-graph-2d": "^1.28.0",
     "react-ga4": "^2.1.0",
@@ -152,6 +150,7 @@
     "@types/clarinet": "^0",
     "@types/crypto-js": "^4",
     "@types/dns-packet": "^5",
+    "@types/eslint-plugin-jsx-a11y": "^6",
     "@types/eslint-plugin-security": "^3",
     "@types/howler": "^2",
     "@types/jest": "^30.0.0",
@@ -168,6 +167,7 @@
     "eslint": "^9.34.0",
     "eslint-config-next": "^15.5.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-security": "^3.0.1",
@@ -177,6 +177,5 @@
     "prettier": "^3.2.5",
     "typescript": "^5.9.2",
     "vitest": "^1.6.0"
-
   }
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -10,6 +10,11 @@ code {
     font-family: 'Fira Code', 'Fira Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
+:focus-visible {
+    outline: 2px solid var(--focus-outline) !important;
+    outline-offset: 2px;
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -3,8 +3,15 @@
   --color-surface: #1e2329;
   --color-accent: #62dafc;
   --color-text: #e6edf3;
+  --focus-outline: #ffffff;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
   --space-lg: 2rem;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --focus-outline: #000000;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,6 +2862,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-plugin-jsx-a11y@npm:^6":
+  version: 6.10.0
+  resolution: "@types/eslint-plugin-jsx-a11y@npm:6.10.0"
+  dependencies:
+    "@types/eslint": "npm:*"
+  checksum: 10c0/ec494e0ea56a0a10140316a74463eb8a6ac5ed02d7408ef91444f7c0c9bc875866a9d0be7a761f1631ea543c2413b1db947bf7cb1df9d936171e5d82f71c6772
+  languageName: node
+  linkType: hard
+
 "@types/eslint-plugin-security@npm:^3":
   version: 3.0.0
   resolution: "@types/eslint-plugin-security@npm:3.0.0"
@@ -7272,7 +7281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsx-a11y@npm:^6.10.0":
+"eslint-plugin-jsx-a11y@npm:^6.10.0, eslint-plugin-jsx-a11y@npm:^6.10.2":
   version: 6.10.2
   resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
   dependencies:
@@ -13350,7 +13359,6 @@ __metadata:
   linkType: hard
 
 "react@npm:^19.1.1":
-
   version: 19.1.1
   resolution: "react@npm:19.1.1"
   checksum: 10c0/8c9769a2dfd02e603af6445058325e6c8a24b47b185d0e461f66a6454765ddcaecb3f0a90184836c68bb509f3c38248359edbc42f0d07c23eb500a5c30c87b4e
@@ -15852,6 +15860,7 @@ __metadata:
     "@types/clarinet": "npm:^0"
     "@types/crypto-js": "npm:^4"
     "@types/dns-packet": "npm:^5"
+    "@types/eslint-plugin-jsx-a11y": "npm:^6"
     "@types/eslint-plugin-security": "npm:^3"
     "@types/howler": "npm:^2"
     "@types/jest": "npm:^30.0.0"
@@ -15898,6 +15907,7 @@ __metadata:
     eslint: "npm:^9.34.0"
     eslint-config-next: "npm:^15.5.0"
     eslint-config-prettier: "npm:^9.0.0"
+    eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-node: "npm:^11.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-security: "npm:^3.0.1"
@@ -15942,7 +15952,6 @@ __metadata:
     react-activity-calendar: "npm:^2.7.13"
     react-chartjs-2: "npm:^5.3.0"
     react-dom: "npm:^19.1.1"
-
     react-force-graph: "npm:^1.48.0"
     react-force-graph-2d: "npm:^1.28.0"
     react-ga4: "npm:^2.1.0"


### PR DESCRIPTION
## Summary
- integrate eslint-plugin-jsx-a11y and next lint rules
- convert key desktop elements to buttons for accessibility
- add high-contrast focus outlines and document accessibility test plan

## Testing
- `JWT_SECRET=dummy npx eslint components/screen/navbar.js components/screen/side_bar.js components/util-components/status_card.js components/apps/settings.js`
- `yarn test:unit` *(fails: jest is not defined, HTMLCanvasElement.prototype.getContext not implemented, and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aba19de8088328956e6824b2a5bc84