### PR TITLE
feat: add game error boundaries

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const SIZE = 4;
 
@@ -155,5 +156,7 @@ const Game2048 = () => {
   );
 };
 
-export default Game2048;
+const Game2048WithBoundary = withGameErrorBoundary(Game2048);
+
+export default Game2048WithBoundary;
 

--- a/components/apps/GameErrorBoundary.tsx
+++ b/components/apps/GameErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface GameErrorBoundaryState {
+  hasError: boolean;
+}
+
+class GameErrorBoundary extends React.Component<React.PropsWithChildren<{}>, GameErrorBoundaryState> {
+  constructor(props: React.PropsWithChildren<{}>) {
+    super(props);
+    this.state = { hasError: false };
+    this.handleReload = this.handleReload.bind(this);
+  }
+
+  static getDerivedStateFromError(): GameErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Error in game component:', error, errorInfo);
+  }
+
+  handleReload() {
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    } else {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
+          <p className="mb-4">Something went wrong.</p>
+          <button
+            onClick={this.handleReload}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded"
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children as React.ReactElement;
+  }
+}
+
+export default GameErrorBoundary;
+
+export const withGameErrorBoundary = <P extends object>(Component: React.ComponentType<P>) => {
+  const Wrapped = (props: P) => (
+    <GameErrorBoundary>
+      <Component {...props} />
+    </GameErrorBoundary>
+  );
+  return Wrapped;
+};

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import LazyGitHubButton from '../LazyGitHubButton';
@@ -151,10 +152,12 @@ export class AboutAlex extends Component {
     }
 }
 
-export default AboutAlex;
+const AboutAlexWithBoundary = withGameErrorBoundary(AboutAlex);
+
+export default AboutAlexWithBoundary;
 
 export const displayAboutAlex = () => {
-    return <AboutAlex />;
+    return <AboutAlexWithBoundary />;
 }
 
 

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import { wrap, createBulletPool, spawnBullet, updateBullets, createGA } from './asteroids-utils';
 
 // Simple Quadtree for collision queries
@@ -459,5 +460,7 @@ const Asteroids = () => {
   return <canvas ref={canvasRef} className="bg-black w-full h-full touch-none" />;
 };
 
-export default Asteroids;
+const AsteroidsWithBoundary = withGameErrorBoundary(Asteroids);
+
+export default AsteroidsWithBoundary;
 

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Draggable from 'react-draggable';
 import { MonteCarloAI, BOARD_SIZE, randomizePlacement } from './battleship/ai';
 
@@ -143,4 +144,6 @@ const Battleship = () => {
   );
 };
 
-export default Battleship;
+const BattleshipWithBoundary = withGameErrorBoundary(Battleship);
+
+export default BattleshipWithBoundary;

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Breakout = () => {
   const canvasRef = useRef(null);
@@ -85,4 +86,6 @@ const Breakout = () => {
   );
 };
 
-export default Breakout;
+const BreakoutWithBoundary = withGameErrorBoundary(Breakout);
+
+export default BreakoutWithBoundary;

--- a/components/apps/calc.js
+++ b/components/apps/calc.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 const Parser = require('expr-eval').Parser;
 
 // configure parser similar to previous implementation
@@ -79,9 +80,11 @@ const Calc = () => {
   );
 };
 
-export default Calc;
+const CalcWithBoundary = withGameErrorBoundary(Calc);
+
+export default CalcWithBoundary;
 
 export const displayTerminalCalc = (addFolder, openApp) => {
-  return <Calc addFolder={addFolder} openApp={openApp} />;
+  return <CalcWithBoundary addFolder={addFolder} openApp={openApp} />;
 };
 

--- a/components/apps/candy-crush.js
+++ b/components/apps/candy-crush.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const width = 8;
 const candyColors = ['#ff6666', '#66b3ff', '#66ff66', '#ffcc66'];
@@ -111,4 +112,6 @@ const CandyCrush = () => {
   );
 };
 
-export default CandyCrush;
+const CandyCrushWithBoundary = withGameErrorBoundary(CandyCrush);
+
+export default CandyCrushWithBoundary;

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 
 // Track constants - circular course
@@ -416,5 +417,7 @@ const CarRacer = () => {
   );
 };
 
