### PR TITLE
feat: add service worker with daily seed storage

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,11 @@ function MyApp({ Component, pageProps }: AppProps) {
     if (trackingId) {
       ReactGA.initialize(trackingId);
     }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/service-worker.js').catch(() => {
+        // ignore registration errors
+      });
+    }
   }, []);
   return (
     <ThemeProvider>

--- a/pages/apps/password_generator.tsx
+++ b/pages/apps/password_generator.tsx
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
+import { getDailySeed } from '../../utils/dailySeed';
 
 const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), { ssr: false });
 
 export default function PasswordGeneratorPage() {
-  return <PasswordGenerator />;
+  return <PasswordGenerator getDailySeed={() => getDailySeed('password_generator')} />;
 }

--- a/pages/apps/phaser_matter.tsx
+++ b/pages/apps/phaser_matter.tsx
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
+import { getDailySeed } from '../../utils/dailySeed';
 
 const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), { ssr: false });
 
 export default function PhaserMatterPage() {
-  return <PhaserMatter />;
+  return <PhaserMatter getDailySeed={() => getDailySeed('phaser_matter')} />;
 }

--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
+import { getDailySeed } from '../../utils/dailySeed';
 
 const Sokoban = dynamic(() => import('../../apps/sokoban'), { ssr: false });
 
 export default function SokobanPage() {
-  return <Sokoban />;
+  return <Sokoban getDailySeed={() => getDailySeed('sokoban')} />;
 }

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
+import { getDailySeed } from '../../utils/dailySeed';
 
 const WordSearch = dynamic(() => import('../../apps/word_search'), { ssr: false });
 
 export default function WordSearchPage() {
-  return <WordSearch />;
+  return <WordSearch getDailySeed={() => getDailySeed('word_search')} />;
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,82 @@
+const CACHE_NAME = 'game-cache-v1';
+const CORE_ASSETS = [
+  '/',
+  '/apps/sokoban',
+  '/apps/word_search',
+  '/apps/password_generator',
+  '/apps/phaser_matter'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(CORE_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((resp) => resp || fetch(event.request))
+  );
+});
+
+// IndexedDB helpers for per-game daily seeds
+const DB_NAME = 'kali-games';
+const STORE_SEEDS = 'seeds';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_SEEDS)) {
+        db.createObjectStore(STORE_SEEDS);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function getSeed(game, date) {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_SEEDS, 'readonly');
+    const req = tx.objectStore(STORE_SEEDS).get(`${game}-${date}`);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(undefined);
+  });
+}
+
+async function setSeed(game, date, seed) {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_SEEDS, 'readwrite');
+    tx.objectStore(STORE_SEEDS).put(seed, `${game}-${date}`);
+    tx.oncomplete = resolve;
+    tx.onerror = resolve;
+  });
+}
+
+self.addEventListener('message', (event) => {
+  const data = event.data;
+  if (data && data.type === 'seed') {
+    const { game, date } = data;
+    event.waitUntil(
+      (async () => {
+        let seed = await getSeed(game, date);
+        if (!seed) {
+          seed = Math.random().toString(36).slice(2, 10);
+          await setSeed(game, date, seed);
+        }
+        event.ports[0].postMessage({ seed });
+      })()
+    );
+  }
+});
+

--- a/utils/dailySeed.ts
+++ b/utils/dailySeed.ts
@@ -1,0 +1,28 @@
+import { getSeed, setSeed } from './idb';
+
+function today(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export async function getDailySeed(game: string): Promise<string> {
+  const date = today();
+  if (typeof window !== 'undefined' && 'serviceWorker' in navigator && navigator.serviceWorker.controller) {
+    const channel = new MessageChannel();
+    const sw = navigator.serviceWorker.controller;
+    return new Promise((resolve) => {
+      channel.port1.onmessage = (event) => {
+        resolve(event.data.seed as string);
+      };
+      sw.postMessage({ type: 'seed', game, date }, [channel.port2]);
+    });
+  }
+  let seed = await getSeed(game, date);
+  if (!seed) {
+    seed = Math.random().toString(36).slice(2, 10);
+    await setSeed(game, date, seed);
+  }
+  return seed;
+}
+
+export { today as currentDateString };
+

--- a/utils/idb.ts
+++ b/utils/idb.ts
@@ -1,0 +1,79 @@
+const DB_NAME = 'kali-games';
+const VERSION = 1;
+const STORE_SEEDS = 'seeds';
+const STORE_REPLAYS = 'replays';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_SEEDS)) {
+        db.createObjectStore(STORE_SEEDS);
+      }
+      if (!db.objectStoreNames.contains(STORE_REPLAYS)) {
+        db.createObjectStore(STORE_REPLAYS);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getSeed(game: string, date: string): Promise<string | undefined> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve) => {
+      const tx = db.transaction(STORE_SEEDS, 'readonly');
+      const store = tx.objectStore(STORE_SEEDS);
+      const req = store.get(`${game}-${date}`);
+      req.onsuccess = () => resolve(req.result as string | undefined);
+      req.onerror = () => resolve(undefined);
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export async function setSeed(game: string, date: string, seed: string): Promise<void> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_SEEDS, 'readwrite');
+      tx.objectStore(STORE_SEEDS).put(seed, `${game}-${date}`);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export async function saveReplay(game: string, id: string, data: any): Promise<void> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_REPLAYS, 'readwrite');
+      tx.objectStore(STORE_REPLAYS).put(data, `${game}-${id}`);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    });
+  } catch {
+    // ignore
+  }
+}
+
+export async function getReplay<T = any>(game: string, id: string): Promise<T | undefined> {
+  try {
+    const db = await openDB();
+    return await new Promise<T | undefined>((resolve) => {
+      const tx = db.transaction(STORE_REPLAYS, 'readonly');
+      const req = tx.objectStore(STORE_REPLAYS).get(`${game}-${id}`);
+      req.onsuccess = () => resolve(req.result as T | undefined);
+      req.onerror = () => resolve(undefined);
+    });
+  } catch {
+    return undefined;
+  }
+}
+


### PR DESCRIPTION
## Summary
- register service worker in app bootstrap and expose daily seed helpers to each game
- implement IndexedDB utilities and daily seed helper
- add service worker to cache core game assets and persist per-game daily seeds

## Testing
- `CI=1 yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae931d9dc88328858ba10b84c6f1bf