### PR TITLE
feat: add asteroids game with controls and scores

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -201,6 +201,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsteroids,
+    defaultWidth: gameDefaults.defaultWidth,
+    defaultHeight: gameDefaults.defaultHeight,
   },
   {
     id: 'battleship',


### PR DESCRIPTION
## Summary
- integrate Asteroids canvas loop with keyboard controls, pause/reset, sound toggle and persistent high score
- register Asteroids in app config using dynamic app loader and default dimensions

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5e23467c83288fbe24c78e29c86f