### PR TITLE
feat: add wave preview and tests for space invaders

### DIFF
--- a/__tests__/space-invaders.test.ts
+++ b/__tests__/space-invaders.test.ts
@@ -1,0 +1,20 @@
+import { bulletHitsInvader, waveAdvance } from '../components/apps/space-invaders';
+
+describe('space invaders mechanics', () => {
+  test('collision removes invader', () => {
+    const invader = { x: 0, y: 0, alive: true } as any;
+    const bullet = { x: 5, y: 5 } as any;
+    const hit = bulletHitsInvader(invader, bullet);
+    if (hit) invader.alive = false;
+    expect(invader.alive).toBe(false);
+  });
+
+  test('wave advances correctly', () => {
+    const cleared = [{ alive: false }, { alive: false }] as any[];
+    const next = waveAdvance(cleared, 1);
+    expect(next).toBe(2);
+    const ongoing = [{ alive: true }] as any[];
+    const same = waveAdvance(ongoing, 1);
+    expect(same).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add testable collision and wave advance helpers
- show wave preview overlay and clamp input latency to 50ms
- cover invader removal and wave progression in unit tests

## Testing
- `yarn test __tests__/space-invaders.test.ts`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae820c6f4c8328971282a4f8fb0b4b