### PR TITLE
fix: ensure X timeline loads and fallback

### DIFF
--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 
 // Load the Twitter embed only on the client to avoid SSR issues.
@@ -8,14 +8,41 @@ const TwitterTimelineEmbed = dynamic(
 );
 
 export default function XApp() {
+  const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  // If the embed does not load within a few seconds, display a fallback link.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!loaded) setFailed(true);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [loaded]);
+
   return (
     <div className="h-full w-full overflow-auto bg-ub-cool-grey">
-      <TwitterTimelineEmbed
-        sourceType="profile"
-        screenName="AUnnippillil"
-        options={{ chrome: 'noheader noborders' }}
-        className="w-full h-full"
-      />
+      {!failed ? (
+        <TwitterTimelineEmbed
+          sourceType="profile"
+          screenName="alexunnippillil"
+          options={{ chrome: 'noheader noborders' }}
+          className="w-full h-full"
+          onLoad={() => setLoaded(true)}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center p-4 text-center text-white">
+          Unable to load timeline. Visit{' '}
+          <a
+            href="https://x.com/alexunnippillil"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            x.com/alexunnippillil
+          </a>
+          .
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- correct X timeline screen name and ensure embed loads
- show fallback link when timeline cannot be retrieved

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a2fa85c83288f50dacde9b64ee7