### PR TITLE
feat: add hangman word lists and info gain meter

### DIFF
--- a/public/apps/hangman/words/animals.json
+++ b/public/apps/hangman/words/animals.json
@@ -1,0 +1,5 @@
+{
+  "easy": ["cat", "dog", "cow", "bat", "hen"],
+  "medium": ["giraffe", "monkey", "rabbit", "eagle"],
+  "hard": ["alligator", "chimpanzee", "hippopotamus", "rhinoceros"]
+}

--- a/public/apps/hangman/words/tech.json
+++ b/public/apps/hangman/words/tech.json
@@ -1,0 +1,5 @@
+{
+  "easy": ["code", "bug", "html", "css", "linux"],
+  "medium": ["react", "nextjs", "python", "docker", "node"],
+  "hard": ["javascript", "typescript", "portfolio", "framework", "terminal"]
+}


### PR DESCRIPTION
## Summary
- move hangman words into themed JSON files for easier expansion
- load words on demand and add entropy-based hint meter to show information gained per guess

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae932a5b948328986821d5a20a6efb