### PR TITLE
Add Metasploit app wrapper

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -75,6 +75,7 @@ const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
+const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -113,6 +114,8 @@ const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
+
+const displayMetasploit = createDisplay(MetasploitApp);
 
 const displayGomoku = createDisplay(GomokuApp);
 
@@ -522,6 +525,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'metasploit',
+    title: 'Metasploit',
+    icon: './themes/Yaru/apps/metasploit.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMetasploit,
   },
   {
     id: 'project-gallery',

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+const MetasploitApp = () => {
+  const [command, setCommand] = useState('');
+  const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const runCommand = async () => {
+    const cmd = command.trim();
+    if (!cmd) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/metasploit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: cmd }),
+      });
+      const data = await res.json();
+      setOutput(data.output || '');
+    } catch (e) {
+      setOutput(`Error: ${e.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white">
+      <div className="flex p-2">
+        <input
+          className="flex-grow bg-ub-grey text-white p-1 rounded"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') runCommand();
+          }}
+          placeholder="msfconsole command"
+          spellCheck={false}
+        />
+        <button
+          onClick={runCommand}
+          className="ml-2 px-2 py-1 bg-ub-orange rounded"
+        >
+          Run
+        </button>
+      </div>
+      <pre className="flex-grow bg-black text-green-400 p-2 overflow-auto whitespace-pre-wrap">
+        {loading ? 'Running...' : output}
+      </pre>
+    </div>
+  );
+};
+
+export default MetasploitApp;
+
+export const displayMetasploit = () => <MetasploitApp />;

--- a/pages/api/metasploit.js
+++ b/pages/api/metasploit.js
@@ -1,0 +1,26 @@
+import { spawn } from 'child_process';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { command } = req.body || {};
+  if (!command || typeof command !== 'string') {
+    return res.status(400).json({ error: 'No command provided' });
+  }
+
+  const proc = spawn('msfconsole', ['-q', '-x', `${command}; exit`]);
+  let output = '';
+
+  proc.stdout.on('data', (data) => {
+    output += data.toString();
+  });
+  proc.stderr.on('data', (data) => {
+    output += data.toString();
+  });
+  proc.on('close', (code) => {
+    res.status(200).json({ output, code });
+  });
+}

--- a/public/themes/Yaru/apps/metasploit.svg
+++ b/public/themes/Yaru/apps/metasploit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#1b1f3b"/>
+  <path d="M16 48V16h8l8 16 8-16h8v32h-8V26l-8 16-8-16v22h-8z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Metasploit React app to run msfconsole commands through backend
- register Metasploit app and icon in config
- provide basic API route to execute msfconsole and new icon asset

## Testing
- `yarn test` (incomplete: 26 suites passed)
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac49cc996c8328ba8802647a9984a4