### PR TITLE
feat: integrate xterm.js terminal with worker simulation

### DIFF
--- a/__tests__/apps.smoke.test.tsx
+++ b/__tests__/apps.smoke.test.tsx
@@ -34,6 +34,7 @@ beforeAll(() => {
     transform: jest.fn(),
     rect: jest.fn(),
     clip: jest.fn(),
+    createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
   }));
 
   // mock fetch for components that request external resources

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import React, { createRef, act } from 'react';
+import { render, screen } from '@testing-library/react';
 import Terminal from '../components/apps/terminal';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
@@ -9,20 +9,20 @@ describe('Terminal component', () => {
   const openApp = jest.fn();
 
   it('runs pwd command successfully', () => {
-    render(<Terminal addFolder={addFolder} openApp={openApp} />);
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: 'pwd' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    expect(screen.getByText('/home/alex')).toBeInTheDocument();
+    const ref = createRef();
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    act(() => {
+      ref.current.runCommand('pwd');
+    });
+    expect(ref.current.getContent()).toContain('/home/alex');
   });
 
   it('handles invalid cd command', () => {
-    render(<Terminal addFolder={addFolder} openApp={openApp} />);
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: 'cd nowhere' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    expect(
-      screen.getByText("bash: cd: nowhere: No such file or directory")
-    ).toBeInTheDocument();
+    const ref = createRef();
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    act(() => {
+      ref.current.runCommand('cd nowhere');
+    });
+    expect(ref.current.getContent()).toContain("bash: cd: nowhere: No such file or directory");
   });
 });

--- a/components/apps/terminal.worker.js
+++ b/components/apps/terminal.worker.js
@@ -1,0 +1,11 @@
+self.onmessage = (e) => {
+  const { command } = e.data || {};
+  if (command === 'simulate') {
+    // Fake heavy computation
+    let total = 0;
+    for (let i = 0; i < 5e7; i += 1) {
+      total += i;
+    }
+    self.postMessage('Simulation complete');
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -14,3 +14,54 @@ class ImageMock {
 
 // @ts-ignore - allow overriding the global Image for the test env
 global.Image = ImageMock as unknown as typeof Image;
+
+// Provide a minimal canvas mock so libraries like xterm.js can run under JSDOM
+// @ts-ignore
+HTMLCanvasElement.prototype.getContext = () => ({
+  fillRect: () => {},
+  clearRect: () => {},
+  getImageData: () => ({ data: [] }),
+  putImageData: () => {},
+  createImageData: () => [],
+  setTransform: () => {},
+  drawImage: () => {},
+  save: () => {},
+  restore: () => {},
+  beginPath: () => {},
+  moveTo: () => {},
+  lineTo: () => {},
+  closePath: () => {},
+  stroke: () => {},
+  translate: () => {},
+  scale: () => {},
+  rotate: () => {},
+  arc: () => {},
+  fill: () => {},
+  measureText: () => ({ width: 0 }),
+  transform: () => {},
+  rect: () => {},
+  clip: () => {},
+  createLinearGradient: () => ({ addColorStop: () => {} }),
+});
+
+// Basic matchMedia mock for libraries that expect it
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  // @ts-ignore
+  window.matchMedia = () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+  });
+}
+
+// Minimal Worker mock for tests
+class WorkerMock {
+  postMessage() {}
+  terminate() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+// @ts-ignore
+global.Worker = WorkerMock as any;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7419,6 +7419,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7756,6 +7759,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- swap custom terminal renderer for xterm.js with fit and search addons
- offload heavy command simulation to a Web Worker
- add Jest polyfills and update tests for new terminal

## Testing
- `yarn lint` *(fails: react/jsx-no-undef and other lint errors in unrelated files)*
- `yarn test` *(fails: multiple app smoke tests such as 2048.js and snake.js)*
- `yarn test __tests__/terminal.test.tsx`
- `yarn test __tests__/apps.smoke.test.tsx` *(fails: 7 failing app components)*

------
https://chatgpt.com/codex/tasks/task_e_68acee3a9f3083289f17d9d293da4a36