### PR TITLE
feat: add YouTube search with recent tracking

### DIFF
--- a/__tests__/youtubeSearch.test.tsx
+++ b/__tests__/youtubeSearch.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import YouTubeSearch from '../components/YouTubeSearch';
+
+const mockData = [
+  { id: '1', title: 'Cat Video' },
+  { id: '2', title: 'Dog Video' },
+];
+
+describe('YouTubeSearch', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('searches mock data and stores recently watched', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeSearch mockData={mockData} />);
+
+    await user.type(screen.getByPlaceholderText(/search youtube/i), 'Cat');
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(screen.getByText('Cat Video')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/play video/i));
+
+    const stored = JSON.parse(window.localStorage.getItem('recentlyWatched')!);
+    expect(stored[0].id).toBe('1');
+
+    const recent = screen.getByTestId('recent-list');
+    expect(within(recent).getByText('Cat Video')).toBeInTheDocument();
+  });
+});
+

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,13 +1,14 @@
 import React, { useRef, useState } from 'react';
 import Head from 'next/head';
 
-export default function YouTubePlayer({ videoId }) {
+export default function YouTubePlayer({ videoId, onPlay }) {
   const [activated, setActivated] = useState(false);
   const playerRef = useRef(null);
 
   const loadPlayer = () => {
     if (activated) return;
     setActivated(true);
+    if (onPlay) onPlay(videoId);
 
     const createPlayer = () => {
       if (!playerRef.current) return;

--- a/components/YouTubeSearch.tsx
+++ b/components/YouTubeSearch.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import YouTubePlayer from './YouTubePlayer';
+
+interface Video {
+  id: string;
+  title: string;
+}
+
+const DEFAULT_MOCK: Video[] = [
+  { id: 'dQw4w9WgXcQ', title: 'Never Gonna Give You Up' },
+  { id: 'M7lc1UVf-VE', title: 'YouTube API Demo' },
+];
+
+export default function YouTubeSearch({ mockData = DEFAULT_MOCK }: { mockData?: Video[] }) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Video[]>([]);
+  const [recent, setRecent] = useState<Video[]>([]);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('recentlyWatched') || '[]');
+      if (Array.isArray(stored)) setRecent(stored);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+
+    const apiKey = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY;
+    if (apiKey) {
+      try {
+        const res = await fetch(
+          `https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&maxResults=5&q=${encodeURIComponent(
+            query
+          )}&key=${apiKey}`
+        );
+        const data = await res.json();
+        const items: Video[] =
+          data.items?.map((i: any) => ({
+            id: i.id.videoId,
+            title: i.snippet.title,
+          })) || [];
+        setResults(items);
+      } catch {
+        setResults([]);
+      }
+    } else {
+      const filtered = mockData.filter((v) =>
+        v.title.toLowerCase().includes(query.toLowerCase())
+      );
+      setResults(filtered);
+    }
+  };
+
+  const addRecent = (video: Video) => {
+    const updated = [video, ...recent.filter((v) => v.id !== video.id)].slice(0, 5);
+    setRecent(updated);
+    localStorage.setItem('recentlyWatched', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-4">
+      <form onSubmit={handleSearch} className="flex gap-2 mb-4">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search YouTube"
+          className="flex-1 px-2 py-1 text-black rounded"
+        />
+        <button type="submit" className="px-3 py-1 bg-blue-600 text-white rounded">
+          Search
+        </button>
+      </form>
+
+      {results.length > 0 && (
+        <div className="space-y-6">
+          {results.map((v) => (
+            <div key={v.id}>
+              <p className="mb-2 font-semibold">{v.title}</p>
+              <YouTubePlayer videoId={v.id} onPlay={() => addRecent(v)} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {recent.length > 0 && (
+        <div className="mt-6">
+          <h2 className="font-semibold mb-2">Recently watched</h2>
+          <ul data-testid="recent-list" className="list-disc pl-5">
+            {recent.map((v) => (
+              <li key={v.id}>{v.title}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extend YouTubePlayer with `onPlay` callback
- add YouTubeSearch component with API/mock search, click-to-load videos, and recent list stored in localStorage
- cover search and recent tracking with component test

## Testing
- `yarn test youtubeSearch.test.tsx`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae48a93eb4832896ba656aa042f8aa