### PR TITLE
refactor(battleship): memoize restart and fire hooks

### DIFF
--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -91,7 +91,7 @@ const Battleship = () => {
       setAi(diff === 'hard' ? new MonteCarloAI() : new RandomSalvoAI());
       setCursor(0);
     },
-    [difficulty, placeShips]
+    [createBoard, difficulty, placeShips, randomizePlacement]
   );
 
   useEffect(() => {
@@ -168,7 +168,7 @@ const Battleship = () => {
         } else setMessage(hit ? 'Hit!' : 'Miss!');
       }, 100); // simulate thinking
     },
-    [ai, enemyBoard, heat, phase, playerBoard, setEnemyBoard, setPlayerBoard, setHeat, setMessage, setPhase, setStats]
+    [ai, enemyBoard, heat, phase, playerBoard]
   );
 
   useGameControls(({ x, y }) => {


### PR DESCRIPTION
## Summary
- ensure restart callback includes all referenced variables in deps
- memoize fire handler and stabilize keydown listener dependencies

## Testing
- `npm test` *(fails: Cannot find module 'xterm')*

------
https://chatgpt.com/codex/tasks/task_e_68ad238830dc8328a549cf81314ea81a