### PR TITLE
feat: add spotify embed with url validation

### DIFF
--- a/__tests__/spotify.test.tsx
+++ b/__tests__/spotify.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SpotifyApp from '../components/apps/spotify';
+
+describe('SpotifyApp', () => {
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true });
+  });
+
+  it('renders embed for valid URL', async () => {
+    render(<SpotifyApp />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/enter spotify url/i),
+      'https://open.spotify.com/playlist/123'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /load/i }));
+    const frame = await screen.findByTitle('Spotify');
+    expect(frame).toBeInTheDocument();
+    expect(frame).toHaveAttribute(
+      'src',
+      'https://open.spotify.com/embed/playlist/123'
+    );
+  });
+
+  it('shows error for invalid URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
+
+    render(<SpotifyApp />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/enter spotify url/i),
+      'https://open.spotify.com/playlist/private'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /load/i }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/could not load spotify url/i);
+    expect(screen.queryByTitle('Spotify')).not.toBeInTheDocument();
+  });
+});
+

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,17 +1,90 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+const TYPES = [
+  { value: 'playlist', label: 'Playlist' },
+  { value: 'track', label: 'Track' },
+  { value: 'album', label: 'Album' },
+  { value: 'user', label: 'Profile' },
+];
 
 export default function SpotifyApp() {
+  const [type, setType] = useState('playlist');
+  const [url, setUrl] = useState('');
+  const [embedSrc, setEmbedSrc] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError('');
+    setEmbedSrc('');
+
+    const pathType = type;
+    let id = url.trim();
+
+    const urlRegex = new RegExp(`open.spotify.com/(?:user|playlist|track|album)/([^/?]+)`, 'i');
+    const match = url.match(urlRegex);
+    if (match) {
+      id = match[1];
+    }
+
+    const targetUrl = `https://open.spotify.com/${pathType}/${id}`;
+
+    try {
+      const res = await fetch(
+        `https://open.spotify.com/oembed?url=${encodeURIComponent(targetUrl)}`
+      );
+      if (!res.ok) throw new Error('Not public');
+      setEmbedSrc(`https://open.spotify.com/embed/${pathType}/${id}`);
+    } catch (err) {
+      setError('Could not load Spotify URL. Make sure it is public.');
+    }
+  }
+
   return (
-    <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
-        src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
-        title="Daily Mix 2"
-        width="100%"
-        height="100%"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      />
+    <div className="h-full w-full bg-ub-cool-grey flex flex-col text-white">
+      <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+        <label htmlFor="spotify-type" className="sr-only">
+          Type
+        </label>
+        <select
+          id="spotify-type"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="text-black px-2 py-1 rounded"
+        >
+          {TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Enter Spotify URL"
+          className="text-black px-2 py-1 rounded"
+        />
+        <button type="submit" className="bg-ub-blue px-2 py-1 rounded text-white">
+          Load
+        </button>
+      </form>
+      {error && (
+        <div role="alert" className="p-4">
+          {error}
+        </div>
+      )}
+      {embedSrc && (
+        <iframe
+          src={embedSrc}
+          title="Spotify"
+          width="100%"
+          height="100%"
+          frameBorder="0"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+          className="flex-1"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add dropdown to choose playlist, track, album, or profile
- validate Spotify URLs before embedding
- test valid and invalid URLs

## Testing
- `npm test __tests__/spotify.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae71be058483288974b0e4ce073032