### PR TITLE
feat: add reusable external frame

### DIFF
--- a/components/ExternalFrame.tsx
+++ b/components/ExternalFrame.tsx
@@ -1,0 +1,47 @@
+import React, { forwardRef } from 'react';
+
+export interface ExternalFrameProps extends React.IframeHTMLAttributes<HTMLIFrameElement> {
+  src: string;
+  title: string;
+  allow?: string;
+}
+
+const ALLOWED_ORIGINS = [
+  'https://www.google.com',
+  'https://duckduckgo.com',
+  'https://www.bing.com',
+  'https://open.spotify.com',
+  'https://stackblitz.com',
+  'https://todoist.com',
+  'https://ghbtns.com',
+  'https://ghidra.app',
+];
+
+function isAllowed(url: string): boolean {
+  try {
+    const parsed = new URL(
+      url,
+      typeof window !== 'undefined' ? window.location.origin : undefined
+    );
+    const origin = parsed.origin;
+    if (typeof window !== 'undefined' && origin === window.location.origin) return true;
+    return ALLOWED_ORIGINS.includes(origin);
+  } catch {
+    return false;
+  }
+}
+
+const ExternalFrame = forwardRef<HTMLIFrameElement, ExternalFrameProps>(
+  ({ src, title, allow, ...rest }, ref) => {
+    if (!isAllowed(src)) {
+      // eslint-disable-next-line no-console
+      console.warn(`Blocked iframe navigation to non-allowlisted URL: ${src}`);
+      return null;
+    }
+
+    return <iframe ref={ref} src={src} title={title} allow={allow} {...rest} />;
+  }
+);
+
+ExternalFrame.displayName = 'ExternalFrame';
+export default ExternalFrame;

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -1,99 +1,147 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import ExternalFrame from '../ExternalFrame';
 
