### PR TITLE
feat: add Nessus scheduling and feedback

### DIFF
--- a/__tests__/nessus.test.ts
+++ b/__tests__/nessus.test.ts
@@ -1,0 +1,17 @@
+import { loadJobDefinitions, saveJobDefinition, loadFalsePositives, recordFalsePositive } from '../components/apps/nessus/index';
+
+describe('nessus scheduling and feedback', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('job definitions persist in localStorage', () => {
+    saveJobDefinition({ scanId: '1', schedule: 'daily' });
+    expect(loadJobDefinitions()).toEqual([{ scanId: '1', schedule: 'daily' }]);
+  });
+
+  test('false positive submissions stored', () => {
+    recordFalsePositive('2', 'sample reason');
+    expect(loadFalsePositives()).toEqual([{ scanId: '2', reason: 'sample reason' }]);
+  });
+});

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -1,4 +1,39 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
+// helpers for persistent storage of jobs and false positives
+export const loadJobDefinitions = () => {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem('nessusJobs') || '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const saveJobDefinition = (job) => {
+  if (typeof window === 'undefined') return [];
+  const jobs = loadJobDefinitions();
+  const updated = [...jobs, job];
+  localStorage.setItem('nessusJobs', JSON.stringify(updated));
+  return updated;
+};
+
+export const loadFalsePositives = () => {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem('nessusFalsePositives') || '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const recordFalsePositive = (scanId, reason) => {
+  if (typeof window === 'undefined') return [];
+  const fps = loadFalsePositives();
+  const updated = [...fps, { scanId, reason }];
+  localStorage.setItem('nessusFalsePositives', JSON.stringify(updated));
+  return updated;
+};
 
 const Nessus = () => {
   const [url, setUrl] = useState('https://localhost:8834');
@@ -7,6 +42,16 @@ const Nessus = () => {
   const [token, setToken] = useState('');
   const [scans, setScans] = useState([]);
   const [error, setError] = useState('');
+  const [jobs, setJobs] = useState([]);
+  const [newJob, setNewJob] = useState({ scanId: '', schedule: '' });
+  const [feedbackScan, setFeedbackScan] = useState(null);
+  const [feedbackText, setFeedbackText] = useState('');
+  const [falsePositives, setFalsePositives] = useState([]);
+
+  useEffect(() => {
+    setJobs(loadJobDefinitions());
+    setFalsePositives(loadFalsePositives());
+  }, []);
 
   const login = async (e) => {
     e.preventDefault();
@@ -41,6 +86,22 @@ const Nessus = () => {
     } catch (err) {
       setError(err.message);
     }
+  };
+
+  const addJob = (e) => {
+    e.preventDefault();
+    if (!newJob.scanId) return;
+    const updated = saveJobDefinition(newJob);
+    setJobs(updated);
+    setNewJob({ scanId: '', schedule: '' });
+  };
+
+  const submitFeedback = (e) => {
+    e.preventDefault();
+    recordFalsePositive(feedbackScan, feedbackText);
+    setFalsePositives(loadFalsePositives());
+    setFeedbackScan(null);
+    setFeedbackText('');
   };
 
   const logout = () => {
@@ -113,10 +174,74 @@ const Nessus = () => {
         </button>
       </div>
       {error && <div className="text-red-500 mb-2">{error}</div>}
+      <form onSubmit={addJob} className="mb-4 space-x-2">
+        <input
+          className="p-1 rounded text-black"
+          placeholder="Scan ID"
+          value={newJob.scanId}
+          onChange={(e) => setNewJob({ ...newJob, scanId: e.target.value })}
+        />
+        <input
+          className="p-1 rounded text-black"
+          placeholder="Schedule"
+          value={newJob.schedule}
+          onChange={(e) => setNewJob({ ...newJob, schedule: e.target.value })}
+        />
+        <button type="submit" className="bg-blue-600 px-2 py-1 rounded">
+          Add Job
+        </button>
+      </form>
+      {jobs.length > 0 && (
+        <div className="mb-4">
+          <h3 className="text-lg mb-1">Scheduled Jobs</h3>
+          <ul className="space-y-1">
+            {jobs.map((job, idx) => (
+              <li key={idx} className="text-sm">
+                Scan {job.scanId} - {job.schedule}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <ul className="space-y-1">
         {scans.map((scan) => (
           <li key={scan.id} className="border-b border-gray-700 pb-1">
-            {scan.name} - {scan.status}
+            <div className="flex justify-between items-center">
+              <span>
+                {scan.name} - {scan.status}
+              </span>
+              <button
+                className="text-xs bg-yellow-600 px-2 py-1 rounded"
+                onClick={() => setFeedbackScan(scan.id)}
+              >
+                False Positive
+              </button>
+            </div>
+            {feedbackScan === scan.id && (
+              <form onSubmit={submitFeedback} className="mt-2 space-y-1">
+                <input
+                  className="w-full p-1 rounded text-black"
+                  value={feedbackText}
+                  onChange={(e) => setFeedbackText(e.target.value)}
+                  placeholder="Reason"
+                />
+                <div className="flex space-x-2">
+                  <button
+                    type="submit"
+                    className="bg-green-600 px-2 py-1 rounded text-xs"
+                  >
+                    Submit
+                  </button>
+                  <button
+                    type="button"
+                    className="bg-gray-600 px-2 py-1 rounded text-xs"
+                    onClick={() => setFeedbackScan(null)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            )}
           </li>
         ))}
       </ul>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
+
+const NessusDashboard: React.FC = () => {
+  const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });
+
+  useEffect(() => {
+    const jobs = loadJobDefinitions();
+    const fps = loadFalsePositives();
+    setTotals({ jobs: jobs.length, falsePositives: fps.length });
+  }, []);
+
+  const max = Math.max(totals.jobs, totals.falsePositives, 1);
+
+  return (
+    <div className="p-4 bg-gray-900 min-h-screen text-white">
+      <h1 className="text-2xl mb-4">Nessus Dashboard</h1>
+      <div className="flex items-end space-x-4 h-48">
+        <div
+          className="bg-blue-600 w-24 text-center flex flex-col justify-end"
+          style={{ height: `${(totals.jobs / max) * 100}%` }}
+        >
+          <span className="pb-2 text-sm">Jobs {totals.jobs}</span>
+        </div>
+        <div
+          className="bg-green-600 w-24 text-center flex flex-col justify-end"
+          style={{ height: `${(totals.falsePositives / max) * 100}%` }}
+        >
+          <span className="pb-2 text-sm">False {totals.falsePositives}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NessusDashboard;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- persist Nessus scan job definitions and false positive reports via localStorage
- add simple dashboard page with bar chart summary of jobs vs false positives
- cover job persistence and feedback submission with tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade56b66c08328b6143040803324cc