### PR TITLE
feat: add persistent settings with accessibility preset

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -188,7 +188,7 @@ export class Window extends Component {
                     <WindowTopBar title={this.props.title} />
                     <WindowEditButtons minimize={this.minimizeWindow} maximize={this.maximizeWindow} isMaximised={this.state.maximized} close={this.closeWindow} id={this.id} allowMaximize={this.props.allowMaximize !== false} />
                     {(this.id === "settings"
-                        ? <Settings changeBackgroundImage={this.props.changeBackgroundImage} currBgImgName={this.props.bg_image_name} />
+                        ? <Settings changeBackgroundImage={this.props.changeBackgroundImage} currBgImgName={this.props.bg_image_name} apps={this.props.apps} />
                         : <WindowMainScreen screen={this.props.screen} title={this.props.title}
                             addFolder={this.props.id === "terminal" ? this.props.addFolder : null}
                             openApp={this.props.openApp} />)}


### PR DESCRIPTION
## Summary
- persist theme, wallpaper, and favorites using `usePersistentState`
- add accessibility preset and reset button in Settings
- sync favorites with desktop sidebar

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0638fb2c83289be0d01d8c283fb0