### PR TITLE
feat: centralize game settings with context

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useGameSettings } from './settings-context';
 import confetti from 'canvas-confetti';
 import ReactGA from 'react-ga4';
 
@@ -52,8 +53,7 @@ const HangmanDrawing = ({ wrong }) => (
 const letters = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
 const Hangman = () => {
-  const [theme, setTheme] = useState('tech');
-  const [difficulty, setDifficulty] = useState('easy');
+  const { theme, setTheme, difficulty, setDifficulty } = useGameSettings();
   const [lengthIndex, setLengthIndex] = useState(0);
   const [word, setWord] = useState('');
   const [guessed, setGuessed] = useState([]);

--- a/components/apps/settings-context.ts
+++ b/components/apps/settings-context.ts
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+export type GameSettings = {
+  theme: string;
+  setTheme: (theme: string) => void;
+  sound: boolean;
+  setSound: (value: boolean) => void;
+  difficulty: string;
+  setDifficulty: (value: string) => void;
+};
+
+function usePersistentState<T>(key: string, defaultValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(key);
+      if (stored !== null) {
+        try {
+          return JSON.parse(stored);
+        } catch {
+          return stored as unknown as T;
+        }
+      }
+    }
+    return defaultValue;
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(key, JSON.stringify(state));
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+const GameSettingsContext = createContext<GameSettings | undefined>(undefined);
+
+export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = usePersistentState('game-theme', 'tech');
+  const [sound, setSound] = usePersistentState('game-sound', true);
+  const [difficulty, setDifficulty] = usePersistentState('game-difficulty', 'easy');
+
+  const value: GameSettings = { theme, setTheme, sound, setSound, difficulty, setDifficulty };
+
+  return <GameSettingsContext.Provider value={value}>{children}</GameSettingsContext.Provider>;
+};
+
+export const useGameSettings = () => {
+  const ctx = useContext(GameSettingsContext);
+  if (!ctx) throw new Error('useGameSettings must be used within GameSettingsProvider');
+  return ctx;
+};
+
+export { usePersistentState };
+

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { useGameSettings } from './settings-context';
 
 const padStyles = [
   {
@@ -25,6 +26,7 @@ export const createToneSchedule = (length, start, step) =>
   Array.from({ length }, (_, i) => start + i * step);
 
 const Simon = () => {
+  const { sound } = useGameSettings();
   const [sequence, setSequence] = useState([]);
   const [step, setStep] = useState(0);
   const [isPlayerTurn, setIsPlayerTurn] = useState(false);
@@ -34,6 +36,7 @@ const Simon = () => {
   const audioCtx = useRef(null);
 
   const scheduleTone = (freq, startTime) => {
+    if (!sound) return;
     const ctx =
       audioCtx.current || new (window.AudioContext || window.webkitAudioContext)();
     audioCtx.current = ctx;

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useGameSettings } from './settings-context';
 
 const SIZE = 9;
 const range = (n) => Array.from({ length: n }, (_, i) => i);
@@ -111,7 +112,7 @@ const generateSudoku = (difficulty = 'easy', seed = Date.now()) => {
 };
 
 const Sudoku = () => {
-  const [difficulty, setDifficulty] = useState('easy');
+  const { difficulty, setDifficulty } = useGameSettings();
   const [useDaily, setUseDaily] = useState(true);
   const [{ puzzle, solution }, setGame] = useState({ puzzle: [], solution: [] });
   const [board, setBoard] = useState([]);

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useGameSettings } from './settings-context';
 import ReactGA from 'react-ga4';
 import confetti from 'canvas-confetti';
 
@@ -49,7 +50,7 @@ const TicTacToe = () => {
   const [status, setStatus] = useState('Choose X or O');
   const [player, setPlayer] = useState(null);
   const [ai, setAi] = useState(null);
-  const [difficulty, setDifficulty] = useState('hard');
+  const { difficulty, setDifficulty } = useGameSettings();
   const [aiMoves, setAiMoves] = useState(0);
   const [winningLine, setWinningLine] = useState([]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
+import { GameSettingsProvider } from '../components/apps/settings-context';
 
 function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -13,10 +14,10 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }, []);
   return (
-    <>
+    <GameSettingsProvider>
       <Component {...pageProps} />
       <Analytics />
-    </>
+    </GameSettingsProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add `GameSettingsContext` with persistent theme, sound and difficulty preferences
- consume shared settings in Hangman, Sudoku, TicTacToe and Simon
- wrap app with settings provider for cross-game persistence

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09bd1fd08328afaca5171f8936f0