### PR TITLE
Add Reaver WPS PIN attack app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const ReaverApp = createDynamicApp('reaver', 'Reaver');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayReaver = createDisplay(ReaverApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -576,6 +578,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQrTool,
+  },
+  {
+    id: 'reaver',
+    title: 'Reaver',
+    icon: './themes/Yaru/apps/reaver.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayReaver,
   },
   {
     id: 'ascii-art',

--- a/components/apps/reaver/index.js
+++ b/components/apps/reaver/index.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+
+const checksum = (num) => {
+  let acc = 0;
+  for (let i = 0; i < 7; i += 1) {
+    const digit = num % 10;
+    acc += i % 2 === 0 ? digit * 3 : digit;
+    num = Math.floor(num / 10);
+  }
+  return (10 - (acc % 10)) % 10;
+};
+
+const derivePin = (bssid) => {
+  const mac = bssid.replace(/:/g, '').toUpperCase();
+  if (mac.length !== 12) return null;
+  const num = parseInt(mac.slice(-6), 16) % 10000000;
+  const cs = checksum(num);
+  return `${num}`.padStart(7, '0') + cs;
+};
+
+export default function ReaverApp() {
+  const [bssid, setBssid] = useState('');
+  const [pin, setPin] = useState('');
+  const [log, setLog] = useState('');
+  const [running, setRunning] = useState(false);
+
+  const startAttack = () => {
+    setRunning(true);
+    setLog(`Starting WPS PIN attack on ${bssid}\n`);
+    let tries = 0;
+    const interval = setInterval(() => {
+      tries += 1;
+      const guess = Math.floor(Math.random() * 1e8)
+        .toString()
+        .padStart(8, '0');
+      setLog((prev) => `${prev}Trying PIN ${guess}\n`);
+      if (tries >= 5) {
+        clearInterval(interval);
+        const result = derivePin(bssid);
+        setLog((prev) =>
+          `${prev}\nAttack complete. PIN discovered: ${result || 'invalid BSSID'}`
+        );
+        setPin(result || '');
+        setRunning(false);
+      }
+    }, 500);
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-ub-cool-grey text-white overflow-auto">
+      <h2 className="text-lg mb-4">Reaver WPS PIN Attack</h2>
+      <div className="mb-2">
+        <label className="block mb-1">Target BSSID</label>
+        <input
+          type="text"
+          className="w-full p-2 rounded bg-gray-700 text-white font-mono"
+          placeholder="00:11:22:33:44:55"
+          value={bssid}
+          onChange={(e) => setBssid(e.target.value)}
+          disabled={running}
+        />
+      </div>
+      <button
+        className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded disabled:opacity-50"
+        onClick={startAttack}
+        disabled={running || !bssid}
+      >
+        Start Attack
+      </button>
+      {pin && (
+        <div className="mt-4">
+          <div className="mb-1">Discovered WPS PIN:</div>
+          <div className="font-mono text-xl">{pin}</div>
+        </div>
+      )}
+      <pre className="mt-4 bg-black text-green-400 p-2 h-48 overflow-y-auto font-mono whitespace-pre-wrap">
+        {log}
+      </pre>
+    </div>
+  );
+}
+

--- a/public/themes/Yaru/apps/reaver.svg
+++ b/public/themes/Yaru/apps/reaver.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#323232"/>
+  <path d="M20 16h14c8 0 14 3 14 11 0 7-5 11-12 11h-8v10h-8V16zm14 16c4 0 6-1 6-5 0-3-2-5-6-5h-6v10h6z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Reaver app to perform simulated WPS PIN attacks
- register Reaver in app configuration and menu
- include Yaru themed icon

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49d636f883289d31af005087ee1a