### PR TITLE
feat: add connect four hover preview and difficulty slider

### DIFF
--- a/__tests__/connect-four.test.ts
+++ b/__tests__/connect-four.test.ts
@@ -1,0 +1,45 @@
+import { performance } from 'perf_hooks';
+import { createEmptyBoard, checkWinner, minimax } from '../components/apps/connect-four';
+
+describe('connect four logic', () => {
+  it('detects diagonal wins', () => {
+    const board = createEmptyBoard();
+    board[5][0] = 'red';
+    board[4][1] = 'red';
+    board[3][2] = 'red';
+    board[2][3] = 'red';
+    const win1 = checkWinner(board, 'red');
+    expect(win1).toEqual([
+      { r: 2, c: 3 },
+      { r: 3, c: 2 },
+      { r: 4, c: 1 },
+      { r: 5, c: 0 },
+    ]);
+
+    const board2 = createEmptyBoard();
+    board2[2][0] = 'yellow';
+    board2[3][1] = 'yellow';
+    board2[4][2] = 'yellow';
+    board2[5][3] = 'yellow';
+    const win2 = checkWinner(board2, 'yellow');
+    expect(win2).toEqual([
+      { r: 2, c: 0 },
+      { r: 3, c: 1 },
+      { r: 4, c: 2 },
+      { r: 5, c: 3 },
+    ]);
+  });
+
+  it('AI depth affects response time', () => {
+    const board = createEmptyBoard();
+    const start1 = performance.now();
+    minimax(board, 1, -Infinity, Infinity, true);
+    const time1 = performance.now() - start1;
+
+    const start3 = performance.now();
+    minimax(board, 3, -Infinity, Infinity, true);
+    const time3 = performance.now() - start3;
+
+    expect(time3).toBeGreaterThan(time1);
+  });
+});

