### PR TITLE
Add EmailJS contact API with honeypot and fallback

### DIFF
--- a/__tests__/gedit.test.tsx
+++ b/__tests__/gedit.test.tsx
@@ -3,35 +3,29 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import Gedit from '../components/apps/gedit';
 
 jest.mock('react-ga4', () => ({ event: jest.fn() }));
-const init = jest.fn();
-const send = jest.fn();
-jest.mock('@emailjs/browser', () => ({ init: (...args: any[]) => init(...args), send: (...args: any[]) => send(...args) }));
 
 describe('Gedit component', () => {
   beforeEach(() => {
-    init.mockClear();
-    send.mockClear();
-    process.env.NEXT_PUBLIC_SERVICE_ID = 'service';
-    process.env.NEXT_PUBLIC_TEMPLATE_ID = 'template';
-    process.env.NEXT_PUBLIC_USER_ID = 'user';
+    (global.fetch as any) = jest.fn().mockResolvedValue({ ok: true });
+    window.alert = jest.fn();
+    window.open = jest.fn();
   });
 
   it('sends message when fields are valid', async () => {
-    send.mockResolvedValueOnce({});
     render(<Gedit />);
     fireEvent.change(screen.getByPlaceholderText('Your Email / Name :'), { target: { value: 'Alex' } });
     fireEvent.change(screen.getByPlaceholderText(/subject/), { target: { value: 'Hi' } });
     fireEvent.change(screen.getByPlaceholderText('Message'), { target: { value: 'Hello' } });
     fireEvent.click(screen.getByText('Send'));
 
-    await waitFor(() => expect(send).toHaveBeenCalled());
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
   });
 
   it('does not send when name is empty', () => {
     render(<Gedit />);
     fireEvent.change(screen.getByPlaceholderText('Message'), { target: { value: 'Hello' } });
     fireEvent.click(screen.getByText('Send'));
-    expect(send).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
     expect(screen.getByPlaceholderText('Name must not be Empty!')).toBeInTheDocument();
   });
 });

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,0 +1,44 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { name, subject, message } = req.body || {};
+  if (!name || !message) {
+    res.status(400).json({ error: 'Missing parameters' });
+    return;
+  }
+
+  const service = process.env.EMAILJS_SERVICE_ID;
+  const template = process.env.EMAILJS_TEMPLATE_ID;
+  const user = process.env.EMAILJS_PUBLIC_KEY;
+
+  if (!service || !template || !user) {
+    res.status(500).json({ error: 'Email service not configured' });
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.emailjs.com/api/v1.0/email/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        service_id: service,
+        template_id: template,
+        user_id: user,
+        template_params: { name, subject, message },
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      res.status(response.status).json({ error: text });
+      return;
+    }
+
+    res.status(200).json({ status: 'sent' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add serverless `/api/contact` route that forwards messages to EmailJS
- improve gedit contact form with honeypot field, simple rate limiting, and mailto fallback
- display toast notifications for success or failure

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae019714748328aba6946e66b138b8