### PR TITLE
Add virtual trash management with restore and empty actions

### DIFF
--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -1,68 +1,57 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import {
+    getDeletedFiles,
+    markDeleted,
+    restoreFile,
+    emptyTrash as vfsEmptyTrash,
+} from '../../utils/virtualFs';
 
 export class Trash extends Component {
     constructor() {
         super();
-        this.trashItems = [
-            {
-                name: "php",
-                icon: "/themes/filetypes/php.png"
-            },
-            {
-                name: "Angular.js",
-                icon: "/themes/filetypes/js.png"
-            },
-            {
-                name: "node_modules",
-                icon: "/themes/Yaru/system/folder.png"
-            },
-
-            {
-                name: "abandoned project",
-                icon: "/themes/Yaru/system/folder.png"
-            },
-            {
-                name: "INFR 4900U blockchain assignment AlexUnnippillil.zip",
-                icon: "/themes/filetypes/zip.png"
-            },
-            {
-                name: "cryptography project final",
-                icon: "/themes/Yaru/system/folder.png"
-            },
-            {
-                name: "project machine learning-final",
-                icon: "/themes/Yaru/system/folder.png"
-            },
-
-        ];
         this.state = {
             empty: false,
+            trashItems: [],
+            selectedIndex: null,
             fileHandle: null,
             filePreview: null,
             confirmDelete: false,
-        }
+        };
     }
 
     componentDidMount() {
-        // get user preference from local-storage
-        let wasEmpty = localStorage.getItem("trash-empty");
-        if (wasEmpty !== null && wasEmpty !== undefined) {
-            if (wasEmpty === "true") this.setState({ empty: true });
+        const items = getDeletedFiles();
+        this.setState({ trashItems: items, empty: items.length === 0 });
+    }
+
+    focusFile = (e, index) => {
+        const children = e.currentTarget.children;
+        if (children[0]) children[0].classList.toggle("opacity-60");
+        if (children[1]) children[1].classList.toggle("bg-ub-orange");
+        if (typeof index === 'number') {
+            this.setState({ selectedIndex: index });
+        } else {
+            this.setState({ selectedIndex: null });
         }
     }
 
-    focusFile = (e) => {
-        // icon
-        const children = e.currentTarget.children;
-        if (children[0]) children[0].classList.toggle("opacity-60");
-        // file name
-        if (children[1]) children[1].classList.toggle("bg-ub-orange");
-    }
-
     emptyTrash = () => {
-        this.setState({ empty: true });
-        localStorage.setItem("trash-empty", true);
+        vfsEmptyTrash();
+        this.setState({ trashItems: [], empty: true, selectedIndex: null });
+    };
+
+    restoreSelected = () => {
+        const { selectedIndex, trashItems } = this.state;
+        if (selectedIndex === null) return;
+        const item = trashItems[selectedIndex];
+        restoreFile(item.originalPath);
+        const items = getDeletedFiles();
+        this.setState({
+            trashItems: items,
+            empty: items.length === 0,
+            selectedIndex: null,
+        });
     };
 
     emptyScreen = () => {
@@ -82,26 +71,31 @@ export class Trash extends Component {
     }
 
     showTrashItems = () => {
+        const { trashItems } = this.state;
         return (
             <div className="flex-grow ml-4 flex flex-wrap items-start content-start justify-start overflow-y-auto windowMainScreen">
-                {
-                    this.trashItems.map((item, index) => {
-                        return (
-                            <div key={index} tabIndex="1" onFocus={this.focusFile} onBlur={this.focusFile} className="flex flex-col items-center text-sm outline-none w-16 my-2 mx-4">
-                                <div className="w-16 h-16 flex items-center justify-center">
-                                    <Image
-                                        src={item.icon}
-                                        alt="Ubuntu File Icons"
-                                        width={48}
-                                        height={48}
-                                        sizes="48px"
-                                    />
-                                </div>
-                                <span className="text-center rounded px-0.5">{item.name}</span>
+                {trashItems.map((item, index) => {
+                    return (
+                        <div
+                            key={index}
+                            tabIndex="1"
+                            onFocus={(e) => this.focusFile(e, index)}
+                            onBlur={this.focusFile}
+                            className="flex flex-col items-center text-sm outline-none w-16 my-2 mx-4"
+                        >
+                            <div className="w-16 h-16 flex items-center justify-center">
+                                <Image
+                                    src={item.icon}
+                                    alt="Ubuntu File Icons"
+                                    width={48}
+                                    height={48}
+                                    sizes="48px"
+                                />
                             </div>
-                        )
-                    })
-                }
+                            <span className="text-center rounded px-0.5">{item.name}</span>
+                        </div>
+                    );
+                })}
             </div>
         );
     }
@@ -139,8 +133,20 @@ export class Trash extends Component {
         } catch (err) {
             console.error(err);
         }
+        markDeleted({
+            name: fileHandle.name,
+            icon: '/themes/Yaru/system/folder.png',
+            originalPath: fileHandle.name,
+        });
+        const items = getDeletedFiles();
         if (filePreview?.url) URL.revokeObjectURL(filePreview.url);
-        this.setState({ fileHandle: null, filePreview: null, confirmDelete: false });
+        this.setState({
+            fileHandle: null,
+            filePreview: null,
+            confirmDelete: false,
+            trashItems: items,
+            empty: items.length === 0,
+        });
     }
 
     cancelDelete = () => {
@@ -155,7 +161,7 @@ export class Trash extends Component {
                 <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
                     <span className="font-bold ml-2">Trash</span>
                     <div className="flex">
-                        <div className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded text-gray-300">Restore</div>
+                        <div onClick={this.restoreSelected} className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80">Restore</div>
                         <div onClick={this.emptyTrash} className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80">Empty</div>
                         <div onClick={this.selectFile} className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80">Delete File</div>
                     </div>

--- a/utils/virtualFs.ts
+++ b/utils/virtualFs.ts
@@ -1,0 +1,43 @@
+export interface VFSItem {
+    name: string;
+    icon: string;
+    originalPath: string;
+    deleted: boolean;
+}
+
+const STORAGE_KEY = 'virtual-fs';
+
+function load(): VFSItem[] {
+    if (typeof window === 'undefined') return [];
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch (e) {
+        console.error(e);
+        return [];
+    }
+}
+
+function save(items: VFSItem[]) {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+export function markDeleted(item: { name: string; icon: string; originalPath: string }) {
+    const items = load();
+    items.push({ ...item, deleted: true });
+    save(items);
+}
+
+export function getDeletedFiles(): VFSItem[] {
+    return load().filter((i) => i.deleted);
+}
+
+export function restoreFile(originalPath: string) {
+    const items = load().filter((i) => !(i.deleted && i.originalPath === originalPath));
+    save(items);
+}
+
+export function emptyTrash() {
+    save([]);
+}


### PR DESCRIPTION
## Summary
- add a simple virtual file system to track deleted items with original paths
- enable restoring individual items and emptying the trash

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae48b4e670832891f863587f7dbd8a