### PR TITLE
feat: add battleship network play

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,12 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",
     "react-twitter-embed": "^4.0.4",
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",

--- a/pages/api/battleship/[room].ts
+++ b/pages/api/battleship/[room].ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest } from 'next';
+import type { NextApiResponse } from 'next';
+import { Server as IOServer } from 'socket.io';
+import { randomizePlacement } from '../../../../components/apps/battleship/ai';
+
+export const config = { api: { bodyParser: false } };
+
+type NextApiResponseServerIO = NextApiResponse & {
+  socket: NextApiResponse['socket'] & { server: { io?: IOServer } };
+};
+
+interface RoomState {
+  ships: Set<number>;
+}
+
+const rooms: Record<string, RoomState> = {};
+
+const getRoom = (room: string): RoomState => {
+  if (!rooms[room]) {
+    const layout = randomizePlacement();
+    const ships = new Set<number>();
+    layout.forEach((s: any) => s.cells.forEach((c: number) => ships.add(c)));
+    rooms[room] = { ships };
+  }
+  return rooms[room];
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponseServerIO
+) {
+  if (!res.socket.server.io) {
+    const io = new IOServer(res.socket.server, {
+      path: '/api/battleship/socket.io',
+    });
+
+    io.on('connection', (socket) => {
+      socket.on('join', (room: string) => {
+        socket.join(room);
+        getRoom(room);
+      });
+
+      socket.on(
+        'salvo',
+        ({ room, cells }: { room: string; cells: number[] }) => {
+          const { ships } = getRoom(room);
+          const results = cells.map((idx) => ({
+            idx,
+            hit: ships.has(idx),
+          }));
+          io.to(room).emit('update', { results });
+        }
+      );
+    });
+
+    res.socket.server.io = io;
+  }
+  res.end();
+}

