### PR TITLE
feat: add temperature and distance conversions

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -2,16 +2,28 @@ import { convertUnit } from '../components/apps/converter/UnitConverter';
 
 describe('Unit conversion', () => {
   it('converts meters to kilometers', () => {
-    expect(convertUnit('length', 'meter', 'kilometer', 1000)).toBeCloseTo(1);
+    expect(convertUnit('distance', 'meter', 'kilometer', 1000)).toBeCloseTo(1);
   });
 
   it('converts kilograms to pounds', () => {
     expect(convertUnit('weight', 'kilogram', 'pound', 1)).toBeCloseTo(2.20462, 5);
   });
 
+  it('converts Celsius to Fahrenheit', () => {
+    expect(
+      convertUnit('temperature', 'celsius', 'fahrenheit', 100)
+    ).toBeCloseTo(212);
+  });
+
+  it('converts Fahrenheit to Kelvin', () => {
+    expect(
+      convertUnit('temperature', 'fahrenheit', 'kelvin', 32)
+    ).toBeCloseTo(273.15, 2);
+  });
+
   it('respects precision when provided', () => {
     expect(
-      convertUnit('length', 'meter', 'kilometer', 1234, 2)
+      convertUnit('distance', 'meter', 'kilometer', 1234, 2)
     ).toBeCloseTo(1.23, 2);
   });
 });

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -4,7 +4,7 @@ import { create, all } from 'mathjs';
 const math = create(all);
 
 const unitMap = {
-  length: {
+  distance: {
     meter: 'm',
     kilometer: 'km',
     mile: 'mi',
@@ -16,6 +16,11 @@ const unitMap = {
     pound: 'lb',
     ounce: 'oz',
   },
+  temperature: {
+    celsius: 'degC',
+    fahrenheit: 'degF',
+    kelvin: 'K',
+  },
 };
 
 export const convertUnit = (category, from, to, amount, precision) => {
@@ -26,7 +31,7 @@ export const convertUnit = (category, from, to, amount, precision) => {
 };
 
 const UnitConverter = () => {
-  const [category, setCategory] = useState('length');
+  const [category, setCategory] = useState('distance');
   const [fromUnit, setFromUnit] = useState('meter');
   const [toUnit, setToUnit] = useState('kilometer');
   const [value, setValue] = useState('');
@@ -68,8 +73,9 @@ const UnitConverter = () => {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
         >
-          <option value="length">Length</option>
+          <option value="distance">Distance</option>
           <option value="weight">Weight</option>
+          <option value="temperature">Temperature</option>
         </select>
       </label>
       <label className="flex flex-col">


### PR DESCRIPTION
## Summary
- extend unit conversion logic with distance and temperature units
- expose selectors for new unit types in Unit Converter UI
- add tests covering temperature and distance conversions

## Testing
- `npm test __tests__/converter.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ad5cef59bc8328b135ec376ffb722e