### PR TITLE
feat: enhance 2048 game with undo, leaderboard, and animations

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -266,3 +266,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .reveal {
     animation: reveal 0.3s ease-out;
 }
+
+@keyframes tilePop {
+    from { transform: scale(0); }
+    to { transform: scale(1); }
+}
+
+@keyframes tileMerge {
+    0% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.tile-pop {
+    animation: tilePop 0.15s ease-out;
+}
+
+.tile-merge {
+    animation: tileMerge 0.15s ease-out;
+}


### PR DESCRIPTION
## Summary
- add move history with undo support and board size selector
- persist scores in localStorage and show leaderboard overlay
- smooth tile spawn/merge with CSS transitions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b1a2e04832888776b05717362b4