### PR TITLE
feat: add gamepad support to arcade games

### DIFF
--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import ReactGA from 'react-ga4';
+import { useGamepad } from '../../utils/gamepad';
 
 // Track constants - circular course
 const WIDTH = 800;
@@ -57,6 +58,13 @@ const WAYPOINTS = [
 ];
 
 const NUM_AI = 6;
+
+// Default gamepad mappings (customizable)
+const GAMEPAD_MAPPING = {
+  steer: { axis: 0 },
+  accel: 0,
+  brake: 1,
+};
 
 const createCar = (x, y, color, isAI = false, angle = -Math.PI / 2) => ({
   x,
@@ -136,6 +144,7 @@ const CarRacer = () => {
   const pausedRef = useRef(false);
   const [reset, setReset] = useState(0);
   const [difficulty, setDifficulty] = useState('normal');
+  const gamepadRef = useGamepad(GAMEPAD_MAPPING);
 
   useEffect(() => {
     if (control === 'tilt') {
@@ -251,6 +260,14 @@ const CarRacer = () => {
         } else if (control === 'buttons') {
           steerInput = steerButtonRef.current * sensitivityRef.current;
           if (keys[' ']) accelInput = 1;
+        }
+        const pad = gamepadRef.current;
+        if (pad) {
+          if (typeof pad.steer === 'number' && Math.abs(pad.steer) > 0.2) {
+            steerInput = pad.steer;
+          }
+          if (pad.accel) accelInput = 1;
+          if (pad.brake) brakeInput = 1;
         }
         car.steer += (steerInput - car.steer) * dt * 5;
         car.accel = accelInput * 100;

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+
+export type GamepadButtonBinding = number;
+export interface GamepadAxisBinding {
+  axis: number;
+  dir?: 1 | -1;
+  threshold?: number;
+}
+export type GamepadBinding = GamepadButtonBinding | GamepadAxisBinding;
+export type GamepadMapping = Record<string, GamepadBinding>;
+export type GamepadState = Record<string, boolean | number>;
+
+class GamepadWrapper {
+  private mapping: GamepadMapping;
+  private index: number;
+
+  constructor(mapping: GamepadMapping = {}, index = 0) {
+    this.mapping = mapping;
+    this.index = index;
+  }
+
+  setMapping(mapping: GamepadMapping): void {
+    this.mapping = mapping;
+  }
+
+  getState(): GamepadState {
+    const pad = navigator.getGamepads ? navigator.getGamepads()[this.index] : null;
+    const state: GamepadState = {};
+    Object.keys(this.mapping).forEach((k) => (state[k] = false));
+    if (!pad) return state;
+
+    for (const [action, bind] of Object.entries(this.mapping)) {
+      if (typeof bind === 'number') {
+        state[action] = !!pad.buttons?.[bind]?.pressed;
+      } else {
+        const val = pad.axes?.[bind.axis] ?? 0;
+        const dir = bind.dir ?? 1;
+        const thr = bind.threshold ?? 0.2;
+        const scaled = val * dir;
+        state[action] = Math.abs(scaled) > thr ? scaled : 0;
+      }
+    }
+    return state;
+  }
+}
+
+export const useGamepad = (mapping: GamepadMapping, index = 0) => {
+  const wrapperRef = useRef(new GamepadWrapper(mapping, index));
+  const stateRef = useRef<GamepadState>({});
+
+  useEffect(() => {
+    wrapperRef.current.setMapping(mapping);
+  }, [mapping]);
+
+  useEffect(() => {
+    let raf: number;
+    const loop = () => {
+      stateRef.current = wrapperRef.current.getState();
+      raf = requestAnimationFrame(loop);
+    };
+    loop();
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return stateRef;
+};
+
+export default useGamepad;


### PR DESCRIPTION
## Summary
- add reusable `useGamepad` hook for mapping buttons and axes
- wire up gamepad controls in Asteroids, Car Racer, and Pong

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae931f2aa48328b80433266f7c4704