--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -202,6 +202,7 @@ const ConnectFour = () => {
     setWinner(null);
     setWinningCells([]);
     setPlayer('red');
+    setSelectedCol(Math.floor(COLS / 2));
   };
 
   return (
@@ -209,19 +210,17 @@ const ConnectFour = () => {
       <div className="mb-2 flex gap-4 items-center">
         <div>Red: {scores.red}</div>
         <div>Yellow: {scores.yellow}</div>
-        <div>
-          Depth:
-          <select
-            className="ml-1 bg-gray-700"
+        <div className="flex items-center">
+          <span>Depth:</span>
+          <input
+            type="range"
+            min={1}
+            max={6}
             value={depth}
             onChange={(e) => setDepth(parseInt(e.target.value, 10))}
-          >
-            {[1, 2, 3, 4, 5].map((d) => (
-              <option key={d} value={d}>
-                {d}
-              </option>
-            ))}
-          </select>
+            className="ml-1"
+          />
+          <span className="ml-1 w-4 text-center">{depth}</span>
         </div>
       </div>
       {winner && (
@@ -230,7 +229,22 @@ const ConnectFour = () => {
         </div>
       )}
       <div className="relative">
-        <div className="grid grid-cols-7 gap-1">
+        {selectedCol >= 0 && (
+          <div
+            className="absolute left-0 -top-10 transition-transform pointer-events-none"
+            style={{ transform: `translateX(${selectedCol * SLOT}px)` }}
+          >
+            <div
+              className={`h-8 w-8 rounded-full opacity-50 ${
+                player === 'red' ? 'bg-red-500' : 'bg-yellow-400'
+              }`}
+            />
+          </div>
+        )}
+        <div
+          className="grid grid-cols-7 gap-1"
+          onMouseLeave={() => setSelectedCol(-1)}
+        >
           {board.map((row, rIdx) =>
             row.map((cell, cIdx) => {
               const isWin = winningCells.some((p) => p.r === rIdx && p.c === cIdx);
@@ -242,6 +256,11 @@ const ConnectFour = () => {
                   }`}
                   onClick={() => dropDisc(cIdx)}
                   onMouseEnter={() => setSelectedCol(cIdx)}
+                  onTouchStart={() => setSelectedCol(cIdx)}
+                  onTouchEnd={(e) => {
+                    e.preventDefault();
+                    dropDisc(cIdx);
+                  }}
                 >
                   {cell && (
                     <div
@@ -281,4 +300,6 @@ const ConnectFour = () => {
 };
 
 export default ConnectFour;
+
+export { createEmptyBoard, checkWinner, minimax };
 

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -1,42 +1,96 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
- * Hook to handle keyboard arrow keys and touch swipe gestures.
- * Calls the provided callback with a direction object: {x, y}.
+ * Game input helper.
+ *
+ * Two modes are supported:
+ *   1. Directional mode – `useGameControls(cb)` where `cb` receives
+ *      `{x, y}` for arrow key or swipe gestures.
+ *   2. Column selection mode – `useGameControls(cols, onSelect)` used by
+ *      grid based games such as Connect Four. Returns `[selected, setSelected]`
+ *      and handles left/right movement as well as Enter/Space to confirm.
  */
-const useGameControls = (onDirection) => {
-  // keyboard controls
+const useGameControls = (arg1, arg2) => {
+  // --- directional mode -------------------------------------------------
+  if (typeof arg1 === 'function') {
+    const onDirection = arg1;
+
+    // keyboard controls
+    useEffect(() => {
+      const handleKey = (e) => {
+        if (e.key === 'ArrowUp') onDirection({ x: 0, y: -1 });
+        if (e.key === 'ArrowDown') onDirection({ x: 0, y: 1 });
+        if (e.key === 'ArrowLeft') onDirection({ x: -1, y: 0 });
+        if (e.key === 'ArrowRight') onDirection({ x: 1, y: 0 });
+      };
+      window.addEventListener('keydown', handleKey);
+      return () => window.removeEventListener('keydown', handleKey);
+    }, [onDirection]);
+
+    // touch swipe controls
+    useEffect(() => {
+      let startX = 0;
+      let startY = 0;
+
+      const start = (e) => {
+        startX = e.touches[0].clientX;
+        startY = e.touches[0].clientY;
+      };
+
+      const end = (e) => {
+        const dx = e.changedTouches[0].clientX - startX;
+        const dy = e.changedTouches[0].clientY - startY;
+        if (Math.abs(dx) > Math.abs(dy)) {
+          if (dx > 30) onDirection({ x: 1, y: 0 });
+          else if (dx < -30) onDirection({ x: -1, y: 0 });
+        } else {
+          if (dy > 30) onDirection({ x: 0, y: 1 });
+          else if (dy < -30) onDirection({ x: 0, y: -1 });
+        }
+      };
+
+      window.addEventListener('touchstart', start);
+      window.addEventListener('touchend', end);
+      return () => {
+        window.removeEventListener('touchstart', start);
+        window.removeEventListener('touchend', end);
+      };
+    }, [onDirection]);
+
+    return;
+  }
+
+  // --- column selection mode -------------------------------------------
+  const cols = arg1;
+  const onSelect = arg2;
+  const [selected, setSelected] = useState(Math.floor(cols / 2));
+
+  // keyboard left/right to move, enter/space to confirm
   useEffect(() => {
     const handleKey = (e) => {
-      if (e.key === 'ArrowUp') onDirection({ x: 0, y: -1 });
-      if (e.key === 'ArrowDown') onDirection({ x: 0, y: 1 });
-      if (e.key === 'ArrowLeft') onDirection({ x: -1, y: 0 });
-      if (e.key === 'ArrowRight') onDirection({ x: 1, y: 0 });
+      if (e.key === 'ArrowLeft')
+        setSelected((s) => Math.max(0, s - 1));
+      if (e.key === 'ArrowRight')
+        setSelected((s) => Math.min(cols - 1, s + 1));
+      if (e.key === 'Enter' || e.key === ' ')
+        onSelect(selected);
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onDirection]);
+  }, [cols, onSelect, selected]);
 
-  // touch swipe controls
+  // touch swipe left/right to move
   useEffect(() => {
     let startX = 0;
-    let startY = 0;
 
     const start = (e) => {
       startX = e.touches[0].clientX;
-      startY = e.touches[0].clientY;
     };
 
     const end = (e) => {
       const dx = e.changedTouches[0].clientX - startX;
-      const dy = e.changedTouches[0].clientY - startY;
-      if (Math.abs(dx) > Math.abs(dy)) {
-        if (dx > 30) onDirection({ x: 1, y: 0 });
-        else if (dx < -30) onDirection({ x: -1, y: 0 });
-      } else {
-        if (dy > 30) onDirection({ x: 0, y: 1 });
-        else if (dy < -30) onDirection({ x: 0, y: -1 });
-      }
+      if (dx > 30) setSelected((s) => Math.min(cols - 1, s + 1));
+      else if (dx < -30) setSelected((s) => Math.max(0, s - 1));
     };
 
     window.addEventListener('touchstart', start);
@@ -45,7 +99,9 @@ const useGameControls = (onDirection) => {
       window.removeEventListener('touchstart', start);
       window.removeEventListener('touchend', end);
     };
-  }, [onDirection]);
+  }, [cols]);
+
+  return [selected, setSelected];
 };
 
 export default useGameControls;


### PR DESCRIPTION
## Summary
- add hover ghost piece and touch controls for one-tap mobile play
- replace depth dropdown with slider controlling minimax search
- expand game controls hook and add connect-four logic tests

## Testing
- `yarn test __tests__/connect-four.test.ts`
- `yarn lint components/apps/connect-four.js components/apps/useGameControls.js __tests__/connect-four.test.ts` *(fails: Could not find pages/app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81fce77c8328924875027d4f0462