### PR TITLE
feat(pwa): add web app manifest and install prompt

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+const InstallButton: React.FC = () => {
+  const [prompt, setPrompt] = useState<any>(null);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      e.preventDefault();
+      setPrompt(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!prompt) return;
+    prompt.prompt();
+    await prompt.userChoice;
+    setPrompt(null);
+  };
+
+  if (!prompt) return null;
+
+  return (
+    <button
+      onClick={handleInstall}
+      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
+    >
+      Install
+    </button>
+  );
+};
+
+export default InstallButton;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,6 +10,8 @@ class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
+          <link rel="manifest" href="/manifest.webmanifest" />
+          <meta name="theme-color" content="#000000" />
           <script
             dangerouslySetInnerHTML={{
               __html: `

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
+import InstallButton from '../components/InstallButton';
 
 const App: React.FC = () => (
   <>
     <Meta />
     <Ubuntu />
+    <InstallButton />
   </>
 );
 

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,37 @@
+{
+  "name": "Kali Linux Portfolio",
+  "short_name": "KaliPortfolio",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/images/logos/fevicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/logos/logo_1024.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Open Terminal",
+      "short_name": "Terminal",
+      "url": "/?open=terminal"
+    },
+    {
+      "name": "New Note",
+      "short_name": "Note",
+      "url": "/apps/sticky_notes/"
+    },
+    {
+      "name": "Open 2048 Daily",
+      "short_name": "2048",
+      "url": "/?open=2048&daily=true"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `public/manifest.webmanifest` with icons, theme color, and app shortcuts
- wire up manifest in document and expose small install button

## Testing
- `yarn lint`
- `CI=true yarn test`
- `npx -y lighthouse http://localhost:3000 --quiet --only-categories=pwa --output=json --output-path=/tmp/lh.json` *(fails: The CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68ae944ff15483289e3e411a48e36557