### PR TITLE
feat: improve accessibility for app components

### DIFF
--- a/components/apps/GameLayout.js
+++ b/components/apps/GameLayout.js
@@ -1,16 +1,43 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-const GameLayout = ({ children, stage, lives, score, highScore }) => (
-  <div className="h-full w-full relative text-white">
-    <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
-      <div>Stage: {stage}</div>
-      <div>Lives: {lives}</div>
-      {score !== undefined && <div>Score: {score}</div>}
-      {highScore !== undefined && <div>High: {highScore}</div>}
+const GameLayout = ({
+  gameId = 'game',
+  title,
+  children,
+  stage,
+  lives,
+  score,
+  highScore,
+}) => {
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        document.getElementById(`close-${gameId}`)?.click();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [gameId]);
+
+  return (
+    <div
+      role="application"
+      aria-labelledby={`${gameId}-label`}
+      className="h-full w-full relative text-white"
+    >
+      <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
+        <label id={`${gameId}-label`} className="font-bold">
+          {title || gameId}
+        </label>
+        <div>Stage: {stage}</div>
+        <div>Lives: {lives}</div>
+        {score !== undefined && <div>Score: {score}</div>}
+        {highScore !== undefined && <div>High: {highScore}</div>}
+      </div>
+      {children}
     </div>
-    {children}
-
-  </div>
-);
+  );
+};
 
 export default GameLayout;

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -13,19 +13,32 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
 
   useEffect(() => {
-    if (!showHelp) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        setShowHelp(false);
+        if (showHelp) {
+          setShowHelp(false);
+        } else {
+          document.getElementById(`close-${gameId}`)?.click();
+        }
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [showHelp]);
+  }, [showHelp, gameId]);
 
   return (
-    <div className="relative h-full w-full">
+    <div
+      role="application"
+      aria-labelledby={`${gameId}-label`}
+      className="relative h-full w-full"
+    >
+      <label
+        id={`${gameId}-label`}
+        className="absolute top-2 left-2 bg-gray-700 text-white px-2 py-1 rounded"
+      >
+        {gameId}
+      </label>
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       <button
         type="button"
@@ -37,7 +50,6 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
         ?
       </button>
       {children}
-
     </div>
   );
 };

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -19,6 +19,17 @@ export class Gedit extends Component {
 
     componentDidMount() {
         emailjs.init(process.env.NEXT_PUBLIC_USER_ID);
+        window.addEventListener('keydown', this.handleKey);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('keydown', this.handleKey);
+    }
+
+    handleKey = (e) => {
+        if (e.key === 'Escape') {
+            document.getElementById('close-gedit')?.click();
+        }
     }
 
     handleChange = (field) => (e) => {
@@ -74,25 +85,25 @@ export class Gedit extends Component {
 
     render() {
         return (
-            <div className="w-full h-full relative flex flex-col bg-ub-cool-grey text-white select-none">
+            <div className="w-full h-full relative flex flex-col bg-ub-cool-grey text-white select-none" role="dialog" aria-labelledby="gedit-label">
                 <div className="flex items-center justify-between w-full bg-ub-gedit-light bg-opacity-60 border-b border-t border-blue-400 text-sm">
-                    <span className="font-bold ml-2">Send a Message to Me</span>
+                    <label id="gedit-label" className="font-bold ml-2">Send a Message to Me</label>
                     <div className="flex">
-                        <div onClick={this.sendMessage} className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80">Send</div>
+                        <button type="button" tabIndex={4} onClick={this.sendMessage} className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80">Send</button>
                     </div>
                 </div>
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} className=" w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent" placeholder={this.state.nameError ? "Name must not be Empty!" : "Your Email / Name :"} spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" tabIndex={1} value={this.state.name} onChange={this.handleChange('name')} className=" w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent" placeholder={this.state.nameError ? "Name must not be Empty!" : "Your Email / Name :"} spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" tabIndex={2} value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} className=" w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent" placeholder={this.state.messageError ? "Message must not be Empty!" : "Message"} spellCheck="false" autoComplete="none" type="text" />
+                        <textarea id="sender-message" tabIndex={3} value={this.state.message} onChange={this.handleChange('message')} className=" w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent" placeholder={this.state.messageError ? "Message must not be Empty!" : "Message"} spellCheck="false" autoComplete="none" type="text" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- label application roots and handle Escape key in shared game layout
- add application labeling and Escape support to classic game layout
- make Gedit dialog accessible with labeling, ordered focus, and Escape close

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae60eec7308328a7b2748aacf966e4