### PR TITLE
Improve accessibility with ARIA attributes and focus trapping

### DIFF
--- a/components/apps/calc.js
+++ b/components/apps/calc.js
@@ -45,13 +45,13 @@ const Calc = () => {
   };
 
   const buttons = [
-    { label: '7' }, { label: '8' }, { label: '9' }, { label: '/' },
-    { label: '4' }, { label: '5' }, { label: '6' }, { label: '*' },
-    { label: '1' }, { label: '2' }, { label: '3' }, { label: '-' },
-    { label: '0' }, { label: '.' }, { label: '=' }, { label: '+' },
-    { label: '(' }, { label: ')' }, { label: '^' }, { label: 'sqrt', value: 'sqrt(' },
-    { label: 'sin', value: 'sin(' }, { label: 'cos', value: 'cos(' }, { label: 'tan', value: 'tan(' }, { label: 'log', value: 'log(' },
-    { label: 'C', type: 'clear', colSpan: 2 },
+    { label: '7' }, { label: '8' }, { label: '9' }, { label: '/', ariaLabel: 'divide' },
+    { label: '4' }, { label: '5' }, { label: '6' }, { label: '*', ariaLabel: 'multiply' },
+    { label: '1' }, { label: '2' }, { label: '3' }, { label: '-', ariaLabel: 'subtract' },
+    { label: '0' }, { label: '.' }, { label: '=', ariaLabel: 'equals' }, { label: '+', ariaLabel: 'add' },
+    { label: '(', ariaLabel: 'open parenthesis' }, { label: ')', ariaLabel: 'close parenthesis' }, { label: '^', ariaLabel: 'power' }, { label: 'sqrt', value: 'sqrt(', ariaLabel: 'square root' },
+    { label: 'sin', value: 'sin(', ariaLabel: 'sine' }, { label: 'cos', value: 'cos(', ariaLabel: 'cosine' }, { label: 'tan', value: 'tan(', ariaLabel: 'tangent' }, { label: 'log', value: 'log(', ariaLabel: 'logarithm' },
+    { label: 'C', type: 'clear', colSpan: 2, ariaLabel: 'clear' },
   ];
 
   return (
@@ -66,7 +66,8 @@ const Calc = () => {
         {buttons.map((btn, idx) => (
           <button
             key={idx}
-            className={`bg-gray-700 hover:bg-gray-600 rounded text-xl flex items-center justify-center ${
+            aria-label={btn.ariaLabel || btn.label}
+            className={`bg-gray-800 hover:bg-gray-700 rounded text-xl flex items-center justify-center ${
               btn.colSpan ? `col-span-${btn.colSpan}` : ''
             }`}
             onClick={() => handleClick(btn)}

--- a/components/apps/qr_tool/index.js
+++ b/components/apps/qr_tool/index.js
@@ -67,30 +67,47 @@ const QRTool = () => {
           onChange={(e) => setText(e.target.value)}
           className="w-full p-2 mb-2 rounded text-black"
           placeholder="Enter text"
+          aria-label="Text to encode"
         />
         <div className="flex space-x-2 mb-2">
-          <button onClick={generate} className="px-4 py-2 bg-blue-600 rounded">
+          <button
+            onClick={generate}
+            className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+            aria-label="Generate QR code"
+          >
             Generate
           </button>
-          <button onClick={download} className="px-4 py-2 bg-green-600 rounded">
+          <button
+            onClick={download}
+            className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded text-white"
+            aria-label="Download QR code"
+          >
             Download
           </button>
         </div>
-        <canvas ref={canvasRef} className="bg-white" />
+        <canvas ref={canvasRef} className="bg-white" aria-label="Generated QR code" />
       </div>
 
       <div>
         <h2 className="text-lg mb-2">Scan QR Code</h2>
-        <input type="file" accept="image/*" onChange={handleFile} className="mb-2" />
+        <input type="file" accept="image/*" onChange={handleFile} className="mb-2" aria-label="Upload image to scan" />
         <div className="flex space-x-2 mb-2">
-          <button onClick={startCamera} className="px-4 py-2 bg-blue-600 rounded">
+          <button
+            onClick={startCamera}
+            className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+            aria-label="Start camera for scanning"
+          >
             Start Camera
           </button>
-          <button onClick={stopCamera} className="px-4 py-2 bg-red-600 rounded">
+          <button
+            onClick={stopCamera}
+            className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-white"
+            aria-label="Stop camera"
+          >
             Stop Camera
           </button>
         </div>
-        <video ref={videoRef} className="w-64 h-64 bg-black" />
+        <video ref={videoRef} className="w-64 h-64 bg-black" aria-label="Camera preview" />
         {decodedText && (
           <p className="mt-2 break-all">Decoded: {decodedText}</p>
         )}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -24,7 +24,16 @@ export function Settings(props) {
                 {
                     Object.keys(wallpapers).map((name, index) => {
                         return (
-                            <div key={index} tabIndex="1" onFocus={changeBackgroundImage} data-path={name} className={((name === props.currBgImgName) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"} style={{ backgroundImage: `url(${wallpapers[name]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}></div>
+                            <div
+                                key={index}
+                                role="button"
+                                aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
+                                tabIndex="0"
+                                onFocus={changeBackgroundImage}
+                                data-path={name}
+                                className={((name === props.currBgImgName) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
+                                style={{ backgroundImage: `url(${wallpapers[name]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
+                            ></div>
                         );
                     })
                 }

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,23 +1,60 @@
-import React from 'react'
+import React, { useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
 
 function DefaultMenu(props) {
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+
     return (
-        <div id="default-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
+        <div
+            id="default-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+        >
 
             <Devider />
-            <a rel="noopener noreferrer" href="https://www.linkedin.com/in/unnippillil/" target="_blank" className="w-full block cursor-default py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <a
+                rel="noopener noreferrer"
+                href="https://www.linkedin.com/in/unnippillil/"
+                target="_blank"
+                role="menuitem"
+                aria-label="Follow on Linkedin"
+                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
-            <a rel="noopener noreferrer" href="https://github.com/Alex-Unnippillil" target="_blank" className="w-full block cursor-default py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <a
+                rel="noopener noreferrer"
+                href="https://github.com/Alex-Unnippillil"
+                target="_blank"
+                role="menuitem"
+                aria-label="Follow on Github"
+                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
-            <a rel="noopener noreferrer" href="mailto:alex.j.unnippillil@gmail.com" target="_blank" className="w-full block cursor-default py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <a
+                rel="noopener noreferrer"
+                href="mailto:alex.j.unnippillil@gmail.com"
+                target="_blank"
+                role="menuitem"
+                aria-label="Contact Me"
+                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
             <Devider />
-            <div onClick={() => { localStorage.clear(); window.location.reload() }} className="w-full block cursor-default py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <button
+                type="button"
+                onClick={() => { localStorage.clear(); window.location.reload() }}
+                role="menuitem"
+                aria-label="Reset Kali Linux"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
-            </div>
+            </button>
         </div>
     )
 }

--- a/hooks/useFocusTrap.ts
+++ b/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const selectors = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+  ];
+  return Array.from(container.querySelectorAll<HTMLElement>(selectors.join(',')));
+}
+
+export default function useFocusTrap(ref: React.RefObject<HTMLElement>, active: boolean = true) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || !active) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusableElements(node);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    const handleFocus = (e: FocusEvent) => {
+      if (!node.contains(e.target as Node)) {
+        const focusable = getFocusableElements(node);
+        focusable[0]?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('focusin', handleFocus);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('focusin', handleFocus);
+    };
+  }, [ref, active]);
+}


### PR DESCRIPTION
## Summary
- add reusable `useFocusTrap` hook to keep focus within active overlays
- apply ARIA roles and labels in context menu, calculator, QR tool, and settings apps
- adjust button colors for better WCAG contrast

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ac09ac75d483288900073aa01a1206