### PR TITLE
feat: add autopsy timeline and plugin system

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Autopsy from '../components/apps/autopsy';
+
+describe('Autopsy plugins and timeline', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([{ id: 'hash', name: 'Hash Analyzer' }]),
+      })
+    );
+    class FileReaderMock {
+      onload: ((e: any) => void) | null = null;
+      readAsArrayBuffer() {
+        const buffer = new ArrayBuffer(20);
+        this.onload && this.onload({ target: { result: buffer } });
+      }
+    }
+    // @ts-ignore
+    global.FileReader = FileReaderMock;
+  });
+
+  it('loads plugins from marketplace', async () => {
+    render(<Autopsy />);
+    fireEvent.change(screen.getByPlaceholderText('Case name'), {
+      target: { value: 'Demo' },
+    });
+    fireEvent.click(screen.getByText('Create Case'));
+    await screen.findByText('Hash Analyzer');
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'hash' } });
+    await waitFor(() =>
+      expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
+        'hash'
+      )
+    );
+  });
+
+  it('renders artifact on timeline after file upload', async () => {
+    render(<Autopsy />);
+    fireEvent.change(screen.getByPlaceholderText('Case name'), {
+      target: { value: 'Demo' },
+    });
+    fireEvent.click(screen.getByText('Create Case'));
+    await screen.findByRole('combobox');
+    const file = new File([new Uint8Array(20)], 'test.bin', {
+      type: 'application/octet-stream',
+    });
+    fireEvent.change(screen.getByLabelText('Upload file'), {
+      target: { files: [file] },
+    });
+    await waitFor(() =>
+      expect(screen.getAllByText(/test.bin/).length).toBeGreaterThan(0)
+    );
+  });
+});

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,9 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 function Autopsy() {
   const [caseName, setCaseName] = useState('');
   const [currentCase, setCurrentCase] = useState(null);
   const [analysis, setAnalysis] = useState('');
+  const [artifacts, setArtifacts] = useState([]);
+  const [plugins, setPlugins] = useState([]);
+  const [selectedPlugin, setSelectedPlugin] = useState('');
+
+  useEffect(() => {
+    fetch('/plugin-marketplace.json')
+      .then((res) => res.json())
+      .then(setPlugins)
+      .catch(() => setPlugins([]));
+  }, []);
 
   const createCase = () => {
     const name = caseName.trim();
@@ -24,8 +34,32 @@ function Autopsy() {
         .map((b) => b.toString(16).padStart(2, '0'))
         .join(' ');
       setAnalysis(`File: ${file.name}\nSize: ${file.size} bytes\nFirst 20 bytes: ${hex}`);
+      setArtifacts((prev) => [
+        ...prev,
+        {
+          name: file.name,
+          size: file.size,
+          hex,
+          plugin: selectedPlugin || 'None',
+          timestamp: new Date().toISOString(),
+        },
+      ]);
     };
     reader.readAsArrayBuffer(file);
+  };
+
+  const downloadReport = () => {
+    const lines = artifacts.map(
+      (a) => `${a.timestamp} - ${a.name} (${a.size} bytes) [Plugin: ${a.plugin}]`
+    );
+    const report = `Case: ${currentCase}\n` + lines.join('\n');
+    const blob = new Blob([report], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${currentCase || 'case'}-report.txt`;
+    link.click();
+    URL.revokeObjectURL(url);
   };
 
   return (
@@ -48,15 +82,55 @@ function Autopsy() {
       {currentCase && (
         <div className="space-y-2">
           <div className="text-sm">Current case: {currentCase}</div>
-          <input type="file" onChange={analyseFile} className="text-sm" />
+          <div className="flex space-x-2 items-center">
+            <select
+              value={selectedPlugin}
+              onChange={(e) => setSelectedPlugin(e.target.value)}
+              className="bg-ub-grey text-white px-2 py-1 rounded"
+            >
+              <option value="">Select Plugin</option>
+              {plugins.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <input
+              aria-label="Upload file"
+              type="file"
+              onChange={analyseFile}
+              className="text-sm"
+            />
+          </div>
         </div>
       )}
       {analysis && (
         <textarea
           readOnly
           value={analysis}
-          className="flex-grow bg-ub-grey text-xs text-white p-2 rounded resize-none"
+          className="bg-ub-grey text-xs text-white p-2 rounded resize-none"
         />
+      )}
+      {artifacts.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-sm font-bold">Timeline</div>
+          <ul className="space-y-1 text-xs">
+            {artifacts.map((a, idx) => (
+              <li key={idx} className="bg-ub-grey p-1 rounded">
+                <div>{new Date(a.timestamp).toLocaleString()}</div>
+                <div>
+                  {a.name} ({a.plugin})
+                </div>
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={downloadReport}
+            className="bg-ub-orange px-3 py-1 rounded text-sm"
+          >
+            Download Report
+          </button>
+        </div>
       )}
     </div>
   );

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -65,3 +65,37 @@ class WorkerMock {
 }
 // @ts-ignore
 global.Worker = WorkerMock as any;
+
+// Mock xterm which isn't available in the test environment
+jest.mock(
+  'xterm',
+  () => ({
+    Terminal: jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      write: jest.fn(),
+      writeln: jest.fn(),
+      loadAddon: jest.fn(),
+      dispose: jest.fn(),
+      onKey: jest.fn(),
+      onData: jest.fn(),
+      focus: jest.fn(),
+    })),
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  'xterm-addon-fit',
+  () => ({
+    FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  'xterm-addon-search',
+  () => ({
+    SearchAddon: jest.fn().mockImplementation(() => ({ findNext: jest.fn() })),
+  }),
+  { virtual: true }
+);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/public/plugin-marketplace.json
+++ b/public/plugin-marketplace.json
@@ -1,0 +1,4 @@
+[
+  { "id": "hash", "name": "Hash Analyzer", "description": "Computes hashes of files." },
+  { "id": "metadata", "name": "Metadata Extractor", "description": "Extracts file metadata." }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add plugin-based artifact analysis with timeline and reports
- mock terminal dependencies for tests
- cover autopsy timeline and plugin loader with tests

## Testing
- `yarn test` *(fails: `battleship-ai.test.js` duration 201ms ≥ 200ms)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade568f93c832888e28b5e193aa3af