### PR TITLE
Fix terminal imports and add history feature

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, act } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import Terminal from '../components/apps/terminal';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
@@ -24,5 +24,19 @@ describe('Terminal component', () => {
       ref.current.runCommand('cd nowhere');
     });
     expect(ref.current.getContent()).toContain("bash: cd: nowhere: No such file or directory");
+  });
+
+  it('supports history and clear commands', () => {
+    const ref = createRef();
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    act(() => {
+      ref.current.runCommand('pwd');
+      ref.current.runCommand('history');
+    });
+    expect(ref.current.getContent()).toContain('pwd');
+    act(() => {
+      ref.current.runCommand('clear');
+    });
+    expect(ref.current.getContent()).toBe('');
   });
 });

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
-import 'xterm/css/xterm.css';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
@@ -12,7 +12,8 @@ const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
   const workerRef = useRef(null);
   const commandRef = useRef('');
   const logRef = useRef('');
-  const knownCommandsRef = useRef(new Set(['pwd', 'cd', 'simulate']));
+  const knownCommandsRef = useRef(new Set(['pwd', 'cd', 'simulate', 'clear', 'history']));
+  const historyRef = useRef([]);
   const suggestionsRef = useRef([]);
   const suggestionIndexRef = useRef(0);
   const showingSuggestionsRef = useRef(false);
@@ -28,6 +29,9 @@ const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
     const first = trimmed.split(' ')[0];
     if (first) {
       knownCommandsRef.current.add(first);
+    }
+    if (trimmed) {
+      historyRef.current.push(trimmed);
     }
     if (trimmed === 'pwd') {
       termRef.current.writeln('');
@@ -46,6 +50,16 @@ const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
       logRef.current += 'Running heavy simulation...\n';
       workerRef.current.postMessage({ command: 'simulate' });
       // prompt will be called when worker responds
+    } else if (trimmed === 'clear') {
+      termRef.current.clear();
+      logRef.current = '';
+      prompt();
+    } else if (trimmed === 'history') {
+      termRef.current.writeln('');
+      const history = historyRef.current.join('\n');
+      termRef.current.writeln(history);
+      logRef.current += `${history}\n`;
+      prompt();
     } else if (trimmed.length === 0) {
       prompt();
     } else {


### PR DESCRIPTION
## Summary
- fix compile errors by migrating terminal to `@xterm/*` packages
- add command history with `history` and `clear` commands
- update terminal tests for new features

## Testing
- `yarn lint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade7052e10832881bae1bd15b79273