### PR TITLE
feat: unify game input controls

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
+import useGameControls from '../../hooks/useGameControls';
+import useGameControls from '../../hooks/useGameControls';
 
 const SIZE = 4;
 
@@ -80,33 +82,53 @@ const Game2048 = () => {
   const [won, setWon] = useState(false);
   const [lost, setLost] = useState(false);
 
-  const handleKey = useCallback(
-    (e) => {
-      if (e.key === 'Escape') {
+  useGameControls({
+    keydown: {
+      Escape: () => {
         document.getElementById('close-2048')?.click();
-        return;
-      }
-      if (won || lost) return;
-      let newBoard;
-      if (e.key === 'ArrowLeft') newBoard = moveLeft(board);
-      else if (e.key === 'ArrowRight') newBoard = moveRight(board);
-      else if (e.key === 'ArrowUp') newBoard = moveUp(board);
-      else if (e.key === 'ArrowDown') newBoard = moveDown(board);
-      else return;
-      if (!boardsEqual(board, newBoard)) {
-        addRandomTile(newBoard);
-        setBoard(newBoard);
-        if (checkWin(newBoard)) setWon(true);
-        else if (!hasMoves(newBoard)) setLost(true);
-      }
+      },
+      ArrowLeft: () => {
+        if (won || lost) return;
+        const newBoard = moveLeft(board);
+        if (!boardsEqual(board, newBoard)) {
+          addRandomTile(newBoard);
+          setBoard(newBoard);
+          if (checkWin(newBoard)) setWon(true);
+          else if (!hasMoves(newBoard)) setLost(true);
+        }
+      },
+      ArrowRight: () => {
+        if (won || lost) return;
+        const newBoard = moveRight(board);
+        if (!boardsEqual(board, newBoard)) {
+          addRandomTile(newBoard);
+          setBoard(newBoard);
+          if (checkWin(newBoard)) setWon(true);
+          else if (!hasMoves(newBoard)) setLost(true);
+        }
+      },
+      ArrowUp: () => {
+        if (won || lost) return;
+        const newBoard = moveUp(board);
+        if (!boardsEqual(board, newBoard)) {
+          addRandomTile(newBoard);
+          setBoard(newBoard);
+          if (checkWin(newBoard)) setWon(true);
+          else if (!hasMoves(newBoard)) setLost(true);
+        }
+      },
+      ArrowDown: () => {
+        if (won || lost) return;
+        const newBoard = moveDown(board);
+        if (!boardsEqual(board, newBoard)) {
+          addRandomTile(newBoard);
+          setBoard(newBoard);
+          if (checkWin(newBoard)) setWon(true);
+          else if (!hasMoves(newBoard)) setLost(true);
+        }
+      },
     },
-    [board, won, lost]
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [handleKey]);
+  });
 
   const reset = () => {
     setBoard(initBoard());

--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import useGameControls from '../../../hooks/useGameControls';
 import ReactGA from 'react-ga4';
 import { BlackjackGame, handValue, basicStrategy, cardValue } from './engine';
 
@@ -84,23 +85,51 @@ const Blackjack = () => {
     });
   };
 
-  useEffect(() => {
-    const onKey = (e) => {
-      if (['1', '2', '3', '4'].includes(e.key) && bet >= 0 && playerHands.length === 0) {
-        const val = CHIP_VALUES[parseInt(e.key, 10) - 1];
-        if (bet + val <= bankroll) setBet(bet + val);
-      }
-      if (e.key === 'Enter' && playerHands.length === 0 && bet > 0) start();
-      if (playerHands.length > 0) {
-        if (e.key.toLowerCase() === 'h') act('hit');
-        if (e.key.toLowerCase() === 's') act('stand');
-        if (e.key.toLowerCase() === 'd') act('double');
-        if (e.key.toLowerCase() === 'p') act('split');
-        if (e.key.toLowerCase() === 'r') act('surrender');
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+  useGameControls({
+    keydown: {
+      '1': () => {
+        if (bet >= 0 && playerHands.length === 0) {
+          const val = CHIP_VALUES[0];
+          if (bet + val <= bankroll) setBet(bet + val);
+        }
+      },
+      '2': () => {
+        if (bet >= 0 && playerHands.length === 0) {
+          const val = CHIP_VALUES[1];
+          if (bet + val <= bankroll) setBet(bet + val);
+        }
+      },
+      '3': () => {
+        if (bet >= 0 && playerHands.length === 0) {
+          const val = CHIP_VALUES[2];
+          if (bet + val <= bankroll) setBet(bet + val);
+        }
+      },
+      '4': () => {
+        if (bet >= 0 && playerHands.length === 0) {
+          const val = CHIP_VALUES[3];
+          if (bet + val <= bankroll) setBet(bet + val);
+        }
+      },
+      Enter: () => {
+        if (playerHands.length === 0 && bet > 0) start();
+      },
+      h: () => {
+        if (playerHands.length > 0) act('hit');
+      },
+      s: () => {
+        if (playerHands.length > 0) act('stand');
+      },
+      d: () => {
+        if (playerHands.length > 0) act('double');
+      },
+      p: () => {
+        if (playerHands.length > 0) act('split');
+      },
+      r: () => {
+        if (playerHands.length > 0) act('surrender');
+      },
+    },
   });
 
   const renderHand = (hand, hideFirst) => (

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,7 +1,20 @@
 import React, { useRef, useEffect } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 
 const Breakout = () => {
   const canvasRef = useRef(null);
+
+  const keys = useRef({ left: false, right: false });
+  useGameControls({
+    keydown: {
+      ArrowLeft: () => (keys.current.left = true),
+      ArrowRight: () => (keys.current.right = true),
+    },
+    keyup: {
+      ArrowLeft: () => (keys.current.left = false),
+      ArrowRight: () => (keys.current.right = false),
+    },
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -13,25 +26,13 @@ const Breakout = () => {
     const paddle = { x: width / 2 - 40, y: height - 20, w: 80, h: 10 };
     const ball = { x: width / 2, y: height / 2, vx: 150, vy: -150, r: 5 };
 
-    const keys = { left: false, right: false };
-
-    const keyDown = (e) => {
-      if (e.key === 'ArrowLeft') keys.left = true;
-      if (e.key === 'ArrowRight') keys.right = true;
-    };
-    const keyUp = (e) => {
-      if (e.key === 'ArrowLeft') keys.left = false;
-      if (e.key === 'ArrowRight') keys.right = false;
-    };
-    window.addEventListener('keydown', keyDown);
-    window.addEventListener('keyup', keyUp);
-
     let lastTime = 0;
     const loop = (time) => {
       const dt = (time - lastTime) / 1000;
       lastTime = time;
 
-      paddle.x += (keys.right - keys.left) * 300 * dt;
+      const k = keys.current;
+      paddle.x += (k.right - k.left) * 300 * dt;
       paddle.x = Math.max(0, Math.min(width - paddle.w, paddle.x));
 
       ball.x += ball.vx * dt;
@@ -69,10 +70,7 @@ const Breakout = () => {
     };
     requestAnimationFrame(loop);
 
-    return () => {
-      window.removeEventListener('keydown', keyDown);
-      window.removeEventListener('keyup', keyUp);
-    };
+    return () => {};
   }, []);
 
   return (

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 import ReactGA from 'react-ga4';
 
 // Track constants - circular course
@@ -117,6 +118,7 @@ const CarRacer = () => {
   const wheelRef = useRef(null);
   const steerButtonRef = useRef(0);
   const sensitivityRef = useRef(1);
+  const keysRef = useRef({});
   const [laps, setLaps] = useState(0);
   const [control, setControl] = useState('keys');
   const [speed, setSpeed] = useState(0);
@@ -124,6 +126,23 @@ const CarRacer = () => {
   const [lastLap, setLastLap] = useState(null);
   const [bestLap, setBestLap] = useState(null);
   const [mobileSensitivity, setMobileSensitivity] = useState(1);
+
+  useGameControls({
+    keydown: {
+      ArrowLeft: () => (keysRef.current['ArrowLeft'] = true),
+      ArrowRight: () => (keysRef.current['ArrowRight'] = true),
+      ArrowUp: () => (keysRef.current['ArrowUp'] = true),
+      ArrowDown: () => (keysRef.current['ArrowDown'] = true),
+      ' ': () => (keysRef.current[' '] = true),
+    },
+    keyup: {
+      ArrowLeft: () => (keysRef.current['ArrowLeft'] = false),
+      ArrowRight: () => (keysRef.current['ArrowRight'] = false),
+      ArrowUp: () => (keysRef.current['ArrowUp'] = false),
+      ArrowDown: () => (keysRef.current['ArrowDown'] = false),
+      ' ': () => (keysRef.current[' '] = false),
+    },
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -151,11 +170,7 @@ const CarRacer = () => {
       aiIdx++;
     }
 
-    const keys = {};
-    const keyDown = (e) => (keys[e.key] = true);
-    const keyUp = (e) => (keys[e.key] = false);
-    window.addEventListener('keydown', keyDown);
-    window.addEventListener('keyup', keyUp);
+    const keys = keysRef.current;
 
     // Touch steering wheel
       let wheelAngle = 0;
@@ -338,8 +353,6 @@ const CarRacer = () => {
 
     return () => {
       cancelAnimationFrame(animationId);
-        window.removeEventListener('keydown', keyDown);
-        window.removeEventListener('keyup', keyUp);
         window.removeEventListener('deviceorientation', handleOrientation);
         wheel && wheel.removeEventListener('pointermove', handleWheel);
       };

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -1,7 +1,27 @@
 import React, { useRef, useEffect } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 
 const FlappyBird = () => {
   const canvasRef = useRef(null);
+
+  const runningRef = useRef(true);
+  const flapRef = useRef(() => {});
+  const resetRef = useRef(() => {});
+  const addPipeRef = useRef(() => {});
+  const updateRef = useRef(() => {});
+  useGameControls({
+    keydown: {
+      Space: () => {
+        if (runningRef.current) {
+          flapRef.current();
+        } else {
+          resetRef.current();
+          addPipeRef.current();
+          requestAnimationFrame(updateRef.current);
+        }
+      },
+    },
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -16,12 +36,14 @@ const FlappyBird = () => {
     let frame = 0;
     let score = 0;
     let running = true;
+    runningRef.current = running;
 
     const addPipe = () => {
       const gap = 80;
       const top = Math.random() * (height - gap - 40) + 20;
       pipes.push({ x: width, top, bottom: top + gap });
     };
+    addPipeRef.current = addPipe;
 
     const reset = () => {
       bird = { x: 50, y: height / 2, vy: 0 };
@@ -29,25 +51,14 @@ const FlappyBird = () => {
       frame = 0;
       score = 0;
       running = true;
+      runningRef.current = running;
     };
+    resetRef.current = reset;
 
     const flap = () => {
       bird.vy = jump;
     };
-
-    const handleKey = (e) => {
-      if (e.code === 'Space') {
-        if (running) {
-          flap();
-        } else {
-          reset();
-          addPipe();
-          requestAnimationFrame(update);
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKey);
+    flapRef.current = flap;
 
     const update = () => {
       if (!running) return;
@@ -61,6 +72,7 @@ const FlappyBird = () => {
 
       if (bird.y + 10 > height || bird.y - 10 < 0) {
         running = false;
+        runningRef.current = running;
       }
 
       pipes.forEach((pipe) => {
@@ -75,6 +87,7 @@ const FlappyBird = () => {
           (bird.y - 10 < pipe.top || bird.y + 10 > pipe.bottom)
         ) {
           running = false;
+          runningRef.current = running;
         }
       });
 
@@ -82,6 +95,7 @@ const FlappyBird = () => {
 
       if (running) requestAnimationFrame(update);
     };
+    updateRef.current = update;
 
     const draw = () => {
       ctx.fillStyle = '#87CEEB';
@@ -118,9 +132,7 @@ const FlappyBird = () => {
     addPipe();
     requestAnimationFrame(update);
 
-    return () => {
-      window.removeEventListener('keydown', handleKey);
-    };
+    return () => {};
   }, []);
 
   return (

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 import ReactGA from 'react-ga4';
 
 const WIDTH = 7;
@@ -155,43 +156,20 @@ const Frogger = () => {
     clearInterval(holdRef.current);
   };
 
-  useEffect(() => {
-    const handleKey = (e) => {
-      if (e.key === 'ArrowLeft') moveFrog(-1, 0);
-      if (e.key === 'ArrowRight') moveFrog(1, 0);
-      if (e.key === 'ArrowUp') moveFrog(0, -1);
-      if (e.key === 'ArrowDown') moveFrog(0, 1);
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, []);
-
-  useEffect(() => {
-    const container = document.getElementById('frogger-container');
-    let startX = 0;
-    let startY = 0;
-    const handleStart = (e) => {
-      startX = e.touches[0].clientX;
-      startY = e.touches[0].clientY;
-    };
-    const handleEnd = (e) => {
-      const dx = e.changedTouches[0].clientX - startX;
-      const dy = e.changedTouches[0].clientY - startY;
-      if (Math.abs(dx) > Math.abs(dy)) {
-        if (dx > 30) moveFrog(1, 0);
-        else if (dx < -30) moveFrog(-1, 0);
-      } else {
-        if (dy > 30) moveFrog(0, 1);
-        else if (dy < -30) moveFrog(0, -1);
-      }
-    };
-    container?.addEventListener('touchstart', handleStart);
-    container?.addEventListener('touchend', handleEnd);
-    return () => {
-      container?.removeEventListener('touchstart', handleStart);
-      container?.removeEventListener('touchend', handleEnd);
-    };
-  }, []);
+  useGameControls({
+    keydown: {
+      ArrowLeft: () => moveFrog(-1, 0),
+      ArrowRight: () => moveFrog(1, 0),
+      ArrowUp: () => moveFrog(0, -1),
+      ArrowDown: () => moveFrog(0, 1),
+    },
+    swipe: {
+      left: () => moveFrog(-1, 0),
+      right: () => moveFrog(1, 0),
+      up: () => moveFrog(0, -1),
+      down: () => moveFrog(0, 1),
+    },
+  });
 
   useEffect(() => {
     ReactGA.event({ category: 'Frogger', action: 'level_start', value: 1 });

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 import confetti from 'canvas-confetti';
 import ReactGA from 'react-ga4';
 
@@ -159,16 +160,15 @@ const Hangman = () => {
     initGame();
   };
 
-  useEffect(() => {
-    const handler = (e) => {
-      const letter = e.key.toLowerCase();
-      if (/^[a-z]$/.test(letter)) {
-        handleGuess(letter);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  });
+  const letterMap = useMemo(() => {
+    const m = {};
+    'abcdefghijklmnopqrstuvwxyz'.split('').forEach((l) => {
+      m[l] = () => handleGuess(l);
+    });
+    return m;
+  }, [handleGuess]);
+
+  useGameControls({ keydown: letterMap });
 
   useEffect(() => {
     const winner = word && word.split('').every((l) => guessed.includes(l));

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 import ReactGA from 'react-ga4';
 import {
   evaluateLine,
@@ -162,60 +163,28 @@ const Nonogram = () => {
     }, [rows, cols, grid, scheduleToggle]);
 
     // keyboard shortcuts
-    useEffect(() => {
-      if (!started) return;
-      const handler = (e) => {
-        if (
-          [
-            'ArrowUp',
-            'ArrowDown',
-            'ArrowLeft',
-            'ArrowRight',
-            ' ',
-            'Enter',
-            'x',
-            'p',
-            'h',
-            'e',
-          ].includes(e.key)
-        )
-          e.preventDefault();
-        switch (e.key) {
-          case 'ArrowUp':
-            setSelected((s) => ({ i: Math.max(0, s.i - 1), j: s.j }));
-            break;
-          case 'ArrowDown':
-            setSelected((s) => ({ i: Math.min(rows.length - 1, s.i + 1), j: s.j }));
-            break;
-          case 'ArrowLeft':
-            setSelected((s) => ({ i: s.i, j: Math.max(0, s.j - 1) }));
-            break;
-          case 'ArrowRight':
-            setSelected((s) => ({ i: s.i, j: Math.min(cols.length - 1, s.j + 1) }));
-            break;
-          case ' ': // fallthrough
-          case 'Enter':
-            scheduleToggle(selected.i, selected.j, pencil ? 'pencil' : 'fill');
-            break;
-          case 'x':
-            scheduleToggle(selected.i, selected.j, 'cross');
-            break;
-          case 'p':
-            setPencil((p) => !p);
-            break;
-          case 'h':
-            handleHint();
-            break;
-          case 'e':
-            toggleMistakes();
-            break;
-          default:
-            break;
-        }
-      };
-      window.addEventListener('keydown', handler);
-      return () => window.removeEventListener('keydown', handler);
-    }, [started, rows, cols, selected, pencil, scheduleToggle, handleHint, toggleMistakes]);
+    useGameControls({
+      keydown: started
+        ? {
+            ArrowUp: () =>
+              setSelected((s) => ({ i: Math.max(0, s.i - 1), j: s.j })),
+            ArrowDown: () =>
+              setSelected((s) => ({ i: Math.min(rows.length - 1, s.i + 1), j: s.j })),
+            ArrowLeft: () =>
+              setSelected((s) => ({ i: s.i, j: Math.max(0, s.j - 1) })),
+            ArrowRight: () =>
+              setSelected((s) => ({ i: s.i, j: Math.min(cols.length - 1, s.j + 1) })),
+            ' ': () =>
+              scheduleToggle(selected.i, selected.j, pencil ? 'pencil' : 'fill'),
+            Enter: () =>
+              scheduleToggle(selected.i, selected.j, pencil ? 'pencil' : 'fill'),
+            x: () => scheduleToggle(selected.i, selected.j, 'cross'),
+            p: () => setPencil((p) => !p),
+            h: () => handleHint(),
+            e: () => toggleMistakes(),
+          }
+        : undefined,
+    });
 
     const handleTouchStart = (i, j) => {
       touchCross.current = false;

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -1,7 +1,20 @@
 import React, { useRef, useEffect } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 
 const Pinball = () => {
   const canvasRef = useRef(null);
+
+  const flippers = useRef({ left: false, right: false });
+  useGameControls({
+    keydown: {
+      ArrowLeft: () => (flippers.current.left = true),
+      ArrowRight: () => (flippers.current.right = true),
+    },
+    keyup: {
+      ArrowLeft: () => (flippers.current.left = false),
+      ArrowRight: () => (flippers.current.right = false),
+    },
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -12,21 +25,7 @@ const Pinball = () => {
 
     const ball = { x: width / 2, y: 50, vx: 100, vy: 0, r: 8 };
     const gravity = 500; // px per second^2
-    const flippers = { left: false, right: false };
     const floor = height - 20;
-
-    const keydown = (e) => {
-      if (e.key === 'ArrowLeft') flippers.left = true;
-      if (e.key === 'ArrowRight') flippers.right = true;
-    };
-
-    const keyup = (e) => {
-      if (e.key === 'ArrowLeft') flippers.left = false;
-      if (e.key === 'ArrowRight') flippers.right = false;
-    };
-
-    window.addEventListener('keydown', keydown);
-    window.addEventListener('keyup', keyup);
 
     const reset = () => {
       ball.x = width / 2;
@@ -61,11 +60,12 @@ const Pinball = () => {
         ball.vy *= -1;
       }
 
+      const f = flippers.current;
       if (ball.y + ball.r > floor) {
-        if (flippers.left && ball.x < width / 2) {
+        if (f.left && ball.x < width / 2) {
           ball.vy = -300;
           ball.vx = -150;
-        } else if (flippers.right && ball.x >= width / 2) {
+        } else if (f.right && ball.x >= width / 2) {
           ball.vy = -300;
           ball.vx = 150;
         } else {
@@ -78,15 +78,16 @@ const Pinball = () => {
       ctx.fillRect(0, 0, width, height);
 
       ctx.fillStyle = '#ff6f00';
+      const f = flippers.current;
       ctx.save();
       ctx.translate(80, floor);
-      ctx.rotate(flippers.left ? -0.5 : 0);
+      ctx.rotate(f.left ? -0.5 : 0);
       ctx.fillRect(-40, -5, 40, 10);
       ctx.restore();
 
       ctx.save();
       ctx.translate(width - 80, floor);
-      ctx.rotate(flippers.right ? 0.5 : 0);
+      ctx.rotate(f.right ? 0.5 : 0);
       ctx.fillRect(0, -5, 40, 10);
       ctx.restore();
 
@@ -101,8 +102,6 @@ const Pinball = () => {
 
     return () => {
       cancelAnimationFrame(animationId);
-      window.removeEventListener('keydown', keydown);
-      window.removeEventListener('keyup', keyup);
     };
   }, []);
 

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 
 // size of the square play field
 const gridSize = 20;
@@ -61,45 +62,21 @@ const Snake = () => {
     dirQueue.current.push(dir);
   }, [direction]);
 
-  // keyboard controls
-  useEffect(() => {
-    const handleKey = (e) => {
-      if (e.key === 'ArrowUp') enqueueDir({ x: 0, y: -1 });
-      if (e.key === 'ArrowDown') enqueueDir({ x: 0, y: 1 });
-      if (e.key === 'ArrowLeft') enqueueDir({ x: -1, y: 0 });
-      if (e.key === 'ArrowRight') enqueueDir({ x: 1, y: 0 });
-      if (e.key === ' ') setPaused((p) => !p);
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [enqueueDir]);
-
-  // swipe controls
-  useEffect(() => {
-    let startX = 0;
-    let startY = 0;
-    const start = (e) => {
-      startX = e.touches[0].clientX;
-      startY = e.touches[0].clientY;
-    };
-    const end = (e) => {
-      const dx = e.changedTouches[0].clientX - startX;
-      const dy = e.changedTouches[0].clientY - startY;
-      if (Math.abs(dx) > Math.abs(dy)) {
-        if (dx > 30) enqueueDir({ x: 1, y: 0 });
-        else if (dx < -30) enqueueDir({ x: -1, y: 0 });
-      } else {
-        if (dy > 30) enqueueDir({ x: 0, y: 1 });
-        else if (dy < -30) enqueueDir({ x: 0, y: -1 });
-      }
-    };
-    window.addEventListener('touchstart', start);
-    window.addEventListener('touchend', end);
-    return () => {
-      window.removeEventListener('touchstart', start);
-      window.removeEventListener('touchend', end);
-    };
-  }, [enqueueDir]);
+  useGameControls({
+    keydown: {
+      ArrowUp: () => enqueueDir({ x: 0, y: -1 }),
+      ArrowDown: () => enqueueDir({ x: 0, y: 1 }),
+      ArrowLeft: () => enqueueDir({ x: -1, y: 0 }),
+      ArrowRight: () => enqueueDir({ x: 1, y: 0 }),
+      ' ': () => setPaused((p) => !p),
+    },
+    swipe: {
+      up: () => enqueueDir({ x: 0, y: -1 }),
+      down: () => enqueueDir({ x: 0, y: 1 }),
+      left: () => enqueueDir({ x: -1, y: 0 }),
+      right: () => enqueueDir({ x: 1, y: 0 }),
+    },
+  });
 
   // movement and game logic
   const step = useCallback(() => {

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -18,6 +18,19 @@ const SpaceInvaders = () => {
   const ufoTimer = useRef(0);
   const initialCount = useRef(0);
 
+  useGameControls({
+    keydown: {
+      ArrowLeft: () => (keys.current['ArrowLeft'] = true),
+      ArrowRight: () => (keys.current['ArrowRight'] = true),
+      Space: () => (keys.current['Space'] = true),
+    },
+    keyup: {
+      ArrowLeft: () => (keys.current['ArrowLeft'] = false),
+      ArrowRight: () => (keys.current['ArrowRight'] = false),
+      Space: () => (keys.current['Space'] = false),
+    },
+  });
+
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
@@ -55,11 +68,6 @@ const SpaceInvaders = () => {
       { x: w * 0.8 - 20, y: h - 60, w: 40, h: 20, hp: 6 },
     ];
 
-    const handleKey = (e) => {
-      keys.current[e.code] = e.type === 'keydown';
-    };
-    window.addEventListener('keydown', handleKey);
-    window.addEventListener('keyup', handleKey);
 
     const shoot = (pool, x, y) => {
       for (const b of pool) {
@@ -263,8 +271,6 @@ const SpaceInvaders = () => {
 
     return () => {
       cancelAnimationFrame(reqRef.current);
-      window.removeEventListener('keydown', handleKey);
-      window.removeEventListener('keyup', handleKey);
     };
   }, []);
 

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
+import useGameControls from '../../hooks/useGameControls';
 
 const WIDTH = 10;
 const HEIGHT = 20;
@@ -26,22 +27,16 @@ const Tetris = () => {
     return () => clearInterval(interval);
   }, []);
 
-  const handleKey = useCallback((e) => {
-    if (e.key === 'ArrowLeft') {
-      setPos((p) => ({ ...p, x: Math.max(0, p.x - 1) }));
-    }
-    if (e.key === 'ArrowRight') {
-      setPos((p) => ({ ...p, x: Math.min(WIDTH - 1, p.x + 1) }));
-    }
-    if (e.key === 'ArrowDown') {
-      setPos((p) => ({ ...p, y: Math.min(HEIGHT - 1, p.y + 1) }));
-    }
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [handleKey]);
+  useGameControls({
+    keydown: {
+      ArrowLeft: () =>
+        setPos((p) => ({ ...p, x: Math.max(0, p.x - 1) })),
+      ArrowRight: () =>
+        setPos((p) => ({ ...p, x: Math.min(WIDTH - 1, p.x + 1) })),
+      ArrowDown: () =>
+        setPos((p) => ({ ...p, y: Math.min(HEIGHT - 1, p.y + 1) })),
+    },
+  });
 
   const cells = [];
   for (let y = 0; y < HEIGHT; y += 1) {

--- a/hooks/useGameControls.ts
+++ b/hooks/useGameControls.ts
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+
+export type KeyHandler = (event: KeyboardEvent) => void;
+export type TouchHandler = (event: TouchEvent) => void;
+
+export interface GameControlOptions {
+  keydown?: Record<string, KeyHandler>;
+  keyup?: Record<string, KeyHandler>;
+  swipe?: {
+    left?: TouchHandler;
+    right?: TouchHandler;
+    up?: TouchHandler;
+    down?: TouchHandler;
+  };
+  touchStart?: TouchHandler;
+  element?: HTMLElement | null;
+  threshold?: number;
+}
+
+const normalizeKey = (key: string) => (key.length === 1 ? key.toLowerCase() : key);
+
+const useGameControls = ({
+  keydown,
+  keyup,
+  swipe,
+  touchStart,
+  element,
+  threshold = 30,
+}: GameControlOptions) => {
+  useEffect(() => {
+    if (!keydown) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      const key = normalizeKey(e.key);
+      const fn = keydown[key] || keydown[e.code];
+      if (fn) fn(e);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [keydown]);
+
+  useEffect(() => {
+    if (!keyup) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      const key = normalizeKey(e.key);
+      const fn = keyup[key] || keyup[e.code];
+      if (fn) fn(e);
+    };
+    window.addEventListener('keyup', handler);
+    return () => window.removeEventListener('keyup', handler);
+  }, [keyup]);
+
+  useEffect(() => {
+    if (!swipe && !touchStart) return undefined;
+    const target: any = element || window;
+    let startX = 0;
+    let startY = 0;
+    const start = (e: TouchEvent) => {
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+      if (touchStart) touchStart(e);
+    };
+    const end = (e: TouchEvent) => {
+      if (!swipe) return;
+      const dx = e.changedTouches[0].clientX - startX;
+      const dy = e.changedTouches[0].clientY - startY;
+      if (Math.abs(dx) > Math.abs(dy)) {
+        if (dx > threshold && swipe.right) swipe.right(e);
+        else if (dx < -threshold && swipe.left) swipe.left(e);
+      } else {
+        if (dy > threshold && swipe.down) swipe.down(e);
+        else if (dy < -threshold && swipe.up) swipe.up(e);
+      }
+    };
+    target.addEventListener('touchstart', start, { passive: true });
+    if (swipe) target.addEventListener('touchend', end);
+    return () => {
+      target.removeEventListener('touchstart', start);
+      if (swipe) target.removeEventListener('touchend', end);
+    };
+  }, [swipe, touchStart, element, threshold]);
+};
+
+export default useGameControls;
+


### PR DESCRIPTION
## Summary
- add `useGameControls` hook for normalized keyboard and touch handling
- replace bespoke input listeners across game components with reusable hook
- allow per-game key and swipe mappings for flexible controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac09a9d20c832896730a831235592c