### PR TITLE
feat(vscode): add external frame and cookie banner

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import VsCode from '../components/apps/vscode';
+
+describe('VsCode app', () => {
+  it('renders external frame', () => {
+    render(<VsCode />);
+    const frame = screen.getByTitle('VsCode');
+    expect(frame.tagName).toBe('IFRAME');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('shows banner when cookies are blocked', async () => {
+    const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => '',
+      set: () => {},
+    });
+
+    render(<VsCode />);
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+
+    if (original) {
+      Object.defineProperty(document, 'cookie', original);
+    }
+  });
+});
+

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+const ALLOWLIST = ['https://vscode.dev', 'https://stackblitz.com'];
+
+const isAllowed = (src) => {
+  try {
+    const url = new URL(src);
+    return ALLOWLIST.some((allowed) => url.href.startsWith(allowed));
+  } catch {
+    return false;
+  }
+};
+
+export default function ExternalFrame({ src, title, prefetch = false, ...props }) {
+  const [cookiesBlocked, setCookiesBlocked] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
+
+  useEffect(() => {
+    try {
+      document.cookie = 'third_party_cookie_test=1';
+      const blocked = !document.cookie.includes('third_party_cookie_test=1');
+      setCookiesBlocked(blocked);
+    } catch {
+      setCookiesBlocked(true);
+    }
+  }, []);
+
+  if (!isAllowed(src)) {
+    return null;
+  }
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      {cookiesBlocked && (
+        <div role="alert" className="bg-red-600 text-white text-sm p-2 text-center">
+          Third-party cookies are blocked.{' '}
+          <button onClick={() => setShowDialog(true)} className="underline">
+            Instructions
+          </button>
+        </div>
+      )}
+      <iframe src={src} title={title} {...props} />
+      {showDialog && (
+        <dialog open>
+          <p>Enable third-party cookies in your browser settings to use this app.</p>
+          <button onClick={() => setShowDialog(false)}>Close</button>
+        </dialog>
+      )}
+    </div>
+  );
+}
+

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,18 +1,21 @@
 import React from 'react';
+import ExternalFrame from '../ExternalFrame';
 
 export default function VsCode() {
     return (
-        <iframe
+        <ExternalFrame
             src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            frameBorder="0"
             title="VsCode"
             className="h-full w-full bg-ub-cool-grey"
             allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
             allowFullScreen
-        ></iframe>
+            frameBorder="0"
+            prefetch={false}
+        />
     );
 }
 
 export const displayVsCode = () => {
     return <VsCode />;
 };
+


### PR DESCRIPTION
## Summary
- wrap VS Code app in reusable `ExternalFrame`
- warn when third-party cookies are blocked and link to help
- test VS Code frame mounting and cookie warning

## Testing
- `yarn test __tests__/vscode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae81d4570083288a71bc42bc435bcb