### PR TITLE
feat: enhance metasploit app functionality

### DIFF
--- a/__tests__/metasploit.test.tsx
+++ b/__tests__/metasploit.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MetasploitApp from '../components/apps/metasploit';
+
+describe('Metasploit app', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({}) })
+    );
+    localStorage.clear();
+  });
+
+  it('refreshes modules on mount', () => {
+    render(<MetasploitApp />);
+    expect(global.fetch).toHaveBeenCalledWith('/api/metasploit');
+  });
+
+  it('persists command history', async () => {
+    // @ts-ignore
+    (global.fetch as jest.Mock).mockImplementation((url, options) => {
+      if (options && options.method === 'POST') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ output: 'res' }),
+        });
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { unmount } = render(<MetasploitApp />);
+    const input = screen.getByPlaceholderText('msfconsole command');
+    fireEvent.change(input, { target: { value: 'search test' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await screen.findByText(/msf6 > search test/);
+    unmount();
+
+    render(<MetasploitApp />);
+    expect(screen.getByText(/msf6 > search test/)).toBeInTheDocument();
+  });
+});
+

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -1,11 +1,29 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import modules from './modules.json';
+import usePersistentState from '../../usePersistentState';
 
 const banner = `Metasploit Framework Console (mock)\nType 'search <term>' to search modules.`;
 
 const MetasploitApp = () => {
   const [command, setCommand] = useState('');
-  const [output, setOutput] = useState(banner);
+  const [output, setOutput] = usePersistentState('metasploit-history', banner);
   const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState('');
+
+  // Refresh modules list in the background on mount
+  useEffect(() => {
+    fetch('/api/metasploit').catch(() => {});
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    if (!q) return [];
+    return modules.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) ||
+        m.description.toLowerCase().includes(q)
+    );
+  }, [query]);
 
   const runCommand = async () => {
     const cmd = command.trim();
@@ -45,6 +63,24 @@ const MetasploitApp = () => {
         >
           Run
         </button>
+      </div>
+      <div className="p-2">
+        <input
+          className="w-full bg-ub-grey text-white p-1 rounded"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search modules"
+          spellCheck={false}
+        />
+        {query && (
+          <ul className="mt-2 max-h-40 overflow-auto text-xs">
+            {filtered.map((m) => (
+              <li key={m.name} className="mb-1">
+                <span className="font-mono">{m.name}</span> - {m.description}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
       <pre className="flex-grow bg-black text-green-400 p-2 overflow-auto whitespace-pre-wrap">
         {loading ? 'Running...' : output}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- refresh metasploit modules in background and persist console output
- add client-side module search and history tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade56412648328b96a9fb343fb6045