### PR TITLE
test: add unit tests for analytics and pointer utils

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,41 @@
+import ReactGA from 'react-ga4';
+import { logEvent, logGameStart, logGameEnd, logGameError } from '../utils/analytics';
+
+jest.mock('react-ga4', () => ({
+  event: jest.fn(),
+}));
+
+describe('analytics utilities', () => {
+  const mockEvent = ReactGA.event as jest.Mock;
+
+  beforeEach(() => {
+    mockEvent.mockReset();
+  });
+
+  it('logs generic events', () => {
+    const event = { category: 'test', action: 'act' } as any;
+    logEvent(event);
+    expect(mockEvent).toHaveBeenCalledWith(event);
+  });
+
+  it('logs game start', () => {
+    logGameStart('chess');
+    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'start' });
+  });
+
+  it('logs game end with label', () => {
+    logGameEnd('chess', 'win');
+    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'end', label: 'win' });
+  });
+
+  it('logs game error with message', () => {
+    logGameError('chess', 'oops');
+    expect(mockEvent).toHaveBeenCalledWith({ category: 'chess', action: 'error', label: 'oops' });
+  });
+
+  it('handles errors from ReactGA.event without throwing', () => {
+    mockEvent.mockImplementationOnce(() => { throw new Error('fail'); });
+    expect(() => logEvent({ category: 't', action: 'a' } as any)).not.toThrow();
+  });
+});
+

--- a/__tests__/pointer.test.ts
+++ b/__tests__/pointer.test.ts
@@ -1,0 +1,19 @@
+import { pointerHandlers } from '../utils/pointer';
+
+describe('pointerHandlers', () => {
+  it('calls handler on click', () => {
+    const handler = jest.fn();
+    const handlers = pointerHandlers(handler);
+    handlers.onClick();
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('calls handler and prevents default on touchstart', () => {
+    const handler = jest.fn();
+    const preventDefault = jest.fn();
+    const handlers = pointerHandlers(handler);
+    handlers.onTouchStart({ preventDefault } as any);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for analytics logging helpers
- add pointer handler tests for click and touch interactions

## Testing
- `npm test __tests__/analytics.test.ts __tests__/pointer.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ae48a044588328beec2892318b0e73