### PR TITLE
feat: add game shell and virtual controls

### DIFF
--- a/__tests__/gameShell.test.tsx
+++ b/__tests__/gameShell.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, fireEvent, act, cleanup } from '@testing-library/react';
+import GameShell from '../components/GameShell';
+import VirtualControls from '../components/VirtualControls';
+
+afterEach(() => {
+  window.localStorage.clear();
+  cleanup();
+});
+
+describe('GameShell pause/resume', () => {
+  it('toggles pause state and disables interaction', () => {
+    const { getByTestId } = render(
+      <GameShell gameKey="test">
+        <div>game</div>
+      </GameShell>
+    );
+
+    fireEvent.click(getByTestId('pause-btn'));
+    expect(getByTestId('game-container')).toHaveClass('pointer-events-none');
+
+    fireEvent.click(getByTestId('resume-btn'));
+    expect(getByTestId('game-container')).not.toHaveClass('pointer-events-none');
+  });
+});
+
+describe('GameShell settings persistence', () => {
+  it('persists settings to localStorage', () => {
+    const { getByTestId, unmount } = render(
+      <GameShell gameKey="persist">
+        <div />
+      </GameShell>
+    );
+
+    fireEvent.click(getByTestId('settings-btn'));
+    fireEvent.change(getByTestId('difficulty-select'), { target: { value: 'hard' } });
+    fireEvent.click(getByTestId('close-settings'));
+
+    unmount();
+
+    const { getByTestId: getByTestId2 } = render(
+      <GameShell gameKey="persist">
+        <div />
+      </GameShell>
+    );
+
+    fireEvent.click(getByTestId2('settings-btn'));
+    expect(getByTestId2('difficulty-select')).toHaveValue('hard');
+  });
+});
+
+describe('VirtualControls auto-hide', () => {
+  it('hides after inactivity', () => {
+    jest.useFakeTimers();
+    const { queryByTestId } = render(<VirtualControls />);
+
+    // show controls
+    act(() => {
+      window.dispatchEvent(new Event('pointerdown'));
+    });
+    expect(queryByTestId('virtual-controls')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3100);
+    });
+
+    expect(queryByTestId('virtual-controls')).toBeNull();
+    jest.useRealTimers();
+  });
+});

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import Phaser from 'phaser';
+import GameShell from '../../components/GameShell';
 
 const PhaserMatter: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -65,7 +66,11 @@ const PhaserMatter: React.FC = () => {
     };
   }, []);
 
