### PR TITLE
feat: enhance openvas scanning

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import OpenVASApp from '../components/apps/openvas';
+
+describe('OpenVASApp', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve('scan complete'),
+      })
+    ) as any;
+
+    const notificationMock: any = jest.fn();
+    (notificationMock as any).permission = 'granted';
+    // @ts-ignore
+    global.Notification = notificationMock;
+
+    // @ts-ignore
+    global.URL.createObjectURL = jest.fn(() => 'blob:summary');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('includes group in scan request', async () => {
+    render(<OpenVASApp />);
+    fireEvent.change(
+      screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
+      { target: { value: '1.2.3.4' } }
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText('Group (e.g. Servers)'),
+      { target: { value: 'servers' } }
+    );
+    fireEvent.click(screen.getByText('Scan'));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/openvas?target=1.2.3.4&group=servers'
+    );
+  });
+
+  it('triggers notification on scan completion', async () => {
+    render(<OpenVASApp />);
+    fireEvent.change(
+      screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
+      { target: { value: '1.2.3.4' } }
+    );
+    fireEvent.click(screen.getByText('Scan'));
+    await waitFor(() =>
+      expect(Notification).toHaveBeenCalledWith('OpenVAS Scan Complete', {
+        body: expect.any(String),
+      })
+    );
+  });
+
+  it('triggers notification on scan failure', async () => {
+    (fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject(new Error('fail'))
+    );
+    render(<OpenVASApp />);
+    fireEvent.change(
+      screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
+      { target: { value: '1.2.3.4' } }
+    );
+    fireEvent.click(screen.getByText('Scan'));
+    await waitFor(() =>
+      expect(Notification).toHaveBeenCalledWith('OpenVAS Scan Failed', {
+        body: 'fail',
+      })
+    );
+  });
+});

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -1,21 +1,47 @@
 import React, { useState } from 'react';
 
+// Simple helper for notifications that falls back to alert()
+const notify = (title, body) => {
+  if (typeof window === 'undefined') return;
+  if ('Notification' in window && Notification.permission === 'granted') {
+    // eslint-disable-next-line no-new
+    new Notification(title, { body });
+  } else {
+    // eslint-disable-next-line no-alert
+    alert(`${title}: ${body}`);
+  }
+};
+
 const OpenVASApp = () => {
   const [target, setTarget] = useState('');
+  const [group, setGroup] = useState('');
   const [output, setOutput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [summaryUrl, setSummaryUrl] = useState(null);
+
+  const generateSummary = (data) => {
+    const summary = `# OpenVAS Scan Summary\n\n- Target: ${target}\n- Group: ${group}\n\n## Output\n\n${data}`;
+    const blob = new Blob([summary], { type: 'text/markdown' });
+    setSummaryUrl(URL.createObjectURL(blob));
+  };
 
   const runScan = async () => {
     if (!target) return;
     setLoading(true);
     setOutput('');
+    setSummaryUrl(null);
     try {
-      const res = await fetch(`/api/openvas?target=${encodeURIComponent(target)}`);
+      const res = await fetch(
+        `/api/openvas?target=${encodeURIComponent(target)}&group=${encodeURIComponent(group)}`
+      );
       if (!res.ok) throw new Error(`Request failed with ${res.status}`);
       const data = await res.text();
       setOutput(data);
+      generateSummary(data);
+      notify('OpenVAS Scan Complete', `Target ${target} finished`);
     } catch (e) {
       setOutput(e.message);
+      notify('OpenVAS Scan Failed', e.message);
     } finally {
       setLoading(false);
     }
@@ -31,6 +57,12 @@ const OpenVASApp = () => {
           value={target}
           onChange={(e) => setTarget(e.target.value)}
         />
+        <input
+          className="flex-1 p-2 rounded text-black"
+          placeholder="Group (e.g. Servers)"
+          value={group}
+          onChange={(e) => setGroup(e.target.value)}
+        />
         <button
           type="button"
           onClick={runScan}
@@ -44,6 +76,15 @@ const OpenVASApp = () => {
         <pre className="bg-black text-green-400 p-2 rounded whitespace-pre-wrap">
           {output}
         </pre>
+      )}
+      {summaryUrl && (
+        <a
+          href={summaryUrl}
+          download="openvas-summary.md"
+          className="inline-block mt-2 px-4 py-2 bg-blue-600 rounded"
+        >
+          Download Summary
+        </a>
       )}
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-search": "^0.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,6 +7558,9 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
     typescript: "npm:^5.9.2"
+    xterm: "npm:^5.3.0"
+    xterm-addon-fit: "npm:^0.8.0"
+    xterm-addon-search: "npm:^0.13.0"
   languageName: unknown
   linkType: soft
 
@@ -7895,6 +7898,31 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xterm-addon-fit@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "xterm-addon-fit@npm:0.8.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/39f77c9ec74bcc048ad74fbc4b9d610070c0a67971837f7edf92a8d21d65189c887986713d6ab22c04e2704253022488324d27fdb2425dc8aa95a9b679703101
+  languageName: node
+  linkType: hard
+
+"xterm-addon-search@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "xterm-addon-search@npm:0.13.0"
+  peerDependencies:
+    xterm: ^5.0.0
+  checksum: 10c0/0612c9cbc0d837eb6c6f21cb726d7927a2fb899272e37c925d77c1fc077c7fcd23a75799e470aa3b467cabd9896b95875b8e2a3884bc8529c6a895c594fc36f4
+  languageName: node
+  linkType: hard
+
+"xterm@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "xterm@npm:5.3.0"
+  checksum: 10c0/39bf5ea933cc2f65d5970560d065b4db645ed03c820bcf6c6239bd504e41a876ab1a773ad9e4e09476ba85a4891534702b9fbb885b0838d79e6620ed2f856bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- allow OpenVAS scans to be tagged with a group and export results as Markdown
- add notifications for scan completion and failure
- cover group queries and notification triggers in new tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ade5767ca0832898142cbd1ec9b234