### PR TITLE
Add deadlock detection, solver hints, and level packs to Sokoban

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -1,5 +1,5 @@
 import { defaultLevels } from '../apps/sokoban/levels';
-import { loadLevel, move, undo, isSolved } from '../apps/sokoban/engine';
+import { loadLevel, move, undo, isSolved, findHint } from '../apps/sokoban/engine';
 
 describe('sokoban engine', () => {
   test('simple level solvable', () => {
@@ -15,5 +15,17 @@ describe('sokoban engine', () => {
     expect(undone.player).toEqual(state.player);
     expect(Array.from(undone.boxes)).toEqual(Array.from(state.boxes));
     expect(undone.pushes).toBe(state.pushes);
+  });
+
+  test('detects corner deadlock', () => {
+    const level = ['#####', '#@$##', '# . #', '#####'];
+    const state = loadLevel(level);
+    expect(state.deadlocks.size).toBe(1);
+  });
+
+  test('solver hint gives first move', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const hint = findHint(state);
+    expect(hint).toBe('ArrowRight');
   });
 });

--- a/apps/sokoban/levels.ts
+++ b/apps/sokoban/levels.ts
@@ -1,4 +1,10 @@
-export const RAW_LEVELS = `
+export interface LevelPack {
+  name: string;
+  difficulty: string;
+  levels: string[][];
+}
+
+const RAW_TUTORIAL = `
 ; Simple tutorial level
 #####
 #@$.#
@@ -8,6 +14,22 @@ export const RAW_LEVELS = `
 ######
 #@ $.#
 ######
+`;
+
+const RAW_CLASSIC = `
+; Small puzzle
+######
+# .@ #
+# $$ #
+# .  #
+######
+
+; Room
+#######
+#  .  #
+# $#$ #
+# .@  #
+#######
 `;
 
 export function parseLevels(data: string): string[][] {
@@ -27,4 +49,10 @@ export function parseLevels(data: string): string[][] {
   return levels;
 }
 
-export const defaultLevels = parseLevels(RAW_LEVELS);
+export const LEVEL_PACKS: LevelPack[] = [
+  { name: 'Tutorial', difficulty: 'Easy', levels: parseLevels(RAW_TUTORIAL) },
+  { name: 'Classic', difficulty: 'Medium', levels: parseLevels(RAW_CLASSIC) },
+];
+
+export const defaultLevels = LEVEL_PACKS[0].levels;
+

--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -1,6 +1,10 @@
+import React from 'react';
 import dynamic from 'next/dynamic';
 
-const Sokoban = dynamic(() => import('../../apps/sokoban'), { ssr: false });
+const Sokoban = dynamic(() => import('../../apps/sokoban'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function SokobanPage() {
   return <Sokoban />;


### PR DESCRIPTION
## Summary
- add solver-backed hint search with deadlock avoidance
- bundle curated Sokoban level packs with difficulty metadata
- expand Sokoban UI with pack selection, hint button, and deadlock warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae93313b208328af94e965f4cedc40