### PR TITLE
feat: add ghidra demo fallback

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -2,39 +2,71 @@ import React, { useEffect, useState } from 'react';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
+function Fallback({ message }) {
+  const sampleCode = `int main(void) {\n  puts("Hello from Ghidra!");\n  return 0;\n}`;
+
+  return (
+    <div className="w-full h-full p-4 overflow-auto bg-ub-cool-grey text-white">
+      {message && <p className="text-yellow-300 mb-2">{message}</p>}
+      <div className="mb-4">
+        <input
+          type="file"
+          disabled
+          className="mb-1 opacity-50 cursor-not-allowed"
+        />
+        <p className="text-sm text-red-400">Uploads are disabled in this demo.</p>
+      </div>
+      <h3 className="font-bold mb-1">Sample Project</h3>
+      <ul className="list-disc list-inside mb-2">
+        <li>hello.c</li>
+      </ul>
+      <pre className="bg-black p-2 rounded text-sm overflow-auto whitespace-pre">
+{sampleCode}
+      </pre>
+    </div>
+  );
+}
+
 export default function GhidraApp() {
-  const [useRemote, setUseRemote] = useState(false);
+  const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL;
+  const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
+  const [embedDenied, setEmbedDenied] = useState(false);
+  const [wasmReady, setWasmReady] = useState(false);
 
   useEffect(() => {
-    const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
-    if (typeof WebAssembly === 'undefined') {
-      setUseRemote(true);
-      return;
+    if (!remoteUrl && typeof WebAssembly !== 'undefined') {
+      WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
+        .then(() => {
+          setWasmReady(true);
+          // Placeholder for actual Ghidra WASM initialization
+        })
+        .catch(() => setWasmReady(false));
     }
-    WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
-      .then(() => {
-        // Placeholder for actual Ghidra WASM initialization
-      })
-      .catch(() => {
-        setUseRemote(true);
-      });
-  }, []);
+  }, [remoteUrl, wasmUrl]);
 
-  if (useRemote) {
-    const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
+  if (remoteUrl && !embedDenied) {
     return (
       <iframe
         src={remoteUrl}
         className="w-full h-full bg-ub-cool-grey"
         frameBorder="0"
         title="Ghidra"
+        onError={() => setEmbedDenied(true)}
       />
     );
   }
 
-  return (
-    <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Ghidra WebAssembly...
-    </div>
-  );
+  if (wasmReady) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Ghidra WebAssembly...
+      </div>
+    );
+  }
+
+  const message = embedDenied
+    ? 'Embedding denied by remote host.'
+    : 'No Ghidra configuration available.';
+  return <Fallback message={message} />;
 }
+


### PR DESCRIPTION
## Summary
- switch Ghidra app between remote iframe and WASM based on env vars
- add demo fallback with sample project, disabled uploads, and embed-denied warning

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae01b3d5d483289058653f6a0a25d1