### PR TITLE
Add dsniff data table with masked details

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -1,18 +1,47 @@
 import React, { useEffect, useState } from 'react';
 
+const MaskedText = ({ text }) => {
+  const [show, setShow] = useState(false);
+  return (
+    <span onClick={() => setShow((s) => !s)} className="cursor-pointer">
+      {show ? text : '••••'}
+    </span>
+  );
+};
+
+const decodeBase64 = (str) => {
+  try {
+    if (typeof atob !== 'undefined') {
+      return atob(str);
+    }
+    return Buffer.from(str, 'base64').toString('utf-8');
+  } catch (e) {
+    return '';
+  }
+};
+
 const Dsniff = () => {
-  const [urlsnarfOutput, setUrlsnarfOutput] = useState('');
-  const [arpspoofOutput, setArpspoofOutput] = useState('');
+  const [data, setData] = useState([]);
+  const [filter, setFilter] = useState('');
+  const [sortKey, setSortKey] = useState('time');
+  const [sortAsc, setSortAsc] = useState(true);
 
   useEffect(() => {
     const fetchOutputs = async () => {
       try {
-        const [urlsnarfRes, arpspoofRes] = await Promise.all([
+        const [u, a] = await Promise.all([
           fetch('/api/dsniff/urlsnarf').then((r) => r.text()).catch(() => ''),
           fetch('/api/dsniff/arpspoof').then((r) => r.text()).catch(() => ''),
         ]);
-        if (urlsnarfRes) setUrlsnarfOutput(urlsnarfRes);
-        if (arpspoofRes) setArpspoofOutput(arpspoofRes);
+        const decode = (str, type) => {
+          try {
+            const arr = JSON.parse(decodeBase64(str));
+            return arr.map((item) => ({ ...item, type }));
+          } catch (e) {
+            return [];
+          }
+        };
+        setData([...decode(u, 'urlsnarf'), ...decode(a, 'arpspoof')]);
       } catch (e) {
         // ignore errors
       }
@@ -22,20 +51,92 @@ const Dsniff = () => {
     return () => clearInterval(interval);
   }, []);
 
+  const toggleSort = (key) => {
+    if (key === sortKey) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  };
+
+  const filtered = data.filter((row) =>
+    Object.values(row)
+      .join(' ')
+      .toLowerCase()
+      .includes(filter.toLowerCase())
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    const va = a[sortKey] || '';
+    const vb = b[sortKey] || '';
+    if (va < vb) return sortAsc ? -1 : 1;
+    if (va > vb) return sortAsc ? 1 : -1;
+    return 0;
+  });
+
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-2 overflow-auto">
       <h1 className="text-lg mb-2">dsniff</h1>
-      <div className="mb-4">
-        <h2 className="font-bold">urlsnarf</h2>
-        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
-          {urlsnarfOutput || 'No data'}
-        </pre>
-      </div>
-      <div>
-        <h2 className="font-bold">arpspoof</h2>
-        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
-          {arpspoofOutput || 'No data'}
-        </pre>
+      <input
+        type="text"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        placeholder="Filter..."
+        className="mb-2 p-1 rounded text-black"
+      />
+      <div className="overflow-auto">
+        <table className="w-full text-xs">
+          <thead className="bg-gray-700">
+            <tr>
+              <th
+                className="p-1 text-left cursor-pointer"
+                onClick={() => toggleSort('time')}
+              >
+                Time
+              </th>
+              <th
+                className="p-1 text-left cursor-pointer"
+                onClick={() => toggleSort('type')}
+              >
+                Type
+              </th>
+              <th
+                className="p-1 text-left cursor-pointer"
+                onClick={() => toggleSort('src')}
+              >
+                Source
+              </th>
+              <th
+                className="p-1 text-left cursor-pointer"
+                onClick={() => toggleSort('dst')}
+              >
+                Destination
+              </th>
+              <th className="p-1 text-left">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row, idx) => (
+              <tr key={idx} className={idx % 2 ? 'bg-gray-700' : ''}>
+                <td className="p-1 whitespace-nowrap">{row.time}</td>
+                <td className="p-1 whitespace-nowrap">{row.type}</td>
+                <td className="p-1 break-all">{row.src}</td>
+                <td className="p-1 break-all">{row.dst}</td>
+                <td className="p-1 break-all">
+                  <MaskedText text={row.detail} />
+                </td>
+              </tr>
+            ))}
+            {!sorted.length && (
+              <tr>
+                <td className="p-4 text-center" colSpan="5">
+                  No data
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/pages/api/dsniff/arpspoof.js
+++ b/pages/api/dsniff/arpspoof.js
@@ -1,0 +1,18 @@
+const sample = [
+  {
+    time: '10:00:03',
+    src: '192.168.1.1',
+    dst: '192.168.1.2',
+    detail: 'ARP reply is-at 00:11:22:33:44:55'
+  },
+  {
+    time: '10:00:07',
+    src: '192.168.1.2',
+    dst: '192.168.1.1',
+    detail: 'ARP reply is-at 66:77:88:99:aa:bb'
+  }
+];
+export default function handler(req, res) {
+  const encoded = Buffer.from(JSON.stringify(sample)).toString('base64');
+  res.status(200).send(encoded);
+}

--- a/pages/api/dsniff/urlsnarf.js
+++ b/pages/api/dsniff/urlsnarf.js
@@ -1,0 +1,18 @@
+const sample = [
+  {
+    time: '10:00:01',
+    src: '192.168.1.2',
+    dst: 'example.com',
+    detail: 'GET /login?user=admin&pass=secret'
+  },
+  {
+    time: '10:00:05',
+    src: '192.168.1.3',
+    dst: 'intranet.local',
+    detail: 'POST /api/token=abcd1234'
+  }
+];
+export default function handler(req, res) {
+  const encoded = Buffer.from(JSON.stringify(sample)).toString('base64');
+  res.status(200).send(encoded);
+}


### PR DESCRIPTION
## Summary
- decode urlsnarf and arpspoof output and combine into a sortable, filterable table
- mask sensitive details with reveal-on-click behavior
- add API endpoints serving base64-encoded dsniff sample data

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/xterm' in terminal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d0508c0832897f115981a08f4e9