### PR TITLE
feat: enhance terminal with built-in commands and history

### DIFF
--- a/components/apps/command-docs-panel.js
+++ b/components/apps/command-docs-panel.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const CommandDocsPanel = () => (
+  <div className="w-48 p-2 bg-ub-dark text-white text-xs overflow-auto hidden md:block">
+    <h2 className="font-bold mb-2">Commands</h2>
+    <ul className="space-y-1">
+      <li><code>pwd</code> - print working directory</li>
+      <li><code>cd &lt;dir&gt;</code> - change directory</li>
+      <li><code>date</code> - show current date/time</li>
+      <li><code>echo &lt;text&gt;</code> - echo text</li>
+      <li><code>ls</code> - list files</li>
+      <li><code>clear</code> - clear terminal</li>
+      <li><code>help</code> - show available commands</li>
+      <li><code>history</code> - show command history</li>
+      <li><code>simulate</code> - run simulation</li>
+    </ul>
+  </div>
+);
+
+export default CommandDocsPanel;

--- a/components/apps/terminal.worker.js
+++ b/components/apps/terminal.worker.js
@@ -1,11 +1,34 @@
+// Simple worker that simulates a few built-in shell commands. It does not
+// execute arbitrary code and only responds to a whitelisted set of commands.
 self.onmessage = (e) => {
-  const { command } = e.data || {};
-  if (command === 'simulate') {
-    // Fake heavy computation
-    let total = 0;
-    for (let i = 0; i < 5e7; i += 1) {
-      total += i;
+  const { command = '' } = e.data || {};
+  const [cmd, ...args] = command.trim().split(/\s+/);
+
+  switch (cmd) {
+    case 'simulate': {
+      // Fake heavy computation to demonstrate worker usage
+      let total = 0;
+      for (let i = 0; i < 5e7; i += 1) {
+        total += i; // eslint-disable-line no-unused-vars
+      }
+      self.postMessage('Simulation complete');
+      break;
     }
-    self.postMessage('Simulation complete');
+    case 'date': {
+      self.postMessage(new Date().toString());
+      break;
+    }
+    case 'echo': {
+      self.postMessage(args.join(' '));
+      break;
+    }
+    case 'ls': {
+      // Return a fixed set of filenames to avoid exposing the real file system
+      self.postMessage('Documents Downloads Music Pictures Videos');
+      break;
+    }
+    default: {
+      self.postMessage(`Command '${cmd}' not found`);
+    }
   }
 };


### PR DESCRIPTION
## Summary
- add worker built-ins for `date`, `echo`, and `ls`
- persist terminal history and enable arrow-key navigation
- show command docs panel next to terminal

## Testing
- `yarn lint`
- `CI=true yarn test --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68ae014e5f888328a77df420b35d4308