### PR TITLE
Add strict mode and timing slider to Simon game

### DIFF
--- a/__tests__/simonGame.test.ts
+++ b/__tests__/simonGame.test.ts
@@ -1,0 +1,18 @@
+import { processGuess } from '../components/apps/simon';
+
+describe('processGuess', () => {
+  test('correct sequence advances round', () => {
+    const rand = jest.fn().mockReturnValue(0.5); // produces 2
+    const result = processGuess([1], 0, 1, false, rand);
+    expect(result.status).toBe('advance');
+    expect(result.sequence).toEqual([1, 2]);
+    expect(result.step).toBe(0);
+  });
+
+  test('strict mode restarts on first error', () => {
+    const result = processGuess([0], 0, 1, true);
+    expect(result.status).toBe('restart');
+    expect(result.sequence).toEqual([]);
+    expect(result.step).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `processGuess` for sequence progression with strict/normal modes
- add timing window slider, strict mode toggle, and color-blind shapes
- test sequence advancement and strict-mode restart

## Testing
- `yarn test simonGame.test.ts simonAudio.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ae820581c483289f5d27c299c8432d