-  return <div ref={containerRef} />;
+  return (
+    <GameShell gameKey="phaser">
+      <div ref={containerRef} />
+    </GameShell>
+  );
 };
 
 export default PhaserMatter;

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { logEvent, logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
+import GameShell from '../../components/GameShell';
 import { defaultLevels, parseLevels } from './levels';
 import {
   loadLevel,
@@ -140,10 +141,11 @@ const Sokoban: React.FC = () => {
   } as React.CSSProperties;
 
   return (
-    <div className="p-4 space-y-2 select-none">
-      <div className="flex space-x-2 mb-2">
-        <select value={index} onChange={(e) => selectLevel(Number(e.target.value))}>
-          {levels.map((_, i) => (
+    <GameShell gameKey="sokoban">
+      <div className="p-4 space-y-2 select-none">
+        <div className="flex space-x-2 mb-2">
+          <select value={index} onChange={(e) => selectLevel(Number(e.target.value))}>
+            {levels.map((_, i) => (
             <option key={i} value={i}>{`Level ${i + 1}`}</option>
           ))}
         </select>
@@ -209,7 +211,7 @@ const Sokoban: React.FC = () => {
           }}
         />
       </div>
-    </div>
+    </GameShell>
   );
 };
 

--- a/components/GameShell.tsx
+++ b/components/GameShell.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect } from 'react';
+import usePause from '../hooks/usePause';
+import useGameSettings from '../hooks/useGameSettings';
+import useFTUE from '../hooks/useFTUE';
+import VirtualControls from './VirtualControls';
+
+interface GameShellProps {
+  gameKey: string;
+  onSave?: () => any;
+  onLoad?: (data: any) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Generic wrapper providing pause/resume, settings and overlays for games.
+ */
+const GameShell: React.FC<GameShellProps> = ({
+  gameKey,
+  onSave,
+  onLoad,
+  children,
+}) => {
+  const { paused, pause, resume } = usePause(() => {
+    if (onSave) {
+      const data = onSave();
+      try {
+        window.localStorage.setItem(`${gameKey}-save`, JSON.stringify(data));
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  useEffect(() => {
+    if (onLoad) {
+      try {
+        const raw = window.localStorage.getItem(`${gameKey}-save`);
+        if (raw) onLoad(JSON.parse(raw));
+      } catch {
+        // ignore
+      }
+    }
+  }, [gameKey, onLoad]);
+
+  const { settings, update } = useGameSettings(gameKey);
+  const { showFTUE, dismissFTUE } = useFTUE(gameKey);
+
+  return (
+    <div className={`relative ${settings.highContrast ? 'contrast-150' : ''}`}> 
+      {showFTUE && (
+        <div className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-20" data-testid="ftue">
+          <div className="text-center space-y-2">
+            <p>Tap to start!</p>
+            <button onClick={dismissFTUE}>Start</button>
+          </div>
+        </div>
+      )}
+
+      <div
+        data-testid="game-container"
+        className={paused ? 'opacity-50 pointer-events-none' : ''}
+      >
+        {children}
+      </div>
+
+      <div className="absolute top-2 right-2 space-x-2 z-30">
+        {paused ? (
+          <button onClick={resume} data-testid="resume-btn">
+            Resume
+          </button>
+        ) : (
+          <button onClick={pause} data-testid="pause-btn">
+            Pause
+          </button>
+        )}
+        <button
+          onClick={() => update({ showSettings: true })}
+          data-testid="settings-btn"
+        >
+          ⚙
+        </button>
+      </div>
+
+      {settings.showSettings && (
+        <div
+          className="absolute inset-0 bg-white bg-opacity-90 flex flex-col p-4 space-y-2 z-40"
+          data-testid="settings-panel"
+        >
+          <label>
+            Difficulty
+            <select
+              value={settings.difficulty}
+              onChange={(e) => update({ difficulty: e.target.value as any })}
+              data-testid="difficulty-select"
+            >
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="hard">Hard</option>
+            </select>
+          </label>
+          <label>
+            Assist
+            <input
+              type="checkbox"
+              checked={settings.assist}
+              onChange={(e) => update({ assist: e.target.checked })}
+              data-testid="assist-toggle"
+            />
+          </label>
+          <label>
+            Quality
+            <input
+              type="range"
+              min={1}
+              max={3}
+              value={settings.quality}
+              onChange={(e) => update({ quality: Number(e.target.value) })}
+              data-testid="quality-slider"
+            />
+          </label>
+          <label>
+            High Contrast
+            <input
+              type="checkbox"
+              checked={settings.highContrast}
+              onChange={(e) => update({ highContrast: e.target.checked })}
+              data-testid="contrast-toggle"
+            />
+          </label>
+          <button
+            onClick={() => update({ showSettings: false })}
+            data-testid="close-settings"
+          >
+            Close
+          </button>
+        </div>
+      )}
+
+      <VirtualControls />
+    </div>
+  );
+};
+
+export default GameShell;

--- a/components/VirtualControls.tsx
+++ b/components/VirtualControls.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react';
+import { useVirtualControls } from '../hooks/useVirtualControls';
+
+interface Props {
+  onInput?: (dir: string) => void;
+  timeout?: number;
+}
+
+/**
+ * On-screen directional controls for touch devices. Automatically hides when
+ * inactive and reappears on user interaction.
+ */
+const VirtualControls: React.FC<Props> = ({ onInput, timeout }) => {
+  const { visible, show } = useVirtualControls(timeout);
+
+  useEffect(() => {
+    const handler = () => show();
+    window.addEventListener('pointerdown', handler);
+    return () => window.removeEventListener('pointerdown', handler);
+  }, [show]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="virtual-controls fixed bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2"
+      data-testid="virtual-controls"
+    >
+      <button onClick={() => onInput?.('left')} aria-label="left">
+        ←
+      </button>
+      <button onClick={() => onInput?.('up')} aria-label="up">
+        ↑
+      </button>
+      <button onClick={() => onInput?.('down')} aria-label="down">
+        ↓
+      </button>
+      <button onClick={() => onInput?.('right')} aria-label="right">
+        →
+      </button>
+    </div>
+  );
+};
+
+export default VirtualControls;

--- a/hooks/useFTUE.ts
+++ b/hooks/useFTUE.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+/**
+ * Simple First Time User Experience hook. Shows overlay until dismissed once.
+ */
+export function useFTUE(key: string) {
+  const storageKey = `ftue-${key}`;
+  const [seen, setSeen] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.localStorage.getItem(storageKey) === '1';
+  });
+
+  const showFTUE = !seen;
+  const dismissFTUE = () => {
+    setSeen(true);
+    try {
+      window.localStorage.setItem(storageKey, '1');
+    } catch {
+      // ignore
+    }
+  };
+
+  return { showFTUE, dismissFTUE } as const;
+}
+
+export default useFTUE;

--- a/hooks/useGameSettings.ts
+++ b/hooks/useGameSettings.ts
@@ -1,0 +1,35 @@
+import usePersistentState from './usePersistentState';
+
+export interface GameSettings {
+  difficulty: 'easy' | 'medium' | 'hard';
+  assist: boolean;
+  quality: number;
+  highContrast: boolean;
+  showSettings: boolean;
+}
+
+const defaultSettings: GameSettings = {
+  difficulty: 'easy',
+  assist: false,
+  quality: 1,
+  highContrast: false,
+  showSettings: false,
+};
+
+/**
+ * Persisted game settings including difficulty, assists and visual options.
+ * Uses `usePersistentState` under the hood.
+ */
+export function useGameSettings(key: string) {
+  const [settings, setSettings] = usePersistentState<GameSettings>(
+    `game-settings-${key}`,
+    defaultSettings,
+  );
+
+  const update = (partial: Partial<GameSettings>) =>
+    setSettings({ ...settings, ...partial });
+
+  return { settings, update } as const;
+}
+
+export default useGameSettings;

--- a/hooks/usePause.ts
+++ b/hooks/usePause.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback, useEffect } from 'react';
+
+/**
+ * Manage paused state for a game. Automatically pauses when the document
+ * becomes hidden. Exposes pause and resume callbacks.
+ */
+export function usePause(onPause?: () => void, onResume?: () => void) {
+  const [paused, setPaused] = useState(false);
+
+  const pause = useCallback(() => {
+    setPaused(true);
+    onPause?.();
+  }, [onPause]);
+
+  const resume = useCallback(() => {
+    setPaused(false);
+    onResume?.();
+  }, [onResume]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) {
+        pause();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [pause]);
+
+  return { paused, pause, resume };
+}
+
+export default usePause;

--- a/hooks/useVirtualControls.ts
+++ b/hooks/useVirtualControls.ts
@@ -1,0 +1,30 @@
+import { useState, useRef, useEffect } from 'react';
+
+/**
+ * Handles visibility of virtual controls with auto-hide timeout.
+ */
+export function useVirtualControls(timeout = 3000) {
+  const [visible, setVisible] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    setVisible(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setVisible(false), timeout);
+  };
+
+  const hide = () => {
+    if (timer.current) clearTimeout(timer.current);
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  return { visible, show, hide } as const;
+}
+
+export default useVirtualControls;


### PR DESCRIPTION
## Summary
- add reusable GameShell with pause, settings, FTUE overlay and virtual controls
- implement VirtualControls with auto-hide hook
- integrate GameShell into Phaser and Sokoban apps and add tests

## Testing
- `yarn test __tests__/gameShell.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae71d387a4832897607276fa63f535