### PR TITLE
chore: replace deprecated xterm packages

### DIFF
--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
   const containerRef = useRef(null);

--- a/package.json
+++ b/package.json
@@ -28,29 +28,29 @@
     "html-to-image": "^1.11.13",
     "jsqr": "^1.4.0",
 
-    "mathjs": "^14.6.0",
+      "mathjs": "^14.6.0",
 
-    "next": "^15.0.0",
-    "phaser": "3.70.0",
+      "next": "^15.0.0",
+      "phaser": "3.70.0",
 
-    "postcss": "^8.4.21",
-    "prop-types": "^15.8.1",
-    "qrcode": "^1.5.4",
-    "react": "^18.2.0",
-    "react-activity-calendar": "^2.7.13",
-    "react-dom": "^18.2.0",
-    "react-draggable": "^4.4.5",
-    "react-ga4": "^2.1.0",
-    "react-github-calendar": "^4.5.9",
-    "react-onclickoutside": "^6.12.2",
-    "react-twitter-embed": "^4.0.4",
-    "stockfish": "^16.0.0",
-    "swr": "^2.2.5",
-    "tailwindcss": "^3.2.4",
-    "three": "^0.179.1",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0",
-    "xterm-addon-search": "^0.13.0"
+      "postcss": "^8.4.21",
+      "prop-types": "^15.8.1",
+      "qrcode": "^1.5.4",
+      "react": "^18.2.0",
+      "react-activity-calendar": "^2.7.13",
+      "react-dom": "^18.2.0",
+      "react-draggable": "^4.4.5",
+      "react-ga4": "^2.1.0",
+      "react-github-calendar": "^4.5.9",
+      "react-onclickoutside": "^6.12.2",
+      "react-twitter-embed": "^4.0.4",
+      "stockfish": "^16.0.0",
+      "swr": "^2.2.5",
+      "tailwindcss": "^3.2.4",
+      "three": "^0.179.1",
+      "@xterm/xterm": "^5.5.0",
+      "@xterm/addon-fit": "^0.10.0",
+      "@xterm/addon-search": "^0.15.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -70,5 +70,8 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "typescript": "^5.9.2"
+  },
+  "overrides": {
+    "glob@*": "^10.3.10"
   }
 }


### PR DESCRIPTION
## Summary
- swap deprecated `xterm` packages for maintained `@xterm/*` modules
- override `glob` dependency to avoid deprecation warnings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d7805788328ad6b9fae771acb58