### PR TITLE
feat: expand terminal with dynamic imports and built-in commands

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,142 +1,74 @@
-jest.mock(
-  '@xterm/xterm',
-  () => ({
-    Terminal: jest.fn().mockImplementation(() => ({
-      open: jest.fn(),
-      focus: jest.fn(),
-      loadAddon: jest.fn(),
-      write: jest.fn(),
-      writeln: jest.fn(),
-      onData: jest.fn(),
-      onKey: jest.fn(),
-      dispose: jest.fn(),
-    })),
-  }),
-  { virtual: true }
-);
-jest.mock(
-  '@xterm/addon-fit',
-  () => ({
-    FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
-  }),
-  { virtual: true }
-);
-jest.mock(
-  '@xterm/addon-search',
-  () => ({
-    SearchAddon: jest.fn().mockImplementation(() => ({
-      activate: jest.fn(),
-      dispose: jest.fn(),
-    })),
-  }),
-  { virtual: true }
-);
-jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
-jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
-
 import React, { createRef, act } from 'react';
 import { render } from '@testing-library/react';
 import Terminal from '../components/apps/terminal';
 
-jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
-jest.mock(
-  'xterm',
-  () => ({
-    Terminal: class {
-      open() {}
-      write() {}
-      onData() {}
-    },
-  }),
-  { virtual: true },
+let onKeyHandler: any = null;
 
-);
-jest.mock(
-  'xterm-addon-fit',
-  () => ({
-    FitAddon: class {
-      fit() {}
-    },
-  }),
-  { virtual: true },
+jest.mock('@xterm/xterm', () => {
+  const Terminal = jest.fn().mockImplementation(() => ({
+    open: jest.fn(),
+    loadAddon: jest.fn(),
+    write: jest.fn(),
+    writeln: jest.fn(),
+    clear: jest.fn(),
+    onKey: jest.fn((cb) => {
+      onKeyHandler = cb;
+    }),
+    dispose: jest.fn(),
+  }));
+  return { Terminal };
+});
 
-);
-jest.mock(
-  'xterm-addon-search',
-  () => ({
-    SearchAddon: class {
-      activate() {}
-    },
-  }),
-  { virtual: true },
-);
+jest.mock('@xterm/addon-fit', () => ({
+  FitAddon: jest.fn().mockImplementation(() => ({ fit: jest.fn() })),
+}));
 
+jest.mock('@xterm/addon-search', () => ({
+  SearchAddon: jest.fn().mockImplementation(() => ({ activate: jest.fn() })),
+}));
 
-describe.skip('Terminal component', () => {
+jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
+
+describe('Terminal component', () => {
   const addFolder = jest.fn();
   const openApp = jest.fn();
 
-  it('runs pwd command successfully', () => {
-    const ref = createRef();
+  const flush = () => act(async () => {
+    await Promise.resolve();
+  });
+
+  it('runCommand pwd returns home path', async () => {
+    const ref: any = createRef();
     render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    await flush();
+    let result = '';
+    act(() => {
+      result = ref.current.runCommand('pwd');
+    });
+    expect(result).toBe('/home/alex');
+  });
+
+  it('invalid cd shows error', async () => {
+    const ref: any = createRef();
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    await flush();
+    let result = '';
+    act(() => {
+      result = ref.current.runCommand('cd nowhere');
+    });
+    expect(result).toContain('No such file or directory');
+  });
+
+  it('Ctrl+L clears output', async () => {
+    const ref: any = createRef();
+    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
+    await flush();
     act(() => {
       ref.current.runCommand('pwd');
     });
-    expect(ref.current.getContent()).toContain('/home/alex');
-  });
-
-  it('handles invalid cd command', () => {
-    const ref = createRef();
-    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
     act(() => {
-      ref.current.runCommand('cd nowhere');
+      onKeyHandler({ key: '', domEvent: { ctrlKey: true, key: 'l', preventDefault: jest.fn() } });
     });
-    expect(ref.current.getContent()).toContain("bash: cd: nowhere: No such file or directory");
-  });
-
-  it('supports history, clear, and help commands', () => {
-    const ref = createRef();
-    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
-    act(() => {
-      ref.current.runCommand('pwd');
-      ref.current.runCommand('history');
-    });
-    expect(ref.current.getContent()).toContain('pwd');
-    act(() => {
-      ref.current.runCommand('clear');
-    });
-    expect(ref.current.getContent()).toContain('pwd');
-    act(() => {
-      ref.current.runCommand('help');
-    });
-    expect(ref.current.getContent()).toContain('Available commands:');
-    expect(ref.current.getContent()).toContain('clear');
-    expect(ref.current.getContent()).toContain('help');
-  });
-
-  it('handles missing Worker gracefully', () => {
-    const ref = createRef();
-    const originalWorker = (global as any).Worker;
-    (global as any).Worker = undefined;
-    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
-    act(() => {
-      ref.current.runCommand('simulate');
-    });
-    expect(ref.current.getContent()).toContain('Web Workers are not supported');
-    (global as any).Worker = originalWorker;
-  });
-
-  it('navigates command history with arrow keys', () => {
-    const ref = createRef();
-    render(<Terminal ref={ref} addFolder={addFolder} openApp={openApp} />);
-    act(() => {
-      ref.current.runCommand('pwd');
-      ref.current.historyNav('up');
-    });
-    expect(ref.current.getCommand()).toBe('pwd');
-    act(() => {
-      ref.current.historyNav('down');
-    });
-    expect(ref.current.getCommand()).toBe('');
+    expect(ref.current.getContent()).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- dynamically import xterm and addons for lighter bundle
- add built-in shell commands, app aliases, and history buffer
- handle Ctrl+L to clear terminal and expose runCommand/getContent

## Testing
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae71bbeb6c8328927a371eead0ca40