### PR TITLE
feat: add configurable weather widget

### DIFF
--- a/apps/weather_widget/cities.json
+++ b/apps/weather_widget/cities.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "London",
+    "tempC": 15,
+    "condition": "cloudy",
+    "icon": "04d"
+  },
+  {
+    "name": "New York",
+    "tempC": 22,
+    "condition": "clear sky",
+    "icon": "01d"
+  },
+  {
+    "name": "Tokyo",
+    "tempC": 18,
+    "condition": "light rain",
+    "icon": "10d"
+  },
+  {
+    "name": "Sydney",
+    "tempC": 25,
+    "condition": "sunny",
+    "icon": "01d"
+  },
+  {
+    "name": "Paris",
+    "tempC": 19,
+    "condition": "few clouds",
+    "icon": "02d"
+  }
+]

--- a/apps/weather_widget/index.html
+++ b/apps/weather_widget/index.html
@@ -7,6 +7,15 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div class="controls">
+    <select id="city-picker"></select>
+    <select id="unit-toggle">
+      <option value="metric">°C</option>
+      <option value="imperial">°F</option>
+    </select>
+    <input type="text" id="api-key-input" placeholder="API Key (optional)" />
+    <button id="save-api-key">Save</button>
+  </div>
   <div id="weather" class="weather">
     <div class="temp">--°C</div>
     <img class="icon" src="" alt="Weather icon" />

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -1,36 +1,49 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const apiKey = 'YOUR_API_KEY'; // Replace with your OpenWeather API key
-  const city = 'London';
   const widget = document.getElementById('weather');
   const tempEl = widget.querySelector('.temp');
   const iconEl = widget.querySelector('.icon');
   const forecastEl = widget.querySelector('.forecast');
+  const cityPicker = document.getElementById('city-picker');
+  const unitToggle = document.getElementById('unit-toggle');
+  const apiKeyInput = document.getElementById('api-key-input');
+  const saveApiKeyBtn = document.getElementById('save-api-key');
 
-  async function fetchWeather() {
+  let apiKey = localStorage.getItem('weatherApiKey') || '';
+  if (apiKey) apiKeyInput.value = apiKey;
+
+  let cities = [];
+  let unit = unitToggle.value;
+
+  async function loadCities() {
     try {
-      const response = await fetch(
-        `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
-      );
-      if (!response.ok) throw new Error('Failed to fetch weather');
-      const data = await response.json();
-      updateWeather(data);
+      const res = await fetch('cities.json');
+      cities = await res.json();
+      cityPicker.innerHTML = cities
+        .map((c) => `<option value="${c.name}">${c.name}</option>`)
+        .join('');
     } catch (err) {
-      console.error(err);
+      console.error('Failed to load city list', err);
     }
   }
 
-  function updateWeather(data) {
+  function convertTemp(celsius) {
+    return unit === 'metric' ? celsius : celsius * 9 / 5 + 32;
+  }
+
+  function renderWeather(data) {
     widget.classList.remove('fade-in');
     widget.classList.add('fade-out');
     widget.addEventListener(
       'animationend',
       function handler() {
         widget.classList.remove('fade-out');
-        tempEl.textContent = `${Math.round(data.main.temp)}°C`;
-        const icon = data.weather[0].icon;
-        iconEl.src = `https://openweathermap.org/img/wn/${icon}@2x.png`;
-        iconEl.alt = data.weather[0].description;
-        forecastEl.textContent = data.weather[0].description;
+        const temp = convertTemp(data.tempC);
+        tempEl.textContent = `${Math.round(temp)}°${unit === 'metric' ? 'C' : 'F'}`;
+        if (data.icon) {
+          iconEl.src = `https://openweathermap.org/img/wn/${data.icon}@2x.png`;
+          iconEl.alt = data.condition;
+        }
+        forecastEl.textContent = data.condition;
         widget.classList.add('fade-in');
         widget.removeEventListener('animationend', handler);
       },
@@ -38,7 +51,59 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   }
 
-  fetchWeather();
-  // Refresh weather every 10 minutes
-  setInterval(fetchWeather, 10 * 60 * 1000);
+  async function fetchLiveWeather(city) {
+    const response = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
+    );
+    if (!response.ok) throw new Error('Failed to fetch weather');
+    const data = await response.json();
+    return {
+      tempC: data.main.temp,
+      condition: data.weather[0].description,
+      icon: data.weather[0].icon,
+    };
+  }
+
+  async function updateWeather() {
+    const city = cityPicker.value;
+    try {
+      let data;
+      if (apiKey) {
+        data = await fetchLiveWeather(city);
+      } else {
+        data = cities.find((c) => c.name === city);
+      }
+      if (data) {
+        renderWeather(data);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  cityPicker.addEventListener('change', updateWeather);
+
+  unitToggle.addEventListener('change', () => {
+    unit = unitToggle.value;
+    updateWeather();
+  });
+
+  saveApiKeyBtn.addEventListener('click', () => {
+    apiKey = apiKeyInput.value.trim();
+    if (apiKey) {
+      localStorage.setItem('weatherApiKey', apiKey);
+    } else {
+      localStorage.removeItem('weatherApiKey');
+    }
+    updateWeather();
+  });
+
+  loadCities().then(() => {
+    if (cities.length) {
+      cityPicker.value = cities[0].name;
+      updateWeather();
+    }
+  });
+
+  setInterval(updateWeather, 10 * 60 * 1000);
 });

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -8,6 +8,15 @@ body {
   margin: 0;
 }
 
+.controls {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 10px;
+}
+
 .weather {
   background: white;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- add sample city dataset with conditions
- support choosing cities, units, and API key in weather widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae4909f380832888ed454b7a0d33ca