### PR TITLE
feat: add Nmap NSE app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const NmapNSEApp = createDynamicApp('nmap-nse', 'Nmap NSE');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayNmapNSE = createDisplay(NmapNSEApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -594,6 +596,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuoteGenerator,
+  },
+  {
+    id: 'nmap-nse',
+    title: 'Nmap NSE',
+    icon: './themes/Yaru/apps/nmap-nse.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNmapNSE,
   },
   {
     id: 'weather',

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+const NmapNSEApp = () => {
+  const [target, setTarget] = useState('');
+  const [script, setScript] = useState('http-title');
+  const [output, setOutput] = useState('');
+  const scripts = [
+    'http-title',
+    'ssl-cert',
+    'vuln',
+    'whois-domain',
+    'ftp-anon',
+  ];
+
+  const runScan = async () => {
+    if (!target) return;
+    setOutput('Running scan...');
+    try {
+      const res = await fetch(`https://api.hackertarget.com/nmap/?q=${encodeURIComponent(target)}&script=${encodeURIComponent(script)}`);
+      const text = await res.text();
+      setOutput(text);
+    } catch (e) {
+      setOutput('Error running scan');
+    }
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col p-4 bg-ub-cool-grey text-white">
+      <div className="mb-4">
+        <input
+          className="w-full p-2 mb-2 rounded text-black"
+          type="text"
+          placeholder="Target host"
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+        />
+        <select
+          className="w-full p-2 mb-2 rounded text-black"
+          value={script}
+          onChange={(e) => setScript(e.target.value)}
+        >
+          {scripts.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <button onClick={runScan} className="px-4 py-2 bg-blue-600 rounded">
+          Run
+        </button>
+      </div>
+      <pre className="flex-grow overflow-auto bg-black text-green-400 p-2 rounded">
+        {output}
+      </pre>
+    </div>
+  );
+};
+
+export default NmapNSEApp;
+
+export const displayNmapNSE = () => {
+  return <NmapNSEApp />;
+};

--- a/public/themes/Yaru/apps/nmap-nse.svg
+++ b/public/themes/Yaru/apps/nmap-nse.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#1e1e1e"/>
+  <circle cx="32" cy="32" r="20" stroke="#0ff" stroke-width="4" fill="none"/>
+  <line x1="32" y1="32" x2="52" y2="32" stroke="#0ff" stroke-width="4"/>
+  <line x1="32" y1="32" x2="44" y2="20" stroke="#0ff" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Nmap NSE application for running selected NSE scripts
- register Nmap NSE in app configuration and desktop apps
- include Nmap NSE icon

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ac49c8a09c83288ea0bee1cd0d6946