### PR TITLE
Add offline Nikto report viewer

### DIFF
--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,23 +1,25 @@
 import React, { useState } from 'react';
+import sampleReport from './sample-report.json';
+
+const severityStyles = {
+  high: 'bg-red-400',
+  medium: 'bg-yellow-300',
+  low: 'bg-green-400',
+  info: 'bg-blue-300',
+};
 
 const NiktoApp = () => {
   const [target, setTarget] = useState('');
-  const [result, setResult] = useState('');
+  const [report, setReport] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const runScan = async () => {
+  const loadReport = () => {
     if (!target) return;
     setLoading(true);
-    setResult('');
-    try {
-      const res = await fetch(`/api/nikto?target=${encodeURIComponent(target)}`);
-      const text = await res.text();
-      setResult(text);
-    } catch (err) {
-      setResult(`Error: ${err.message}`);
-    } finally {
+    setTimeout(() => {
+      setReport({ ...sampleReport, target });
       setLoading(false);
-    }
+    }, 500);
   };
 
   return (
@@ -33,17 +35,82 @@ const NiktoApp = () => {
         />
         <button
           type="button"
-          onClick={runScan}
+          onClick={loadReport}
           className="px-4 bg-ubt-blue rounded-r"
         >
-          Scan
+          Load Report
         </button>
       </div>
-      {loading ? (
-        <p>Running scan...</p>
-      ) : (
-        <pre className="whitespace-pre-wrap flex-1 overflow-auto">{result}</pre>
+      {loading && <p>Loading sample report...</p>}
+      {!loading && report && (
+        <div className="flex-1 overflow-auto">
+          <p className="mb-4">Sample report for {report.target}</p>
+          {report.sections.map((section) => (
+            <div key={section.title} className="mb-4">
+              <h2 className="font-bold mb-2">{section.title}</h2>
+              <ul className="list-disc ml-6 space-y-1">
+                {section.items.map((item, idx) => (
+                  <li key={idx} className="flex items-start">
+                    <span
+                      className={`capitalize mr-2 px-2 rounded text-black ${
+                        severityStyles[item.severity] || 'bg-gray-400'
+                      }`}
+                    >
+                      {item.severity}
+                    </span>
+                    <span>{item.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
       )}
+      {!loading && !report && (
+        <p>Enter a target URL to view the sample report.</p>
+      )}
+      <div className="mt-4">
+        <h2 className="text-lg font-bold mb-2">Understanding Response Headers</h2>
+        <p className="mb-2">
+          Response headers can greatly improve the security of your application.
+          Explore the resources below to learn more:
+        </p>
+        <ul className="list-disc ml-6 space-y-1">
+          <li>
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy"
+              target="_blank"
+              rel="noreferrer"
+              className="text-ubt-blue underline"
+            >
+              Content-Security-Policy
+            </a>{' '}
+            - restricts resources the browser is allowed to load.
+          </li>
+          <li>
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options"
+              target="_blank"
+              rel="noreferrer"
+              className="text-ubt-blue underline"
+            >
+              X-Content-Type-Options
+            </a>{' '}
+            - prevents MIME type sniffing.
+          </li>
+          <li>
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options"
+              target="_blank"
+              rel="noreferrer"
+              className="text-ubt-blue underline"
+            >
+              X-Frame-Options
+            </a>{' '}
+            - protects against clickjacking.
+          </li>
+        </ul>
+      </div>
     </div>
   );
 };

--- a/components/apps/nikto/sample-report.json
+++ b/components/apps/nikto/sample-report.json
@@ -1,0 +1,20 @@
+{
+  "target": "http://example.com",
+  "sections": [
+    {
+      "title": "Server Info",
+      "items": [
+        { "severity": "info", "message": "Server: Apache/2.4.41 (Ubuntu)" },
+        { "severity": "info", "message": "Allowed HTTP methods: GET, POST, OPTIONS, HEAD" }
+      ]
+    },
+    {
+      "title": "Potential Vulnerabilities",
+      "items": [
+        { "severity": "low", "message": "Cookie without HttpOnly flag" },
+        { "severity": "medium", "message": "X-Frame-Options header not present" },
+        { "severity": "high", "message": "Outdated OpenSSL version" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- load local sample Nikto report for a user-supplied URL
- show report findings with color-coded severity labels
- add educational links about security response headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae01ad89408328b001f091d01d42e9