### PR TITLE
Add Metasploit Post module app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayMsfPost = createDisplay(MsfPostApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -603,6 +605,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'msf-post',
+    title: 'Metasploit Post',
+    icon: './themes/Yaru/apps/msf-post.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMsfPost,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+
+const MsfPostApp = () => {
+  const [modules, setModules] = useState([]);
+  const [selected, setSelected] = useState('');
+  const [output, setOutput] = useState('');
+
+  useEffect(() => {
+    const fetchModules = async () => {
+      try {
+        const res = await fetch('/api/metasploit/modules?type=post');
+        const data = await res.json();
+        setModules(data.modules || []);
+      } catch (err) {
+        setModules([]);
+      }
+    };
+
+    fetchModules();
+  }, []);
+
+  const runModule = async () => {
+    if (!selected) return;
+    setOutput('Running...');
+    try {
+      const res = await fetch('/api/metasploit/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ module: selected }),
+      });
+      const data = await res.json();
+      setOutput(data.output || 'No output');
+    } catch (err) {
+      setOutput('Error running module');
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
+      <h2 className="text-lg mb-2">Metasploit Post Modules</h2>
+      <div className="flex mb-4">
+        <select
+          className="flex-1 bg-gray-800 p-2 rounded"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+        >
+          <option value="">Select a module</option>
+          {modules.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={runModule}
+          className="ml-2 px-4 py-2 bg-blue-600 rounded"
+        >
+          Run
+        </button>
+      </div>
+      <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">
+        {output}
+      </pre>
+    </div>
+  );
+};
+
+export default MsfPostApp;

--- a/public/themes/Yaru/apps/msf-post.svg
+++ b/public/themes/Yaru/apps/msf-post.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#1e293b"/>
+  <text x="32" y="38" font-size="20" text-anchor="middle" fill="#38bdf8" font-family="Arial, sans-serif">MSF</text>
+</svg>


### PR DESCRIPTION
## Summary
- add MsfPost app to browse and execute Metasploit post modules
- register MsfPost app in application configuration and include icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac49de7b3c8328844a11faf2fcb8a1