### PR TITLE
feat: enhance sudoku with mistake limits and number pad

### DIFF
--- a/__tests__/sudoku.test.ts
+++ b/__tests__/sudoku.test.ts
@@ -1,0 +1,29 @@
+import { generateSudoku, solveBoard, hasConflict } from '../components/apps/sudoku';
+
+describe('sudoku utilities', () => {
+  test('solver completes generated puzzle', () => {
+    const { puzzle, solution } = generateSudoku('easy', 1234);
+    const board = puzzle.map((row) => row.slice());
+    const solved = solveBoard(board);
+    expect(solved).toBe(true);
+    expect(board).toEqual(solution);
+  });
+
+  test('hasConflict detects duplicates', () => {
+    const board = [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [4, 5, 6, 7, 8, 9, 1, 2, 3],
+      [7, 8, 9, 1, 2, 3, 4, 5, 6],
+      [2, 3, 4, 5, 6, 7, 8, 9, 1],
+      [5, 6, 7, 8, 9, 1, 2, 3, 4],
+      [8, 9, 1, 2, 3, 4, 5, 6, 7],
+      [3, 4, 5, 6, 7, 8, 9, 1, 2],
+      [6, 7, 8, 9, 1, 2, 3, 4, 5],
+      [9, 1, 2, 3, 4, 5, 6, 7, 8],
+    ];
+    // introduce a conflict: duplicate 1 in first row
+    board[0][1] = 1;
+    expect(hasConflict(board, 0, 1, 1)).toBe(true);
+    expect(hasConflict(board, 1, 1, 5)).toBe(false);
+  });
+});

--- a/pages/apps/sudoku.tsx
+++ b/pages/apps/sudoku.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const Sudoku = dynamic(() => import('../../components/apps/sudoku'), { ssr: false });
+
+export default function SudokuPage() {
+  return <Sudoku />;
+}


### PR DESCRIPTION
## Summary
- add optional mistake limit with failure tracking
- provide one-hand friendly number pad input
- cover solver and conflict detection with tests

## Testing
- `yarn test __tests__/sudoku.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae820d47348328984faae35d02e2d6