### PR TITLE
Replace reaver attack simulation with static explainer

### DIFF
--- a/components/apps/reaver/index.js
+++ b/components/apps/reaver/index.js
@@ -1,82 +1,28 @@
-import React, { useState } from 'react';
-
-const checksum = (num) => {
-  let acc = 0;
-  for (let i = 0; i < 7; i += 1) {
-    const digit = num % 10;
-    acc += i % 2 === 0 ? digit * 3 : digit;
-    num = Math.floor(num / 10);
-  }
-  return (10 - (acc % 10)) % 10;
-};
-
-const derivePin = (bssid) => {
-  const mac = bssid.replace(/:/g, '').toUpperCase();
-  if (mac.length !== 12) return null;
-  const num = parseInt(mac.slice(-6), 16) % 10000000;
-  const cs = checksum(num);
-  return `${num}`.padStart(7, '0') + cs;
-};
+import React from 'react';
 
 export default function ReaverApp() {
-  const [bssid, setBssid] = useState('');
-  const [pin, setPin] = useState('');
-  const [log, setLog] = useState('');
-  const [running, setRunning] = useState(false);
-
-  const startAttack = () => {
-    setRunning(true);
-    setLog(`Starting WPS PIN attack on ${bssid}\n`);
-    let tries = 0;
-    const interval = setInterval(() => {
-      tries += 1;
-      const guess = Math.floor(Math.random() * 1e8)
-        .toString()
-        .padStart(8, '0');
-      setLog((prev) => `${prev}Trying PIN ${guess}\n`);
-      if (tries >= 5) {
-        clearInterval(interval);
-        const result = derivePin(bssid);
-        setLog((prev) =>
-          `${prev}\nAttack complete. PIN discovered: ${result || 'invalid BSSID'}`
-        );
-        setPin(result || '');
-        setRunning(false);
-      }
-    }, 500);
-  };
-
   return (
     <div className="h-full w-full p-4 bg-ub-cool-grey text-white overflow-auto">
       <h2 className="text-lg mb-4">Reaver WPS PIN Attack</h2>
-      <div className="mb-2">
-        <label className="block mb-1">Target BSSID</label>
-        <input
-          type="text"
-          className="w-full p-2 rounded bg-gray-700 text-white font-mono"
-          placeholder="00:11:22:33:44:55"
-          value={bssid}
-          onChange={(e) => setBssid(e.target.value)}
-          disabled={running}
+      <div className="flex justify-center mb-4">
+        <img
+          src="/images/reaver-diagram.svg"
+          alt="Diagram of Reaver attacking a WPS-enabled router"
+          className="max-w-full"
         />
       </div>
-      <button
-        className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded disabled:opacity-50"
-        onClick={startAttack}
-        disabled={running || !bssid}
-      >
-        Start Attack
-      </button>
-      {pin && (
-        <div className="mt-4">
-          <div className="mb-1">Discovered WPS PIN:</div>
-          <div className="font-mono text-xl">{pin}</div>
-        </div>
-      )}
-      <pre className="mt-4 bg-black text-green-400 p-2 h-48 overflow-y-auto font-mono whitespace-pre-wrap">
-        {log}
-      </pre>
+      <p className="mb-4">
+        Reaver implements a brute force attack against Wi-Fi Protected Setup (WPS) PINs to recover WPA/WPA2 passphrases. Learn more on{' '}
+        <a
+          href="https://www.kali.org/tools/reaver/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 underline"
+        >
+          the official site
+        </a>
+        .
+      </p>
     </div>
   );
 }
-

--- a/public/images/reaver-diagram.svg
+++ b/public/images/reaver-diagram.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100" viewBox="0 0 300 100">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="15" y="20" width="80" height="60" fill="#e5e7eb" stroke="#000" />
+  <text x="55" y="55" text-anchor="middle" font-size="12" fill="#000">Reaver</text>
+  <rect x="205" y="20" width="80" height="60" fill="#e5e7eb" stroke="#000" />
+  <text x="245" y="55" text-anchor="middle" font-size="12" fill="#000">WPS Router</text>
+  <line x1="95" y1="50" x2="205" y2="50" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- Replace Reaver app's live WPS attack simulation with diagram and link to official site
- Add simple SVG diagram for Reaver workflow

## Testing
- `yarn test` *(fails: useAssetLoader is not defined)*
- `yarn lint` *(fails: GameLayout is not defined, parsing errors, React hooks warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aceed417bc8328abe0797bd0b8a8e4