### PR TITLE
Add autopsy templates with selector and pre-fill

### DIFF
--- a/components/apps/autopsy/basic.json
+++ b/components/apps/autopsy/basic.json
@@ -1,0 +1,6 @@
+{
+  "templateName": "Basic Case",
+  "caseName": "New Case",
+  "examiner": "Investigator",
+  "notes": ""
+}

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,14 +1,37 @@
 import React, { useState } from 'react';
+import basicTemplate from './basic.json';
+import networkTemplate from './network.json';
+
+const templates = [basicTemplate, networkTemplate];
 
 function Autopsy() {
   const [caseName, setCaseName] = useState('');
+  const [examiner, setExaminer] = useState('');
+  const [notes, setNotes] = useState('');
+  const [template, setTemplate] = useState('');
   const [currentCase, setCurrentCase] = useState(null);
   const [analysis, setAnalysis] = useState('');
+
+  const handleTemplateChange = (e) => {
+    const selected = templates.find(
+      (t) => t.templateName === e.target.value
+    );
+    setTemplate(e.target.value);
+    if (selected) {
+      setCaseName(selected.caseName || '');
+      setExaminer(selected.examiner || '');
+      setNotes(selected.notes || '');
+    } else {
+      setCaseName('');
+      setExaminer('');
+      setNotes('');
+    }
+  };
 
   const createCase = () => {
     const name = caseName.trim();
     if (name) {
-      setCurrentCase(name);
+      setCurrentCase({ caseName: name, examiner: examiner.trim(), notes });
       setAnalysis('');
     }
   };
@@ -30,24 +53,58 @@ function Autopsy() {
 
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 space-y-4">
-      <div className="flex space-x-2">
-        <input
-          type="text"
-          value={caseName}
-          onChange={(e) => setCaseName(e.target.value)}
-          placeholder="Case name"
-          className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+      <div className="space-y-2">
+        <div className="flex space-x-2">
+          <select
+            value={template}
+            onChange={handleTemplateChange}
+            className="bg-ub-grey text-white px-2 py-1 rounded"
+          >
+            <option value="">Template</option>
+            {templates.map((t) => (
+              <option key={t.templateName} value={t.templateName}>
+                {t.templateName}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={caseName}
+            onChange={(e) => setCaseName(e.target.value)}
+            placeholder="Case name"
+            className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+          />
+          <input
+            type="text"
+            value={examiner}
+            onChange={(e) => setExaminer(e.target.value)}
+            placeholder="Examiner"
+            className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+          />
+          <button
+            onClick={createCase}
+            className="bg-ub-orange px-3 py-1 rounded"
+          >
+            Create Case
+          </button>
+        </div>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Notes"
+          className="w-full bg-ub-grey text-white p-2 rounded resize-none"
+          rows={2}
         />
-        <button
-          onClick={createCase}
-          className="bg-ub-orange px-3 py-1 rounded"
-        >
-          Create Case
-        </button>
       </div>
       {currentCase && (
         <div className="space-y-2">
-          <div className="text-sm">Current case: {currentCase}</div>
+          <div className="text-sm">Current case: {currentCase.caseName}</div>
+          {currentCase.examiner && (
+            <div className="text-xs">Examiner: {currentCase.examiner}</div>
+          )}
+          {currentCase.notes && (
+            <div className="text-xs whitespace-pre-wrap">Notes: {currentCase.notes}</div>
+          )}
           <input type="file" onChange={analyseFile} className="text-sm" />
         </div>
       )}

--- a/components/apps/autopsy/network.json
+++ b/components/apps/autopsy/network.json
@@ -1,0 +1,6 @@
+{
+  "templateName": "Network Analysis",
+  "caseName": "Network Investigation",
+  "examiner": "Network Examiner",
+  "notes": "Collect network traffic and logs."
+}


### PR DESCRIPTION
## Summary
- add basic and network investigation templates for Autopsy
- allow choosing a template when creating a case
- pre-fill case name, examiner, and notes from the selected template

## Testing
- `npm test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5cf53d408328a97c805406ed3f16