### PR TITLE
feat: improve checkers interactions and tests

### DIFF
--- a/__tests__/checkers.ui.test.tsx
+++ b/__tests__/checkers.ui.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Checkers from '../components/apps/checkers';
+
+jest.mock('react-ga4', () => ({ event: jest.fn() }));
+
+class WorkerMock {
+  public onmessage: ((ev: MessageEvent) => void) | null = null;
+  postMessage() {}
+  terminate() {}
+}
+// @ts-ignore
+global.Worker = WorkerMock;
+
+describe('Checkers UI', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('illegal moves are rejected', () => {
+    const { getByTestId } = render(<Checkers />);
+    const from = getByTestId('square-5-0');
+    const illegal = getByTestId('square-5-2');
+    fireEvent.click(from);
+    fireEvent.click(illegal);
+    expect(getByTestId('piece-5-0')).toBeTruthy();
+  });
+
+  test('kinged piece shows crown', () => {
+    const customBoard = Array.from({ length: 8 }, () => Array(8).fill(null));
+    // place a single red piece ready to king
+    customBoard[1][2] = { color: 'red', king: false } as any;
+    localStorage.setItem(
+      'checkersState',
+      JSON.stringify({
+        board: customBoard,
+        turn: 'red',
+        history: [],
+        future: [],
+        noCapture: 0,
+        winner: null,
+        draw: false,
+        lastMove: [],
+      })
+    );
+    const { getByTestId } = render(<Checkers />);
+    const from = getByTestId('square-1-2');
+    const to = getByTestId('square-0-1');
+    fireEvent.click(from);
+    fireEvent.click(to);
+    expect(getByTestId('piece-0-1').textContent).toContain('👑');
+  });
+});


### PR DESCRIPTION
## Summary
- highlight forced jumps and kings with a crown
- add drag-and-drop and keyboard controls for moving pieces
- test illegal move rejection and king crowning

## Testing
- `npm test __tests__/checkers.validator.test.ts __tests__/checkers.ui.test.tsx`
- `npm test` *(fails: process hangs after running most suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81fb7ff883288c018340a515d1b5