### PR TITLE
feat: add Spotify playlist component with mini-player

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -3,7 +3,6 @@ import dynamic from 'next/dynamic';
 import { logEvent } from './utils/analytics';
 
 import { displayX } from './components/apps/x';
-import { displaySpotify } from './components/apps/spotify';
 import { displayVsCode } from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/chrome';
@@ -78,6 +77,7 @@ const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
+const SpotifyApp = createDynamicApp('spotify', 'Spotify');
 
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
@@ -144,6 +144,7 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayRadare2 = createDisplay(Radare2App);
+const displaySpotify = createDisplay(SpotifyApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 

--- a/components/apps/spotify-playlist.json
+++ b/components/apps/spotify-playlist.json
@@ -1,0 +1,5 @@
+[
+  "4uLU6hMCjMI75M1A2tKUQC",
+  "1301WleyT98MSxVHPZCA6M",
+  "3AJwUDP919kvQ9QcozQPxg"
+]

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,20 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import tracks from './spotify-playlist.json';
 
 export default function SpotifyApp() {
+  const [mini, setMini] = useState(false);
+
   return (
-    <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
-        src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
-        title="Daily Mix 2"
-        width="100%"
-        height="100%"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      />
+    <div className="h-full w-full bg-ub-cool-grey text-white flex flex-col">
+      <div className="p-2 flex justify-end">
+        <button
+          className="px-2 py-1 bg-ub-grey text-xs rounded"
+          onClick={() => setMini((m) => !m)}
+        >
+          {mini ? 'Full Player' : 'Mini Player'}
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto space-y-2 p-2">
+        {tracks.map((id) => (
+          <iframe
+            key={id}
+            src={`https://open.spotify.com/embed/track/${id}?utm_source=generator&theme=0`}
+            width="100%"
+            height={mini ? '80' : '152'}
+            frameBorder="0"
+            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            loading="lazy"
+          />
+        ))}
+      </div>
     </div>
   );
 }
-
-export const displaySpotify = () => <SpotifyApp />;
-


### PR DESCRIPTION
## Summary
- load tracks from editable JSON and render Spotify embed
- add mini-player toggle for compact iframe
- register Spotify app using dynamic factory

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae48a62f908328a6c7c7cec953c4a1