### PR TITLE
feat(nonogram): add propagation and lives

### DIFF
--- a/__tests__/nonogram.test.ts
+++ b/__tests__/nonogram.test.ts
@@ -1,4 +1,12 @@
-import { validateSolution, findHint, getPuzzleBySeed, generateLinePatterns, lineToClues } from '../components/apps/nonogramUtils';
+import {
+  validateSolution,
+  findHint,
+  getPuzzleBySeed,
+  generateLinePatterns,
+  lineToClues,
+  propagateFills,
+  puzzles,
+} from '../components/apps/nonogramUtils';
 
 describe('nonogram utilities', () => {
   test('validateSolution confirms grid matches clues', () => {
@@ -51,5 +59,16 @@ describe('nonogram utilities', () => {
     const a = getPuzzleBySeed('2024-01-01');
     const b = getPuzzleBySeed('2024-01-01');
     expect(a).toEqual(b);
+  });
+
+  test('propagateFills solves diamond without guessing', () => {
+    const p = puzzles.find((x) => x.name === 'Diamond');
+    if (!p) return;
+    let g = Array(p.rows.length)
+      .fill(null)
+      .map(() => Array(p.cols.length).fill(0));
+    g = propagateFills(g, p.rows, p.cols);
+    const normalized = g.map((row) => row.map((c) => (c === -1 ? 0 : c)));
+    expect(normalized).toEqual(p.grid);
   });
 });

--- a/components/apps/nonogramUtils.js
+++ b/components/apps/nonogramUtils.js
@@ -113,6 +113,38 @@ export const autoFillLines = (grid, rows, cols) => {
   return g;
 };
 
+export const propagateFills = (grid, rows, cols) => {
+  let g = grid.map((row) => row.slice());
+  let changed = true;
+  while (changed) {
+    changed = false;
+    rows.forEach((clue, i) => {
+      const forced = findForcedCellsInLine(clue, g[i]);
+      forced.forEach(({ index, value }) => {
+        if (g[i][index] !== value) {
+          g[i][index] = value;
+          changed = true;
+        }
+      });
+    });
+    cols.forEach((clue, j) => {
+      const col = g.map((row) => row[j]);
+      const forced = findForcedCellsInLine(clue, col);
+      forced.forEach(({ index, value }) => {
+        if (g[index][j] !== value) {
+          g[index][j] = value;
+          changed = true;
+        }
+      });
+    });
+    const filled = autoFillLines(g, rows, cols);
+    const diff = filled.some((row, r) => row.some((cell, c) => cell !== g[r][c]));
+    if (diff) changed = true;
+    g = filled;
+  }
+  return g;
+};
+
 export const validateSolution = (grid, rows, cols) => {
   const rowsValid = grid.every((row, i) =>
     JSON.stringify(lineToClues(row)) === JSON.stringify(rows[i])
@@ -179,6 +211,7 @@ const nonogramUtils = {
   findForcedCellsInLine,
   findHint,
   autoFillLines,
+  propagateFills,
   validateSolution,
   getPuzzleBySeed,
   puzzles,


### PR DESCRIPTION
## Summary
- extend nonogram utilities with forced-cell propagation
- show row/column progress counts, add optional lives with error flashes
- cover propagation logic with a dedicated test

## Testing
- `yarn test __tests__/nonogram.test.ts`
- `yarn lint components/apps/nonogram.js components/apps/nonogramUtils.js __tests__/nonogram.test.ts` *(fails: couldn't find pages or app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae820be3e883289eb6f5b74054931d