### PR TITLE
feat: add width slider and presets to ASCII art app

### DIFF
--- a/components/apps/ascii_art/worker.js
+++ b/components/apps/ascii_art/worker.js
@@ -1,8 +1,8 @@
 self.onmessage = async (e) => {
-  const { bitmap, charSet, cellSize, useColor, palette } = e.data;
+  const { bitmap, charSet, width: outWidth, useColor, palette } = e.data;
   const chars = charSet.split('');
-  const width = Math.floor(bitmap.width / cellSize);
-  const height = Math.floor(bitmap.height / cellSize);
+  const width = outWidth;
+  const height = Math.round((bitmap.height / bitmap.width) * outWidth);
   let canvas;
   if (typeof OffscreenCanvas !== 'undefined') {
     canvas = new OffscreenCanvas(width, height);


### PR DESCRIPTION
## Summary
- add adjustable width slider for ASCII output
- render preview inside monospace block with inline copy button
- persist user presets in localStorage with save/load/delete controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae019c76e88328bb96fcc89fcd68f2