### PR TITLE
feat: expand converter features

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -1,4 +1,8 @@
-import { convertUnit } from '../components/apps/converter/UnitConverter';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import UnitConverter, {
+  convertUnit,
+} from '../components/apps/converter/UnitConverter';
 
 describe('Unit conversion', () => {
   it('converts meters to kilometers', () => {
@@ -13,5 +17,20 @@ describe('Unit conversion', () => {
     expect(
       convertUnit('length', 'meter', 'kilometer', 1234, 2)
     ).toBeCloseTo(1.23, 2);
+  });
+
+  it('throws on invalid unit', () => {
+    expect(() => convertUnit('length', 'meter', 'lightyear', 1)).toThrow();
+  });
+
+  it('swap inverts units without crashing', () => {
+    const { getByLabelText, getByTestId } = render(<UnitConverter />);
+    fireEvent.change(getByLabelText('Value'), { target: { value: '1000' } });
+    fireEvent.click(getByTestId('unit-swap'));
+    const fromSelect = getByLabelText('From');
+    const toSelect = getByLabelText('To');
+    expect((fromSelect as HTMLSelectElement).value).toBe('kilometer');
+    expect((toSelect as HTMLSelectElement).value).toBe('meter');
+    expect(getByTestId('unit-result').textContent).toContain('kilometer');
   });
 });

--- a/components/apps/converter/CurrencyConverter.js
+++ b/components/apps/converter/CurrencyConverter.js
@@ -33,12 +33,12 @@ const CurrencyConverter = () => {
         Amount
         <input
           className="text-black p-1 rounded"
-          type="number"
+          type="text"
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
         />
       </label>
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-2 gap-2 items-end">
         <label className="flex flex-col">
           From
           <select
@@ -68,9 +68,34 @@ const CurrencyConverter = () => {
           </select>
         </label>
       </div>
-      <div data-testid="currency-result" className="mt-2">
-        {result && `${amount} ${from} = ${result} ${to}`}
-      </div>
+      <button
+        data-testid="currency-swap"
+        className="bg-gray-600 p-1 rounded"
+        onClick={() => {
+          setFrom(to);
+          setTo(from);
+        }}
+      >
+        Swap
+      </button>
+      {result && (
+        <div className="mt-2 flex items-center gap-2">
+          <span data-testid="currency-result">
+            {`${amount} ${from} = ${result} ${to}`}
+          </span>
+          <button
+            data-testid="currency-copy"
+            className="bg-gray-600 px-2 py-1 rounded"
+            onClick={() =>
+              navigator.clipboard?.writeText(
+                `${result}`
+              )
+            }
+          >
+            Copy
+          </button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- broaden `convertUnit` to handle length, weight, temperature, base, case, date, and timezone conversions
- allow scientific notation inputs, add swap and clipboard features for unit and currency converters
- cover invalid units and swap behavior with new tests

## Testing
- `npm test __tests__/converter.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae81e840208328b3b606e685c7cdad