### PR TITLE
feat(solitaire): add variants and daily deal

### DIFF
--- a/__tests__/solitaireEngine.test.ts
+++ b/__tests__/solitaireEngine.test.ts
@@ -10,6 +10,7 @@ import {
   suits,
   Card,
   GameState,
+  createDeck,
 } from '../components/apps/solitaire/engine';
 
 const card = (s: any, v: number, faceUp = true): Card => ({
@@ -30,6 +31,14 @@ const emptyState = (): GameState => ({
 });
 
 describe('Solitaire engine', () => {
+  test('createDeck supports deterministic seed', () => {
+    const a = createDeck(1234);
+    const b = createDeck(1234);
+    expect(a).toEqual(b);
+    const c = createDeck(5678);
+    expect(a).not.toEqual(c);
+  });
+
   test('initializeGame deals tableau correctly', () => {
     const game = initializeGame(1, Array.from({ length: 52 }, (_, i) => card(suits[i % 4], (i % 13) + 1, false)));
     expect(game.tableau.length).toBe(7);


### PR DESCRIPTION
## Summary
- allow seeded deck creation for deterministic "daily deal" games
- track game stats and daily streaks with a new variant selector
- introduce Spider and FreeCell options in the solitaire UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9332172c8328bcacc3c1c5da2d89