### PR TITLE
feat: enhance 2048 game with undo and accessibility

### DIFF
--- a/__tests__/game2048.test.tsx
+++ b/__tests__/game2048.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Game2048, { setSeed } from '../components/apps/2048';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setSeed(1);
+});
+
+test('merging two 2s creates one 4', () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 2, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  render(<Game2048 />);
+  fireEvent.keyDown(window, { key: 'ArrowLeft' });
+  const board = JSON.parse(window.localStorage.getItem('2048-board') || '[]');
+  expect(board[0][0]).toBe(4);
+});
+
+test('undo only restores last move', () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 2, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  const { getByText } = render(<Game2048 />);
+  const initial = JSON.parse(window.localStorage.getItem('2048-board') || '[]');
+  fireEvent.keyDown(window, { key: 'ArrowLeft' });
+  const undoBtn = getByText('Undo');
+  fireEvent.click(undoBtn);
+  let board = JSON.parse(window.localStorage.getItem('2048-board') || '[]');
+  expect(board).toEqual(initial);
+  fireEvent.click(undoBtn);
+  board = JSON.parse(window.localStorage.getItem('2048-board') || '[]');
+  expect(board).toEqual(initial);
+});
+
+test('colorblind palette toggle changes tile class', () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  const { container, getByLabelText } = render(<Game2048 />);
+  const firstCell = container.querySelector('.grid div');
+  expect(firstCell?.className).toContain('bg-gray-300');
+  const toggle = getByLabelText('Colorblind');
+  fireEvent.click(toggle);
+  const updated = container.querySelector('.grid div');
+  expect(updated?.className).not.toContain('bg-gray-300');
+});


### PR DESCRIPTION
## Summary
- add seeded RNG and swipe-based movement handler
- support single-step undo with vibration feedback and animated tile spawn
- add color-blind palette toggle
- cover game logic and UI with tests

## Testing
- `yarn test __tests__/game2048.test.tsx`
- `yarn lint components/apps/2048.js __tests__/game2048.test.tsx` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81f799b08328aeb98e12b6115878