### PR TITLE
feat: add blackjack strategy hints and card counting

### DIFF
--- a/__tests__/blackjack.test.ts
+++ b/__tests__/blackjack.test.ts
@@ -114,3 +114,24 @@ describe('Split rules', () => {
     expect(() => game.split()).toThrow('Cannot split');
   });
 });
+
+describe('Counting and penetration', () => {
+  test('running count updates with drawn cards', () => {
+    const shoe = new Shoe(1, 1);
+    shoe.cards = [card('2'), card('5'), card('K')];
+    shoe.shufflePoint = Infinity;
+    shoe.dealt = 0;
+    shoe.runningCount = 0;
+    shoe.draw();
+    expect(shoe.runningCount).toBe(-1); // K
+    shoe.draw();
+    expect(shoe.runningCount).toBe(0); // 5
+    shoe.draw();
+    expect(shoe.runningCount).toBe(1); // 2
+  });
+
+  test('BlackjackGame allows custom penetration', () => {
+    const game = new BlackjackGame({ decks: 1, bankroll: 1000, penetration: 0.6 });
+    expect(game.shoe.penetration).toBe(0.6);
+  });
+});

--- a/components/apps/blackjack/engine.js
+++ b/components/apps/blackjack/engine.js
@@ -25,6 +25,7 @@ export class Shoe {
     this.decks = decks;
     this.penetration = penetration;
     this.shuffleCount = 0;
+    this.runningCount = 0;
     this.shuffle();
   }
 
@@ -37,6 +38,7 @@ export class Shoe {
     this.shufflePoint = Math.floor(this.cards.length * this.penetration);
     this.dealt = 0;
     this.shuffleCount += 1;
+    this.runningCount = 0;
     // burn one card
     this.draw();
   }
@@ -46,7 +48,11 @@ export class Shoe {
       this.shuffle();
     }
     this.dealt += 1;
-    return this.cards.pop();
+    const card = this.cards.pop();
+    const v = card.value;
+    if (['2', '3', '4', '5', '6'].includes(v)) this.runningCount += 1;
+    else if (['10', 'J', 'Q', 'K', 'A'].includes(v)) this.runningCount -= 1;
+    return card;
   }
 }
 
@@ -133,8 +139,8 @@ export function basicStrategy(playerCards, dealerUpCard, options = {}) {
 }
 
 export class BlackjackGame {
-  constructor({ decks = 6, bankroll = 10000, hitSoft17 = true } = {}) {
-    this.shoe = new Shoe(decks);
+  constructor({ decks = 6, bankroll = 10000, hitSoft17 = true, penetration = 0.75 } = {}) {
+    this.shoe = new Shoe(decks, penetration);
     this.bankroll = bankroll; // in chips (integers)
     this.stats = { wins: 0, losses: 0, pushes: 0, hands: 0 };
     this.hitSoft17 = hitSoft17;


### PR DESCRIPTION
## Summary
- add running count tracking to blackjack shoe and expose deck penetration option
- show basic strategy hints, running count toggle, and penetration input in UI
- test card counting logic and custom penetration

## Testing
- `npx jest __tests__/blackjack.test.ts`
- `npm test` *(fails: App component smoke tests render errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acef0730c88328b6f9d5bb80a9398a