### PR TITLE
feat: enhance ettercap app with plugin API and SSL strip simulation

### DIFF
--- a/__tests__/ettercap.test.tsx
+++ b/__tests__/ettercap.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import Ettercap from '../components/apps/ettercap';
+
+describe('Ettercap app', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('loads and executes plugins', () => {
+    render(<Ettercap />);
+    fireEvent.change(screen.getByPlaceholderText('Target 1'), { target: { value: 'a' } });
+    fireEvent.change(screen.getByPlaceholderText('Target 2'), { target: { value: 'b' } });
+    fireEvent.change(screen.getByPlaceholderText('Plugin code'), {
+      target: { value: 'packet.protocol = "PLUGIN"; return packet;' },
+    });
+    fireEvent.click(screen.getByText('Load Plugin'));
+    fireEvent.click(screen.getByText('Start'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('PLUGIN')).toBeInTheDocument();
+  });
+
+  it('simulates SSL stripping when enabled', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.8);
+    render(<Ettercap />);
+    fireEvent.change(screen.getByPlaceholderText('Target 1'), { target: { value: 'a' } });
+    fireEvent.change(screen.getByPlaceholderText('Target 2'), { target: { value: 'b' } });
+    fireEvent.click(screen.getByText('SSL Strip'));
+    fireEvent.click(screen.getByText('Start'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('HTTP (stripped)')).toBeInTheDocument();
+  });
+});

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,5 +1,24 @@
 import React, { createRef, act } from 'react';
 import { render, screen } from '@testing-library/react';
+
+jest.mock('xterm', () => {
+  return {
+    Terminal: function () {
+      return {
+        loadAddon: jest.fn(),
+        open: jest.fn(),
+        write: jest.fn(),
+        writeln: jest.fn(),
+        dispose: jest.fn(),
+        onKey: jest.fn(),
+        onData: jest.fn(),
+      };
+    },
+  };
+}, { virtual: true });
+jest.mock('xterm-addon-fit', () => ({ FitAddon: function () { return { fit: jest.fn() }; } }), { virtual: true });
+jest.mock('xterm-addon-search', () => ({ SearchAddon: function () {} }), { virtual: true });
+jest.mock('xterm/css/xterm.css', () => ({}), { virtual: true });
 import Terminal from '../components/apps/terminal';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-const protocols = ['TCP', 'UDP', 'ICMP', 'ARP', 'HTTP', 'DNS'];
+const protocols = ['TCP', 'UDP', 'ICMP', 'ARP', 'HTTP', 'HTTPS', 'DNS'];
 
 const generatePacket = (src, dst) => ({
   time: new Date().toLocaleTimeString(),
@@ -15,24 +15,51 @@ const EttercapApp = () => {
   const [target2, setTarget2] = useState('');
   const [running, setRunning] = useState(false);
   const [traffic, setTraffic] = useState([]);
+  const [sslStrip, setSslStrip] = useState(false);
+  const [pluginCode, setPluginCode] = useState('');
+  const [plugins, setPlugins] = useState([]);
   const intervalRef = useRef(null);
 
   useEffect(() => {
     return () => clearInterval(intervalRef.current);
   }, []);
 
+  const applyPlugins = (pkt) =>
+    plugins.reduce((acc, plugin) => {
+      try {
+        return plugin(acc) || acc;
+      } catch {
+        return acc;
+      }
+    }, pkt);
+
   const startSession = () => {
     if (!target1 || !target2) return;
     setTraffic([]);
     setRunning(true);
     intervalRef.current = setInterval(() => {
-      setTraffic((t) => [generatePacket(target1, target2), ...t]);
+      let packet = generatePacket(target1, target2);
+      if (sslStrip && packet.protocol === 'HTTPS') {
+        packet = { ...packet, protocol: 'HTTP', sslStripped: true };
+      }
+      packet = applyPlugins(packet);
+      setTraffic((t) => [packet, ...t]);
     }, 1000);
   };
 
   const stopSession = () => {
     clearInterval(intervalRef.current);
     setRunning(false);
+  };
+
+  const loadPlugin = () => {
+    try {
+      const fn = new Function('packet', pluginCode);
+      setPlugins((p) => [...p, fn]);
+      setPluginCode('');
+    } catch {
+      // ignore plugin errors
+    }
   };
 
   return (
@@ -67,6 +94,31 @@ const EttercapApp = () => {
             Stop
           </button>
         )}
+        <label className="flex items-center space-x-1 ml-2">
+          <input
+            type="checkbox"
+            checked={sslStrip}
+            onChange={() => setSslStrip((s) => !s)}
+            disabled={running}
+          />
+          <span className="text-sm">SSL Strip</span>
+        </label>
+      </div>
+      <div className="flex mb-4 space-x-2">
+        <textarea
+          className="flex-1 p-2 rounded text-black"
+          placeholder="Plugin code"
+          value={pluginCode}
+          onChange={(e) => setPluginCode(e.target.value)}
+          disabled={running}
+        />
+        <button
+          className="px-4 py-2 bg-blue-600 rounded"
+          onClick={loadPlugin}
+          disabled={!pluginCode}
+        >
+          Load Plugin
+        </button>
       </div>
       <div className="flex-1 overflow-auto bg-gray-800 rounded">
         <table className="w-full text-xs">
@@ -85,7 +137,10 @@ const EttercapApp = () => {
                 <td className="p-1 whitespace-nowrap">{pkt.time}</td>
                 <td className="p-1 break-all">{pkt.src}</td>
                 <td className="p-1 break-all">{pkt.dst}</td>
-                <td className="p-1">{pkt.protocol}</td>
+                <td className="p-1">
+                  {pkt.protocol}
+                  {pkt.sslStripped ? ' (stripped)' : ''}
+                </td>
                 <td className="p-1">{pkt.length}</td>
               </tr>
             ))}
@@ -98,6 +153,15 @@ const EttercapApp = () => {
             )}
           </tbody>
         </table>
+      </div>
+      <div className="mt-4 p-2 bg-gray-700 rounded text-xs">
+        <h3 className="font-bold mb-1">ARP Poisoning Tips</h3>
+        <ul className="list-disc pl-4 space-y-1">
+          <li>Monitor ARP tables for unexpected changes.</li>
+          <li>Use static ARP entries on critical hosts.</li>
+          <li>Enable dynamic ARP inspection on switches.</li>
+          <li>Encrypt traffic with VPNs to mitigate risks.</li>
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add SSL stripping simulation and plugin-based packet processing to Ettercap
- expose SSL strip toggle and plugin loader UI with ARP poisoning tips
- cover new functionality with tests and mock terminal dependencies

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade56324888328b0f4f45ae9083480