### PR TITLE
Fix Frogger difficulty reset dependencies

### DIFF
--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -301,7 +301,7 @@ const Frogger = () => {
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-      }, [difficulty, level, loseLife, reset]);
+      }, [difficulty, level, loseLife, reset, handlePads, PAD_POSITIONS, initialFrog]);
 
   useEffect(() => {
     if (score >= nextLife.current) {


### PR DESCRIPTION
## Summary
- ensure Frogger game loop effect depends on difficulty and other referenced variables to properly reset state

## Testing
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading 'toUpperCase'))*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad238a95c08328a2fd57993a5069ec