### PR TITLE
Add security education page with sandboxed documentation links

### DIFF
--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+interface FrameProps {
+  title: string;
+  link: string;
+  description: string;
+}
+
+const InfoFrame = ({ title, link, description }: FrameProps) => (
+  <iframe
+    title={title}
+    sandbox=""
+    srcDoc={`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"></head><body><h2>${title}</h2><p>${description}</p><p><a href='${link}' target='_blank' rel='noopener noreferrer'>Official Documentation</a></p></body></html>`}
+    style={{ width: '100%', border: '1px solid #ccc', height: '200px' }}
+  />
+);
+
+const SecurityEducation = () => (
+  <main>
+    <div style={{ backgroundColor: '#fcd34d', padding: '1rem', textAlign: 'center', fontWeight: 'bold' }}>
+      Use Kali Linux and related tools legally and ethically with proper authorization.
+    </div>
+    <div className="grid gap-4 p-4 md:grid-cols-2">
+      <InfoFrame
+        title="What"
+        link="https://www.kali.org/docs/introduction/what-is-kali-linux/"
+        description="Overview of Kali Linux and its purpose."
+      />
+      <InfoFrame
+        title="Why"
+        link="https://www.kali.org/docs/introduction/should-i-use-kali-linux/"
+        description="Reasons to use Kali Linux for authorized security assessments."
+      />
+      <InfoFrame
+        title="Risks"
+        link="https://owasp.org/www-project-top-ten/"
+        description="Common security risks highlighted by the OWASP Top Ten."
+      />
+      <InfoFrame
+        title="Defenses"
+        link="https://www.cisa.gov/secure-our-world"
+        description="CISA guidance on defending against cyber threats."
+      />
+    </div>
+  </main>
+);
+
+export default SecurityEducation;
+


### PR DESCRIPTION
## Summary
- add `security-education` page with legal-use banner
- show What, Why, Risks, Defenses in sandboxed frames with links to official docs

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9459e1608328a41d66442e8c928a