### PR TITLE
Add reusable game shell and hooks with TicTacToe integration

### DIFF
--- a/__tests__/tictactoeShell.test.tsx
+++ b/__tests__/tictactoeShell.test.tsx
@@ -1,0 +1,41 @@
+import { render, fireEvent } from '@testing-library/react';
+import TicTacToeApp from '../components/apps/tictactoe';
+
+describe('TicTacToe with GameShell', () => {
+  it('hides virtual controls on keyboard input', () => {
+    const { queryByTestId } = render(<TicTacToeApp />);
+    const ftue = queryByTestId('ftue-overlay');
+    if (ftue) fireEvent.click(ftue);
+    expect(queryByTestId('virtual-controls')).toBeTruthy();
+    fireEvent.keyDown(window, { key: 'ArrowUp' });
+    expect(queryByTestId('virtual-controls')).toBeNull();
+  });
+
+  it('auto pauses on visibility change', () => {
+    const { queryByTestId } = render(<TicTacToeApp />);
+    const ftue = queryByTestId('ftue-overlay');
+    if (ftue) fireEvent.click(ftue);
+    expect(queryByTestId('pause-overlay')).toBeNull();
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    fireEvent(document, new Event('visibilitychange'));
+    expect(queryByTestId('pause-overlay')).toBeTruthy();
+  });
+
+  it('persists settings between sessions', () => {
+    let view = render(<TicTacToeApp />);
+    const { getByTestId, getByLabelText, getByText, container, unmount } = view;
+    const ftue = view.queryByTestId('ftue-overlay');
+    if (ftue) fireEvent.click(ftue);
+    fireEvent.click(getByText('X'));
+    fireEvent.click(getByTestId('settings-btn'));
+    fireEvent.click(getByLabelText('High contrast'));
+    fireEvent.click(getByText('Close'));
+    expect(container.querySelector('.bg-black')).toBeTruthy();
+    unmount();
+    view = render(<TicTacToeApp />);
+    const ftue2 = view.queryByTestId('ftue-overlay');
+    if (ftue2) fireEvent.click(ftue2);
+    fireEvent.click(view.getByText('X'));
+    expect(view.container.querySelector('.bg-black')).toBeTruthy();
+  });
+});

--- a/__tests__/useGameInput.test.js
+++ b/__tests__/useGameInput.test.js
@@ -1,0 +1,17 @@
+import { renderHook, act } from '@testing-library/react';
+import useGameInput from '../hooks/useGameInput';
+
+describe('useGameInput', () => {
+  it('tracks last input type and hides virtual controls on keyboard', () => {
+    const { result } = renderHook(() => useGameInput());
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+    expect(result.current.lastInput).toBe('keyboard');
+    expect(result.current.hideVirtualControls).toBe(true);
+    act(() => {
+      window.dispatchEvent(new Event('pointerdown'));
+    });
+    expect(result.current.lastInput).toBe('touch');
+  });
+});

