### PR TITLE
feat: revamp frogger with canvas, pause, sound, and highscore

### DIFF
--- a/__tests__/frogger.config.test.ts
+++ b/__tests__/frogger.config.test.ts
@@ -1,0 +1,13 @@
+jest.mock('next/dynamic', () => jest.fn(() => () => null));
+
+import { games } from '../apps.config';
+
+describe('frogger config', () => {
+  test('frogger game is registered with defaults', () => {
+    const frogger = games.find((g) => g.id === 'frogger');
+    expect(frogger).toBeDefined();
+    expect(frogger?.defaultWidth).toBe(50);
+    expect(frogger?.defaultHeight).toBe(60);
+    expect(typeof frogger?.screen).toBe('function');
+  });
+});

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 const WIDTH = 7;
 const HEIGHT = 8;
 const SUB_STEP = 0.5;
+const CELL = 32;
 
 const PAD_POSITIONS = [1, 3, 5];
 const DIFFICULTY_MULTIPLIERS = {
@@ -133,6 +134,13 @@ const Frogger = () => {
   const [lives, setLives] = useState(3);
   const [level, setLevel] = useState(1);
   const [difficulty, setDifficulty] = useState('normal');
+  const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(paused);
+  const [sound, setSound] = useState(true);
+  const soundRef = useRef(sound);
+  const [highScore, setHighScore] = useState(0);
+  const canvasRef = useRef(null);
+  const audioCtxRef = useRef(null);
   const nextLife = useRef(500);
   const holdRef = useRef();
 
@@ -140,14 +148,48 @@ const Frogger = () => {
   useEffect(() => { carsRef.current = cars; }, [cars]);
   useEffect(() => { logsRef.current = logs; }, [logs]);
   useEffect(() => { padsRef.current = pads; }, [pads]);
+  useEffect(() => { pausedRef.current = paused; }, [paused]);
+  useEffect(() => { soundRef.current = sound; }, [sound]);
+
+  useEffect(() => {
+    const saved = Number(localStorage.getItem('frogger-highscore') || 0);
+    setHighScore(saved);
+  }, []);
+  useEffect(() => {
+    if (score > highScore) {
+      setHighScore(score);
+      try {
+        localStorage.setItem('frogger-highscore', String(score));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [score, highScore]);
+
+  const playTone = (freq, duration = 0.1) => {
+    if (!soundRef.current) return;
+    if (!audioCtxRef.current)
+      audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
+    const ctx = audioCtxRef.current;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0.1, ctx.currentTime);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + duration);
+  };
 
   const moveFrog = (dx, dy) => {
+    if (pausedRef.current) return;
     setFrog((prev) => {
       const x = prev.x + dx;
       const y = prev.y + dy;
       if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT) return prev;
       if (navigator.vibrate) navigator.vibrate(50);
       if (dy === -1) setScore((s) => s + 10);
+      playTone(440, 0.05);
       return { x, y };
     });
   };
@@ -164,9 +206,11 @@ const Frogger = () => {
   useEffect(() => {
     const handleKey = (e) => {
       if (e.key === 'ArrowLeft') moveFrog(-1, 0);
-      if (e.key === 'ArrowRight') moveFrog(1, 0);
-      if (e.key === 'ArrowUp') moveFrog(0, -1);
-      if (e.key === 'ArrowDown') moveFrog(0, 1);
+      else if (e.key === 'ArrowRight') moveFrog(1, 0);
+      else if (e.key === 'ArrowUp') moveFrog(0, -1);
+      else if (e.key === 'ArrowDown') moveFrog(0, 1);
+      else if (e.key === 'p' || e.key === 'P') setPaused((p) => !p);
+      else if (e.key === 'm' || e.key === 'M') setSound((s) => !s);
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
@@ -203,107 +247,153 @@ const Frogger = () => {
     ReactGA.event({ category: 'Frogger', action: 'level_start', value: 1 });
   }, []);
 
-    const reset = useCallback(
-      (full = false, diff = difficulty, lvl = level) => {
-        setFrog(initialFrog);
-        const mult = DIFFICULTY_MULTIPLIERS[diff];
-        setCars(
-          carLaneDefs.map((l, i) =>
-            initLane(rampLane(l, lvl, 0.3, mult), i + 1)
-          )
-        );
-        setLogs(
-          logLaneDefs.map((l, i) =>
-            initLane(rampLane(l, lvl, 0.5, mult), i + 101)
-          )
-        );
-        setStatus('');
-        if (full) {
-          setScore(0);
-          setLives(3);
-          setPads(PAD_POSITIONS.map(() => false));
-          setLevel(1);
-          nextLife.current = 500;
-          ReactGA.event({
-            category: 'Frogger',
-            action: 'level_start',
-            value: 1,
-          });
-        }
-      },
-      [difficulty, level]
-    );
+  const reset = useCallback(
+    (full = false, diff = difficulty, lvl = level) => {
+      setFrog(initialFrog);
+      const mult = DIFFICULTY_MULTIPLIERS[diff];
+      setCars(
+        carLaneDefs.map((l, i) => initLane(rampLane(l, lvl, 0.3, mult), i + 1))
+      );
+      setLogs(
+        logLaneDefs.map((l, i) => initLane(rampLane(l, lvl, 0.5, mult), i + 101))
+      );
+      setStatus('');
+      setPaused(false);
+      if (full) {
+        setScore(0);
+        setLives(3);
+        setPads(PAD_POSITIONS.map(() => false));
+        setLevel(1);
+        nextLife.current = 500;
+        ReactGA.event({
+          category: 'Frogger',
+          action: 'level_start',
+          value: 1,
+        });
+      }
+    },
+    [difficulty, level]
+  );
 
-    const loseLife = useCallback(() => {
-      ReactGA.event({ category: 'Frogger', action: 'death', value: level });
-      setLives((l) => {
-        const newLives = l - 1;
-        if (newLives <= 0) {
-          setStatus('Game Over');
-          setTimeout(() => reset(true), 1000);
-          return 0;
-        }
-        reset();
-        return newLives;
-      });
-    }, [level, reset]);
+  const loseLife = useCallback(() => {
+    ReactGA.event({ category: 'Frogger', action: 'death', value: level });
+    playTone(220, 0.2);
+    setLives((l) => {
+      const newLives = l - 1;
+      if (newLives <= 0) {
+        setStatus('Game Over');
+        setTimeout(() => reset(true), 1000);
+        return 0;
+      }
+      reset();
+      return newLives;
+    });
+  }, [level, reset]);
 
-
-    useEffect(() => {
-      let last = performance.now();
+  useEffect(() => {
+    let last = performance.now();
     let raf;
+    const draw = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (let y = 0; y < HEIGHT; y += 1) {
+        for (let x = 0; x < WIDTH; x += 1) {
+          if (y === 0) {
+            const idx = PAD_POSITIONS.indexOf(x);
+            if (idx >= 0) ctx.fillStyle = padsRef.current[idx] ? '#22c55e' : '#15803d';
+            else ctx.fillStyle = '#1e3a8a';
+          } else if (y === 3 || y === 6) ctx.fillStyle = '#15803d';
+          else if (y >= 4 && y <= 5) ctx.fillStyle = '#374151';
+          else ctx.fillStyle = '#1e3a8a';
+          ctx.fillRect(x * CELL, y * CELL, CELL, CELL);
+        }
+      }
+      logsRef.current.forEach((lane) => {
+        ctx.fillStyle = '#d97706';
+        lane.entities.forEach((e) => {
+          ctx.fillRect(e.x * CELL, lane.y * CELL, lane.length * CELL, CELL);
+        });
+      });
+      carsRef.current.forEach((lane) => {
+        ctx.fillStyle = '#ef4444';
+        lane.entities.forEach((e) => {
+          ctx.fillRect(e.x * CELL, lane.y * CELL, lane.length * CELL, CELL);
+        });
+      });
+      ctx.fillStyle = '#22c55e';
+      ctx.fillRect(frogRef.current.x * CELL, frogRef.current.y * CELL, CELL, CELL);
+      if (pausedRef.current) {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#fff';
+        ctx.font = '20px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('Paused', canvas.width / 2, canvas.height / 2);
+      }
+    };
     const loop = (time) => {
       const dt = (time - last) / 1000;
       last = time;
-
-      const carResult = updateCars(carsRef.current, frogRef.current, dt);
-      carsRef.current = carResult.lanes;
-      const logResult = updateLogs(logsRef.current, frogRef.current, dt);
-      logsRef.current = logResult.lanes;
-      frogRef.current = logResult.frog;
-      if (
-        carResult.dead ||
-        logResult.dead ||
-        frogRef.current.x < 0 ||
-        frogRef.current.x >= WIDTH
-      ) {
-        loseLife();
-        frogRef.current = { ...initialFrog };
-      } else {
-        const padResult = handlePads(frogRef.current, padsRef.current);
-        padsRef.current = padResult.pads;
-        if (padResult.dead) {
+      if (!pausedRef.current) {
+        const carResult = updateCars(carsRef.current, frogRef.current, dt);
+        carsRef.current = carResult.lanes;
+        const logResult = updateLogs(logsRef.current, frogRef.current, dt);
+        logsRef.current = logResult.lanes;
+        frogRef.current = logResult.frog;
+        if (
+          carResult.dead ||
+          logResult.dead ||
+          frogRef.current.x < 0 ||
+          frogRef.current.x >= WIDTH
+        ) {
           loseLife();
           frogRef.current = { ...initialFrog };
-        } else if (padResult.levelComplete) {
-          setStatus('Level Complete!');
-          setScore((s) => s + 100);
-          ReactGA.event({ category: 'Frogger', action: 'level_complete', value: level });
-          const newLevel = level + 1;
-          setLevel(newLevel);
-          ReactGA.event({ category: 'Frogger', action: 'level_start', value: newLevel });
-          setPads(PAD_POSITIONS.map(() => false));
-          reset(false, difficulty, newLevel);
-          frogRef.current = { ...initialFrog };
         } else {
-          if (padResult.padHit) {
-            setScore((s) => s + 100);
-            setPads([...padsRef.current]);
+          const padResult = handlePads(frogRef.current, padsRef.current);
+          padsRef.current = padResult.pads;
+          if (padResult.dead) {
+            loseLife();
             frogRef.current = { ...initialFrog };
+          } else if (padResult.levelComplete) {
+            setStatus('Level Complete!');
+            setScore((s) => s + 100);
+            playTone(880, 0.2);
+            ReactGA.event({
+              category: 'Frogger',
+              action: 'level_complete',
+              value: level,
+            });
+            const newLevel = level + 1;
+            setLevel(newLevel);
+            ReactGA.event({
+              category: 'Frogger',
+              action: 'level_start',
+              value: newLevel,
+            });
+            setPads(PAD_POSITIONS.map(() => false));
+            reset(false, difficulty, newLevel);
+            frogRef.current = { ...initialFrog };
+          } else {
+            if (padResult.padHit) {
+              setScore((s) => s + 100);
+              setPads([...padsRef.current]);
+              playTone(660, 0.1);
+              frogRef.current = { ...initialFrog };
+            }
           }
-          setCars([...carsRef.current]);
-          setLogs([...logsRef.current]);
-          setFrog({ ...frogRef.current });
         }
+        setFrog({ ...frogRef.current });
+        setCars([...carsRef.current]);
+        setLogs([...logsRef.current]);
       }
-
+      draw();
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  // Only include dynamic values to prevent unnecessary re-renders
   }, [difficulty, level, loseLife, reset]);
-
 
   useEffect(() => {
     if (score >= nextLife.current) {
@@ -311,53 +401,6 @@ const Frogger = () => {
       nextLife.current += 500;
     }
   }, [score]);
-
-  // lanes are initialized via reset using current level and difficulty
-
-  const renderCell = (x, y) => {
-    const isFrog = Math.floor(frog.x) === x && frog.y === y;
-    const carLane = cars.find((l) => l.y === y);
-    const logLane = logs.find((l) => l.y === y);
-
-    let className = 'w-8 h-8';
-    if (y === 0) {
-      const idx = PAD_POSITIONS.indexOf(x);
-      if (idx >= 0) className += pads[idx] ? ' bg-green-400' : ' bg-green-700';
-      else className += ' bg-blue-700';
-    } else if (y === 3 || y === 6) className += ' bg-green-700';
-    else if (y >= 4 && y <= 5) className += ' bg-gray-700';
-    else className += ' bg-blue-700';
-
-    if (isFrog) className += ' bg-green-400';
-    else if (
-      carLane &&
-      carLane.entities.some((e) => x >= Math.floor(e.x) && x < Math.floor(e.x + carLane.length))
-    )
-      className += ' bg-red-500';
-    else if (logLane) {
-      const onLog = logLane.entities.some(
-        (e) => x >= Math.floor(e.x) && x < Math.floor(e.x + logLane.length)
-      );
-      const preview = logLane.entities.some((e) => {
-        const nextX = e.x + logLane.dir * logLane.speed;
-        return (
-          x >= Math.floor(nextX) &&
-          x < Math.floor(nextX + logLane.length)
-        );
-      });
-      if (onLog) className += ' bg-yellow-700';
-      else if (preview) className += ' bg-yellow-700 opacity-50';
-    }
-
-    return <div key={`${x}-${y}`} className={className} />;
-  };
-
-  const grid = [];
-  for (let y = 0; y < HEIGHT; y += 1) {
-    for (let x = 0; x < WIDTH; x += 1) {
-      grid.push(renderCell(x, y));
-    }
-  }
 
   const mobileControls = [
     null,
@@ -376,10 +419,29 @@ const Frogger = () => {
       id="frogger-container"
       className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4"
     >
-      <div className="grid grid-cols-7 gap-1">{grid}</div>
-      <div className="mt-4">Score: {score} Lives: {lives}</div>
+      <canvas
+        ref={canvasRef}
+        width={WIDTH * CELL}
+        height={HEIGHT * CELL}
+        className="border border-gray-700"
+      />
+      <div className="mt-4">Score: {score} High: {highScore} Lives: {lives}</div>
       <div className="mt-1">{status}</div>
       <div className="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setPaused((p) => !p)}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setSound((s) => !s)}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          Sound: {sound ? 'On' : 'Off'}
+        </button>
         <label htmlFor="difficulty">Difficulty:</label>
         <select
           id="difficulty"


### PR DESCRIPTION
## Summary
- render Frogger on canvas with requestAnimationFrame, lane collisions, pause overlay and sound effects
- track lives, levels, and highscore in localStorage
- add tests validating Frogger dynamic import configuration uses game defaults

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5e28c5f48328bb6601d777ab216a