### PR TITLE
feat: add contact form app

### DIFF
--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Contact from '../components/apps/contact';
+
+describe('Contact app', () => {
+  beforeEach(() => {
+    (navigator as any).clipboard = { writeText: jest.fn() };
+    (window as any).open = jest.fn();
+  });
+
+  it('blocks invalid email', () => {
+    render(<Contact />);
+    fireEvent.change(screen.getByLabelText('name'), { target: { value: 'Alex' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'invalid' } });
+    fireEvent.change(screen.getByLabelText('message'), { target: { value: 'Hi' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect((navigator as any).clipboard.writeText).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Message copied to clipboard!/i)).not.toBeInTheDocument();
+  });
+
+  it('copies full message on success', () => {
+    render(<Contact />);
+    fireEvent.change(screen.getByLabelText('name'), { target: { value: 'Alex' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'alex@example.com' } });
+    fireEvent.change(screen.getByLabelText('message'), { target: { value: 'Hello there' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    const expected = 'Name: Alex\nEmail: alex@example.com\n\nHello there';
+    expect((navigator as any).clipboard.writeText).toHaveBeenCalledWith(expected);
+    expect(screen.getByText(/Message copied to clipboard!/i)).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -21,6 +21,7 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 import { displayNikto } from './components/apps/nikto';
+import { displayContact } from './components/apps/contact';
 
 const createDynamicApp = (path, name) =>
   dynamic(
@@ -622,6 +623,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'contact',
+    title: 'Contact',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayContact,
   },
   {
     id: 'wireshark',

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+
+const CONTACT_EMAIL = 'alex.j.unnippillil@gmail.com';
+
+const Contact = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !email || !message) {
+      setError('All fields are required');
+      setSuccess(false);
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError('Invalid email');
+      setSuccess(false);
+      return;
+    }
+    setError('');
+    const full = `Name: ${name}\nEmail: ${email}\n\n${message}`;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(full);
+    }
+    const mailto = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+      `Message from ${name}`
+    )}&body=${encodeURIComponent(full)}`;
+    window.open(mailto);
+    setSuccess(true);
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-ub-cool-grey text-white flex flex-col gap-2">
+      {revealed ? (
+        <div data-testid="contact-email" className="text-sm">{CONTACT_EMAIL}</div>
+      ) : (
+        <button
+          data-testid="reveal-email"
+          className="underline text-sm self-start"
+          onClick={() => setRevealed(true)}
+        >
+          Reveal Email
+        </button>
+      )}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 flex-1">
+        <input
+          aria-label="name"
+          placeholder="Name"
+          className="p-2 rounded text-black"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          aria-label="email"
+          placeholder="Email"
+          className="p-2 rounded text-black"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <textarea
+          aria-label="message"
+          placeholder="Message"
+          className="p-2 rounded text-black flex-1"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-ub-orange text-black rounded p-2 mt-2 self-start"
+        >
+          Send
+        </button>
+      </form>
+      {error && (
+        <div role="alert" className="text-red-500 text-sm">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div role="status" className="text-green-500 text-sm">
+          Message copied to clipboard!
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Contact;
+
+export const displayContact = () => <Contact />;
+


### PR DESCRIPTION
## Summary
- add contact form with name, email, and message fields
- copy submissions to clipboard, open mailto link, and hide email until revealed
- test invalid email handling and successful copy

## Testing
- `yarn test contact`


------
https://chatgpt.com/codex/tasks/task_e_68ae71c78eb483288238ee889a959425