### PR TITLE
feat(calc): add equation solver, fraction mode, and graph pad

### DIFF
--- a/__tests__/fraction_solver.test.ts
+++ b/__tests__/fraction_solver.test.ts
@@ -1,0 +1,22 @@
+import { toFraction } from '../utils/fraction';
+import { solveLinearEquation, solveQuadraticEquation, newtonMethod } from '../utils/solver';
+
+test('toFraction converts decimal to fraction', () => {
+  expect(toFraction(0.75)).toBe('3/4');
+});
+
+test('solveLinearEquation solves ax+b=0', () => {
+  const { solution } = solveLinearEquation('2x+4=0');
+  expect(solution).toBe(-2);
+});
+
+test('solveQuadraticEquation solves ax^2+bx+c=0', () => {
+  const { solutions } = solveQuadraticEquation('x^2-5x+6=0');
+  expect(solutions[0]).toBeCloseTo(3);
+  expect(solutions[1]).toBeCloseTo(2);
+});
+
+test('newtonMethod approximates root', () => {
+  const { root } = newtonMethod('x^2-2', 1);
+  expect(root).toBeCloseTo(Math.sqrt(2), 3);
+});

--- a/components/apps/GraphPad.js
+++ b/components/apps/GraphPad.js
@@ -1,0 +1,121 @@
+import React, { useRef, useState, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Parser } from 'expr-eval';
+
+const GraphPad = forwardRef(({ height = 200 }, ref) => {
+  const canvasRef = useRef(null);
+  const [scale, setScale] = useState(40); // pixels per unit
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [cursor, setCursor] = useState({ x: 0, y: 0 });
+  const parserRef = useRef(null);
+
+  useImperativeHandle(ref, () => ({
+    plot: (expr) => {
+      try {
+        parserRef.current = new Parser().parse(expr);
+        draw();
+      } catch (e) {
+        parserRef.current = null;
+        draw();
+      }
+    },
+  }));
+
+  const drawAxes = (ctx, width, height) => {
+    ctx.strokeStyle = '#555';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, height / 2 + offset.y);
+    ctx.lineTo(width, height / 2 + offset.y);
+    ctx.moveTo(width / 2 + offset.x, 0);
+    ctx.lineTo(width / 2 + offset.x, height);
+    ctx.stroke();
+  };
+
+  const drawFunction = (ctx, width, height) => {
+    if (!parserRef.current) return;
+    ctx.strokeStyle = '#0f0';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    for (let px = 0; px < width; px++) {
+      const x = (px - width / 2 - offset.x) / scale;
+      let y;
+      try {
+        y = parserRef.current.evaluate({ x });
+      } catch {
+        y = NaN;
+      }
+      const py = height / 2 - y * scale + offset.y;
+      if (px === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  };
+
+  const draw = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    drawAxes(ctx, width, height);
+    drawFunction(ctx, width, height);
+  };
+
+  useEffect(() => {
+    draw();
+  }, [scale, offset]);
+
+  const handleWheel = (e) => {
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? 1.1 : 0.9;
+    setScale((s) => Math.min(Math.max(10, s * delta), 400));
+  };
+
+  const isDragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+
+  const handleMouseDown = (e) => {
+    isDragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const handleMouseMove = (e) => {
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = (e.clientX - rect.left - rect.width / 2 - offset.x) / scale;
+    const y = (rect.height / 2 + offset.y - (e.clientY - rect.top)) / scale;
+    setCursor({ x: x.toFixed(2), y: y.toFixed(2) });
+    if (isDragging.current) {
+      const dx = e.clientX - lastPos.current.x;
+      const dy = e.clientY - lastPos.current.y;
+      setOffset((o) => ({ x: o.x + dx, y: o.y + dy }));
+      lastPos.current = { x: e.clientX, y: e.clientY };
+    }
+  };
+
+  const handleMouseUp = () => {
+    isDragging.current = false;
+  };
+
+  return (
+    <div className="mt-4 relative">
+      <canvas
+        ref={canvasRef}
+        width={400}
+        height={height}
+        className="w-full border border-gray-700"
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      />
+      <div className="absolute top-0 left-0 text-xs bg-gray-800 text-white p-1">
+        x: {cursor.x}, y: {cursor.y}
+      </div>
+    </div>
+  );
+});
+
+export default GraphPad;

--- a/components/apps/calc.js
+++ b/components/apps/calc.js
@@ -1,5 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 const Parser = require('expr-eval').Parser;
+import GraphPad from './GraphPad';
+import { toFraction } from '../../utils/fraction';
+import { solveEquation } from '../../utils/solver';
 
 // configure parser similar to previous implementation
 const parser = new Parser({
@@ -33,12 +36,24 @@ export const evaluateExpression = (expression) => {
 
 const Calc = () => {
   const [display, setDisplay] = useState('');
+  const [fractionMode, setFractionMode] = useState(false);
+  const graphRef = useRef(null);
 
   const handleClick = (btn) => {
     if (btn.type === 'clear') {
       setDisplay('');
+    } else if (btn.value === 'plot') {
+      graphRef.current && graphRef.current.plot(display);
+    } else if (btn.value === 'frac') {
+      setFractionMode((f) => !f);
+    } else if (btn.value === 'solve') {
+      setDisplay(solveEquation(display));
     } else if (btn.label === '=') {
-      setDisplay(evaluateExpression(display));
+      let result = evaluateExpression(display);
+      if (fractionMode && !isNaN(result)) {
+        result = toFraction(parseFloat(result));
+      }
+      setDisplay(String(result));
     } else {
       setDisplay((prev) => prev + (btn.value || btn.label));
     }
@@ -51,7 +66,8 @@ const Calc = () => {
     { label: '0' }, { label: '.' }, { label: '=', ariaLabel: 'equals' }, { label: '+', ariaLabel: 'add' },
     { label: '(', ariaLabel: 'open parenthesis' }, { label: ')', ariaLabel: 'close parenthesis' }, { label: '^', ariaLabel: 'power' }, { label: 'sqrt', value: 'sqrt(', ariaLabel: 'square root' },
     { label: 'sin', value: 'sin(', ariaLabel: 'sine' }, { label: 'cos', value: 'cos(', ariaLabel: 'cosine' }, { label: 'tan', value: 'tan(', ariaLabel: 'tangent' }, { label: 'log', value: 'log(', ariaLabel: 'logarithm' },
-    { label: 'C', type: 'clear', colSpan: 2, ariaLabel: 'clear' },
+    { label: 'x', ariaLabel: 'x variable' }, { label: 'Frac', value: 'frac', ariaLabel: 'fraction mode' }, { label: 'Solve', value: 'solve', ariaLabel: 'solve equation' }, { label: 'Plot', value: 'plot', ariaLabel: 'plot graph' },
+    { label: 'C', type: 'clear', colSpan: 4, ariaLabel: 'clear' },
   ];
 
   return (
@@ -62,7 +78,7 @@ const Calc = () => {
       >
         {display}
       </div>
-      <div className="grid grid-cols-4 gap-2 flex-grow">
+      <div className="grid grid-cols-4 gap-2">
         {buttons.map((btn, idx) => (
           <button
             key={idx}
@@ -76,6 +92,7 @@ const Calc = () => {
           </button>
         ))}
       </div>
+      <GraphPad ref={graphRef} />
     </div>
   );
 };

--- a/utils/fraction.js
+++ b/utils/fraction.js
@@ -1,0 +1,20 @@
+export function toFraction(value, tolerance = 1e-10) {
+  if (!Number.isFinite(value)) return String(value);
+  const sign = value < 0 ? -1 : 1;
+  let x = Math.abs(value);
+  if (Math.floor(x) === x) return `${sign * x}/1`;
+  let h1 = 1, h2 = 0, k1 = 0, k2 = 1;
+  let b = x;
+  while (true) {
+    const a = Math.floor(b);
+    const h = a * h1 + h2;
+    const k = a * k1 + k2;
+    const approx = h / k;
+    if (Math.abs(x - approx) <= tolerance || k > 1000) {
+      return `${sign * h}/${k}`;
+    }
+    h2 = h1; h1 = h;
+    k2 = k1; k1 = k;
+    b = 1 / (b - a);
+  }
+}

--- a/utils/solver.js
+++ b/utils/solver.js
@@ -1,0 +1,77 @@
+import { Parser } from 'expr-eval';
+
+function parseCoeff(str, defaultValue = 1) {
+  if (str === '' || str === '+') return defaultValue;
+  if (str === '-' ) return -defaultValue;
+  const num = parseFloat(str);
+  return isNaN(num) ? defaultValue : num;
+}
+
+export function solveLinearEquation(expr) {
+  const cleaned = expr.replace(/\s+/g, '').replace('=0', '');
+  const match = cleaned.match(/([+-]?\d*\.?\d*)x([+-]\d*\.?\d*)?/);
+  if (!match) return { solution: null, steps: ['Unable to parse equation'] };
+  const a = parseCoeff(match[1]);
+  const b = parseCoeff(match[2] || '0', 0);
+  const solution = -b / a;
+  const steps = [
+    `${a}x + ${b} = 0`,
+    `${a}x = ${-b}`,
+    `x = ${-b}/${a} = ${solution}`,
+  ];
+  return { solution, steps };
+}
+
+export function solveQuadraticEquation(expr) {
+  const cleaned = expr.replace(/\s+/g, '').replace('=0', '');
+  const match = cleaned.match(/([+-]?\d*\.?\d*)x\^2([+-]\d*\.?\d*)x([+-]\d*\.?\d*)/);
+  if (!match) return { solutions: [], steps: ['Unable to parse equation'] };
+  const a = parseCoeff(match[1]);
+  const b = parseCoeff(match[2], 0);
+  const c = parseCoeff(match[3], 0);
+  const disc = b * b - 4 * a * c;
+  const sqrtDisc = Math.sqrt(disc);
+  const x1 = (-b + sqrtDisc) / (2 * a);
+  const x2 = (-b - sqrtDisc) / (2 * a);
+  const steps = [
+    `${a}x^2 + ${b}x + ${c} = 0`,
+    `D = b^2 - 4ac = ${disc}`,
+    `x = (-${b} \u00B1 sqrt(D)) / (2*${a})`,
+    `x1 = ${x1}`,
+    `x2 = ${x2}`,
+  ];
+  return { solutions: [x1, x2], steps };
+}
+
+export function newtonMethod(expr, guess = 1, tol = 1e-7, maxIter = 20) {
+  const parser = new Parser();
+  const f = parser.parse(expr);
+  let x = guess;
+  const steps = [`x0 = ${x}`];
+  for (let i = 0; i < maxIter; i++) {
+    const fx = f.evaluate({ x });
+    const derivative = (f.evaluate({ x: x + 1e-6 }) - f.evaluate({ x: x - 1e-6 })) / (2e-6);
+    const x1 = x - fx / derivative;
+    steps.push(`x${i + 1} = ${x1}`);
+    if (Math.abs(x1 - x) < tol) {
+      x = x1;
+      break;
+    }
+    x = x1;
+  }
+  return { root: x, steps };
+}
+
+export function solveEquation(expr) {
+  const cleaned = expr.replace(/\s+/g, '');
+  if (cleaned.includes('x^2')) {
+    const { steps } = solveQuadraticEquation(cleaned);
+    return steps.join(' | ');
+  } else if (cleaned.includes('x')) {
+    const { steps } = solveLinearEquation(cleaned);
+    return steps.join(' | ');
+  } else {
+    const { steps } = newtonMethod(cleaned, 1);
+    return steps.join(' | ');
+  }
+}


### PR DESCRIPTION
## Summary
- extend calculator with fraction mode, solver, and plotting
- add continued fraction conversion and equation solving utilities
- include graph scratchpad with panning and cursor readout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9454e73883288e540f6698ecf524