### PR TITLE
test: expand YouTube coverage

### DIFF
--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -10,7 +10,11 @@ const CHANNEL_HANDLE = 'Alex-Unnippillil';
 // Renders a small YouTube browser similar to the YouTube mobile UI.
 // Videos can be fetched from the real API if an API key is provided or
 // injected via the `initialVideos` prop (used in tests).
-export default function YouTubeApp({ initialVideos = [] }) {
+export default function YouTubeApp({
+  initialVideos = [],
+  categoriesRef,
+  sortedRef,
+}) {
   const [videos, setVideos] = useState(initialVideos);
   const [playlists, setPlaylists] = useState([]); // [{id,title}]
   const [activeCategory, setActiveCategory] = useState('All');
@@ -123,6 +127,7 @@ export default function YouTubeApp({ initialVideos = [] }) {
     ],
     [playlists, videos]
   );
+  if (categoriesRef) categoriesRef.current = categories;
 
   const filtered = useMemo(
     () =>
@@ -156,6 +161,7 @@ export default function YouTubeApp({ initialVideos = [] }) {
         );
     }
   }, [filtered, sortBy]);
+  if (sortedRef) sortedRef.current = sorted;
 
   const handleCategoryClick = useCallback((cat) => setActiveCategory(cat), []);
 


### PR DESCRIPTION
## Summary
- exercise YouTube playlist loading with concurrent fetches and Promise.all
- guard against null video fields and verify transition class usage
- expose categories/sorted refs for stable memoization tests

## Testing
- `yarn test __tests__/youtube.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f548f1c8328bc87ea6566d94b20