### PR TITLE
feat: add hashcat benchmark and auto-detection

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import HashcatApp, { detectHashType } from '../components/apps/hashcat';
+
+describe('HashcatApp', () => {
+  it('auto-detects hash types', () => {
+    expect(detectHashType('d41d8cd98f00b204e9800998ecf8427e')).toBe('0');
+    expect(detectHashType('da39a3ee5e6b4b0d3255bfef95601890afd80709')).toBe('100');
+    expect(
+      detectHashType(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      )
+    ).toBe('1400');
+    expect(
+      detectHashType('$2y$10$' + 'a'.repeat(53))
+    ).toBe('3200');
+  });
+
+  it('displays benchmark results', async () => {
+    const { getByText, getByTestId } = render(<HashcatApp />);
+    fireEvent.click(getByText('Run Benchmark'));
+    await waitFor(() => {
+      expect(getByTestId('benchmark-output').textContent).toMatch(/GPU0/);
+    });
+  });
+});

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -3,6 +3,43 @@ import { render, screen } from '@testing-library/react';
 import Terminal from '../components/apps/terminal';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock(
+  'xterm',
+  () => ({
+    Terminal: jest.fn().mockImplementation(() => ({
+      open: jest.fn(),
+      write: jest.fn(),
+      writeln: jest.fn(),
+      onKey: jest.fn(),
+      dispose: jest.fn(),
+      loadAddon: jest.fn(),
+      onData: jest.fn(),
+    })),
+  }),
+  { virtual: true }
+);
+jest.mock(
+  'xterm-addon-fit',
+  () => ({
+    FitAddon: jest.fn().mockImplementation(() => ({
+      activate: jest.fn(),
+      dispose: jest.fn(),
+      fit: jest.fn(),
+    })),
+  }),
+  { virtual: true }
+);
+jest.mock(
+  'xterm-addon-search',
+  () => ({
+    SearchAddon: jest.fn().mockImplementation(() => ({
+      activate: jest.fn(),
+      dispose: jest.fn(),
+    })),
+  }),
+  { virtual: true }
+);
+jest.mock('xterm/css/xterm.css', () => ({}), { virtual: true });
 
 describe('Terminal component', () => {
   const addFolder = jest.fn();

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,11 +1,38 @@
 import React, { useState, useEffect } from 'react';
 
 const hashTypes = [
-  { id: '0', name: 'MD5' },
-  { id: '100', name: 'SHA1' },
-  { id: '1400', name: 'SHA256' },
-  { id: '3200', name: 'bcrypt' },
+  { id: '0', name: 'MD5', regex: /^[a-f0-9]{32}$/i },
+  { id: '100', name: 'SHA1', regex: /^[a-f0-9]{40}$/i },
+  { id: '1400', name: 'SHA256', regex: /^[a-f0-9]{64}$/i },
+  { id: '3200', name: 'bcrypt', regex: /^\$2[aby]\$.{56}$/ },
 ];
+
+export const detectHashType = (hash) => {
+  const type = hashTypes.find((t) => t.regex.test(hash));
+  return type ? type.id : hashTypes[0].id;
+};
+
+export const generateWordlist = (pattern) => {
+  const results = [];
+  const max = 1000;
+  const helper = (prefix, rest) => {
+    if (results.length >= max) return;
+    if (!rest.length) {
+      results.push(prefix);
+      return;
+    }
+    const ch = rest[0];
+    if (ch === '?') {
+      for (let i = 0; i < 10 && results.length < max; i++) {
+        helper(prefix + i, rest.slice(1));
+      }
+    } else {
+      helper(prefix + ch, rest.slice(1));
+    }
+  };
+  helper('', pattern || '');
+  return results;
+};
 
 const Gauge = ({ value }) => (
   <div className="w-48">
@@ -21,7 +48,11 @@ const Gauge = ({ value }) => (
 
 function HashcatApp() {
   const [hashType, setHashType] = useState(hashTypes[0].id);
+  const [hashInput, setHashInput] = useState('');
   const [gpuUsage, setGpuUsage] = useState(0);
+  const [benchmark, setBenchmark] = useState('');
+  const [pattern, setPattern] = useState('');
+  const [wordlistUrl, setWordlistUrl] = useState('');
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -32,8 +63,40 @@ function HashcatApp() {
 
   const selectedHash = hashTypes.find((h) => h.id === hashType)?.name;
 
+  const handleHashChange = (e) => {
+    const value = e.target.value.trim();
+    setHashInput(value);
+    setHashType(detectHashType(value));
+  };
+
+  const runBenchmark = () => {
+    setBenchmark('Running benchmark...');
+    setTimeout(() => {
+      const speed = (4000 + Math.random() * 1000).toFixed(0);
+      setBenchmark(`GPU0: ${speed} MH/s`);
+    }, 500);
+  };
+
+  const createWordlist = () => {
+    const list = generateWordlist(pattern);
+    const blob = new Blob([list.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    setWordlistUrl(url);
+  };
+
   return (
     <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-ub-cool-grey text-white">
+      <div>
+        <label className="mr-2" htmlFor="hash-input">
+          Hash:
+        </label>
+        <input
+          id="hash-input"
+          className="text-black px-2 py-1"
+          value={hashInput}
+          onChange={handleHashChange}
+        />
+      </div>
       <div>
         <label className="mr-2" htmlFor="hash-type">
           Hash Type:
@@ -51,7 +114,34 @@ function HashcatApp() {
           ))}
         </select>
       </div>
-      <div>Selected: {selectedHash}</div>
+      <div>Detected: {selectedHash}</div>
+      <button onClick={runBenchmark}>Run Benchmark</button>
+      {benchmark && (
+        <div data-testid="benchmark-output">{benchmark}</div>
+      )}
+      <div>
+        <label className="mr-2" htmlFor="word-pattern">
+          Wordlist Pattern:
+        </label>
+        <input
+          id="word-pattern"
+          className="text-black px-2 py-1"
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+        />
+        <button className="ml-2" onClick={createWordlist}>
+          Generate
+        </button>
+        {wordlistUrl && (
+          <a
+            className="ml-2 underline"
+            href={wordlistUrl}
+            download="wordlist.txt"
+          >
+            Download
+          </a>
+        )}
+      </div>
       <Gauge value={gpuUsage} />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add hash auto-detection, mock GPU benchmark and wordlist generator to Hashcat app
- install xterm dependencies and add mocks for terminal tests
- add tests for hash detection and benchmark output

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade5737ea48328896bc7eb15394bba