### PR TITLE
refactor: split utilities from games

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayQuoteGenerator } from './components/apps/quote_generator';
 import { displayProjectGallery } from './components/apps/project-gallery';
+import { displayShowcase } from './components/apps/showcase';
 import { displayNikto } from './components/apps/nikto';
 
 const createDynamicApp = (path, name) =>
@@ -483,7 +484,7 @@ const gameList = [
 
 export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
 
-const apps = [
+const utilities = [
   {
     id: 'chrome',
     title: 'Google Chrome',
@@ -622,6 +623,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'showcase',
+    title: 'Showcase',
+    icon: './themes/Yaru/apps/showcase.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayShowcase,
   },
   {
     id: 'wireshark',
@@ -865,8 +875,10 @@ const apps = [
     desktop_shortcut: false,
     screen: displayReconNG,
   },
-  // Games are included so they appear alongside apps
-  ...games,
 ];
+
+export { utilities };
+
+const apps = [...utilities, ...games];
 
 export default apps;

--- a/components/apps/showcase.js
+++ b/components/apps/showcase.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Showcase = () => (
+  <div className="w-full h-full p-4 bg-ub-cool-grey text-white overflow-auto">
+    <p>Showcase placeholder</p>
+  </div>
+);
+
+export default Showcase;
+
+export const displayShowcase = () => <Showcase />;
+

--- a/public/themes/Yaru/apps/showcase.svg
+++ b/public/themes/Yaru/apps/showcase.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect x="4" y="4" width="40" height="40" rx="3" ry="3" fill="#4A4A4A"/>
+  <circle cx="16" cy="16" r="5" fill="#FFFFFF"/>
+  <path d="M4 32l10-10 8 8 5-5 13 13H4V32z" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
## Summary
- isolate non-game apps into new `utilities` array
- export utilities and build master app list from utilities and games
- add Showcase app stub and icon

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae5de5bbd88328a81d74124e267d4c