### PR TITLE
feat: add reconng workspace import/export

### DIFF
--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 const modules = [
   'DNS Enumeration',
@@ -10,10 +10,53 @@ const ReconNG = () => {
   const [selectedModule, setSelectedModule] = useState(modules[0]);
   const [target, setTarget] = useState('');
   const [output, setOutput] = useState('');
+  const fileInputRef = useRef(null);
 
   const runModule = () => {
     if (!target) return;
     setOutput(`Running ${selectedModule} on ${target}...\nResults will appear here.`);
+  };
+
+  const exportWorkspace = () => {
+    const data = JSON.stringify(
+      { selectedModule, target, output },
+      null,
+      2,
+    );
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'reconng-workspace.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      try {
+        const data = JSON.parse(evt.target.result);
+        if (
+          typeof data !== 'object' ||
+          typeof data.selectedModule !== 'string' ||
+          typeof data.target !== 'string' ||
+          typeof data.output !== 'string' ||
+          !modules.includes(data.selectedModule)
+        ) {
+          throw new Error('Invalid workspace');
+        }
+        setSelectedModule(data.selectedModule);
+        setTarget(data.target);
+        setOutput(data.output);
+      } catch (err) {
+        alert('Invalid workspace file');
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
   };
 
   return (
@@ -44,6 +87,27 @@ const ReconNG = () => {
         >
           Run
         </button>
+        <button
+          type="button"
+          onClick={exportWorkspace}
+          className="bg-green-600 hover:bg-green-500 px-3 py-1 rounded"
+        >
+          Export
+        </button>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="bg-yellow-600 hover:bg-yellow-500 px-3 py-1 rounded"
+        >
+          Import
+        </button>
+        <input
+          type="file"
+          accept="application/json"
+          ref={fileInputRef}
+          onChange={handleImport}
+          className="hidden"
+        />
       </div>
       <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">{output}</pre>
     </div>


### PR DESCRIPTION
## Summary
- enable exporting ReconNG workspace to JSON file
- add import to restore workspace with validation

## Testing
- `npm test` (fails: Cannot find module '@xterm/xterm')
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d0bf36c8328ba4a9e608659b07f