### PR TITLE
feat(memory): add image upload support

### DIFF
--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -28,9 +28,22 @@ export function fisherYatesShuffle(array) {
   return arr;
 }
 
-export function createDeck(size) {
+export function createDeck(size, images = []) {
   const pairs = (size * size) / 2;
-  const selected = EMOJIS.slice(0, pairs);
-  const doubled = [...selected, ...selected].map((value, index) => ({ id: index, value }));
+
+  // Take as many uploaded images as needed for pairs
+  const selectedImages = images.slice(0, pairs).map((src) => ({ type: 'image', value: src }));
+  const remainingPairs = pairs - selectedImages.length;
+
+  // Use emojis to fill any remaining pairs
+  const selectedEmojis = EMOJIS.slice(0, remainingPairs).map((value) => ({ type: 'emoji', value }));
+
+  const combined = [...selectedImages, ...selectedEmojis];
+
+  const doubled = combined.flatMap((item, index) => [
+    { id: index * 2, ...item },
+    { id: index * 2 + 1, ...item },
+  ]);
+
   return fisherYatesShuffle(doubled);
 }


### PR DESCRIPTION
## Summary
- add image upload interface for memory game
- build matching pairs from uploaded images with validation

## Testing
- `yarn test` (fails: Cannot find module '@xterm/xterm')
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d3785ac8328b6005b8539c18a49