### PR TITLE
feat(msf-post): add templates and report generation

### DIFF
--- a/__tests__/msf-post.test.tsx
+++ b/__tests__/msf-post.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import MsfPostApp from '../components/apps/msf-post';
+
+describe('MsfPostApp', () => {
+  it('populates module when selecting a template', async () => {
+    global.fetch = jest.fn(async () => ({
+      json: async () => ({ modules: ['post/multi/gather/system_info'] }),
+    })) as any;
+
+    const { getByTestId } = render(<MsfPostApp />);
+
+    await waitFor(() =>
+      expect(getByTestId('module-select').children.length).toBeGreaterThan(1)
+    );
+
+    fireEvent.change(getByTestId('template-select'), {
+      target: { value: 'post/multi/gather/system_info' },
+    });
+
+    expect(
+      (getByTestId('module-select') as HTMLSelectElement).value
+    ).toBe('post/multi/gather/system_info');
+  });
+
+  it('generates a report after running a module', async () => {
+    global.URL.createObjectURL = jest.fn(() => 'blob:report');
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ modules: ['mod1'] }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ output: 'result' }),
+      }) as any;
+
+    const { getByTestId } = render(<MsfPostApp />);
+
+    await waitFor(() =>
+      expect(getByTestId('module-select').children.length).toBeGreaterThan(1)
+    );
+
+    fireEvent.change(getByTestId('module-select'), {
+      target: { value: 'mod1' },
+    });
+
+    fireEvent.click(getByTestId('run-button'));
+
+    await waitFor(() => getByTestId('download-report'));
+  });
+});
+

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -1,9 +1,17 @@
 import React, { useEffect, useState } from 'react';
 
+const templates = [
+  { name: 'Gather System Info', module: 'post/multi/gather/system_info' },
+  { name: 'Windows Hashdump', module: 'post/windows/gather/hashdump' },
+];
+
 const MsfPostApp = () => {
   const [modules, setModules] = useState([]);
   const [selected, setSelected] = useState('');
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const [search, setSearch] = useState('');
   const [output, setOutput] = useState('');
+  const [reportUrl, setReportUrl] = useState('');
 
   useEffect(() => {
     const fetchModules = async () => {
@@ -29,7 +37,17 @@ const MsfPostApp = () => {
         body: JSON.stringify({ module: selected }),
       });
       const data = await res.json();
-      setOutput(data.output || 'No output');
+      const out = data.output || 'No output';
+      setOutput(out);
+        const markdown = `# Post Exploit Report
+
+## Module: ${selected}
+
+${'```'}
+${out}
+${'```'}`;
+        const blob = new Blob([markdown], { type: 'text/markdown' });
+        setReportUrl(URL.createObjectURL(blob));
     } catch (err) {
       setOutput('Error running module');
     }
@@ -38,22 +56,50 @@ const MsfPostApp = () => {
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
       <h2 className="text-lg mb-2">Metasploit Post Modules</h2>
+      <input
+        type="text"
+        placeholder="Search modules"
+        className="mb-2 p-2 bg-gray-800 rounded"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        data-testid="search-input"
+      />
+      <select
+        className="mb-2 p-2 bg-gray-800 rounded"
+        value={selectedTemplate}
+        onChange={(e) => {
+          setSelectedTemplate(e.target.value);
+          setSelected(e.target.value);
+        }}
+        data-testid="template-select"
+      >
+        <option value="">Select a template</option>
+        {templates.map((t) => (
+          <option key={t.module} value={t.module}>
+            {t.name}
+          </option>
+        ))}
+      </select>
       <div className="flex mb-4">
         <select
           className="flex-1 bg-gray-800 p-2 rounded"
           value={selected}
           onChange={(e) => setSelected(e.target.value)}
+          data-testid="module-select"
         >
           <option value="">Select a module</option>
-          {modules.map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
+          {modules
+            .filter((m) => m.toLowerCase().includes(search.toLowerCase()))
+            .map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
         </select>
         <button
           onClick={runModule}
           className="ml-2 px-4 py-2 bg-blue-600 rounded"
+          data-testid="run-button"
         >
           Run
         </button>
@@ -61,6 +107,16 @@ const MsfPostApp = () => {
       <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">
         {output}
       </pre>
+      {reportUrl && (
+        <a
+          href={reportUrl}
+          download="post-exploit-report.md"
+          className="mt-2 underline text-blue-400"
+          data-testid="download-report"
+        >
+          Download Report
+        </a>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add selectable script templates and module search to msf-post app
- create markdown report after running modules with download link
- test template selection and report generation

## Testing
- `yarn test` *(fails: Cannot find module 'xterm')*
- `yarn build` *(fails: Can't resolve 'xterm' and 'xterm/css/xterm.css')*

------
https://chatgpt.com/codex/tasks/task_e_68ade564ac7c8328a7b80a441bdebe0d