### PR TITLE
chore: ensure Yarn uses node-modules linker

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,1 @@
-# Yarn configuration
 nodeLinker: node-modules


### PR DESCRIPTION
## Summary
- streamline Yarn config to use node-modules linker

## Testing
- `yarn test` *(fails: Breakout API, rateLimitedFetch, e2e apps, tictactoe)*

------
https://chatgpt.com/codex/tasks/task_e_68abd3fdc09883289dbd58742e281e4b