### PR TITLE
Replace Kali references with Ubuntu

### DIFF
--- a/apps/wordle/index.tsx
+++ b/apps/wordle/index.tsx
@@ -23,7 +23,7 @@ interface SavedState {
 
 const keyboardRows = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'];
 
-const KaliWordle = () => {
+const UbuntuWordle = () => {
   const seed = seedIndex();
   const [answer, setAnswer] = useState('');
   const [guesses, setGuesses] = useState<string[]>([]);
@@ -138,7 +138,7 @@ const KaliWordle = () => {
   }, [handleKey]);
 
   const share = async () => {
-    const header = `Kali Wordle ${seed} ${
+    const header = `Ubuntu Wordle ${seed} ${
       guesses.some((g, i) =>
         statuses[i]?.every((s) => s === 'correct'),
       )
@@ -191,7 +191,7 @@ const KaliWordle = () => {
 
   return (
     <div className="p-4 text-center text-white select-none">
-      <h1 className="text-2xl mb-2 font-bold text-purple-300">Kali Wordle</h1>
+      <h1 className="text-2xl mb-2 font-bold text-purple-300">Ubuntu Wordle</h1>
       <div className="space-y-1 mb-2">
         {Array.from({ length: ROWS }).map((_, r) => (
           <div key={r} className="flex justify-center space-x-1">
@@ -276,5 +276,5 @@ const KaliWordle = () => {
   );
 };
 
-export default KaliWordle;
+export default UbuntuWordle;
 

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -308,7 +308,7 @@ function Skills() {
     { src: 'https://img.shields.io/badge/PowerShell-%235391FE.svg?logo=powershell&logoColor=white', alt: 'PowerShell', description: 'Automation Shell' },
     { src: 'https://img.shields.io/badge/-VMware-FFCA28?style=flat&logo=vmware&logoColor=ffffff', alt: 'VMware', description: 'Virtualization Platform' },
     { src: 'https://img.shields.io/badge/Windows-0078D6?logo=windows&logoColor=white', alt: 'Windows', description: 'Windows OS' },
-    { src: 'https://img.shields.io/badge/Kali%20Linux-557C94?logo=kalilinux&logoColor=fff', alt: 'Kali Linux', description: 'Penetration Testing Distribution' },
+    { src: 'https://img.shields.io/badge/Ubuntu%20Linux-557C94?logo=ubuntu&logoColor=fff', alt: 'Ubuntu Linux', description: 'Linux Distribution' },
     { src: 'https://img.shields.io/badge/Fedora-51A2DA?logo=fedora&logoColor=fff', alt: 'Fedora', description: 'Fedora Linux' },
     { src: 'https://img.shields.io/badge/macOS-000000?logo=macos&logoColor=F0F0F0', alt: 'macOS', description: 'Apple Operating System' },
     { src: 'https://img.shields.io/badge/PyCharm-143?logo=pycharm&logoColor=black&color=black&labelColor=green', alt: 'PyCharm', description: 'Python IDE' },

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -151,7 +151,7 @@ export class Chrome extends Component {
                     <Image
                         className="w-5"
                         src="/themes/Yaru/status/chrome_refresh.svg"
-                        alt="Kali Browser Refresh"
+                        alt="Ubuntu Browser Refresh"
                         width={20}
                         height={20}
                         sizes="20px"
@@ -161,7 +161,7 @@ export class Chrome extends Component {
                     <Image
                         className="w-5"
                         src="/themes/Yaru/status/chrome_home.svg"
-                        alt="Kali Browser Home"
+                        alt="Ubuntu Browser Home"
                         width={20}
                         height={20}
                         sizes="20px"
@@ -182,7 +182,7 @@ export class Chrome extends Component {
                         className="w-full h-full"
                         id="chrome-screen"
                         frameBorder="0"
-                        title="Kali Browser Url"
+                        title="Ubuntu Browser Url"
                         sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms"
                         onError={this.handleIframeError}
                     ></iframe>

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -36,7 +36,7 @@ export class UbuntuApp extends Component {
                     height={40}
                     className="mb-1 w-10"
                     src={this.props.icon.replace('./', '/')}
-                    alt={"Kali " + this.props.name}
+                    alt={"Ubuntu " + this.props.name}
                     sizes="40px"
                 />
                 {this.props.name}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -374,7 +374,7 @@ export function WindowEditButtons(props) {
             >
                 <NextImage
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
+                    alt="Ubuntu window minimize"
                     className="h-5 w-5 inline"
                     width={20}
                     height={20}
@@ -391,7 +391,7 @@ export function WindowEditButtons(props) {
                     >
                         <NextImage
                             src="/themes/Yaru/window/window-restore-symbolic.svg"
-                            alt="Kali window restore"
+                            alt="Ubuntu window restore"
                             className="h-5 w-5 inline"
                             width={20}
                             height={20}
@@ -407,7 +407,7 @@ export function WindowEditButtons(props) {
                     >
                         <NextImage
                             src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                            alt="Kali window maximize"
+                            alt="Ubuntu window maximize"
                             className="h-5 w-5 inline"
                             width={20}
                             height={20}
@@ -425,7 +425,7 @@ export function WindowEditButtons(props) {
             >
                 <NextImage
                     src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
+                    alt="Ubuntu window close"
                     className="h-5 w-5 inline"
                     width={20}
                     height={20}

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -5,13 +5,13 @@ const MENU_STRINGS = {
         defaultMenu: 'Main menu',
         follow: 'Follow on',
         contact: 'Contact Me',
-        reset: 'Reset Kali Linux',
+        reset: 'Reset Ubuntu Linux',
     },
     es: {
         defaultMenu: 'Menú principal',
         follow: 'Seguir en',
         contact: 'Contáctame',
-        reset: 'Restablecer Kali Linux',
+        reset: 'Restablecer Ubuntu Linux',
     },
 };
 
@@ -19,7 +19,7 @@ const MENU_LABELS = {
     followLinkedIn: 'Follow on Linkedin',
     followGithub: 'Follow on Github',
     contact: 'Contact Me',
-    reset: 'Reset Kali Linux',
+    reset: 'Reset Ubuntu Linux',
 }
 
 function DefaultMenu(props) {
@@ -60,7 +60,7 @@ function DefaultMenu(props) {
         }
     };
 
-    const resetKali = () => {
+    const resetUbuntu = () => {
         localStorage.clear();
         window.location.reload();
     };
@@ -119,7 +119,7 @@ function DefaultMenu(props) {
             </a>
             <Devider />
             <div
-                onClick={resetKali}
+                onClick={resetUbuntu}
                 role="menuitem"
                 tabIndex={-1}
                 ref={(el) => el && itemRefs.current.push(el)}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -24,7 +24,7 @@ function BootingScreen(props) {
                 height={100}
                 className="md:w-1/5 w-1/2"
                 src="/themes/Yaru/status/ubuntu_white_hex.svg"
-                alt="Kali Linux Name"
+                alt="Ubuntu Linux Name"
                 sizes="(max-width: 768px) 50vw, 20vw"
             />
             <div className="text-white mb-4">


### PR DESCRIPTION
## Summary
- Replace "Kali" alt text with "Ubuntu" across base and app components
- Update context menu strings and badges to Ubuntu
- Rename Wordle app and related strings to "Ubuntu Wordle"

## Testing
- `rg -n 'Kali' components apps`
- `JWT_SECRET=dummy yarn test` *(fails: ENOENT for test fixtures and other test failures)*
- `JWT_SECRET=dummy yarn lint` *(fails: Plugin "plugin:@next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba18c6f2883289d93a2a12489360b