### PR TITLE
refactor: centralize unit definitions

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -14,4 +14,8 @@ describe('Unit conversion', () => {
       convertUnit('length', 'meter', 'kilometer', 1234, 2)
     ).toBeCloseTo(1.23, 2);
   });
+
+  it('converts Celsius to Fahrenheit', () => {
+    expect(convertUnit('temperature', 'celsius', 'fahrenheit', 0)).toBeCloseTo(32);
+  });
 });

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -1,22 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { create, all } from 'mathjs';
+import { unitMap } from './units';
 
 const math = create(all);
-
-const unitMap = {
-  length: {
-    meter: 'm',
-    kilometer: 'km',
-    mile: 'mi',
-    foot: 'ft',
-  },
-  weight: {
-    gram: 'g',
-    kilogram: 'kg',
-    pound: 'lb',
-    ounce: 'oz',
-  },
-};
 
 export const convertUnit = (category, from, to, amount, precision) => {
   const fromUnit = unitMap[category][from];
@@ -26,9 +12,10 @@ export const convertUnit = (category, from, to, amount, precision) => {
 };
 
 const UnitConverter = () => {
-  const [category, setCategory] = useState('length');
-  const [fromUnit, setFromUnit] = useState('meter');
-  const [toUnit, setToUnit] = useState('kilometer');
+  const categories = Object.keys(unitMap);
+  const [category, setCategory] = useState(categories[0]);
+  const [fromUnit, setFromUnit] = useState('');
+  const [toUnit, setToUnit] = useState('');
   const [value, setValue] = useState('');
   const [result, setResult] = useState('');
   const [precision, setPrecision] = useState(4);
@@ -68,8 +55,11 @@ const UnitConverter = () => {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
         >
-          <option value="length">Length</option>
-          <option value="weight">Weight</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c.charAt(0).toUpperCase() + c.slice(1)}
+            </option>
+          ))}
         </select>
       </label>
       <label className="flex flex-col">
@@ -129,4 +119,3 @@ const UnitConverter = () => {
 };
 
 export default UnitConverter;
-

--- a/components/apps/converter/units.js
+++ b/components/apps/converter/units.js
@@ -1,0 +1,21 @@
+export const unitMap = {
+  length: {
+    meter: 'm',
+    kilometer: 'km',
+    mile: 'mi',
+    foot: 'ft',
+  },
+  weight: {
+    gram: 'g',
+    kilogram: 'kg',
+    pound: 'lb',
+    ounce: 'oz',
+  },
+  temperature: {
+    celsius: 'degC',
+    fahrenheit: 'degF',
+    kelvin: 'K',
+  },
+};
+
+export default unitMap;


### PR DESCRIPTION
## Summary
- centralize unit mappings for converter
- use shared unit map within `UnitConverter`
- add temperature conversion test

## Testing
- `npm test`
- `npm test __tests__/converter.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae48b70998832897580924a6a6f0ed