### PR TITLE
feat(wireshark): add TLS key support and filter persistence

### DIFF
--- a/__tests__/wireshark.test.tsx
+++ b/__tests__/wireshark.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WiresharkApp from '../components/apps/wireshark';
+
+describe('WiresharkApp', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists filter expressions via localStorage', async () => {
+    const packets = [
+      { timestamp: '1', src: '1.1.1.1', dest: '2.2.2.2', protocol: 6, info: 'foo' },
+      { timestamp: '2', src: '3.3.3.3', dest: '4.4.4.4', protocol: 17, info: 'bar' },
+    ];
+    const user = userEvent.setup();
+    const { unmount } = render(<WiresharkApp initialPackets={packets} />);
+
+    const filterInput = screen.getByPlaceholderText(/filter expression/i);
+    await user.type(filterInput, 'bar');
+
+    // Only packets matching the filter should remain
+    expect(screen.getByText('bar')).toBeInTheDocument();
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('wireshark-filter')).toBe('bar');
+
+    // Unmount and remount to ensure the filter persists
+    unmount();
+    render(<WiresharkApp initialPackets={packets} />);
+    expect(screen.getByPlaceholderText(/filter expression/i)).toHaveValue('bar');
+    expect(screen.getByText('bar')).toBeInTheDocument();
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+  });
+
+  it('applies coloring rules for protocols and IPs', async () => {
+    const packets = [
+      { timestamp: '1', src: '1.1.1.1', dest: '2.2.2.2', protocol: 6, info: 'tcp packet' },
+      { timestamp: '2', src: '3.3.3.3', dest: '8.8.8.8', protocol: 17, info: 'udp packet' },
+    ];
+
+    render(<WiresharkApp initialPackets={packets} />);
+    const colorInput = screen.getByPlaceholderText(/color rules/i);
+    const rules =
+      '[{"protocol":"TCP","color":"text-red-500"},{"ip":"8.8.8.8","color":"text-blue-500"}]';
+    fireEvent.change(colorInput, { target: { value: rules } });
+
+    const tcpRow = screen.getByText('tcp packet').closest('tr');
+    const udpRow = screen.getByText('udp packet').closest('tr');
+    expect(tcpRow).toHaveClass('text-red-500');
+    expect(udpRow).toHaveClass('text-blue-500');
+  });
+});
+

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
-import 'xterm/css/xterm.css';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const protocolName = (proto) => {
   switch (proto) {
@@ -13,13 +13,75 @@ const protocolName = (proto) => {
   }
 };
 
-const WiresharkApp = () => {
-  const [packets, setPackets] = useState([]);
+// Determine if a packet matches the active filter expression
+const matchesFilter = (packet, filter) => {
+  if (!filter) return true;
+  const term = filter.toLowerCase();
+  return (
+    packet.src.toLowerCase().includes(term) ||
+    packet.dest.toLowerCase().includes(term) ||
+    protocolName(packet.protocol).toLowerCase().includes(term) ||
+    (packet.info || '').toLowerCase().includes(term) ||
+    (packet.decrypted || '').toLowerCase().includes(term)
+  );
+};
+
+// Determine the color class for a packet based on user rules
+export const getRowColor = (packet, rules) => {
+  const proto = protocolName(packet.protocol);
+  const rule = rules.find(
+    (r) =>
+      (r.protocol && r.protocol === proto) ||
+      (r.ip && (packet.src === r.ip || packet.dest === r.ip))
+  );
+  return rule ? rule.color : '';
+};
+
+const WiresharkApp = ({ initialPackets = [] }) => {
+  const [packets, setPackets] = useState(initialPackets);
   const [socket, setSocket] = useState(null);
+  const [tlsKeys, setTlsKeys] = useState('');
+  const [filter, setFilter] = useState('');
+  const [colorRuleText, setColorRuleText] = useState('[]');
+  const [colorRules, setColorRules] = useState([]);
+
+  // Load persisted filter on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage.getItem('wireshark-filter');
+      if (saved) setFilter(saved);
+    }
+  }, []);
+
+  const handleFilterChange = (e) => {
+    const val = e.target.value;
+    setFilter(val);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('wireshark-filter', val);
+    }
+  };
+
+  const handleTLSKeyChange = (e) => setTlsKeys(e.target.value);
+
+  const handleColorRulesChange = (e) => {
+    const text = e.target.value;
+    setColorRuleText(text);
+    try {
+      const parsed = JSON.parse(text);
+      setColorRules(Array.isArray(parsed) ? parsed : []);
+    } catch {
+      // ignore invalid JSON
+    }
+  };
 
   const startCapture = () => {
     if (socket || typeof window === 'undefined') return;
     const ws = new WebSocket('ws://localhost:8080');
+    ws.onopen = () => {
+      if (tlsKeys) {
+        ws.send(JSON.stringify({ type: 'tlsKeys', keys: tlsKeys }));
+      }
+    };
     ws.onmessage = (event) => {
       try {
         const pkt = JSON.parse(event.data);
@@ -56,6 +118,24 @@ const WiresharkApp = () => {
         >
           Stop
         </button>
+        <input
+          value={tlsKeys}
+          onChange={handleTLSKeyChange}
+          placeholder="TLS keys"
+          className="px-2 py-1 bg-gray-800 rounded text-white"
+        />
+        <input
+          value={filter}
+          onChange={handleFilterChange}
+          placeholder="Filter expression"
+          className="px-2 py-1 bg-gray-800 rounded text-white"
+        />
+        <input
+          value={colorRuleText}
+          onChange={handleColorRulesChange}
+          placeholder='Color rules JSON'
+          className="px-2 py-1 bg-gray-800 rounded text-white"
+        />
       </div>
       <div className="flex-1 overflow-auto">
         <table className="min-w-full text-xs">
@@ -69,13 +149,19 @@ const WiresharkApp = () => {
             </tr>
           </thead>
           <tbody>
-            {packets.map((p, i) => (
-              <tr key={i} className={i % 2 ? 'bg-gray-900' : 'bg-gray-800'}>
+            {packets.filter((p) => matchesFilter(p, filter)).map((p, i) => (
+              <tr
+                key={i}
+                className={`${i % 2 ? 'bg-gray-900' : 'bg-gray-800'} ${getRowColor(
+                  p,
+                  colorRules
+                )}`}
+              >
                 <td className="px-2 py-1 whitespace-nowrap">{p.timestamp}</td>
                 <td className="px-2 py-1 whitespace-nowrap">{p.src}</td>
                 <td className="px-2 py-1 whitespace-nowrap">{p.dest}</td>
                 <td className="px-2 py-1 whitespace-nowrap">{protocolName(p.protocol)}</td>
-                <td className="px-2 py-1">{p.info}</td>
+                <td className="px-2 py-1">{p.decrypted || p.info}</td>
               </tr>
             ))}
           </tbody>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -65,3 +65,46 @@ class WorkerMock {
 }
 // @ts-ignore
 global.Worker = WorkerMock as any;
+
+// Mock xterm and addons so terminal tests run without the real library
+jest.mock(
+  'xterm',
+  () => ({
+    Terminal: class {
+      loadAddon() {}
+      write() {}
+      writeln() {}
+      open() {}
+      dispose() {}
+      onKey() {}
+      onData() {}
+      get buffer() {
+        return { active: { getLine: () => ({ translateToString: () => '' }) } };
+      }
+    },
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  'xterm-addon-fit',
+  () => ({
+    FitAddon: class {
+      activate() {}
+      dispose() {}
+      fit() {}
+    },
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  'xterm-addon-search',
+  () => ({
+    SearchAddon: class {
+      activate() {}
+      dispose() {}
+    },
+  }),
+  { virtual: true }
+);


### PR DESCRIPTION
## Summary
- allow providing TLS keys to decrypt packets and display decrypted info
- add configurable protocol/IP coloring and persistent filter expressions
- add tests for Wireshark filter persistence and coloring rules
- fix terminal imports and mock xterm for tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade5653ae48328a16ca9254eb489b4