### PR TITLE
Enable touch interactions on board games

### DIFF
--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
+import { pointerHandlers } from '../../../utils/pointer';
 import {
   createBoard,
   getPieceMoves,
@@ -192,7 +193,9 @@ const Checkers = () => {
             return (
               <div
                 key={`${r}-${c}`}
-                onClick={() => (selected ? tryMove(r, c) : selectPiece(r, c))}
+                {...pointerHandlers(() =>
+                  selected ? tryMove(r, c) : selectPiece(r, c)
+                )}
                 className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center ${
                   isDark ? 'bg-gray-700' : 'bg-gray-400'
                 } ${isMove ? 'ring-2 ring-yellow-300' : ''} ${

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Chess } from 'chess.js';
+import { pointerHandlers } from '../../utils/pointer';
 // Stockfish engine removed for compatibility; using simple AI instead
 
 const pieceUnicode = {
@@ -200,8 +201,8 @@ const ChessGame = () => {
     return (
       <div
         key={squareName}
-        onClick={() => handleSquareClick(file, rank)}
-        className={`w-10 h-10 md:w-12 md:h-12 flex items-center justify-center select-none ${squareColor} ${
+        {...pointerHandlers(() => handleSquareClick(file, rank))}
+        className={`w-11 h-11 md:w-12 md:h-12 flex items-center justify-center select-none ${squareColor} ${
           isSelected ? 'ring-2 ring-yellow-400' : ''
         } ${isHighlight ? 'bg-green-500 bg-opacity-50' : ''}`}
       >

--- a/utils/pointer.ts
+++ b/utils/pointer.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+
+// Helper to normalize pointer events for both mouse and touch
+// Returns props that can be spread onto an element to handle both
+// mouse and touch interactions consistently.
+export const pointerHandlers = (handler: () => void) => ({
+  onClick: () => handler(),
+  onTouchStart: (e: React.TouchEvent) => {
+    e.preventDefault();
+    handler();
+  },
+});
+
+export default pointerHandlers;


### PR DESCRIPTION
## Summary
- add `pointerHandlers` utility to normalize mouse and touch events
- wire chess and checkers boards to use touch-capable handlers
- enlarge chess squares to 44px minimum for easier tapping

## Testing
- `CI=1 yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ac09ba28988328812d44387d1f1bdb