### PR TITLE
chore: replace deprecated xterm packages

### DIFF
--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {


### PR DESCRIPTION
## Summary
- replace deprecated xterm packages with maintained `@xterm` equivalents

## Testing
- `yarn build`
- `yarn test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ad229096208328aefa3176169826e8