### PR TITLE
Add Recon-ng reconnaissance interface

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,8 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+
+const displayReconNG = createDisplay(ReconNGApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -603,6 +606,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'recon-ng',
+    title: 'Recon-ng',
+    icon: './themes/Yaru/apps/reconng.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayReconNG,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+const modules = [
+  'DNS Enumeration',
+  'WHOIS Lookup',
+  'Reverse IP Lookup',
+];
+
+const ReconNG = () => {
+  const [selectedModule, setSelectedModule] = useState(modules[0]);
+  const [target, setTarget] = useState('');
+  const [output, setOutput] = useState('');
+
+  const runModule = () => {
+    if (!target) return;
+    setOutput(`Running ${selectedModule} on ${target}...\nResults will appear here.`);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-gray-900 text-white p-4">
+      <div className="flex gap-2 mb-2">
+        <select
+          value={selectedModule}
+          onChange={(e) => setSelectedModule(e.target.value)}
+          className="bg-gray-800 px-2 py-1"
+        >
+          {modules.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+          placeholder="Target"
+          className="flex-1 bg-gray-800 px-2 py-1"
+        />
+        <button
+          type="button"
+          onClick={runModule}
+          className="bg-blue-600 hover:bg-blue-500 px-3 py-1 rounded"
+        >
+          Run
+        </button>
+      </div>
+      <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">{output}</pre>
+    </div>
+  );
+};
+
+export default ReconNG;
+
+export const displayReconNG = () => <ReconNG />;
+

--- a/public/themes/Yaru/apps/reconng.svg
+++ b/public/themes/Yaru/apps/reconng.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#4a86cf" stroke="white" stroke-width="4"/>
+  <line x1="32" y1="2" x2="32" y2="62" stroke="white" stroke-width="4"/>
+  <line x1="2" y1="32" x2="62" y2="32" stroke="white" stroke-width="4"/>
+  <circle cx="32" cy="32" r="10" fill="none" stroke="white" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Recon-ng app with modular reconnaissance interface
- register Recon-ng in app configuration
- include Recon-ng icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac49c350a483288518ae0e309c5192