### PR TITLE
Enhance word search with difficulty, seed sharing, timer and hints

### DIFF
--- a/__tests__/wordSearch.test.ts
+++ b/__tests__/wordSearch.test.ts
@@ -3,7 +3,7 @@ import { generateGrid } from '../apps/word_search/generator';
 describe('word search generator', () => {
   it('places words without conflicts', () => {
     const words = ['CAT', 'DOG'];
-    const { grid, placements } = generateGrid(words, 8, 'seed');
+    const { grid, placements } = generateGrid(words, 'easy', 'seed');
     placements.forEach(({ word, positions }) => {
       const placed = positions.map((p) => grid[p.row][p.col]).join('');
       const reversed = placed.split('').reverse().join('');
@@ -13,8 +13,8 @@ describe('word search generator', () => {
 
   it('is deterministic with the same seed', () => {
     const words = ['ALPHA', 'BETA'];
-    const a = generateGrid(words, 10, 'same');
-    const b = generateGrid(words, 10, 'same');
+    const a = generateGrid(words, 'medium', 'same');
+    const b = generateGrid(words, 'medium', 'same');
     expect(a.grid).toEqual(b.grid);
   });
 });

--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -29,7 +29,7 @@ export function createRNG(seed: string) {
   return mulberry32(seedFunc());
 }
 
-const DIRECTIONS = [
+const ALL_DIRECTIONS = [
   { dx: 1, dy: 0 },
   { dx: -1, dy: 0 },
   { dx: 0, dy: 1 },
@@ -40,6 +40,12 @@ const DIRECTIONS = [
   { dx: -1, dy: 1 },
 ];
 
+export const DIFFICULTY_SETTINGS = {
+  easy: { size: 8, directions: ALL_DIRECTIONS.slice(0, 4), wordCount: 5 },
+  medium: { size: 12, directions: ALL_DIRECTIONS, wordCount: 8 },
+  hard: { size: 16, directions: ALL_DIRECTIONS, wordCount: 12 },
+};
+
 export interface GenerateResult {
   grid: string[][];
   placements: WordPlacement[];
@@ -47,16 +53,18 @@ export interface GenerateResult {
 
 export function generateGrid(
   words: string[],
-  size = 12,
+  difficulty: keyof typeof DIFFICULTY_SETTINGS = 'medium',
   seed = 'seed'
 ): GenerateResult {
+  const { size, directions } =
+    DIFFICULTY_SETTINGS[difficulty] || DIFFICULTY_SETTINGS.medium;
   const rng = createRNG(seed);
   const grid: string[][] = Array.from({ length: size }, () => Array(size).fill(''));
   const placements: WordPlacement[] = [];
   words.forEach((w) => {
     const word = w.toUpperCase();
     for (let attempt = 0; attempt < 200; attempt += 1) {
-      const dir = DIRECTIONS[Math.floor(rng() * DIRECTIONS.length)];
+      const dir = directions[Math.floor(rng() * directions.length)];
       const maxRow = dir.dy > 0 ? size - word.length : dir.dy < 0 ? word.length - 1 : size - 1;
       const maxCol = dir.dx > 0 ? size - word.length : dir.dx < 0 ? word.length - 1 : size - 1;
       const startRow = Math.floor(rng() * (maxRow + 1));


### PR DESCRIPTION
## Summary
- expand word search generator with difficulty presets and deterministic seed support
- add UI for difficulty selection, shareable seed links, timer and limited hints
- update tests for new generator signature

## Testing
- `npm test __tests__/wordSearch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ae9334a69c832894ebbeb09db2a8cb