### PR TITLE
Add persistent settings toggles with reset option

### DIFF
--- a/__tests__/settings.test.tsx
+++ b/__tests__/settings.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '../hooks/useTheme';
+import { Settings } from '../components/apps/settings';
+
+const renderSettings = () =>
+  render(
+    <ThemeProvider>
+      <Settings changeBackgroundImage={() => {}} currBgImgName="wall-1" />
+    </ThemeProvider>
+  );
+
+describe('Settings app', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists toggles across reloads', () => {
+    const { unmount } = renderSettings();
+    const themeToggle = screen.getByLabelText('Dark theme');
+    const soundToggle = screen.getByLabelText('Sound effects');
+    const motionToggle = screen.getByLabelText('Reduced motion');
+
+    fireEvent.click(themeToggle);
+    fireEvent.click(soundToggle);
+    fireEvent.click(motionToggle);
+
+    unmount();
+
+    renderSettings();
+
+    expect(screen.getByLabelText('Dark theme')).not.toBeChecked();
+    expect(screen.getByLabelText('Sound effects')).not.toBeChecked();
+    expect(screen.getByLabelText('Reduced motion')).toBeChecked();
+  });
+
+  it('reset clears keys and displays toast', () => {
+    localStorage.setItem('dummy', '1');
+    renderSettings();
+    fireEvent.click(screen.getByText('Reset apps'));
+    expect(localStorage.getItem('dummy')).toBeNull();
+    expect(screen.getByRole('status')).toHaveTextContent('Apps reset');
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,8 +1,20 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export function Settings(props) {
     const { theme, setTheme } = useTheme();
+    const [sound, setSound] = usePersistentState('sound-effects', true, v => typeof v === 'boolean');
+    const [motion, setMotion] = usePersistentState('reduced-motion', false, v => typeof v === 'boolean');
+    const [toast, setToast] = useState('');
+
+    useEffect(() => {
+        document.documentElement.dataset.sound = sound ? 'on' : 'off';
+    }, [sound]);
+
+    useEffect(() => {
+        document.documentElement.dataset.motion = motion ? 'reduced' : 'normal';
+    }, [motion]);
 
     const wallpapers = {
         "wall-1": "./images/wallpapers/wall-1.webp",
@@ -15,24 +27,69 @@ export function Settings(props) {
         "wall-8": "./images/wallpapers/wall-8.webp",
     };
 
-    let changeBackgroundImage = (e) => {
-        props.changeBackgroundImage(e.target.dataset.path);
-    }
+    const changeBackgroundImage = (e) => {
+        props.changeBackgroundImage && props.changeBackgroundImage(e.target.dataset.path);
+    };
+
+    const resetApps = () => {
+        const t = theme;
+        const s = sound;
+        const m = motion;
+        localStorage.clear();
+        localStorage.setItem('theme', JSON.stringify(t));
+        localStorage.setItem('sound-effects', JSON.stringify(s));
+        localStorage.setItem('reduced-motion', JSON.stringify(m));
+        setToast('Apps reset');
+        setTimeout(() => setToast(''), 2000);
+    };
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
-                <select
-                    value={theme}
-                    onChange={(e) => setTheme(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <label className="flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={theme === 'dark'}
+                        onChange={(e) => setTheme(e.target.checked ? 'dark' : 'light')}
+                        className="mr-2"
+                        aria-label="Dark theme"
+                    />
+                    <span className="text-ubt-grey">Dark theme</span>
+                </label>
+                <label className="flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={sound}
+                        onChange={(e) => setSound(e.target.checked)}
+                        className="mr-2"
+                        aria-label="Sound effects"
+                    />
+                    <span className="text-ubt-grey">Sound effects</span>
+                </label>
+                <label className="flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={motion}
+                        onChange={(e) => setMotion(e.target.checked)}
+                        className="mr-2"
+                        aria-label="Reduced motion"
+                    />
+                    <span className="text-ubt-grey">Reduced motion</span>
+                </label>
+                <button
+                    type="button"
+                    onClick={resetApps}
+                    className="mt-2 px-3 py-1 bg-ubt-green text-black rounded"
                 >
-                    <option value="dark">Dark</option>
-                    <option value="light">Light</option>
-                </select>
+                    Reset apps
+                </button>
+                {toast && (
+                    <div role="status" className="mt-2 text-ubt-grey">
+                        {toast}
+                    </div>
+                )}
+            </div>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {


### PR DESCRIPTION
## Summary
- add theme, sound effects, and reduced motion toggles to Settings
- allow clearing all app state with Reset apps button and toast
- test persistence of toggles and reset behavior

## Testing
- `yarn test settings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae71c1502c8328b8993b5ebbba63e7