### PR TITLE
feat(hydra): add wordlist manager and session controls

### DIFF
--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import HydraApp from '../components/apps/hydra';
+
+describe('Hydra wordlists', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists added wordlists in localStorage', async () => {
+    class MockFileReader {
+      onload: ((e: any) => void) | null = null;
+      readAsText() {
+        if (this.onload) this.onload({ target: { result: 'user\n' } });
+      }
+    }
+    // @ts-ignore
+    global.FileReader = MockFileReader;
+
+    const file = new File(['user\n'], 'users.txt', { type: 'text/plain' });
+    const { unmount } = render(<HydraApp />);
+    fireEvent.change(screen.getByTestId('user-file-input'), {
+      target: { files: [file] },
+    });
+
+    await screen.findByText('users.txt', { selector: 'li' });
+    unmount();
+    render(<HydraApp />);
+    expect(screen.getAllByText('users.txt').length).toBeGreaterThan(0);
+  });
+});
+
+describe('Hydra pause and resume', () => {
+  beforeEach(() => {
+    localStorage.setItem(
+      'hydraUserLists',
+      JSON.stringify([{ name: 'u', content: 'a' }])
+    );
+    localStorage.setItem(
+      'hydraPassLists',
+      JSON.stringify([{ name: 'p', content: 'b' }])
+    );
+  });
+
+  it('pauses and resumes cracking progress', async () => {
+    let runResolve: Function = () => {};
+    // @ts-ignore
+    global.fetch = jest.fn((url, options) => {
+      if (options && options.body && options.body.includes('action')) {
+        return Promise.resolve({ json: async () => ({}) });
+      }
+      return new Promise((resolve) => {
+        runResolve = () => resolve({ json: async () => ({ output: '' }) });
+      });
+    });
+
+    render(<HydraApp />);
+    fireEvent.change(screen.getByPlaceholderText('192.168.0.1'), {
+      target: { value: '1.1.1.1' },
+    });
+    fireEvent.click(screen.getByText('Run Hydra'));
+
+    const pauseBtn = await screen.findByTestId('pause-button');
+    fireEvent.click(pauseBtn);
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/hydra',
+      expect.objectContaining({ body: JSON.stringify({ action: 'pause' }) })
+    );
+
+    const resumeBtn = await screen.findByTestId('resume-button');
+    fireEvent.click(resumeBtn);
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/hydra',
+      expect.objectContaining({ body: JSON.stringify({ action: 'resume' }) })
+    );
+
+    await act(async () => {
+      runResolve();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add plugin registry and wordlist persistence to Hydra app
- support pausing and resuming Hydra cracking sessions
- test wordlist storage and pause/resume handling

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade56e34808328a71dd7f4e4edbbd8