### PR TITLE
feat: add document pip portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ yarn lint
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
+- **`components/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 
 ---
 

--- a/components/PipPortal.tsx
+++ b/components/PipPortal.tsx
@@ -1,0 +1,91 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+declare global {
+  interface Window {
+    documentPictureInPicture?: {
+      requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
+    };
+  }
+
+  interface PictureInPictureWindowOptions {
+    width?: number;
+    height?: number;
+  }
+}
+
+interface PipPortalContextValue {
+  open: (content: React.ReactNode) => Promise<void>;
+  close: () => void;
+}
+
+const PipPortalContext = createContext<PipPortalContextValue>({
+  open: async () => {},
+  close: () => {},
+});
+
+export const usePipPortal = () => useContext(PipPortalContext);
+
+const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const pipWindowRef = useRef<Window | null>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [content, setContent] = useState<React.ReactNode>(null);
+
+  const close = useCallback(() => {
+    const win = pipWindowRef.current;
+    if (win && !win.closed) {
+      win.close();
+    }
+    pipWindowRef.current = null;
+    setContainer(null);
+    setContent(null);
+  }, []);
+
+  const open = useCallback(
+    async (node: React.ReactNode) => {
+      if (typeof window === 'undefined' || !window.documentPictureInPicture) return;
+      let win = pipWindowRef.current;
+      if (!win || win.closed) {
+        try {
+          win = await window.documentPictureInPicture.requestWindow();
+        } catch {
+          return;
+        }
+        pipWindowRef.current = win;
+        setContainer(win.document.body);
+
+        const handlePageHide = () => close();
+        window.addEventListener('pagehide', handlePageHide, { once: true });
+        win.addEventListener('pagehide', handlePageHide, { once: true });
+      }
+      setContent(node);
+    },
+    [close],
+  );
+
+  useEffect(() => {
+    const win = pipWindowRef.current;
+    if (!win) return;
+
+    const handleUnload = () => {
+      pipWindowRef.current = null;
+      setContainer(null);
+      setContent(null);
+    };
+
+    win.addEventListener('unload', handleUnload);
+    return () => {
+      win.removeEventListener('unload', handleUnload);
+    };
+  }, [container]);
+
+  return (
+    <PipPortalContext.Provider value={{ open, close }}>
+      {children}
+      {container && content ? createPortal(content, container) : null}
+    </PipPortalContext.Provider>
+  );
+};
+
+export default PipPortalProvider;
+

--- a/docs/pip-portal.md
+++ b/docs/pip-portal.md
@@ -1,0 +1,45 @@
+# Pip Portal
+
+The `PipPortal` component provides a simple API for rendering React
+content inside a [Document Picture-in-Picture](https://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API) window.
+
+## Usage
+
+Wrap your application with `PipPortalProvider` and use the `usePipPortal`
+hook to open or close the PiP window.
+
+```tsx
+import PipPortalProvider, { usePipPortal } from '../components/PipPortal';
+
+function HudButton() {
+  const { open, close } = usePipPortal();
+
+  return (
+    <div>
+      <button
+        onClick={() =>
+          open(<div className="p-2">Timer: 00:30</div>)
+        }
+      >
+        Show Timer
+      </button>
+      <button onClick={close}>Close</button>
+    </div>
+  );
+}
+
+// in _app.tsx
+export default function App({ Component, pageProps }) {
+  return (
+    <PipPortalProvider>
+      <Component {...pageProps} />
+    </PipPortalProvider>
+  );
+}
+```
+
+The PiP window persists as long as the tab is open and automatically
+closes on the `pagehide` event.  
+You can mount timers, heads-up displays or other widgets into this portal
+to keep them visible while the user navigates the site.
+


### PR DESCRIPTION
## Summary
- implement PipPortal provider and hook to open and close document Picture-in-Picture windows
- document PiP portal usage and note in README

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae945109e08328910f6e2373764d75