### PR TITLE
feat(john): support rule testing and task distribution

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__tests__/john-utils.test.js
+++ b/__tests__/john-utils.test.js
@@ -1,0 +1,17 @@
+import { parseRules, distributeTasks } from '../components/apps/john/utils';
+
+describe('john utilities', () => {
+  test('parseRules filters comments and empty lines', () => {
+    const text = '# comment\nrule1\n\nrule2\n# another';
+    expect(parseRules(text)).toEqual(['rule1', 'rule2']);
+  });
+
+  test('distributeTasks assigns hashes round-robin', () => {
+    const hashes = ['h1', 'h2', 'h3', 'h4'];
+    const endpoints = ['e1', 'e2'];
+    expect(distributeTasks(hashes, endpoints)).toEqual({
+      e1: ['h1', 'h3'],
+      e2: ['h2', 'h4'],
+    });
+  });
+});

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -1,34 +1,75 @@
 import React, { useState } from 'react';
+import {
+  parseRules,
+  distributeTasks,
+  identifyHashType,
+} from './utils';
 
-// Simple John the Ripper interface that sends hash input to an API
-// route which in turn runs the `john` binary using Node's child_process.
+// Enhanced John the Ripper interface that supports rule uploads,
+// basic hash analysis and mock distribution of cracking tasks.
 
 const JohnApp = () => {
-  const [hash, setHash] = useState('');
+  const [hashes, setHashes] = useState('');
+  const [hashTypes, setHashTypes] = useState([]);
+  const [rules, setRules] = useState([]);
+  const [endpoints, setEndpoints] = useState('');
   const [output, setOutput] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
+  const handleRuleUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result || '';
+      setRules(parseRules(String(text)));
+    };
+    reader.readAsText(file);
+  };
+
+  const handleHashesChange = (e) => {
+    const value = e.target.value;
+    setHashes(value);
+    const arr = value.split(/\r?\n/).filter(Boolean);
+    setHashTypes(arr.map((h) => identifyHashType(h)));
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!hash) {
-      setError('Hash is required');
+    const hashArr = hashes.split(/\r?\n/).filter(Boolean);
+    if (!hashArr.length) {
+      setError('At least one hash is required');
       return;
     }
+    const endpointArr = endpoints
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
     setError('');
     setLoading(true);
     setOutput('');
     try {
-      const res = await fetch('/api/john', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ hash }),
-      });
-      const data = await res.json();
-      if (data.error) {
-        setError(data.error);
+      const assignments = endpointArr.length
+        ? distributeTasks(hashArr, endpointArr)
+        : { local: hashArr };
+      const results = [];
+      for (const [endpoint, hs] of Object.entries(assignments)) {
+        for (const h of hs) {
+          const res = await fetch('/api/john', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ hash: h, rules }),
+          });
+          const data = await res.json();
+          results.push(
+            `${endpoint} (${identifyHashType(h)}): ${
+              data.output || data.error || 'No output'
+            }`
+          );
+        }
       }
-      setOutput(data.output || data.error || 'No output');
+      setOutput(results.join('\n'));
     } catch (err) {
       setError(err.message);
     } finally {
@@ -39,28 +80,53 @@ const JohnApp = () => {
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white">
       <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
-        <label htmlFor="john-hash" className="text-sm">
-          Hash
+        <label htmlFor="john-hashes" className="text-sm">
+          Hashes (one per line)
         </label>
-        <div className="flex gap-2">
-          <input
-            id="john-hash"
-            type="text"
-            value={hash}
-            onChange={(e) => setHash(e.target.value)}
-            placeholder="Enter hash"
-            className="flex-1 px-2 py-1 bg-gray-800 text-white rounded"
-            aria-invalid={error ? 'true' : undefined}
-            aria-describedby={error ? 'john-error' : undefined}
-          />
-          <button
-            type="submit"
-            className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded"
-            disabled={loading}
-          >
-            {loading ? 'Running...' : 'Crack'}
-          </button>
-        </div>
+        <textarea
+          id="john-hashes"
+          value={hashes}
+          onChange={handleHashesChange}
+          placeholder="Enter hashes"
+          className="flex-1 px-2 py-1 bg-gray-800 text-white rounded h-24"
+          aria-invalid={error ? 'true' : undefined}
+          aria-describedby={error ? 'john-error' : undefined}
+        />
+        {hashTypes.length > 0 && (
+          <ul className="text-xs text-gray-300">
+            {hashTypes.map((t, i) => (
+              <li key={i}>{`Hash ${i + 1}: ${t}`}</li>
+            ))}
+          </ul>
+        )}
+        <label htmlFor="john-rule" className="text-sm">
+          Rule file
+        </label>
+        <input
+          id="john-rule"
+          type="file"
+          accept=".rule,.rules,.txt"
+          onChange={handleRuleUpload}
+          className="text-sm"
+        />
+        <label htmlFor="john-endpoints" className="text-sm">
+          Endpoints (comma separated)
+        </label>
+        <input
+          id="john-endpoints"
+          type="text"
+          value={endpoints}
+          onChange={(e) => setEndpoints(e.target.value)}
+          placeholder="endpoint1, endpoint2"
+          className="px-2 py-1 bg-gray-800 text-white rounded"
+        />
+        <button
+          type="submit"
+          className="px-4 py-1 bg-gray-700 hover:bg-gray-600 rounded self-start"
+          disabled={loading}
+        >
+          {loading ? 'Running...' : 'Crack'}
+        </button>
         {error && (
           <p id="john-error" role="alert" className="text-red-500 text-sm">
             {error}

--- a/components/apps/john/utils.js
+++ b/components/apps/john/utils.js
@@ -1,0 +1,25 @@
+export const parseRules = (text) =>
+  text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+
+export const distributeTasks = (hashes, endpoints) => {
+  const assignments = {};
+  if (!endpoints.length) return assignments;
+  endpoints.forEach((ep) => {
+    assignments[ep] = [];
+  });
+  hashes.forEach((hash, idx) => {
+    const ep = endpoints[idx % endpoints.length];
+    assignments[ep].push(hash);
+  });
+  return assignments;
+};
+
+export const identifyHashType = (hash) => {
+  if (/^[a-fA-F0-9]{32}$/.test(hash)) return 'MD5';
+  if (/^[a-fA-F0-9]{40}$/.test(hash)) return 'SHA1';
+  if (/^[a-fA-F0-9]{64}$/.test(hash)) return 'SHA256';
+  return 'Unknown';
+};

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { SearchAddon } from 'xterm-addon-search';
-import 'xterm/css/xterm.css';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ const createJestConfig = nextJest({ dir: './' });
 const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- extend John the Ripper app with rule upload, hash analysis, and task distribution UI
- add utilities for rule parsing, hash identification, and endpoint distribution
- cover new logic with jest tests and align terminal/xterm imports for builds

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade57521fc83289f4fe6707655a116