-export class Chrome extends Component {
-    constructor() {
-        super();
-        this.home_url = 'https://www.google.com/webhp?igu=1';
-        this.state = {
-            url: this.home_url,
-            display_url: this.home_url,
-        }
+export default function Chrome() {
+  const homeUrl = 'https://www.google.com/webhp?igu=1';
+  const [url, setUrl] = useState(homeUrl);
+  const [displayUrl, setDisplayUrl] = useState(homeUrl);
+  const iframeRef = useRef(null);
+  const inputRef = useRef(null);
+  const [online, setOnline] = useState(
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  );
+  const [loading, setLoading] = useState(true);
+
+  const storeVisitedUrl = (u, d) => {
+    try {
+      localStorage.setItem('chrome-url', u);
+      localStorage.setItem('chrome-display-url', d);
+    } catch {
+      /* ignore */
     }
+  };
 
-    componentDidMount() {
-        // Previously the component attempted to restore the last visited URL,
-        // but many sites restrict being loaded inside an iframe which resulted
-        // in error pages on reload. Default to the home page instead.
-        // The "igu=1" parameter allows Google Search to load inside an iframe.
-        this.setState({ url: this.home_url, display_url: this.home_url }, this.refreshChrome);
+  const refreshChrome = useCallback(() => {
+    if (!iframeRef.current) return;
+    setLoading(true);
+    const iframe = iframeRef.current;
+    const timer = setTimeout(() => setLoading(false), 10000);
+    const handleLoad = () => {
+      setLoading(false);
+      clearTimeout(timer);
+      iframe.removeEventListener('load', handleLoad);
+    };
+    iframe.addEventListener('load', handleLoad);
+    iframe.src = url;
+  }, [url]);
+
+  useEffect(() => {
+    refreshChrome();
+  }, [url, refreshChrome]);
+
+  useEffect(() => {
+    const updateOnline = () => setOnline(navigator.onLine);
+    window.addEventListener('online', updateOnline);
+    window.addEventListener('offline', updateOnline);
+    return () => {
+      window.removeEventListener('online', updateOnline);
+      window.removeEventListener('offline', updateOnline);
+    };
+  }, []);
+
+  const goToHome = () => {
+    setUrl(homeUrl);
+    setDisplayUrl(homeUrl);
+  };
+
+  const checkKey = (e) => {
+    if (e.key === 'Enter') {
+      let val = e.target.value.trim();
+      if (!val.length) return;
+      if (!/^https?:\/\//i.test(val)) {
+        val = 'https://' + val;
+      }
+      const display = encodeURI(val);
+      setUrl(display);
+      setDisplayUrl(display);
+      storeVisitedUrl(display, display);
+      inputRef.current?.blur();
     }
+  };
 
-    storeVisitedUrl = (url, display_url) => {
-        localStorage.setItem("chrome-url", url);
-        localStorage.setItem("chrome-display-url", display_url);
-    }
+  const handleDisplayUrl = (e) => {
+    setDisplayUrl(e.target.value);
+  };
 
-    refreshChrome = () => {
-        document.getElementById("chrome-screen").src += '';
-    }
+  const tryAgain = () => refreshChrome();
 
-    goToHome = () => {
-        this.setState({ url: this.home_url, display_url: this.home_url });
-        this.refreshChrome();
-    }
+  const displayUrlBar = () => (
+    <div className="w-full pt-0.5 pb-1 flex justify-start items-center text-white text-sm border-b border-gray-900">
+      <div
+        onClick={refreshChrome}
+        className=" ml-2 mr-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10"
+      >
+        <Image
+          className="w-5"
+          src="/themes/Yaru/status/chrome_refresh.svg"
+          alt="Ubuntu Chrome Refresh"
+          width={20}
+          height={20}
+          sizes="20px"
+        />
+      </div>
+      <div
+        onClick={goToHome}
+        className=" mr-2 ml-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10"
+      >
+        <Image
+          className="w-5"
+          src="/themes/Yaru/status/chrome_home.svg"
+          alt="Ubuntu Chrome Home"
+          width={20}
+          height={20}
+          sizes="20px"
+        />
+      </div>
+      <input
+        ref={inputRef}
+        onKeyDown={checkKey}
+        onChange={handleDisplayUrl}
+        value={displayUrl}
+        className="outline-none bg-ub-grey rounded-full pl-3 py-0.5 mr-3 w-5/6 text-gray-300 focus:text-white"
+        type="url"
+        spellCheck={false}
+        autoComplete="off"
+      />
+    </div>
+  );
 
-    checkKey = (e) => {
-        if (e.key === "Enter") {
-            let url = e.target.value.trim();
-            if (url.length === 0) return;
-
-            if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
-                url = "https://" + url;
-            }
-
-            const display_url = encodeURI(url);
-            this.setState({ url: display_url, display_url }, () => {
-                this.storeVisitedUrl(display_url, display_url);
-                document.getElementById("chrome-url-bar").blur();
-            });
-        }
-    }
-
-    handleDisplayUrl = (e) => {
-        this.setState({ display_url: e.target.value });
-    }
-
-    displayUrlBar = () => {
-        return (
-            <div className="w-full pt-0.5 pb-1 flex justify-start items-center text-white text-sm border-b border-gray-900">
-                <div onClick={this.refreshChrome} className=" ml-2 mr-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10">
-                    <Image
-                        className="w-5"
-                        src="/themes/Yaru/status/chrome_refresh.svg"
-                        alt="Ubuntu Chrome Refresh"
-                        width={20}
-                        height={20}
-                        sizes="20px"
-                    />
-                </div>
-                <div onClick={this.goToHome} className=" mr-2 ml-1 flex justify-center items-center rounded-full bg-gray-50 bg-opacity-0 hover:bg-opacity-10">
-                    <Image
-                        className="w-5"
-                        src="/themes/Yaru/status/chrome_home.svg"
-                        alt="Ubuntu Chrome Home"
-                        width={20}
-                        height={20}
-                        sizes="20px"
-                    />
-                </div>
-                <input onKeyDown={this.checkKey} onChange={this.handleDisplayUrl} value={this.state.display_url} id="chrome-url-bar" className="outline-none bg-ub-grey rounded-full pl-3 py-0.5 mr-3 w-5/6 text-gray-300 focus:text-white" type="url" spellCheck={false} autoComplete="off" />
-            </div>
-        );
-    }
-
-    render() {
-        return (
-            <div className="h-full w-full flex flex-col bg-ub-cool-grey">
-                {this.displayUrlBar()}
-                <iframe src={this.state.url} className="flex-grow" id="chrome-screen" frameBorder="0" title="Ubuntu Chrome Url"></iframe>
-            </div>
-        )
-    }
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey">
+      {displayUrlBar()}
+      {!online && (
+        <div className="bg-red-600 text-white text-sm p-2 flex justify-between items-center">
+          <span>No internet connection.</span>
+          <button className="underline" onClick={tryAgain}>
+            Try again
+          </button>
+        </div>
+      )}
+      {loading && (
+        <div className="flex-grow flex items-center justify-center">
+          <div className="h-8 w-8 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+        </div>
+      )}
+      <ExternalFrame
+        ref={iframeRef}
+        src={url}
+        title="Ubuntu Chrome Url"
+        className={`flex-grow ${loading ? 'hidden' : ''}`}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      />
+    </div>
+  );
 }
 
-export default Chrome
-
-export const displayChrome = () => {
-    return <Chrome> </Chrome>;
-}
+export const displayChrome = () => <Chrome />;


### PR DESCRIPTION
## Summary
- add `ExternalFrame` component with URL allowlist
- refactor Chrome app to use `ExternalFrame`, React refs, offline handling and loading spinner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8245d6a48328ac8626ee2fe94d83