-export default CarRacer;
+const CarRacerWithBoundary = withGameErrorBoundary(CarRacer);
+
+export default CarRacerWithBoundary;
 

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Certs = () => {
   const certBadges = [
@@ -54,5 +55,7 @@ const Certs = () => {
   );
 };
 
-export default Certs;
+const CertsWithBoundary = withGameErrorBoundary(Certs);
+
+export default CertsWithBoundary;
 

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import { Chess } from 'chess.js';
 // Stockfish engine removed for compatibility; using simple AI instead
 
@@ -265,5 +266,7 @@ const ChessGame = () => {
   );
 };
 
-export default ChessGame;
+const ChessGameWithBoundary = withGameErrorBoundary(ChessGame);
+
+export default ChessGameWithBoundary;
 

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Image from 'next/image';
 
 export class Chrome extends Component {
@@ -92,8 +93,10 @@ export class Chrome extends Component {
     }
 }
 
-export default Chrome
+const ChromeWithBoundary = withGameErrorBoundary(Chrome);
+
+export default ChromeWithBoundary;
 
 export const displayChrome = () => {
-    return <Chrome> </Chrome>;
+    return <ChromeWithBoundary> </ChromeWithBoundary>;
 }

--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const ROWS = 6;
 const COLS = 7;
@@ -94,5 +95,7 @@ const ConnectFour = () => {
   );
 };
 
-export default ConnectFour;
+const ConnectFourWithBoundary = withGameErrorBoundary(ConnectFour);
+
+export default ConnectFourWithBoundary;
 

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const FlappyBird = () => {
   const canvasRef = useRef(null);
@@ -133,5 +134,7 @@ const FlappyBird = () => {
   );
 };
 
-export default FlappyBird;
+const FlappyBirdWithBoundary = withGameErrorBoundary(FlappyBird);
+
+export default FlappyBirdWithBoundary;
 

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 
 const WIDTH = 7;
@@ -384,7 +385,9 @@ const Frogger = () => {
   );
 };
 
-export default Frogger;
+const FroggerWithBoundary = withGameErrorBoundary(Frogger);
+
+export default FroggerWithBoundary;
 
 export {
   makeRng,

--- a/components/apps/game.js
+++ b/components/apps/game.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const lines = [
   [0, 1, 2],
@@ -85,7 +86,9 @@ const GameApp = () => {
   );
 };
 
-export default GameApp;
+const GameAppWithBoundary = withGameErrorBoundary(GameApp);
 
-export const displayGame = () => <GameApp />;
+export default GameAppWithBoundary;
+
+export const displayGame = () => <GameAppWithBoundary />;
 

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
@@ -118,8 +119,10 @@ export class Gedit extends Component {
     }
 }
 
-export default Gedit;
+const GeditWithBoundary = withGameErrorBoundary(Gedit);
+
+export default GeditWithBoundary;
 
 export const displayGedit = () => {
-    return <Gedit> </Gedit>;
+    return <GeditWithBoundary> </GeditWithBoundary>;
 }

--- a/components/apps/gomoku.js
+++ b/components/apps/gomoku.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const SIZE = 15;
 
@@ -85,5 +86,7 @@ const Gomoku = () => {
   );
 };
 
-export default Gomoku;
+const GomokuWithBoundary = withGameErrorBoundary(Gomoku);
+
+export default GomokuWithBoundary;
 

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import confetti from 'canvas-confetti';
 import ReactGA from 'react-ga4';
 
