### PR TITLE
feat: improve calculator precision and history

### DIFF
--- a/__tests__/calculator-app.test.ts
+++ b/__tests__/calculator-app.test.ts
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+
+describe('Calculator app', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="display" class="display"></div>
+      <button id="toggle-scientific"></button>
+      <button id="toggle-precise"></button>
+      <div id="scientific" class="hidden"></div>
+      <div class="buttons">
+        <button class="btn" data-action="equals">=</button>
+        <button class="btn" data-action="clear">C</button>
+      </div>
+      <details id="history-container"><summary>History</summary>
+        <div id="history" class="history"></div>
+      </details>
+    `;
+    const { create, all } = require('mathjs');
+    // @ts-ignore
+    global.math = create(all);
+    localStorage.clear();
+    require('../apps/calculator/main.js');
+  });
+
+  test('evaluates decimals precisely', () => {
+    const display = document.getElementById('display')!;
+    display.textContent = '1.1+2.2';
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(display.textContent).toBe('3.3');
+  });
+
+  test('keeps at most 10 history entries', () => {
+    const display = document.getElementById('display')!;
+    for (let i = 0; i < 11; i++) {
+      display.textContent = `${i}+1`;
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    }
+    const stored = JSON.parse(localStorage.getItem('calc-history') || '[]');
+    expect(stored.length).toBeLessThanOrEqual(10);
+    const entries = document.querySelectorAll('#history .history-entry');
+    expect(entries.length).toBeLessThanOrEqual(10);
+  });
+
+  test('Enter key triggers evaluation', () => {
+    const display = document.getElementById('display')!;
+    display.textContent = '1+1';
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(display.textContent).toBe('2');
+  });
+});
+

--- a/apps/calculator/index.html
+++ b/apps/calculator/index.html
@@ -9,7 +9,7 @@
 <body>
   <div class="calculator">
     <div id="display" class="display" tabindex="0"></div>
-    <button id="toggle-precise" class="toggle" aria-pressed="false">Precise Mode: Off</button>
+    <button id="toggle-precise" class="toggle" aria-pressed="true">Precise Mode: On</button>
     <button id="toggle-scientific" class="toggle" aria-pressed="false">Scientific</button>
     <div class="buttons">
       <button class="btn" data-value="7">7</button>
@@ -38,7 +38,10 @@
       <button class="btn" data-value="(">(</button>
       <button class="btn" data-value=")">)</button>
     </div>
-    <div id="history" class="history" aria-live="polite"></div>
+    <details id="history-container">
+      <summary>History</summary>
+      <div id="history" class="history" aria-live="polite"></div>
+    </details>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/mathjs@13.2.3/lib/browser/math.js"></script>
   <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- use mathjs BigNumber config to avoid floating point errors
- persist last 10 calculator results to localStorage and show collapsible history
- add keyboard tests for accurate evaluation and history limit

## Testing
- `yarn test __tests__/calculator-app.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae71bb973c832889e602a96b99d69d