### PR TITLE
feat: add persistent preferences and reset in settings app

### DIFF
--- a/__tests__/settings.test.tsx
+++ b/__tests__/settings.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Settings from '../components/apps/settings';
+
+describe('Settings app', () => {
+  const renderSettings = () =>
+    render(<Settings changeBackgroundImage={() => {}} currBgImgName="wall-1" />);
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('toggles persist via localStorage', () => {
+    const { getByTestId, unmount } = renderSettings();
+    const sound = getByTestId('sound-toggle') as HTMLInputElement;
+    const motion = getByTestId('motion-toggle') as HTMLInputElement;
+    fireEvent.click(sound);
+    fireEvent.click(motion);
+    expect(sound.checked).toBe(false);
+    expect(motion.checked).toBe(true);
+    unmount();
+    const { getByTestId: getAgain } = renderSettings();
+    expect((getAgain('sound-toggle') as HTMLInputElement).checked).toBe(false);
+    expect((getAgain('motion-toggle') as HTMLInputElement).checked).toBe(true);
+  });
+
+  test('reset clears app state but keeps preferences', () => {
+    localStorage.setItem('some-app-state', '1');
+    const { getByTestId, queryByText } = renderSettings();
+    fireEvent.click(getByTestId('reset-apps'));
+    expect(localStorage.getItem('some-app-state')).toBeNull();
+    expect(queryByText('App data cleared')).toBeInTheDocument();
+  });
+
+  test('import applies preferences', async () => {
+    const { getByTestId } = renderSettings();
+    const file = new File(
+      [JSON.stringify({ sound: false, reducedMotion: true })],
+      'prefs.json',
+      { type: 'application/json' }
+    );
+    fireEvent.change(getByTestId('import-input'), { target: { files: [file] } });
+    await waitFor(() => {
+      expect((getByTestId('sound-toggle') as HTMLInputElement).checked).toBe(false);
+      expect((getByTestId('motion-toggle') as HTMLInputElement).checked).toBe(true);
+    });
+  });
+});
+

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,8 +1,30 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTheme } from '../../hooks/useTheme';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export function Settings(props) {
     const { theme, setTheme } = useTheme();
+    const bool = (v) => typeof v === 'boolean';
+    const [sound, setSound] = usePersistentState('pref-sound', true, bool);
+    const [reducedMotion, setReducedMotion] = usePersistentState('pref-reduced-motion', false, bool);
+    const [renderScale, setRenderScale] = usePersistentState('pref-render-scale', 1, (v) => typeof v === 'number');
+    const defaultKeys = {
+        up: 'ArrowUp',
+        down: 'ArrowDown',
+        left: 'ArrowLeft',
+        right: 'ArrowRight',
+        action: 'Space',
+    };
+    const [keyMap, setKeyMap] = usePersistentState('pref-keymap', defaultKeys, (v) => typeof v === 'object' && v);
+    const updateKey = (action, value) => setKeyMap({ ...keyMap, [action]: value });
+    const preferenceKeys = ['theme', 'pref-sound', 'pref-reduced-motion', 'pref-render-scale', 'pref-keymap'];
+    const [toast, setToast] = useState('');
+
+    useEffect(() => {
+        if (!toast) return;
+        const t = setTimeout(() => setToast(''), 3000);
+        return () => clearTimeout(t);
+    }, [toast]);
 
     const wallpapers = {
         "wall-1": "./images/wallpapers/wall-1.webp",
@@ -17,7 +39,46 @@ export function Settings(props) {
 
     let changeBackgroundImage = (e) => {
         props.changeBackgroundImage(e.target.dataset.path);
-    }
+    };
+
+    const resetApps = () => {
+        const preserve = new Set(preferenceKeys);
+        Object.keys(localStorage).forEach((key) => {
+            if (!preserve.has(key)) {
+                localStorage.removeItem(key);
+            }
+        });
+        setToast('App data cleared');
+    };
+
+    const exportPrefs = () => {
+        const data = { theme, sound, reducedMotion, renderScale, keyMap };
+        const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'preferences.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const importPrefs = (file) => {
+        const reader = new FileReader();
+        reader.onload = (ev) => {
+            try {
+                const data = JSON.parse(ev.target.result);
+                if (typeof data.theme === 'string') setTheme(data.theme);
+                if (typeof data.sound === 'boolean') setSound(data.sound);
+                if (typeof data.reducedMotion === 'boolean') setReducedMotion(data.reducedMotion);
+                if (typeof data.renderScale === 'number') setRenderScale(data.renderScale);
+                if (data.keyMap && typeof data.keyMap === 'object') setKeyMap(data.keyMap);
+                setToast('Preferences imported');
+            } catch {
+                setToast('Import failed');
+            }
+        };
+        reader.readAsText(file);
+    };
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
@@ -33,6 +94,79 @@ export function Settings(props) {
                     <option value="dark">Dark</option>
                     <option value="light">Light</option>
                 </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey" htmlFor="sound">Sound Effects:</label>
+                <input
+                    id="sound"
+                    type="checkbox"
+                    checked={sound}
+                    onChange={(e) => setSound(e.target.checked)}
+                    data-testid="sound-toggle"
+                />
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey" htmlFor="motion">Reduced Motion:</label>
+                <input
+                    id="motion"
+                    type="checkbox"
+                    checked={reducedMotion}
+                    onChange={(e) => setReducedMotion(e.target.checked)}
+                    data-testid="motion-toggle"
+                />
+            </div>
+            <div className="flex flex-col items-center my-4">
+                <label className="text-ubt-grey mb-2" htmlFor="render-scale">Render Scale: {renderScale.toFixed(1)}</label>
+                <input
+                    id="render-scale"
+                    type="range"
+                    min="0.5"
+                    max="2"
+                    step="0.1"
+                    value={renderScale}
+                    onChange={(e) => setRenderScale(parseFloat(e.target.value))}
+                    className="w-1/2"
+                />
+            </div>
+            <div className="flex flex-col items-center my-4">
+                <h3 className="text-ubt-grey mb-2">Keyboard Mapping</h3>
+                {Object.keys(keyMap).map((action) => (
+                    <div key={action} className="my-1">
+                        <label className="mr-2 capitalize">{action}:</label>
+                        <input
+                            value={keyMap[action]}
+                            onChange={(e) => updateKey(action, e.target.value)}
+                            className="text-black px-1"
+                        />
+                    </div>
+                ))}
+            </div>
+            <div className="flex justify-center space-x-2 my-4">
+                <button
+                    type="button"
+                    onClick={exportPrefs}
+                    className="px-2 py-1 bg-blue-700 rounded"
+                >
+                    Export Preferences
+                </button>
+                <label className="px-2 py-1 bg-blue-700 rounded cursor-pointer">
+                    Import Preferences
+                    <input
+                        type="file"
+                        accept="application/json"
+                        onChange={(e) => e.target.files && e.target.files[0] && importPrefs(e.target.files[0])}
+                        className="hidden"
+                        data-testid="import-input"
+                    />
+                </label>
+                <button
+                    type="button"
+                    onClick={resetApps}
+                    className="px-2 py-1 bg-red-700 rounded"
+                    data-testid="reset-apps"
+                >
+                    Reset Apps
+                </button>
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {
@@ -52,6 +186,14 @@ export function Settings(props) {
                     })
                 }
             </div>
+            {toast && (
+                <div
+                    role="alert"
+                    className="fixed bottom-2 right-2 bg-black text-white px-2 py-1 rounded"
+                >
+                    {toast}
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- add sound and reduced-motion toggles that persist in localStorage
- enable keyboard mapping and render scale options with preference export/import and reset
- add tests verifying persistence, import, and reset behavior

## Testing
- `npm test __tests__/settings.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae81d84fc0832881a82c2bc6ba5716