### PR TITLE
feat: add packets per second chart

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Simple chart container used in Wireshark packets/second graph */
+.chart-container {
+    height: 120px;
+    padding: 4px;
+}
+
+.chart-container svg {
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
## Summary
- visualize packets per second for Wireshark using simple chart
- style chart container for readability

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2b021208328a225b44fa8eb2241