### PR TITLE
Memoize tunnel check in Pacman

### DIFF
--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -388,7 +388,7 @@ const Pacman = () => {
         }
       }
     });
-  }, [pellets, score, availableDirs, levelIndex, isTunnel]);
+  }, [pellets, score, availableDirs, levelIndex]);
 
   const stepRef = useRef(step);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Memoize `isTunnel` with `useCallback` and remove it from the `step` callback dependency list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad236a98fc832892a237a67a91c950