### PR TITLE
Handle absence of Web Workers in terminal component

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -39,4 +39,16 @@ describe('Terminal component', () => {
     });
     expect(ref.current.getContent()).toBe('');
   });
+
+  it('handles missing Worker gracefully', () => {
+    const ref = createRef();
+    const originalWorker = (global as any).Worker;
+    (global as any).Worker = undefined;
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    act(() => {
+      ref.current.runCommand('simulate');
+    });
+    expect(ref.current.getContent()).toContain('Web Workers are not supported');
+    (global as any).Worker = originalWorker;
+  });
 });

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -46,10 +46,17 @@ const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
       prompt();
     } else if (trimmed === 'simulate') {
       termRef.current.writeln('');
-      termRef.current.writeln('Running heavy simulation...');
-      logRef.current += 'Running heavy simulation...\n';
-      workerRef.current.postMessage({ command: 'simulate' });
-      // prompt will be called when worker responds
+      if (workerRef.current) {
+        termRef.current.writeln('Running heavy simulation...');
+        logRef.current += 'Running heavy simulation...\n';
+        workerRef.current.postMessage({ command: 'simulate' });
+        // prompt will be called when worker responds
+      } else {
+        const msg = 'Web Workers are not supported in this environment.';
+        termRef.current.writeln(msg);
+        logRef.current += `${msg}\n`;
+        prompt();
+      }
     } else if (trimmed === 'clear') {
       termRef.current.clear();
       logRef.current = '';
@@ -173,13 +180,17 @@ const Terminal = forwardRef(({ addFolder, openApp }, ref) => {
         showingSuggestionsRef.current = false;
       }
     });
-    workerRef.current = new Worker(new URL('./terminal.worker.js', import.meta.url));
-    workerRef.current.onmessage = (e) => {
-      term.writeln('');
-      term.writeln(String(e.data));
-      logRef.current += `${String(e.data)}\n`;
-      prompt();
-    };
+    if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+      workerRef.current = new Worker(new URL('./terminal.worker.js', import.meta.url));
+      workerRef.current.onmessage = (e) => {
+        term.writeln('');
+        term.writeln(String(e.data));
+        logRef.current += `${String(e.data)}\n`;
+        prompt();
+      };
+    } else {
+      workerRef.current = null;
+    }
 
     const handleResize = () => fitAddon.fit();
     window.addEventListener('resize', handleResize);


### PR DESCRIPTION
## Summary
- Guard terminal worker initialization with runtime check for Web Worker support
- Ensure simulate command reports an error when no worker is available
- Add unit test covering environments without Web Worker support

## Testing
- `npm test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adeacbd01c8328a20bde981ea0a1ba