### PR TITLE
feat: add asset loader hook

### DIFF
--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
+import useAssetLoader from '../../hooks/useAssetLoader';
 
 /**
  * Small Pacman implementation used inside the portfolio.  The goal of this
@@ -49,6 +50,11 @@ const modeSchedule = [
 const fruitSpawnDots = [10, 30];
 
 const Pacman = () => {
+  const { loading, error } = useAssetLoader({
+    images: ['/themes/Yaru/status/ubuntu_white_hex.svg'],
+    sounds: [],
+  });
+
   const canvasRef = useRef(null);
   const mazeRef = useRef(mazeTemplate.map((row) => row.slice()));
   const pacRef = useRef({
@@ -277,6 +283,7 @@ const Pacman = () => {
   }, [step]);
 
   useEffect(() => {
+    if (loading || error) return;
     const canvas = canvasRef.current;
     canvas.width = mazeRef.current[0].length * tileSize;
     canvas.height = mazeRef.current.length * tileSize;
@@ -340,7 +347,23 @@ const Pacman = () => {
       canvas.removeEventListener('touchstart', handleTouch);
       cancelAnimationFrame(id);
     };
-  }, []);
+  }, [loading, error]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="h-8 w-8 border-4 border-yellow-400 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        Failed to load assets.
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -1,6 +1,12 @@
 import React, { useRef, useEffect } from 'react';
+import useAssetLoader from '../../hooks/useAssetLoader';
 
 const SpaceInvaders = () => {
+  const { loading, error } = useAssetLoader({
+    images: ['/themes/Yaru/status/ubuntu_white_hex.svg'],
+    sounds: [],
+  });
+
   const canvasRef = useRef(null);
   const reqRef = useRef();
   const keys = useRef({});
@@ -19,6 +25,7 @@ const SpaceInvaders = () => {
   const initialCount = useRef(0);
 
   useEffect(() => {
+    if (loading || error) return;
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     canvas.width = canvas.offsetWidth;
@@ -266,7 +273,7 @@ const SpaceInvaders = () => {
       window.removeEventListener('keydown', handleKey);
       window.removeEventListener('keyup', handleKey);
     };
-  }, []);
+  }, [loading, error]);
 
   const touchStart = (key) => () => {
     touch.current[key] = true;
@@ -274,6 +281,22 @@ const SpaceInvaders = () => {
   const touchEnd = (key) => () => {
     touch.current[key] = false;
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="h-8 w-8 border-4 border-yellow-400 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-full text-white bg-black">
+        Failed to load assets.
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full relative bg-black text-white">

--- a/hooks/useAssetLoader.ts
+++ b/hooks/useAssetLoader.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+
+interface AssetLoaderOptions {
+  images?: string[];
+  sounds?: string[];
+}
+
+interface AssetLoaderState {
+  loading: boolean;
+  error: boolean;
+}
+
+/**
+ * Preload a list of image and audio assets.  The hook returns loading and
+ * error flags so components can render placeholders or fallbacks while assets
+ * are being fetched.  If any asset fails to load the hook will report an error.
+ */
+export default function useAssetLoader(
+  { images = [], sounds = [] }: AssetLoaderOptions,
+): AssetLoaderState {
+  const [state, setState] = useState<AssetLoaderState>({ loading: true, error: false });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadImage = (src: string) => new Promise<void>((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+      img.src = src;
+    });
+
+    const loadSound = (src: string) => new Promise<void>((resolve, reject) => {
+      const audio = new Audio();
+      // oncanplaythrough fires when enough data has loaded to play the audio
+      audio.oncanplaythrough = () => resolve();
+      audio.onerror = () => reject(new Error(`Failed to load audio: ${src}`));
+      audio.src = src;
+      // Some browsers require calling load() manually for audio elements
+      audio.load();
+    });
+
+    Promise.all([
+      ...images.map(loadImage),
+      ...sounds.map(loadSound),
+    ])
+      .then(() => {
+        if (!cancelled) setState({ loading: false, error: false });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ loading: false, error: true });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [images, sounds]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- preload images and sounds with new `useAssetLoader` hook
- show loading spinner and error fallback in Pacman and Space Invaders
- guard game initialization until assets are ready

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ac09bea34883288ad008ed5823bbf8