### PR TITLE
Add Battleship AI with difficulty controls and persistent stats

### DIFF
--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -1,33 +1,99 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Draggable from 'react-draggable';
-import { MonteCarloAI, BOARD_SIZE, randomizePlacement } from './battleship/ai';
+import {
+  MonteCarloAI,
+  RandomSalvoAI,
+  BOARD_SIZE,
+  randomizePlacement,
+} from './battleship/ai';
+import GameLayout from './battleship/GameLayout';
+import usePersistentState from '../hooks/usePersistentState';
 
 const CELL = 32; // px
 
 const createBoard = () => Array(BOARD_SIZE * BOARD_SIZE).fill(null);
+
+const HitMarker = () => (
+  <svg
+    className="absolute inset-0 w-full h-full"
+    viewBox="0 0 32 32"
+    stroke="red"
+    strokeWidth="4"
+  >
+    <line x1="4" y1="4" x2="28" y2="28">
+      <animate
+        attributeName="stroke-opacity"
+        from="0"
+        to="1"
+        dur="0.2s"
+        fill="freeze"
+      />
+    </line>
+    <line x1="28" y1="4" x2="4" y2="28">
+      <animate
+        attributeName="stroke-opacity"
+        from="0"
+        to="1"
+        dur="0.2s"
+        fill="freeze"
+      />
+    </line>
+  </svg>
+);
+
+const MissMarker = () => (
+  <svg
+    className="absolute inset-0 w-full h-full"
+    viewBox="0 0 32 32"
+    stroke="white"
+    strokeWidth="3"
+    fill="none"
+  >
+    <circle cx="16" cy="16" r="0">
+      <animate attributeName="r" from="0" to="10" dur="0.3s" fill="freeze" />
+      <animate attributeName="opacity" from="0" to="1" dur="0.3s" fill="freeze" />
+    </circle>
+  </svg>
+);
 
 const Battleship = () => {
   const [phase, setPhase] = useState('placement');
   const [playerBoard, setPlayerBoard] = useState(createBoard());
   const [enemyBoard, setEnemyBoard] = useState(createBoard());
   const [ships, setShips] = useState([]); // player's ship objects
-  const [ai, setAi] = useState(new MonteCarloAI());
   const [heat, setHeat] = useState(Array(BOARD_SIZE * BOARD_SIZE).fill(0));
   const [message, setMessage] = useState('Place your ships');
+  const [difficulty, setDifficulty] = useState('easy');
+  const [ai, setAi] = useState(null);
+  const [stats, setStats] = usePersistentState('battleship-stats', {
+    wins: 0,
+    losses: 0,
+  });
 
-  useEffect(() => {
-    // init player ships
-    const layout = randomizePlacement();
-    setShips(layout.map((s, i) => ({ id: i, ...s })));
-    // enemy ships
-    setEnemyBoard(placeShips(createBoard(), randomizePlacement()));
+  const placeShips = useCallback((board, layout) => {
+    const newBoard = board.slice();
+    layout.forEach((ship) => ship.cells.forEach((c) => (newBoard[c] = 'ship')));
+    return newBoard;
   }, []);
 
-  const placeShips = (board, layout) => {
-    const newBoard = board.slice();
-    layout.forEach(ship => ship.cells.forEach(c => newBoard[c] = 'ship'));
-    return newBoard;
-  };
+  const restart = useCallback(
+    (diff = difficulty) => {
+      const layout = randomizePlacement();
+      const newShips = layout.map((s, i) => ({ ...s, id: i }));
+      setShips(newShips);
+      setPlayerBoard(placeShips(createBoard(), newShips));
+      setEnemyBoard(placeShips(createBoard(), randomizePlacement()));
+      setPhase('placement');
+      setMessage('Place your ships');
+      setHeat(Array(BOARD_SIZE * BOARD_SIZE).fill(0));
+      setAi(diff === 'hard' ? new MonteCarloAI() : new RandomSalvoAI());
+    },
+    [difficulty, placeShips]
+  );
+
+  useEffect(() => {
+    restart();
+  }, []);
 
   const handleDragStop = (i, e, data) => {
     const x = Math.round(data.x / CELL);
@@ -52,7 +118,7 @@ const Battleship = () => {
 
   const randomize = () => {
     const layout = randomizePlacement();
-    const newShips = layout.map((s,i)=>({...s,id:i}));
+    const newShips = layout.map((s, i) => ({ ...s, id: i }));
     setShips(newShips);
     setPlayerBoard(placeShips(createBoard(), newShips));
   };
@@ -73,25 +139,30 @@ const Battleship = () => {
     const hit = newBoard[idx]==='ship';
     newBoard[idx]= hit?'hit':'miss';
     setEnemyBoard(newBoard);
-    ai.record(idx, hit);
-    if(!newBoard.includes('ship')){
+    if (!newBoard.includes('ship')) {
       setMessage('You win!');
       setPhase('done');
+      setStats((s) => ({ ...s, wins: s.wins + 1 }));
       return;
     }
     // AI turn
-    setTimeout(()=>{
+    setTimeout(() => {
       const move = ai.nextMove();
-      if(move==null) return;
+      if (move == null) return;
       const pb = playerBoard.slice();
-      const hit2 = pb[move]==='ship';
-      pb[move]= hit2?'hit':'miss';
+      const hit2 = pb[move] === 'ship';
+      pb[move] = hit2 ? 'hit' : 'miss';
       setPlayerBoard(pb);
-      const nh = heat.slice(); nh[move]++; setHeat(nh);
+      const nh = heat.slice();
+      nh[move]++;
+      setHeat(nh);
       ai.record(move, hit2);
-      if(!pb.includes('ship')){ setMessage('AI wins!'); setPhase('done'); }
-      else setMessage(hit?'Hit!':'Miss!');
-    },100); // simulate thinking
+      if (!pb.includes('ship')) {
+        setMessage('AI wins!');
+        setPhase('done');
+        setStats((s) => ({ ...s, losses: s.losses + 1 }));
+      } else setMessage(hit ? 'Hit!' : 'Miss!');
+    }, 100); // simulate thinking
   };
 
   const renderBoard = (board, isEnemy=false) => (
@@ -104,8 +175,8 @@ const Battleship = () => {
             {isEnemy && phase==='battle' && !['hit','miss'].includes(cell)?(
               <button className="w-full h-full" onClick={()=>fire(idx)} />
             ):null}
-            {cell==='hit' && <div className="absolute inset-0 bg-red-600 transition-opacity"/>}
-            {cell==='miss' && <div className="absolute inset-0 bg-gray-500 transition-opacity"/>}
+            {cell==='hit' && <HitMarker />}
+            {cell==='miss' && <MissMarker />}
             {!isEnemy && <div className="absolute inset-0" style={{background:color}}/>}
           </div>
         );
@@ -114,7 +185,15 @@ const Battleship = () => {
   );
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
+    <GameLayout
+      difficulty={difficulty}
+      onDifficultyChange={(d) => {
+        setDifficulty(d);
+        restart(d);
+      }}
+      onRestart={() => restart()}
+      stats={stats}
+    >
       <div className="mb-2">{message}</div>
       {phase==='placement' && (
         <div className="flex space-x-4">
@@ -139,7 +218,7 @@ const Battleship = () => {
           <div>{renderBoard(enemyBoard,true)}</div>
         </div>
       )}
-    </div>
+    </GameLayout>
   );
 };
 

--- a/components/apps/battleship/GameLayout.js
+++ b/components/apps/battleship/GameLayout.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats }) => {
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
+      <div className="flex items-center space-x-2 mb-2">
+        <label className="text-sm">
+          Difficulty:
+          <select
+            className="ml-1 bg-gray-700 text-white p-1"
+            value={difficulty}
+            onChange={(e) => onDifficultyChange(e.target.value)}
+          >
+            <option value="easy">Easy</option>
+            <option value="hard">Hard</option>
+          </select>
+        </label>
+        <button className="px-2 py-1 bg-gray-700" onClick={onRestart}>
+          Restart
+        </button>
+        {stats && (
+          <div className="ml-4 text-sm">
+            W: {stats.wins} L: {stats.losses}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default GameLayout;

--- a/components/apps/battleship/ai.js
+++ b/components/apps/battleship/ai.js
@@ -88,3 +88,43 @@ export function randomizePlacement() {
   }
 }
 
+
+export class RandomSalvoAI {
+  constructor() {
+    this.available = new Set(Array.from({ length: BOARD_SIZE * BOARD_SIZE }, (_, i) => i));
+    this.queue = [];
+  }
+
+  record(idx, hit) {
+    this.available.delete(idx);
+    if (hit) {
+      const x = idx % BOARD_SIZE;
+      const y = Math.floor(idx / BOARD_SIZE);
+      const neighbors = [
+        [x + 1, y],
+        [x - 1, y],
+        [x, y + 1],
+        [x, y - 1],
+      ];
+      neighbors.forEach(([nx, ny]) => {
+        if (nx >= 0 && ny >= 0 && nx < BOARD_SIZE && ny < BOARD_SIZE) {
+          const nIdx = ny * BOARD_SIZE + nx;
+          if (this.available.has(nIdx) && !this.queue.includes(nIdx)) {
+            this.queue.push(nIdx);
+          }
+        }
+      });
+    }
+  }
+
+  nextMove() {
+    if (this.queue.length) {
+      return this.queue.shift();
+    }
+    const choices = Array.from(this.available);
+    if (!choices.length) return null;
+    const choice = choices[Math.floor(Math.random() * choices.length)];
+    this.available.delete(choice);
+    return choice;
+  }
+}

--- a/components/hooks/usePersistentState.js
+++ b/components/hooks/usePersistentState.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+export default function usePersistentState(key, initialValue) {
+  const [state, setState] = useState(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // ignore
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}
+


### PR DESCRIPTION
## Summary
- add basic RandomSalvoAI for enemy targeting
- add GameLayout with difficulty selection, restart, and stats
- track wins/losses with new usePersistentState hook
- show animated SVG markers for hits and misses

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b1bfe8483288d45d0b9023f4e62