### PR TITLE
Show thumbnails in trash list

### DIFF
--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -34,6 +34,10 @@ export class Trash extends Component {
                 name: "project machine learning-final",
                 icon: "/themes/Yaru/system/folder.png"
             },
+            {
+                name: "used-sudo-command.webp",
+                thumbnail: "/images/memes/used-sudo-command.webp"
+            },
 
         ];
         this.state = {
@@ -89,13 +93,18 @@ export class Trash extends Component {
                         return (
                             <div key={index} tabIndex="1" onFocus={this.focusFile} onBlur={this.focusFile} className="flex flex-col items-center text-sm outline-none w-16 my-2 mx-4">
                                 <div className="w-16 h-16 flex items-center justify-center">
-                                    <Image
-                                        src={item.icon}
-                                        alt="Ubuntu File Icons"
-                                        width={48}
-                                        height={48}
-                                        sizes="48px"
-                                    />
+                                    {item.thumbnail ? (
+                                        <img src={item.thumbnail} alt={item.name} className="trash-thumbnail" />
+                                    ) : (
+                                        <Image
+                                            src={item.icon}
+                                            alt={item.name}
+                                            width={48}
+                                            height={48}
+                                            sizes="48px"
+                                            className="trash-thumbnail"
+                                        />
+                                    )}
                                 </div>
                                 <span className="text-center rounded px-0.5">{item.name}</span>
                             </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,15 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Trash thumbnails */
+.trash-thumbnail {
+    width: 48px;
+    height: 48px;
+    object-fit: cover;
+    transition: transform 0.2s;
+}
+
+.trash-thumbnail:hover {
+    transform: scale(1.1);
+}


### PR DESCRIPTION
## Summary
- Show image previews or file-type icons in Trash app list
- Style trash thumbnails with consistent sizing and hover effects

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2b4669c8328bec32553b87f01b5