### PR TITLE
feat: add centralized settings store and reset option

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../../hooks/useTheme';
+import { setWallpaper, resetSettings } from '../../utils/settingsStore';
 
 export function Settings(props) {
     const { theme, setTheme } = useTheme();
@@ -16,7 +17,9 @@ export function Settings(props) {
     };
 
     let changeBackgroundImage = (e) => {
-        props.changeBackgroundImage(e.target.dataset.path);
+        const name = e.target.dataset.path;
+        setWallpaper(name);
+        props.changeBackgroundImage(name);
     }
 
     return (
@@ -51,6 +54,14 @@ export function Settings(props) {
                         );
                     })
                 }
+            </div>
+            <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
+                <button
+                    onClick={() => { resetSettings(); window.location.reload(); }}
+                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                >
+                    Reset Desktop
+                </button>
             </div>
         </div>
     )

--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -4,6 +4,7 @@ import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
+import { getWallpaper, setWallpaper } from '../utils/settingsStore';
 
 interface UbuntuProps {}
 
@@ -40,10 +41,8 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
   };
 
   getLocalData = (): void => {
-    const bg_image_name = localStorage.getItem('bg-image');
-    if (bg_image_name !== null && bg_image_name !== undefined) {
-      this.setState({ bg_image_name });
-    }
+    const bg_image_name = getWallpaper();
+    this.setState({ bg_image_name });
 
     const booting_screen = localStorage.getItem('booting_screen');
     if (booting_screen !== null && booting_screen !== undefined) {
@@ -89,7 +88,7 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
 
   changeBackgroundImage = (img_name: string): void => {
     this.setState({ bg_image_name: img_name });
-    localStorage.setItem('bg-image', img_name);
+    setWallpaper(img_name);
   };
 
   shutDown = (): void => {

--- a/hooks/useTheme.tsx
+++ b/hooks/useTheme.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useEffect, ReactNode } from 'react';
-import usePersistentState from './usePersistentState';
+import { createContext, useContext, useEffect, ReactNode, useState } from 'react';
+import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/settingsStore';
 
 type Theme = 'light' | 'dark';
 
@@ -14,17 +14,18 @@ const ThemeContext = createContext<ThemeContextValue>({
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = usePersistentState<Theme>('theme', () => {
+  const [theme, setTheme] = useState<Theme>(() => {
     if (typeof document !== 'undefined' && document.documentElement.dataset.theme) {
       return document.documentElement.dataset.theme as Theme;
     }
-    return 'dark';
+    return loadTheme() as Theme;
   });
 
   useEffect(() => {
     if (typeof document !== 'undefined') {
       document.documentElement.dataset.theme = theme;
     }
+    saveTheme(theme);
   }, [theme]);
 
   return (

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,0 +1,31 @@
+const DEFAULT_SETTINGS = {
+  theme: 'dark',
+  wallpaper: 'wall-2',
+};
+
+export function getTheme() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.theme;
+  return window.localStorage.getItem('theme') || DEFAULT_SETTINGS.theme;
+}
+
+export function setTheme(theme) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('theme', theme);
+}
+
+export function getWallpaper() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  return window.localStorage.getItem('bg-image') || DEFAULT_SETTINGS.wallpaper;
+}
+
+export function setWallpaper(wallpaper) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('bg-image', wallpaper);
+}
+
+export function resetSettings() {
+  if (typeof window === 'undefined') return;
+  window.localStorage.clear();
+}
+
+export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- centralize theme and wallpaper persistence in a new `settingsStore`
- expose reset button in Settings to clear local preferences
- wire theme and wallpaper to use the shared store

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae48ae9e988328b921246e615e5c6f