### PR TITLE
feat: draggable YouTube mini-player

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,20 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* YouTube mini-player */
+.youtube-player {
+    width: 100%;
+    height: 315px;
+    transition: width 0.3s ease, height 0.3s ease, bottom 0.3s ease, right 0.3s ease;
+}
+
+.youtube-player.mini {
+    width: 200px;
+    height: 113px;
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 100;
+    cursor: move;
+}


### PR DESCRIPTION
## Summary
- add scroll-aware draggable mini-player to YouTube app
- apply CSS transitions for smooth minimization and restoration

## Testing
- `yarn lint`
- `yarn test __tests__/youtube.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aea29d4284832892cf2a7b49d73442