### PR TITLE
feat: add john mode selector

### DIFF
--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -3,8 +3,11 @@ import React, { useState } from 'react';
 // Simple John the Ripper interface that sends hash input to an API
 // route which in turn runs the `john` binary using Node's child_process.
 
+const modes = ['single', 'wordlist', 'incremental'];
+
 const JohnApp = () => {
   const [hash, setHash] = useState('');
+  const [mode, setMode] = useState('single');
   const [output, setOutput] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -17,18 +20,18 @@ const JohnApp = () => {
     }
     setError('');
     setLoading(true);
-    setOutput('');
+    setOutput(`Running in ${mode} mode...`);
     try {
       const res = await fetch('/api/john', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ hash }),
+        body: JSON.stringify({ hash, mode }),
       });
       const data = await res.json();
       if (data.error) {
         setError(data.error);
       }
-      setOutput(data.output || data.error || 'No output');
+      setOutput(`Mode: ${mode}\n${data.output || data.error || 'No output'}`);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -39,6 +42,21 @@ const JohnApp = () => {
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white">
       <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+        <label htmlFor="john-mode" className="text-sm">
+          Mode
+        </label>
+        <select
+          id="john-mode"
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+          className="px-2 py-1 bg-gray-800 text-white rounded"
+        >
+          {modes.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
         <label htmlFor="john-hash" className="text-sm">
           Hash
         </label>

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -9,16 +9,28 @@ export default async function handler(req, res) {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
-  const { hash } = req.body || {};
+  const { hash, mode } = req.body || {};
   if (!hash) {
     res.status(400).json({ error: 'No hash provided' });
     return;
   }
 
+  const selectedMode = ['wordlist', 'incremental'].includes(mode)
+    ? mode
+    : 'single';
+
   const file = path.join(tmpdir(), `john-${Date.now()}.txt`);
   try {
     await fs.writeFile(file, `${hash}\n`);
-    exec(`john ${file}`, async (error, stdout, stderr) => {
+
+    let cmd = `john --single ${file}`;
+    if (selectedMode === 'wordlist') {
+      cmd = `john --wordlist=/usr/share/wordlists/rockyou.txt ${file}`;
+    } else if (selectedMode === 'incremental') {
+      cmd = `john --incremental ${file}`;
+    }
+
+    exec(cmd, async (error, stdout, stderr) => {
       await fs.unlink(file).catch(() => {});
       if (error) {
         res.status(500).json({ error: stderr || error.message });


### PR DESCRIPTION
## Summary
- add selectable cracking modes for the John the Ripper UI
- send selected mode to backend and tailor john command
- display the current mode within status output

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d0734bc83289a63c19dc0361479