### PR TITLE
feat: add preset support to ettercap

### DIFF
--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -10,16 +10,29 @@ const generatePacket = (src, dst) => ({
   length: Math.floor(Math.random() * 1500) + 60,
 });
 
+const defaultPresets = [
+  { name: 'Local Gateway', target1: '192.168.0.1', target2: '192.168.0.255' },
+  { name: 'Sample Pair', target1: '192.168.0.100', target2: '192.168.0.101' },
+];
+
 const EttercapApp = () => {
   const [target1, setTarget1] = useState('');
   const [target2, setTarget2] = useState('');
   const [running, setRunning] = useState(false);
   const [traffic, setTraffic] = useState([]);
+  const [presets, setPresets] = useState([]);
+  const [selectedPreset, setSelectedPreset] = useState('');
   const intervalRef = useRef(null);
 
   useEffect(() => {
+    const stored = localStorage.getItem('ettercap-presets');
+    setPresets(stored ? JSON.parse(stored) : defaultPresets);
     return () => clearInterval(intervalRef.current);
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('ettercap-presets', JSON.stringify(presets));
+  }, [presets]);
 
   const startSession = () => {
     if (!target1 || !target2) return;
@@ -35,21 +48,64 @@ const EttercapApp = () => {
     setRunning(false);
   };
 
+  const applyPreset = (name) => {
+    setSelectedPreset(name);
+    const preset = presets.find((p) => p.name === name);
+    if (preset) {
+      setTarget1(preset.target1);
+      setTarget2(preset.target2);
+    }
+  };
+
+  const savePreset = () => {
+    const name = prompt('Preset name', selectedPreset || '');
+    if (!name) return;
+    const existingIndex = presets.findIndex((p) => p.name === name);
+    const newPresets = [...presets];
+    const data = { name, target1, target2 };
+    if (existingIndex >= 0) {
+      newPresets[existingIndex] = data;
+    } else {
+      newPresets.push(data);
+    }
+    setPresets(newPresets);
+    setSelectedPreset(name);
+  };
+
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-4 flex flex-col">
       <div className="flex mb-4 space-x-2">
+        <select
+          className="p-2 rounded text-black"
+          value={selectedPreset}
+          onChange={(e) => applyPreset(e.target.value)}
+          disabled={running}
+        >
+          <option value="">Custom</option>
+          {presets.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
         <input
           className="flex-1 p-2 rounded text-black"
           placeholder="Target 1"
           value={target1}
-          onChange={(e) => setTarget1(e.target.value)}
+          onChange={(e) => {
+            setTarget1(e.target.value);
+            setSelectedPreset('');
+          }}
           disabled={running}
         />
         <input
           className="flex-1 p-2 rounded text-black"
           placeholder="Target 2"
           value={target2}
-          onChange={(e) => setTarget2(e.target.value)}
+          onChange={(e) => {
+            setTarget2(e.target.value);
+            setSelectedPreset('');
+          }}
           disabled={running}
         />
         {!running ? (
@@ -67,6 +123,13 @@ const EttercapApp = () => {
             Stop
           </button>
         )}
+        <button
+          className="px-4 py-2 bg-blue-600 rounded"
+          onClick={savePreset}
+          disabled={running}
+        >
+          Save Preset
+        </button>
       </div>
       <div className="flex-1 overflow-auto bg-gray-800 rounded">
         <table className="w-full text-xs">


### PR DESCRIPTION
## Summary
- add default preset definitions and persistence
- allow users to select and save Ettercap session presets

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*
- `yarn lint components/apps/ettercap/index.js` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5c7c8c0883288ab6ca5193a1d34f