### PR TITLE
Use react-twitter-widgets for X app timeline

### DIFF
--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 
-// Load the Twitter embed only on the client to avoid SSR issues.
-const TwitterTimelineEmbed = dynamic(
-  () => import('react-twitter-embed').then((mod) => mod.TwitterTimelineEmbed),
+// Load the Twitter timeline only on the client to avoid SSR issues.
+const Timeline = dynamic(
+  () => import('react-twitter-widgets').then((mod) => mod.Timeline),
   { ssr: false }
 );
 
 export default function XApp() {
   return (
     <div className="h-full w-full overflow-auto bg-panel">
-      <TwitterTimelineEmbed
-        sourceType="profile"
-        screenName="AUnnippillil"
-        options={{ chrome: 'noheader noborders' }}
-        className="w-full h-full"
+      <Timeline
+        dataSource={{ sourceType: 'profile', screenName: 'AUnnippillil' }}
+        options={{ chrome: 'noheader noborders', theme: 'dark' }}
       />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-github-calendar": "^4.5.9",
     "react-markdown": "^10.1.0",
     "react-simple-code-editor": "^0.14.1",
-    "react-twitter-embed": "^4.0.4",
+    "react-twitter-widgets": "^1.11.0",
     "react-visjs-timeline": "^1.6.0",
     "react-window": "^1.8.11",
     "rehype-sanitize": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10359,6 +10359,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loadjs@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "loadjs@npm:4.3.0"
+  checksum: 10c0/8884520a7c5f3b0f6e4d3bc01d200c73b9c468986bea26acb54939d4a3f5da08f40f712812fadc1ff6030fca936e8c9eeb842aaafd287e32ca0ce6ae9f10e759
+  languageName: node
+  linkType: hard
+
 "local-pkg@npm:^0.5.0":
   version: 0.5.1
   resolution: "local-pkg@npm:0.5.1"
@@ -13179,15 +13186,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-twitter-embed@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "react-twitter-embed@npm:4.0.4"
+"react-twitter-widgets@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "react-twitter-widgets@npm:1.11.0"
   dependencies:
-    scriptjs: "npm:^2.5.9"
+    loadjs: "npm:^4.2.0"
   peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/5c5395a8421fd67752f4eae993b682175a3757e73c338f1d0ec56cf413206ae01c9197d39dfee41d0726f4740703a9a9fdce4ac66d1529dbecf0967f7953be39
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 10c0/958967e41fc5098f2dc7078eeb8b42244dd60d7d88dca732cfc92ee9a3dbf67b83326775cd32d6cfd866c342bfd2fb3c31e5d413e91be2c30cec62b5c9008401
   languageName: node
   linkType: hard
 
@@ -13873,13 +13879,6 @@ __metadata:
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
   checksum: 10c0/5b8d5bfddaae3513410eda54f2268e98a376a429931921a81b5c3a2873aab7ca4d775a8caac5498f8cbc7d0daeab947cf923dbd8e215d61671f9f4e392d34356
-  languageName: node
-  linkType: hard
-
-"scriptjs@npm:^2.5.9":
-  version: 2.5.9
-  resolution: "scriptjs@npm:2.5.9"
-  checksum: 10c0/7b81adefb3ce7761a9b13f4cc22c6c77418a3f6a828bf400c9184ea3801c3fc2c352c4966382cece4a60cc843e0d1a1087bcf96b9a81a1bb6de7ddc60fd80811
   languageName: node
   linkType: hard
 
@@ -15814,7 +15813,7 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-markdown: "npm:^10.1.0"
     react-simple-code-editor: "npm:^0.14.1"
-    react-twitter-embed: "npm:^4.0.4"
+    react-twitter-widgets: "npm:^1.11.0"
     react-visjs-timeline: "npm:^1.6.0"
     react-window: "npm:^1.8.11"
     rehype-sanitize: "npm:^6.0.0"


### PR DESCRIPTION
## Summary
- replace `react-twitter-embed` with a dynamic import of `react-twitter-widgets` Timeline
- show the X profile timeline in dark theme
- update dependencies to use `react-twitter-widgets`

## Testing
- `yarn build` *(fails: Type error in pages/api/settings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68abd4013ec8832884873045cf704e92