### PR TITLE
Add Hydra credential brute force app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const HydraApp = createDynamicApp('hydra', 'Hydra');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayHydra = createDisplay(HydraApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -594,6 +596,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'hydra',
+    title: 'Hydra',
+    icon: './themes/Yaru/apps/hydra.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHydra,
   },
   {
     id: 'weather',

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+const services = ['ssh', 'ftp', 'http-get', 'http-post-form', 'smtp'];
+
+const HydraApp = () => {
+  const [target, setTarget] = useState('');
+  const [service, setService] = useState('ssh');
+  const [users, setUsers] = useState('');
+  const [passwords, setPasswords] = useState('');
+  const [output, setOutput] = useState('');
+  const [running, setRunning] = useState(false);
+
+  const readFile = (file, setter) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => setter(e.target.result);
+    reader.readAsText(file);
+  };
+
+  const runHydra = async () => {
+    if (!target || !users || !passwords) {
+      setOutput('Please provide target, user list and password list');
+      return;
+    }
+
+    setRunning(true);
+    setOutput('');
+    try {
+      const res = await fetch('/api/hydra', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target, service, userList: users, passList: passwords }),
+      });
+      const data = await res.json();
+      setOutput(data.output || data.error || 'No output');
+    } catch (err) {
+      setOutput(err.message);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto">
+      <div className="space-y-2">
+        <div>
+          <label className="block mb-1">Target</label>
+          <input
+            type="text"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            className="w-full p-2 rounded text-black"
+            placeholder="192.168.0.1"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Service</label>
+          <select
+            value={service}
+            onChange={(e) => setService(e.target.value)}
+            className="w-full p-2 rounded text-black"
+          >
+            {services.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">User List</label>
+          <input
+            type="file"
+            accept="text/plain"
+            onChange={(e) => readFile(e.target.files[0], setUsers)}
+            className="w-full p-2 rounded text-black"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Password List</label>
+          <input
+            type="file"
+            accept="text/plain"
+            onChange={(e) => readFile(e.target.files[0], setPasswords)}
+            className="w-full p-2 rounded text-black"
+          />
+        </div>
+        <button
+          onClick={runHydra}
+          disabled={running}
+          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+        >
+          {running ? 'Running...' : 'Run Hydra'}
+        </button>
+      </div>
+
+      {output && (
+        <pre className="mt-4 bg-black p-2 overflow-auto h-64 whitespace-pre-wrap">{output}</pre>
+      )}
+    </div>
+  );
+};
+
+export default HydraApp;
+
+export const displayHydra = () => {
+  return <HydraApp />;
+};
+

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -1,0 +1,42 @@
+import { execFile } from 'child_process';
+import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { target, service, userList, passList } = req.body || {};
+  if (!target || !service || !userList || !passList) {
+    res.status(400).json({ error: 'Missing parameters' });
+    return;
+  }
+
+  const userPath = `/tmp/hydra-users-${randomUUID()}.txt`;
+  const passPath = `/tmp/hydra-pass-${randomUUID()}.txt`;
+
+  try {
+    await fs.writeFile(userPath, userList);
+    await fs.writeFile(passPath, passList);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+    return;
+  }
+
+  const args = ['-L', userPath, '-P', passPath, `${service}://${target}`];
+
+  execFile('hydra', args, { timeout: 1000 * 60 }, (error, stdout, stderr) => {
+    // Clean up temp files
+    fs.unlink(userPath).catch(() => {});
+    fs.unlink(passPath).catch(() => {});
+
+    if (error) {
+      const msg = stderr?.toString() || error.message;
+      res.status(200).json({ output: msg });
+      return;
+    }
+    res.status(200).json({ output: stdout.toString() });
+  });
+}

--- a/public/themes/Yaru/apps/hydra.svg
+++ b/public/themes/Yaru/apps/hydra.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="15" fill="#292929"/>
+  <path d="M20 20h20v60H20zM60 20h20v60H60zM40 50h20v10H40z" fill="#10b981"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Hydra app to run password brute-force attacks with custom wordlists
- support Hydra execution through a simple API endpoint
- register app and icon in configuration and theme assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49d111c08328a6271e1669ae6b6d