### PR TITLE
feat: add storage and sync utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "figlet": "^1.8.2",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
+    "idb-keyval": "^6.2.1",
     "jsqr": "^1.4.0",
     "mathjs": "^14.6.0",
     "next": "^15.0.0",
@@ -41,7 +42,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,44 @@
+import { get, set, update } from 'idb-keyval';
+
+const PROGRESS_KEY = 'progress';
+const KEYBINDS_KEY = 'keybinds';
+const REPLAYS_KEY = 'replays';
+
+export type ProgressData = Record<string, unknown>;
+export type Keybinds = Record<string, string>;
+export type Replay = { id: string; data: unknown };
+
+export const getProgress = async (): Promise<ProgressData> =>
+  (await get<ProgressData>(PROGRESS_KEY)) || {};
+
+export const setProgress = async (progress: ProgressData): Promise<void> => {
+  await set(PROGRESS_KEY, progress);
+};
+
+export const getKeybinds = async (): Promise<Keybinds> =>
+  (await get<Keybinds>(KEYBINDS_KEY)) || {};
+
+export const setKeybinds = async (keybinds: Keybinds): Promise<void> => {
+  await set(KEYBINDS_KEY, keybinds);
+};
+
+export const getReplays = async (): Promise<Replay[]> =>
+  (await get<Replay[]>(REPLAYS_KEY)) || [];
+
+export const saveReplay = async (replay: Replay): Promise<void> => {
+  await update<Replay[]>(REPLAYS_KEY, (replays = []) => [...replays, replay]);
+};
+
+export const clearReplays = async (): Promise<void> => {
+  await set(REPLAYS_KEY, []);
+};
+
+export default {
+  getProgress,
+  setProgress,
+  getKeybinds,
+  setKeybinds,
+  getReplays,
+  saveReplay,
+  clearReplays,
+};

--- a/utils/sync.ts
+++ b/utils/sync.ts
@@ -1,0 +1,42 @@
+type StateMessage = { type: 'state'; state: unknown };
+type LeaderboardMessage = { type: 'leaderboard'; leaderboard: unknown };
+type SyncMessage = StateMessage | LeaderboardMessage;
+
+const channel =
+  typeof window !== 'undefined' && 'BroadcastChannel' in self
+    ? new BroadcastChannel('sync')
+    : null;
+
+export const broadcastState = (state: unknown): void => {
+  channel?.postMessage({ type: 'state', state } as StateMessage);
+};
+
+export const broadcastLeaderboard = (leaderboard: unknown): void => {
+  channel?.postMessage({ type: 'leaderboard', leaderboard } as LeaderboardMessage);
+};
+
+export const subscribe = (
+  handlers: {
+    onState?: (state: unknown) => void;
+    onLeaderboard?: (leaderboard: unknown) => void;
+  },
+): (() => void) => {
+  if (!channel) return () => {};
+
+  const listener = (event: MessageEvent<SyncMessage>) => {
+    if (event.data.type === 'state') {
+      handlers.onState?.(event.data.state);
+    } else if (event.data.type === 'leaderboard') {
+      handlers.onLeaderboard?.(event.data.leaderboard);
+    }
+  };
+
+  channel.addEventListener('message', listener);
+  return () => channel.removeEventListener('message', listener);
+};
+
+export default {
+  broadcastState,
+  broadcastLeaderboard,
+  subscribe,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4450,6 +4450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"idb-keyval@npm:^6.2.1":
+  version: 6.2.2
+  resolution: "idb-keyval@npm:6.2.2"
+  checksum: 10c0/b52f0d2937cc2ec9f1da536b0b5c0875af3043ca210714beaffead4ec1f44f2ad322220305fd024596203855224d9e3523aed83e971dfb62ddc21b5b1721aeef
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -6669,7 +6676,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -8029,6 +8035,7 @@ __metadata:
     figlet: "npm:^1.8.2"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
+    idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
     jsqr: "npm:^1.4.0"
@@ -8043,7 +8050,6 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"


### PR DESCRIPTION
## Summary
- wrap progress, keybind, and replay storage with idb-keyval
- add BroadcastChannel-based sync helper for sharing state and leaderboards

## Testing
- `yarn jest __tests__/solitaireEngine.test.ts --runInBand --ci`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae932277dc8328b0e8100d345b8af2