### PR TITLE
Add post-exploitation summary and example report page

### DIFF
--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Meta from '../components/SEO/Meta';
+
+export default function PostExploitation() {
+  return (
+    <>
+      <Meta />
+      <main className="prose mx-auto p-4">
+        <h1>Metasploit Post-Exploitation Modules</h1>
+        <p>
+          Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s <a href="https://docs.rapid7.com/metasploit/about-post-exploitation/" target="_blank" rel="noopener noreferrer">Metasploit documentation</a> explains that these modules run on an active session to help operators gather deeper information, escalate privileges, pivot within the network, or maintain persistence.
+        </p>
+        <h2>Example Report</h2>
+        <p>The following sample shows data a post-exploitation run might collect:</p>
+        <ul>
+          <li>Host: 192.0.2.10</li>
+          <li>Session type: Meterpreter</li>
+          <li>Privilege level: Administrator</li>
+          <li>Key actions: Collected user tokens, enabled persistence, dumped credentials.</li>
+        </ul>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add page summarizing Rapid7 post-exploitation modules and sample report

## Testing
- `yarn test` *(fails: ReferenceError useAssetLoader is not defined)*
- `yarn lint` *(fails: GameLayout is not defined; parsing errors in existing components)*

------
https://chatgpt.com/codex/tasks/task_e_68aceecee6a4832896519760a286f31f