### PR TITLE
feat(bluetooth): add signal strength bars

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Bluetooth signal strength indicator */
+.bluetooth-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 12px;
+}
+
+.bluetooth-bar {
+    width: 3px;
+    background: linear-gradient(to top, var(--color-ubt-green), var(--color-ubt-blue));
+    opacity: 0.3;
+}
+
+.bluetooth-bar.active {
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary
- display signal strength bars next to discovered Bluetooth devices
- add gradient styling for Bluetooth signal bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2a1d2348328a00b5ac2629b0246