### PR TITLE
feat(checkers): add hint system with limits

### DIFF
--- a/components/apps/checkers/engine.ts
+++ b/components/apps/checkers/engine.ts
@@ -153,3 +153,26 @@ export const evaluateBoard = (board: Board): number => {
 };
 
 export const isDraw = (noCaptureMoves: number) => noCaptureMoves >= 40;
+
+export const getHintMove = (board: Board, color: Color): Move | null => {
+  const moves = getAllMoves(board, color);
+  if (!moves.length) return null;
+  let bestMove = moves[0];
+  let bestScore = color === 'red' ? -Infinity : Infinity;
+  for (const move of moves) {
+    const { board: newBoard } = applyMove(board, move);
+    const score = evaluateBoard(newBoard);
+    if (color === 'red') {
+      if (score > bestScore) {
+        bestScore = score;
+        bestMove = move;
+      }
+    } else {
+      if (score < bestScore) {
+        bestScore = score;
+        bestMove = move;
+      }
+    }
+  }
+  return bestMove;
+};


### PR DESCRIPTION
## Summary
- add simple evaluation-based hint generator for checkers
- highlight hint move and track remaining hints with a button indicator
- persist hint counts per game and reset on new game

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module '@xterm/xterm')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d29299c8328ba1c0bc44ba5eec3