### PR TITLE
Add level selection, editor, and timing to platformer

### DIFF
--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -6,13 +6,20 @@ const Platformer = () => {
   const [progress, setProgress] = usePersistentState('platformer-progress', {
     level: 0,
     checkpoint: null,
+    bestTimes: {},
   });
   const frameRef = useRef(null);
 
   useEffect(() => {
     fetch('/apps/platformer/levels.json')
       .then(r => r.json())
-      .then(d => setLevels(d.levels || []));
+      .then(d => {
+        const list = d.levels || [];
+        try {
+          if (localStorage.getItem('platformer-custom-level')) list.push('custom');
+        } catch {}
+        setLevels(list);
+      });
   }, []);
 
   useEffect(() => {
@@ -21,12 +28,22 @@ const Platformer = () => {
       if (e.data.type === 'checkpoint') {
         setProgress(p => ({ ...p, checkpoint: e.data.checkpoint }));
       } else if (e.data.type === 'levelComplete') {
-        setProgress(p => ({ level: p.level + 1, checkpoint: null }));
+        setProgress(p => {
+          const levelPath = levels[p.level];
+          const bestTimes = { ...p.bestTimes };
+          const time = parseFloat(e.data.time);
+          if (!isNaN(time)) {
+            const prev = bestTimes[levelPath];
+            if (!prev || time < prev) bestTimes[levelPath] = time;
+          }
+          const nextLevel = Math.min(p.level + 1, levels.length - 1);
+          return { level: nextLevel, checkpoint: null, bestTimes };
+        });
       }
     };
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [setProgress]);
+  }, [levels, setProgress]);
 
   const levelPath = levels[progress.level];
   if (!levelPath) return <div className="w-full h-full flex items-center justify-center">All levels complete!</div>;
@@ -36,13 +53,37 @@ const Platformer = () => {
   }`;
 
   return (
-    <iframe
-      ref={frameRef}
-      src={src}
-      title="Platformer"
-      className="w-full h-full"
-      frameBorder="0"
-    ></iframe>
+    <div className="relative w-full h-full">
+      <iframe
+        ref={frameRef}
+        src={src}
+        title="Platformer"
+        className="w-full h-full"
+        frameBorder="0"
+      ></iframe>
+      <div className="absolute top-2 left-2 bg-black bg-opacity-50 text-white p-2 rounded">
+        <select
+          value={progress.level}
+          onChange={e =>
+            setProgress(p => ({ ...p, level: parseInt(e.target.value), checkpoint: null }))
+          }
+        >
+          {levels.map((lvl, i) => (
+            <option key={lvl} value={i}>
+              {lvl === 'custom' ? 'Custom' : `Level ${i + 1}`}
+              {progress.bestTimes[lvl]
+                ? ` (${progress.bestTimes[lvl].toFixed(2)}s)`
+                : ''}
+            </option>
+          ))}
+        </select>
+        {progress.bestTimes[levelPath] && (
+          <div className="text-xs mt-1">
+            Best: {progress.bestTimes[levelPath].toFixed(2)}s
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/public/apps/platformer/index.html
+++ b/public/apps/platformer/index.html
@@ -9,6 +9,17 @@
   <canvas id="game" width="640" height="360"></canvas>
   <div id="timer"></div>
   <div id="complete" class="hidden">Level Complete!</div>
+  <div id="ui">
+    <button id="editToggle">Edit</button>
+    <div id="palette" class="hidden">
+      <button data-tile="1">Block</button>
+      <button data-tile="5">Coin</button>
+      <button data-tile="6">Checkpoint</button>
+      <button data-tile="0">Erase</button>
+      <button data-tile="spawn">Spawn</button>
+      <button id="saveLevel">Save</button>
+    </div>
+  </div>
   <div id="controls">
     <button id="btnLeft">◀</button>
     <button id="btnRight">▶</button>


### PR DESCRIPTION
## Summary
- add persistent level selection menu with best-time tracking
- build basic tile-based level editor that saves custom levels to localStorage
- report completion times and enable loading custom levels

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae01d4bf608328b9a95357fa8d8002