### PR TITLE
feat(hashcat): add resume with manual save

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import HashcatApp from '../components/apps/hashcat';
+
+describe('HashcatApp state persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test('restores saved state on mount', () => {
+    localStorage.setItem(
+      'hashcatState',
+      JSON.stringify({ hashType: '100', progress: 45 })
+    );
+    render(<HashcatApp />);
+    expect(screen.getByText(/Selected: SHA1/)).toBeInTheDocument();
+    expect(screen.getByText(/Progress: 45%/)).toBeInTheDocument();
+  });
+
+  test('saves state manually', () => {
+    render(<HashcatApp />);
+    fireEvent.change(screen.getByLabelText(/Hash Type/), {
+      target: { value: '3200' },
+    });
+    fireEvent.click(screen.getByText(/Save State/));
+    const saved = JSON.parse(localStorage.getItem('hashcatState') ?? '{}');
+    expect(saved.hashType).toBe('3200');
+  });
+});

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -22,13 +22,48 @@ const Gauge = ({ value }) => (
 function HashcatApp() {
   const [hashType, setHashType] = useState(hashTypes[0].id);
   const [gpuUsage, setGpuUsage] = useState(0);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const usageInterval = setInterval(() => {
       setGpuUsage(Math.floor(Math.random() * 100));
     }, 3000);
-    return () => clearInterval(interval);
+
+    const progressInterval = setInterval(() => {
+      setProgress((p) => (p < 100 ? p + 5 : 100));
+    }, 2000);
+
+    return () => {
+      clearInterval(usageInterval);
+      clearInterval(progressInterval);
+    };
   }, []);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('hashcatState');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed.hashType) setHashType(parsed.hashType);
+        if (typeof parsed.progress === 'number') setProgress(parsed.progress);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  const saveState = () => {
+    localStorage.setItem(
+      'hashcatState',
+      JSON.stringify({ hashType, progress })
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      saveState();
+    };
+  }, [hashType, progress]);
 
   const selectedHash = hashTypes.find((h) => h.id === hashType)?.name;
 
@@ -53,6 +88,21 @@ function HashcatApp() {
       </div>
       <div>Selected: {selectedHash}</div>
       <Gauge value={gpuUsage} />
+      <div className="w-48">
+        <div className="text-sm mb-1">Progress: {progress}%</div>
+        <div className="w-full h-4 bg-gray-700 rounded">
+          <div
+            className="h-4 bg-blue-500 rounded"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+      <button
+        className="px-2 py-1 bg-green-500 text-black rounded"
+        onClick={saveState}
+      >
+        Save State
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- persist hashcat cracking state to localStorage
- restore progress and hash type on reload
- add manual save button and tests for persistence

## Testing
- `yarn test __tests__/hashcat.test.tsx`
- `yarn lint components/apps/hashcat/index.js __tests__/hashcat.test.tsx` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d02b4088328ac25a14fbb9e24a0