### PR TITLE
feat: add Norvig sudoku solver with difficulty rating

### DIFF
--- a/__tests__/sudokuSolver.test.ts
+++ b/__tests__/sudokuSolver.test.ts
@@ -1,0 +1,36 @@
+import { solve, ratePuzzle, getHint } from '../workers/sudokuSolver';
+
+const puzzle: number[][] = [
+  [0, 0, 3, 0, 2, 0, 6, 0, 0],
+  [9, 0, 0, 3, 0, 5, 0, 0, 1],
+  [0, 0, 1, 8, 0, 6, 4, 0, 0],
+  [0, 0, 8, 1, 0, 2, 9, 0, 0],
+  [7, 0, 0, 0, 0, 0, 0, 0, 8],
+  [0, 0, 6, 7, 0, 8, 2, 0, 0],
+  [0, 0, 2, 6, 0, 9, 5, 0, 0],
+  [8, 0, 0, 2, 0, 3, 0, 0, 9],
+  [0, 0, 5, 0, 1, 0, 3, 0, 0],
+];
+
+const solution = '483921657967345821251876493548132976729564138136798245372689514814253769695417382';
+
+describe('sudokuSolver', () => {
+  test('solves puzzle', () => {
+    const { solution: solved } = solve(puzzle);
+    expect(solved.flat().join('')).toBe(solution);
+  });
+
+  test('rates puzzle and provides steps', () => {
+    const { difficulty, steps } = ratePuzzle(puzzle);
+    expect(['easy', 'medium', 'hard']).toContain(difficulty);
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test('provides a hint', () => {
+    const hint = getHint(puzzle);
+    expect(hint).not.toBeNull();
+    if (hint) {
+      expect(hint.value).toBeGreaterThan(0);
+    }
+  });
+});

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { ratePuzzle, getHint } from '../../workers/sudokuSolver';
 
 const SIZE = 9;
 const range = (n) => Array.from({ length: n }, (_, i) => i);
@@ -120,6 +121,8 @@ const Sudoku = () => {
   const [autoNotes, setAutoNotes] = useState(false);
   const [hint, setHint] = useState('');
   const [hintCell, setHintCell] = useState(null);
+  const [ratedDifficulty, setRatedDifficulty] = useState('');
+  const [hintStats, setHintStats] = useState({});
   const [completed, setCompleted] = useState(false);
   const [time, setTime] = useState(0);
   const [bestTime, setBestTime] = useState(null);
@@ -137,6 +140,13 @@ const Sudoku = () => {
     setCompleted(false);
     setHint('');
     setHintCell(null);
+    const { difficulty: rating, steps } = ratePuzzle(puzzle);
+    setRatedDifficulty(rating);
+    const stats = steps.reduce((acc, s) => {
+      acc[s.technique] = (acc[s.technique] || 0) + 1;
+      return acc;
+    }, {});
+    setHintStats(stats);
     setTime(0);
     setBestTime(() => {
       if (typeof window === 'undefined') return null;
@@ -249,20 +259,14 @@ const Sudoku = () => {
   };
 
   const getHintHandler = () => {
-    for (let r = 0; r < SIZE; r++) {
-      for (let c = 0; c < SIZE; c++) {
-        if (board[r][c] === 0) {
-          const cand = getCandidates(board, r, c);
-          if (cand.length === 1) {
-            setHint(`Cell (${r + 1},${c + 1}) must be ${cand[0]} (single candidate)`);
-            setHintCell({ r, c });
-            return;
-          }
-        }
-      }
+    const h = getHint(board);
+    if (h) {
+      setHint(`Cell (${h.r + 1},${h.c + 1}) must be ${h.value} (${h.technique})`);
+      setHintCell({ r: h.r, c: h.c });
+    } else {
+      setHint('No hints available');
+      setHintCell(null);
     }
-    setHint('No simple hints available');
-    setHintCell(null);
   };
 
   const hasConflict = (b, r, c, val) => {
@@ -416,6 +420,18 @@ const Sudoku = () => {
       </div>
       {completed && <div className="mt-2">Completed!</div>}
       {hint && <div className="mt-2 text-yellow-300">{hint}</div>}
+      {ratedDifficulty && (
+        <div className="mt-2 text-gray-300">Difficulty: {ratedDifficulty}</div>
+      )}
+      {Object.keys(hintStats).length > 0 && (
+        <div className="mt-1 text-xs text-gray-400">
+          {Object.entries(hintStats).map(([k, v]) => (
+            <div key={k}>
+              {k}: {v}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/workers/sudokuSolver.ts
+++ b/workers/sudokuSolver.ts
@@ -1,0 +1,203 @@
+const digits = '123456789';
+const rows = 'ABCDEFGHI';
+const cols = digits;
+
+const cross = (a: string, b: string): string[] => {
+  const result: string[] = [];
+  for (const x of a) {
+    for (const y of b) result.push(x + y);
+  }
+  return result;
+};
+
+const squares = cross(rows, cols);
+
+const unitList: string[][] = [];
+for (const r of rows) unitList.push(cross(r, cols));
+for (const c of cols) unitList.push(cross(rows, c));
+const rowBlocks = ['ABC', 'DEF', 'GHI'];
+const colBlocks = ['123', '456', '789'];
+for (const rs of rowBlocks) {
+  for (const cs of colBlocks) unitList.push(cross(rs, cs));
+}
+
+const units: Record<string, string[][]> = {};
+const peers: Record<string, Set<string>> = {};
+for (const s of squares) {
+  units[s] = unitList.filter((u) => u.includes(s));
+  const p = new Set<string>();
+  for (const u of units[s]) {
+    for (const s2 of u) if (s2 !== s) p.add(s2);
+  }
+  peers[s] = p;
+}
+
+export interface Step {
+  square: string;
+  value: string;
+  technique: string;
+}
+
+const gridValues = (grid: string): Record<string, string> => {
+  const chars = grid.replace(/[^0-9\.]/g, '').split('');
+  if (chars.length !== 81) throw new Error('Grid must be 81 chars');
+  const res: Record<string, string> = {};
+  squares.forEach((s, i) => (res[s] = chars[i] === '0' || chars[i] === '.' ? '.' : chars[i]));
+  return res;
+};
+
+const assign = (
+  values: Record<string, string>,
+  s: string,
+  d: string,
+  steps?: Step[],
+  technique = 'assign',
+): Record<string, string> | false => {
+  const other = values[s].replace(d, '');
+  for (const d2 of other) {
+    const res = eliminate(values, s, d2, steps);
+    if (!res) return false;
+  }
+  if (steps && technique !== 'given') steps.push({ square: s, value: d, technique });
+  return values;
+};
+
+const eliminate = (
+  values: Record<string, string>,
+  s: string,
+  d: string,
+  steps?: Step[],
+): Record<string, string> | false => {
+  if (!values[s].includes(d)) return values; // already eliminated
+  values[s] = values[s].replace(d, '');
+  if (values[s].length === 0) return false;
+  if (values[s].length === 1) {
+    const d2 = values[s];
+    for (const s2 of peers[s]) {
+      const res = eliminate(values, s2, d2, steps);
+      if (!res) return false;
+    }
+    if (steps) steps.push({ square: s, value: d2, technique: 'single candidate' });
+  }
+  for (const u of units[s]) {
+    const places = u.filter((s2) => values[s2].includes(d));
+    if (places.length === 0) return false;
+    if (places.length === 1) {
+      if (!assign(values, places[0], d, steps, 'hidden single')) return false;
+    }
+  }
+  return values;
+};
+
+const parseGrid = (grid: string, steps?: Step[]): Record<string, string> | false => {
+  const values: Record<string, string> = {};
+  squares.forEach((s) => (values[s] = digits));
+  const gridVals = gridValues(grid);
+  for (const s of squares) {
+    const d = gridVals[s];
+    if (digits.includes(d)) {
+      if (!assign(values, s, d, steps, 'given')) return false;
+    }
+  }
+  return values;
+};
+
+const solved = (values: Record<string, string>): boolean => squares.every((s) => values[s].length === 1);
+
+const deepCopy = (obj: Record<string, string>): Record<string, string> => {
+  const res: Record<string, string> = {};
+  for (const k in obj) res[k] = obj[k];
+  return res;
+};
+
+const search = (
+  values: Record<string, string> | false,
+  steps: Step[],
+): Record<string, string> | false => {
+  if (!values) return false;
+  if (solved(values)) return values;
+  let minSq: string | null = null;
+  let minCount = 10;
+  for (const s of squares) {
+    const l = values[s].length;
+    if (l > 1 && l < minCount) {
+      minCount = l;
+      minSq = s;
+    }
+  }
+  if (!minSq) return false;
+  for (const d of values[minSq]) {
+    const snapshot = steps.length;
+    steps.push({ square: minSq, value: d, technique: 'guess' });
+    const newVals = search(assign(deepCopy(values), minSq, d, steps, 'guess'), steps);
+    if (newVals) return newVals;
+    steps.splice(snapshot);
+  }
+  return false;
+};
+
+const stringToBoard = (grid: string): number[][] => {
+  const board: number[][] = [];
+  for (let r = 0; r < 9; r++) {
+    board.push([]);
+    for (let c = 0; c < 9; c++) {
+      const ch = grid[r * 9 + c];
+      board[r][c] = ch === '.' || ch === '0' ? 0 : parseInt(ch, 10);
+    }
+  }
+  return board;
+};
+
+const boardToString = (board: number[][]): string => board.flat().map((n) => (n === 0 ? '.' : String(n))).join('');
+
+const squareToIndices = (s: string): [number, number] => [rows.indexOf(s[0]), cols.indexOf(s[1])];
+
+export const solve = (board: number[][]): { solution: number[][]; steps: Step[] } => {
+  const grid = boardToString(board);
+  const steps: Step[] = [];
+  const values = parseGrid(grid, steps);
+  if (!values) throw new Error('Invalid puzzle');
+  const result = search(values, steps);
+  if (!result) throw new Error('No solution');
+  return { solution: stringToBoard(squares.map((s) => result[s]).join('')), steps };
+};
+
+export const ratePuzzle = (board: number[][]): { difficulty: string; steps: Step[] } => {
+  const { steps } = solve(board);
+  const guesses = steps.filter((s) => s.technique === 'guess').length;
+  let difficulty: string;
+  if (guesses === 0) difficulty = 'easy';
+  else if (guesses < 3) difficulty = 'medium';
+  else difficulty = 'hard';
+  return { difficulty, steps };
+};
+
+export const getHint = (
+  board: number[][],
+): { r: number; c: number; value: number; technique: string } | null => {
+  const grid = boardToString(board);
+  const values = parseGrid(grid);
+  if (!values) return null;
+  for (const s of squares) {
+    const [r, c] = squareToIndices(s);
+    if (board[r][c] === 0 && values[s].length === 1) {
+      return { r, c, value: parseInt(values[s], 10), technique: 'single candidate' };
+    }
+  }
+  for (const u of unitList) {
+    for (const d of digits) {
+      const places = u.filter((s) => values[s].includes(d));
+      if (places.length === 1) {
+        const [r, c] = squareToIndices(places[0]);
+        if (board[r][c] === 0) {
+          return { r, c, value: parseInt(d, 10), technique: 'hidden single' };
+        }
+      }
+    }
+  }
+  return null;
+};
+
+export const utils = { boardToString, stringToBoard };
+
+export default { solve, ratePuzzle, getHint };


### PR DESCRIPTION
## Summary
- add Norvig-style solver using constraint propagation and search
- rate puzzles and compute hint breakdowns
- integrate solver into Sudoku app and provide hint system

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9337616c83288f4ad79391ef1965