### PR TITLE
feat: add tool docs and embed handling

### DIFF
--- a/__tests__/toolApp.test.tsx
+++ b/__tests__/toolApp.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ToolApp from '../components/apps/tool-app';
+
+describe('ToolApp', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('renders docs panel when safe_embed is false', async () => {
+    global.fetch = jest.fn((url: RequestInfo) => {
+      if (typeof url === 'string' && url.endsWith('.yaml')) {
+        return Promise.resolve({ text: () => Promise.resolve(`title: Test\nhomepage: https://example.com\ndocs: https://example.com/docs\nlicense: MIT\nsafe_embed: false`) }) as any;
+      }
+      return Promise.resolve({ text: () => Promise.resolve('## Overview\nDocs content') }) as any;
+    });
+
+    render(<ToolApp id="test" />);
+
+    await waitFor(() => expect(screen.getByText('Docs content')).toBeInTheDocument());
+    expect(screen.getAllByText('Overview').length).toBeGreaterThan(0);
+  });
+
+  test('renders sandboxed iframe when safe_embed is true', async () => {
+    global.fetch = jest.fn((url: RequestInfo) =>
+      Promise.resolve({ text: () => Promise.resolve(`title: Frame\nhomepage: https://frame.example\ndocs: https://frame.example/docs\nlicense: MIT\nsafe_embed: true`) }) as any
+    );
+
+    render(<ToolApp id="frame" />);
+
+    await waitFor(() => expect(screen.getByTitle('Frame')).toBeInTheDocument());
+    const iframe = screen.getByTitle('Frame');
+    expect(iframe).toHaveAttribute('sandbox');
+    expect(iframe).toHaveAttribute('src', 'https://frame.example');
+  });
+});

--- a/components/apps/DocsPanel.js
+++ b/components/apps/DocsPanel.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { marked } from 'marked';
+
+export default function DocsPanel({ id }) {
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    const renderer = new marked.Renderer();
+    renderer.code = (code) => {
+      const encoded = encodeURIComponent(code);
+      return `<pre class="relative"><code>${code}</code><button class="copy-btn absolute top-1 right-1 bg-ubt-blue text-xs px-1" data-code="${encoded}">Copy</button></pre>`;
+    };
+    fetch(`/docs/${id}.md`)
+      .then((res) => res.text())
+      .then((md) => {
+        setHtml(marked(md, { renderer }));
+      });
+  }, [id]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const code = e.target.getAttribute('data-code');
+      if (code) {
+        navigator.clipboard && navigator.clipboard.writeText(decodeURIComponent(code));
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [html]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white p-4">
+      <p className="text-xs mb-4">
+        Use these tools responsibly and only in environments where you have explicit authorization.
+      </p>
+      <nav className="mb-4 text-sm">
+        <ul className="space-y-1">
+          <li><a href="#overview">Overview</a></li>
+          <li><a href="#install">Install</a></li>
+          <li><a href="#commands">Commands</a></li>
+          <li><a href="#lab">Lab</a></li>
+          <li><a href="#further-reading">Further reading</a></li>
+        </ul>
+      </nav>
+      <article className="prose prose-invert" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}

--- a/components/apps/ExternalFrame.js
+++ b/components/apps/ExternalFrame.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ExternalFrame({ src, title }) {
+  return (
+    <iframe
+      src={src}
+      title={title}
+      className="w-full h-full bg-ub-cool-grey"
+      sandbox="allow-same-origin allow-scripts"
+    />
+  );
+}

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,40 +1,8 @@
-import React, { useEffect, useState } from 'react';
-
-const DEFAULT_WASM = '/wasm/ghidra.wasm';
+import React from 'react';
+import ToolApp from '../tool-app';
 
 export default function GhidraApp() {
-  const [useRemote, setUseRemote] = useState(false);
-
-  useEffect(() => {
-    const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
-    if (typeof WebAssembly === 'undefined') {
-      setUseRemote(true);
-      return;
-    }
-    WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
-      .then(() => {
-        // Placeholder for actual Ghidra WASM initialization
-      })
-      .catch(() => {
-        setUseRemote(true);
-      });
-  }, []);
-
-  if (useRemote) {
-    const remoteUrl = process.env.NEXT_PUBLIC_GHIDRA_URL || 'https://ghidra.app';
-    return (
-      <iframe
-        src={remoteUrl}
-        className="w-full h-full bg-ub-cool-grey"
-        frameBorder="0"
-        title="Ghidra"
-      />
-    );
-  }
-
-  return (
-    <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Ghidra WebAssembly...
-    </div>
-  );
+  return <ToolApp id="ghidra" />;
 }
+
+export const displayGhidra = () => <GhidraApp />;

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,54 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
+import ToolApp from '../tool-app';
 
