### PR TITLE
feat: add volatility memory analysis app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const VolatilityApp = createDynamicApp('volatility', 'Volatility');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayVolatility = createDisplay(VolatilityApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -603,6 +605,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'volatility',
+    title: 'Volatility',
+    icon: './themes/Yaru/apps/volatility.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayVolatility,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+const VolatilityApp = () => {
+  const [file, setFile] = useState(null);
+  const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const analyze = async () => {
+    if (!file) return;
+    setLoading(true);
+    setOutput('');
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/volatility', {
+        method: 'POST',
+        body: formData,
+      });
+      const text = await res.text();
+      setOutput(text);
+    } catch (err) {
+      setOutput('Analysis failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white">
+      <div className="p-4 space-y-2">
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="w-full text-black"
+        />
+        <button
+          onClick={analyze}
+          disabled={!file || loading}
+          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+        >
+          {loading ? 'Analyzing...' : 'Analyze'}
+        </button>
+      </div>
+      <pre className="flex-1 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap">
+        {output}
+      </pre>
+    </div>
+  );
+};
+
+export default VolatilityApp;
+
+export const displayVolatility = () => {
+  return <VolatilityApp />;
+};
+

--- a/public/themes/Yaru/apps/volatility.svg
+++ b/public/themes/Yaru/apps/volatility.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="12" width="48" height="40" rx="4" ry="4" fill="#4c4f69" />
+  <text x="32" y="37" font-size="24" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif">V</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Volatility memory dump analysis app
- register Volatility in app configuration and menu
- include Volatility icon asset

## Testing
- `yarn lint`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ac49e078e48328a865dbc60c398d3f