### PR TITLE
Add demo autopsy dataset with search features

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -1,57 +1,46 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Autopsy from '../components/apps/autopsy';
 
-describe('Autopsy plugins and timeline', () => {
+describe('Autopsy demo dataset', () => {
   beforeEach(() => {
     (global as any).fetch = jest.fn(() =>
       Promise.resolve({
         json: () =>
-          Promise.resolve([{ id: 'hash', name: 'Hash Analyzer' }]),
+          Promise.resolve({
+            caseName: 'Sample',
+            files: [
+              {
+                path: 'documents/evidence.txt',
+                content: 'This file contains evidence of the breach.',
+                timestamp: '2023-06-01T10:00:00Z',
+                hash: 'abc123',
+              },
+            ],
+          }),
       })
     );
-    class FileReaderMock {
-      onload: ((e: any) => void) | null = null;
-      readAsArrayBuffer() {
-        const buffer = new ArrayBuffer(20);
-        this.onload && this.onload({ target: { result: buffer } });
-      }
-    }
-    // @ts-ignore
-    global.FileReader = FileReaderMock;
   });
 
-  it('loads plugins from marketplace', async () => {
+  it('renders file tree and timeline', async () => {
     render(<Autopsy />);
-    fireEvent.change(screen.getByPlaceholderText('Case name'), {
-      target: { value: 'Demo' },
-    });
-    fireEvent.click(screen.getByText('Create Case'));
-    await screen.findByText('Hash Analyzer');
-    const select = screen.getByRole('combobox');
-    fireEvent.change(select, { target: { value: 'hash' } });
-    await waitFor(() =>
-      expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
-        'hash'
-      )
-    );
+    await screen.findByText('File Tree');
+    await screen.findByText('Timeline');
   });
 
-  it('renders artifact on timeline after file upload', async () => {
+  it('searches by hash and keyword', async () => {
     render(<Autopsy />);
-    fireEvent.change(screen.getByPlaceholderText('Case name'), {
-      target: { value: 'Demo' },
+    await screen.findByText('File Tree');
+    fireEvent.change(screen.getByPlaceholderText('Hash lookup'), {
+      target: { value: 'abc123' },
     });
-    fireEvent.click(screen.getByText('Create Case'));
-    await screen.findByRole('combobox');
-    const file = new File([new Uint8Array(20)], 'test.bin', {
-      type: 'application/octet-stream',
+    fireEvent.click(screen.getByText('Find'));
+    await screen.findByText(/abc123/);
+    fireEvent.change(screen.getByPlaceholderText('Keyword search'), {
+      target: { value: 'breach' },
     });
-    fireEvent.change(screen.getByLabelText('Upload file'), {
-      target: { files: [file] },
-    });
-    await waitFor(() =>
-      expect(screen.getAllByText(/test.bin/).length).toBeGreaterThan(0)
-    );
+    fireEvent.click(screen.getByText('Search'));
+    const hits = await screen.findAllByText('documents/evidence.txt');
+    expect(hits.length).toBeGreaterThan(0);
   });
 });

--- a/public/demo/autopsy/sample-case.json
+++ b/public/demo/autopsy/sample-case.json
@@ -1,0 +1,29 @@
+{
+  "caseName": "Sample Case",
+  "files": [
+    {
+      "path": "documents/evidence.txt",
+      "content": "This file contains evidence of the breach.",
+      "timestamp": "2023-06-01T10:00:00Z",
+      "hash": "b8946362af5510a5d53d21df92766fa050168180e14c9659198465cb866d51c6"
+    },
+    {
+      "path": "documents/notes.txt",
+      "content": "Buy milk and eggs.",
+      "timestamp": "2023-06-02T09:30:00Z",
+      "hash": "547b3793570b58afdd103ebf83d32c5ab4f5564b2257a9f42fa528a2198eb4a4"
+    },
+    {
+      "path": "logs/system.log",
+      "content": "2023-06-01 12:00:00 user login\n2023-06-02 14:00:00 unauthorized access attempt",
+      "timestamp": "2023-06-02T14:00:00Z",
+      "hash": "b9372c569230ddecbec91df5a7d72619f1b782878f61331aa7be512599893225"
+    },
+    {
+      "path": "images/photo.jpg",
+      "content": "[binary]",
+      "timestamp": "2023-06-03T08:15:00Z",
+      "hash": "553dcf932a632f1394530335fbfd8c6a167f819693051947208f6579b40483ab"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Bundle a small sample forensic dataset for Autopsy under `public/demo/autopsy`
- Load demo data in the Autopsy app with file tree, timeline, hash lookup, and keyword search
- Note that the included forensic data is for demonstration purposes only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae01af001c8328b8754082f650a461