### PR TITLE
feat: add simulated hash cracking demo

### DIFF
--- a/components/apps/john/utils.js
+++ b/components/apps/john/utils.js
@@ -23,3 +23,20 @@ export const identifyHashType = (hash) => {
   if (/^[a-fA-F0-9]{64}$/.test(hash)) return 'SHA256';
   return 'Unknown';
 };
+
+export const getSampleCrack = (type) => {
+  const samples = {
+    MD5: 'password123',
+    SHA1: 'letmein',
+    SHA256: 'qwerty123',
+    Unknown: 'N/A',
+  };
+  return samples[type] || 'N/A';
+};
+
+export const estimateCrackTime = (type, wordlist) => {
+  const base = { MD5: 1, SHA1: 5, SHA256: 10 }[type] || 0;
+  const factors = { 'rockyou.txt': 1, 'top100.txt': 0.1, 'custom.txt': 2 };
+  if (!base) return 'unknown';
+  return `${(base * (factors[wordlist] || 1)).toFixed(1)}s`;
+};


### PR DESCRIPTION
## Summary
- detect hash types client-side as users paste them
- provide sample cracking results with wordlist selection and estimated times
- clarify that the John app performs only a simulation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0626312c83288d39bc096fbf3c2e