### PR TITLE
Add level pack import and touch controls to Sokoban

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -89,7 +89,7 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
   },
   sokoban: {
     objective: 'Push all boxes onto target squares.',
-    controls: 'Use arrow keys to move and push boxes.',
+    controls: 'Use arrow keys or swipe to move and push boxes.',
   },
   solitaire: {
     objective: 'Move all cards to the foundation piles.',


### PR DESCRIPTION
## Summary
- add persistent undo history and WASD/arrow/swipe controls to Sokoban
- support importing level packs from JSON or text files and reset best move stats
- update help text and instructions for keyboard and touch play

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae01d978d8832897bb80b6dc8d89df