### PR TITLE
Add theme toggle with persistent context

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,9 @@
 import React from 'react';
+import { useTheme } from '../../hooks/useTheme';
 
 export function Settings(props) {
+    const { theme, setTheme } = useTheme();
+
     const wallpapers = {
         "wall-1": "./images/wallpapers/wall-1.webp",
         "wall-2": "./images/wallpapers/wall-2.webp",
@@ -18,7 +21,18 @@ export function Settings(props) {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className=" md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Theme:</label>
+                <select
+                    value={theme}
+                    onChange={(e) => setTheme(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="dark">Dark</option>
+                    <option value="light">Light</option>
+                </select>
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {

--- a/hooks/useTheme.tsx
+++ b/hooks/useTheme.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, ReactNode } from 'react';
+import usePersistentState from './usePersistentState';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  setTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = usePersistentState<Theme>('theme', () => {
+    if (typeof document !== 'undefined' && document.documentElement.dataset.theme) {
+      return document.documentElement.dataset.theme as Theme;
+    }
+    return 'dark';
+  });
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.dataset.theme = theme;
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
+import { ThemeProvider } from '../hooks/useTheme';
 
 function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -13,10 +14,10 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }, []);
   return (
-    <>
+    <ThemeProvider>
       <Component {...pageProps} />
       <Analytics />
-    </>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add ThemeProvider using persistent state to store selected theme
- wrap app with ThemeProvider to apply theme globally
- extend settings app with theme selector

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c7633c88328aa4ac22ed0489c5a