### PR TITLE
feat(trash): enable deletion with preview

### DIFF
--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -38,6 +38,9 @@ export class Trash extends Component {
         ];
         this.state = {
             empty: false,
+            fileHandle: null,
+            filePreview: null,
+            confirmDelete: false,
         }
     }
 
@@ -103,22 +106,77 @@ export class Trash extends Component {
         );
     }
 
+    selectFile = async () => {
+        if (!window.showOpenFilePicker) {
+            alert('File System Access API not supported');
+            return;
+        }
+        try {
+            const [handle] = await window.showOpenFilePicker();
+            const permission = await handle.requestPermission({ mode: 'readwrite' });
+            if (permission !== 'granted') return;
+            const file = await handle.getFile();
+            let preview;
+            if (file.type.startsWith('image/')) {
+                preview = { type: 'image', url: URL.createObjectURL(file) };
+            } else {
+                const text = await file.text();
+                preview = { type: 'text', text: text.slice(0, 100) };
+            }
+            this.setState({ fileHandle: handle, filePreview: preview, confirmDelete: true });
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    deleteSelected = async () => {
+        const { fileHandle, filePreview } = this.state;
+        if (!fileHandle) return;
+        try {
+            if (fileHandle.remove) {
+                await fileHandle.remove();
+            }
+        } catch (err) {
+            console.error(err);
+        }
+        if (filePreview?.url) URL.revokeObjectURL(filePreview.url);
+        this.setState({ fileHandle: null, filePreview: null, confirmDelete: false });
+    }
+
+    cancelDelete = () => {
+        const { filePreview } = this.state;
+        if (filePreview?.url) URL.revokeObjectURL(filePreview.url);
+        this.setState({ fileHandle: null, filePreview: null, confirmDelete: false });
+    }
+
     render() {
         return (
-            <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
+            <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none relative">
                 <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
                     <span className="font-bold ml-2">Trash</span>
                     <div className="flex">
                         <div className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded text-gray-300">Restore</div>
                         <div onClick={this.emptyTrash} className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80">Empty</div>
+                        <div onClick={this.selectFile} className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80">Delete File</div>
                     </div>
                 </div>
-                {
-                    (this.state.empty
-                        ? this.emptyScreen()
-                        : this.showTrashItems()
-                    )
-                }
+                {this.state.empty ? this.emptyScreen() : this.showTrashItems()}
+                {this.state.confirmDelete && (
+                    <div className="absolute inset-0 bg-black bg-opacity-80 flex flex-col items-center justify-center p-4">
+                        <div className="bg-ub-warm-grey p-4 rounded shadow-md max-w-full">
+                            <p className="mb-2">Delete {this.state.fileHandle?.name}?</p>
+                            {this.state.filePreview?.type === 'image' ? (
+                                <img src={this.state.filePreview.url} alt="Preview" className="max-w-xs max-h-64 mb-2" />
+                            ) : (
+                                <pre className="whitespace-pre-wrap max-w-xs max-h-64 overflow-auto mb-2">{this.state.filePreview?.text}</pre>
+                            )}
+                            <div className="flex justify-end space-x-2">
+                                <button onClick={this.deleteSelected} className="px-3 py-1 bg-red-600 rounded">Delete</button>
+                                <button onClick={this.cancelDelete} className="px-3 py-1 bg-gray-600 rounded">Cancel</button>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
         )
     }


### PR DESCRIPTION
## Summary
- allow selecting files via the File System Access API
- preview the file and confirm before deletion

## Testing
- `yarn lint` *(fails: react/jsx-no-undef in components/apps/battleship.js, parsing errors in snake.js, etc.)*
- `yarn test` *(fails: Syntax Error in components/apps/snake.js, ReferenceError in components/apps/sokoban.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aceebbc3288328ba8d74e92e93df68