### PR TITLE
Add hotseat mode and ship placement utilities

### DIFF
--- a/__tests__/battleship-utils.test.js
+++ b/__tests__/battleship-utils.test.js
@@ -1,0 +1,17 @@
+import { canPlaceShip, isGameOver } from '../components/apps/battleship/utils';
+import { BOARD_SIZE } from '../components/apps/battleship/ai';
+
+test('canPlaceShip rejects overlaps', () => {
+  const ships = [{ id: 0, cells: [0, 1] }];
+  const res = canPlaceShip(ships, 0, 0, 0, 2, 1);
+  expect(res).toBeNull();
+});
+
+test('isGameOver detects when all ships sunk', () => {
+  const board = Array(BOARD_SIZE * BOARD_SIZE).fill(null);
+  expect(isGameOver(board)).toBe(true);
+  board[0] = 'ship';
+  expect(isGameOver(board)).toBe(false);
+  board[0] = 'hit';
+  expect(isGameOver(board)).toBe(true);
+});

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -2,11 +2,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Draggable from 'react-draggable';
 import {
   MonteCarloAI,
-  RandomSalvoAI,
+  HuntTargetAI,
   BOARD_SIZE,
   randomizePlacement,
 } from './battleship/ai';
 import GameLayout from './battleship/GameLayout';
+import { canPlaceShip, isGameOver } from './battleship/utils';
 import usePersistentState from '../hooks/usePersistentState';
 import useGameControls from './useGameControls';
 
@@ -22,22 +23,10 @@ const HitMarker = () => (
     strokeWidth="4"
   >
     <line x1="4" y1="4" x2="28" y2="28">
-      <animate
-        attributeName="stroke-opacity"
-        from="0"
-        to="1"
-        dur="0.2s"
-        fill="freeze"
-      />
+      <animate attributeName="stroke-opacity" from="0" to="1" dur="0.2s" fill="freeze" />
     </line>
     <line x1="28" y1="4" x2="4" y2="28">
-      <animate
-        attributeName="stroke-opacity"
-        from="0"
-        to="1"
-        dur="0.2s"
-        fill="freeze"
-      />
+      <animate attributeName="stroke-opacity" from="0" to="1" dur="0.2s" fill="freeze" />
     </line>
   </svg>
 );
