### PR TITLE
Organize converter with persistent searchable tabs

### DIFF
--- a/components/apps/converter/CurrencyConverter.js
+++ b/components/apps/converter/CurrencyConverter.js
@@ -1,11 +1,16 @@
 import React, { useState, useEffect } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
 
 const CurrencyConverter = () => {
   const [rates, setRates] = useState({});
-  const [from, setFrom] = useState('USD');
-  const [to, setTo] = useState('EUR');
+  const [from, setFrom] = usePersistentState('currency-from', 'USD');
+  const [to, setTo] = usePersistentState('currency-to', 'EUR');
   const [amount, setAmount] = useState('');
   const [result, setResult] = useState('');
+  const [amountError, setAmountError] = useState('');
+  const [fromError, setFromError] = useState('');
+  const [toError, setToError] = useState('');
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     fetch('https://open.er-api.com/v6/latest/USD')
@@ -15,16 +20,57 @@ const CurrencyConverter = () => {
   }, []);
 
   useEffect(() => {
-    if (!amount || !rates[from] || !rates[to]) {
+    if (
+      !amount ||
+      isNaN(parseFloat(amount)) ||
+      amountError ||
+      fromError ||
+      toError ||
+      !rates[from] ||
+      !rates[to]
+    ) {
       setResult('');
       return;
     }
     const usdAmount = parseFloat(amount) / rates[from];
     const converted = usdAmount * rates[to];
     setResult(converted.toFixed(2));
-  }, [amount, from, to, rates]);
+  }, [amount, from, to, rates, amountError, fromError, toError]);
 
   const currencyOptions = Object.keys(rates);
