### PR TITLE
Add Supabase realtime leaderboard

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { supabase, subscribeToScores, subscribeToAchievements } from '../utils/supabase';
+
+interface Score {
+  id: number;
+  player: string;
+  score: number;
+}
+
+interface Achievement {
+  id: number;
+  player: string;
+  achievement: string;
+}
+
+interface LeaderboardProps {
+  game: string;
+}
+
+const Leaderboard: React.FC<LeaderboardProps> = ({ game }) => {
+  const [scores, setScores] = useState<Score[]>([]);
+  const [achievements, setAchievements] = useState<Achievement[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/leaderboard/${game}`);
+      const data = await res.json();
+      setScores(data.scores || []);
+      setAchievements(data.achievements || []);
+    };
+    load();
+    const scoreChannel = subscribeToScores(game, (payload) => {
+      setScores((prev) => {
+        const next = [payload.new, ...prev];
+        next.sort((a, b) => b.score - a.score);
+        return next.slice(0, 10);
+      });
+    });
+    const achievementChannel = subscribeToAchievements(game, (payload) => {
+      setAchievements((prev) => [payload.new, ...prev].slice(0, 10));
+    });
+    return () => {
+      supabase.removeChannel(scoreChannel);
+      supabase.removeChannel(achievementChannel);
+    };
+  }, [game]);
+
+  return (
+    <div className="mb-4 p-4 bg-gray-100 rounded">
+      <h2 className="text-lg font-bold mb-2">Leaderboard</h2>
+      <ul className="mb-4">
+        {scores.map((s) => (
+          <li key={s.id}>
+            {s.player}: {s.score}
+          </li>
+        ))}
+      </ul>
+      <h3 className="font-semibold">Recent Achievements</h3>
+      <ul>
+        {achievements.map((a) => (
+          <li key={a.id}>
+            {a.player}: {a.achievement}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
+    "@supabase/supabase-js": "^2.56.0",
     "@vercel/analytics": "^1.5.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
@@ -41,7 +42,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",

--- a/pages/api/leaderboard/[game].ts
+++ b/pages/api/leaderboard/[game].ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '../../../utils/supabase';
+
+interface RateInfo {
+  count: number;
+  time: number;
+}
+
+const RATE_LIMIT_WINDOW = 60_000; // 1 minute
+const RATE_LIMIT_MAX = 10;
+const rateLimit = new Map<string, RateInfo>();
+
+function isRateLimited(key: string): boolean {
+  const current = Date.now();
+  const info = rateLimit.get(key);
+  if (!info || current - info.time > RATE_LIMIT_WINDOW) {
+    rateLimit.set(key, { count: 1, time: current });
+    return false;
+  }
+  if (info.count >= RATE_LIMIT_MAX) {
+    return true;
+  }
+  info.count += 1;
+  return false;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress || '') as string;
+  if (isRateLimited(ip)) {
+    res.status(429).json({ error: 'Too many requests' });
+    return;
+  }
+
+  const { game } = req.query as { game: string };
+
+  if (req.method === 'GET') {
+    const [scores, achievements] = await Promise.all([
+      supabase
+        .from('leaderboard')
+        .select('*')
+        .eq('game', game)
+        .order('score', { ascending: false })
+        .limit(10),
+      supabase
+        .from('achievements')
+        .select('*')
+        .eq('game', game)
+        .order('created_at', { ascending: false })
+        .limit(10),
+    ]);
+    if (scores.error || achievements.error) {
+      res.status(500).json({ error: scores.error?.message || achievements.error?.message });
+      return;
+    }
+    res.status(200).json({ scores: scores.data, achievements: achievements.data });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const { player, score, achievement } = req.body as { player: string; score: number; achievement?: string };
+    const { error } = await supabase.from('leaderboard').insert({ game, player, score });
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+    if (achievement) {
+      await supabase.from('achievements').insert({ game, player, achievement });
+    }
+    res.status(201).json({ success: true });
+    return;
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  res.status(405).end('Method Not Allowed');
+}

--- a/pages/apps/password_generator.tsx
+++ b/pages/apps/password_generator.tsx
@@ -1,7 +1,13 @@
 import dynamic from 'next/dynamic';
+import Leaderboard from '../../components/Leaderboard';
 
 const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), { ssr: false });
 
 export default function PasswordGeneratorPage() {
-  return <PasswordGenerator />;
+  return (
+    <div className="space-y-4">
+      <Leaderboard game="password_generator" />
+      <PasswordGenerator />
+    </div>
+  );
 }

--- a/pages/apps/phaser_matter.tsx
+++ b/pages/apps/phaser_matter.tsx
@@ -1,7 +1,13 @@
 import dynamic from 'next/dynamic';
+import Leaderboard from '../../components/Leaderboard';
 
 const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), { ssr: false });
 
 export default function PhaserMatterPage() {
-  return <PhaserMatter />;
+  return (
+    <div className="space-y-4">
+      <Leaderboard game="phaser_matter" />
+      <PhaserMatter />
+    </div>
+  );
 }

--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -1,7 +1,13 @@
 import dynamic from 'next/dynamic';
+import Leaderboard from '../../components/Leaderboard';
 
 const Sokoban = dynamic(() => import('../../apps/sokoban'), { ssr: false });
 
 export default function SokobanPage() {
-  return <Sokoban />;
+  return (
+    <div className="space-y-4">
+      <Leaderboard game="sokoban" />
+      <Sokoban />
+    </div>
+  );
 }

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -1,7 +1,13 @@
 import dynamic from 'next/dynamic';
+import Leaderboard from '../../components/Leaderboard';
 
 const WordSearch = dynamic(() => import('../../apps/word_search'), { ssr: false });
 
 export default function WordSearchPage() {
-  return <WordSearch />;
+  return (
+    <div className="space-y-4">
+      <Leaderboard game="word_search" />
+      <WordSearch />
+    </div>
+  );
 }

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1,0 +1,20 @@
+import { createClient, SupabaseClient, RealtimeChannel } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+export function subscribeToScores(game: string, cb: (payload: any) => void): RealtimeChannel {
+  return supabase
+    .channel(`leaderboard-${game}`)
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'leaderboard', filter: `game=eq.${game}` }, cb)
+    .subscribe();
+}
+
+export function subscribeToAchievements(game: string, cb: (payload: any) => void): RealtimeChannel {
+  return supabase
+    .channel(`achievements-${game}`)
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'achievements', filter: `game=eq.${game}` }, cb)
+    .subscribe();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,6 +1432,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@supabase/auth-js@npm:2.71.1":
+  version: 2.71.1
+  resolution: "@supabase/auth-js@npm:2.71.1"
+  dependencies:
+    "@supabase/node-fetch": "npm:^2.6.14"
+  checksum: 10c0/970966525119dea83067ff3b87a219e5b357ffad3c22e19b00ceb83fc30dd485815a7ceb78eeedf9436f8c1674b5a9ac96929f3a82a50091d3ad66d1bc3215d4
+  languageName: node
+  linkType: hard
+
+"@supabase/functions-js@npm:2.4.5":
+  version: 2.4.5
+  resolution: "@supabase/functions-js@npm:2.4.5"
+  dependencies:
+    "@supabase/node-fetch": "npm:^2.6.14"
+  checksum: 10c0/43d0a40e863e20cadae38de65930c203f50c625bad91736bf78c095e347131ea3328716a43dad58fb8d058c69b901b41fdc062e77221196d8dfc93ad772519b5
+  languageName: node
+  linkType: hard
+
+"@supabase/node-fetch@npm:2.6.15, @supabase/node-fetch@npm:^2.6.13, @supabase/node-fetch@npm:^2.6.14":
+  version: 2.6.15
+  resolution: "@supabase/node-fetch@npm:2.6.15"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  checksum: 10c0/98d25cab2eba53c93c59e730d52d50065b1a7fe216c65224471e83e2064ebd45ae51ad09cb39ec263c3cb59e3d41870fc2e789ea2e9587480d7ba212b85daf38
+  languageName: node
+  linkType: hard
+
+"@supabase/postgrest-js@npm:1.21.3":
+  version: 1.21.3
+  resolution: "@supabase/postgrest-js@npm:1.21.3"
+  dependencies:
+    "@supabase/node-fetch": "npm:^2.6.14"
+  checksum: 10c0/317a80efb4e4462895d6bc4ad40582aa09457cc794a2a5d97a002105057b2b90c0dc16981bf9f5bbd3392c9a4426786b0c00f7e395f415e2260005af612af101
+  languageName: node
+  linkType: hard
+
+"@supabase/realtime-js@npm:2.15.1":
+  version: 2.15.1
+  resolution: "@supabase/realtime-js@npm:2.15.1"
+  dependencies:
+    "@supabase/node-fetch": "npm:^2.6.13"
+    "@types/phoenix": "npm:^1.6.6"
+    "@types/ws": "npm:^8.18.1"
+    ws: "npm:^8.18.2"
+  checksum: 10c0/69c5b2a253da8e3b7cef689ad6196cba7b992d274fe11aa19352f713180c80e01e912c2220ffad6acf718e599f5f4d26c0d2cc517bad2abec4c0a9393da5a7cd
+  languageName: node
+  linkType: hard
+
+"@supabase/storage-js@npm:^2.10.4":
+  version: 2.11.0
+  resolution: "@supabase/storage-js@npm:2.11.0"
+  dependencies:
+    "@supabase/node-fetch": "npm:^2.6.14"
+  checksum: 10c0/353f8cbca29e385692796ffb1a6e08fb0d71c7f7fa5f6c4564a79dbf6a4fc8123c6883b7ed3b5c5f5c02c10a60a8403569816a775ff2c11561b139e51c82d9ca
+  languageName: node
+  linkType: hard
+
+"@supabase/supabase-js@npm:^2.56.0":
+  version: 2.56.0
+  resolution: "@supabase/supabase-js@npm:2.56.0"
+  dependencies:
+    "@supabase/auth-js": "npm:2.71.1"
+    "@supabase/functions-js": "npm:2.4.5"
+    "@supabase/node-fetch": "npm:2.6.15"
+    "@supabase/postgrest-js": "npm:1.21.3"
+    "@supabase/realtime-js": "npm:2.15.1"
+    "@supabase/storage-js": "npm:^2.10.4"
+  checksum: 10c0/2d49393500a7651906f011409dbe1d88e48d5cde7e0895804b0e137843336ed813db3aee4c39dd33e6d05ba3e6368edc2476ea2e944530b9a12b7a5c0be9ef5a
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.15":
   version: 0.5.15
   resolution: "@swc/helpers@npm:0.5.15"
@@ -1668,6 +1739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/phoenix@npm:^1.6.6":
+  version: 1.6.6
+  resolution: "@types/phoenix@npm:1.6.6"
+  checksum: 10c0/4dfcb3fd36341ed5500de030291af14163c599857e00d2d4ff065d4c4600317d5d20aa170913fb9609747a09436e3add44db7d0c709bdf80f36cddcc67a42021
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:^19.1.10":
   version: 19.1.11
   resolution: "@types/react@npm:19.1.11"
@@ -1717,6 +1795,15 @@ __metadata:
   version: 0.5.22
   resolution: "@types/webxr@npm:0.5.22"
   checksum: 10c0/dd015cadd71b2cdd3b7bab18152e579d33ff66652b2eab26f371f3583ca607e9a1f1bd5af5e2f7ff861a50aa352f44b3be40f26b64561e365d1fec254c7dfdcd
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -6669,7 +6756,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -7824,6 +7910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "ts-api-utils@npm:2.1.0"
@@ -8004,6 +8097,7 @@ __metadata:
   resolution: "unnippillil@workspace:."
   dependencies:
     "@emailjs/browser": "npm:^3.10.0"
+    "@supabase/supabase-js": "npm:^2.56.0"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"
     "@testing-library/react": "npm:^16.3.0"
@@ -8043,7 +8137,6 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"
@@ -8194,6 +8287,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^7.0.0":
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
@@ -8224,6 +8324,16 @@ __metadata:
     tr46: "npm:^5.1.0"
     webidl-conversions: "npm:^7.0.0"
   checksum: 10c0/f746fc2f4c906607d09537de1227b13f9494c171141e5427ed7d2c0dd0b6a48b43d8e71abaae57d368d0c06b673fd8ec63550b32ad5ed64990c7b0266c2b4272
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -8367,7 +8477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0":
+"ws@npm:^8.18.0, ws@npm:^8.18.2":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:


### PR DESCRIPTION
## Summary
- add Supabase client with realtime helpers
- implement rate-limited leaderboard API with achievements support
- show shared Leaderboard component on all game pages

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae931ed3588328bf82df418078725a