### PR TITLE
feat: add depth-limited minimax with draw detection

### DIFF
--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -24,18 +24,18 @@ const checkWinner = (board) => {
   return { winner: null, line: [] };
 };
 
-const minimax = (board, player) => {
+const minimax = (board, player, depth = 0, maxDepth = Infinity) => {
   const { winner } = checkWinner(board);
-  if (winner === 'O') return { score: 1 };
-  if (winner === 'X') return { score: -1 };
-  if (winner === 'draw') return { score: 0 };
+  if (winner === 'O') return { score: 10 - depth };
+  if (winner === 'X') return { score: depth - 10 };
+  if (winner === 'draw' || depth === maxDepth) return { score: 0 };
 
   const moves = [];
   board.forEach((cell, idx) => {
     if (!cell) {
       const newBoard = board.slice();
       newBoard[idx] = player;
-      const result = minimax(newBoard, player === 'O' ? 'X' : 'O');
+      const result = minimax(newBoard, player === 'O' ? 'X' : 'O', depth + 1, maxDepth);
       moves.push({ index: idx, score: result.score });
     }
   });


### PR DESCRIPTION
## Summary
- extend TicTacToe minimax to support depth cutoffs
- return neutral scores when draw or depth limit reached

## Testing
- `npm test` *(fails: TypeError in apps.smoke.test.tsx and other component smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acef1874588328a4483ce656136401