+
+  const handleAmountChange = (e) => {
+    const val = e.target.value;
+    setAmount(val);
+    setAmountError(val === '' || isNaN(Number(val)) ? 'Enter a valid number' : '');
+  };
+
+  const handleFromChange = (e) => {
+    const val = e.target.value.toUpperCase();
+    setFrom(val);
+    setFromError(currencyOptions.includes(val) ? '' : 'Invalid currency');
+  };
+
+  const handleToChange = (e) => {
+    const val = e.target.value.toUpperCase();
+    setTo(val);
+    setToError(currencyOptions.includes(val) ? '' : 'Invalid currency');
+  };
+
+  const resultText = result ? `${amount} ${from} = ${result} ${to}` : '';
+
+  const copyResult = async () => {
+    if (!resultText) return;
+    try {
+      if (navigator && navigator.clipboard) {
+        await navigator.clipboard.writeText(resultText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
 
   return (
     <div className="bg-gray-700 p-4 rounded flex flex-col gap-2">
@@ -33,43 +79,63 @@ const CurrencyConverter = () => {
         Amount
         <input
           className="text-black p-1 rounded"
-          type="number"
+          type="text"
           value={amount}
-          onChange={(e) => setAmount(e.target.value)}
+          onChange={handleAmountChange}
         />
+        {amountError && (
+          <span className="text-red-500 text-sm">{amountError}</span>
+        )}
       </label>
       <div className="grid grid-cols-2 gap-2">
         <label className="flex flex-col">
           From
-          <select
+          <input
             className="text-black p-1 rounded"
+            list="currency-from-options"
             value={from}
-            onChange={(e) => setFrom(e.target.value)}
-          >
+            onChange={handleFromChange}
+          />
+          <datalist id="currency-from-options">
             {currencyOptions.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
+              <option key={c} value={c} />
             ))}
-          </select>
+          </datalist>
+          {fromError && (
+            <span className="text-red-500 text-sm">{fromError}</span>
+          )}
         </label>
         <label className="flex flex-col">
           To
-          <select
+          <input
             className="text-black p-1 rounded"
+            list="currency-to-options"
             value={to}
-            onChange={(e) => setTo(e.target.value)}
-          >
+            onChange={handleToChange}
+          />
+          <datalist id="currency-to-options">
             {currencyOptions.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
+              <option key={c} value={c} />
             ))}
-          </select>
+          </datalist>
+          {toError && <span className="text-red-500 text-sm">{toError}</span>}
         </label>
       </div>
-      <div data-testid="currency-result" className="mt-2">
-        {result && `${amount} ${from} = ${result} ${to}`}
+      <div data-testid="currency-result" className="mt-2 flex items-center gap-2">
+        {result && (
+          <>
+            <span>{resultText}</span>
+            <button
+              className="bg-gray-600 px-2 py-1 rounded"
+              onClick={copyResult}
+            >
+              Copy
+            </button>
+            {copied && (
+              <span className="text-green-400 text-sm">Copied!</span>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { create, all } from 'mathjs';
+import usePersistentState from '../../../hooks/usePersistentState';
 
 const math = create(all);
 
@@ -26,21 +27,37 @@ export const convertUnit = (category, from, to, amount, precision) => {
 };
 
 const UnitConverter = () => {
-  const [category, setCategory] = useState('length');
-  const [fromUnit, setFromUnit] = useState('meter');
-  const [toUnit, setToUnit] = useState('kilometer');
+  const [category, setCategory] = usePersistentState('unit-category', 'length');
+  const [fromUnit, setFromUnit] = usePersistentState('unit-from', 'meter');
+  const [toUnit, setToUnit] = usePersistentState('unit-to', 'kilometer');
+  const [precision, setPrecision] = usePersistentState('unit-precision', 4);
   const [value, setValue] = useState('');
   const [result, setResult] = useState('');
-  const [precision, setPrecision] = useState(4);
+  const [valueError, setValueError] = useState('');
+  const [precisionError, setPrecisionError] = useState('');
+  const [fromError, setFromError] = useState('');
+  const [toError, setToError] = useState('');
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     const units = Object.keys(unitMap[category]);
-    setFromUnit(units[0]);
-    setToUnit(units[1] || units[0]);
-  }, [category]);
+    if (!units.includes(fromUnit)) {
+      setFromUnit(units[0]);
+    }
+    if (!units.includes(toUnit)) {
+      setToUnit(units[1] || units[0]);
+    }
+  }, [category, fromUnit, toUnit, setFromUnit, setToUnit]);
 
   useEffect(() => {
-    if (value === '' || isNaN(parseFloat(value))) {
+    if (
+      value === '' ||
+      isNaN(parseFloat(value)) ||
+      valueError ||
+      precisionError ||
+      fromError ||
+      toError
+    ) {
       setResult('');
       return;
     }
@@ -54,9 +71,54 @@ const UnitConverter = () => {
     setResult(
       math.format(converted, { notation: 'fixed', precision })
     );
-  }, [value, fromUnit, toUnit, category, precision]);
+  }, [value, fromUnit, toUnit, category, precision, valueError, precisionError, fromError, toError]);
 
   const units = Object.keys(unitMap[category]);
+
+  const handleValueChange = (e) => {
+    const val = e.target.value;
+    setValue(val);
+    setValueError(val === '' || isNaN(Number(val)) ? 'Enter a valid number' : '');
+  };
+
+  const handlePrecisionChange = (e) => {
+    const val = e.target.value;
+    const num = Number(val);
+    setPrecision(num);
+    setPrecisionError(
+      val === '' || !Number.isInteger(num) || num < 0
+        ? 'Precision must be a non-negative integer'
+        : ''
+    );
+  };
+
+  const handleFromChange = (e) => {
+    const val = e.target.value;
+    setFromUnit(val);
+    setFromError(units.includes(val) ? '' : 'Invalid unit');
+  };
+
+  const handleToChange = (e) => {
+    const val = e.target.value;
+    setToUnit(val);
+    setToError(units.includes(val) ? '' : 'Invalid unit');
+  };
+
+  const resultText =
+    result ? `${value} ${fromUnit} = ${result} ${toUnit}` : '';
+
+  const copyResult = async () => {
+    if (!resultText) return;
+    try {
+      if (navigator && navigator.clipboard) {
+        await navigator.clipboard.writeText(resultText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
 
   return (
     <div className="bg-gray-700 p-4 rounded flex flex-col gap-2">
@@ -76,53 +138,77 @@ const UnitConverter = () => {
         Value
         <input
           className="text-black p-1 rounded"
-          type="number"
+          type="text"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={handleValueChange}
         />
+        {valueError && (
+          <span className="text-red-500 text-sm">{valueError}</span>
+        )}
       </label>
       <label className="flex flex-col">
         Precision
         <input
           className="text-black p-1 rounded"
-          type="number"
-          min="0"
+          type="text"
           value={precision}
-          onChange={(e) => setPrecision(Number(e.target.value))}
+          onChange={handlePrecisionChange}
         />
+        {precisionError && (
+          <span className="text-red-500 text-sm">{precisionError}</span>
+        )}
       </label>
       <div className="grid grid-cols-2 gap-2">
         <label className="flex flex-col">
           From
-          <select
+          <input
             className="text-black p-1 rounded"
+            list="unit-from-options"
             value={fromUnit}
-            onChange={(e) => setFromUnit(e.target.value)}
-          >
+            onChange={handleFromChange}
+          />
+          <datalist id="unit-from-options">
             {units.map((u) => (
-              <option key={u} value={u}>
-                {u}
-              </option>
+              <option key={u} value={u} />
             ))}
-          </select>
+          </datalist>
+          {fromError && (
+            <span className="text-red-500 text-sm">{fromError}</span>
+          )}
         </label>
         <label className="flex flex-col">
           To
-          <select
+          <input
             className="text-black p-1 rounded"
+            list="unit-to-options"
             value={toUnit}
-            onChange={(e) => setToUnit(e.target.value)}
-          >
+            onChange={handleToChange}
+          />
+          <datalist id="unit-to-options">
             {units.map((u) => (
-              <option key={u} value={u}>
-                {u}
-              </option>
+              <option key={u} value={u} />
             ))}
-          </select>
+          </datalist>
+          {toError && (
+            <span className="text-red-500 text-sm">{toError}</span>
+          )}
         </label>
       </div>
-      <div data-testid="unit-result" className="mt-2">
-        {result && `${value} ${fromUnit} = ${result} ${toUnit}`}
+      <div data-testid="unit-result" className="mt-2 flex items-center gap-2">
+        {result && (
+          <>
+            <span>{resultText}</span>
+            <button
+              className="bg-gray-600 px-2 py-1 rounded"
+              onClick={copyResult}
+            >
+              Copy
+            </button>
+            {copied && (
+              <span className="text-green-400 text-sm">Copied!</span>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/components/apps/converter/index.js
+++ b/components/apps/converter/index.js
@@ -1,14 +1,38 @@
 import React from 'react';
 import UnitConverter from './UnitConverter';
 import CurrencyConverter from './CurrencyConverter';
+import usePersistentState from '../../../hooks/usePersistentState';
 
 const Converter = () => {
+  const [activeTab, setActiveTab] = usePersistentState('converter-tab', 'unit');
+
   return (
     <div className="h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
-      <div className="grid gap-4 md:grid-cols-2">
-        <UnitConverter />
-        <CurrencyConverter />
+      <div className="mb-4 flex gap-2 border-b border-gray-600">
+        <button
+          className={
+            'px-3 py-1 rounded-t ' +
+            (activeTab === 'unit'
+              ? 'bg-gray-700'
+              : 'bg-gray-600 text-gray-300')
+          }
+          onClick={() => setActiveTab('unit')}
+        >
+          Units
+        </button>
+        <button
+          className={
+            'px-3 py-1 rounded-t ' +
+            (activeTab === 'currency'
+              ? 'bg-gray-700'
+              : 'bg-gray-600 text-gray-300')
+          }
+          onClick={() => setActiveTab('currency')}
+        >
+          Currency
+        </button>
       </div>
+      {activeTab === 'currency' ? <CurrencyConverter /> : <UnitConverter />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Replace side-by-side layout with tabbed navigation for unit and currency converters
- Add searchable dropdowns with `usePersistentState` to remember selections
- Validate numeric input and show errors, with copy-to-clipboard support for results

## Testing
- `npm test`
- `npm test __tests__/converter.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae01996e088328a52a96f3ecb4f815