### PR TITLE
feat: add share buttons with Web Share API fallback

### DIFF
--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
+import { share } from '../../utils/share';
 
 export class Gedit extends Component {
 
@@ -79,6 +80,12 @@ export class Gedit extends Component {
                     <span className="font-bold ml-2">Send a Message to Me</span>
                     <div className="flex">
                         <div onClick={this.sendMessage} className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80">Send</div>
+                        <div
+                            onClick={() => share({ title: 'Contact', text: 'Get in touch with me:', url: window.location.href })}
+                            className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80"
+                        >
+                            Share
+                        </div>
                     </div>
                 </div>
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
+import { share } from '../../utils/share';
 
 const GITHUB_USER = 'Alex-Unnippillil';
 
@@ -90,6 +91,18 @@ export default function ProjectGallery() {
                       Repo
                     </a>
                   )}
+                  <button
+                    onClick={() =>
+                      share({
+                        title: project.title,
+                        text: project.description,
+                        url: project.live || project.repo,
+                      })
+                    }
+                    className="px-3 py-1 text-sm bg-green-600 rounded hover:bg-green-500"
+                  >
+                    Share
+                  </button>
                 </div>
               </div>
             </div>

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import usePersistentState from '../usePersistentState';
+import { share } from '../../utils/share';
 
 const WIDTH = 10;
 const HEIGHT = 20;
@@ -375,6 +376,18 @@ const Tetris = () => {
           <div>High: {highScore}</div>
           <div>Level: {level}</div>
           <div>Max Level: {maxLevel}</div>
+          <button
+            onClick={() =>
+              share({
+                title: 'Tetris High Score',
+                text: `I scored ${highScore} points in Tetris!`,
+                url: window.location.href,
+              })
+            }
+            className="mt-2 px-2 py-1 bg-green-600 rounded hover:bg-green-500"
+          >
+            Share
+          </button>
         </div>
       </div>
       {showSettings && (

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,0 +1,28 @@
+export interface ShareData {
+  title?: string;
+  text: string;
+  url?: string;
+}
+
+export async function share(data: ShareData): Promise<void> {
+  const { title, text, url } = data;
+  try {
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      if (!navigator.canShare || navigator.canShare({ title, text, url })) {
+        await navigator.share({ title, text, url });
+        return;
+      }
+    }
+  } catch (err) {
+    // ignore and fallback
+  }
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    const fallback = [text, url].filter(Boolean).join(' ');
+    try {
+      await navigator.clipboard.writeText(fallback);
+    } catch (e) {
+      // ignore
+    }
+  }
+}
+export default share;


### PR DESCRIPTION
## Summary
- add share utility with Web Share API and clipboard fallback
- integrate share buttons into contact form, project gallery, and Tetris high score

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae945171cc8328a4c5eee2d0741b47