--- a/pages/apps/battleship.tsx
+++ b/pages/apps/battleship.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import { io, Socket } from 'socket.io-client';
+import { BOARD_SIZE, SHIPS } from '../../components/apps/battleship/ai';
+
+const rand = (n: number) => Math.floor(Math.random() * n);
+const shuffle = <T,>(arr: T[]): T[] => {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = rand(i + 1);
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+};
+
+interface Layout {
+  x: number;
+  y: number;
+  dir: number;
+  len: number;
+  cells: number[];
+}
+
+function randomLayout(hits: Set<number>, misses: Set<number>): Layout[] | null {
+  const grid = Array(BOARD_SIZE * BOARD_SIZE).fill(0);
+  const hitSet = new Set(hits);
+  misses.forEach((m) => (grid[m] = -1));
+  hits.forEach((h) => (grid[h] = 2));
+  const layout: Layout[] = [];
+
+  const canPlace = (
+    x: number,
+    y: number,
+    dir: number,
+    len: number
+  ): number[] | null => {
+    const cells: number[] = [];
+    for (let i = 0; i < len; i++) {
+      const cx = x + (dir === 0 ? i : 0);
+      const cy = y + (dir === 1 ? i : 0);
+      if (cx < 0 || cy < 0 || cx >= BOARD_SIZE || cy >= BOARD_SIZE) return null;
+      const idx = cy * BOARD_SIZE + cx;
+      if (grid[idx] === -1 || grid[idx] === 1) return null;
+      cells.push(idx);
+    }
+    return cells;
+  };
+
+  const shipLens = SHIPS.slice();
+  shuffle(shipLens);
+
+  const placeShip = (i: number): boolean => {
+    if (i >= shipLens.length) return true;
+    const len = shipLens[i];
+    const options: Layout[] = [];
+    for (let dir = 0; dir < 2; dir++) {
+      const maxX = dir === 0 ? BOARD_SIZE - len : BOARD_SIZE - 1;
+      const maxY = dir === 1 ? BOARD_SIZE - len : BOARD_SIZE - 1;
+      for (let x = 0; x <= maxX; x++) {
+        for (let y = 0; y <= maxY; y++) {
+          const cells = canPlace(x, y, dir, len);
+          if (cells) options.push({ x, y, dir, len, cells });
+        }
+      }
+    }
+    shuffle(options);
+    for (const opt of options) {
+      opt.cells.forEach((c) => (grid[c] = 1));
+      layout.push(opt);
+      if (placeShip(i + 1)) return true;
+      layout.pop();
+      opt.cells.forEach((c) => (grid[c] = hitSet.has(c) ? 2 : 0));
+    }
+    return false;
+  };
+
+  if (!placeShip(0)) return null;
+
+  const allCells = new Set<number>();
+  layout.forEach((sh) => sh.cells.forEach((c) => allCells.add(c)));
+  for (const h of hits) {
+    if (!allCells.has(h)) return null;
+  }
+
+  return layout;
+}
+
+function estimateProbabilities(
+  hits: Set<number>,
+  misses: Set<number>,
+  simulations = 200
+): number[] {
+  const scores = new Array(BOARD_SIZE * BOARD_SIZE).fill(0);
+  for (let s = 0; s < simulations; s++) {
+    const layout = randomLayout(hits, misses);
+    if (!layout) continue;
+    const occ = new Set<number>();
+    layout.forEach((sh) => sh.cells.forEach((c) => occ.add(c)));
+    for (let i = 0; i < scores.length; i++) {
+      if (hits.has(i) || misses.has(i)) continue;
+      if (occ.has(i)) scores[i]++;
+    }
+  }
+  const max = Math.max(...scores);
+  return scores.map((v) => (max ? v / max : 0));
+}
+
+export default function BattleshipPage() {
+  const router = useRouter();
+  const room =
+    typeof router.query.room === 'string' ? router.query.room : 'default';
+  const socketRef = useRef<Socket | null>(null);
+  const [board, setBoard] = useState<(null | 'hit' | 'miss' | 'pending')[]>(
+    Array(BOARD_SIZE * BOARD_SIZE).fill(null)
+  );
+  const [selected, setSelected] = useState<number[]>([]);
+  const [prob, setProb] = useState<number[]>(
+    Array(BOARD_SIZE * BOARD_SIZE).fill(0)
+  );
+  const shotsPerTurn = 3;
+
+  useEffect(() => {
+    const socket: Socket = io({ path: '/api/battleship/socket.io' });
+    socket.emit('join', room);
+    socket.on('update', ({ results }) => {
+      setBoard((prev) => {
+        const nb = prev.slice();
+        results.forEach((r: any) => {
+          nb[r.idx] = r.hit ? 'hit' : 'miss';
+        });
+        return nb;
+      });
+    });
+    socketRef.current = socket;
+    return () => socket.disconnect();
+  }, [room]);
+
+  useEffect(() => {
+    const hits = new Set<number>();
+    const misses = new Set<number>();
+    board.forEach((c, idx) => {
+      if (c === 'hit') hits.add(idx);
+      else if (c === 'miss') misses.add(idx);
+    });
+    setProb(estimateProbabilities(hits, misses));
+  }, [board]);
+
+  const toggle = (idx: number) => {
+    if (board[idx]) return;
+    setSelected((prev) => {
+      if (prev.includes(idx)) return prev.filter((i) => i !== idx);
+      if (prev.length >= shotsPerTurn) return prev;
+      return [...prev, idx];
+    });
+  };
+
+  const fire = () => {
+    if (!socketRef.current) return;
+    socketRef.current.emit('salvo', { room, cells: selected });
+    setBoard((prev) => {
+      const nb = prev.slice();
+      selected.forEach((i) => (nb[i] = 'pending'));
+      return nb;
+    });
+    setSelected([]);
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <div className="mb-2">Select up to {shotsPerTurn} targets then fire.</div>
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `repeat(${BOARD_SIZE},32px)` }}
+      >
+        {board.map((cell, idx) => {
+          const probVal = prob[idx];
+          const color = `rgba(0,255,0,${probVal})`;
+          return (
+            <div
+              key={idx}
+              className="relative w-8 h-8 border border-gray-600"
+            >
+              {!board[idx] && (
+                <button className="w-full h-full" onClick={() => toggle(idx)} />
+              )}
+              {selected.includes(idx) && (
+                <div className="absolute inset-0 bg-yellow-300 opacity-50" />
+              )}
+              {cell === 'hit' && (
+                <div className="absolute inset-0 bg-red-500 opacity-50" />
+              )}
+              {cell === 'miss' && (
+                <div className="absolute inset-0 bg-white opacity-25" />
+              )}
+              {cell === 'pending' && (
+                <div className="absolute inset-0 bg-gray-400 opacity-25 animate-pulse" />
+              )}
+              {(!cell || cell === 'pending') && probVal > 0 && (
+                <div
+                  className="absolute inset-0"
+                  style={{ background: color }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <button
+        className="mt-4 px-2 py-1 bg-gray-700"
+        onClick={fire}
+        disabled={!selected.length}
+      >
+        Fire Salvo
+      </button>
+    </div>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,6 +1432,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socket.io/component-emitter@npm:~3.1.0":
+  version: 3.1.2
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
+  checksum: 10c0/c4242bad66f67e6f7b712733d25b43cbb9e19a595c8701c3ad99cbeb5901555f78b095e24852f862fffb43e96f1d8552e62def885ca82ae1bb05da3668fd87d7
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.15":
   version: 0.5.15
   resolution: "@swc/helpers@npm:0.5.15"
@@ -1578,6 +1585,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cors@npm:^2.8.12":
+  version: 2.8.19
+  resolution: "@types/cors@npm:2.8.19"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b5dd407040db7d8aa1bd36e79e5f3f32292f6b075abc287529e9f48df1a25fda3e3799ba30b4656667ffb931d3b75690c1d6ca71e39f7337ea6dfda8581916d0
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
@@ -1659,7 +1675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^24.2.1":
+"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:^24.2.1":
   version: 24.3.0
   resolution: "@types/node@npm:24.3.0"
   dependencies:
@@ -2081,6 +2097,16 @@ __metadata:
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
   checksum: 10c0/21ba8f574ea57a3106d6d35623f2c4a9111d9ee3e9a5be47baed46ec2457d2eac46e07a5c4a60186f88cb98abbe3e24f2d4cca70bc2b12f1692523e2209a9ccf
+  languageName: node
+  linkType: hard
+
+"accepts@npm:~1.3.4":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
   languageName: node
   linkType: hard
 
@@ -2515,6 +2541,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64id@npm:2.0.0, base64id@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "base64id@npm:2.0.0"
+  checksum: 10c0/6919efd237ed44b9988cbfc33eca6f173a10e810ce50292b271a1a421aac7748ef232a64d1e6032b08f19aae48dce6ee8f66c5ae2c9e5066c82b884861d4d453
+  languageName: node
+  linkType: hard
+
 "bezier-js@npm:3 - 6":
   version: 6.1.4
   resolution: "bezier-js@npm:6.1.4"
@@ -2868,6 +2901,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:~0.7.2":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
+"cors@npm:~2.8.5":
+  version: 2.8.5
+  resolution: "cors@npm:2.8.5"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/373702b7999409922da80de4a61938aabba6929aea5b6fd9096fefb9e8342f626c0ebd7507b0e8b0b311380744cc985f27edebc0a26e0ddb784b54e1085de761
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -3172,6 +3222,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
 "decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
@@ -3351,6 +3413,43 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.3
+  resolution: "engine.io-client@npm:6.6.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10c0/ebe0b1da6831d5a68564f9ffb80efe682da4f0538488eaffadf0bcf5177a8b4472cdb01d18a9f20dece2f8de30e2df951eb4635bef2f1b492e9f08a523db91a0
+  languageName: node
+  linkType: hard
+
+"engine.io-parser@npm:~5.2.1":
+  version: 5.2.3
+  resolution: "engine.io-parser@npm:5.2.3"
+  checksum: 10c0/ed4900d8dbef470ab3839ccf3bfa79ee518ea8277c7f1f2759e8c22a48f64e687ea5e474291394d0c94f84054749fd93f3ef0acb51fa2f5f234cc9d9d8e7c536
+  languageName: node
+  linkType: hard
+
+"engine.io@npm:~6.6.0":
+  version: 6.6.4
+  resolution: "engine.io@npm:6.6.4"
+  dependencies:
+    "@types/cors": "npm:^2.8.12"
+    "@types/node": "npm:>=10.0.0"
+    accepts: "npm:~1.3.4"
+    base64id: "npm:2.0.0"
+    cookie: "npm:~0.7.2"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.17.1"
+  checksum: 10c0/845761163f8ea7962c049df653b75dafb6b3693ad6f59809d4474751d7b0392cbf3dc2730b8a902ff93677a91fd28711d34ab29efd348a8a4b49c6b0724021ab
   languageName: node
   linkType: hard
 
@@ -5769,6 +5868,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:~2.1.34":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
 "mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
@@ -5933,6 +6048,13 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
+"negotiator@npm:0.6.3":
+  version: 0.6.3
+  resolution: "negotiator@npm:0.6.3"
+  checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
   languageName: node
   linkType: hard
 
@@ -6125,7 +6247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
@@ -6669,7 +6791,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -7261,6 +7382,53 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"socket.io-adapter@npm:~2.5.2":
+  version: 2.5.5
+  resolution: "socket.io-adapter@npm:2.5.5"
+  dependencies:
+    debug: "npm:~4.3.4"
+    ws: "npm:~8.17.1"
+  checksum: 10c0/04a5a2a9c4399d1b6597c2afc4492ab1e73430cc124ab02b09e948eabf341180b3866e2b61b5084cb899beb68a4db7c328c29bda5efb9207671b5cb0bc6de44e
+  languageName: node
+  linkType: hard
+
+"socket.io-client@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io-client@npm:4.8.1"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.2"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/544c49cc8cc77118ef68b758a8a580c8e680a5909cae05c566d2cc07ec6cd6720a4f5b7e985489bf2a8391749177a5437ac30b8afbdf30b9da6402687ad51c86
+  languageName: node
+  linkType: hard
+
+"socket.io-parser@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "socket.io-parser@npm:4.2.4"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.3.1"
+  checksum: 10c0/9383b30358fde4a801ea4ec5e6860915c0389a091321f1c1f41506618b5cf7cd685d0a31c587467a0c4ee99ef98c2b99fb87911f9dfb329716c43b587f29ca48
+  languageName: node
+  linkType: hard
+
+"socket.io@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "socket.io@npm:4.8.1"
+  dependencies:
+    accepts: "npm:~1.3.4"
+    base64id: "npm:~2.0.0"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.3.2"
+    engine.io: "npm:~6.6.0"
+    socket.io-adapter: "npm:~2.5.2"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/acf931a2bb235be96433b71da3d8addc63eeeaa8acabd33dc8d64e12287390a45f1e9f389a73cf7dc336961cd491679741b7a016048325c596835abbcc017ca9
   languageName: node
   linkType: hard
 
@@ -8043,11 +8211,12 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"
     react-twitter-embed: "npm:^4.0.4"
+    socket.io: "npm:^4.8.1"
+    socket.io-client: "npm:^4.8.1"
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"
     tailwindcss: "npm:^3.2.4"
@@ -8173,6 +8342,13 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
+  languageName: node
+  linkType: hard
+
+"vary@npm:^1":
+  version: 1.1.2
+  resolution: "vary@npm:1.1.2"
+  checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
   languageName: node
   linkType: hard
 
@@ -8382,6 +8558,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:~8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^5.0.0":
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
@@ -8393,6 +8584,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add Battleship page with fog-of-war salvo mode and probability hints
- enable Socket.IO based Battleship rooms for async play
- add socket.io dependencies

## Testing
- `yarn test __tests__/battleship-ai.test.js`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9324e2988328870107146bdfe304