### PR TITLE
Enhance Minesweeper game features

### DIFF
--- a/components/apps/GameLayout.js
+++ b/components/apps/GameLayout.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const GameLayout = ({ minesLeft, time, children }) => (
+  <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4 select-none">
+    <div className="mb-2 flex space-x-4">
+      <span>Mines: {minesLeft}</span>
+      <span>Time: {time.toFixed(1)}s</span>
+    </div>
+    {children}
+  </div>
+);
+
+export default GameLayout;


### PR DESCRIPTION
## Summary
- Guarantee first click safety by regenerating board around initial selection
- Add GameLayout with live timer and remaining mine counter
- Allow long-press flagging and track best times per difficulty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b2eda74832898c4991146211641