### PR TITLE
feat: allow custom figlet fonts

### DIFF
--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -6,7 +6,14 @@ figlet.parseFont('Standard', standard);
 figlet.parseFont('Slant', slant);
 
 self.onmessage = (e) => {
-  const { text, font } = e.data;
-  const rendered = figlet.textSync(text || '', { font });
-  self.postMessage(rendered);
+  const { type } = e.data;
+  if (type === 'parseFont') {
+    const { name, data } = e.data;
+    figlet.parseFont(name, data);
+    self.postMessage({ type: 'fontParsed', name });
+  } else if (type === 'render') {
+    const { text, font } = e.data;
+    const rendered = figlet.textSync(text || '', { font });
+    self.postMessage({ type: 'render', output: rendered });
+  }
 };


### PR DESCRIPTION
## Summary
- support uploading and registering custom FIGlet font files
- allow switching between default and uploaded fonts
- render text via worker with newly parsed fonts

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' from 'components/apps/terminal.js')*


------
https://chatgpt.com/codex/tasks/task_e_68ad5cfa97a88328a0d0e58071ab6b4c