### PR TITLE
fix: resolve duplicate crypto import in Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@
 
 const crypto = require('crypto');
 const { validateEnv } = require('./lib/validate.js');
-const crypto = require('crypto');
 
 function getContentSecurityPolicy(nonce) {
   return [


### PR DESCRIPTION
## Summary
- fix Next.js build failure by removing duplicate `crypto` import in `next.config.js`

## Testing
- `yarn test` *(fails: analytics-noop.test.ts, gitSecretsTester.api.test.ts, rateLimitedFetch.test.ts, e2e/apps.spec.ts, tictactoe.test.ts)*
- `CI=1 yarn build` *(fails: process terminated/hung)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe8262308328ae9e2a314c807f8f