### PR TITLE
feat: add reusable game layout wrapper

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import GameLayout from './GameLayout';
 
 const SIZE = 4;
 
@@ -119,39 +120,46 @@ const Game2048 = () => {
   };
 
   return (
-    <div className="h-full w-full p-4 flex flex-col items-center justify-center bg-ub-cool-grey text-white select-none">
-      <div className="grid grid-cols-4 gap-2">
-        {board.map((row, rIdx) =>
-          row.map((cell, cIdx) => (
-            <div
-              key={`${rIdx}-${cIdx}`}
-              className={`h-16 w-16 flex items-center justify-center text-2xl font-bold rounded ${
-                cell ? tileColors[cell] || 'bg-gray-700' : 'bg-gray-800'
-              }`}
-            >
-              {cell !== 0 ? cell : ''}
-            </div>
-          ))
+    <GameLayout
+      title="2048"
+      instructions="Use arrow keys to move tiles. Reach 2048 to win."
+      controls={
+        <>
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={reset}
+          >
+            Reset
+          </button>
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={close}
+          >
+            Close
+          </button>
+        </>
+      }
+    >
+      <>
+        <div className="grid grid-cols-4 gap-2">
+          {board.map((row, rIdx) =>
+            row.map((cell, cIdx) => (
+              <div
+                key={`${rIdx}-${cIdx}`}
+                className={`h-16 w-16 flex items-center justify-center text-2xl font-bold rounded ${
+                  cell ? tileColors[cell] || 'bg-gray-700' : 'bg-gray-800'
+                }`}
+              >
+                {cell !== 0 ? cell : ''}
+              </div>
+            ))
+          )}
+        </div>
+        {(won || lost) && (
+          <div className="mt-4 text-xl">{won ? 'You win!' : 'Game over'}</div>
         )}
-      </div>
-      {(won || lost) && (
-        <div className="mt-4 text-xl">{won ? 'You win!' : 'Game over'}</div>
-      )}
-      <div className="mt-4 space-x-2">
-        <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-          onClick={reset}
-        >
-          Reset
-        </button>
-        <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-          onClick={close}
-        >
-          Close
-        </button>
-      </div>
-    </div>
+      </>
+    </GameLayout>
   );
 };
 

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface GameLayoutProps {
+  title: string;
+  score?: React.ReactNode;
+  instructions?: React.ReactNode;
+  controls?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const GameLayout: React.FC<GameLayoutProps> = ({
+  title,
+  score,
+  instructions,
+  controls,
+  children,
+}) => {
+  return (
+    <div className="h-full w-full p-4 flex flex-col bg-ub-cool-grey text-white">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold">{title}</h2>
+        {score && <div>{score}</div>}
+      </div>
+      <div className="flex-1 flex flex-col items-center justify-center">
+        {children}
+      </div>
+      {instructions && (
+        <div className="mt-4 text-sm text-center">{instructions}</div>
+      )}
+      {controls && (
+        <div className="mt-4 flex space-x-2 justify-center">{controls}</div>
+      )}
+    </div>
+  );
+};
+
+export default GameLayout;

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import GameLayout from './GameLayout';
 
 const FlappyBird = () => {
   const canvasRef = useRef(null);
@@ -124,12 +125,14 @@ const FlappyBird = () => {
   }, []);
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={400}
-      height={300}
-      className="w-full h-full bg-black"
-    />
+    <GameLayout title="Flappy Bird" instructions="Press Space to flap.">
+      <canvas
+        ref={canvasRef}
+        width={400}
+        height={300}
+        className="w-full h-full bg-black"
+      />
+    </GameLayout>
   );
 };
 

--- a/components/apps/game.js
+++ b/components/apps/game.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import GameLayout from './GameLayout';
 
 const lines = [
   [0, 1, 2],
@@ -62,8 +63,18 @@ const GameApp = () => {
   }, []);
 
   return (
-    <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col items-center justify-center">
-      <div className="mb-4 text-xl">{status}</div>
+    <GameLayout
+      title="Tic Tac Toe"
+      score={<div className="text-xl">{status}</div>}
+      controls={
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={reset}
+        >
+          Reset
+        </button>
+      }
+    >
       <div className="grid grid-cols-3 gap-2">
         {squares.map((value, idx) => (
           <button
@@ -75,13 +86,7 @@ const GameApp = () => {
           </button>
         ))}
       </div>
-      <button
-        className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-        onClick={reset}
-      >
-        Reset
-      </button>
-    </div>
+    </GameLayout>
   );
 };
 

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import GameLayout from './GameLayout';
 
 // size of the square play field
 const gridSize = 20;
