### PR TITLE
feat(kismet): map, alerts, and vendor lookup

### DIFF
--- a/__tests__/kismetUtils.test.ts
+++ b/__tests__/kismetUtils.test.ts
@@ -1,0 +1,27 @@
+import { lookupVendor, getNetworkAlerts } from '../components/apps/kismet/utils';
+
+describe('OUI lookup', () => {
+  test('returns vendor for known prefix', () => {
+    expect(lookupVendor('00:11:22:33:44:55')).toBe('Test Vendor');
+  });
+
+  test('returns unknown for unrecognized prefix', () => {
+    expect(lookupVendor('FF:FF:FF:00:00:00')).toBe('Unknown');
+  });
+});
+
+describe('network alerts', () => {
+  test('detects new network', () => {
+    const prev = [{ ssid: 'A', strength: -50 }];
+    const curr = [...prev, { ssid: 'B', strength: -40 }];
+    expect(getNetworkAlerts(prev, curr)).toEqual([{ type: 'new', ssid: 'B' }]);
+  });
+
+  test('detects sharp strength change', () => {
+    const prev = [{ ssid: 'A', strength: -50 }];
+    const curr = [{ ssid: 'A', strength: -20 }];
+    expect(getNetworkAlerts(prev, curr, 20)).toEqual([
+      { type: 'strength', ssid: 'A', delta: 30 },
+    ]);
+  });
+});

--- a/components/apps/kismet/index.js
+++ b/components/apps/kismet/index.js
@@ -1,39 +1,122 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { getNetworkAlerts, lookupVendor } from './utils';
 
 // Simple helpers to generate demo data
-const demoNetworks = () => [
-  { ssid: 'CoffeeShopWiFi', strength: -45 },
-  { ssid: 'FreeAirport', strength: -70 },
-  { ssid: 'HomeWiFi', strength: -30 },
-];
-
 const randomHex = () => Math.floor(Math.random() * 256).toString(16).padStart(2, '0');
 const randomMac = () =>
   `${randomHex()}:${randomHex()}:${randomHex()}:${randomHex()}:${randomHex()}:${randomHex()}`;
 
