### PR TITLE
Add Phaser platformer with checkpoints and coyote time

### DIFF
--- a/__tests__/phaserMatter.test.ts
+++ b/__tests__/phaserMatter.test.ts
@@ -1,0 +1,16 @@
+import { GameState } from '../apps/phaser_matter/gameLogic';
+
+describe('phaser matter platformer', () => {
+  test('falling off map resets to spawn', () => {
+    const gs = new GameState({ x: 10, y: 20 });
+    const pos = gs.respawnIfOutOfBounds({ x: 5, y: 2000 }, 1000);
+    expect(pos).toEqual({ x: 10, y: 20 });
+  });
+
+  test('checkpoint respawn overrides spawn', () => {
+    const gs = new GameState({ x: 10, y: 20 });
+    gs.setCheckpoint({ x: 100, y: 200 });
+    const pos = gs.respawnIfOutOfBounds({ x: 5, y: 2000 }, 1000);
+    expect(pos).toEqual({ x: 100, y: 200 });
+  });
+});

--- a/apps/phaser_matter/gameLogic.ts
+++ b/apps/phaser_matter/gameLogic.ts
@@ -1,0 +1,32 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export class GameState {
+  spawn: Point;
+  checkpoint?: Point;
+
+  constructor(spawn: Point) {
+    this.spawn = { ...spawn };
+  }
+
+  /**
+   * Updates the active checkpoint, used as respawn point after death.
+   */
+  setCheckpoint(p: Point) {
+    this.checkpoint = { ...p };
+  }
+
+  /**
+   * Returns the position a player should respawn to when falling below
+   * the provided boundary. If the player is above the boundary their
+   * current position is returned.
+   */
+  respawnIfOutOfBounds(player: Point, boundaryY: number): Point {
+    if (player.y > boundaryY) {
+      return this.checkpoint ? { ...this.checkpoint } : { ...this.spawn };
+    }
+    return player;
+  }
+}

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -1,71 +1,129 @@
 import React, { useEffect, useRef } from 'react';
 import Phaser from 'phaser';
