### PR TITLE
Document browser compatibility and add scan fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ To introduce a new game:
 
 The new game will then appear alongside the other games on the desktop.
 
+## Browser Compatibility
+
+Some applications rely on modern or experimental Web APIs such as Web
+Bluetooth or camera access. These features are not available in every
+browser or on all platforms. Demos require an explicit user gesture
+(like clicking a **Scan** button) before attempting to access hardware.
+When a feature is unsupported the interface falls back to a read-only
+mock so the experience remains visible without granting device access.
+
 ## Privacy
 
 The contact application records only non-PII metadata in Google Analytics.

--- a/components/apps/bluetooth/index.js
+++ b/components/apps/bluetooth/index.js
@@ -3,13 +3,20 @@ import React, { useState } from 'react';
 const BluetoothApp = () => {
   const [devices, setDevices] = useState([]);
   const [error, setError] = useState('');
+  const [demo, setDemo] = useState(false);
 
   const scan = async () => {
     setError('');
     if (!navigator.bluetooth) {
-      setError('Web Bluetooth API is not supported in this browser.');
+      setDemo(true);
+      setError('Web Bluetooth API is not supported in this browser. Showing demo devices.');
+      setDevices([
+        { id: 'demo-1', name: 'Demo Device 1' },
+        { id: 'demo-2', name: 'Demo Device 2' },
+      ]);
       return;
     }
+    setDemo(false);
     try {
       const device = await navigator.bluetooth.requestDevice({
         acceptAllDevices: true,
@@ -60,7 +67,9 @@ const BluetoothApp = () => {
             className="mb-2 flex items-center justify-between"
           >
             <span>{device.name || 'Unnamed device'}</span>
-            {device.gatt && device.gatt.connected ? (
+            {demo ? (
+              <span className="text-gray-400">Read-only</span>
+            ) : device.gatt && device.gatt.connected ? (
               <button
                 onClick={() => disconnect(device)}
                 className="px-2 py-1 bg-red-600 rounded"

--- a/components/apps/qr_tool/index.js
+++ b/components/apps/qr_tool/index.js
@@ -5,6 +5,7 @@ import QrScanner from 'qr-scanner';
 const QRTool = () => {
   const [text, setText] = useState('');
   const [decodedText, setDecodedText] = useState('');
+  const [demo, setDemo] = useState(false);
   const canvasRef = useRef(null);
   const videoRef = useRef(null);
   const scannerRef = useRef(null);
@@ -35,6 +36,11 @@ const QRTool = () => {
   };
 
   const startCamera = () => {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      setDemo(true);
+      setDecodedText('Demo result: https://example.com');
+      return;
+    }
     if (scannerRef.current) {
       scannerRef.current.start();
       return;
@@ -48,6 +54,7 @@ const QRTool = () => {
   };
 
   const stopCamera = () => {
+    if (demo) return;
     scannerRef.current?.stop();
   };
 
@@ -104,11 +111,18 @@ const QRTool = () => {
             onClick={stopCamera}
             className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-white"
             aria-label="Stop camera"
+            disabled={demo}
           >
             Stop Camera
           </button>
         </div>
-        <video ref={videoRef} className="w-64 h-64 bg-black" aria-label="Camera preview" />
+        {demo ? (
+          <div className="w-64 h-64 bg-black flex items-center justify-center text-gray-400">
+            Camera Demo
+          </div>
+        ) : (
+          <video ref={videoRef} className="w-64 h-64 bg-black" aria-label="Camera preview" />
+        )}
         {decodedText && (
           <p className="mt-2 break-all">Decoded: {decodedText}</p>
         )}


### PR DESCRIPTION
## Summary
- document browser API support and user gesture requirement
- add demo mode for Bluetooth scanning when Web Bluetooth unsupported
- add camera demo fallback in QR tool

## Testing
- `yarn lint` (fails: react/jsx-no-undef, Parsing error, etc.)
- `yarn test --runInBand` (fails: Syntax Error, usePersistentState is not defined, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68aceed4b77c83289ad67d593c66ac93