### PR TITLE
Add Showcase app configuration

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -79,6 +79,8 @@ const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 
+const ShowcaseApp = createDynamicApp('showcase', 'Showcase');
+
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 
@@ -144,6 +146,8 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayRadare2 = createDisplay(Radare2App);
+
+const displayShowcase = createDisplay(ShowcaseApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -622,6 +626,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'showcase',
+    title: 'Showcase',
+    icon: './themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayShowcase,
   },
   {
     id: 'wireshark',

--- a/components/apps/showcase/index.js
+++ b/components/apps/showcase/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Showcase() {
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+      Showcase App
+    </div>
+  );
+}
+
+export default Showcase;


### PR DESCRIPTION
## Summary
- add new Showcase app component with simple placeholder UI
- register Showcase app in configuration via dynamic loader and display helper
- expose Showcase app in utilities list

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5de305688328ba82d9d2dcebbe00