### PR TITLE
Add checkers page with forced capture rules and AI

### DIFF
--- a/pages/apps/checkers.tsx
+++ b/pages/apps/checkers.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { pointerHandlers } from '../../utils/pointer';
+import {
+  Board,
+  Move,
+  createBoard,
+  getPieceMoves,
+  getAllMoves as getForcedMoves,
+  applyMove,
+  hasMoves,
+  isDraw,
+} from '../../components/apps/checkers/engine';
+
+// Helper to get all moves without enforcing capture
+const getAllMovesNoForce = (board: Board, color: 'red' | 'black'): Move[] => {
+  let result: Move[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      if (board[r][c]?.color === color) {
+        const moves = getPieceMoves(board, r, c);
+        if (moves.length) result = result.concat(moves);
+      }
+    }
+  }
+  return result;
+};
+
+export default function CheckersPage() {
+  const [board, setBoard] = useState<Board>(createBoard());
+  const [turn, setTurn] = useState<'red' | 'black'>('red');
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+  const [moves, setMoves] = useState<Move[]>([]);
+  const [rule, setRule] = useState<'forced' | 'relaxed'>('forced');
+  const [algorithm, setAlgorithm] = useState<'alphabeta' | 'mcts'>('alphabeta');
+  const [difficulty, setDifficulty] = useState(3);
+  const [winner, setWinner] = useState<string | null>(null);
+  const [noCapture, setNoCapture] = useState(0);
+  const workerRef = useRef<Worker | null>(null);
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('../../workers/checkersAI.ts', import.meta.url));
+    workerRef.current.onmessage = (e: MessageEvent<Move>) => {
+      const move = e.data;
+      if (move) makeMove(move);
+    };
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  const allMoves = useMemo(
+    () =>
+      rule === 'forced'
+        ? getForcedMoves(board, turn)
+        : getAllMovesNoForce(board, turn),
+    [board, turn, rule]
+  );
+
+  const selectPiece = (r: number, c: number) => {
+    const piece = board[r][c];
+    if (winner || !piece || piece.color !== turn) return;
+    const pieceMoves = getPieceMoves(board, r, c);
+    const mustCapture = rule === 'forced' && allMoves.some((m) => m.captured);
+    const filtered = mustCapture ? pieceMoves.filter((m) => m.captured) : pieceMoves;
+    if (filtered.length) {
+      setSelected([r, c]);
+      setMoves(filtered);
+    }
+  };
+
+  const tryMove = (r: number, c: number) => {
+    const move = moves.find((m) => m.to[0] === r && m.to[1] === c);
+    if (move) makeMove(move);
+  };
+
+  const makeMove = (move: Move) => {
+    const { board: newBoard, capture } = applyMove(board, move);
+    const further = capture
+      ? getPieceMoves(newBoard, move.to[0], move.to[1]).filter((m) => m.captured)
+      : [];
+    setBoard(newBoard);
+    if (capture && further.length) {
+      setSelected([move.to[0], move.to[1]]);
+      setMoves(further);
+      setNoCapture(0);
+      return;
+    }
+    const next = turn === 'red' ? 'black' : 'red';
+    const newNo = capture ? 0 : noCapture + 1;
+    setNoCapture(newNo);
+    if (isDraw(newNo)) {
+      setWinner('Draw');
+    } else {
+      const hasNext =
+        rule === 'forced'
+          ? hasMoves(newBoard, next)
+          : getAllMovesNoForce(newBoard, next).length > 0;
+      if (!hasNext) {
+        setWinner(turn);
+        return;
+      }
+      setTurn(next);
+      if (next === 'black') {
+        workerRef.current?.postMessage({
+          board: newBoard,
+          color: 'black',
+          difficulty,
+          algorithm,
+          enforceCapture: rule === 'forced',
+        });
+      }
+    }
+    setSelected(null);
+    setMoves([]);
+  };
+
+  const reset = () => {
+    setBoard(createBoard());
+    setTurn('red');
+    setSelected(null);
+    setMoves([]);
+    setWinner(null);
+    setNoCapture(0);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full bg-ub-cool-grey text-white p-4">
+      {winner && <div className="mb-2 text-xl">{winner === 'Draw' ? 'Draw!' : `${winner} wins!`}</div>}
+      <div className="mb-4 flex gap-4 items-center">
+        <label>
+          Rules:
+          <select
+            className="ml-2 bg-gray-700 px-1"
+            value={rule}
+            onChange={(e) => setRule(e.target.value as any)}
+          >
+            <option value="forced">Forced Capture</option>
+            <option value="relaxed">Capture Optional</option>
+          </select>
+        </label>
+        <label>
+          AI:
+          <select
+            className="ml-2 bg-gray-700 px-1"
+            value={algorithm}
+            onChange={(e) => setAlgorithm(e.target.value as any)}
+          >
+            <option value="alphabeta">Alpha-Beta</option>
+            <option value="mcts">MCTS</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1">
+          Difficulty {difficulty}
+          <input
+            type="range"
+            min={1}
+            max={8}
+            value={difficulty}
+            onChange={(e) => setDifficulty(Number(e.target.value))}
+          />
+        </label>
+        <button
+          className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={reset}
+        >
+          Reset
+        </button>
+      </div>
+      <div className="grid grid-cols-8 gap-0">
+        {board.map((row, r) =>
+          row.map((cell, c) => {
+            const isDark = (r + c) % 2 === 1;
+            const isMove = moves.some((m) => m.to[0] === r && m.to[1] === c);
+            const isSelected = selected && selected[0] === r && selected[1] === c;
+            return (
+              <div
+                key={`${r}-${c}`}
+                {...pointerHandlers(() =>
+                  selected ? tryMove(r, c) : selectPiece(r, c)
+                )}
+                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center ${
+                  isDark ? 'bg-gray-700' : 'bg-gray-400'
+                } ${isMove ? 'ring-2 ring-yellow-300 animate-pulse' : ''} ${
+                  isSelected ? 'ring-2 ring-green-400' : ''
+                }`}
+              >
+                {cell && (
+                  <div
+                    className={`w-10 h-10 md:w-12 md:h-12 rounded-full flex items-center justify-center ${
+                      cell.color === 'red' ? 'bg-red-500' : 'bg-black'
+                    } ${cell.king ? 'border-4 border-yellow-300' : ''}`}
+                  />
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/workers/checkersAI.ts
+++ b/workers/checkersAI.ts
@@ -1,0 +1,218 @@
+export type Color = 'red' | 'black';
+export interface Piece { color: Color; king: boolean; }
+export type Board = (Piece | null)[][];
+export interface Move { from:[number,number]; to:[number,number]; captured?:[number,number]; }
+
+const directions: Record<Color, number[][]> = {
+  red: [[-1, -1], [-1, 1]],
+  black: [[1, -1], [1, 1]],
+};
+
+const inBounds = (r: number, c: number) => r >= 0 && r < 8 && c >= 0 && c < 8;
+
+const cloneBoard = (board: Board): Board =>
+  board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
+
+const getPieceMoves = (board: Board, r: number, c: number): Move[] => {
+  const piece = board[r][c];
+  if (!piece) return [];
+  const dirs = [...directions[piece.color]];
+  if (piece.king) {
+    dirs.push(...directions[piece.color === 'red' ? 'black' : 'red']);
+  }
+  const moves: Move[] = [];
+  const captures: Move[] = [];
+  for (const [dr, dc] of dirs) {
+    const r1 = r + dr;
+    const c1 = c + dc;
+    if (!inBounds(r1, c1)) continue;
+    const target = board[r1][c1];
+    if (!target) {
+      moves.push({ from: [r, c], to: [r1, c1] });
+    } else if (target.color !== piece.color) {
+      const r2 = r + dr * 2;
+      const c2 = c + dc * 2;
+      if (inBounds(r2, c2) && !board[r2][c2]) {
+        captures.push({ from: [r, c], to: [r2, c2], captured: [r1, c1] });
+      }
+    }
+  }
+  return captures.length ? captures : moves;
+};
+
+const getAllMoves = (
+  board: Board,
+  color: Color,
+  enforceCapture: boolean,
+): Move[] => {
+  let result: Move[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      if (board[r][c]?.color === color) {
+        const moves = getPieceMoves(board, r, c);
+        if (moves.length) result = result.concat(moves);
+      }
+    }
+  }
+  const anyCapture = result.some((m) => m.captured);
+  return enforceCapture && anyCapture ? result.filter((m) => m.captured) : result;
+};
+
+const applyMove = (board: Board, move: Move): { board: Board } => {
+  const newBoard = cloneBoard(board);
+  const piece = newBoard[move.from[0]][move.from[1]]!;
+  newBoard[move.from[0]][move.from[1]] = null;
+  newBoard[move.to[0]][move.to[1]] = piece;
+  if (move.captured) {
+    const [cr, cc] = move.captured;
+    newBoard[cr][cc] = null;
+  }
+  if (
+    !piece.king &&
+    ((piece.color === 'red' && move.to[0] === 0) ||
+      (piece.color === 'black' && move.to[0] === 7))
+  ) {
+    piece.king = true;
+  }
+  return { board: newBoard };
+};
+
+const boardToBitboards = (board: Board) => {
+  let red = 0n;
+  let black = 0n;
+  let kings = 0n;
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const piece = board[r][c];
+      if (!piece) continue;
+      const bit = 1n << BigInt((7 - r) * 8 + c);
+      if (piece.color === 'red') red |= bit;
+      else black |= bit;
+      if (piece.king) kings |= bit;
+    }
+  }
+  return { red, black, kings };
+};
+
+const bitCount = (n: bigint) => {
+  let count = 0;
+  while (n) {
+    n &= n - 1n;
+    count++;
+  }
+  return count;
+};
+
+const evaluate = (board: Board): number => {
+  const { red, black, kings } = boardToBitboards(board);
+  const redKings = red & kings;
+  const blackKings = black & kings;
+  const redMen = bitCount(red) - bitCount(redKings);
+  const blackMen = bitCount(black) - bitCount(blackKings);
+  const mobility =
+    getAllMoves(board, 'red', true).length - getAllMoves(board, 'black', true).length;
+  return (
+    redMen - blackMen +
+    1.5 * (bitCount(redKings) - bitCount(blackKings)) +
+    0.1 * mobility
+  );
+};
+
+const alphaBeta = (
+  board: Board,
+  depth: number,
+  maximizing: boolean,
+  alpha: number,
+  beta: number,
+  enforceCapture: boolean,
+): { score: number; move?: Move } => {
+  if (depth === 0) return { score: evaluate(board) };
+  const color: Color = maximizing ? 'red' : 'black';
+  const moves = getAllMoves(board, color, enforceCapture);
+  if (!moves.length) return { score: maximizing ? -Infinity : Infinity };
+  let bestMove = moves[0];
+  for (const move of moves) {
+    const next = applyMove(board, move).board;
+    const { score } = alphaBeta(next, depth - 1, !maximizing, alpha, beta, enforceCapture);
+    if (maximizing) {
+      if (score > alpha) {
+        alpha = score;
+        bestMove = move;
+      }
+      if (alpha >= beta) break;
+    } else {
+      if (score < beta) {
+        beta = score;
+        bestMove = move;
+      }
+      if (beta <= alpha) break;
+    }
+  }
+  return { score: maximizing ? alpha : beta, move: bestMove };
+};
+
+const randomPlayout = (
+  board: Board,
+  color: Color,
+  enforceCapture: boolean,
+): Color => {
+  let current = color;
+  let b = cloneBoard(board);
+  while (true) {
+    const moves = getAllMoves(b, current, enforceCapture);
+    if (moves.length === 0) return current === 'red' ? 'black' : 'red';
+    const move = moves[Math.floor(Math.random() * moves.length)];
+    b = applyMove(b, move).board;
+    current = current === 'red' ? 'black' : 'red';
+  }
+};
+
+const mcts = (
+  board: Board,
+  color: Color,
+  iterations: number,
+  enforceCapture: boolean,
+): Move | null => {
+  const moves = getAllMoves(board, color, enforceCapture);
+  if (!moves.length) return null;
+  const scores = new Array(moves.length).fill(0);
+  for (let i = 0; i < iterations; i++) {
+    const idx = i % moves.length;
+    const move = moves[idx];
+    const nextBoard = applyMove(board, move).board;
+    const winner = randomPlayout(nextBoard, color === 'red' ? 'black' : 'red', enforceCapture);
+    if (winner === color) scores[idx]++;
+  }
+  let best = 0;
+  for (let i = 1; i < moves.length; i++) {
+    if (scores[i] > scores[best]) best = i;
+  }
+  return moves[best];
+};
+
+self.onmessage = (e: MessageEvent) => {
+  const { board, color, difficulty, algorithm, enforceCapture } = e.data as {
+    board: Board;
+    color: Color;
+    difficulty: number;
+    algorithm: 'alphabeta' | 'mcts';
+    enforceCapture: boolean;
+  };
+  let move: Move | null = null;
+  if (algorithm === 'mcts') {
+    move = mcts(board, color, Math.max(10, difficulty * 200), enforceCapture);
+  } else {
+    move = alphaBeta(
+      board,
+      Math.max(1, difficulty),
+      color === 'red',
+      -Infinity,
+      Infinity,
+      enforceCapture,
+    ).move || null;
+  }
+  // eslint-disable-next-line no-restricted-globals
+  (self as any).postMessage(move);
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add new Checkers page with forced-capture rule variants and AI difficulty slider
- implement MCTS and alpha-beta search in a dedicated worker

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9327beb08328a1610fa34ca1e4ca