### PR TITLE
Add reader with Readability and PDF viewing

### DIFF
--- a/__tests__/pdfviewer.test.tsx
+++ b/__tests__/pdfviewer.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PdfViewer from '../components/common/PdfViewer';
+
+jest.mock('pdfjs-dist', () => {
+  const getDocument = jest.fn(() => ({
+    promise: Promise.resolve({
+      numPages: 1,
+      getPage: jest.fn(async () => ({
+        getViewport: () => ({ width: 100, height: 100, scale: 1 }),
+        render: () => ({ promise: Promise.resolve() }),
+        getTextContent: async () => ({ items: [{ str: 'hello world' }] }),
+      })),
+    }),
+  }));
+  return { getDocument, GlobalWorkerOptions: { workerSrc: '' } };
+});
+
+describe('PdfViewer', () => {
+  it('renders PDF and searches text', async () => {
+    const user = userEvent.setup();
+    render(<PdfViewer url="/sample.pdf" />);
+    const canvas = await screen.findByTestId('pdf-canvas');
+    expect(canvas).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/search/i), 'hello');
+    await user.click(screen.getByText('Search'));
+    expect(await screen.findByText('Page 1')).toBeInTheDocument();
+  });
+});

--- a/__tests__/readLater.test.tsx
+++ b/__tests__/readLater.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReadLaterList from '../components/apps/chrome/ReadLaterList';
+
+describe('ReadLaterList', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('displays saved articles with title and excerpt', () => {
+    localStorage.setItem(
+      'read-later-items',
+      JSON.stringify([{ title: 'A', url: '/a', excerpt: 'excerpt' }])
+    );
+    render(<ReadLaterList />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('excerpt')).toBeInTheDocument();
+  });
+});

--- a/__tests__/reader.test.tsx
+++ b/__tests__/reader.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Reader from '../components/apps/chrome/Reader';
+
+const sampleHtml = `<!DOCTYPE html><html><head><title>t</title></head><body><article><h1>Sample</h1><p>Content here</p></article></body></html>`;
+
+const writeTextMock = jest.fn();
+
+describe('Reader', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn(async () => ({ text: async () => sampleHtml }));
+    writeTextMock.mockClear();
+  });
+
+  it('parses same-origin pages', async () => {
+    render(<Reader url="/test" />);
+    expect(await screen.findByText('Sample')).toBeInTheDocument();
+  });
+
+  it('shows fallback on cross-origin', async () => {
+    render(<Reader url="https://example.com" />);
+    expect(
+      await screen.findByText(/Cross-origin content cannot be loaded/i)
+    ).toBeInTheDocument();
+  });
+
+  it('copies markdown', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+    render(<Reader url="/test" />);
+    await screen.findByText('Sample');
+    await user.click(screen.getByText('Copy as Markdown'));
+    expect(writeTextMock).toHaveBeenCalled();
+  });
+});

