### PR TITLE
Fix malformed CSP configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 // Allows external badges and same-origin PDF embedding without inline styles.
 
 const { validateEnv } = require('./lib/validate.js');
+const crypto = require('crypto');
 
 function getContentSecurityPolicy(nonce) {
   return [
@@ -16,26 +17,10 @@ function getContentSecurityPolicy(nonce) {
     `script-src 'self' 'nonce-${nonce}' https://platform.twitter.com`,
     "worker-src 'self' blob:",
     "child-src 'self' blob:",
-
-const ContentSecurityPolicy = [
-  "default-src 'self'",
-  // Allow external images and data URIs for badges/icons
-  "img-src 'self' https: data:",
-  // Allow styles from self and Google Fonts
-  "style-src 'self' https://fonts.googleapis.com",
-  // Allow external font resources
-  "font-src 'self' https://fonts.gstatic.com",
-  // External script required for embedded timelines
-  "script-src 'self' 'nonce-__CSP_NONCE__' https://platform.twitter.com",
-  "worker-src 'self' blob:",
-  "child-src 'self' blob:",
-
-  // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com https://api.axiom.co",
-  // Allow iframes from specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
-
-
+    // Allow outbound connections for embeds and the in-browser Chrome app
+    "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com https://api.axiom.co",
+    // Allow iframes from specific providers so the Chrome and StackBlitz apps can load arbitrary content
+    "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     // Allow this site to embed its own resources (resume PDF)
     "frame-ancestors 'self'",
     // Disallow plugins and limit base/submit targets
@@ -145,6 +130,7 @@ module.exports = {
       return [];
     }
     validateEnv(process.env);
+    const securityHeaders = await getSecurityHeaders();
     return [
       {
         source: '/(.*)',


### PR DESCRIPTION
## Summary
- repair `getContentSecurityPolicy` in `next.config.js`
- generate security headers at runtime with nonce support
- import `crypto` to avoid reference errors

## Testing
- `yarn build` *(fails: Module not found: ESM packages (earcut) need to be imported)*
- `yarn test` *(fails: jwks-fetcher.api.test.ts missing fixtures, analytics-noop.test.ts vitest import, serviceWorkerRegistration.test.tsx validatePublicEnv not a function, breakpoint in breakout.api.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68abb937ae188328bc0cbffba6a2746a