### PR TITLE
Add dsniff aggregation app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -76,6 +76,7 @@ const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
+const DsniffApp = createDynamicApp('dsniff', 'dsniff');
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
 
@@ -114,6 +115,7 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 
+const displayDsniff = createDisplay(DsniffApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
@@ -603,6 +605,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'dsniff',
+    title: 'dsniff',
+    icon: './themes/Yaru/apps/dsniff.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDsniff,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+
+const Dsniff = () => {
+  const [urlsnarfOutput, setUrlsnarfOutput] = useState('');
+  const [arpspoofOutput, setArpspoofOutput] = useState('');
+
+  useEffect(() => {
+    const fetchOutputs = async () => {
+      try {
+        const [urlsnarfRes, arpspoofRes] = await Promise.all([
+          fetch('/api/dsniff/urlsnarf').then((r) => r.text()).catch(() => ''),
+          fetch('/api/dsniff/arpspoof').then((r) => r.text()).catch(() => ''),
+        ]);
+        if (urlsnarfRes) setUrlsnarfOutput(urlsnarfRes);
+        if (arpspoofRes) setArpspoofOutput(arpspoofRes);
+      } catch (e) {
+        // ignore errors
+      }
+    };
+    fetchOutputs();
+    const interval = setInterval(fetchOutputs, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white p-2 overflow-auto">
+      <h1 className="text-lg mb-2">dsniff</h1>
+      <div className="mb-4">
+        <h2 className="font-bold">urlsnarf</h2>
+        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
+          {urlsnarfOutput || 'No data'}
+        </pre>
+      </div>
+      <div>
+        <h2 className="font-bold">arpspoof</h2>
+        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
+          {arpspoofOutput || 'No data'}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default Dsniff;
+
+export const displayDsniff = (addFolder, openApp) => (
+  <Dsniff addFolder={addFolder} openApp={openApp} />
+);

--- a/public/themes/Yaru/apps/dsniff.svg
+++ b/public/themes/Yaru/apps/dsniff.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" fill="#2e3440"/>
+  <circle cx="32" cy="32" r="20" fill="#4c566a"/>
+  <path d="M16 32h32M32 16v32" stroke="#88c0d0" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add dsniff app component aggregating urlsnarf and arpspoof outputs
- register Dsniff app in configuration and app list
- include dsniff icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49dbcdfc8328ad3cce994a61d720