--- a/components/apps/chrome/ReadLaterList.tsx
+++ b/components/apps/chrome/ReadLaterList.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+export interface ReadLaterItem {
+  title: string;
+  url: string;
+  excerpt: string;
+}
+
+const STORAGE_KEY = 'read-later-items';
+
+const loadItems = (): ReadLaterItem[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? (JSON.parse(data) as ReadLaterItem[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const saveItems = (items: ReadLaterItem[]) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+};
+
+export const useReadLater = () => {
+  const [items, setItems] = React.useState<ReadLaterItem[]>(loadItems);
+
+  const add = (item: ReadLaterItem) => {
+    setItems((prev) => {
+      const next = [...prev, item];
+      saveItems(next);
+      return next;
+    });
+  };
+
+  const remove = (url: string) => {
+    setItems((prev) => {
+      const next = prev.filter((i) => i.url !== url);
+      saveItems(next);
+      return next;
+    });
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(items, null, 2)], {
+      type: 'application/json',
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'read-later.json';
+    a.click();
+  };
+
+  return { items, add, remove, exportJson };
+};
+
+const ReadLaterList: React.FC = () => {
+  const { items, exportJson } = useReadLater();
+  return (
+    <div>
+      <h2>Read Later</h2>
+      <ul>
+        {items.map((item) => (
+          <li key={item.url}>
+            <a href={item.url}>{item.title}</a>
+            <p>{item.excerpt}</p>
+          </li>
+        ))}
+      </ul>
+      <button onClick={exportJson}>Export</button>
+    </div>
+  );
+};
+
+export default ReadLaterList;

--- a/components/apps/chrome/Reader.tsx
+++ b/components/apps/chrome/Reader.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { Readability } from '@mozilla/readability';
+import TurndownService from 'turndown';
+import { useReadLater } from './ReadLaterList';
+
+interface ReaderProps {
+  url: string;
+}
+
+interface Article {
+  title: string;
+  content: string;
+  excerpt: string;
+}
+
+const Reader: React.FC<ReaderProps> = ({ url }) => {
+  const [article, setArticle] = useState<Article | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { add } = useReadLater();
+
+  useEffect(() => {
+    const target = new URL(url, window.location.href);
+    if (target.origin !== window.location.origin) {
+      setError('Cross-origin content cannot be loaded.');
+      return;
+    }
+
+    fetch(target.href)
+      .then((res) => res.text())
+      .then((html) => {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const reader = new Readability(doc);
+        const parsed = reader.parse();
+        if (parsed) {
+          setArticle({
+            title: parsed.title,
+            content: parsed.content,
+            excerpt: parsed.excerpt,
+          });
+        } else {
+          setError('Unable to parse article.');
+        }
+      })
+      .catch(() => setError('Unable to load page.'));
+  }, [url]);
+
+  const copyMarkdown = () => {
+    if (!article) return;
+    const turndown = new TurndownService();
+    const md = turndown.turndown(article.content);
+    const text = `# ${article.title}\n\n${md}`;
+    navigator.clipboard?.writeText(text);
+  };
+
+  const saveForLater = () => {
+    if (!article) return;
+    add({ title: article.title, url, excerpt: article.excerpt });
+  };
+
+  if (error) return <div>{error}</div>;
+  if (!article) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>{article.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: article.content }} />
+      <div className="flex gap-2 mt-4">
+        <button onClick={copyMarkdown}>Copy as Markdown</button>
+        <button onClick={saveForLater}>Read Later</button>
+      </div>
+    </div>
+  );
+};
+
+export default Reader;

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as pdfjsLib from 'pdfjs-dist';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
+
+interface PdfViewerProps {
+  url: string;
+}
+
+const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [pdf, setPdf] = useState<any>(null);
+  const [page, setPage] = useState(1);
+  const [thumbs, setThumbs] = useState<HTMLCanvasElement[]>([]);
+  const [query, setQuery] = useState('');
+  const [matches, setMatches] = useState<number[]>([]);
+
+  useEffect(() => {
+    pdfjsLib.getDocument(url).promise.then(setPdf);
+  }, [url]);
+
+  useEffect(() => {
+    if (!pdf) return;
+    const render = async () => {
+      const pg = await pdf.getPage(page);
+      const viewport = pg.getViewport({ scale: 1.5 });
+      const canvas = canvasRef.current!;
+      canvas.height = viewport.height;
+      canvas.width = viewport.width;
+      await pg.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+    };
+    render();
+  }, [pdf, page]);
+
+  useEffect(() => {
+    if (!pdf) return;
+    const loadThumbs = async () => {
+      const arr: HTMLCanvasElement[] = [];
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const pg = await pdf.getPage(i);
+        const viewport = pg.getViewport({ scale: 0.2 });
+        const canvas = document.createElement('canvas');
+        canvas.height = viewport.height;
+        canvas.width = viewport.width;
+        await pg.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+        arr.push(canvas);
+      }
+      setThumbs(arr);
+    };
+    loadThumbs();
+  }, [pdf]);
+
+  const search = async () => {
+    if (!pdf) return;
+    const found: number[] = [];
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const pg = await pdf.getPage(i);
+      const textContent = await pg.getTextContent();
+      const text = textContent.items.map((it: any) => it.str).join(' ');
+      if (text.toLowerCase().includes(query.toLowerCase())) found.push(i);
+    }
+    setMatches(found);
+    if (found[0]) setPage(found[0]);
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search"
+        />
+        <button onClick={search}>Search</button>
+      </div>
+      <canvas ref={canvasRef} data-testid="pdf-canvas" />
+      <div className="flex gap-2 overflow-x-auto mt-2">
+        {thumbs.map((t, i) => (
+          <canvas
+            key={i}
+            data-testid={`thumb-${i + 1}`}
+            onClick={() => setPage(i + 1)}
+            ref={(el) => {
+              if (el) el.getContext('2d')?.drawImage(t, 0, 0);
+            }}
+            width={t.width}
+            height={t.height}
+          />
+        ))}
+      </div>
+      {matches.length > 0 && (
+        <div data-testid="search-results">
+          {matches.map((m) => (
+            <div key={m}>Page {m}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PdfViewer;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
+    "@mozilla/readability": "^0.6.0",
     "@vercel/analytics": "^1.5.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
@@ -32,6 +33,7 @@
     "jsqr": "^1.4.0",
     "mathjs": "^14.6.0",
     "next": "^15.0.0",
+    "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",
     "postcss": "^8.4.21",
     "prop-types": "^15.8.1",
@@ -41,7 +43,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",
@@ -50,6 +51,7 @@
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
+    "turndown": "^7.2.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-search": "^0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,129 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
+  languageName: node
+  linkType: hard
+
+"@mozilla/readability@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@mozilla/readability@npm:0.6.0"
+  checksum: 10c0/05c0fdb837f6bddd307b9dbc396538cdf17ab6a0d3bec96971c2dfc079737fb7ab830a0797c5fad3d66db71cb9c305d8e05fe68d9b7eb0be951d4b802e43e588
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-android-arm64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.77"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-darwin-arm64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.77"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-darwin-x64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.77"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-arm64-musl@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.77"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-x64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.77"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-linux-x64-musl@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.77"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-win32-x64-msvc@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.77"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas@npm:^0.1.74":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas@npm:0.1.77"
+  dependencies:
+    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
+  dependenciesMeta:
+    "@napi-rs/canvas-android-arm64":
+      optional: true
+    "@napi-rs/canvas-darwin-arm64":
+      optional: true
+    "@napi-rs/canvas-darwin-x64":
+      optional: true
+    "@napi-rs/canvas-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/canvas-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-arm64-musl":
+      optional: true
+    "@napi-rs/canvas-linux-riscv64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-x64-gnu":
+      optional: true
+    "@napi-rs/canvas-linux-x64-musl":
+      optional: true
+    "@napi-rs/canvas-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/f7a1b33e86e53c210db873a6b5b9be9961d9a57b4e1c4e61c2667ed3cb166dec334b4f14d548c8790d9ffc79cf49b9762340f3b3d3f7fc991e9c8cc0a5f8654d
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -6366,6 +6489,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pdfjs-dist@npm:^5.4.54":
+  version: 5.4.54
+  resolution: "pdfjs-dist@npm:5.4.54"
+  dependencies:
+    "@napi-rs/canvas": "npm:^0.1.74"
+  dependenciesMeta:
+    "@napi-rs/canvas":
+      optional: true
+  checksum: 10c0/7f709185439351457c646e63ea19c42dbc4752fb2a61dd57857d1882f6f066bf3da4b4534a29aa0b4a218ffd9f751d9ad54e247772f90d0a2a1ed11648b4287b
+  languageName: node
+  linkType: hard
+
 "phaser@npm:3.70.0":
   version: 3.70.0
   resolution: "phaser@npm:3.70.0"
@@ -6669,7 +6804,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -7859,6 +7993,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"turndown@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "turndown@npm:7.2.1"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/a2ed7b05624ad20d243fab424a256f029340782ea0c023229813b732a29af8857e313761b5a9e3d224aede1712bd47a382c3d0923712592b8756c698945eccb1
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -8004,6 +8147,7 @@ __metadata:
   resolution: "unnippillil@workspace:."
   dependencies:
     "@emailjs/browser": "npm:^3.10.0"
+    "@mozilla/readability": "npm:^0.6.0"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"
     "@testing-library/react": "npm:^16.3.0"
@@ -8034,6 +8178,7 @@ __metadata:
     jsqr: "npm:^1.4.0"
     mathjs: "npm:^14.6.0"
     next: "npm:^15.0.0"
+    pdfjs-dist: "npm:^5.4.54"
     phaser: "npm:3.70.0"
     postcss: "npm:^8.4.21"
     prop-types: "npm:^15.8.1"
@@ -8043,7 +8188,6 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"
@@ -8052,6 +8196,7 @@ __metadata:
     swr: "npm:^2.2.5"
     tailwindcss: "npm:^3.2.4"
     three: "npm:^0.179.1"
+    turndown: "npm:^7.2.1"
     typescript: "npm:^5.9.2"
     xterm: "npm:^5.3.0"
     xterm-addon-fit: "npm:^0.8.0"


### PR DESCRIPTION
## Summary
- add Reader component using Mozilla Readability with Markdown copy and read-later saving
- introduce PDF viewer with thumbnails and text search
- store read-later items with export to JSON

## Testing
- `yarn test __tests__/reader.test.tsx __tests__/pdfviewer.test.tsx __tests__/readLater.test.tsx`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae945421808328a3bc7050fd42d7d8