### PR TITLE
feat: add resilient external frame

### DIFF
--- a/__tests__/ExternalFrame.test.tsx
+++ b/__tests__/ExternalFrame.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ExternalFrame from '../components/ExternalFrame';
+
+describe('ExternalFrame', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('mounts and handles load event', () => {
+    const { getByTitle, queryByText } = render(
+      <ExternalFrame src="https://allowed.com/page" title="frame" allowlist={['https://allowed.com']} />
+    );
+    const frame = getByTitle('frame');
+    act(() => {
+      fireEvent.load(frame);
+    });
+    expect(queryByText(/Loading/)).not.toBeInTheDocument();
+  });
+
+  it('shows offline banner and retries', () => {
+    Object.defineProperty(window.navigator, 'onLine', { configurable: true, value: false });
+    const { getByText } = render(
+      <ExternalFrame src="https://allowed.com/page" title="frame" allowlist={['https://allowed.com']} />
+    );
+    expect(getByText(/offline/i)).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(getByText(/retry/i));
+    });
+    expect(getByText(/Loading/)).toBeInTheDocument();
+    Object.defineProperty(window.navigator, 'onLine', { configurable: true, value: true });
+  });
+
+  it('surfaces error after timeout', () => {
+    render(<ExternalFrame src="https://allowed.com/page" title="frame" allowlist={['https://allowed.com']} />);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -21,6 +21,10 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 import { displayNikto } from './components/apps/nikto';
+export const FRAME_ALLOWLIST = {
+  chrome: ["https://www.google.com/webhp?igu=1"],
+};
+
 
 const createDynamicApp = (path, name) =>
   dynamic(

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const ExternalFrame = ({ src, allowlist = [], className = '', title, id, ...rest }) => {
+  const iframeRef = useRef(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [online, setOnline] = useState(typeof navigator === 'undefined' ? true : navigator.onLine);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const retry = () => setReloadKey((k) => k + 1);
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (allowlist.length && !allowlist.some((allowed) => src && src.startsWith(allowed))) {
+      setError('URL not allowlisted');
+      setLoading(false);
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+    let loaded = false;
+    const handleLoad = () => {
+      loaded = true;
+      setLoading(false);
+    };
+    const frame = iframeRef.current;
+    frame && frame.addEventListener('load', handleLoad);
+    const timer = setTimeout(() => {
+      if (!loaded) {
+        setError('Failed to load');
+        setLoading(false);
+      }
+    }, 10000);
+    return () => {
+      frame && frame.removeEventListener('load', handleLoad);
+      clearTimeout(timer);
+    };
+  }, [src, allowlist, reloadKey]);
+
+  return (
+    <div className="relative h-full w-full">
+      {!online && (
+        <div className="absolute top-0 left-0 right-0 bg-yellow-400 text-black text-sm p-1 flex justify-center items-center z-10">
+          <span className="mr-2">You are offline.</span>
+          <button className="underline" onClick={retry}>Retry</button>
+        </div>
+      )}
+      {error && (
+        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+          {error}
+        </div>
+      )}
+      {!error && (
+        <>
+          {loading && (
+            <div className="absolute inset-0 flex items-center justify-center bg-ub-cool-grey text-white">
+              Loading...
+            </div>
+          )}
+          <iframe
+            key={reloadKey}
+            ref={iframeRef}
+            src={src}
+            id={id}
+            title={title}
+            className={className}
+            {...rest}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ExternalFrame;

--- a/components/LazyGitHubButton.js
+++ b/components/LazyGitHubButton.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ExternalFrame from './ExternalFrame';
 
 const LazyGitHubButton = ({ user, repo }) => {
   const ref = useRef(null);
@@ -22,14 +23,15 @@ const LazyGitHubButton = ({ user, repo }) => {
   return (
     <div ref={ref} className="inline-block">
       {visible ? (
-        <iframe
+        <ExternalFrame
           src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
           frameBorder="0"
           scrolling="0"
           width="150"
           height="20"
           title={`${repo}-star`}
-        ></iframe>
+          allowlist={['https://ghbtns.com']}
+        />
       ) : (
         <div className="h-5 w-24 bg-gray-200 animate-pulse rounded"></div>
       )}

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import ExternalFrame from '../ExternalFrame';
+import { FRAME_ALLOWLIST } from '../../apps.config';
 
 export class Chrome extends Component {
     constructor() {
@@ -86,7 +88,13 @@ export class Chrome extends Component {
         return (
             <div className="h-full w-full flex flex-col bg-ub-cool-grey">
                 {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
+                <ExternalFrame
+                    src={this.state.url}
+                    className="flex-grow"
+                    id="chrome-screen"
+                    title="Ubuntu Chrome Url"
+                    allowlist={FRAME_ALLOWLIST.chrome}
+                />
             </div>
         )
     }

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ExternalFrame from '../../ExternalFrame';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
@@ -23,11 +24,12 @@ export default function GhidraApp() {
   if (useRemote) {
     const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
     return (
-      <iframe
+      <ExternalFrame
         src={remoteUrl}
         className="w-full h-full bg-ub-cool-grey"
         frameBorder="0"
         title="Ghidra"
+        allowlist={[remoteUrl]}
       />
     );
   }

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import usePersistentState from '../usePersistentState';
+import ExternalFrame from '../ExternalFrame';
 
 const Platformer = () => {
   const [levels, setLevels] = useState([]);
@@ -7,8 +8,6 @@ const Platformer = () => {
     level: 0,
     checkpoint: null,
   });
-  const frameRef = useRef(null);
-
   useEffect(() => {
     fetch('/apps/platformer/levels.json')
       .then(r => r.json())
@@ -36,13 +35,13 @@ const Platformer = () => {
   }`;
 
   return (
-    <iframe
-      ref={frameRef}
+    <ExternalFrame
       src={src}
       title="Platformer"
       className="w-full h-full"
       frameBorder="0"
-    ></iframe>
+      allowlist={[`/apps/platformer`]}
+    />
   );
 };
 

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
 
 export default function SpotifyApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
+      <ExternalFrame
         src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
         title="Daily Mix 2"
         width="100%"
@@ -11,6 +12,7 @@ export default function SpotifyApp() {
         frameBorder="0"
         allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
         loading="lazy"
+        allowlist={['https://open.spotify.com']}
       />
     </div>
   );

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import ExternalFrame from '../ExternalFrame'
 
 export default function Todoist() {
     return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
+        <ExternalFrame src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full" allowlist={['https://todoist.com']} />
         // just to bypass the headers 🙃
     )
 }

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,15 +1,17 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
 
 export default function VsCode() {
     return (
-        <iframe
+        <ExternalFrame
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
             frameBorder="0"
             title="VsCode"
             className="h-full w-full bg-ub-cool-grey"
             allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
             allowFullScreen
-        ></iframe>
+            allowlist={['https://stackblitz.com']}
+        />
     );
 }
 


### PR DESCRIPTION
## Summary
- add `ExternalFrame` enforcing URL allowlists with loader and offline retry
- replace legacy iframes across apps
- add Chrome allowlist entry in app config

## Testing
- `yarn test __tests__/ExternalFrame.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae60f0e4fc832898eee2fe93b614e7