### PR TITLE
Add beat-synced Web Audio latency test

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
+const LatencyTestApp = createDynamicApp('latency-test', 'Latency Test');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
@@ -143,6 +144,7 @@ const displaySpaceInvaders = createDisplay(SpaceInvadersApp);
 const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
+const displayLatencyTest = createDisplay(LatencyTestApp);
 const displayRadare2 = createDisplay(Radare2App);
 
 const displayGhidra = createDisplay(GhidraApp);
@@ -864,6 +866,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayReconNG,
+  },
+  {
+    id: 'latency-test',
+    title: 'Latency Test',
+    icon: './themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLatencyTest,
   },
   // Games are included so they appear alongside apps
   ...games,

--- a/components/apps/latency-test.js
+++ b/components/apps/latency-test.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { scheduleEnvelope, measureLatency } from '../../utils/audio';
+
+export default function LatencyTest() {
+  const [bpm, setBpm] = useState(120);
+  const [latency, setLatency] = useState(0);
+  const ctxRef = useRef(null);
+  const lastBeatRef = useRef(0);
+  const offsetRef = useRef(0);
+
+  useEffect(() => {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    const ctx = new AudioCtx();
+    ctxRef.current = ctx;
+
+    const beat = 60 / bpm;
+    const tick = () => {
+      lastBeatRef.current = scheduleEnvelope(ctx, bpm, offsetRef.current);
+    };
+
+    tick();
+    const id = setInterval(tick, beat * 1000);
+    return () => {
+      clearInterval(id);
+      ctx.close();
+    };
+  }, [bpm]);
+
+  const handleTap = () => {
+    const ctx = ctxRef.current;
+    if (!ctx) return;
+    const ms = measureLatency(ctx, lastBeatRef.current);
+    setLatency(ms);
+    // Adjust scheduling offset by measured latency in seconds
+    offsetRef.current -= ms / 1000;
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <div className="mb-4 flex items-center">
+        <label htmlFor="bpm" className="mr-2">BPM:</label>
+        <input
+          id="bpm"
+          type="number"
+          className="text-black p-1"
+          value={bpm}
+          onChange={(e) => setBpm(Number(e.target.value) || 60)}
+        />
+      </div>
+      <button onClick={handleTap} className="bg-ub-hot-red px-4 py-2 rounded">
+        Tap
+      </button>
+      <div className="mt-4">Latency: {latency.toFixed(1)} ms</div>
+    </div>
+  );
+}

--- a/utils/audio.ts
+++ b/utils/audio.ts
@@ -1,0 +1,54 @@
+export interface EnvelopeConfig {
+  attack?: number;
+  release?: number;
+}
+
+/**
+ * Schedule a short oscillator with a gain envelope aligned to the next beat.
+ *
+ * @param ctx Web Audio context
+ * @param bpm Tempo in beats per minute
+ * @param offset Time offset in seconds applied to schedule (used for latency)
+ * @param config Envelope configuration
+ * @returns The scheduled start time in context time
+ */
+export function scheduleEnvelope(
+  ctx: AudioContext,
+  bpm: number,
+  offset = 0,
+  config: EnvelopeConfig = {}
+): number {
+  const attack = config.attack ?? 0.01;
+  const release = config.release ?? 0.1;
+  const beat = 60 / bpm;
+  const now = ctx.currentTime;
+  // Find the next beat time and apply any latency offset
+  const start = Math.ceil((now + offset) / beat) * beat;
+
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sine';
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+
+  gain.gain.setValueAtTime(0, start);
+  gain.gain.linearRampToValueAtTime(1, start + attack);
+  gain.gain.linearRampToValueAtTime(0, start + attack + release);
+
+  osc.start(start);
+  osc.stop(start + attack + release);
+
+  return start;
+}
+
+/**
+ * Calculate latency in milliseconds between a user input and the last beat.
+ *
+ * @param ctx Web Audio context
+ * @param lastBeatTime Time of the last scheduled beat (seconds)
+ * @returns Latency in milliseconds
+ */
+export function measureLatency(ctx: AudioContext, lastBeatTime: number): number {
+  const now = ctx.currentTime;
+  return (now - lastBeatTime) * 1000;
+}


### PR DESCRIPTION
## Summary
- schedule Web Audio envelopes to the tempo and expose latency measurement utilities
- add React latency test app that aligns oscillator envelopes with beats and adjusts scheduling based on input timing
- register latency test app in desktop app configuration

## Testing
- `npm test -- --forceExit` *(fails: process hung after tests but individual suites passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9330113883288e16ad29155fcab7