--- a/__tests__/usePersistedState.test.js
+++ b/__tests__/usePersistedState.test.js
@@ -1,0 +1,13 @@
+import { renderHook, act } from '@testing-library/react';
+import usePersistedState from '../hooks/usePersistedState';
+
+describe('usePersistedState', () => {
+  it('persists value to localStorage', () => {
+    const { result, rerender } = renderHook(() => usePersistedState('test-key', 0));
+    expect(result.current[0]).toBe(0);
+    act(() => result.current[1](42));
+    rerender();
+    expect(result.current[0]).toBe(42);
+    expect(JSON.parse(window.localStorage.getItem('test-key'))).toBe(42);
+  });
+});

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import confetti from 'canvas-confetti';
-import GameLayout from './GameLayout';
+import { GameShell } from '../games';
 
 const winningLines = [
   [0, 1, 2],
@@ -64,7 +64,7 @@ const getMediumMove = (board, ai) => {
   return available[Math.floor(Math.random() * available.length)];
 };
 
-const TicTacToe = () => {
+const TicTacToe = ({ settings, setSettings, paused, setPaused }) => {
   const [board, setBoard] = useState(Array(9).fill(null));
   const [status, setStatus] = useState('Choose X or O');
   const [player, setPlayer] = useState(null);
@@ -74,6 +74,7 @@ const TicTacToe = () => {
   const [winningLine, setWinningLine] = useState([]);
   const [lastMove, setLastMove] = useState(null);
   const [score, setScore] = useState({ player: 0, ai: 0, draw: 0 });
+  const [showSettings, setShowSettings] = useState(false);
 
   const startGame = (p) => {
     const a = p === 'X' ? 'O' : 'X';
@@ -191,12 +192,14 @@ const TicTacToe = () => {
 
   if (player === null) {
     return (
-      <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <div className={`h-full w-full flex flex-col items-center justify-center ${
+        settings.highContrast ? 'bg-black text-white' : 'bg-ub-cool-grey text-white'
+      } p-4`}>
         {difficultySlider}
         <div className="mb-4">Choose X or O</div>
         <div className="flex space-x-4">
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className={`${settings.highContrast ? 'bg-white text-black' : 'bg-gray-700 hover:bg-gray-600'} px-4 py-2 rounded`}
             onClick={() => startGame('X')}
             onTouchStart={() => startGame('X')}
             onKeyDown={(e) => {
@@ -209,7 +212,7 @@ const TicTacToe = () => {
             X
           </button>
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className={`${settings.highContrast ? 'bg-white text-black' : 'bg-gray-700 hover:bg-gray-600'} px-4 py-2 rounded`}
             onClick={() => startGame('O')}
             onTouchStart={() => startGame('O')}
             onKeyDown={(e) => {
@@ -228,13 +231,64 @@ const TicTacToe = () => {
   }
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+    <div className={`h-full w-full flex flex-col items-center justify-center ${
+      settings.highContrast ? 'bg-black text-white' : 'bg-ub-cool-grey text-white'
+    } p-4 relative`}>
+      {showSettings && (
+        <div
+          className="absolute inset-0 bg-black/70 flex items-center justify-center z-20"
+          data-testid="settings-overlay"
+        >
+          <div className="bg-gray-800 p-4 rounded">
+            <label className="block mb-2">
+              <input
+                type="checkbox"
+                checked={settings.highContrast}
+                onChange={() => setSettings((s) => ({ ...s, highContrast: !s.highContrast }))}
+              />{' '}
+              High contrast
+            </label>
+            <label className="block mb-4">
+              <input
+                type="checkbox"
+                checked={settings.colorBlind}
+                onChange={() => setSettings((s) => ({ ...s, colorBlind: !s.colorBlind }))}
+              />{' '}
+              Color blind
+            </label>
+            <button
+              className="px-2 py-1 bg-gray-700 rounded"
+              onClick={() => setShowSettings(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="flex space-x-2 mb-2">
+        <button
+          className="px-2 py-1 bg-gray-700 rounded"
+          onClick={() => setPaused(!paused)}
+          data-testid="pause-btn"
+        >
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-700 rounded"
+          onClick={() => setShowSettings(true)}
+          data-testid="settings-btn"
+        >
+          Settings
+        </button>
+      </div>
       {difficultySlider}
       <div className="grid grid-cols-3 gap-1 w-60 mb-4">
         {board.map((cell, idx) => (
           <button
             key={idx}
-            className={`h-20 w-20 text-4xl flex items-center justify-center bg-gray-700 hover:bg-gray-600 ${
+            className={`h-20 w-20 text-4xl flex items-center justify-center ${
+              settings.highContrast ? 'bg-white text-black' : 'bg-gray-700 hover:bg-gray-600'
+            } ${
               winningLine.includes(idx)
                 ? 'bg-green-600 animate-pulse'
                 : lastMove === idx
@@ -251,7 +305,17 @@ const TicTacToe = () => {
               }
             }}
           >
-            {cell}
+            <span
+              className={
+                settings.colorBlind
+                  ? cell === 'X'
+                    ? 'text-blue-400'
+                    : 'text-yellow-400'
+                  : ''
+              }
+            >
+              {cell}
+            </span>
           </button>
         ))}
       </div>
@@ -261,14 +325,18 @@ const TicTacToe = () => {
       <div className="mb-4">{status}</div>
       <div className="flex space-x-4">
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className={`${
+            settings.highContrast ? 'bg-white text-black' : 'bg-gray-700 hover:bg-gray-600'
+          } px-4 py-2 rounded`}
           onClick={restart}
           onTouchStart={restart}
         >
           Restart
         </button>
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className={`${
+            settings.highContrast ? 'bg-white text-black' : 'bg-gray-700 hover:bg-gray-600'
+          } px-4 py-2 rounded`}
           onClick={reset}
           onTouchStart={reset}
         >
@@ -284,8 +352,11 @@ export { checkWinner, minimax };
 
 export default function TicTacToeApp() {
   return (
-    <GameLayout gameId="tictactoe">
+    <GameShell
+      gameId="tictactoe"
+      initialSettings={{ highContrast: false, colorBlind: false }}
+    >
       <TicTacToe />
-    </GameLayout>
+    </GameShell>
   );
 }

--- a/components/games/GameShell.jsx
+++ b/components/games/GameShell.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState, useRef } from 'react';
+import VirtualControls from './VirtualControls';
+import useGameInput from '../../hooks/useGameInput';
+import usePersistedState from '../../hooks/usePersistedState';
+import useOrientationGuard from '../../hooks/useOrientationGuard';
+
+/**
+ * Generic shell that wraps simple canvas games. It provides:
+ *  - Pause / resume handling
+ *  - Auto pause when the tab becomes hidden
+ *  - Settings persistence via usePersistedState
+ *  - Optional FTUE overlay on first load
+ *  - Rendering of on screen virtual controls
+ */
+export default function GameShell({
+  gameId,
+  children,
+  initialSettings = {},
+}) {
+  const [paused, setPaused] = useState(false);
+  const [showFtue, setShowFtue] = usePersistedState(`game:${gameId}:ftue`, true);
+  const [settings, setSettings] = usePersistedState(
+    `game:${gameId}:settings`,
+    initialSettings
+  );
+  const { lastInput, hideVirtualControls } = useGameInput();
+  const orientationOk = useOrientationGuard();
+
+  // Auto pause on tab hide
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        setPaused(true);
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, []);
+
+  // hide FTUE after first interaction
+  const dismissFtue = () => setShowFtue(false);
+
+  return (
+    <div className="relative w-full h-full select-none">
+      {!orientationOk && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black text-white z-50">
+          Rotate your device
+        </div>
+      )}
+      {showFtue && (
+        <div
+          className="absolute inset-0 bg-black/70 text-white flex items-center justify-center z-40"
+          onClick={dismissFtue}
+          data-testid="ftue-overlay"
+        >
+          Tap to start
+        </div>
+      )}
+      {paused && (
+        <div
+          className="absolute inset-0 bg-black/50 text-white flex items-center justify-center z-30"
+          data-testid="pause-overlay"
+        >
+          Paused
+        </div>
+      )}
+      <div className="w-full h-full" aria-hidden={paused}>
+        {React.cloneElement(children, {
+          settings,
+          setSettings,
+          paused,
+          setPaused,
+        })}
+      </div>
+      {!hideVirtualControls && <VirtualControls lastInput={lastInput} />}
+    </div>
+  );
+}

--- a/components/games/VirtualControls.jsx
+++ b/components/games/VirtualControls.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+/**
+ * Simple on screen virtual controls used for touch devices.
+ * They disappear after a keyboard or gamepad input is detected.
+ */
+export default function VirtualControls({ lastInput }) {
+  const [hidden, setHidden] = useState(false);
+
+  // hide when lastInput is keyboard or gamepad
+  React.useEffect(() => {
+    if (lastInput === 'keyboard' || lastInput === 'gamepad') {
+      setHidden(true);
+    }
+  }, [lastInput]);
+
+  if (hidden) return null;
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 flex flex-col gap-2 z-20"
+      data-testid="virtual-controls"
+    >
+      <button className="bg-gray-700 text-white rounded p-2">▲</button>
+      <div className="flex gap-2">
+        <button className="bg-gray-700 text-white rounded p-2">◀</button>
+        <button className="bg-gray-700 text-white rounded p-2">▶</button>
+      </div>
+      <button className="bg-gray-700 text-white rounded p-2">▼</button>
+    </div>
+  );
+}

--- a/components/games/index.js
+++ b/components/games/index.js
@@ -1,0 +1,2 @@
+export { default as GameShell } from './GameShell.jsx';
+export { default as VirtualControls } from './VirtualControls.jsx';

--- a/hooks/useGameAudio.js
+++ b/hooks/useGameAudio.js
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+// Minimal audio helper using the Web Audio API
+export default function useGameAudio(src, { volume = 1 } = {}) {
+  const audioRef = useRef(null);
+
+  useEffect(() => {
+    if (!src) return;
+    const audio = new Audio(src);
+    audio.volume = volume;
+    audioRef.current = audio;
+    return () => {
+      audio.pause();
+    };
+  }, [src, volume]);
+
+  const play = () => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = 0;
+      audioRef.current.play();
+    }
+  };
+
+  return { play };
+}

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -1,0 +1,9 @@
+// Very small wrapper for the Vibration API
+export default function useGameHaptics() {
+  const vibrate = (pattern = [50]) => {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) {
+      navigator.vibrate(pattern);
+    }
+  };
+  return { vibrate };
+}

--- a/hooks/useGameInput.js
+++ b/hooks/useGameInput.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks the last input source used (keyboard, touch, gamepad)
+ * and exposes a flag to hide virtual touch controls when a
+ * hardware input is detected.
+ */
+export default function useGameInput() {
+  const [lastInput, setLastInput] = useState('touch');
+  const [hideVirtualControls, setHideVirtualControls] = useState(false);
+
+  useEffect(() => {
+    const onKey = () => {
+      setLastInput('keyboard');
+      setHideVirtualControls(true);
+    };
+    const onGamepad = () => {
+      setLastInput('gamepad');
+      setHideVirtualControls(true);
+    };
+    const onTouch = () => {
+      setLastInput('touch');
+    };
+
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('gamepadconnected', onGamepad);
+    window.addEventListener('pointerdown', onTouch);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('gamepadconnected', onGamepad);
+      window.removeEventListener('pointerdown', onTouch);
+    };
+  }, []);
+
+  return { lastInput, hideVirtualControls };
+}

--- a/hooks/useOrientationGuard.js
+++ b/hooks/useOrientationGuard.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+// Returns true when the device is in landscape mode
+export default function useOrientationGuard() {
+  const [ok, setOk] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.innerWidth >= window.innerHeight;
+  });
+
+  useEffect(() => {
+    const check = () => setOk(window.innerWidth >= window.innerHeight);
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  return ok;
+}

--- a/hooks/usePersistedState.js
+++ b/hooks/usePersistedState.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+// A small wrapper around useState that persists the value to localStorage
+export default function usePersistedState(key, initialValue) {
+  const [state, setState] = useState(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // ignore
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
## Summary
- add GameShell and VirtualControls components with auto-pause and FTUE overlay
- introduce game utility hooks (input, audio, haptics, orientation, persisted state)
- refactor TicTacToe to use GameShell with persistent high-contrast/color-blind settings
- add unit tests for hooks and TicTacToe flows

## Testing
- `npx jest __tests__/useGameInput.test.js __tests__/usePersistedState.test.js __tests__/tictactoeShell.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ae81ec95ac8328a2991ff0bc906a0d