### PR TITLE
refactor: use scoped xterm packages

### DIFF
--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {


### PR DESCRIPTION
## Summary
- replace deprecated `xterm` imports with scoped `@xterm` packages in the terminal app

## Testing
- `yarn install` (fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))
- `yarn test` (fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))
- `yarn lint` (fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))

------
https://chatgpt.com/codex/tasks/task_e_68ad2385d9d48328b7af0d733be7070c