### PR TITLE
Add Hashcat app with hash type selection

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,8 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+
+const displayHashcat = createDisplay(HashcatApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -603,6 +606,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'hashcat',
+    title: 'Hashcat',
+    icon: './themes/Yaru/apps/hashcat.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHashcat,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+const hashTypes = [
+  { id: '0', name: 'MD5' },
+  { id: '100', name: 'SHA1' },
+  { id: '1400', name: 'SHA256' },
+  { id: '3200', name: 'bcrypt' },
+];
+
+const Gauge = ({ value }) => (
+  <div className="w-48">
+    <div className="text-sm mb-1">GPU Usage: {value}%</div>
+    <div className="w-full h-4 bg-gray-700 rounded">
+      <div
+        className="h-4 bg-green-500 rounded"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  </div>
+);
+
+function HashcatApp() {
+  const [hashType, setHashType] = useState(hashTypes[0].id);
+  const [gpuUsage, setGpuUsage] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setGpuUsage(Math.floor(Math.random() * 100));
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const selectedHash = hashTypes.find((h) => h.id === hashType)?.name;
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-ub-cool-grey text-white">
+      <div>
+        <label className="mr-2" htmlFor="hash-type">
+          Hash Type:
+        </label>
+        <select
+          id="hash-type"
+          className="text-black px-2 py-1"
+          value={hashType}
+          onChange={(e) => setHashType(e.target.value)}
+        >
+          {hashTypes.map((h) => (
+            <option key={h.id} value={h.id}>
+              {h.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>Selected: {selectedHash}</div>
+      <Gauge value={gpuUsage} />
+    </div>
+  );
+}
+
+export default HashcatApp;
+
+export const displayHashcat = () => <HashcatApp />;
+

--- a/public/themes/Yaru/apps/hashcat.svg
+++ b/public/themes/Yaru/apps/hashcat.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4c566a"/>
+  <text x="32" y="42" font-size="32" text-anchor="middle" fill="#fff" font-family="sans-serif">HC</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Hashcat app with hash type dropdown and GPU usage indicator
- register Hashcat in app config and app list
- include Yaru icon for Hashcat

## Testing
- `yarn test`
- `yarn test __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac49d263748328a87401e8f239b12c