### PR TITLE
feat: enhance ghidra with plugins and symbols

### DIFF
--- a/__tests__/ghidra.test.tsx
+++ b/__tests__/ghidra.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import GhidraApp from '../components/apps/ghidra';
+
+describe('Ghidra plugin upload', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('handles plugin upload and shows plugin name', () => {
+    render(<GhidraApp />);
+    const file = new File(['content'], 'plugin.jar', { type: 'application/java-archive' });
+    const input = screen.getByTestId('plugin-input');
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(screen.getByText('Loaded plugin: plugin.jar')).toBeInTheDocument();
+  });
+
+  it('allows symbol renaming and persists it', () => {
+    const { unmount } = render(<GhidraApp />);
+    const input = screen.getByTestId('symbol-0') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'start' } });
+    unmount();
+    render(<GhidraApp />);
+    expect(screen.getByDisplayValue('start')).toBeInTheDocument();
+  });
+});

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,13 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import usePersistentState from '../../usePersistentState';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
+const DEFAULT_SYMBOLS = ['main', 'init'];
 
 export default function GhidraApp() {
   const [useRemote, setUseRemote] = useState(false);
+  const [showTutorial, setShowTutorial] = useState(false);
+  const [pluginName, setPluginName] = useState('');
+  const [envKey, setEnvKey] = useState(0);
+  const fileInputRef = useRef(null);
+  const [symbols, setSymbols] = usePersistentState('ghidra-symbols', DEFAULT_SYMBOLS);
 
   useEffect(() => {
     const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
-    if (typeof WebAssembly === 'undefined') {
+    if (typeof WebAssembly === 'undefined' || typeof fetch === 'undefined') {
       setUseRemote(true);
       return;
     }
@@ -18,23 +25,86 @@ export default function GhidraApp() {
       .catch(() => {
         setUseRemote(true);
       });
-  }, []);
+  }, [envKey]);
 
-  if (useRemote) {
-    const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
-    return (
-      <iframe
-        src={remoteUrl}
-        className="w-full h-full bg-ub-cool-grey"
-        frameBorder="0"
-        title="Ghidra"
-      />
-    );
-  }
+  const handlePluginUpload = (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) {
+      setPluginName(file.name);
+      setEnvKey((k) => k + 1); // reinitialize environment
+    }
+  };
+
+  const handleRename = (index, value) => {
+    const updated = [...symbols];
+    updated[index] = value;
+    setSymbols(updated);
+  };
+
+  const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
+  const tutorialUrl = process.env.NEXT_PUBLIC_GHIDRA_TUTORIAL_URL || 'https://ghidra.app/tutorial';
+
+  const ghidraView = useRemote ? (
+    <iframe
+      key={envKey}
+      src={remoteUrl}
+      className="w-full flex-1 bg-ub-cool-grey"
+      frameBorder="0"
+      title="Ghidra"
+    />
+  ) : (
+    <div key={envKey} className="w-full flex-1 flex items-center justify-center bg-ub-cool-grey">
+      Loading Ghidra WebAssembly...
+    </div>
+  );
+
+  const tutorialView = (
+    <iframe
+      src={tutorialUrl}
+      className="w-full flex-1 bg-white"
+      title="Ghidra Tutorial"
+    />
+  );
 
   return (
-    <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Ghidra WebAssembly...
+    <div className="w-full h-full flex flex-col text-white">
+      <div className="p-2 space-x-2 bg-gray-800 flex">
+        <button
+          className="px-2 py-1 bg-gray-700 rounded text-sm"
+          onClick={() => setShowTutorial((v) => !v)}
+        >
+          {showTutorial ? 'Hide Tutorial' : 'Show Tutorial'}
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-700 rounded text-sm"
+          onClick={() => fileInputRef.current && fileInputRef.current.click()}
+        >
+          Upload Plugin
+        </button>
+        <input
+          data-testid="plugin-input"
+          ref={fileInputRef}
+          type="file"
+          onChange={handlePluginUpload}
+          className="hidden"
+        />
+      </div>
+      {pluginName && (
+        <div className="px-2 py-1 bg-gray-700 text-sm">Loaded plugin: {pluginName}</div>
+      )}
+      {showTutorial ? tutorialView : ghidraView}
+      <div className="p-2 bg-gray-800">
+        <h2 className="text-sm mb-1">Symbols</h2>
+        {symbols.map((sym, idx) => (
+          <input
+            key={idx}
+            data-testid={`symbol-${idx}`}
+            value={sym}
+            onChange={(e) => handleRename(idx, e.target.value)}
+            className="w-full mb-1 p-1 text-black"
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add in-app Ghidra scripting tutorial with plugin upload dialog
- enable symbol renaming with local persistence
- test plugin uploads and symbol renaming

## Testing
- `yarn test`
- `yarn build` *(fails: Module not found: Can't resolve 'xterm')*

------
https://chatgpt.com/codex/tasks/task_e_68ade56c35f083289ea2914e4aeb8549