### PR TITLE
feat: add lazy responsive images

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import LazyImage from './LazyImage';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
@@ -19,10 +20,12 @@ const BadgeList = ({ badges, className = '' }) => {
       />
       <div className="flex flex-wrap justify-center items-start w-full">
         {filteredBadges.map((badge, idx) => (
-          <img
+          <LazyImage
             key={idx}
             className="m-1 hover:scale-110 transition-transform cursor-pointer"
             src={badge.src}
+            srcSet={`${badge.src} 1x, ${badge.src} 2x`}
+            sizes="(max-width: 768px) 20vw, 10vw"
             alt={badge.alt}
             title={badge.description || badge.label}
             onClick={() => setSelected(badge)}

--- a/components/LazyImage.js
+++ b/components/LazyImage.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+const LazyImage = ({ src, srcSet, sizes, alt = '', className = '', ...props }) => {
+  const imgRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const node = imgRef.current;
+    if (!node) return;
+    let observer;
+    if (typeof window !== 'undefined' && 'IntersectionObserver' in window) {
+      observer = new IntersectionObserver(
+        entries => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              setIsVisible(true);
+              observer.disconnect();
+            }
+          });
+        },
+        { rootMargin: '200px' }
+      );
+      observer.observe(node);
+    } else {
+      // Fallback for browsers without IntersectionObserver support
+      setIsVisible(true);
+    }
+    return () => observer && observer.disconnect();
+  }, [src]);
+
+  return (
+    <img
+      ref={imgRef}
+      src={isVisible ? src : PLACEHOLDER}
+      srcSet={isVisible ? srcSet : undefined}
+      sizes={isVisible ? sizes : undefined}
+      alt={alt}
+      className={className}
+      loading="lazy"
+      {...props}
+    />
+  );
+};
+
+export default LazyImage;

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import LazyGitHubButton from '../LazyGitHubButton';
+import LazyImage from '../LazyImage';
 import Certs from './certs';
 
 export class AboutAlex extends Component {
@@ -249,10 +250,12 @@ const SkillSection = ({ title, badges }) => {
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map(badge => (
-          <img
+          <LazyImage
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}
+            srcSet={`${badge.src} 1x, ${badge.src} 2x`}
+            sizes="(max-width: 768px) 20vw, 10vw"
             alt={badge.alt}
             title={badge.description}
             onClick={() => setSelected(badge)}
@@ -377,8 +380,10 @@ function Skills() {
         <div className="w-full md:w-10/12 flex flex-col items-center mt-8">
           <div className="font-bold text-sm md:text-base mb-2 text-center">GitHub Contributions</div>
           <div className="bg-ub-gedit-light bg-opacity-20 p-1 md:p-2 rounded-md shadow-md">
-            <img
+            <LazyImage
               src="https://ghchart.rshah.org/Alex-Unnippillil"
+              srcSet="https://ghchart.rshah.org/Alex-Unnippillil 1x, https://ghchart.rshah.org/Alex-Unnippillil 2x"
+              sizes="(max-width: 768px) 90vw, 600px"
               alt="Alex Unnippillil's GitHub contribution graph"
               className="w-full rounded"
             />

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import LazyImage from '../LazyImage';
 
 const Certs = () => {
   const certBadges = [
@@ -42,11 +43,22 @@ const Certs = () => {
       </ul>
       <div className="w-full md:w-10/12 flex flex-wrap justify-center items-center mt-4">
         <a href="https://data.typeracer.com/pit/profile?user=ulexa&ref=badge" target="_blank" rel="noopener noreferrer" className="m-2">
-          <img src="https://data.typeracer.com/misc/badge?user=ulexa" alt="TypeRacer.com scorecard for user ulexa" />
+          <LazyImage
+            src="https://data.typeracer.com/misc/badge?user=ulexa"
+            srcSet="https://data.typeracer.com/misc/badge?user=ulexa 1x, https://data.typeracer.com/misc/badge?user=ulexa 2x"
+            sizes="(max-width: 768px) 50vw, 128px"
+            alt="TypeRacer.com scorecard for user ulexa"
+          />
         </a>
         {certBadges.map((badge) => (
           <a key={badge.href} href={badge.href} target="_blank" rel="noopener noreferrer" className="m-2">
-            <img src={badge.src} alt={badge.alt} className="w-24 h-24 md:w-28 md:h-28" />
+            <LazyImage
+              src={badge.src}
+              srcSet={`${badge.src} 1x, ${badge.src} 2x`}
+              sizes="(max-width: 768px) 25vw, 7rem"
+              alt={badge.alt}
+              className="w-24 h-24 md:w-28 md:h-28"
+            />
           </a>
         ))}
       </div>

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ReactGA from 'react-ga4';
+import LazyImage from '../LazyImage';
 
 const MAX_HISTORY = 50;
 
@@ -296,7 +297,13 @@ export class Terminal extends Component {
         ReactGA.event({ category: 'Sudo Access', action: 'lol' });
         result = (
           <div className="my-2 font-normal">
-            <img className="w-2/5" src="./images/memes/used-sudo-command.webp" alt="sudo meme" />
+            <LazyImage
+              className="w-2/5"
+              src="./images/memes/used-sudo-command.webp"
+              srcSet="./images/memes/used-sudo-command.webp 1x, ./images/memes/used-sudo-command.webp 2x"
+              sizes="(max-width: 768px) 60vw, 250px"
+              alt="sudo meme"
+            />
           </div>
         );
         break;

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+import LazyImage from '../LazyImage';
 
 const CHANNEL_HANDLE = 'Alex-Unnippillil';
 
@@ -228,7 +229,13 @@ export default function YouTubeApp({ initialVideos = [] }) {
               >
                 <a href={video.url} target="_blank" rel="noreferrer" className="block">
                   {video.thumbnail && (
-                    <img src={video.thumbnail} alt={video.title} className="w-full" />
+                    <LazyImage
+                      src={video.thumbnail}
+                      srcSet={`${video.thumbnail} 1x, ${video.thumbnail} 2x`}
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 200px"
+                      alt={video.title}
+                      className="w-full"
+                    />
                   )}
                   <div
                     className="p-2 font-semibold text-sm"


### PR DESCRIPTION
## Summary
- add LazyImage component using IntersectionObserver for deferred loading
- use LazyImage to provide srcset/sizes and native lazy loading across badges, certs, YouTube, and terminal components

## Testing
- `yarn lint` *(fails: React hooks issues in existing files)*
- `yarn test` *(fails: apps.smoke.test.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aceeb8e8508328ba8f01cf6e862832