### PR TITLE
feat: add daily challenge utilities and replay support

### DIFF
--- a/__tests__/dailyLeaderboard.test.ts
+++ b/__tests__/dailyLeaderboard.test.ts
@@ -1,0 +1,23 @@
+import { getDailySeed, recordScore, getLeaderboard } from '../utils/dailyChallenge';
+
+describe('daily challenge and leaderboard', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('daily seed identical across devices', () => {
+    const seed1 = getDailySeed('hangman', new Date('2024-05-01T00:00:00Z'));
+    const seed2 = getDailySeed('hangman', new Date('2024-05-01T23:59:59Z'));
+    expect(seed1).toBe(seed2);
+  });
+
+  test('leaderboard stored via localStorage', () => {
+    recordScore('hangman', 'Alice', 10);
+    recordScore('hangman', 'Bob', 20);
+    const board = getLeaderboard('hangman');
+    expect(board[0]).toEqual({ name: 'Bob', score: 20 });
+    expect(board[1]).toEqual({ name: 'Alice', score: 10 });
+    const raw = window.localStorage.getItem('leaderboard:hangman');
+    expect(raw && JSON.parse(raw).length).toBe(2);
+  });
+});

--- a/__tests__/replay.test.ts
+++ b/__tests__/replay.test.ts
@@ -1,0 +1,33 @@
+import { createGame, guess } from '../apps/hangman/engine';
+import { Replay } from '../utils/replay';
+
+describe('replay system', () => {
+  test('playback matches recorded run', () => {
+    const recorder = new Replay<string>();
+    recorder.startRecording();
+    const game = createGame('code');
+    ['c', 'o', 'd', 'e'].forEach((l) => {
+      guess(game, l);
+      recorder.record(l);
+    });
+    const playbackGame = createGame('code');
+    recorder.play((l) => {
+      guess(playbackGame, l);
+    });
+    expect(playbackGame).toEqual(game);
+  });
+
+  test('can scrub to intermediate state', () => {
+    const recorder = new Replay<string>();
+    recorder.startRecording();
+    const game = createGame('code');
+    ['c', 'o', 'd', 'e'].forEach((l) => {
+      guess(game, l);
+      recorder.record(l);
+    });
+    const partialGame = createGame('code');
+    const secondEventTime = recorder.getEvents()[1].t;
+    recorder.play((l) => guess(partialGame, l), secondEventTime);
+    expect(partialGame.guessed).toEqual(['c', 'o']);
+  });
+});

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,0 +1,20 @@
+import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+
+describe('theme persistence and unlocking', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('theme persists across sessions', () => {
+    setTheme('dark');
+    expect(getTheme()).toBe('dark');
+    // simulate reload by reading from localStorage again
+    expect(window.localStorage.getItem('app:theme')).toBe('dark');
+  });
+
+  test('themes unlock at score milestones', () => {
+    const unlocked = getUnlockedThemes(600);
+    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).not.toContain('matrix');
+  });
+});

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+
+interface Props {
+  highScore?: number;
+}
+
+const SettingsDrawer = ({ highScore = 0 }: Props) => {
+  const [open, setOpen] = useState(false);
+  const [theme, setThemeState] = useState('default');
+  const unlocked = getUnlockedThemes(highScore);
+
+  useEffect(() => {
+    setThemeState(getTheme());
+  }, []);
+
+  const changeTheme = (t: string) => {
+    setThemeState(t);
+    setTheme(t);
+  };
+
+  return (
+    <div>
+      <button aria-label="settings" onClick={() => setOpen(!open)}>
+        Settings
+      </button>
+      {open && (
+        <div role="dialog">
+          <label>
+            Theme
+            <select
+              aria-label="theme-select"
+              value={theme}
+              onChange={(e) => changeTheme(e.target.value)}
+            >
+              {unlocked.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SettingsDrawer;

--- a/utils/dailyChallenge.ts
+++ b/utils/dailyChallenge.ts
@@ -1,0 +1,63 @@
+export interface LeaderboardEntry {
+  name: string;
+  score: number;
+}
+
+const SEED_PREFIX = 'dailySeed:';
+const LEADERBOARD_PREFIX = 'leaderboard:';
+
+// Simple deterministic hash for string
+const hash = (str: string): string => {
+  let h = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h * 31 + str.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16);
+};
+
+// Generate a daily seed based on UTC date so all devices share the same seed
+export const getDailySeed = (gameId: string, date: Date = new Date()): string => {
+  const day = date.toISOString().split('T')[0];
+  const key = `${gameId}:${day}`;
+  const seed = hash(key);
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(`${SEED_PREFIX}${gameId}`, seed);
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+  return seed;
+};
+
+export const getLeaderboard = (gameId: string): LeaderboardEntry[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(`${LEADERBOARD_PREFIX}${gameId}`);
+    if (!raw) return [];
+    return JSON.parse(raw) as LeaderboardEntry[];
+  } catch {
+    return [];
+  }
+};
+
+export const recordScore = (
+  gameId: string,
+  name: string,
+  score: number,
+  limit = 10
+): LeaderboardEntry[] => {
+  const board = getLeaderboard(gameId);
+  board.push({ name, score });
+  board.sort((a, b) => b.score - a.score);
+  const trimmed = board.slice(0, limit);
+  try {
+    window.localStorage.setItem(
+      `${LEADERBOARD_PREFIX}${gameId}`,
+      JSON.stringify(trimmed)
+    );
+  } catch {
+    /* ignore storage errors */
+  }
+  return trimmed;
+};

--- a/utils/replay.ts
+++ b/utils/replay.ts
@@ -1,0 +1,36 @@
+export interface InputEvent<T = any> {
+  t: number; // milliseconds since start
+  data: T;
+}
+
+export class Replay<T = any> {
+  private events: InputEvent<T>[] = [];
+  private start = 0;
+
+  startRecording(): void {
+    this.events = [];
+    this.start = Date.now();
+  }
+
+  record(data: T): void {
+    const t = Date.now() - this.start;
+    const last = this.events[this.events.length - 1]?.t ?? -1;
+    this.events.push({ t: t <= last ? last + 1 : t, data });
+  }
+
+  getEvents(): InputEvent<T>[] {
+    return this.events;
+  }
+
+  // Play back events up to a given time (ms). Defaults to full playback
+  play(process: (data: T) => void, time = Infinity): void {
+    for (const evt of this.events) {
+      if (evt.t > time) break;
+      process(evt.data);
+    }
+  }
+
+  duration(): number {
+    return this.events.length ? this.events[this.events.length - 1].t : 0;
+  }
+}

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,0 +1,35 @@
+export const THEME_KEY = 'app:theme';
+
+// Score required to unlock each theme
+export const THEME_UNLOCKS: Record<string, number> = {
+  default: 0,
+  neon: 100,
+  dark: 500,
+  matrix: 1000,
+};
+
+export const getTheme = (): string => {
+  if (typeof window === 'undefined') return 'default';
+  try {
+    return window.localStorage.getItem(THEME_KEY) || 'default';
+  } catch {
+    return 'default';
+  }
+};
+
+export const setTheme = (theme: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+export const getUnlockedThemes = (highScore: number): string[] =>
+  Object.entries(THEME_UNLOCKS)
+    .filter(([, score]) => highScore >= score)
+    .map(([theme]) => theme);
+
+export const isThemeUnlocked = (theme: string, highScore: number): boolean =>
+  highScore >= (THEME_UNLOCKS[theme] ?? Infinity);


### PR DESCRIPTION
## Summary
- add daily challenge seed + local leaderboard utilities
- introduce theme unlocking and settings drawer
- implement input replay system with scrub support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae71d72c408328b875580f05d6fa48