@@ -61,16 +50,22 @@ const Battleship = () => {
   const [phase, setPhase] = useState('placement');
   const [playerBoard, setPlayerBoard] = useState(createBoard());
   const [enemyBoard, setEnemyBoard] = useState(createBoard());
-  const [ships, setShips] = useState([]); // player's ship objects
+  const [ships, setShips] = useState([]);
   const [heat, setHeat] = useState(Array(BOARD_SIZE * BOARD_SIZE).fill(0));
   const [message, setMessage] = useState('Place your ships');
   const [difficulty, setDifficulty] = useState('easy');
+  const [mode, setMode] = useState('ai');
   const [ai, setAi] = useState(null);
   const [stats, setStats] = usePersistentState('battleship-stats', {
     wins: 0,
     losses: 0,
   });
   const [cursor, setCursor] = useState(0);
+  const [privacy, setPrivacy] = useState(false);
+  const [placing, setPlacing] = useState(0);
+  const [boards, setBoards] = useState([createBoard(), createBoard()]);
+  const [fleets, setFleets] = useState([[], []]);
+  const [turn, setTurn] = useState(0);
 
   const placeShips = useCallback((board, layout) => {
     const newBoard = board.slice();
@@ -79,19 +74,31 @@ const Battleship = () => {
   }, []);
 
   const restart = useCallback(
-    (diff = difficulty) => {
+    (diff = difficulty, m = mode) => {
       const layout = randomizePlacement();
       const newShips = layout.map((s, i) => ({ ...s, id: i }));
+      const pb = placeShips(createBoard(), newShips);
       setShips(newShips);
-      setPlayerBoard(placeShips(createBoard(), newShips));
-      setEnemyBoard(placeShips(createBoard(), randomizePlacement()));
+      setPlayerBoard(pb);
+      if (m === 'ai') {
+        setEnemyBoard(placeShips(createBoard(), randomizePlacement()));
+        setAi(diff === 'hard' ? new MonteCarloAI() : new HuntTargetAI());
+      } else {
+        setEnemyBoard(createBoard());
+        setAi(null);
+      }
+      setBoards([pb, createBoard()]);
+      setFleets([newShips, []]);
       setPhase('placement');
       setMessage('Place your ships');
       setHeat(Array(BOARD_SIZE * BOARD_SIZE).fill(0));
-      setAi(diff === 'hard' ? new MonteCarloAI() : new RandomSalvoAI());
       setCursor(0);
+      setPlacing(0);
+      setTurn(0);
+      setMode(m);
+      setPrivacy(false);
     },
-    [difficulty, placeShips]
+    [difficulty, mode, placeShips]
   );
 
   useEffect(() => {
@@ -102,19 +109,22 @@ const Battleship = () => {
     const x = Math.round(data.x / CELL);
     const y = Math.round(data.y / CELL);
     const ship = ships[i];
-    const cells = [];
-    for(let k=0;k<ship.len;k++){
-      const cx = x + (ship.dir===0? k:0);
-      const cy = y + (ship.dir===1? k:0);
-      if(cx<0||cy<0||cx>=BOARD_SIZE||cy>=BOARD_SIZE) return; // out
-      const idx = cy*BOARD_SIZE+cx;
-      // check overlap with other ships
-      for(const s of ships){
-        if(s.id!==ship.id && s.cells && s.cells.includes(idx)) return;
-      }
-      cells.push(idx);
-    }
-    const updated = ships.map(s=>s.id===ship.id?{...s,x,y,cells}:s);
+    const cells = canPlaceShip(ships, x, y, ship.dir, ship.len, ship.id);
+    if (!cells) return;
+    const updated = ships.map((s) => (s.id === ship.id ? { ...s, x, y, cells } : s));
+    setShips(updated);
+    setPlayerBoard(placeShips(createBoard(), updated));
+  };
+
+  const handleRotate = (i) => {
+    if (phase !== 'placement') return;
+    const ship = ships[i];
+    const x = ship.x || 0;
+    const y = ship.y || 0;
+    const newDir = ship.dir === 0 ? 1 : 0;
+    const cells = canPlaceShip(ships, x, y, newDir, ship.len, ship.id);
+    if (!cells) return;
+    const updated = ships.map((s) => (s.id === ship.id ? { ...s, dir: newDir, cells } : s));
     setShips(updated);
     setPlayerBoard(placeShips(createBoard(), updated));
   };
@@ -127,10 +137,40 @@ const Battleship = () => {
   };
 
   const start = () => {
-    // ensure all ships placed (cells present)
-    if(ships.some(s=>!s.cells)){
+    if (ships.some((s) => !s.cells)) {
       setMessage('Place all ships');
       return;
+    }
+    if (mode === 'hotseat') {
+      if (placing === 0) {
+        const newBoards = boards.slice();
+        const newFleets = fleets.slice();
+        newBoards[0] = playerBoard;
+        newFleets[0] = ships;
+        setBoards(newBoards);
+        setFleets(newFleets);
+        setShips([]);
+        setPlayerBoard(createBoard());
+        setPlacing(1);
+        setMessage('Player 2: Place your ships');
+        setPrivacy(true);
+        return;
+      } else {
+        const newBoards = boards.slice();
+        const newFleets = fleets.slice();
+        newBoards[1] = playerBoard;
+        newFleets[1] = ships;
+        setBoards(newBoards);
+        setFleets(newFleets);
+        setPlayerBoard(newBoards[0]);
+        setEnemyBoard(newBoards[1]);
+        setShips(newFleets[0]);
+        setPhase('battle');
+        setMessage('Player 1 turn');
+        setTurn(0);
+        setPrivacy(true);
+        return;
+      }
     }
     setPhase('battle');
     setMessage('Your turn');
@@ -143,32 +183,56 @@ const Battleship = () => {
       const hit = newBoard[idx] === 'ship';
       newBoard[idx] = hit ? 'hit' : 'miss';
       setEnemyBoard(newBoard);
-      if (!newBoard.includes('ship')) {
-        setMessage('You win!');
+      if (isGameOver(newBoard)) {
+        setMessage(mode === 'ai' ? 'You win!' : `Player ${turn + 1} wins!`);
         setPhase('done');
-        setStats((s) => ({ ...s, wins: s.wins + 1 }));
+        if (mode === 'ai') {
+          setStats((s) => ({ ...s, wins: s.wins + 1 }));
+        }
         return;
       }
-      // AI turn
       setTimeout(() => {
-        const move = ai.nextMove();
-        if (move == null) return;
-        const pb = playerBoard.slice();
-        const hit2 = pb[move] === 'ship';
-        pb[move] = hit2 ? 'hit' : 'miss';
-        setPlayerBoard(pb);
-        const nh = heat.slice();
-        nh[move]++;
-        setHeat(nh);
-        ai.record(move, hit2);
-        if (!pb.includes('ship')) {
-          setMessage('AI wins!');
-          setPhase('done');
-          setStats((s) => ({ ...s, losses: s.losses + 1 }));
-        } else setMessage(hit ? 'Hit!' : 'Miss!');
-      }, 100); // simulate thinking
+        if (mode === 'ai') {
+          const move = ai.nextMove();
+          if (move == null) return;
+          const pb = playerBoard.slice();
+          const hit2 = pb[move] === 'ship';
+          pb[move] = hit2 ? 'hit' : 'miss';
+          setPlayerBoard(pb);
+          const nh = heat.slice();
+          nh[move]++;
+          setHeat(nh);
+          ai.record(move, hit2);
+          if (isGameOver(pb)) {
+            setMessage('AI wins!');
+            setPhase('done');
+            setStats((s) => ({ ...s, losses: s.losses + 1 }));
+          } else setMessage(hit ? 'Hit!' : 'Miss!');
+        } else {
+          const turnPlayer = 1 - turn;
+          const boardsCopy = boards.slice();
+          const myBoard = boardsCopy[turnPlayer].slice();
+          const move = cursor; // use cursor as firing position for simplicity
+          if (myBoard[move]) return;
+          const h = myBoard[move] === 'ship';
+          myBoard[move] = h ? 'hit' : 'miss';
+          boardsCopy[turnPlayer] = myBoard;
+          setBoards(boardsCopy);
+          setPlayerBoard(myBoard);
+          if (isGameOver(myBoard)) {
+            setMessage(`Player ${turnPlayer + 1} wins!`);
+            setPhase('done');
+          } else {
+            setTurn(turnPlayer);
+            setPlayerBoard(boardsCopy[turnPlayer]);
+            setEnemyBoard(boardsCopy[1 - turnPlayer]);
+            setPrivacy(true);
+            setMessage(`Player ${turnPlayer + 1} turn`);
+          }
+        }
+      }, 100);
     },
-    [ai, enemyBoard, heat, phase, playerBoard, setEnemyBoard, setPlayerBoard, setHeat, setMessage, setPhase, setStats]
+    [ai, enemyBoard, heat, mode, phase, playerBoard, boards, cursor, turn, setStats]
   );
 
   useGameControls(({ x, y }) => {
@@ -193,22 +257,20 @@ const Battleship = () => {
     return () => window.removeEventListener('keydown', handleKey);
   }, [phase, cursor, fire]);
 
-  const renderBoard = (board, isEnemy=false) => (
-    <div className="grid" style={{gridTemplateColumns:`repeat(${BOARD_SIZE}, ${CELL}px)`}}>
-      {board.map((cell,idx)=>{
+  const renderBoard = (board, isEnemy = false) => (
+    <div className="grid" style={{ gridTemplateColumns: `repeat(${BOARD_SIZE}, ${CELL}px)` }}>
+      {board.map((cell, idx) => {
         const heatVal = heat[idx];
-        const color = heatVal? `rgba(255,0,0,${Math.min(heatVal/5,0.5)})` : 'transparent';
+        const color = heatVal ? `rgba(255,0,0,${Math.min(heatVal / 5, 0.5)})` : 'transparent';
         return (
-          <div key={idx} className="border border-ub-dark-grey relative" style={{width:CELL,height:CELL}}>
-            {isEnemy && phase==='battle' && !['hit','miss'].includes(cell)?(
-              <button className="w-full h-full" onClick={()=>fire(idx)} />
-            ):null}
-            {cell==='hit' && <HitMarker />}
-            {cell==='miss' && <MissMarker />}
-            {!isEnemy && <div className="absolute inset-0" style={{background:color}}/>}
-            {isEnemy && phase==='battle' && idx===cursor && (
-              <div className="absolute inset-0 border-2 border-yellow-300 pointer-events-none" />
-            )}
+          <div
+            key={idx}
+            onClick={() => (!isEnemy && phase === 'battle' ? setCursor(idx) : null)}
+            className={`w-${CELL} h-${CELL} border border-ub-dark-grey relative`}
+            style={{ backgroundColor: color }}
+          >
+            {cell === 'hit' && <HitMarker />}
+            {cell === 'miss' && <MissMarker />}
           </div>
         );
       })}
@@ -216,38 +278,60 @@ const Battleship = () => {
   );
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto font-ubuntu">
+    <div className="relative w-full h-full">
       <GameLayout
         difficulty={difficulty}
         onDifficultyChange={(d) => {
           setDifficulty(d);
           restart(d);
         }}
+        mode={mode}
+        onModeChange={(m) => restart(difficulty, m)}
         onRestart={() => restart()}
-        stats={stats}
+        stats={mode === 'ai' ? stats : null}
       >
         <div className="mb-2">{message}</div>
-        {phase==='placement' && (
+        {phase === 'placement' && (
           <div className="flex space-x-4">
-            <div className="relative border border-ub-dark-grey" style={{width:BOARD_SIZE*CELL,height:BOARD_SIZE*CELL}}>
+            <div className="relative border border-ub-dark-grey" style={{ width: BOARD_SIZE * CELL, height: BOARD_SIZE * CELL }}>
               {renderBoard(playerBoard)}
-              {ships.map((ship,i)=>(
-                <Draggable key={ship.id} grid={[CELL,CELL]} position={{x:(ship.x||0)*CELL,y:(ship.y||0)*CELL}}
-                  onStop={(e,data)=>handleDragStop(i,e,data)} disabled={phase!=='placement'}>
-                  <div className="absolute bg-blue-700 opacity-80" style={{width:(ship.dir===0?ship.len:1)*CELL,height:(ship.dir===1?ship.len:1)*CELL}}/>
+              {ships.map((ship, i) => (
+                <Draggable
+                  key={ship.id}
+                  grid={[CELL, CELL]}
+                  position={{ x: (ship.x || 0) * CELL, y: (ship.y || 0) * CELL }}
+                  onStop={(e, data) => handleDragStop(i, e, data)}
+                  disabled={phase !== 'placement'}
+                >
+                  <div
+                    onDoubleClick={() => handleRotate(i)}
+                    className="absolute bg-blue-700 opacity-80"
+                    style={{ width: (ship.dir === 0 ? ship.len : 1) * CELL, height: (ship.dir === 1 ? ship.len : 1) * CELL }}
+                  />
                 </Draggable>
               ))}
             </div>
             <div className="flex flex-col space-y-2">
-              <button className="px-2 py-1 bg-gray-700" onClick={randomize}>Randomize</button>
-              <button className="px-2 py-1 bg-gray-700" onClick={start}>Start</button>
+              <button className="px-2 py-1 bg-gray-700" onClick={randomize}>
+                Randomize
+              </button>
+              <button className="px-2 py-1 bg-gray-700" onClick={start}>
+                Start
+              </button>
             </div>
           </div>
         )}
-        {phase!=='placement' && (
+        {phase !== 'placement' && (
           <div className="flex space-x-8">
             <div>{renderBoard(playerBoard)}</div>
-            <div>{renderBoard(enemyBoard,true)}</div>
+            <div>{renderBoard(enemyBoard, true)}</div>
+          </div>
+        )}
+        {privacy && (
+          <div className="absolute inset-0 bg-black bg-opacity-80 flex items-center justify-center">
+            <button className="px-4 py-2 bg-gray-700" onClick={() => setPrivacy(false)}>
+              Continue
+            </button>
           </div>
         )}
       </GameLayout>

--- a/components/apps/battleship/GameLayout.js
+++ b/components/apps/battleship/GameLayout.js
@@ -1,9 +1,16 @@
 import React from 'react';
 
-const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats }) => {
+const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats, mode, onModeChange }) => {
   return (
     <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
       <div className="flex items-center space-x-2 mb-2">
+        <label className="text-sm">
+          Mode:
+          <select className="ml-1 bg-gray-700 text-white p-1" value={mode} onChange={(e) => onModeChange(e.target.value)}>
+            <option value="ai">AI</option>
+            <option value="hotseat">Hotseat</option>
+          </select>
+        </label>
         <label className="text-sm">
           Difficulty:
           <select

--- a/components/apps/battleship/ai.js
+++ b/components/apps/battleship/ai.js
@@ -133,7 +133,7 @@ export function randomizePlacement(noAdjacency = false) {
 }
 
 
-export class RandomSalvoAI {
+export class HuntTargetAI {
   constructor() {
     this.available = new Set(Array.from({ length: BOARD_SIZE * BOARD_SIZE }, (_, i) => i));
     this.queue = [];

--- a/components/apps/battleship/utils.js
+++ b/components/apps/battleship/utils.js
@@ -1,0 +1,24 @@
+import { BOARD_SIZE } from './ai';
+
+// Determine if a ship can be placed at given coordinates without overlaps.
+export function canPlaceShip(ships, x, y, dir, len, ignoreId) {
+  const cells = [];
+  for (let k = 0; k < len; k++) {
+    const cx = x + (dir === 0 ? k : 0);
+    const cy = y + (dir === 1 ? k : 0);
+    if (cx < 0 || cy < 0 || cx >= BOARD_SIZE || cy >= BOARD_SIZE) return null;
+    const idx = cy * BOARD_SIZE + cx;
+    for (const s of ships) {
+      if (ignoreId != null && s.id === ignoreId) continue;
+      if (s.cells && s.cells.includes(idx)) return null;
+    }
+    cells.push(idx);
+  }
+  return cells;
+}
+
+// Check if all ships on a board have been sunk.
+export function isGameOver(board) {
+  return !board.includes('ship');
+}
+


### PR DESCRIPTION
## Summary
- add rotation-aware ship placement utilities and game-over check
- integrate hotseat mode and hunt-target AI
- expose mode selector in Battleship game layout

## Testing
- `yarn test __tests__/battleship-utils.test.js __tests__/battleship-ai.test.js` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81f85d3c8328963096f11a03a53a