@@ -232,47 +233,58 @@ const Snake = () => {
   }
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white select-none">
-      <div className="mb-2 flex space-x-2">
-        <span>Score: {score}</span>
-        <span>| High Score: {highScore}</span>
-        <button
-          className="ml-2 px-2 py-0.5 bg-gray-700 rounded"
-          onClick={() => setPaused((p) => !p)}
-        >
-          {paused ? 'Resume' : 'Pause'}
-        </button>
-        <button
-          className="ml-2 px-2 py-0.5 bg-gray-700 rounded"
-          onClick={() => setWrap((w) => !w)}
-        >
-          {wrap ? 'No Wrap' : 'Wrap'}
-        </button>
-      </div>
-      <div
-        className="grid"
-        style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(0, 1fr))` }}
-      >
-        {cells}
-      </div>
-      {gameOver && (
-        <div className="mt-2 flex items-center space-x-2">
-          <span>Game Over</span>
-          <button
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
-            onClick={reset}
-          >
-            Retry
-          </button>
-          <button
-            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
-            onClick={playReplay}
-          >
-            Replay
-          </button>
+    <GameLayout
+      title="Snake"
+      score={
+        <div className="flex space-x-2">
+          <span>Score: {score}</span>
+          <span>| High Score: {highScore}</span>
         </div>
-      )}
-    </div>
+      }
+      controls={
+        <>
+          <button
+            className="px-2 py-0.5 bg-gray-700 rounded"
+            onClick={() => setPaused((p) => !p)}
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+          <button
+            className="px-2 py-0.5 bg-gray-700 rounded"
+            onClick={() => setWrap((w) => !w)}
+          >
+            {wrap ? 'No Wrap' : 'Wrap'}
+          </button>
+        </>
+      }
+      instructions="Use arrow keys or swipe to move."
+    >
+      <>
+        <div
+          className="grid"
+          style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(0, 1fr))` }}
+        >
+          {cells}
+        </div>
+        {gameOver && (
+          <div className="mt-2 flex items-center space-x-2">
+            <span>Game Over</span>
+            <button
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={reset}
+            >
+              Retry
+            </button>
+            <button
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={playReplay}
+            >
+              Replay
+            </button>
+          </div>
+        )}
+      </>
+    </GameLayout>
   );
 };
 

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import confetti from 'canvas-confetti';
+import GameLayout from './GameLayout';
 
 const winningLines = [
   [0, 1, 2],
@@ -145,58 +146,70 @@ const TicTacToe = () => {
 
   if (player === null) {
     return (
-      <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
-        {difficultySlider}
-        <div className="mb-4">Choose X or O</div>
-        <div className="flex space-x-4">
-          <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-            onClick={() => startGame('X')}
-          >
-            X
-          </button>
-          <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-            onClick={() => startGame('O')}
-          >
-            O
-          </button>
-        </div>
-      </div>
+      <GameLayout
+        title="Tic Tac Toe"
+        controls={
+          <div className="flex space-x-4">
+            <button
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={() => startGame('X')}
+            >
+              X
+            </button>
+            <button
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+              onClick={() => startGame('O')}
+            >
+              O
+            </button>
+          </div>
+        }
+      >
+        <>
+          {difficultySlider}
+          <div className="mb-4">Choose X or O</div>
+        </>
+      </GameLayout>
     );
   }
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
-      {difficultySlider}
-      <div className="grid grid-cols-3 gap-1 w-60 mb-4">
-        {board.map((cell, idx) => (
-          <button
-            key={idx}
-            className={`h-20 w-20 text-4xl flex items-center justify-center bg-gray-700 hover:bg-gray-600 ${
-              winningLine.includes(idx) ? 'bg-green-600 animate-pulse' : ''
-            }`}
-            onClick={() => handleClick(idx)}
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                handleClick(idx);
-              }
-            }}
-          >
-            {cell}
-          </button>
-        ))}
-      </div>
-      <div className="mb-4">{status}</div>
-      <button
-        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
-        onClick={reset}
-      >
-        Reset
-      </button>
-    </div>
+    <GameLayout
+      title="Tic Tac Toe"
+      score={<div>{status}</div>}
+      controls={
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={reset}
+        >
+          Reset
+        </button>
+      }
+    >
+      <>
+        {difficultySlider}
+        <div className="grid grid-cols-3 gap-1 w-60 mb-4">
+          {board.map((cell, idx) => (
+            <button
+              key={idx}
+              className={`h-20 w-20 text-4xl flex items-center justify-center bg-gray-700 hover:bg-gray-600 ${
+                winningLine.includes(idx) ? 'bg-green-600 animate-pulse' : ''
+              }`}
+              onClick={() => handleClick(idx)}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleClick(idx);
+                }
+              }}
+            >
+              {cell}
+            </button>
+          ))}
+        </div>
+      </>
+    </GameLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- add shared `GameLayout` component to standardize game UIs
- wrap several games (`2048`, `Flappy Bird`, `Snake`, `Tic Tac Toe`) with the new layout

## Testing
- `CI=true yarn test 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68ac09a43f208328b8e6d5292889d8bb