@@ -240,7 +241,7 @@ const Hangman = () => {
         </select>
       </div>
       <div className="mb-2">Score: {score}</div>
-      <HangmanDrawing wrong={wrong} />
+      <HangmanWithBoundaryDrawing wrong={wrong} />
       <div className="flex space-x-2 mb-4 text-2xl">
         {word.split('').map((letter, idx) => (
           <span
@@ -300,5 +301,7 @@ const Hangman = () => {
   );
 };
 
-export default Hangman;
+const HangmanWithBoundary = withGameErrorBoundary(Hangman);
+
+export default HangmanWithBoundary;
 

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import { createDeck } from './memory_utils';
 
 const modes = [2, 4, 6];
@@ -184,4 +185,6 @@ const Memory = () => {
   );
 };
 
-export default Memory;
+const MemoryWithBoundary = withGameErrorBoundary(Memory);
+
+export default MemoryWithBoundary;

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const BOARD_SIZE = 8;
 const MINES_COUNT = 10;
@@ -393,4 +394,6 @@ const Minesweeper = () => {
   );
 };
 
-export default Minesweeper;
+const MinesweeperWithBoundary = withGameErrorBoundary(Minesweeper);
+
+export default MinesweeperWithBoundary;

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 import {
   evaluateLine,
@@ -455,4 +456,6 @@ const Nonogram = () => {
   );
 };
 
-export default Nonogram;
+const NonogramWithBoundary = withGameErrorBoundary(Nonogram);
+
+export default NonogramWithBoundary;

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 /**
  * Small Pacman implementation used inside the portfolio.  The goal of this
@@ -351,5 +352,7 @@ const Pacman = () => {
   );
 };
 
-export default Pacman;
+const PacmanWithBoundary = withGameErrorBoundary(Pacman);
+
+export default PacmanWithBoundary;
 

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Pinball = () => {
   const canvasRef = useRef(null);
@@ -113,5 +114,7 @@ const Pinball = () => {
   );
 };
 
-export default Pinball;
+const PinballWithBoundary = withGameErrorBoundary(Pinball);
+
+export default PinballWithBoundary;
 

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Platformer = () => (
   <iframe
@@ -9,4 +10,6 @@ const Platformer = () => (
   ></iframe>
 );
 
-export default Platformer;
+const PlatformerWithBoundary = withGameErrorBoundary(Platformer);
+
+export default PlatformerWithBoundary;

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 // Basic timing constants so the simulation is consistent across refresh rates
 const FRAME_TIME = 1000 / 60; // ideal frame time in ms
@@ -368,5 +369,7 @@ const Pong = () => {
   );
 };
 
-export default Pong;
+const PongWithBoundary = withGameErrorBoundary(Pong);
+
+export default PongWithBoundary;
 

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 
 const GITHUB_USER = 'Alex-Unnippillil';
 
-export default function ProjectGallery() {
+function ProjectGallery() {
   const [projects, setProjects] = useState([]);
 
   useEffect(() => {
@@ -100,5 +101,8 @@ export default function ProjectGallery() {
   );
 }
 
-export const displayProjectGallery = () => <ProjectGallery />;
+export const displayProjectGallery = () => <ProjectGalleryWithBoundary />;
 
+
+const ProjectGalleryWithBoundary = withGameErrorBoundary(ProjectGallery);
+export default ProjectGalleryWithBoundary;

--- a/components/apps/quote_generator.js
+++ b/components/apps/quote_generator.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Filter from 'bad-words';
 import { toPng } from 'html-to-image';
 
@@ -243,6 +244,8 @@ const QuoteGenerator = () => {
   );
 };
 
-export default QuoteGenerator;
-export const displayQuoteGenerator = () => <QuoteGenerator />;
+const QuoteGeneratorWithBoundary = withGameErrorBoundary(QuoteGenerator);
+
+export default QuoteGeneratorWithBoundary;
+export const displayQuoteGenerator = () => <QuoteGeneratorWithBoundary />;
 

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Gauge = ({ value, label }) => {
   const radius = 45;
@@ -87,8 +88,10 @@ const ResourceMonitor = () => {
   );
 };
 
-export default ResourceMonitor;
+const ResourceMonitorWithBoundary = withGameErrorBoundary(ResourceMonitor);
+
+export default ResourceMonitorWithBoundary;
 
 export const displayResourceMonitor = (addFolder, openApp) => {
-  return <ResourceMonitor addFolder={addFolder} openApp={openApp} />;
+  return <ResourceMonitorWithBoundary addFolder={addFolder} openApp={openApp} />;
 };

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 import {
   createBoard,
@@ -248,5 +249,7 @@ const Reversi = () => {
   );
 };
 
-export default Reversi;
+const ReversiWithBoundary = withGameErrorBoundary(Reversi);
+
+export default ReversiWithBoundary;
 

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 export function Settings(props) {
     const wallpapers = {
@@ -33,9 +34,11 @@ export function Settings(props) {
     )
 }
 
-export default Settings
+const SettingsWithBoundary = withGameErrorBoundary(Settings);
+
+export default SettingsWithBoundary;
 
 
 export const displaySettings = () => {
-    return <Settings> </Settings>;
+    return <SettingsWithBoundary> </SettingsWithBoundary>;
 }

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const padStyles = [
   {
@@ -163,4 +164,6 @@ const Simon = () => {
   );
 };
 
-export default Simon;
+const SimonWithBoundary = withGameErrorBoundary(Simon);
+
+export default SimonWithBoundary;

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 // size of the square play field
 const gridSize = 20;
@@ -276,5 +277,7 @@ const Snake = () => {
   );
 };
 
-export default Snake;
+const SnakeWithBoundary = withGameErrorBoundary(Snake);
+
+export default SnakeWithBoundary;
 

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const defaultLevels = [
   [
@@ -387,5 +388,7 @@ const Sokoban = () => {
   );
 };
 
-export default Sokoban;
+const SokobanWithBoundary = withGameErrorBoundary(Sokoban);
+
+export default SokobanWithBoundary;
 

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const SpaceInvaders = () => {
   const canvasRef = useRef(null);
@@ -305,4 +306,6 @@ const SpaceInvaders = () => {
   );
 };
 
-export default SpaceInvaders;
+const SpaceInvadersWithBoundary = withGameErrorBoundary(SpaceInvaders);
+
+export default SpaceInvadersWithBoundary;

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
-export default function SpotifyApp() {
+function SpotifyApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey">
       <iframe
@@ -16,5 +17,8 @@ export default function SpotifyApp() {
   );
 }
 
-export const displaySpotify = () => <SpotifyApp />;
+export const displaySpotify = () => <SpotifyAppWithBoundary />;
 
+
+const SpotifyAppWithBoundary = withGameErrorBoundary(SpotifyApp);
+export default SpotifyAppWithBoundary;

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const SIZE = 9;
 const range = (n) => Array.from({ length: n }, (_, i) => i);
@@ -325,5 +326,7 @@ const Sudoku = () => {
   );
 };
 
-export default Sudoku;
+const SudokuWithBoundary = withGameErrorBoundary(Sudoku);
+
+export default SudokuWithBoundary;
 

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 
 const MAX_HISTORY = 50;
@@ -395,8 +396,10 @@ export class Terminal extends Component {
   }
 }
 
-export default Terminal;
+const TerminalWithBoundary = withGameErrorBoundary(Terminal);
+
+export default TerminalWithBoundary;
 
 export const displayTerminal = (addFolder, openApp) => {
-  return <Terminal addFolder={addFolder} openApp={openApp}></Terminal>;
+  return <TerminalWithBoundary addFolder={addFolder} openApp={openApp}></TerminalWithBoundary>;
 };

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const WIDTH = 10;
 const HEIGHT = 20;
@@ -65,5 +66,7 @@ const Tetris = () => {
   );
 };
 
-export default Tetris;
+const TetrisWithBoundary = withGameErrorBoundary(Tetris);
+
+export default TetrisWithBoundary;
 

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 import confetti from 'canvas-confetti';
 
@@ -201,4 +202,6 @@ const TicTacToe = () => {
 };
 
 export { checkWinner, minimax };
-export default TicTacToe;
+const TicTacToeWithBoundary = withGameErrorBoundary(TicTacToe);
+
+export default TicTacToeWithBoundary;

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,6 +1,7 @@
 import React from 'react'
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
-export default function Todoist() {
+function Todoist() {
     return (
         <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
         // just to bypass the headers 🙃
@@ -8,5 +9,8 @@ export default function Todoist() {
 }
 
 export const displayTodoist = () => {
-    return <Todoist />;
+    return <TodoistWithBoundary />;
 };
+
+const TodoistWithBoundary = withGameErrorBoundary(Todoist);
+export default TodoistWithBoundary;

--- a/components/apps/tower-defense.js
+++ b/components/apps/tower-defense.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import ReactGA from 'react-ga4';
 import Quadtree from './quadtree';
 import {
@@ -318,4 +319,6 @@ const TowerDefense = () => {
   );
 };
 
-export default TowerDefense;
+const TowerDefenseWithBoundary = withGameErrorBoundary(TowerDefense);
+
+export default TowerDefenseWithBoundary;

--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import Image from 'next/image';
 
 export class Trash extends Component {
@@ -124,8 +125,10 @@ export class Trash extends Component {
     }
 }
 
-export default Trash;
+const TrashWithBoundary = withGameErrorBoundary(Trash);
+
+export default TrashWithBoundary;
 
 export const displayTrash = () => {
-    return <Trash> </Trash>;
+    return <TrashWithBoundary> </TrashWithBoundary>;
 }

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
-export default function VsCode() {
+function VsCode() {
     return (
         <iframe
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
@@ -14,5 +15,8 @@ export default function VsCode() {
 }
 
 export const displayVsCode = () => {
-    return <VsCode />;
+    return <VsCodeWithBoundary />;
 };
+
+const VsCodeWithBoundary = withGameErrorBoundary(VsCode);
+export default VsCodeWithBoundary;

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Weather = () => {
   return (
@@ -9,9 +10,11 @@ const Weather = () => {
   );
 };
 
-export default Weather;
+const WeatherWithBoundary = withGameErrorBoundary(Weather);
+
+export default WeatherWithBoundary;
 
 export const displayWeather = () => {
-  return <Weather />;
+  return <WeatherWithBoundary />;
 };
 

--- a/components/apps/word-search.js
+++ b/components/apps/word-search.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const SIZE = 10;
 const WORDS = ['REACT', 'CODE', 'TAILWIND', 'NODE', 'JS'];
@@ -154,5 +155,7 @@ const WordSearch = () => {
   );
 };
 
-export default WordSearch;
+const WordSearchWithBoundary = withGameErrorBoundary(WordSearch);
+
+export default WordSearchWithBoundary;
 

--- a/components/apps/wordle.js
+++ b/components/apps/wordle.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const Wordle = () => {
   const [guess, setGuess] = useState('');
@@ -37,4 +38,6 @@ const Wordle = () => {
   );
 };
 
-export default Wordle;
+const WordleWithBoundary = withGameErrorBoundary(Wordle);
+
+export default WordleWithBoundary;

--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 import dynamic from 'next/dynamic';
 
 // Load the Twitter embed only on the client to avoid SSR issues.
@@ -7,7 +8,7 @@ const TwitterTimelineEmbed = dynamic(
   { ssr: false }
 );
 
-export default function XApp() {
+function XApp() {
   return (
     <div className="h-full w-full overflow-auto bg-ub-cool-grey">
       <TwitterTimelineEmbed
@@ -20,5 +21,8 @@ export default function XApp() {
   );
 }
 
-export const displayX = () => <XApp />;
+export const displayX = () => <XAppWithBoundary />;
 
+
+const XAppWithBoundary = withGameErrorBoundary(XApp);
+export default XAppWithBoundary;

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -4,13 +4,14 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+import { withGameErrorBoundary } from './GameErrorBoundary';
 
 const CHANNEL_HANDLE = 'Alex-Unnippillil';
 
 // Renders a small YouTube browser similar to the YouTube mobile UI.
 // Videos can be fetched from the real API if an API key is provided or
 // injected via the `initialVideos` prop (used in tests).
-export default function YouTubeApp({ initialVideos = [] }) {
+function YouTubeApp({ initialVideos = [] }) {
   const [videos, setVideos] = useState(initialVideos);
   const [playlists, setPlaylists] = useState([]); // [{id,title}]
   const [activeCategory, setActiveCategory] = useState('All');
@@ -254,6 +255,9 @@ export default function YouTubeApp({ initialVideos = [] }) {
     </div>
   );
 }
+
+const YouTubeAppWithBoundary = withGameErrorBoundary(YouTubeApp);
+export default YouTubeAppWithBoundary;
 
 // Wrapper used by the window manager in this portfolio project.
 export const displayYouTube = () => <YouTubeApp />;


### PR DESCRIPTION
## Summary
- add `GameErrorBoundary` with friendly reload UI
- wrap each app export in an error boundary for isolation

## Testing
- `yarn test`
- `yarn lint` *(fails: next lint deprecation warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09a6ebc48328ae32dfd15d815163