### PR TITLE
feat: add QR generator and scanner tabs

### DIFF
--- a/__tests__/qr_tool.test.ts
+++ b/__tests__/qr_tool.test.ts
@@ -1,0 +1,39 @@
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder as any;
+global.TextDecoder = TextDecoder as any;
+
+import { generateDataUrl, decodeImageData } from '../components/apps/qr_tool/utils';
+import QRCode from 'qrcode';
+
+describe('QR Tool', () => {
+  it('generating returns data URL', async () => {
+    const url = await generateDataUrl('hello');
+    expect(url.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  it('scanner decodes sample frame', () => {
+    const qr = QRCode.create('sample');
+    const border = 4;
+    const scale = 4;
+    const size = qr.modules.size;
+    const width = (size + border * 2) * scale;
+    const data = new Uint8ClampedArray(width * width * 4).fill(255);
+    for (let y = 0; y < size; y += 1) {
+      for (let x = 0; x < size; x += 1) {
+        const val = qr.modules.get(x, y) ? 0 : 255;
+        for (let dy = 0; dy < scale; dy += 1) {
+          for (let dx = 0; dx < scale; dx += 1) {
+            const idx =
+              (((y + border) * scale + dy) * width + ((x + border) * scale + dx)) * 4;
+            data[idx] = val;
+            data[idx + 1] = val;
+            data[idx + 2] = val;
+            data[idx + 3] = 255;
+          }
+        }
+      }
+    }
+    const imageData = { data, width, height: width };
+    expect(decodeImageData(imageData)).toBe('sample');
+  });
+});

--- a/components/apps/qr_tool/Generate.js
+++ b/components/apps/qr_tool/Generate.js
@@ -1,0 +1,56 @@
+import React, { useRef, useState } from 'react';
+import QRCode from 'qrcode';
+
+const Generate = () => {
+  const [text, setText] = useState('');
+  const canvasRef = useRef(null);
+
+  const handleGenerate = async () => {
+    if (!text) return;
+    try {
+      await QRCode.toCanvas(canvasRef.current, text, { width: 256 });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDownload = () => {
+    const link = document.createElement('a');
+    link.download = 'qr.png';
+    link.href = canvasRef.current.toDataURL('image/png');
+    link.click();
+  };
+
+  return (
+    <div className="mb-6">
+      <h2 className="text-lg mb-2">Generate QR Code</h2>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className="w-full p-2 mb-2 rounded text-black"
+        placeholder="Enter text"
+        aria-label="Text to encode"
+      />
+      <div className="flex space-x-2 mb-2">
+        <button
+          onClick={handleGenerate}
+          className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+          aria-label="Generate QR code"
+        >
+          Generate
+        </button>
+        <button
+          onClick={handleDownload}
+          className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded text-white"
+          aria-label="Download QR code"
+        >
+          Download
+        </button>
+      </div>
+      <canvas ref={canvasRef} className="bg-white w-full h-full" />
+    </div>
+  );
+};
+
+export default Generate;

--- a/components/apps/qr_tool/Scan.js
+++ b/components/apps/qr_tool/Scan.js
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { decodeImageData } from './utils';
+
+const isSecure = () =>
+  typeof window !== 'undefined' &&
+  (window.location.protocol === 'https:' ||
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1');
+
+const Scan = () => {
+  const [decodedText, setDecodedText] = useState('');
+  const [message, setMessage] = useState('');
+  const [paused, setPaused] = useState(true);
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const animationRef = useRef(null);
+
+  const scan = () => {
+    if (paused || !videoRef.current || !canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    canvas.width = videoRef.current.videoWidth;
+    canvas.height = videoRef.current.videoHeight;
+    ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const code = decodeImageData(imageData);
+    if (code) {
+      setDecodedText(code);
+    }
+    animationRef.current = requestAnimationFrame(scan);
+  };
+
+  const startCamera = async () => {
+    if (!isSecure()) {
+      setMessage('Camera requires HTTPS or localhost');
+      return;
+    }
+    try {
+      setMessage('Requesting camera permission...');
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+      });
+      videoRef.current.srcObject = stream;
+      await videoRef.current.play();
+      setMessage('Place the QR code within the square');
+      setPaused(false);
+      scan();
+    } catch (err) {
+      setMessage('Camera permission denied or unavailable');
+    }
+  };
+
+  const pause = () => {
+    setPaused(true);
+    if (animationRef.current) cancelAnimationFrame(animationRef.current);
+  };
+
+  const resume = () => {
+    if (!paused) return;
+    setPaused(false);
+    scan();
+  };
+
+  const stop = () => {
+    pause();
+    const stream = videoRef.current?.srcObject;
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop());
+      videoRef.current.srcObject = null;
+    }
+    setMessage('');
+  };
+
+  useEffect(() => () => stop(), []);
+
+  return (
+    <div>
+      <h2 className="text-lg mb-2">Scan QR Code</h2>
+      <div className="flex space-x-2 mb-2">
+        <button
+          onClick={startCamera}
+          className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+          aria-label="Start camera for scanning"
+        >
+          Start
+        </button>
+        <button
+          onClick={pause}
+          disabled={paused}
+          className="px-4 py-2 bg-yellow-700 hover:bg-yellow-600 rounded text-white disabled:opacity-50"
+          aria-label="Pause scanning"
+        >
+          Pause
+        </button>
+        <button
+          onClick={resume}
+          disabled={!paused}
+          className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded text-white disabled:opacity-50"
+          aria-label="Resume scanning"
+        >
+          Resume
+        </button>
+        <button
+          onClick={stop}
+          className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-white"
+          aria-label="Stop camera"
+        >
+          Stop
+        </button>
+      </div>
+      <div className="relative w-64 h-64 bg-black">
+        <video ref={videoRef} className="w-full h-full object-cover" aria-label="Camera preview" />
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="w-40 h-40 border-2 border-green-500" />
+        </div>
+      </div>
+      {message && <p className="mt-2">{message}</p>}
+      {decodedText && <p className="mt-2 break-all">Decoded: {decodedText}</p>}
+      <canvas ref={canvasRef} className="hidden" />
+    </div>
+  );
+};
+
+export default Scan;

--- a/components/apps/qr_tool/index.js
+++ b/components/apps/qr_tool/index.js
@@ -1,165 +1,29 @@
-import React, { useEffect, useRef, useState } from 'react';
-import QRCode from 'qrcode';
-import jsQR from 'jsqr';
+import React, { useState } from 'react';
+import Generate from './Generate';
+import Scan from './Scan';
 
 const QRTool = () => {
-  const [text, setText] = useState('');
-  const [decodedText, setDecodedText] = useState('');
-  const [message, setMessage] = useState('');
-  const generateCanvasRef = useRef(null);
-  const scanCanvasRef = useRef(null);
-  const videoRef = useRef(null);
-  const animationRef = useRef(null);
-
-  const generate = () => {
-    if (!text) return;
-    QRCode.toCanvas(generateCanvasRef.current, text, { width: 256 }, (err) => {
-      if (err) console.error(err);
-    });
-  };
-
-  const download = () => {
-    const link = document.createElement('a');
-    link.download = 'qr.png';
-    link.href = generateCanvasRef.current.toDataURL('image/png');
-    link.click();
-  };
-
-  const handleFile = async (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-    const img = new Image();
-    img.onload = () => {
-      const canvas = scanCanvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = img.width;
-      canvas.height = img.height;
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const code = jsQR(imageData.data, imageData.width, imageData.height);
-      setDecodedText(code ? code.data : 'No QR code found');
-    };
-    img.onerror = () => setDecodedText('Could not load image');
-    img.src = URL.createObjectURL(file);
-  };
-
-  const scan = () => {
-    if (videoRef.current && scanCanvasRef.current) {
-      const canvas = scanCanvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = videoRef.current.videoWidth;
-      canvas.height = videoRef.current.videoHeight;
-      ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const code = jsQR(imageData.data, imageData.width, imageData.height);
-      if (code) {
-        setDecodedText(code.data);
-      }
-    }
-    animationRef.current = requestAnimationFrame(scan);
-  };
-
-  const startCamera = async () => {
-    try {
-      setMessage('Requesting camera permission...');
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: { facingMode: 'environment' },
-      });
-      videoRef.current.srcObject = stream;
-      await videoRef.current.play();
-      setMessage('Place the QR code within the square');
-      scan();
-    } catch (err) {
-      setMessage('Camera permission denied or unavailable');
-    }
-  };
-
-  const stopCamera = () => {
-    const stream = videoRef.current?.srcObject;
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop());
-      videoRef.current.srcObject = null;
-    }
-    if (animationRef.current) cancelAnimationFrame(animationRef.current);
-    setMessage('');
-  };
-
-  useEffect(() => {
-    return () => {
-      stopCamera();
-    };
-  }, []);
+  const [tab, setTab] = useState('generate');
 
   return (
     <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto">
-      <div className="mb-6">
-        <h2 className="text-lg mb-2">Generate QR Code</h2>
-        <input
-          type="text"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          className="w-full p-2 mb-2 rounded text-black"
-          placeholder="Enter text"
-          aria-label="Text to encode"
-        />
-        <div className="flex space-x-2 mb-2">
-          <button
-            onClick={generate}
-            className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
-            aria-label="Generate QR code"
-          >
-            Generate
-          </button>
-          <button
-            onClick={download}
-            className="px-4 py-2 bg-green-700 hover:bg-green-600 rounded text-white"
-            aria-label="Download QR code"
-          >
-            Download
-          </button>
-        </div>
-        <canvas ref={generateCanvasRef} className="bg-white w-full h-full" />
-
+      <div className="flex space-x-2 mb-4">
+        <button
+          onClick={() => setTab('generate')}
+          className={`px-4 py-2 rounded ${tab === 'generate' ? 'bg-blue-700' : 'bg-gray-700 hover:bg-gray-600'}`}
+        >
+          Generate
+        </button>
+        <button
+          onClick={() => setTab('scan')}
+          className={`px-4 py-2 rounded ${tab === 'scan' ? 'bg-blue-700' : 'bg-gray-700 hover:bg-gray-600'}`}
+        >
+          Scan
+        </button>
       </div>
-
-      <div>
-        <h2 className="text-lg mb-2">Scan QR Code</h2>
-        <input type="file" accept="image/*" onChange={handleFile} className="mb-2" aria-label="Upload image to scan" />
-        <div className="flex space-x-2 mb-2">
-          <button
-            onClick={startCamera}
-            className="px-4 py-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
-            aria-label="Start camera for scanning"
-          >
-            Start Camera
-          </button>
-          <button
-            onClick={stopCamera}
-            className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-white"
-            aria-label="Stop camera"
-          >
-            Stop Camera
-          </button>
-        </div>
-        <div className="relative w-64 h-64 bg-black">
-          <video ref={videoRef} className="w-full h-full object-cover" aria-label="Camera preview" />
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <div className="w-40 h-40 border-2 border-green-500" />
-          </div>
-        </div>
-        {message && <p className="mt-2">{message}</p>}
-        {decodedText && (
-          <p className="mt-2 break-all">Decoded: {decodedText}</p>
-        )}
-        <canvas ref={scanCanvasRef} className="hidden" />
-      </div>
+      {tab === 'generate' ? <Generate /> : <Scan />}
     </div>
   );
 };
 
 export default QRTool;
-
-export const displayQrTool = () => {
-  return <QRTool />;
-};
-

--- a/components/apps/qr_tool/utils.js
+++ b/components/apps/qr_tool/utils.js
@@ -1,0 +1,12 @@
+import QRCode from 'qrcode';
+import jsQR from 'jsqr';
+
+export const generateDataUrl = (text) => {
+  if (!text) return Promise.resolve('');
+  return QRCode.toDataURL(text);
+};
+
+export const decodeImageData = (imageData) => {
+  const code = jsQR(imageData.data, imageData.width, imageData.height);
+  return code ? code.data : '';
+};


### PR DESCRIPTION
## Summary
- split QR tool into Generate and Scan tabs
- enable QR code canvas download and camera scanning with pause/resume
- add utilities and tests for QR generation and decoding

## Testing
- `npm test __tests__/qr_tool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae71c875a08328ae19ce7b953c780b