### PR TITLE
feat: instrument app analytics

### DIFF
--- a/__tests__/apps.smoke.test.tsx
+++ b/__tests__/apps.smoke.test.tsx
@@ -5,6 +5,12 @@ import { render } from '@testing-library/react';
 
 // Some apps import this package which isn't installed in the test env
 jest.mock('styled-jsx/style', () => () => null, { virtual: true });
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+  logGameStart: jest.fn(),
+  logGameEnd: jest.fn(),
+  logGameError: jest.fn(),
+}));
 
 // Mock browser APIs that may be missing in the Jest environment
 beforeAll(() => {

--- a/__tests__/passwordGenerator.test.tsx
+++ b/__tests__/passwordGenerator.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import PasswordGenerator from '../apps/password_generator';
 
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+  logGameStart: jest.fn(),
+  logGameEnd: jest.fn(),
+  logGameError: jest.fn(),
+}));
+
 describe('PasswordGenerator', () => {
   it('generates password of specified length', () => {
     const { getByText, getByLabelText, getByTestId } = render(<PasswordGenerator />);

--- a/apps.config.js
+++ b/apps.config.js
@@ -26,7 +26,7 @@ const createDynamicApp = (path, name) =>
   dynamic(
     () =>
       import(`./components/apps/${path}`).then((mod) => {
-        logEvent({ category: 'Application', action: `Loaded ${name}` });
+        logEvent('app_action', { id: path, action: 'load' });
         return mod.default;
       }),
     {

--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { logEvent } from '../../utils/analytics';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -13,7 +14,12 @@ const PasswordGenerator: React.FC = () => {
   const [useSymbols, setUseSymbols] = useState(false);
   const [password, setPassword] = useState('');
 
+  useEffect(() => {
+    logEvent('app_open', { id: 'password_generator' });
+  }, []);
+
   const generatePassword = () => {
+    logEvent('app_action', { id: 'password_generator', action: 'generate' });
     let chars = '';
     if (useLower) chars += LOWER;
     if (useUpper) chars += UPPER;
@@ -35,6 +41,7 @@ const PasswordGenerator: React.FC = () => {
     if (!password) return;
     try {
       await navigator.clipboard?.writeText(password);
+      logEvent('app_action', { id: 'password_generator', action: 'copy' });
     } catch (e) {
       // ignore
     }

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import Phaser from 'phaser';
+import { logEvent } from '../../utils/analytics';
 
 const PhaserMatter: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    logEvent('app_open', { id: 'phaser_matter' });
     if (!containerRef.current) return;
 
     const config: Phaser.Types.Core.GameConfig = {

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -27,7 +27,7 @@ const Sokoban: React.FC = () => {
     setState(st);
     setReach(reachable(st));
     logGameStart('sokoban');
-    logEvent({ category: 'sokoban', action: 'level_select', value: i });
+    logEvent('app_action', { id: 'sokoban', action: 'level_select', value: i });
   };
 
   const handleUndo = () => {
@@ -35,7 +35,7 @@ const Sokoban: React.FC = () => {
     if (st !== state) {
       setState(st);
       setReach(reachable(st));
-      logEvent({ category: 'sokoban', action: 'undo' });
+      logEvent('app_action', { id: 'sokoban', action: 'undo' });
     }
   };
 
@@ -61,6 +61,7 @@ const Sokoban: React.FC = () => {
   };
 
   useEffect(() => {
+    logEvent('app_open', { id: 'sokoban' });
     logGameStart('sokoban');
     try {
       const params = new URLSearchParams(window.location.search);
@@ -113,12 +114,12 @@ const Sokoban: React.FC = () => {
       setState(newState);
       setReach(reachable(newState));
       if (newState.pushes > state.pushes) {
-        logEvent({ category: 'sokoban', action: 'push' });
+        logEvent('app_action', { id: 'sokoban', action: 'push' });
       }
       if (isSolved(newState)) {
         logGameEnd('sokoban', `level_complete`);
-        logEvent({
-          category: 'sokoban',
+        logEvent('app_action', {
+          id: 'sokoban',
           action: 'level_complete',
           value: newState.pushes,
         });

--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { generateGrid, createRNG } from './generator';
 import type { Position, WordPlacement } from './types';
 import wordList from '../../components/apps/wordle_words.json';
-import { logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
+import { logEvent, logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
 
 const WORD_COUNT = 5;
 const GRID_SIZE = 12;
@@ -70,6 +70,10 @@ const WordSearch: React.FC = () => {
     logGameStart('word_search');
   }, [seed, words]);
 
+  useEffect(() => {
+    logEvent('app_open', { id: 'word_search' });
+  }, []);
+
   const handleMouseDown = (r: number, c: number) => {
     setSelecting(true);
     const s = { row: r, col: c };
@@ -114,6 +118,7 @@ const WordSearch: React.FC = () => {
     const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
     try {
       await navigator.clipboard?.writeText(url);
+      logEvent('app_action', { id: 'word_search', action: 'copy_link' });
     } catch (e: any) {
       logGameError('word_search', e?.message || String(e));
     }
@@ -126,6 +131,7 @@ const WordSearch: React.FC = () => {
       undefined,
       { shallow: true }
     );
+    logEvent('app_action', { id: 'word_search', action: 'new_puzzle' });
   };
 
   return (

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -67,6 +67,10 @@ const Hangman = () => {
   const [shake, setShake] = useState(false);
   const usedWordsRef = useRef([]);
 
+  useEffect(() => {
+    logEvent('app_open', { id: 'hangman' });
+  }, []);
+
   const length = lengthOptions[lengthIndex];
 
   const hintLimits = { easy: Infinity, medium: 1, hard: 0 };
@@ -124,7 +128,7 @@ const Hangman = () => {
         setTimeout(() => btn.classList.remove('key-press'), 100);
       }
       if (guessed.includes(letter) || isGameOver()) return;
-      logEvent({ category: 'hangman', action: 'guess', label: letter });
+      logEvent('app_action', { id: 'hangman', action: 'guess', label: letter });
       setGuessed((g) => [...g, letter]);
       if (!word.includes(letter)) {
         setWrong((w) => w + 1);
@@ -155,7 +159,7 @@ const Hangman = () => {
         return acc;
       }, {});
       const best = Object.keys(counts).sort((a, b) => counts[b] - counts[a])[0];
-      logEvent({ category: 'hangman', action: 'hint' });
+      logEvent('app_action', { id: 'hangman', action: 'hint' });
       setHint(`Try letter ${best.toUpperCase()}`);
       setScore((s) => s - 5);
       setHintsUsed((h) => h + 1);
@@ -196,8 +200,8 @@ const Hangman = () => {
     useEffect(() => {
       if (!gameEnded && isGameOver()) {
         logGameEnd('hangman', isWinner() ? 'win' : 'lose');
-        logEvent({
-          category: 'hangman',
+        logEvent('app_action', {
+          id: 'hangman',
           action: 'game_over',
           label: isWinner() ? 'win' : 'lose',
           value: guessed.length,
@@ -207,8 +211,8 @@ const Hangman = () => {
     }, [gameEnded, guessed, isGameOver, isWinner]);
 
   useEffect(() => {
-    logEvent({
-      category: 'hangman',
+    logEvent('app_action', {
+      id: 'hangman',
       action: 'category_select',
       label: `${theme}-${difficulty}`,
     });

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,6 +1,6 @@
 import ReactGA from 'react-ga4';
 
-type EventInput = Parameters<typeof ReactGA.event>[0];
+type EventParams = Record<string, any>;
 
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   try {
@@ -12,18 +12,20 @@ const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   }
 };
 
-export const logEvent = (event: EventInput): void => {
-  safeEvent(event as any);
+export const logEvent = (event: string, params?: EventParams): void => {
+  safeEvent(event as any, params as any);
 };
 
-export const logGameStart = (game: string): void => {
-  logEvent({ category: game, action: 'start' });
+export const logGameStart = (id: string): void => {
+  logEvent('game_start', { id });
 };
 
-export const logGameEnd = (game: string, label?: string): void => {
-  logEvent({ category: game, action: 'end', label });
+export const logGameEnd = (id: string, label?: string): void => {
+  logEvent('game_end', { id, label });
 };
 
-export const logGameError = (game: string, message?: string): void => {
-  logEvent({ category: game, action: 'error', label: message });
+export const logGameError = (id: string, message?: string): void => {
+  logEvent('game_error', { id, label: message });
 };
+
+export default { logEvent, logGameStart, logGameEnd, logGameError };


### PR DESCRIPTION
## Summary
- provide tree-shakeable analytics utilities and default export
- instrument apps with `app_open` and `app_action` events
- mock analytics in tests

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae60edf0a08328a8f01d2960a6a67e