+import { GameState } from './gameLogic';
 
 const PhaserMatter: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const controls = useRef({ left: false, right: false, jump: false });
 
   useEffect(() => {
     if (!containerRef.current) return;
 
-    const config: Phaser.Types.Core.GameConfig = {
+    class LevelScene extends Phaser.Scene {
+      player!: Phaser.Physics.Matter.Image;
+      state!: GameState;
+      lastGrounded = 0;
+      coyoteTime = 100; // ms
+
+      constructor() {
+        super('level');
+      }
+
+      preload() {
+        this.load.json('level', 'apps/phaser_matter/level1.json');
+      }
+
+      create() {
+        const data = this.cache.json.get('level');
+        this.state = new GameState(data.spawn);
+
+        // Platforms
+        data.platforms.forEach((p: any) => {
+          this.matter.add.rectangle(p.x, p.y, p.width, p.height, { isStatic: true });
+        });
+
+        // Hazards
+        data.hazards.forEach((h: any) => {
+          this.matter.add.rectangle(h.x, h.y, h.width, h.height, {
+            isStatic: true,
+            label: 'hazard',
+          });
+        });
+
+        // Checkpoints
+        data.checkpoints.forEach((c: any) => {
+          this.matter.add.rectangle(c.x, c.y, c.width, c.height, {
+            isStatic: true,
+            isSensor: true,
+            label: 'checkpoint',
+          });
+        });
+
+        this.player = this.matter.add.image(data.spawn.x, data.spawn.y, undefined, undefined, {
+          shape: { type: 'rectangle', width: 32, height: 32 },
+        });
+
+        // Camera dead-zone
+        this.cameras.main.setBounds(0, 0, data.bounds.width, data.bounds.height);
+        this.cameras.main.setDeadzone(data.bounds.deadZoneWidth, data.bounds.deadZoneHeight);
+        this.cameras.main.startFollow(this.player);
+
+        // Collision events
+        this.matter.world.on('collisionstart', (_: any, bodyA: MatterJS.BodyType, bodyB: MatterJS.BodyType) => {
+          [bodyA, bodyB].forEach((body) => {
+            if (body.label === 'checkpoint') {
+              this.state.setCheckpoint({ x: body.position.x, y: body.position.y });
+            }
+            if (body.label === 'hazard') {
+              const s = this.state.checkpoint || this.state.spawn;
+              this.player.setPosition(s.x, s.y);
+              this.player.setVelocity(0, 0);
+            }
+          });
+        });
+      }
+
+      update(time: number) {
+        const ctrl = controls.current;
+        const speed = 5;
+        if (ctrl.left) this.player.setVelocityX(-speed);
+        else if (ctrl.right) this.player.setVelocityX(speed);
+        else this.player.setVelocityX(0);
+
+        const onGround = Math.abs(this.player.body.velocity.y) < 0.01;
+        if (onGround) this.lastGrounded = time;
+        if (ctrl.jump && (onGround || time - this.lastGrounded < this.coyoteTime)) {
+          this.player.setVelocityY(-10);
+          ctrl.jump = false; // consume jump
+        }
+
+        const data = this.cache.json.get('level');
+        const pos = this.state.respawnIfOutOfBounds({ x: this.player.x, y: this.player.y }, data.bounds.fallY);
+        if (pos !== this.player) {
+          this.player.setPosition(pos.x, pos.y);
+          this.player.setVelocity(0, 0);
+        }
+      }
+    }
+
+    const game = new Phaser.Game({
       type: Phaser.AUTO,
       width: 800,
       height: 600,
       parent: containerRef.current,
-      physics: {
-        default: 'matter',
-        matter: {
-          gravity: { y: 1 },
-        },
-      },
-      scene: {
-        create() {
-          const groundCategory = this.matter.world.nextCategory();
-          const ballCategory = this.matter.world.nextCategory();
+      physics: { default: 'matter', matter: { gravity: { y: 1 } } },
+      scene: LevelScene,
+    });
 
-          // Ground with high friction
-          this.matter.add.rectangle(400, 580, 800, 40, {
-            isStatic: true,
-            friction: 1,
-            collisionFilter: { category: groundCategory },
-            render: { fillColor: 0x888888 },
-          });
-
-          // Platform with low friction
-          this.matter.add.rectangle(400, 400, 200, 20, {
-            isStatic: true,
-            friction: 0,
-            collisionFilter: { category: groundCategory },
-            render: { fillColor: 0xaaaaaa },
-          });
-
-          // Ball that collides only with ground layer
-          this.matter.add.circle(150, 0, 20, {
-            restitution: 0.8,
-            friction: 0.05,
-            frictionAir: 0.001,
-            collisionFilter: { category: ballCategory, mask: groundCategory },
-            render: { fillColor: 0xff0000 },
-          });
-
-          // Box on separate collision layer that ignores the ball
-          const boxCategory = this.matter.world.nextCategory();
-          this.matter.add.rectangle(650, 0, 40, 40, {
-            restitution: 0.1,
-            collisionFilter: { category: boxCategory, mask: groundCategory | boxCategory },
-            render: { fillColor: 0x00ff00 },
-          });
-        },
-      },
-    };
-
-    const game = new Phaser.Game(config);
     return () => {
       game.destroy(true);
     };
   }, []);
 
-  return <div ref={containerRef} />;
+  const bind = (key: 'left' | 'right' | 'jump') => ({
+    onMouseDown: () => (controls.current[key] = true),
+    onMouseUp: () => (controls.current[key] = false),
+    onTouchStart: () => (controls.current[key] = true),
+    onTouchEnd: () => (controls.current[key] = false),
+  });
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button className="absolute left-4 bottom-4" {...bind('left')}>◀</button>
+      <button className="absolute left-20 bottom-4" {...bind('right')}>▶</button>
+      <button className="absolute right-4 bottom-4" {...bind('jump')}>⇧</button>
+    </div>
+  );
 };
 
 export default PhaserMatter;

--- a/public/apps/phaser_matter/level1.json
+++ b/public/apps/phaser_matter/level1.json
@@ -1,0 +1,14 @@
+{
+  "spawn": { "x": 100, "y": 100 },
+  "platforms": [
+    { "x": 400, "y": 580, "width": 800, "height": 40 },
+    { "x": 400, "y": 400, "width": 200, "height": 20 }
+  ],
+  "hazards": [
+    { "x": 600, "y": 570, "width": 40, "height": 40 }
+  ],
+  "checkpoints": [
+    { "x": 700, "y": 540, "width": 20, "height": 60 }
+  ],
+  "bounds": { "width": 1600, "height": 600, "deadZoneWidth": 200, "deadZoneHeight": 100, "fallY": 800 }
+}


### PR DESCRIPTION
## Summary
- Load platformer level layout from JSON and build Matter physics scene with hazards, checkpoints, and camera deadzone
- Add on-screen controls supporting hold-to-run movement and coyote-time jumping
- Implement game state utilities and tests verifying respawn from spawn and checkpoints

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae8202f0b48328a20f5085c41514c0