### PR TITLE
feat: share ExternalFrame with registry and CI mocks

### DIFF
--- a/apps.ts
+++ b/apps.ts
@@ -1,0 +1,41 @@
+export interface AppInfo {
+  title: string;
+  icon: string;
+  type: string;
+  url: string;
+}
+
+const apps: Record<string, AppInfo> = {
+  vscode: {
+    title: 'Visual Studio Code',
+    icon: './themes/Yaru/apps/vscode.png',
+    type: 'external',
+    url: 'https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md',
+  },
+  chrome: {
+    title: 'Google Chrome',
+    icon: './themes/Yaru/apps/chrome.png',
+    type: 'external',
+    url: 'https://www.google.com/webhp?igu=1',
+  },
+  spotify: {
+    title: 'Spotify',
+    icon: './themes/Yaru/apps/spotify.svg',
+    type: 'external',
+    url: 'https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0',
+  },
+  todoist: {
+    title: 'Todoist',
+    icon: './themes/Yaru/apps/todoist.png',
+    type: 'external',
+    url: 'https://todoist.com/showProject?id=220474322',
+  },
+  ghidra: {
+    title: 'Ghidra',
+    icon: './themes/Yaru/apps/ghidra.svg',
+    type: 'external',
+    url: 'https://ghidra.app',
+  },
+};
+
+export default apps;

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
+          Failed to load.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import apps from '../apps';
+
+const ExternalFrame = React.forwardRef(({ appId, src, title, className = 'h-full w-full', ...props }, ref) => {
+  const app = appId ? apps[appId] : null;
+  const frameSrc = src || (app ? app.url : undefined);
+  const frameTitle = title || (app ? app.title : undefined);
+
+  return <iframe ref={ref} src={frameSrc} title={frameTitle} className={className} frameBorder="0" {...props} />;
+});
+
+ExternalFrame.displayName = 'ExternalFrame';
+
+export default ExternalFrame;

--- a/components/LazyGitHubButton.js
+++ b/components/LazyGitHubButton.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ExternalFrame from './ExternalFrame';
+import ErrorBoundary from './ErrorBoundary';
 
 const LazyGitHubButton = ({ user, repo }) => {
   const ref = useRef(null);
@@ -22,14 +24,16 @@ const LazyGitHubButton = ({ user, repo }) => {
   return (
     <div ref={ref} className="inline-block">
       {visible ? (
-        <iframe
-          src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
-          frameBorder="0"
-          scrolling="0"
-          width="150"
-          height="20"
-          title={`${repo}-star`}
-        ></iframe>
+        <ErrorBoundary>
+          <ExternalFrame
+            src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
+            frameBorder="0"
+            scrolling="0"
+            width="150"
+            height="20"
+            title={`${repo}-star`}
+          />
+        </ErrorBoundary>
       ) : (
         <div className="h-5 w-24 bg-gray-200 animate-pulse rounded"></div>
       )}

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export class Chrome extends Component {
     constructor() {
@@ -86,7 +88,15 @@ export class Chrome extends Component {
         return (
             <div className="h-full w-full flex flex-col bg-ub-cool-grey">
                 {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
+                <ErrorBoundary>
+                    <ExternalFrame
+                        appId="chrome"
+                        src={this.state.url}
+                        className="flex-grow"
+                        id="chrome-screen"
+                        title="Ubuntu Chrome Url"
+                    />
+                </ErrorBoundary>
             </div>
         )
     }

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import ExternalFrame from '../../ExternalFrame';
+import ErrorBoundary from '../../ErrorBoundary';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
@@ -23,12 +25,14 @@ export default function GhidraApp() {
   if (useRemote) {
     const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
     return (
-      <iframe
-        src={remoteUrl}
-        className="w-full h-full bg-ub-cool-grey"
-        frameBorder="0"
-        title="Ghidra"
-      />
+      <ErrorBoundary>
+        <ExternalFrame
+          appId="ghidra"
+          src={remoteUrl}
+          className="w-full h-full bg-ub-cool-grey"
+          title="Ghidra"
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../usePersistentState';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 const Platformer = () => {
   const [levels, setLevels] = useState([]);
@@ -36,13 +38,14 @@ const Platformer = () => {
   }`;
 
   return (
-    <iframe
-      ref={frameRef}
-      src={src}
-      title="Platformer"
-      className="w-full h-full"
-      frameBorder="0"
-    ></iframe>
+    <ErrorBoundary>
+      <ExternalFrame
+        ref={frameRef}
+        src={src}
+        title="Platformer"
+        className="w-full h-full"
+      />
+    </ErrorBoundary>
   );
 };
 

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,20 +1,18 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export default function SpotifyApp() {
   return (
-    <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
-        src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
-        title="Daily Mix 2"
-        width="100%"
-        height="100%"
-        frameBorder="0"
+    <ErrorBoundary>
+      <ExternalFrame
+        appId="spotify"
+        className="h-full w-full bg-ub-cool-grey"
         allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
         loading="lazy"
       />
-    </div>
+    </ErrorBoundary>
   );
 }
 
 export const displaySpotify = () => <SpotifyApp />;
-

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,8 +1,12 @@
 import React from 'react'
+import ExternalFrame from '../ExternalFrame'
+import ErrorBoundary from '../ErrorBoundary'
 
 export default function Todoist() {
     return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
+        <ErrorBoundary>
+            <ExternalFrame appId="todoist" className="h-full w-full" />
+        </ErrorBoundary>
         // just to bypass the headers 🙃
     )
 }

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,15 +1,17 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
+import ErrorBoundary from '../ErrorBoundary';
 
 export default function VsCode() {
     return (
-        <iframe
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-        ></iframe>
+        <ErrorBoundary>
+            <ExternalFrame
+                appId="vscode"
+                className="h-full w-full bg-ub-cool-grey"
+                allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
+                allowFullScreen
+            />
+        </ErrorBoundary>
     );
 }
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -111,3 +111,24 @@ jest.mock(
   }),
   { virtual: true }
 );
+
+// Mock analytics and audio libraries for headless CI
+jest.mock('react-ga4', () => ({
+  send: jest.fn(),
+  event: jest.fn(),
+}));
+
+jest.mock('howler', () => ({
+  Howl: class {
+    constructor() {}
+    play() {}
+    pause() {}
+    stop() {}
+    on() {}
+    off() {}
+  },
+  Howler: {
+    mute: () => {},
+    volume: () => {},
+  },
+}));


### PR DESCRIPTION
## Summary
- add central `apps.ts` registry for external apps and allowlisted URLs
- introduce `ExternalFrame` and `ErrorBoundary` components and replace raw iframes
- mock analytics and audio libs in Jest for headless CI

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae71d2c4ac8328a9fcbeffd4204cb7