### PR TITLE
refactor: centralize dynamic app creation

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1,6 +1,4 @@
-import React from 'react';
-import dynamic from 'next/dynamic';
-import { logEvent } from './utils/analytics';
+import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
 
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
@@ -21,27 +19,6 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 import { displayNikto } from './components/apps/nikto';
-
-const createDynamicApp = (path, name) =>
-  dynamic(
-    () =>
-      import(`./components/apps/${path}`).then((mod) => {
-        logEvent({ category: 'Application', action: `Loaded ${name}` });
-        return mod.default;
-      }),
-    {
-      ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${name}...`}
-        </div>
-      ),
-    }
-  );
-
-const createDisplay = (Component) => (addFolder, openApp) => (
-  <Component addFolder={addFolder} openApp={openApp} />
-);
 
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import dynamic from 'next/dynamic';
+import { logEvent } from './analytics';
+
+export const createDynamicApp = (path, name) =>
+  dynamic(
+    () =>
+      import(`../components/apps/${path}`).then((mod) => {
+        logEvent({ category: 'Application', action: `Loaded ${name}` });
+        return mod.default;
+      }),
+    {
+      ssr: false,
+      loading: () => (
+        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+          {`Loading ${name}...`}
+        </div>
+      ),
+    }
+  );
+
+export const createDisplay = (Component) => (addFolder, openApp) => (
+  <Component addFolder={addFolder} openApp={openApp} />
+);
+


### PR DESCRIPTION
## Summary
- extract `createDynamicApp` and `createDisplay` into `utils/createDynamicApp.js`
- import these helpers in `apps.config.js` and remove inline factories
- register all dynamic apps/games using the new helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae489cf9148328bb6eb2db97d87219