### PR TITLE
feat: add external frame with cookie warning for VS Code app

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import VsCode from '../components/apps/vscode';
+
+describe('VsCode app', () => {
+  it('renders iframe', () => {
+    render(<VsCode />);
+    const frame = screen.getByTitle('VsCode');
+    expect(frame).toBeInTheDocument();
+    expect(frame).toHaveAttribute('src', expect.stringContaining('stackblitz.com'));
+  });
+
+  it('shows banner when cookies disabled', async () => {
+    const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => '',
+      set: () => {}
+    });
+
+    render(<VsCode />);
+
+    expect(
+      await screen.findByText(/Third-party cookies are blocked/i)
+    ).toBeInTheDocument();
+
+    if (original) {
+      Object.defineProperty(Document.prototype, 'cookie', original);
+    }
+  });
+});

--- a/components/ExternalFrame.tsx
+++ b/components/ExternalFrame.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+
+const ALLOWLIST = ['vscode.dev', 'stackblitz.com'];
+
+export interface ExternalFrameProps extends React.IframeHTMLAttributes<HTMLIFrameElement> {
+  src: string;
+  prefetch?: boolean;
+}
+
+export default function ExternalFrame({ src, prefetch = true, ...props }: ExternalFrameProps) {
+  let allowed = false;
+  let origin = '';
+  try {
+    const url = new URL(src);
+    origin = url.origin;
+    const host = url.hostname;
+    allowed = ALLOWLIST.some((domain) => host === domain || host.endsWith(`.${domain}`));
+  } catch {
+    allowed = false;
+  }
+
+  useEffect(() => {
+    if (!allowed || !prefetch) return;
+    const link = document.createElement('link');
+    link.rel = 'preconnect';
+    link.href = origin;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, [allowed, origin, prefetch]);
+
+  if (!allowed) return null;
+
+  return <iframe src={src} {...props} />;
+}

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,15 +1,45 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import ExternalFrame from '../ExternalFrame';
 
 export default function VsCode() {
+    const [cookiesEnabled, setCookiesEnabled] = useState(true);
+
+    useEffect(() => {
+        try {
+            document.cookie = 'vscookie=1';
+            setCookiesEnabled(document.cookie.includes('vscookie=1'));
+            document.cookie = 'vscookie=1; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        } catch {
+            setCookiesEnabled(false);
+        }
+    }, []);
+
     return (
-        <iframe
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-        ></iframe>
+        <div className="h-full w-full flex flex-col">
+            {!cookiesEnabled && (
+                <div className="bg-yellow-300 text-black p-2 text-sm" role="alert">
+                    Third-party cookies are blocked. Please{' '}
+                    <a
+                        className="underline"
+                        href="https://support.google.com/chrome/answer/95647"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        enable cookies
+                    </a>{' '}
+                    to use VS Code.
+                </div>
+            )}
+            <ExternalFrame
+                src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+                frameBorder="0"
+                title="VsCode"
+                className="flex-grow w-full bg-ub-cool-grey"
+                allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
+                allowFullScreen
+                prefetch={false}
+            />
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary
- add `ExternalFrame` component that preconnects allowlisted hosts
- load VS Code via ExternalFrame with prefetch disabled
- show banner when third-party cookies are blocked
- test iframe mount and cookie-block banner

## Testing
- `npm test -- __tests__/vscode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae71bc8af883288b27bba391a57623