### PR TITLE
fix: resolve xterm import paths for terminal app

### DIFF
--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback 
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {


### PR DESCRIPTION
## Summary
- use scoped `@xterm/*` modules and CSS in the terminal component to satisfy build-time imports

## Testing
- `yarn test` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*
- `yarn lint` *(fails: Cannot read properties of undefined (reading 'toUpperCase'))*

------
https://chatgpt.com/codex/tasks/task_e_68ad2ce7ca388328940fc64f3fc5d9c3