### PR TITLE
feat: add local project gallery with search and tags

### DIFF
--- a/__tests__/projectGallery.test.tsx
+++ b/__tests__/projectGallery.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProjectGallery from '../components/apps/project-gallery';
+
+jest.mock('react-ga4', () => ({ event: jest.fn() }));
+
+describe('ProjectGallery', () => {
+  it('search narrows items', async () => {
+    render(<ProjectGallery />);
+    expect(screen.getAllByTestId('project-card')).toHaveLength(3);
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'Beta');
+    expect(screen.getAllByTestId('project-card')).toHaveLength(1);
+    expect(screen.getByText(/Beta Build/i)).toBeInTheDocument();
+  });
+
+  it('tag selection filters cards', async () => {
+    render(<ProjectGallery />);
+    await userEvent.click(screen.getByRole('button', { name: 'Vue' }));
+    expect(screen.getAllByTestId('project-card')).toHaveLength(1);
+    expect(screen.getByText(/Beta Build/i)).toBeInTheDocument();
+  });
+});

--- a/components/apps/project-gallery/projects.json
+++ b/components/apps/project-gallery/projects.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Alpha Project",
+    "description": "First example project.",
+    "image": "https://placehold.co/600x400?text=Alpha",
+    "tech": ["React", "Node"],
+    "live": "https://alpha.example.com",
+    "repo": "https://github.com/example/alpha"
+  },
+  {
+    "title": "Beta Build",
+    "description": "Second example project.",
+    "image": "https://placehold.co/600x400?text=Beta",
+    "tech": ["Vue", "Django"],
+    "live": "https://beta.example.com",
+    "repo": "https://github.com/example/beta"
+  },
+  {
+    "title": "Gamma Gadget",
+    "description": "Third example project.",
+    "image": "https://placehold.co/600x400?text=Gamma",
+    "tech": ["React", "Django"],
+    "live": "https://gamma.example.com",
+    "repo": "https://github.com/example/gamma"
+  }
+]


### PR DESCRIPTION
## Summary
- load project data from local JSON instead of GitHub API
- add fuzzy search input and tag filtering UI for project cards
- test gallery search and tag filter behaviors

## Testing
- `yarn test __tests__/projectGallery.test.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae71c434d08328862edf8b98cb2eb1