### PR TITLE
feat: add contact form with vcard and tests

### DIFF
--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -1,0 +1,55 @@
+import { processContactForm, generateVCard } from '../components/apps/contact';
+
+describe('contact form', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('invalid email blocked', async () => {
+    const clipboard = { writeText: jest.fn() } as any;
+    const result = await processContactForm(
+      { name: 'A', email: 'invalid', message: 'Hi', honeypot: '' },
+      {
+        clipboard,
+        open: jest.fn(),
+        createObjectURL: jest.fn(),
+        document,
+        sessionStorage: window.sessionStorage,
+        now: () => 0,
+      }
+    );
+    expect(result.success).toBe(false);
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('success copies full message', async () => {
+    const clipboard = { writeText: jest.fn().mockResolvedValue(undefined) } as any;
+    const open = jest.fn();
+    const anchor = document.createElement('a');
+    const click = jest.spyOn(anchor, 'click');
+    const createElement = jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+    await processContactForm(
+      { name: 'Alex', email: 'alex@example.com', message: 'Hello', honeypot: '' },
+      {
+        clipboard,
+        open,
+        createObjectURL: jest.fn().mockReturnValue('blob:'),
+        document,
+        sessionStorage: window.sessionStorage,
+        now: () => 60_001,
+      }
+    );
+    expect(clipboard.writeText).toHaveBeenCalledWith(
+      'Name: Alex\nEmail: alex@example.com\nMessage: Hello'
+    );
+    expect(open).toHaveBeenCalledWith(expect.stringMatching(/^mailto:/));
+    expect(click).toHaveBeenCalled();
+    createElement.mockRestore();
+  });
+
+  it('vCard downloads', () => {
+    const v = generateVCard('Alex', 'alex@example.com');
+    expect(v).toContain('BEGIN:VCARD');
+    expect(v).toContain('EMAIL:alex@example.com');
+  });
+});

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+
+const DEV_EMAIL = 'alex.j.unnippillil@gmail.com';
+export const RATE_LIMIT_MS = 60_000;
+
+export const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
+
+export const generateVCard = (name: string, email: string) =>
+  `BEGIN:VCARD\nVERSION:3.0\nFN:${name}\nEMAIL:${email}\nEND:VCARD`;
+
+export const processContactForm = async (
+  data: { name: string; email: string; message: string; honeypot: string },
+  env = {
+    clipboard: navigator.clipboard,
+    open: (url: string) => window.open(url),
+    createObjectURL: (blob: Blob) => URL.createObjectURL(blob),
+    document: document,
+    sessionStorage: window.sessionStorage,
+    now: () => Date.now(),
+  }
+) => {
+  if (data.honeypot) return { success: false };
+  if (!isValidEmail(data.email)) return { success: false, error: 'Invalid email' };
+
+  const last = parseInt(env.sessionStorage.getItem('contact-last') || '0', 10);
+  if (env.now() - last < RATE_LIMIT_MS)
+    return { success: false, error: 'Rate limited' };
+
+  const fullMessage = `Name: ${data.name}\nEmail: ${data.email}\nMessage: ${data.message}`;
+  await env.clipboard.writeText(fullMessage);
+
+  const mailto = `mailto:${DEV_EMAIL}?subject=${encodeURIComponent(
+    'Contact from ' + data.name
+  )}&body=${encodeURIComponent(fullMessage)}`;
+  env.open(mailto);
+
+  const vcard = generateVCard(data.name, data.email);
+  const blob = new Blob([vcard], { type: 'text/vcard' });
+  const url = env.createObjectURL(blob);
+  const a = env.document.createElement('a');
+  a.href = url;
+  a.download = 'contact.vcf';
+  env.document.body.appendChild(a);
+  a.click();
+  env.document.body.removeChild(a);
+
+  env.sessionStorage.setItem('contact-last', String(env.now()));
+  return { success: true };
+};
+
+const ContactApp = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [honeypot, setHoneypot] = useState('');
+  const [error, setError] = useState('');
+  const [reveal, setReveal] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = await processContactForm({ name, email, message, honeypot });
+    if (!result.success) setError(result.error || 'Submission failed');
+    else setError('');
+  };
+
+  return (
+    <div className="p-4 text-black">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="p-1 border"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          className="p-1 border"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <textarea
+          className="p-1 border"
+          placeholder="Message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+        />
+        <input
+          className="hidden"
+          tabIndex={-1}
+          autoComplete="off"
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Send
+        </button>
+      </form>
+      {error && (
+        <div role="alert" className="text-red-500 mt-2">
+          {error}
+        </div>
+      )}
+      <div className="mt-4">
+        {reveal ? (
+          <a href={`mailto:${DEV_EMAIL}`}>{DEV_EMAIL}</a>
+        ) : (
+          <button onClick={() => setReveal(true)} className="underline">
+            Reveal Email
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ContactApp;
+


### PR DESCRIPTION
## Summary
- add contact form with validation, honeypot, rate limiting, and email reveal
- generate vCard, copy to clipboard, and open mailto on submit
- add tests for email validation, clipboard copy, and vCard generation

## Testing
- `yarn lint`
- `yarn test contact.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae81e7cad08328a26b1dbbc7adef06