### PR TITLE
Add word search enhancements with hints and selection fixes

### DIFF
--- a/__tests__/wordSearch.test.ts
+++ b/__tests__/wordSearch.test.ts
@@ -1,9 +1,11 @@
 import { generateGrid } from '../apps/word_search/generator';
+import { computePath } from '../apps/word_search/utils';
 
 describe('word search generator', () => {
   it('places words without conflicts', () => {
     const words = ['CAT', 'DOG'];
     const { grid, placements } = generateGrid(words, 8, 'seed');
+    expect(placements).toHaveLength(words.length);
     placements.forEach(({ word, positions }) => {
       const placed = positions.map((p) => grid[p.row][p.col]).join('');
       const reversed = placed.split('').reverse().join('');
@@ -16,5 +18,16 @@ describe('word search generator', () => {
     const a = generateGrid(words, 10, 'same');
     const b = generateGrid(words, 10, 'same');
     expect(a.grid).toEqual(b.grid);
+  });
+
+  it('computes straight paths correctly', () => {
+    const path = computePath({ row: 0, col: 0 }, { row: 2, col: 2 });
+    expect(path).toEqual([
+      { row: 0, col: 0 },
+      { row: 1, col: 1 },
+      { row: 2, col: 2 },
+    ]);
+    const invalid = computePath({ row: 0, col: 0 }, { row: 2, col: 1 });
+    expect(invalid).toEqual([{ row: 0, col: 0 }]);
   });
 });

--- a/__tests__/wordSearchUI.test.tsx
+++ b/__tests__/wordSearchUI.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import WordSearch from '../apps/word_search';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('word search selection', () => {
+  it('prevents default text selection on drag', () => {
+    (useRouter as jest.Mock).mockReturnValue({
+      query: { seed: 'seed', words: 'CAT,DOG' },
+      pathname: '/',
+      replace: jest.fn(),
+    });
+    const { container } = render(<WordSearch />);
+    const cell = container.querySelector('.grid > div') as HTMLElement;
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    cell.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -2,29 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { generateGrid, createRNG } from './generator';
 import type { Position, WordPlacement } from './types';
+import { computePath, key } from './utils';
 import wordList from '../../components/apps/wordle_words.json';
 import { logGameStart, logGameEnd, logGameError } from '../../utils/analytics';
 
 const WORD_COUNT = 5;
 const GRID_SIZE = 12;
-
-function key(p: Position) {
-  return `${p.row}-${p.col}`;
-}
-
-function computePath(start: Position, end: Position): Position[] {
-  const dx = Math.sign(end.col - start.col);
-  const dy = Math.sign(end.row - start.row);
-  const len = Math.max(Math.abs(end.col - start.col), Math.abs(end.row - start.row));
-  if (dx !== 0 && dy !== 0 && Math.abs(end.col - start.col) !== Math.abs(end.row - start.row)) {
-    return [start];
-  }
-  const path: Position[] = [];
-  for (let i = 0; i <= len; i += 1) {
-    path.push({ row: start.row + dy * i, col: start.col + dx * i });
-  }
-  return path;
-}
 
 const WordSearch: React.FC = () => {
   const router = useRouter();
@@ -35,9 +18,11 @@ const WordSearch: React.FC = () => {
   const [placements, setPlacements] = useState<WordPlacement[]>([]);
   const [found, setFound] = useState<Set<string>>(new Set());
   const [foundCells, setFoundCells] = useState<Set<string>>(new Set());
+  const [hints, setHints] = useState<Set<string>>(new Set());
   const [selecting, setSelecting] = useState(false);
   const [start, setStart] = useState<Position | null>(null);
   const [selection, setSelection] = useState<Position[]>([]);
+  const [filter, setFilter] = useState<'all' | 'remaining' | 'found'>('all');
 
   function pickWords(s: string) {
     const rng = createRNG(s);
@@ -67,20 +52,23 @@ const WordSearch: React.FC = () => {
     setPlacements(p);
     setFound(new Set());
     setFoundCells(new Set());
+    setHints(new Set());
     logGameStart('word_search');
   }, [seed, words]);
 
-  const handleMouseDown = (r: number, c: number) => {
+  const handleMouseDown = (r: number, c: number, e: React.MouseEvent) => {
+    e.preventDefault();
     setSelecting(true);
     const s = { row: r, col: c };
     setStart(s);
     setSelection([s]);
   };
 
-  const handleMouseEnter = (r: number, c: number) => {
+  const handleMouseEnter = (r: number, c: number, e: React.MouseEvent<HTMLDivElement>) => {
     if (!selecting || !start) return;
     const path = computePath(start, { row: r, col: c });
     setSelection(path);
+    e.currentTarget.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   };
 
   const handleMouseUp = () => {
@@ -128,9 +116,23 @@ const WordSearch: React.FC = () => {
     );
   };
 
+  const revealHint = () => {
+    const remaining = words.filter((w) => !found.has(w));
+    if (!remaining.length) return;
+    const word = remaining[Math.floor(Math.random() * remaining.length)];
+    const placement = placements.find((p) => p.word === word);
+    if (!placement) return;
+    const available = placement.positions.filter((p) => !hints.has(key(p)));
+    if (!available.length) return;
+    const pos = available[Math.floor(Math.random() * available.length)];
+    const newHints = new Set(hints);
+    newHints.add(key(pos));
+    setHints(newHints);
+  };
+
   return (
     <div className="p-4 select-none">
-      <div className="flex space-x-2 mb-2 print:hidden">
+      <div className="flex flex-wrap gap-2 mb-2 print:hidden">
         <button
           type="button"
           onClick={newPuzzle}
@@ -152,6 +154,26 @@ const WordSearch: React.FC = () => {
         >
           Print
         </button>
+        <button
+          type="button"
+          onClick={revealHint}
+          className="px-2 py-1 bg-purple-700 text-white rounded"
+        >
+          Hint
+        </button>
+        <div className="flex items-center space-x-1">
+          <label htmlFor="filter" className="text-sm">Filter:</label>
+          <select
+            id="filter"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as any)}
+            className="border rounded p-1 text-sm"
+          >
+            <option value="all">All</option>
+            <option value="remaining">Remaining</option>
+            <option value="found">Found</option>
+          </select>
+        </div>
       </div>
       <div
         style={{
@@ -166,13 +188,16 @@ const WordSearch: React.FC = () => {
             const posKey = key({ row: r, col: c });
             const isSelected = selection.some((p) => p.row === r && p.col === c);
             const isFound = foundCells.has(posKey);
+            const isHint = hints.has(posKey);
             return (
               <div
                 key={posKey}
-                onMouseDown={() => handleMouseDown(r, c)}
-                onMouseEnter={() => handleMouseEnter(r, c)}
+                onMouseDown={(e) => handleMouseDown(r, c, e)}
+                onMouseEnter={(e) => handleMouseEnter(r, c, e)}
                 onMouseUp={handleMouseUp}
-                className={`w-8 h-8 flex items-center justify-center border text-sm font-bold cursor-pointer select-none ${isFound ? 'bg-green-300' : isSelected ? 'bg-yellow-300' : 'bg-white'}`}
+                className={`w-8 h-8 flex items-center justify-center border text-sm font-bold cursor-pointer select-none ${
+                  isFound ? 'bg-green-300' : isHint ? 'bg-blue-300' : isSelected ? 'bg-yellow-300' : 'bg-white'
+                }`}
               >
                 {letter}
               </div>
@@ -181,11 +206,15 @@ const WordSearch: React.FC = () => {
         )}
       </div>
       <ul className="mt-4 columns-2 md:columns-3">
-        {words.map((w) => (
-          <li key={w} className={found.has(w) ? 'line-through text-gray-500' : ''}>
-            {w}
-          </li>
-        ))}
+        {words
+          .filter((w) =>
+            filter === 'all' ? true : filter === 'found' ? found.has(w) : !found.has(w)
+          )
+          .map((w) => (
+            <li key={w} className={found.has(w) ? 'line-through text-gray-500' : ''}>
+              {w}
+            </li>
+          ))}
       </ul>
     </div>
   );

--- a/apps/word_search/utils.ts
+++ b/apps/word_search/utils.ts
@@ -1,0 +1,19 @@
+import type { Position } from './types';
+
+export function key(p: Position) {
+  return `${p.row}-${p.col}`;
+}
+
+export function computePath(start: Position, end: Position): Position[] {
+  const dx = Math.sign(end.col - start.col);
+  const dy = Math.sign(end.row - start.row);
+  const len = Math.max(Math.abs(end.col - start.col), Math.abs(end.row - start.row));
+  if (dx !== 0 && dy !== 0 && Math.abs(end.col - start.col) !== Math.abs(end.row - start.row)) {
+    return [start];
+  }
+  const path: Position[] = [];
+  for (let i = 0; i <= len; i += 1) {
+    path.push({ row: start.row + dy * i, col: start.col + dx * i });
+  }
+  return path;
+}


### PR DESCRIPTION
## Summary
- add utility helpers for word search grid paths
- support hints, filtering, and improved drag-select handling
- add tests for word placement, path detection, and selection prevention

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae820a99388328b54308fa37bd7e8c