### PR TITLE
refactor: central external frame and test mocks

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
 
     steps:

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface State { hasError: boolean }
+
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
+          Something went wrong.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/components/ExternalFrame.tsx
+++ b/components/ExternalFrame.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import appRegistry from '../utils/apps';
+
+interface Props extends React.IframeHTMLAttributes<HTMLIFrameElement> {
+  appId?: string;
+  src: string;
+}
+
+const isAllowed = (src: string, appId?: string): boolean => {
+  if (!appId) return true;
+  const entry = appRegistry[appId];
+  if (!entry || !entry.url) return true;
+  try {
+    const allowedOrigin = new URL(entry.url, window.location.origin).origin;
+    const srcOrigin = new URL(src, window.location.origin).origin;
+    return allowedOrigin === '*' || allowedOrigin === srcOrigin;
+  } catch {
+    return false;
+  }
+};
+
+const ExternalFrame: React.FC<Props> = ({ appId, src, title, className, ...rest }) => {
+  if (!isAllowed(src, appId)) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Blocked external content
+      </div>
+    );
+  }
+  return (
+    <iframe
+      src={src}
+      title={title}
+      className={className}
+      frameBorder="0"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+      {...rest}
+    />
+  );
+};
+
+export default ExternalFrame;

--- a/components/LazyGitHubButton.js
+++ b/components/LazyGitHubButton.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ExternalFrame from './ExternalFrame';
+import ErrorBoundary from './ErrorBoundary';
 
 const LazyGitHubButton = ({ user, repo }) => {
   const ref = useRef(null);
@@ -22,14 +24,16 @@ const LazyGitHubButton = ({ user, repo }) => {
   return (
     <div ref={ref} className="inline-block">
       {visible ? (
-        <iframe
-          src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
-          frameBorder="0"
-          scrolling="0"
-          width="150"
-          height="20"
-          title={`${repo}-star`}
-        ></iframe>
+        <ErrorBoundary>
+          <ExternalFrame
+            appId="github-button"
+            src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
+            scrolling="0"
+            width="150"
+            height="20"
+            title={`${repo}-star`}
+          />
+        </ErrorBoundary>
       ) : (
         <div className="h-5 w-24 bg-gray-200 animate-pulse rounded"></div>
       )}

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export class Chrome extends Component {
     constructor() {
@@ -86,7 +88,15 @@ export class Chrome extends Component {
         return (
             <div className="h-full w-full flex flex-col bg-ub-cool-grey">
                 {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
+                <ErrorBoundary>
+                    <ExternalFrame
+                        appId="chrome"
+                        src={this.state.url}
+                        title="Ubuntu Chrome Url"
+                        className="flex-grow"
+                        id="chrome-screen"
+                    />
+                </ErrorBoundary>
             </div>
         )
     }

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import ExternalFrame from '../../ExternalFrame';
+import ErrorBoundary from '../../ErrorBoundary';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
@@ -23,12 +25,14 @@ export default function GhidraApp() {
   if (useRemote) {
     const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
     return (
-      <iframe
-        src={remoteUrl}
-        className="w-full h-full bg-ub-cool-grey"
-        frameBorder="0"
-        title="Ghidra"
-      />
+      <ErrorBoundary>
+        <ExternalFrame
+          appId="ghidra"
+          src={remoteUrl}
+          className="w-full h-full bg-ub-cool-grey"
+          title="Ghidra"
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -1,5 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import usePersistentState from '../usePersistentState';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 const Platformer = () => {
   const [levels, setLevels] = useState([]);
@@ -7,7 +9,6 @@ const Platformer = () => {
     level: 0,
     checkpoint: null,
   });
-  const frameRef = useRef(null);
 
   useEffect(() => {
     fetch('/apps/platformer/levels.json')
@@ -36,13 +37,14 @@ const Platformer = () => {
   }`;
 
   return (
-    <iframe
-      ref={frameRef}
-      src={src}
-      title="Platformer"
-      className="w-full h-full"
-      frameBorder="0"
-    ></iframe>
+    <ErrorBoundary>
+      <ExternalFrame
+        appId="platformer"
+        src={src}
+        title="Platformer"
+        className="w-full h-full"
+      />
+    </ErrorBoundary>
   );
 };
 

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,17 +1,21 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export default function SpotifyApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
-        src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
-        title="Daily Mix 2"
-        width="100%"
-        height="100%"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      />
+      <ErrorBoundary>
+        <ExternalFrame
+          appId="spotify"
+          src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
+          title="Daily Mix 2"
+          width="100%"
+          height="100%"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+        />
+      </ErrorBoundary>
     </div>
   );
 }

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,12 +1,20 @@
-import React from 'react'
+import React from 'react';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export default function Todoist() {
-    return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
-        // just to bypass the headers 🙃
-    )
+  return (
+    <ErrorBoundary>
+      <ExternalFrame
+        appId="todoist"
+        src="https://todoist.com/showProject?id=220474322"
+        title="Todoist"
+        className="h-full w-full"
+      />
+    </ErrorBoundary>
+  );
 }
 
 export const displayTodoist = () => {
-    return <Todoist />;
+  return <Todoist />;
 };

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,18 +1,22 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export default function VsCode() {
-    return (
-        <iframe
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-        ></iframe>
-    );
+  return (
+    <ErrorBoundary>
+      <ExternalFrame
+        appId="vscode"
+        src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+        title="VsCode"
+        className="h-full w-full bg-ub-cool-grey"
+        allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
+        allowFullScreen
+      />
+    </ErrorBoundary>
+  );
 }
 
 export const displayVsCode = () => {
-    return <VsCode />;
+  return <VsCode />;
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -111,3 +111,23 @@ jest.mock(
   }),
   { virtual: true }
 );
+
+// Minimal GA4 mock to avoid network requests during tests
+jest.mock('react-ga4', () => ({
+  initialize: jest.fn(),
+  send: jest.fn(),
+  event: jest.fn(),
+}));
+
+// Mock howler.js audio to prevent errors in JSDOM
+jest.mock('howler', () => ({
+  Howl: class {
+    constructor() {}
+    play() {}
+    stop() {}
+    pause() {}
+    seek() {
+      return 0;
+    }
+  },
+}));

--- a/utils/apps.ts
+++ b/utils/apps.ts
@@ -1,0 +1,64 @@
+export type AppType = 'internal' | 'external' | 'game';
+
+export interface AppEntry {
+  id: string;
+  title: string;
+  icon: string;
+  type: AppType;
+  url?: string; // allowlisted URL for external apps
+}
+
+export const appRegistry: Record<string, AppEntry> = {
+  chrome: {
+    id: 'chrome',
+    title: 'Google Chrome',
+    icon: './themes/Yaru/apps/chrome.png',
+    type: 'external',
+    // Allow navigation to any URL within the embedded browser
+    url: '*',
+  },
+  todoist: {
+    id: 'todoist',
+    title: 'Todoist',
+    icon: './themes/Yaru/apps/todoist.png',
+    type: 'external',
+    url: 'https://todoist.com/showProject?id=220474322',
+  },
+  ghidra: {
+    id: 'ghidra',
+    title: 'Ghidra',
+    icon: './themes/Yaru/apps/ghidra.svg',
+    type: 'external',
+    url: 'https://ghidra.app',
+  },
+  vscode: {
+    id: 'vscode',
+    title: 'Visual Studio Code',
+    icon: './themes/Yaru/apps/vscode.png',
+    type: 'external',
+    url: 'https://stackblitz.com',
+  },
+  platformer: {
+    id: 'platformer',
+    title: 'Platformer',
+    icon: './themes/Yaru/apps/platformer.svg',
+    type: 'game',
+    url: '/apps/platformer/index.html',
+  },
+  spotify: {
+    id: 'spotify',
+    title: 'Spotify',
+    icon: './themes/Yaru/apps/spotify.svg',
+    type: 'external',
+    url: 'https://open.spotify.com',
+  },
+  'github-button': {
+    id: 'github-button',
+    title: 'GitHub Button',
+    icon: '',
+    type: 'external',
+    url: 'https://ghbtns.com',
+  },
+};
+
+export default appRegistry;


### PR DESCRIPTION
## Summary
- add shared ErrorBoundary and ExternalFrame components
- centralize app metadata in `apps.ts`
- mock analytics and audio for tests and update CI to Node 20

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae60e61f988328b6cf99e38053ec54