### PR TITLE
feat: expand calculator with precise and programmer modes

### DIFF
--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -1,0 +1,66 @@
+const { JSDOM } = require('jsdom');
+const { TextEncoder, TextDecoder } = require('util');
+
+function setupDom() {
+  global.TextEncoder = TextEncoder;
+  global.TextDecoder = TextDecoder;
+  const dom = new JSDOM(
+    `<!DOCTYPE html><html><body>
+      <input id="display" />
+      <div class="buttons"></div>
+      <button id="toggle-scientific"></button>
+      <button id="toggle-precise"></button>
+      <button id="toggle-programmer"></button>
+      <button id="toggle-history"></button>
+      <div id="scientific"></div>
+      <div id="programmer"></div>
+      <select id="base-select"></select>
+      <div id="history"></div>
+      <div id="paren-indicator"></div>
+      <button id="print-tape"></button>
+    </body></html>`
+  );
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.navigator = dom.window.navigator;
+  global.math = require('mathjs');
+}
+
+describe('calculator', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    setupDom();
+  });
+
+  test('1.1 + 2.2 equals 3.3', () => {
+    const calc = require('../apps/calculator/main.js');
+    calc.setPreciseMode(true);
+    expect(calc.evaluate('1.1+2.2')).toBe('3.3');
+  });
+
+  test('history capped at 10', () => {
+    const calc = require('../apps/calculator/main.js');
+    for (let i = 0; i < 12; i++) {
+      calc.addHistory(String(i), String(i));
+    }
+    const stored = JSON.parse(localStorage.getItem(calc.HISTORY_KEY));
+    expect(stored).toHaveLength(10);
+  });
+
+  test('Enter evaluates', () => {
+    const calc = require('../apps/calculator/main.js');
+    const display = document.getElementById('display');
+    display.value = '1+1';
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(display.value).toBe('2');
+  });
+
+  test('base conversions round trip', () => {
+    const calc = require('../apps/calculator/main.js');
+    const hex = 'FF';
+    const bin = calc.convertBase(hex, 16, 2);
+    expect(calc.convertBase(bin, 2, 16).toUpperCase()).toBe(hex);
+  });
+});
+

--- a/apps/calculator/index.html
+++ b/apps/calculator/index.html
@@ -8,9 +8,11 @@
 </head>
 <body>
   <div class="calculator">
-    <div id="display" class="display" tabindex="0"></div>
+    <input id="display" class="display" />
     <button id="toggle-precise" class="toggle" aria-pressed="false">Precise Mode: Off</button>
     <button id="toggle-scientific" class="toggle" aria-pressed="false">Scientific</button>
+    <button id="toggle-programmer" class="toggle" aria-pressed="false">Programmer</button>
+    <button id="toggle-history" class="toggle" aria-pressed="false">History</button>
     <div class="buttons">
       <button class="btn" data-value="7">7</button>
       <button class="btn" data-value="8">8</button>
@@ -38,7 +40,24 @@
       <button class="btn" data-value="(">(</button>
       <button class="btn" data-value=")">)</button>
     </div>
-    <div id="history" class="history" aria-live="polite"></div>
+    <div id="programmer" class="programmer hidden">
+      <select id="base-select">
+        <option value="2">Bin</option>
+        <option value="8">Oct</option>
+        <option value="10" selected>Dec</option>
+        <option value="16">Hex</option>
+      </select>
+      <button class="btn" data-value="&amp;">&amp;</button>
+      <button class="btn" data-value="|">|</button>
+      <button class="btn" data-value="^">^</button>
+      <button class="btn" data-value="~">~</button>
+      <button class="btn" data-value="<<">&lt;&lt;</button>
+      <button class="btn" data-value=">>">&gt;&gt;</button>
+      <button class="btn" data-action="ans">Ans</button>
+      <button id="print-tape" class="btn" data-action="print">Print</button>
+      <div id="paren-indicator"></div>
+    </div>
+    <div id="history" class="history hidden" aria-live="polite"></div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/mathjs@13.2.3/lib/browser/math.js"></script>
   <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- support fraction-based precise calculations with optional programmer mode
- persist and print history with collapsible view and keyboard controls
- add unit tests for precision, history capping, keyboard eval and base conversion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae81d31a2c832891df8282ee9605e9