### PR TITLE
feat: add customizable waves and balance tower defense

### DIFF
--- a/components/apps/tower-defense-core.js
+++ b/components/apps/tower-defense-core.js
@@ -6,9 +6,9 @@ export const GOAL = { x: GRID_SIZE - 1, y: 4 };
 // Tower statistics per type and level
 export const TOWER_TYPES = {
   single: [
-    { damage: 1, range: 2, fireRate: 1 },
-    { damage: 2, range: 3, fireRate: 0.8 },
-    { damage: 3, range: 3, fireRate: 0.6 },
+    { damage: 2, range: 3, fireRate: 1 },
+    { damage: 3, range: 3, fireRate: 0.8 },
+    { damage: 5, range: 4, fireRate: 0.6 },
   ],
   splash: [
     { damage: 1, range: 2, fireRate: 1, splash: 1 },
@@ -21,9 +21,9 @@ export const TOWER_TYPES = {
     { damage: 0, range: 4, fireRate: 0.6, slow: { amount: 0.7, duration: 3 } },
   ],
   aoe: [
-    { damage: 0.5, range: 2, fireRate: 1, aoe: true },
-    { damage: 1, range: 3, fireRate: 1, aoe: true },
-    { damage: 1.5, range: 3, fireRate: 0.8, aoe: true },
+    { damage: 0.7, range: 2, fireRate: 1, aoe: true },
+    { damage: 1.2, range: 3, fireRate: 1, aoe: true },
+    { damage: 2, range: 3, fireRate: 0.8, aoe: true },
   ],
 };
 


### PR DESCRIPTION
## Summary
- add interactive wave editor with high score persistence
- balance tower and enemy stats for fairer gameplay
- improve grid controls for keyboard and touch accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae061af17c83288cc3f04cf2a63097