+const demoNetworks = () => [
+  {
+    ssid: 'CoffeeShopWiFi',
+    strength: -45,
+    mac: randomMac(),
+    lat: 37.7749,
+    lng: -122.4194,
+  },
+  {
+    ssid: 'FreeAirport',
+    strength: -70,
+    mac: randomMac(),
+    lat: 40.7128,
+    lng: -74.006,
+  },
+  {
+    ssid: 'HomeWiFi',
+    strength: -30,
+    mac: randomMac(),
+    lat: 34.0522,
+    lng: -118.2437,
+  },
+];
+
+const randomNetwork = () => ({
+  ssid: `Net${Math.floor(Math.random() * 1000)}`,
+  strength: -20 - Math.floor(Math.random() * 80),
+  mac: randomMac(),
+  lat: Math.random() * 180 - 90,
+  lng: Math.random() * 360 - 180,
+});
+
+const getMarkerStyle = (lat, lng) => {
+  const x = ((lng + 180) / 360) * 100;
+  const y = ((90 - lat) / 180) * 100;
+  return { left: `${x}%`, top: `${y}%` };
+};
+
 const KismetApp = () => {
   const [networks, setNetworks] = useState([]);
   const [packets, setPackets] = useState([]);
+  const [alert, setAlert] = useState(null);
+  const audioCtxRef = useRef(null);
+
+  const playBeep = () => {
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    if (!audioCtxRef.current && AudioContext) {
+      audioCtxRef.current = new AudioContext();
+    }
+    const ctx = audioCtxRef.current;
+    if (!ctx) return;
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = 1000;
+    osc.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.2);
+  };
+
+  const triggerAlert = (a) => {
+    const msg =
+      a.type === 'new'
+        ? `New network detected: ${a.ssid}`
+        : `Signal change for ${a.ssid}`;
+    setAlert(msg);
+    playBeep();
+    setTimeout(() => setAlert(null), 3000);
+  };
 
   useEffect(() => {
     // In browsers we cannot access wireless cards directly. For demo purposes,
     // populate with static data and simulate packets.
     setNetworks(demoNetworks());
 
-    const interval = setInterval(() => {
+    const netInterval = setInterval(() => {
+      setNetworks((prev) => {
+        let updated = prev.map((n) => ({
+          ...n,
+          strength: n.strength + Math.floor(Math.random() * 10 - 5),
+        }));
+        if (Math.random() < 0.3) {
+          updated = [...updated, randomNetwork()];
+        }
+        const alerts = getNetworkAlerts(prev, updated);
+        alerts.forEach(triggerAlert);
+        return updated;
+      });
+    }, 4000);
+
+    const pktInterval = setInterval(() => {
       setPackets((prev) => [
         ...prev,
         { ts: Date.now(), from: randomMac(), to: randomMac() },
       ]);
     }, 1500);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(netInterval);
+      clearInterval(pktInterval);
+    };
   }, []);
 
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
-      <div className="px-3 py-1 border-b border-gray-700">
+      <div className="px-3 py-1 border-b border-gray-700 relative">
         <span className="font-bold">Kismet</span>
+        {alert && (
+          <div className="absolute inset-x-0 top-full bg-red-600 text-center text-xs py-1">
+            {alert}
+          </div>
+        )}
       </div>
       <div className="flex flex-grow overflow-hidden">
         <div className="w-1/2 p-2 overflow-y-auto">
@@ -42,7 +125,12 @@ const KismetApp = () => {
             <ul>
               {networks.map((net) => (
                 <li key={net.ssid} className="flex justify-between mb-1">
-                  <span>{net.ssid}</span>
+                  <div>
+                    <span>{net.ssid}</span>
+                    <span className="ml-2 text-gray-500 text-xs">
+                      {lookupVendor(net.mac)}
+                    </span>
+                  </div>
                   <span className="text-gray-400 text-xs">{net.strength} dBm</span>
                 </li>
               ))}
@@ -51,19 +139,38 @@ const KismetApp = () => {
             <p className="text-gray-400 text-sm">No networks detected.</p>
           )}
         </div>
-        <div className="w-1/2 p-2 overflow-y-auto border-l border-gray-700">
-          <h2 className="text-sm font-semibold mb-2">Packet Capture</h2>
-          {packets.length ? (
-            <ul>
-              {packets.slice(-100).map((pkt, idx) => (
-                <li key={`${pkt.ts}-${idx}`} className="text-xs mb-1">
-                  [{new Date(pkt.ts).toLocaleTimeString()}] {pkt.from} → {pkt.to}
-                </li>
+        <div className="w-1/2 flex flex-col border-l border-gray-700">
+          <div className="flex-1 p-2 overflow-hidden">
+            <h2 className="text-sm font-semibold mb-2">Network Map</h2>
+            <div className="relative w-full h-full bg-gray-800">
+              {networks.map((net) => (
+                <div
+                  key={net.ssid}
+                  className="absolute"
+                  style={getMarkerStyle(net.lat, net.lng)}
+                >
+                  <div
+                    className="w-2 h-2 bg-red-500 rounded-full"
+                    title={`${net.ssid} (${net.strength} dBm)`}
+                  />
+                </div>
               ))}
-            </ul>
-          ) : (
-            <p className="text-gray-400 text-sm">No packets captured.</p>
-          )}
+            </div>
+          </div>
+          <div className="flex-1 p-2 overflow-y-auto border-t border-gray-700">
+            <h2 className="text-sm font-semibold mb-2">Packet Capture</h2>
+            {packets.length ? (
+              <ul>
+                {packets.slice(-100).map((pkt, idx) => (
+                  <li key={`${pkt.ts}-${idx}`} className="text-xs mb-1">
+                    [{new Date(pkt.ts).toLocaleTimeString()}] {pkt.from} → {pkt.to}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-gray-400 text-sm">No packets captured.</p>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/components/apps/kismet/utils.js
+++ b/components/apps/kismet/utils.js
@@ -1,0 +1,26 @@
+export const ouiDatabase = {
+  '00:11:22': 'Test Vendor',
+  'AA:BB:CC': 'Another Vendor',
+};
+
+export const lookupVendor = (mac) => {
+  if (!mac) return 'Unknown';
+  const prefix = mac.toUpperCase().slice(0, 8);
+  return ouiDatabase[prefix] || 'Unknown';
+};
+
+export const getNetworkAlerts = (prev, curr, threshold = 20) => {
+  const alerts = [];
+  const prevMap = Object.fromEntries(prev.map((n) => [n.ssid, n]));
+  curr.forEach((n) => {
+    if (!prevMap[n.ssid]) {
+      alerts.push({ type: 'new', ssid: n.ssid });
+    } else {
+      const delta = n.strength - prevMap[n.ssid].strength;
+      if (Math.abs(delta) >= threshold) {
+        alerts.push({ type: 'strength', ssid: n.ssid, delta });
+      }
+    }
+  });
+  return alerts;
+};


### PR DESCRIPTION
## Summary
- plot detected networks on a simple map with placeholder coordinates
- add audio/visual alerts for new networks or sharp signal changes
- perform OUI vendor lookups for MAC addresses and expose helpers with tests

## Testing
- `yarn test` *(fails: battleship-ai, terminal)*
- `yarn build` *(fails: Can't resolve 'xterm/css/xterm.css')*

------
https://chatgpt.com/codex/tasks/task_e_68ade565ef748328b3bf3ee4da849489