### PR TITLE
Fix xterm import path and update tests

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -4,7 +4,7 @@ import Terminal from '../components/apps/terminal';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock(
-  'xterm',
+  '@xterm/xterm',
   () => ({
     Terminal: jest.fn().mockImplementation(() => ({
       open: jest.fn(),
@@ -16,12 +16,13 @@ jest.mock(
       reset: jest.fn(),
       onKey: jest.fn(),
       writeln: jest.fn(),
+      clear: jest.fn(),
     })),
   }),
   { virtual: true }
 );
 jest.mock(
-  'xterm-addon-fit',
+  '@xterm/addon-fit',
   () => ({
     FitAddon: jest.fn().mockImplementation(() => ({
       activate: jest.fn(),
@@ -31,13 +32,13 @@ jest.mock(
   { virtual: true }
 );
 jest.mock(
-  'xterm-addon-search',
+  '@xterm/addon-search',
   () => ({
     SearchAddon: jest.fn().mockImplementation(() => ({ activate: jest.fn() })),
   }),
   { virtual: true }
 );
-jest.mock('xterm/css/xterm.css', () => ({}), { virtual: true });
+jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
 
 describe('Terminal component', () => {
   const addFolder = jest.fn();

--- a/components/apps/terminal.js
+++ b/components/apps/terminal.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, forwardRef, useImperativeHandle, useCallback 
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
-import '@xterm/xterm/css/xterm.css';
 
 
 const Terminal = forwardRef(({ addFolder, openApp }, ref) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
+import '@xterm/xterm/css/xterm.css';
 import { ThemeProvider } from '../hooks/useTheme';
 
 function MyApp({ Component, pageProps }: AppProps) {


### PR DESCRIPTION
## Summary
- load xterm stylesheet globally in `_app`
- drop in-component stylesheet import for terminal
- update terminal tests for scoped xterm packages

## Testing
- `yarn lint`
- `yarn build`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adf5d59cc48328928fd1a9c5295dc9