### PR TITLE
feat: add bluetooth tools app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -75,6 +75,7 @@ const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
+const BluetoothApp = createDynamicApp('bluetooth', 'Bluetooth Tools');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -113,6 +114,7 @@ const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
+const displayBluetooth = createDisplay(BluetoothApp);
 
 const displayGomoku = createDisplay(GomokuApp);
 
@@ -522,6 +524,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'bluetooth-tools',
+    title: 'Bluetooth Tools',
+    icon: './themes/Yaru/apps/bluetooth.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayBluetooth,
   },
   {
     id: 'project-gallery',

--- a/components/apps/bluetooth/index.js
+++ b/components/apps/bluetooth/index.js
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+const BluetoothApp = () => {
+  const [devices, setDevices] = useState([]);
+  const [error, setError] = useState('');
+
+  const scan = async () => {
+    setError('');
+    if (!navigator.bluetooth) {
+      setError('Web Bluetooth API is not supported in this browser.');
+      return;
+    }
+    try {
+      const device = await navigator.bluetooth.requestDevice({
+        acceptAllDevices: true,
+      });
+      setDevices((prev) => {
+        if (prev.find((d) => d.id === device.id)) return prev;
+        return [...prev, device];
+      });
+    } catch (e) {
+      setError(e.message || 'Failed to scan for devices');
+    }
+  };
+
+  const connect = async (device) => {
+    try {
+      if (!device.gatt.connected) {
+        await device.gatt.connect();
+        setDevices([...devices]);
+      }
+    } catch (e) {
+      setError(e.message || 'Failed to connect');
+    }
+  };
+
+  const disconnect = (device) => {
+    try {
+      if (device.gatt.connected) {
+        device.gatt.disconnect();
+        setDevices([...devices]);
+      }
+    } catch (e) {
+      setError(e.message || 'Failed to disconnect');
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-ub-cool-grey text-white overflow-auto">
+      <div className="mb-4">
+        <button onClick={scan} className="px-4 py-2 bg-blue-600 rounded">
+          Scan for Devices
+        </button>
+      </div>
+      {error && <div className="mb-4 text-red-400">{error}</div>}
+      <ul>
+        {devices.map((device, idx) => (
+          <li
+            key={device.id || idx}
+            className="mb-2 flex items-center justify-between"
+          >
+            <span>{device.name || 'Unnamed device'}</span>
+            {device.gatt && device.gatt.connected ? (
+              <button
+                onClick={() => disconnect(device)}
+                className="px-2 py-1 bg-red-600 rounded"
+              >
+                Disconnect
+              </button>
+            ) : (
+              <button
+                onClick={() => connect(device)}
+                className="px-2 py-1 bg-green-600 rounded"
+              >
+                Connect
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      {devices.length === 0 && (
+        <div>No devices found. Click scan to search.</div>
+      )}
+    </div>
+  );
+};
+
+export default BluetoothApp;
+
+export const displayBluetooth = () => {
+  return <BluetoothApp />;
+};
+

--- a/public/themes/Yaru/apps/bluetooth.svg
+++ b/public/themes/Yaru/apps/bluetooth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 4v56l16-16-16-16 16-16L32 4zm0 0" fill="#4a90e2"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Bluetooth Tools app with device scanning and connections via Web Bluetooth
- register Bluetooth Tools in apps configuration and include icon

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49d833108328993b003a1fd1f01e