### PR TITLE
Use nonce-based CSP and document allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@
 4. Update `.env.example` whenever new environment variables are added.
 5. Run `yarn validate:icons` to ensure all icon paths in `apps.config.js` exist under `public/themes/` before committing.
 
+## Content Security Policy
+
+External resources are tightly restricted by a Content Security Policy.
+The following origins are allowed:
+
+- **Styles & fonts** – `https://fonts.googleapis.com`, `https://fonts.gstatic.com`
+- **Scripts** – `https://platform.twitter.com`
+- **Connections** – `https://cdn.syndication.twimg.com`, `https://*.twitter.com`, `https://stackblitz.com`, `https://api.axiom.co`
+- **Frames** – `https://stackblitz.com`, `https://ghbtns.com`, `https://platform.twitter.com`, `https://open.spotify.com`, `https://todoist.com`, `https://www.youtube.com`, `https://www.youtube-nocookie.com`
+
+Inline scripts require a nonce generated at request time. If an embed or widget
+fails to load, check the browser console for CSP errors and ensure the
+provider's origin is included in the relevant directive.
+
 ## Local File Storage
 
 Some API routes persist data to the filesystem when running locally. This file-based storage is best effort and may be cleared between runs. Production deployments fall back to a no-op implementation or external storage via `lib/store`.

--- a/__tests__/nextConfigCSP.test.ts
+++ b/__tests__/nextConfigCSP.test.ts
@@ -45,15 +45,16 @@ describe('next.config.js Content Security Policy', () => {
         'https://stackblitz.com',
       ])
     );
-    expect(parsed['script-src']).toEqual(
-      expect.arrayContaining([
-        "'self'",
-        'https://platform.twitter.com',
-      ])
-    );
-    expect(parsed['script-src']).not.toEqual(
-      expect.arrayContaining(["'unsafe-inline'"])
-    );
+      expect(parsed['script-src']).toEqual(
+        expect.arrayContaining([
+          "'self'",
+          expect.stringMatching(/^'nonce-/),
+          'https://platform.twitter.com',
+        ])
+      );
+      expect(parsed['script-src']).not.toEqual(
+        expect.arrayContaining(["'unsafe-inline'"])
+      );
     expect(parsed['style-src']).toEqual(
       expect.arrayContaining([
         "'self'",

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const BASE_CSP = [
+  "default-src 'self'",
+  "img-src 'self' https: data:",
+  "style-src 'self' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "script-src 'self' 'nonce-__CSP_NONCE__' https://platform.twitter.com",
+  "worker-src 'self' blob:",
+  "child-src 'self' blob:",
+  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com https://api.axiom.co",
+  "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+  "frame-ancestors 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "report-to csp-endpoint",
+].join('; ');
+
+function generateNonce(): string {
+  const array = crypto.getRandomValues(new Uint8Array(16));
+  let str = '';
+  array.forEach((b) => (str += String.fromCharCode(b)));
+  return btoa(str);
+}
+
+export function middleware(req: NextRequest) {
+  const nonce = generateNonce();
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const res = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  const csp = BASE_CSP.replace(/__CSP_NONCE__/g, nonce);
+  res.headers.set('Content-Security-Policy', csp);
+  return res;
+}
+

--- a/next.config.js
+++ b/next.config.js
@@ -14,14 +14,14 @@ const ContentSecurityPolicy = [
   // Allow external font resources
   "font-src 'self' https://fonts.gstatic.com",
   // External script required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com",
+  "script-src 'self' 'nonce-__CSP_NONCE__' https://platform.twitter.com",
   "worker-src 'self' blob:",
   "child-src 'self' blob:",
 
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.googleapis.com https://api.axiom.co https://stackblitz.com https://api64.ipify.org https://cloudflare-dns.com https://dns.google https://www.googleapis.com https://crt.sh https://services.nvd.nist.gov https://osv.dev https://data.typeracer.com https://ghbtns.com stun:stun.l.google.com:19302",
+  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com https://api.axiom.co",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://stackblitz.com https://*.google.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+  "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
 
 
   // Allow this site to embed its own resources (resume PDF)

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,18 +1,42 @@
-import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from 'next/document';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+} from 'next/document';
+import React from 'react';
 
-class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-    const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+interface MyDocumentProps extends DocumentInitialProps {
+  nonce?: string;
+}
+
+class MyDocument extends Document<MyDocumentProps> {
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<MyDocumentProps> {
+    const nonce = ctx.req?.headers['x-nonce'] as string | undefined;
+    const initialProps = await Document.getInitialProps({
+      ...ctx,
+      renderPage: () =>
+        ctx.renderPage({
+          enhanceApp: (App) => (props) => (
+            <App {...props} pageProps={{ ...props.pageProps, nonce }} />
+          ),
+        }),
+    });
+    return { ...initialProps, nonce };
   }
 
   render() {
+    const nonce = (this.props as MyDocumentProps).nonce;
     return (
       <Html lang="en">
-        <Head />
+        <Head nonce={nonce} />
         <body>
           <Main />
-          <NextScript />
+          <NextScript nonce={nonce} />
         </body>
       </Html>
     );


### PR DESCRIPTION
## Summary
- Replace `unsafe-inline` with nonce-based `script-src` and restrict external `connect-src` and `frame-src` hosts
- Generate and propagate CSP nonces at request time through middleware and custom Document
- Document allowed origins and CSP troubleshooting tips in README

## Testing
- `JWT_SECRET=test yarn test` *(fails: 10 failed, 121 passed, 131 total)*
- `JWT_SECRET=test yarn lint` *(fails: Plugin "plugin:@next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba194153483289df7bfd1cbb6d39a