### PR TITLE
test: cover Tic-Tac-Toe win lines and draws

### DIFF
--- a/__tests__/tictactoe.test.ts
+++ b/__tests__/tictactoe.test.ts
@@ -22,8 +22,31 @@ describe('tic tac toe AI', () => {
       expect(result).not.toBe('X'); // AI is O, losing means X wins
     }
   });
+});
 
-  it('detects draws correctly', () => {
+describe('checkWinner', () => {
+  it('detects row win', () => {
+    const board = ['X', 'X', 'X', null, null, null, null, null, null];
+    const result = checkWinner(board);
+    expect(result.winner).toBe('X');
+    expect(result.line).toEqual([0, 1, 2]);
+  });
+
+  it('detects column win', () => {
+    const board = ['O', null, null, 'O', null, null, 'O', null, null];
+    const result = checkWinner(board);
+    expect(result.winner).toBe('O');
+    expect(result.line).toEqual([0, 3, 6]);
+  });
+
+  it('detects diagonal win', () => {
+    const board = ['X', null, null, null, 'X', null, null, null, 'X'];
+    const result = checkWinner(board);
+    expect(result.winner).toBe('X');
+    expect(result.line).toEqual([0, 4, 8]);
+  });
+
+  it('detects draws', () => {
     const board = ['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X'];
     const { winner } = checkWinner(board);
     expect(winner).toBe('draw');


### PR DESCRIPTION
## Summary
- verify Tic-Tac-Toe draws and wins across rows, columns and diagonals
- keep AI never-loses simulation

## Testing
- `npm test -- __tests__/tictactoe.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae82088ef48328a6009eddbd6e4121