### PR TITLE
Refactor game window defaults

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { logEvent } from './utils/analytics';
+import { gameDefaultSizes, fallbackGameWindow } from './utils/gameDefaults';
 
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
@@ -174,12 +175,6 @@ const displayHashcat = createDisplay(HashcatApp);
 const displayKismet = createDisplay(KismetApp);
 
 
-// Default window sizing for games to prevent oversized frames
-const gameDefaults = {
-  defaultWidth: 50,
-  defaultHeight: 60,
-};
-
 // Games list used for the "Games" folder on the desktop
 const gameList = [
   {
@@ -190,8 +185,6 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: display2048,
-    defaultWidth: 35,
-    defaultHeight: 45,
   },
   {
     id: 'asteroids',
@@ -462,7 +455,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayCandyCrush,
-
+  },
+  {
     id: 'gomoku',
     title: 'Gomoku',
     icon: './themes/Yaru/apps/gomoku.svg',
@@ -470,7 +464,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayGomoku,
-
+  },
+  {
     id: 'pinball',
     title: 'Pinball',
     icon: './themes/Yaru/apps/pinball.svg',
@@ -481,7 +476,11 @@ const gameList = [
   },
 ];
 
-export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
+export const games = gameList.map((game) => ({
+  ...fallbackGameWindow,
+  ...(gameDefaultSizes[game.id] || {}),
+  ...game,
+}));
 
 const apps = [
   {

--- a/utils/gameDefaults.js
+++ b/utils/gameDefaults.js
@@ -1,0 +1,11 @@
+export const fallbackGameWindow = {
+  defaultWidth: 50,
+  defaultHeight: 60,
+};
+
+export const gameDefaultSizes = {
+  '2048': { defaultWidth: 35, defaultHeight: 45 },
+  wordle: { defaultWidth: 25, defaultHeight: 40 },
+};
+
+export default { fallbackGameWindow, gameDefaultSizes };


### PR DESCRIPTION
## Summary
- centralize game window sizing in `utils/gameDefaults`
- apply default sizes to games in `apps.config.js`
- fix trailing game entries in config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae489f6dfc8328a6e7275f0a3a87d8