### PR TITLE
feat(dsniff): add interactive log viewer with filters and simulation

### DIFF
--- a/__tests__/dsniff.test.tsx
+++ b/__tests__/dsniff.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import Dsniff from '../components/apps/dsniff';
+
+describe('Dsniff component', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ text: () => Promise.resolve('') }) as any;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('toggles simulation mode', () => {
+    render(<Dsniff />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Simulation'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText('No data')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Simulation'));
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('applies host filter', () => {
+    render(<Dsniff />);
+    fireEvent.click(screen.getByLabelText('Simulation'));
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // Apply host filter
+    fireEvent.change(screen.getByPlaceholderText('Value'), {
+      target: { value: 'example.com' },
+    });
+    fireEvent.click(screen.getByText('Add'));
+    expect(screen.getAllByText(/example.com/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/test.com/)).toBeNull();
+  });
+});
+

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -1,41 +1,198 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+// Simple parser that attempts to extract protocol and host from a log line
+const parseLines = (text) =>
+  text
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.trim().split(/\s+/);
+      return { raw: line, protocol: parts[0] || '', host: parts[1] || '' };
+    });
+
+// Example traffic used when simulation mode is enabled
+const exampleUrlsnarf = [
+  { raw: 'HTTP example.com/index.html', protocol: 'HTTP', host: 'example.com' },
+  { raw: 'HTTPS test.com/login', protocol: 'HTTPS', host: 'test.com' },
+];
+
+const exampleArpspoof = [
+  {
+    raw: 'ARP reply 192.168.0.1 is-at 00:11:22:33:44:55',
+    protocol: 'ARP',
+    host: '192.168.0.1',
+  },
+  {
+    raw: 'ARP reply 192.168.0.2 is-at aa:bb:cc:dd:ee:ff',
+    protocol: 'ARP',
+    host: '192.168.0.2',
+  },
+];
 
 const Dsniff = () => {
-  const [urlsnarfOutput, setUrlsnarfOutput] = useState('');
-  const [arpspoofOutput, setArpspoofOutput] = useState('');
+  const [urlsnarfLogs, setUrlsnarfLogs] = useState([]);
+  const [arpspoofLogs, setArpspoofLogs] = useState([]);
+  const [activeTab, setActiveTab] = useState('urlsnarf');
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState([]); // { field: 'host' | 'protocol', value: string }
+  const [newField, setNewField] = useState('host');
+  const [newValue, setNewValue] = useState('');
+  const [simulate, setSimulate] = useState(false);
+  const simInterval = useRef(null);
+  const simIndex = useRef(0);
+
+  const fetchOutputs = async () => {
+    try {
+      const [urlsnarfRes, arpspoofRes] = await Promise.all([
+        fetch('/api/dsniff/urlsnarf').then((r) => r.text()).catch(() => ''),
+        fetch('/api/dsniff/arpspoof').then((r) => r.text()).catch(() => ''),
+      ]);
+      if (urlsnarfRes) setUrlsnarfLogs(parseLines(urlsnarfRes));
+      if (arpspoofRes) setArpspoofLogs(parseLines(arpspoofRes));
+    } catch (e) {
+      // ignore errors
+    }
+  };
 
   useEffect(() => {
-    const fetchOutputs = async () => {
-      try {
-        const [urlsnarfRes, arpspoofRes] = await Promise.all([
-          fetch('/api/dsniff/urlsnarf').then((r) => r.text()).catch(() => ''),
-          fetch('/api/dsniff/arpspoof').then((r) => r.text()).catch(() => ''),
+    if (!simulate) {
+      fetchOutputs();
+      const interval = setInterval(fetchOutputs, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [simulate]);
+
+  useEffect(() => {
+    if (simulate) {
+      simIndex.current = 0;
+      setUrlsnarfLogs([]);
+      setArpspoofLogs([]);
+      simInterval.current = setInterval(() => {
+        setUrlsnarfLogs((prev) => [
+          ...prev,
+          exampleUrlsnarf[simIndex.current % exampleUrlsnarf.length],
         ]);
-        if (urlsnarfRes) setUrlsnarfOutput(urlsnarfRes);
-        if (arpspoofRes) setArpspoofOutput(arpspoofRes);
-      } catch (e) {
-        // ignore errors
-      }
+        setArpspoofLogs((prev) => [
+          ...prev,
+          exampleArpspoof[simIndex.current % exampleArpspoof.length],
+        ]);
+        simIndex.current += 1;
+      }, 1000);
+    } else {
+      setUrlsnarfLogs([]);
+      setArpspoofLogs([]);
+      if (simInterval.current) clearInterval(simInterval.current);
+    }
+    return () => {
+      if (simInterval.current) clearInterval(simInterval.current);
     };
-    fetchOutputs();
-    const interval = setInterval(fetchOutputs, 5000);
-    return () => clearInterval(interval);
-  }, []);
+  }, [simulate]);
+
+  const addFilter = () => {
+    if (newValue.trim()) {
+      setFilters([...filters, { field: newField, value: newValue.trim() }]);
+      setNewValue('');
+    }
+  };
+
+  const removeFilter = (idx) => {
+    setFilters(filters.filter((_, i) => i !== idx));
+  };
+
+  const logs = activeTab === 'urlsnarf' ? urlsnarfLogs : arpspoofLogs;
+  const filteredLogs = logs.filter((log) => {
+    const searchMatch = log.raw
+      .toLowerCase()
+      .includes(search.toLowerCase());
+    const filterMatch = filters.every((f) =>
+      log[f.field].toLowerCase().includes(f.value.toLowerCase())
+    );
+    return searchMatch && filterMatch;
+  });
 
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-2 overflow-auto">
       <h1 className="text-lg mb-2">dsniff</h1>
-      <div className="mb-4">
-        <h2 className="font-bold">urlsnarf</h2>
-        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
-          {urlsnarfOutput || 'No data'}
-        </pre>
+      <div className="mb-2 flex space-x-2 items-center">
+        <button
+          className={`px-2 ${
+            activeTab === 'urlsnarf' ? 'bg-black text-green-500' : 'bg-ub-grey'
+          }`}
+          onClick={() => setActiveTab('urlsnarf')}
+        >
+          urlsnarf
+        </button>
+        <button
+          className={`px-2 ${
+            activeTab === 'arpspoof' ? 'bg-black text-green-500' : 'bg-ub-grey'
+          }`}
+          onClick={() => setActiveTab('arpspoof')}
+        >
+          arpspoof
+        </button>
+        <label className="ml-auto flex items-center space-x-1">
+          <input
+            type="checkbox"
+            checked={simulate}
+            onChange={() => setSimulate(!simulate)}
+          />
+          <span>Simulation</span>
+        </label>
       </div>
-      <div>
-        <h2 className="font-bold">arpspoof</h2>
-        <pre className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
-          {arpspoofOutput || 'No data'}
-        </pre>
+      <div className="mb-2">
+        <input
+          className="w-full text-black p-1"
+          placeholder="Search logs"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+      <div className="mb-2">
+        <div className="flex space-x-2 mb-2">
+          <select
+            value={newField}
+            onChange={(e) => setNewField(e.target.value)}
+            className="text-black"
+          >
+            <option value="host">host</option>
+            <option value="protocol">protocol</option>
+          </select>
+          <input
+            className="flex-1 text-black p-1"
+            placeholder="Value"
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+          />
+          <button
+            className="bg-ub-blue text-white px-2"
+            onClick={addFilter}
+          >
+            Add
+          </button>
+        </div>
+        <div className="flex flex-wrap">
+          {filters.map((f, i) => (
+            <span
+              key={i}
+              className="bg-ub-grey text-white px-2 py-1 mr-1 mb-1"
+            >
+              {`${f.field}:${f.value}`}
+              <button
+                className="ml-1 text-red-400"
+                onClick={() => removeFilter(i)}
+              >
+                x
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
+        {filteredLogs.length ? (
+          filteredLogs.map((log, i) => <div key={i}>{log.raw}</div>)
+        ) : (
+          'No data'
+        )}
       </div>
     </div>
   );

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
-import 'xterm/css/xterm.css';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {


### PR DESCRIPTION
## Summary
- replace static dsniff outputs with tabbed log viewer featuring search, filter builder, and traffic simulation
- update terminal imports to @xterm packages for compatibility
- add tests for dsniff filter rules and simulation toggle

## Testing
- `yarn test` (fails: AI computes move under 200ms)
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade5746cf483288a341af873d1aadc