-const NiktoApp = () => {
-  const [target, setTarget] = useState('');
-  const [result, setResult] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const runScan = async () => {
-    if (!target) return;
-    setLoading(true);
-    setResult('');
-    try {
-      const res = await fetch(`/api/nikto?target=${encodeURIComponent(target)}`);
-      const text = await res.text();
-      setResult(text);
-    } catch (err) {
-      setResult(`Error: ${err.message}`);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 overflow-auto">
-      <h1 className="text-lg mb-4 font-bold">Nikto Scanner</h1>
-      <div className="flex mb-4">
-        <input
-          type="text"
-          value={target}
-          onChange={(e) => setTarget(e.target.value)}
-          placeholder="http://example.com"
-          className="flex-1 p-2 rounded-l text-black"
-        />
-        <button
-          type="button"
-          onClick={runScan}
-          className="px-4 bg-ubt-blue rounded-r"
-        >
-          Scan
-        </button>
-      </div>
-      {loading ? (
-        <p>Running scan...</p>
-      ) : (
-        <pre className="whitespace-pre-wrap flex-1 overflow-auto">{result}</pre>
-      )}
-    </div>
-  );
-};
-
-export default NiktoApp;
+export default function NiktoApp() {
+  return <ToolApp id="nikto" />;
+}
 
 export const displayNikto = () => <NiktoApp />;
-

--- a/components/apps/tool-app.js
+++ b/components/apps/tool-app.js
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import yaml from 'js-yaml';
+import ExternalFrame from './ExternalFrame';
+import DocsPanel from './DocsPanel';
+
+export default function ToolApp({ id }) {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    fetch(`/configs/${id}.yaml`)
+      .then((res) => res.text())
+      .then((text) => {
+        setConfig(yaml.load(text));
+      });
+  }, [id]);
+
+  if (!config) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading...
+      </div>
+    );
+  }
+
+  if (config.safe_embed) {
+    return <ExternalFrame src={config.homepage} title={config.title} />;
+  }
+
+  return <DocsPanel id={id} />;
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "figlet": "^1.8.2",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
+    "js-yaml": "^4.1.0",
     "jsqr": "^1.4.0",
+    "marked": "^12.0.2",
     "mathjs": "^14.6.0",
     "next": "^15.0.0",
     "phaser": "3.70.0",
@@ -41,7 +43,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",

--- a/public/configs/ghidra.yaml
+++ b/public/configs/ghidra.yaml
@@ -1,0 +1,5 @@
+title: Ghidra
+homepage: https://ghidra-sre.org/
+docs: https://ghidra-sre.org/Documentation.html
+license: Apache-2.0
+safe_embed: true

--- a/public/configs/nikto.yaml
+++ b/public/configs/nikto.yaml
@@ -1,0 +1,5 @@
+title: Nikto
+homepage: https://cirt.net/Nikto2
+docs: https://cirt.net/Nikto2
+license: GPL-2.0
+safe_embed: false

--- a/public/docs/ghidra.md
+++ b/public/docs/ghidra.md
@@ -1,0 +1,16 @@
+# Ghidra
+
+## Overview
+Ghidra is a software reverse engineering framework from the NSA.
+
+## Install
+Download the latest release from the [official site](https://ghidra-sre.org/).
+
+## Commands
+- `analyzeHeadless` – run headless analysis
+
+## Lab
+Try analyzing a simple binary and explore the decompiler output.
+
+## Further reading
+- [Ghidra Documentation](https://ghidra-sre.org/Documentation.html)

--- a/public/docs/nikto.md
+++ b/public/docs/nikto.md
@@ -1,0 +1,16 @@
+# Nikto
+
+## Overview
+Nikto is a web server vulnerability scanner.
+
+## Install
+`apt install nikto`
+
+## Commands
+- `nikto -h http://example.com`
+
+## Lab
+Run Nikto against a deliberately vulnerable web server in a controlled environment.
+
+## Further reading
+- [Nikto Project](https://cirt.net/Nikto2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,6 +5712,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:^12.0.2":
+  version: 12.0.2
+  resolution: "marked@npm:12.0.2"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/45ae2e1e3f06b30a5b5f64efc6cde9830c81d1d024fd7668772a3217f1bc0f326e66a6b8970482d9783edf1f581fecac7023a7fa160f2c14dbcc16e064b4eafb
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -6669,7 +6678,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -8031,7 +8039,9 @@ __metadata:
     html-to-image: "npm:^1.11.13"
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
+    js-yaml: "npm:^4.1.0"
     jsqr: "npm:^1.4.0"
+    marked: "npm:^12.0.2"
     mathjs: "npm:^14.6.0"
     next: "npm:^15.0.0"
     phaser: "npm:3.70.0"
@@ -8043,7 +8053,6 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"


### PR DESCRIPTION
## Summary
- add generic tool app that reads YAML config and renders either docs panel or sandboxed iframe
- include docs panel with left-hand navigation, disclaimers, and copy buttons
- provide example configs and cheat sheets for Ghidra and Nikto

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae81d9aaa88328853dbd7a8247f7fa