### PR TITLE
Add dummy-contact form with validation

### DIFF
--- a/pages/api/dummy.ts
+++ b/pages/api/dummy.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    res.status(200).json({ message: 'Received' });
+  } else {
+    res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+
+const DummyForm: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!name || !email || !message) {
+      setError('All fields are required');
+      return;
+    }
+    if (!emailRegex.test(email)) {
+      setError('Please enter a valid email');
+      return;
+    }
+    setError('');
+    setSuccess(false);
+    await fetch('/api/dummy', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name, email, message }),
+    });
+    setSuccess(true);
+    setName('');
+    setEmail('');
+    setMessage('');
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+      <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
+        <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
+        {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+        {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
+        <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>
+        <input
+          id="name"
+          className="mb-4 w-full rounded border p-2"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <label className="mb-2 block text-sm font-medium" htmlFor="email">Email</label>
+        <input
+          id="email"
+          className="mb-4 w-full rounded border p-2"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <label className="mb-2 block text-sm font-medium" htmlFor="message">Message</label>
+        <textarea
+          id="message"
+          className="mb-4 w-full rounded border p-2"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">Submit</button>
+        <p className="mt-4 text-xs text-gray-500">
+          This form posts to a dummy endpoint. No data is stored. By submitting, you consent to this temporary processing of your information.
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default DummyForm;


### PR DESCRIPTION
## Summary
- add sample `/dummy-form` page with client-side validation and privacy notice
- add `/api/dummy` endpoint to accept form submissions

## Testing
- `yarn test --runInBand`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae48b5aa5c832892e9c9c7385a85f6