### PR TITLE
Add smoke test for app components and run tests in CI

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Installing Packages
         run: yarn install
 
+      - name: Test
+        run: yarn test
+
       - name: Lint
         run: yarn lint
 

--- a/__tests__/apps.smoke.test.tsx
+++ b/__tests__/apps.smoke.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import fs from 'fs';
+import path from 'path';
+import { render } from '@testing-library/react';
+
+// Some apps import this package which isn't installed in the test env
+jest.mock('styled-jsx/style', () => () => null, { virtual: true });
+
+// Mock browser APIs that may be missing in the Jest environment
+beforeAll(() => {
+  // Some apps rely on canvas APIs which aren't implemented in jsdom
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({ data: [] })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => []),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    fillText: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    transform: jest.fn(),
+    rect: jest.fn(),
+    clip: jest.fn(),
+  }));
+
+  // mock fetch for components that request external resources
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({}) })
+  );
+
+  // basic Worker mock for components using web workers
+  class WorkerMock {
+    onmessage: ((e: any) => void) | null = null;
+    postMessage() {}
+    terminate() {}
+    addEventListener() {}
+    removeEventListener() {}
+  }
+  (global as any).Worker = WorkerMock;
+
+  // matchMedia mock
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+    }));
+});
+
+describe('App component smoke tests', () => {
+  const appsDir = path.join(process.cwd(), 'components', 'apps');
+  const entries = fs.readdirSync(appsDir);
+
+  const skip = new Set(['quadtree.js']);
+
+  const targets = entries.flatMap((entry) => {
+    const fullPath = path.join(appsDir, entry);
+    const stat = fs.statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      const candidate = [
+        'index.tsx',
+        'index.ts',
+        'index.jsx',
+        'index.js',
+        `${entry}.tsx`,
+        `${entry}.ts`,
+        `${entry}.jsx`,
+        `${entry}.js`,
+      ].find((file) => fs.existsSync(path.join(fullPath, file)));
+      return candidate ? [path.join(fullPath, candidate)] : [];
+    }
+
+    if (skip.has(entry)) return [];
+    return /\.(tsx|ts|jsx|js)$/.test(entry) ? [fullPath] : [];
+  });
+
+  targets.forEach((file) => {
+    const importPath = path
+      .relative(__dirname, file)
+      .replace(/\\/g, '/');
+    const name = path.relative(appsDir, file);
+
+    it(`renders ${name} without crashing`, async () => {
+      const mod = await import(importPath);
+      const Component = mod.default || Object.values(mod)[0];
+
+      if (typeof Component !== 'function') {
+        // Skip files that don't default export a component
+        return;
+      }
+
+      render(React.createElement(Component));
+    });
+  });
+});

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import ReactGA from 'react-ga4';
 
 const WIDTH = 7;


### PR DESCRIPTION
## Summary
- add smoke tests that dynamically render all apps
- mock required browser APIs for test environment
- run unit tests in CI workflow

## Testing
- `yarn test __tests__/apps.smoke.test.tsx`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ac09b2212c832882d23e556be6fbcf