### PR TITLE
Add D-pad and haptic feedback to Snake game

### DIFF
--- a/__tests__/snake.test.ts
+++ b/__tests__/snake.test.ts
@@ -1,0 +1,23 @@
+import { moveSnake, calcSpeed, speedLevels, SPEED_INTERVAL, SPEED_STEP } from '../components/apps/snake';
+
+describe('snake mechanics', () => {
+  test('self-collision ends game', () => {
+    const snake = [
+      { x: 2, y: 2 },
+      { x: 1, y: 2 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+    ];
+    const dir = { x: -1, y: 0 };
+    const { dead } = moveSnake(snake, dir, false, []);
+    expect(dead).toBe(true);
+  });
+
+  test('speed increases after N foods', () => {
+    let speed = speedLevels.normal;
+    for (let i = 1; i <= SPEED_INTERVAL; i += 1) {
+      speed = calcSpeed(i, speed);
+    }
+    expect(speed).toBe(speedLevels.normal - SPEED_STEP);
+  });
+});


### PR DESCRIPTION
## Summary
- Export core Snake logic and add haptic vibration when food is eaten
- Introduce on-screen D-pad, wrap toggle, and speed ramp progress indicator
- Cover collision and speed ramping with dedicated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8205ecf88328bb83ee9d077c8314