### PR TITLE
feat: add theHarvester reconnaissance app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -78,6 +78,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
+const TheHarvesterApp = createDynamicApp('theHarvester', 'theHarvester');
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -117,6 +118,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayGomoku = createDisplay(GomokuApp);
 
 const displayPinball = createDisplay(PinballApp);
+const displayTheHarvester = createDisplay(TheHarvesterApp);
 
 
 // Default window sizing for games to prevent oversized frames
@@ -603,6 +605,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'theHarvester',
+    title: 'theHarvester',
+    icon: './themes/Yaru/apps/theharvester.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTheHarvester,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/theHarvester/index.js
+++ b/components/apps/theHarvester/index.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+const TheHarvester = () => {
+  const [domain, setDomain] = useState('');
+  const [engine, setEngine] = useState('google');
+  const [output, setOutput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const runHarvester = async () => {
+    if (!domain) return;
+    setLoading(true);
+    setOutput('');
+    try {
+      const res = await fetch('/api/theharvester', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain, engine }),
+      });
+      const data = await res.json();
+      setOutput(data.output || data.error || 'No output');
+    } catch (e) {
+      setOutput('Failed to run theHarvester');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-ub-cool-grey text-white overflow-auto">
+      <div className="mb-4">
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          className="w-full p-2 mb-2 rounded text-black"
+          placeholder="Domain"
+        />
+        <select
+          value={engine}
+          onChange={(e) => setEngine(e.target.value)}
+          className="w-full p-2 mb-2 rounded text-black"
+        >
+          <option value="google">Google</option>
+          <option value="bing">Bing</option>
+          <option value="duckduckgo">DuckDuckGo</option>
+        </select>
+        <button
+          onClick={runHarvester}
+          className="px-4 py-2 bg-blue-600 rounded"
+          disabled={loading}
+        >
+          {loading ? 'Running...' : 'Run'}
+        </button>
+      </div>
+      {output && (
+        <pre className="whitespace-pre-wrap text-sm bg-black p-2 rounded">{output}</pre>
+      )}
+    </div>
+  );
+};
+
+export default TheHarvester;
+
+export const displayTheHarvester = () => {
+  return <TheHarvester />;
+};
+

--- a/pages/api/theharvester.js
+++ b/pages/api/theharvester.js
@@ -1,0 +1,17 @@
+import { exec } from 'child_process';
+
+export default function handler(req, res) {
+  const { domain, engine } = req.body || {};
+  if (!domain) {
+    res.status(400).json({ error: 'Domain required' });
+    return;
+  }
+  const cmd = `theHarvester -d ${domain} -b ${engine}`;
+  exec(cmd, { timeout: 1000 * 60 }, (error, stdout, stderr) => {
+    if (error) {
+      res.status(500).json({ error: stderr || error.message });
+    } else {
+      res.status(200).json({ output: stdout });
+    }
+  });
+}

--- a/public/themes/Yaru/apps/theharvester.svg
+++ b/public/themes/Yaru/apps/theharvester.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#772953" rx="8"/>
+  <text x="32" y="40" font-size="32" text-anchor="middle" fill="white" font-family="Arial">H</text>
+</svg>


### PR DESCRIPTION
## Summary
- add theHarvester reconnaissance tool with domain and search engine options
- dynamically load theHarvester app and register in app catalog
- include API endpoint and icon for theHarvester

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac49c137c48328a56e7dc3c5bc8559