### PR TITLE
Add milestone timeline to About section

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -159,6 +159,28 @@ export const displayAboutAlex = () => {
 
 
 function About() {
+    const milestones = [
+        {
+            year: '2012',
+            text: 'Started High School',
+            icon: '/themes/Yaru/status/education.svg'
+        },
+        {
+            year: '2016',
+            text: 'Graduated High School',
+            icon: '/themes/Yaru/status/experience.svg'
+        },
+        {
+            year: '2020',
+            text: 'Joined Ontario Tech University',
+            icon: '/themes/Yaru/status/projects.svg'
+        },
+        {
+            year: '2024',
+            text: 'Completed Networking and I.T. Security',
+            icon: '/themes/Yaru/status/download.svg'
+        }
+    ];
     return (
         <>
             <div className="w-20 md:w-28 my-4 full">
@@ -231,6 +253,15 @@ function About() {
                     I also have interests in deep learning, software development, and animation.
                 </li>
             </ul>
+            <div className="timeline w-5/6 md:w-3/4 mt-6 mb-2">
+                {milestones.map((m) => (
+                    <div key={m.year} className="timeline-milestone">
+                        <Image src={m.icon} alt={m.text} width={32} height={32} className="milestone-icon" />
+                        <div className="font-bold mt-1">{m.year}</div>
+                        <div className="text-xs md:text-sm">{m.text}</div>
+                    </div>
+                ))}
+            </div>
         </>
     )
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,34 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Horizontal timeline for About section */
+.timeline {
+    display: flex;
+    overflow-x: auto;
+    gap: 1rem;
+    padding-bottom: 0.5rem;
+}
+
+.timeline-milestone {
+    flex: 0 0 auto;
+    text-align: center;
+    min-width: 6rem;
+    transition: transform 0.2s ease;
+    cursor: default;
+}
+
+.timeline-milestone:hover {
+    transform: scale(1.05);
+}
+
+.milestone-icon {
+    width: 32px;
+    height: 32px;
+    transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+.timeline-milestone:hover .milestone-icon {
+    filter: drop-shadow(0 0 4px var(--color-ubt-blue));
+    transform: scale(1.1);
+}


### PR DESCRIPTION
## Summary
- show key milestones on a horizontally scrollable timeline in the About screen
- style milestones with icon hover effects

## Testing
- `npm test` *(fails: AI computes move under 500ms)*

------
https://chatgpt.com/codex/tasks/task_e_68aea29f145483288f84cecb41d8086c