### PR TITLE
fix: tidy frogger useEffect dependencies

### DIFF
--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -301,7 +301,7 @@ const Frogger = () => {
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-      }, [difficulty, level, loseLife, reset, handlePads, PAD_POSITIONS, initialFrog]);
+      }, [difficulty, level, loseLife, reset]);
 
   useEffect(() => {
     if (score >= nextLife.current) {


### PR DESCRIPTION
## Summary
- remove unnecessary constants from Frogger's main loop useEffect dependencies

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5aacbe308328ae76f7b02abec2ee