### PR TITLE
feat: centralize external iframe handling

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -3,14 +3,11 @@ import dynamic from 'next/dynamic';
 import { logEvent } from './utils/analytics';
 
 import { displayX } from './components/apps/x';
-import { displaySpotify } from './components/apps/spotify';
-import { displayVsCode } from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/chrome';
 import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayAboutAlex } from './components/apps/alex';
-import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
 import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
@@ -21,6 +18,8 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
 import { displayNikto } from './components/apps/nikto';
+import { ExternalFrame } from './components';
+import appRegistry from './apps';
 
 const createDynamicApp = (path, name) =>
   dynamic(
@@ -482,6 +481,22 @@ const gameList = [
 ];
 
 export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
+const externalApps = Object.entries(appRegistry).map(([id, meta]) => ({
+  id,
+  title: meta.title,
+  icon: meta.icon,
+  disabled: false,
+  favourite: false,
+  desktop_shortcut: false,
+  screen: () => (
+    <ExternalFrame
+      src={meta.url}
+      title={meta.title}
+      className="h-full w-full bg-ub-cool-grey"
+      frameBorder="0"
+    />
+  ),
+}));
 
 const apps = [
   {
@@ -493,6 +508,7 @@ const apps = [
     desktop_shortcut: true,
     screen: displayChrome,
   },
+  ...externalApps,
   {
     id: 'calc',
     title: 'Calc',
@@ -516,15 +532,6 @@ const apps = [
     screen: displayTerminal,
   },
   {
-    id: 'vscode',
-    title: 'Visual Studio Code',
-    icon: './themes/Yaru/apps/vscode.png',
-    disabled: false,
-    favourite: true,
-    desktop_shortcut: false,
-    screen: displayVsCode,
-  },
-  {
     id: 'x',
     title: 'X',
     icon: './themes/Yaru/apps/x.png',
@@ -532,15 +539,6 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayX,
-  },
-  {
-    id: 'spotify',
-    title: 'Spotify',
-    icon: './themes/Yaru/apps/spotify.svg',
-    disabled: false,
-    favourite: true,
-    desktop_shortcut: false,
-    screen: displaySpotify,
   },
   {
     id: 'youtube',
@@ -631,15 +629,6 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWireshark,
-  },
-  {
-    id: 'todoist',
-    title: 'Todoist',
-    icon: './themes/Yaru/apps/todoist.png',
-    disabled: false,
-    favourite: false,
-    desktop_shortcut: false,
-    screen: displayTodoist,
   },
   {
     id: 'trash',

--- a/apps.ts
+++ b/apps.ts
@@ -1,0 +1,35 @@
+export interface AppMeta {
+  title: string;
+  icon: string;
+  type: 'external';
+  url: string;
+}
+
+const apps: Record<string, AppMeta> = {
+  vscode: {
+    title: 'Visual Studio Code',
+    icon: './themes/Yaru/apps/vscode.png',
+    type: 'external',
+    url: 'https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md',
+  },
+  spotify: {
+    title: 'Spotify',
+    icon: './themes/Yaru/apps/spotify.svg',
+    type: 'external',
+    url: 'https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0',
+  },
+  todoist: {
+    title: 'Todoist',
+    icon: './themes/Yaru/apps/todoist.png',
+    type: 'external',
+    url: 'https://todoist.com/showProject?id=220474322',
+  },
+  ghidra: {
+    title: 'Ghidra',
+    icon: './themes/Yaru/apps/ghidra.svg',
+    type: 'external',
+    url: process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app',
+  },
+};
+
+export default apps;

--- a/components/LazyGitHubButton.js
+++ b/components/LazyGitHubButton.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { ExternalFrame } from '.';
 
 const LazyGitHubButton = ({ user, repo }) => {
   const ref = useRef(null);
@@ -22,14 +23,14 @@ const LazyGitHubButton = ({ user, repo }) => {
   return (
     <div ref={ref} className="inline-block">
       {visible ? (
-        <iframe
+        <ExternalFrame
           src={`https://ghbtns.com/github-btn.html?user=${user}&repo=${repo}&type=star&count=true`}
           frameBorder="0"
           scrolling="0"
           width="150"
           height="20"
           title={`${repo}-star`}
-        ></iframe>
+        />
       ) : (
         <div className="h-5 w-24 bg-gray-200 animate-pulse rounded"></div>
       )}

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
+import { ExternalFrame } from '..';
 
 export class Chrome extends Component {
     constructor() {
@@ -86,7 +87,7 @@ export class Chrome extends Component {
         return (
             <div className="h-full w-full flex flex-col bg-ub-cool-grey">
                 {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
+                <ExternalFrame src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url" />
             </div>
         )
     }

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { ExternalFrame } from '../..';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
@@ -23,7 +24,7 @@ export default function GhidraApp() {
   if (useRemote) {
     const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
     return (
-      <iframe
+      <ExternalFrame
         src={remoteUrl}
         className="w-full h-full bg-ub-cool-grey"
         frameBorder="0"

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../usePersistentState';
+import { ExternalFrame } from '..';
 
 const Platformer = () => {
   const [levels, setLevels] = useState([]);
@@ -36,13 +37,13 @@ const Platformer = () => {
   }`;
 
   return (
-    <iframe
+    <ExternalFrame
       ref={frameRef}
       src={src}
       title="Platformer"
       className="w-full h-full"
       frameBorder="0"
-    ></iframe>
+    />
   );
 };
 

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import { ExternalFrame } from '..';
 
 export default function SpotifyApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
+      <ExternalFrame
         src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
         title="Daily Mix 2"
         width="100%"

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,12 +1,18 @@
-import React from 'react'
+import React from 'react';
+import { ExternalFrame } from '..';
 
 export default function Todoist() {
-    return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
-        // just to bypass the headers 🙃
-    )
+  return (
+    <ExternalFrame
+      src="https://todoist.com/showProject?id=220474322"
+      frameBorder="0"
+      title="Todoist"
+      className="h-full w-full"
+    />
+    // just to bypass the headers 🙃
+  );
 }
 
 export const displayTodoist = () => {
-    return <Todoist />;
+  return <Todoist />;
 };

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,18 +1,19 @@
 import React from 'react';
+import { ExternalFrame } from '..';
 
 export default function VsCode() {
-    return (
-        <iframe
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-        ></iframe>
-    );
+  return (
+    <ExternalFrame
+      src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+      frameBorder="0"
+      title="VsCode"
+      className="h-full w-full bg-ub-cool-grey"
+      allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
+      allowFullScreen
+    />
+  );
 }
 
 export const displayVsCode = () => {
-    return <VsCode />;
+  return <VsCode />;
 };

--- a/components/common/ErrorBoundary.tsx
+++ b/components/common/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="w-full h-full flex items-center justify-center">
+          <p>Something went wrong.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/components/common/ExternalFrame.tsx
+++ b/components/common/ExternalFrame.tsx
@@ -1,0 +1,14 @@
+import React, { forwardRef } from 'react';
+import ErrorBoundary from './ErrorBoundary';
+
+type Props = React.IframeHTMLAttributes<HTMLIFrameElement>;
+
+const ExternalFrame = forwardRef<HTMLIFrameElement, Props>((props, ref) => (
+  <ErrorBoundary>
+    <iframe ref={ref} {...props} />
+  </ErrorBoundary>
+));
+
+ExternalFrame.displayName = 'ExternalFrame';
+
+export default ExternalFrame;

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,2 @@
+export { default as ExternalFrame } from './common/ExternalFrame';
+export { default as ErrorBoundary } from './common/ErrorBoundary';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,22 @@
 import '@testing-library/jest-dom';
 
+jest.mock('react-ga4', () => ({
+  initialize: jest.fn(),
+  event: jest.fn(),
+  send: jest.fn(),
+}));
+
+class AudioMock {
+  play() {
+    return Promise.resolve();
+  }
+  pause() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+// @ts-ignore
+global.Audio = AudioMock as any;
+
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient
 // for our tests because we only rely on the instance existing.


### PR DESCRIPTION
## Summary
- add ErrorBoundary and ExternalFrame components
- register external apps via apps.ts and consume in apps.config
- mock analytics and audio in Jest setup

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae81d16a248328a6b4bf7aa7931e24