### PR TITLE
feat: add compose UI and refresh for X app

### DIFF
--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
 
 // Load the Twitter embed only on the client to avoid SSR issues.
@@ -8,14 +8,60 @@ const TwitterTimelineEmbed = dynamic(
 );
 
 export default function XApp() {
+  const [text, setText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [timelineKey, setTimelineKey] = useState(0);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/x', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text.trim() }),
+      });
+      if (res.ok) {
+        setText('');
+        setTimelineKey((k) => k + 1);
+      }
+    } catch (err) {
+      // Silently fail for now
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
-    <div className="h-full w-full overflow-auto bg-ub-cool-grey">
-      <TwitterTimelineEmbed
-        sourceType="profile"
-        screenName="AUnnippillil"
-        options={{ chrome: 'noheader noborders' }}
-        className="w-full h-full"
-      />
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey flex flex-col">
+      <form
+        onSubmit={handleSubmit}
+        className="p-2 flex flex-col gap-2 border-b border-gray-600"
+      >
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="What's happening?"
+          className="w-full p-2 rounded bg-gray-800 text-white"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !text.trim()}
+          className="self-end px-4 py-1 bg-blue-500 text-white rounded disabled:opacity-50"
+        >
+          {submitting ? 'Posting...' : 'Post'}
+        </button>
+      </form>
+      <div className="flex-1">
+        <TwitterTimelineEmbed
+          key={timelineKey}
+          sourceType="profile"
+          screenName="AUnnippillil"
+          options={{ chrome: 'noheader noborders' }}
+          className="w-full h-full"
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add simple compose form to X app
- submit posts through existing API utilities
- refresh X timeline after posting

## Testing
- `yarn lint`
- `CI=1 yarn test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5c5abf3c8328a9836e934976a1e9