### PR TITLE
feat: add external frame component with cookie check

### DIFF
--- a/__tests__/externalFrame.test.tsx
+++ b/__tests__/externalFrame.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ExternalFrame from '../components/ExternalFrame';
+
+describe('ExternalFrame', () => {
+  const originalCookie = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie') ||
+    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'cookie');
+
+  afterEach(() => {
+    if (originalCookie) {
+      Object.defineProperty(document, 'cookie', originalCookie);
+    }
+  });
+
+  it('mounts iframe for allowlisted domain', () => {
+    render(<ExternalFrame src="https://vscode.dev" title="frame" />);
+    expect(screen.getByTestId('external-frame')).toBeInTheDocument();
+    expect(screen.queryByTestId('cookie-banner')).toBeNull();
+  });
+
+  it('shows banner when cookies are disabled', () => {
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => '',
+      set: () => { throw new Error('blocked'); },
+    });
+    render(<ExternalFrame src="https://vscode.dev" title="frame" />);
+    expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
+  });
+});

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const ALLOWLIST = ['vscode.dev', 'stackblitz.com'];
+
+export default function ExternalFrame({ src, title = 'External frame', ...props }) {
+  const [cookiesBlocked, setCookiesBlocked] = useState(false);
+
+  useEffect(() => {
+    try {
+      document.cookie = 'thirdpartytest=1';
+      const enabled = document.cookie.includes('thirdpartytest=');
+      if (!enabled) setCookiesBlocked(true);
+    } catch (e) {
+      setCookiesBlocked(true);
+    }
+  }, []);
+
+  let url;
+  try {
+    url = new URL(src);
+  } catch (e) {
+    return null;
+  }
+  const allowed = ALLOWLIST.some((domain) => url.hostname === domain || url.hostname.endsWith(`.${domain}`));
+  if (!allowed) {
+    return null;
+  }
+
+  return (
+    <div className="h-full w-full relative">
+      {cookiesBlocked && (
+        <div data-testid="cookie-banner" className="absolute inset-0 bg-yellow-200 p-2 text-sm z-10 flex items-center">
+          Third-party cookies are disabled.{' '}
+          <Link href="https://support.google.com/chrome/answer/95647" prefetch={false} className="underline ml-1">
+            Learn more
+          </Link>
+        </div>
+      )}
+      <iframe
+        src={src}
+        title={title}
+        data-testid="external-frame"
+        className="h-full w-full"
+        frameBorder="0"
+        {...props}
+      ></iframe>
+    </div>
+  );
+}

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,18 +1,18 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
 
 export default function VsCode() {
-    return (
-        <iframe
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-        ></iframe>
-    );
+  return (
+    <ExternalFrame
+      src="https://vscode.dev/github/Alex-Unnippillil/kali-linux-portfolio"
+      title="VsCode"
+      className="h-full w-full bg-ub-cool-grey"
+      allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
+      allowFullScreen
+    />
+  );
 }
 
 export const displayVsCode = () => {
-    return <VsCode />;
+  return <VsCode />;
 };


### PR DESCRIPTION
## Summary
- add ExternalFrame component with third-party cookie detection and help banner
- use ExternalFrame for VS Code app
- test frame mounting and cookie banner

## Testing
- `yarn test __tests__/externalFrame.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae60f79db08328a46c571386b6a9a1