### PR TITLE
feat: add Ettercap traffic monitor app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayEttercap = createDisplay(EttercapApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -522,6 +524,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'ettercap',
+    title: 'Ettercap',
+    icon: './themes/Yaru/apps/ettercap.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEttercap,
   },
   {
     id: 'project-gallery',

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -1,0 +1,109 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const protocols = ['TCP', 'UDP', 'ICMP', 'ARP', 'HTTP', 'DNS'];
+
+const generatePacket = (src, dst) => ({
+  time: new Date().toLocaleTimeString(),
+  src,
+  dst,
+  protocol: protocols[Math.floor(Math.random() * protocols.length)],
+  length: Math.floor(Math.random() * 1500) + 60,
+});
+
+const EttercapApp = () => {
+  const [target1, setTarget1] = useState('');
+  const [target2, setTarget2] = useState('');
+  const [running, setRunning] = useState(false);
+  const [traffic, setTraffic] = useState([]);
+  const intervalRef = useRef(null);
+
+  useEffect(() => {
+    return () => clearInterval(intervalRef.current);
+  }, []);
+
+  const startSession = () => {
+    if (!target1 || !target2) return;
+    setTraffic([]);
+    setRunning(true);
+    intervalRef.current = setInterval(() => {
+      setTraffic((t) => [generatePacket(target1, target2), ...t]);
+    }, 1000);
+  };
+
+  const stopSession = () => {
+    clearInterval(intervalRef.current);
+    setRunning(false);
+  };
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white p-4 flex flex-col">
+      <div className="flex mb-4 space-x-2">
+        <input
+          className="flex-1 p-2 rounded text-black"
+          placeholder="Target 1"
+          value={target1}
+          onChange={(e) => setTarget1(e.target.value)}
+          disabled={running}
+        />
+        <input
+          className="flex-1 p-2 rounded text-black"
+          placeholder="Target 2"
+          value={target2}
+          onChange={(e) => setTarget2(e.target.value)}
+          disabled={running}
+        />
+        {!running ? (
+          <button
+            className="px-4 py-2 bg-green-600 rounded"
+            onClick={startSession}
+          >
+            Start
+          </button>
+        ) : (
+          <button
+            className="px-4 py-2 bg-red-600 rounded"
+            onClick={stopSession}
+          >
+            Stop
+          </button>
+        )}
+      </div>
+      <div className="flex-1 overflow-auto bg-gray-800 rounded">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-700">
+              <th className="p-1 text-left">Time</th>
+              <th className="p-1 text-left">Source</th>
+              <th className="p-1 text-left">Destination</th>
+              <th className="p-1 text-left">Protocol</th>
+              <th className="p-1 text-left">Length</th>
+            </tr>
+          </thead>
+          <tbody>
+            {traffic.map((pkt, idx) => (
+              <tr key={idx} className={idx % 2 ? 'bg-gray-700' : ''}>
+                <td className="p-1 whitespace-nowrap">{pkt.time}</td>
+                <td className="p-1 break-all">{pkt.src}</td>
+                <td className="p-1 break-all">{pkt.dst}</td>
+                <td className="p-1">{pkt.protocol}</td>
+                <td className="p-1">{pkt.length}</td>
+              </tr>
+            ))}
+            {!traffic.length && (
+              <tr>
+                <td className="p-4 text-center" colSpan="5">
+                  {running ? 'Capturing traffic...' : 'No traffic'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default EttercapApp;
+
+export const displayEttercap = () => <EttercapApp />;
+

--- a/public/themes/Yaru/apps/ettercap.svg
+++ b/public/themes/Yaru/apps/ettercap.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="12" r="6" fill="#4ade80"/>
+  <circle cx="12" cy="52" r="6" fill="#4ade80"/>
+  <circle cx="52" cy="52" r="6" fill="#4ade80"/>
+  <line x1="32" y1="18" x2="12" y2="46" stroke="#ffffff" stroke-width="4"/>
+  <line x1="32" y1="18" x2="52" y2="46" stroke="#ffffff" stroke-width="4"/>
+  <line x1="12" y1="52" x2="52" y2="52" stroke="#ffffff" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Ettercap app to simulate MITM sessions and visualize network traffic
- register Ettercap in app configuration with dynamic loader
- include Ettercap icon in Yaru theme assets

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49db4ca483289e94bfccc67e8afc