### PR TITLE
Add legal banner and documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Kali Linux Portfolio
+
+> ⚖️ **Legal and Ethical Use Only**
+>
+> This project is intended for authorized security testing and educational purposes. Unauthorized access or malicious activity is prohibited.
+> Official guidance is available in the [Kali Linux Documentation](https://www.kali.org/docs/).
+
+All sample outputs in this repository are sanitized and static to avoid exposing sensitive information.
+
 ## Adding New Apps
 
 Heavy applications should be loaded with [`next/dynamic`](https://nextjs.org/docs/advanced-features/dynamic-import) so that they do not bloat the initial bundle.

--- a/components/LegalBanner.tsx
+++ b/components/LegalBanner.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const LegalBanner: React.FC = () => (
+  <div className="bg-red-700 text-white text-center text-sm p-2">
+    Use this project responsibly and within legal boundaries. Unauthorized access or malicious activity is prohibited. Visit the{' '}
+    <a href="https://www.kali.org/docs/" className="underline" target="_blank" rel="noopener noreferrer">official Kali Linux documentation</a> for guidance.
+  </div>
+);
+
+export default LegalBanner;
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
+import LegalBanner from '../components/LegalBanner';
 
 function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -14,6 +15,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
   return (
     <>
+      <LegalBanner />
       <Component {...pageProps} />
       <Analytics />
     </>


### PR DESCRIPTION
## Summary
- add LegalBanner component with link to official Kali Linux docs
- show LegalBanner across the app
- document legal/ethical usage and sanitized outputs in README

## Testing
- `yarn test --bail` *(fails: App component smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aceec95b508328afc6b3d57914c047