### PR TITLE
Add seedable quote generator with deterministic tests

### DIFF
--- a/__tests__/quoteGenerator.test.tsx
+++ b/__tests__/quoteGenerator.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import QuoteGenerator from '../components/apps/quote_generator';
+
+describe('QuoteGenerator', () => {
+  const sequenceForSeed = async (seed: string) => {
+    const { getByText, getByPlaceholderText, getByTestId, unmount } = render(
+      <QuoteGenerator />
+    );
+    fireEvent.change(getByPlaceholderText('Seed'), { target: { value: seed } });
+    await waitFor(() => {
+      expect(getByTestId('quote-content').textContent).toBeTruthy();
+    });
+    const seq: (string | null)[] = [];
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(getByText('New Quote'));
+      seq.push(getByTestId('quote-content').textContent);
+    }
+    unmount();
+    return seq;
+  };
+
+  it('produces same sequence for same seed', async () => {
+    const a = await sequenceForSeed('test-seed');
+    const b = await sequenceForSeed('test-seed');
+    expect(b).toEqual(a);
+  });
+
+  it('copies quote to clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    // @ts-ignore
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { getByText, getByPlaceholderText, getByTestId } = render(<QuoteGenerator />);
+    fireEvent.change(getByPlaceholderText('Seed'), { target: { value: 'copy' } });
+    await waitFor(() => {
+      expect(getByTestId('quote-content').textContent).toBeTruthy();
+    });
+    const quote = getByTestId('quote-content').textContent || '';
+    const author = getByTestId('quote-author').textContent || '';
+    fireEvent.click(getByText('Copy'));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(`${quote} ${author}`.trim());
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- load quotes from bundled JSON instead of fetching
- select quotes via seedable PRNG with user-provided seed input
- expose tag filtering with copy and Tweet actions
- add tests for deterministic sequence and clipboard copy

## Testing
- `yarn test __tests__/quoteGenerator.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae71ca6a6c83289ab1ace15dc5c4d2