### PR TITLE
Load Sokoban levels from text file and add push checks

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -2,10 +2,18 @@ import { defaultLevels } from '../apps/sokoban/levels';
 import { loadLevel, move, undo, isSolved } from '../apps/sokoban/engine';
 
 describe('sokoban engine', () => {
-  test('simple level solvable', () => {
+  test('impossible pushes are blocked', () => {
+    const level = ['#####', '#@$##', '#####'];
+    const state = loadLevel(level);
+    const result = move(state, 'ArrowRight');
+    expect(result).toBe(state);
+  });
+
+  test('detects when all goals are solved', () => {
     const state = loadLevel(defaultLevels[0]);
-    const moved = move(state, 'ArrowRight');
-    expect(isSolved(moved)).toBe(true);
+    expect(isSolved(state)).toBe(false);
+    const solved = move(state, 'ArrowRight');
+    expect(isSolved(solved)).toBe(true);
   });
 
   test('undo restores previous state', () => {

--- a/apps/sokoban/levels.ts
+++ b/apps/sokoban/levels.ts
@@ -1,14 +1,10 @@
-export const RAW_LEVELS = `
-; Simple tutorial level
-#####
-#@$.#
-#####
+import fs from 'fs';
+import path from 'path';
 
-; Two box level
-######
-#@ $.#
-######
-`;
+export const RAW_LEVELS = fs.readFileSync(
+  path.join(__dirname, 'levels.txt'),
+  'utf-8'
+);
 
 export function parseLevels(data: string): string[][] {
   const levels: string[][] = [];

--- a/apps/sokoban/levels.txt
+++ b/apps/sokoban/levels.txt
@@ -1,0 +1,9 @@
+; Simple tutorial level
+#####
+#@$.#
+#####
+
+; Two box level
+######
+#@ $.#
+######


### PR DESCRIPTION
## Summary
- Move Sokoban level definitions into a plain text file and load them dynamically.
- Extend Sokoban tests to block invalid pushes and confirm win condition when all goals are filled.

## Testing
- `npm test __tests__/sokoban.test.ts __tests__/radare2.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae820686748328bf28f60b320d4ed5