### PR TITLE
Add dismissible help overlay to BeEF app

### DIFF
--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+const STORAGE_KEY = 'beefHelpDismissed';
+
+export default function GuideOverlay({ onClose }) {
+  const [dontShow, setDontShow] = useState(false);
+
+  const handleClose = () => {
+    if (dontShow) {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true');
+      } catch (e) {
+        // ignore storage errors
+      }
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+        <h2 className="text-xl font-bold mb-2">BeEF Workflow</h2>
+        <ul className="list-disc pl-5 mb-4 space-y-1">
+          <li>Use <strong>Refresh</strong> to load hooked browsers.</li>
+          <li>Select a browser from the list to target.</li>
+          <li>Enter a <strong>Module ID</strong> and click <strong>Run Module</strong> to execute it.</li>
+          <li>View the module output below the controls.</li>
+        </ul>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={dontShow}
+            onChange={(e) => setDontShow(e.target.checked)}
+          />
+            <span>Don&apos;t show again</span>
+          </label>
+        <button
+          onClick={handleClose}
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          autoFocus
+        >
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import GuideOverlay from './GuideOverlay';
 
 export default function Beef() {
   const [hooks, setHooks] = useState([]);
   const [selected, setSelected] = useState(null);
   const [moduleId, setModuleId] = useState('');
   const [output, setOutput] = useState('');
+  const [showHelp, setShowHelp] = useState(false);
 
   const baseUrl = process.env.NEXT_PUBLIC_BEEF_URL || 'http://127.0.0.1:3000';
 
@@ -22,6 +24,13 @@ export default function Beef() {
     fetchHooks();
   }, [fetchHooks]);
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const dismissed = localStorage.getItem('beefHelpDismissed');
+      if (!dismissed) setShowHelp(true);
+    }
+  }, []);
+
   const runModule = async () => {
     if (!selected || !moduleId) return;
     try {
@@ -38,7 +47,8 @@ export default function Beef() {
   };
 
   return (
-    <div className="flex h-full w-full bg-ub-cool-grey text-white">
+    <div className="relative flex h-full w-full bg-ub-cool-grey text-white">
+      {showHelp && <GuideOverlay onClose={() => setShowHelp(false)} />}
       <div className="w-1/3 border-r border-gray-700 overflow-y-auto">
         <div className="flex items-center justify-between p-2">
           <h2 className="font-bold">Hooked Browsers</h2>


### PR DESCRIPTION
## Summary
- Add local help overlay component for BeEF explaining refresh, selection, and module execution workflow
- Persist "Don't show again" preference in `localStorage`
- Show overlay on first load and integrate into BeEF app

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' in terminal test)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c6b5ad88328a645574eaa4ca557