### PR TITLE
feat(weather): add offline demo mode and unit toggle

### DIFF
--- a/__tests__/weather.test.tsx
+++ b/__tests__/weather.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Weather from '../components/apps/weather';
+
+describe('Weather component', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('unit toggle converts temperatures', async () => {
+    const { findByTestId } = render(<Weather demo />);
+    const temp = await findByTestId('temp');
+    expect(temp.textContent).toBe('21°C');
+    const toggle = await findByTestId('unit-toggle');
+    fireEvent.click(toggle);
+    expect(temp.textContent).toBe('70°F');
+  });
+
+  it('renders in demo mode without fetch', async () => {
+    const fetchSpy = jest.fn();
+    // @ts-ignore
+    global.fetch = fetchSpy;
+    const { findByTestId } = render(<Weather demo />);
+    const temp = await findByTestId('temp');
+    expect(temp.textContent).toBe('21°C');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/components/apps/weather-demo.json
+++ b/components/apps/weather-demo.json
@@ -1,0 +1,9 @@
+{
+  "city": "Demo City",
+  "current_weather": { "temperature": 21 },
+  "daily": {
+    "time": ["2023-01-01", "2023-01-02", "2023-01-03"],
+    "temperature_2m_max": [24, 23, 22],
+    "temperature_2m_min": [16, 15, 14]
+  }
+}

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,58 +1,82 @@
 import React, { useEffect, useState } from 'react';
+import demoData from './weather-demo.json';
 
-const demoForecast = () => {
-  const now = new Date();
-  const day = (n) => {
-    const d = new Date(now);
-    d.setDate(d.getDate() + n);
-    return d.toISOString().slice(0, 10);
-  };
-  return {
-    current_weather: { temperature: 21 },
-    daily: {
-      time: [day(0), day(1), day(2)],
-      temperature_2m_max: [24, 23, 22],
-      temperature_2m_min: [16, 15, 14],
-    },
-  };
-};
+const CACHE_KEY = 'weather-cache';
 
-const Weather = () => {
+const Weather = ({ demo = false }) => {
+  const [city, setCity] = useState('');
+  const [query, setQuery] = useState('');
+  const [units, setUnits] = useState('C');
   const [data, setData] = useState(null);
 
-  useEffect(() => {
-    const load = async () => {
-      if (!navigator.geolocation) {
-        setData(demoForecast());
-        return;
-      }
-      navigator.geolocation.getCurrentPosition(
-        async (pos) => {
-          try {
-            const { latitude, longitude } = pos.coords;
-            const url =
-              `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&current_weather=true&timezone=auto`;
-            const res = await fetch(url);
-            if (!res.ok) throw new Error('Failed to fetch forecast');
-            const json = await res.json();
-            setData(json);
-          } catch {
-            setData(demoForecast());
-          }
-        },
-        () => setData(demoForecast())
-      );
-    };
-    load();
-  }, []);
+  const loadCache = () => {
+    try {
+      const raw = localStorage.getItem(CACHE_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch {}
+    return null;
+  };
 
-  if (!data) {
-    return (
-      <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
-        Loading...
-      </div>
-    );
-  }
+  const saveCache = (cityName, forecast) => {
+    try {
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({ city: cityName, data: forecast })
+      );
+    } catch {}
+  };
+
+  const fetchForecast = async (cityName) => {
+    if (demo) {
+      setCity(demoData.city);
+      setData(demoData);
+      return;
+    }
+    try {
+      const geoRes = await fetch(
+        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+          cityName
+        )}&count=1`
+      );
+      if (!geoRes.ok) throw new Error('geocode');
+      const geo = await geoRes.json();
+      if (!geo.results?.length) throw new Error('not found');
+      const { latitude, longitude, name } = geo.results[0];
+      const weatherRes = await fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=temperature_2m_max,temperature_2m_min&current_weather=true&timezone=auto`
+      );
+      if (!weatherRes.ok) throw new Error('forecast');
+      const json = await weatherRes.json();
+      setCity(name);
+      setData(json);
+      saveCache(name, json);
+    } catch {
+      const cache = loadCache();
+      if (cache) {
+        setCity(cache.city);
+        setData(cache.data);
+      } else {
+        setCity(demoData.city);
+        setData(demoData);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const cache = loadCache();
+    if (cache) {
+      setCity(cache.city);
+      setData(cache.data);
+    }
+    if (demo) {
+      fetchForecast(demoData.city);
+    } else {
+      fetchForecast(cache?.city || 'London');
+    }
+  }, [demo]);
+
+  const convert = (t) =>
+    units === 'C' ? Math.round(t) : Math.round((t * 9) / 5 + 32);
 
   const formatDate = (str) =>
     new Intl.DateTimeFormat(undefined, {
@@ -61,22 +85,56 @@ const Weather = () => {
       day: 'numeric',
     }).format(new Date(str));
 
+  const handleSearch = (e) => {
+    e.preventDefault();
+    if (query.trim()) {
+      fetchForecast(query.trim());
+      setQuery('');
+    }
+  };
+
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4 overflow-auto">
-      <div className="text-4xl mb-4">
-        {Math.round(data.current_weather.temperature)}°C
-      </div>
-      <ul className="text-sm w-full max-w-xs space-y-1">
-        {data.daily.time.map((t, i) => (
-          <li key={t} className="flex justify-between">
-            <span>{formatDate(t)}</span>
-            <span>
-              {Math.round(data.daily.temperature_2m_max[i])}/
-              {Math.round(data.daily.temperature_2m_min[i])}°C
-            </span>
-          </li>
-        ))}
-      </ul>
+    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
+      <form onSubmit={handleSearch} className="mb-4 flex w-full max-w-xs">
+        <input
+          data-testid="city-input"
+          className="flex-grow text-black px-2 py-1"
+          placeholder="Enter city"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button type="submit" className="ml-2 px-2 py-1 bg-ub-hot-orange rounded">
+          Search
+        </button>
+      </form>
+      {!data ? (
+        <div>Loading...</div>
+      ) : (
+        <>
+          <div className="text-xl mb-2">{city}</div>
+          <div data-testid="temp" className="text-4xl mb-4">
+            {convert(data.current_weather.temperature)}°{units}
+          </div>
+          <button
+            data-testid="unit-toggle"
+            className="mb-4 px-2 py-1 bg-ub-hot-orange rounded"
+            onClick={() => setUnits(units === 'C' ? 'F' : 'C')}
+          >
+            Switch to °{units === 'C' ? 'F' : 'C'}
+          </button>
+          <ul className="text-sm w-full max-w-xs space-y-1">
+            {data.daily.time.map((t, i) => (
+              <li key={t} className="flex justify-between">
+                <span>{formatDate(t)}</span>
+                <span>
+                  {convert(data.daily.temperature_2m_max[i])}/
+                  {convert(data.daily.temperature_2m_min[i])}°{units}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enhance weather widget with localStorage cache, city search and C/F unit toggle
- add demo mode using baked JSON forecast for offline use
- cover unit conversion and demo rendering in tests

## Testing
- `yarn test __tests__/weather.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae71cb424c8328a0de2660343f09e6