### PR TITLE
feat(figlet): dynamic font loading and text export

### DIFF
--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -1,28 +1,67 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-const fonts = ['Standard', 'Slant'];
+const FONT_LIST_KEY = 'figlet-fonts';
+const FONT_BASE_URL = 'https://unpkg.com/figlet@1.8.2/importable-fonts';
 
 const FigletApp = () => {
   const [text, setText] = useState('');
-  const [font, setFont] = useState(fonts[0]);
+  const [font, setFont] = useState('');
+  const [fonts, setFonts] = useState([]);
   const [output, setOutput] = useState('');
   const workerRef = useRef(null);
 
   useEffect(() => {
-    workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
+    workerRef.current = new Worker(new URL('./worker.js', import.meta.url), {
+      type: 'module',
+    });
     workerRef.current.onmessage = (e) => setOutput(e.data);
     return () => workerRef.current?.terminate();
   }, []);
 
   useEffect(() => {
-    if (workerRef.current) {
-      workerRef.current.postMessage({ text, font });
+    const stored = localStorage.getItem(FONT_LIST_KEY);
+    if (stored) {
+      const list = JSON.parse(stored);
+      setFonts(list);
+      setFont(list.includes('Standard') ? 'Standard' : list[0]);
+      return;
+    }
+    fetch(`${FONT_BASE_URL}?meta`)
+      .then((res) => res.json())
+      .then((data) => {
+        const list = data.files
+          .filter((f) => f.path.endsWith('.js'))
+          .map((f) =>
+            decodeURIComponent(
+              f.path.replace('/importable-fonts/', '').replace('.js', '')
+            )
+          )
+          .sort();
+        localStorage.setItem(FONT_LIST_KEY, JSON.stringify(list));
+        setFonts(list);
+        setFont(list.includes('Standard') ? 'Standard' : list[0]);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (workerRef.current && font) {
+      workerRef.current.postMessage({ text, font, baseUrl: FONT_BASE_URL });
     }
   }, [text, font]);
 
+  const exportText = () => {
+    const blob = new Blob([output], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${text || 'figlet'}.txt`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="flex flex-col h-full w-full bg-ub-cool-grey text-white font-mono">
-      <div className="p-2 flex gap-2 bg-ub-gedit-dark">
+      <div className="p-2 flex gap-2 bg-ub-gedit-dark items-center">
         <select
           className="bg-gray-700 text-white px-1"
           value={font}
@@ -41,6 +80,12 @@ const FigletApp = () => {
           value={text}
           onChange={(e) => setText(e.target.value)}
         />
+        <button
+          className="bg-gray-700 text-white px-2 py-1 hover:bg-gray-600"
+          onClick={exportText}
+        >
+          Export
+        </button>
       </div>
       <pre className="flex-1 overflow-auto p-2 whitespace-pre">{output}</pre>
     </div>
@@ -49,3 +94,4 @@ const FigletApp = () => {
 
 export default FigletApp;
 export const displayFiglet = () => <FigletApp />;
+

--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -1,12 +1,17 @@
 import figlet from 'figlet';
-import standard from 'figlet/importable-fonts/Standard.js';
-import slant from 'figlet/importable-fonts/Slant.js';
 
-figlet.parseFont('Standard', standard);
-figlet.parseFont('Slant', slant);
+const loadedFonts = {};
 
-self.onmessage = (e) => {
-  const { text, font } = e.data;
+self.onmessage = async (e) => {
+  const { text, font, baseUrl } = e.data;
+  if (font && !loadedFonts[font]) {
+    const module = await import(
+      /* webpackIgnore: true */ `${baseUrl}/${encodeURIComponent(font)}.js?module`
+    );
+    figlet.parseFont(font, module.default);
+    loadedFonts[font] = true;
+  }
   const rendered = figlet.textSync(text || '', { font });
   self.postMessage(rendered);
 };
+


### PR DESCRIPTION
## Summary
- fetch figlet font list on demand and cache in localStorage
- add font selector with live preview and export-as-text button
- lazy-load selected figlet fonts in worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae019d9234832893eddb3c06f3a14f