### PR TITLE
feat: add wake lock controller and toggles

### DIFF
--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,9 +1,12 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import Head from 'next/head';
+import { setWakeLock } from '../utils/wakeLock';
 
 export default function YouTubePlayer({ videoId }) {
   const [activated, setActivated] = useState(false);
   const playerRef = useRef(null);
+  const [awake, setAwake] = useState(false);
+  const [error, setError] = useState('');
 
   const loadPlayer = () => {
     if (activated) return;
@@ -32,6 +35,18 @@ export default function YouTubePlayer({ videoId }) {
     }
   };
 
+  const toggleWake = useCallback(async () => {
+    const next = !awake;
+    try {
+      await setWakeLock(next);
+      setAwake(next);
+      setError('');
+    } catch (err) {
+      setError(err?.message || String(err));
+      setAwake(false);
+    }
+  }, [awake]);
+
   return (
     <>
       <Head>
@@ -39,6 +54,18 @@ export default function YouTubePlayer({ videoId }) {
         <link rel="preconnect" href="https://i.ytimg.com" />
       </Head>
       <div className="relative w-full pb-[56.25%]">{/* 16:9 aspect ratio */}
+        <button
+          type="button"
+          aria-pressed={awake}
+          onClick={toggleWake}
+          aria-label="Toggle wake lock"
+          className="absolute top-2 right-2 z-10 bg-gray-700 text-white rounded px-2 py-1"
+        >
+          {awake ? 'Awake' : 'Sleep'}
+        </button>
+        {error && (
+          <p className="absolute bottom-2 left-2 text-xs text-red-500">{error}</p>
+        )}
         <div className="absolute inset-0" ref={playerRef}>
           {!activated && (
             <button

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
+import { setWakeLock } from '../../utils/wakeLock';
 
 interface GameLayoutProps {
   gameId: string;
@@ -8,9 +9,23 @@ interface GameLayoutProps {
 
 const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
   const [showHelp, setShowHelp] = useState(false);
+  const [awake, setAwake] = useState(false);
+  const [wakeError, setWakeError] = useState('');
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
+
+  const toggleWake = useCallback(async () => {
+    const next = !awake;
+    try {
+      await setWakeLock(next);
+      setAwake(next);
+      setWakeError('');
+    } catch (err: any) {
+      setWakeError(err?.message || String(err));
+      setAwake(false);
+    }
+  }, [awake]);
 
   useEffect(() => {
     if (!showHelp) return;
@@ -27,15 +42,29 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
   return (
     <div className="relative h-full w-full">
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
-      <button
-        type="button"
-        aria-label="Help"
-        aria-expanded={showHelp}
-        onClick={toggle}
-        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
-      >
-        ?
-      </button>
+      <div className="absolute top-2 right-2 z-40 flex gap-2">
+        <button
+          type="button"
+          aria-label="Toggle wake lock"
+          aria-pressed={awake}
+          onClick={toggleWake}
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        >
+          {awake ? '☕' : '⚡'}
+        </button>
+        <button
+          type="button"
+          aria-label="Help"
+          aria-expanded={showHelp}
+          onClick={toggle}
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        >
+          ?
+        </button>
+      </div>
+      {wakeError && (
+        <p className="absolute bottom-2 left-2 text-xs text-red-500">{wakeError}</p>
+      )}
       {children}
 
     </div>

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,8 +1,36 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { setWakeLock } from '../../utils/wakeLock';
 
 export default function SpotifyApp() {
+  const [awake, setAwake] = useState(false);
+  const [error, setError] = useState('');
+
+  const toggle = useCallback(async () => {
+    const next = !awake;
+    try {
+      await setWakeLock(next);
+      setAwake(next);
+      setError('');
+    } catch (err) {
+      setError(err?.message || String(err));
+      setAwake(false);
+    }
+  }, [awake]);
+
   return (
-    <div className="h-full w-full bg-ub-cool-grey">
+    <div className="h-full w-full bg-ub-cool-grey relative">
+      <button
+        type="button"
+        aria-pressed={awake}
+        onClick={toggle}
+        aria-label="Toggle wake lock"
+        className="absolute top-2 right-2 z-10 bg-gray-700 text-white rounded px-2 py-1"
+      >
+        {awake ? 'Awake' : 'Sleep'}
+      </button>
+      {error && (
+        <p className="absolute bottom-2 left-2 text-xs text-red-500">{error}</p>
+      )}
       <iframe
         src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
         title="Daily Mix 2"

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+import { setWakeLock } from '../../utils/wakeLock';
 
 const CHANNEL_HANDLE = 'Alex-Unnippillil';
 
@@ -16,6 +17,8 @@ export default function YouTubeApp({ initialVideos = [] }) {
   const [activeCategory, setActiveCategory] = useState('All');
   const [sortBy, setSortBy] = useState('date');
   const [search, setSearch] = useState('');
+  const [awake, setAwake] = useState(false);
+  const [wakeError, setWakeError] = useState('');
 
   const apiKey = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY;
 
@@ -169,8 +172,32 @@ export default function YouTubeApp({ initialVideos = [] }) {
     setSearch(value);
   }, []);
 
+  const toggleWake = useCallback(async () => {
+    const next = !awake;
+    try {
+      await setWakeLock(next);
+      setAwake(next);
+      setWakeError('');
+    } catch (err) {
+      setWakeError(err?.message || String(err));
+      setAwake(false);
+    }
+  }, [awake]);
+
   return (
-    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white">
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white relative">
+      <button
+        type="button"
+        aria-pressed={awake}
+        onClick={toggleWake}
+        aria-label="Toggle wake lock"
+        className="absolute top-2 right-2 z-10 bg-gray-700 text-white rounded px-2 py-1"
+      >
+        {awake ? 'Awake' : 'Sleep'}
+      </button>
+      {wakeError && (
+        <p className="absolute bottom-2 left-2 text-xs text-red-500">{wakeError}</p>
+      )}
       {!apiKey && videos.length === 0 ? (
         <div className="p-2">
           <p>YouTube API key is not configured.</p>

--- a/utils/wakeLock.ts
+++ b/utils/wakeLock.ts
@@ -1,0 +1,39 @@
+let wakeLock: WakeLockSentinel | null = null;
+let enabled = false;
+
+async function requestLock(): Promise<void> {
+  if (!('wakeLock' in navigator)) {
+    throw new Error('Wake Lock API is not supported');
+  }
+  wakeLock = await navigator.wakeLock.request('screen');
+}
+
+async function releaseLock(): Promise<void> {
+  if (wakeLock) {
+    await wakeLock.release();
+    wakeLock = null;
+  }
+}
+
+async function handleVisibility(): Promise<void> {
+  if (document.visibilityState === 'visible' && enabled && !wakeLock) {
+    try {
+      await requestLock();
+    } catch {
+      // Ignore re-acquisition errors
+    }
+  } else if (document.visibilityState !== 'visible' && wakeLock) {
+    await releaseLock();
+  }
+}
+
+export async function setWakeLock(on: boolean): Promise<void> {
+  enabled = on;
+  if (on) {
+    await requestLock();
+    document.addEventListener('visibilitychange', handleVisibility);
+  } else {
+    document.removeEventListener('visibilitychange', handleVisibility);
+    await releaseLock();
+  }
+}


### PR DESCRIPTION
## Summary
- add wake lock controller utility handling visibility changes
- allow games and media apps to toggle wake lock with error messaging
- expose wake lock toggle for YouTube and Spotify embeds

## Testing
- `CI=true npm test --runInBand`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9452cae083289179dd33c23dfa79