### PR TITLE
feat(hydra): add scheduling interface

### DIFF
--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -7,8 +7,9 @@ const HydraApp = () => {
   const [service, setService] = useState('ssh');
   const [users, setUsers] = useState('');
   const [passwords, setPasswords] = useState('');
-  const [output, setOutput] = useState('');
-  const [running, setRunning] = useState(false);
+  const [runAt, setRunAt] = useState('');
+  const [message, setMessage] = useState('');
+  const [tasks, setTasks] = useState([]);
 
   const readFile = (file, setter) => {
     if (!file) return;
@@ -17,27 +18,64 @@ const HydraApp = () => {
     reader.readAsText(file);
   };
 
-  const runHydra = async () => {
-    if (!target || !users || !passwords) {
-      setOutput('Please provide target, user list and password list');
-      return;
-    }
-
-    setRunning(true);
-    setOutput('');
+  const runTask = async (task) => {
+    setTasks((prev) =>
+      prev.map((t) => (t.id === task.id ? { ...t, status: 'running' } : t))
+    );
     try {
       const res = await fetch('/api/hydra', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ target, service, userList: users, passList: passwords }),
+        body: JSON.stringify({
+          target: task.target,
+          service: task.service,
+          userList: task.users,
+          passList: task.passwords,
+        }),
       });
       const data = await res.json();
-      setOutput(data.output || data.error || 'No output');
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === task.id
+            ? { ...t, status: 'completed', output: data.output || data.error || 'No output' }
+            : t
+        )
+      );
     } catch (err) {
-      setOutput(err.message);
-    } finally {
-      setRunning(false);
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === task.id
+            ? { ...t, status: 'failed', output: err.message }
+            : t
+        )
+      );
     }
+  };
+
+  const scheduleTask = (task) => {
+    const delay = task.runAt - Date.now();
+    if (delay <= 0) runTask(task);
+    else setTimeout(() => runTask(task), delay);
+  };
+
+  const addTask = () => {
+    if (!target || !users || !passwords || !runAt) {
+      setMessage('Please provide target, user list, password list and run time');
+      return;
+    }
+    setMessage('');
+    const newTask = {
+      id: Date.now(),
+      target,
+      service,
+      users,
+      passwords,
+      runAt: new Date(runAt).getTime(),
+      status: 'scheduled',
+      output: '',
+    };
+    setTasks((prev) => [...prev, newTask]);
+    scheduleTask(newTask);
   };
 
   return (
@@ -85,17 +123,62 @@ const HydraApp = () => {
             className="w-full p-2 rounded text-black"
           />
         </div>
+        <div>
+          <label className="block mb-1">Run Time</label>
+          <input
+            type="datetime-local"
+            value={runAt}
+            onChange={(e) => setRunAt(e.target.value)}
+            className="w-full p-2 rounded text-black"
+          />
+        </div>
         <button
-          onClick={runHydra}
-          disabled={running}
-          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+          onClick={addTask}
+          className="px-4 py-2 bg-green-600 rounded"
         >
-          {running ? 'Running...' : 'Run Hydra'}
+          Add to Queue
         </button>
+        {message && <p className="text-red-400">{message}</p>}
       </div>
 
-      {output && (
-        <pre className="mt-4 bg-black p-2 overflow-auto h-64 whitespace-pre-wrap">{output}</pre>
+      <div className="mt-6">
+        <h2 className="text-lg mb-2">Scheduled Tasks</h2>
+        {tasks.length === 0 ? (
+          <p>No tasks scheduled</p>
+        ) : (
+          <table className="w-full text-sm text-left">
+            <thead>
+              <tr>
+                <th className="border p-2">Target</th>
+                <th className="border p-2">Service</th>
+                <th className="border p-2">Run Time</th>
+                <th className="border p-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tasks.map((t) => (
+                <tr key={t.id} className="border-t">
+                  <td className="p-2">{t.target}</td>
+                  <td className="p-2">{t.service}</td>
+                  <td className="p-2">{new Date(t.runAt).toLocaleString()}</td>
+                  <td className="p-2">{t.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {tasks.map(
+        (t) =>
+          t.output && (
+            <div key={`out-${t.id}`} className="mt-4">
+              <h3 className="font-bold">Output for {t.target}</h3>
+              <pre className="bg-black p-2 overflow-auto h-64 whitespace-pre-wrap">
+                {t.output}
+              </pre>
+            </div>
+          )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add task scheduling to Hydra UI
- allow queueing of target configs with run times
- show scheduled tasks and status updates

## Testing
- `npm test` *(fails: AI computes move under 200ms; Cannot find module '@xterm/xterm')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5cfda96c8328abd0a6847cc0d42c