### PR TITLE
Add category icons to converter app

### DIFF
--- a/components/apps/converter/index.js
+++ b/components/apps/converter/index.js
@@ -2,9 +2,26 @@ import React from 'react';
 import UnitConverter from './UnitConverter';
 import CurrencyConverter from './CurrencyConverter';
 
+const CATEGORY_ICONS = [
+  { key: 'length', label: 'Length', icon: '/themes/Yaru/apps/length.svg' },
+  { key: 'weight', label: 'Weight', icon: '/themes/Yaru/apps/weight.svg' },
+];
+
 const Converter = () => {
   return (
     <div className="h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
+      <div className="flex gap-4 mb-4">
+        {CATEGORY_ICONS.map((cat) => (
+          <div key={cat.key} className="converter-category">
+            <img
+              src={cat.icon}
+              alt={`${cat.label} icon`}
+              className="converter-category-icon"
+            />
+            <span className="text-sm">{cat.label}</span>
+          </div>
+        ))}
+      </div>
       <div className="grid gap-4 md:grid-cols-2">
         <UnitConverter />
         <CurrencyConverter />

--- a/public/themes/Yaru/apps/length.svg
+++ b/public/themes/Yaru/apps/length.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#3465A4"/>
+  <path d="M16 32h32" stroke="#fff" stroke-width="4"/>
+  <path d="M16 32l6-6v12z" fill="#fff"/>
+  <path d="M48 32l-6-6v12z" fill="#fff"/>
+</svg>

--- a/public/themes/Yaru/apps/weight.svg
+++ b/public/themes/Yaru/apps/weight.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#C17D11"/>
+  <path d="M22 48h20l-4-24H26z" fill="#fff"/>
+  <rect x="28" y="16" width="8" height="6" fill="#fff"/>
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,17 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Converter category icon styles */
+.converter-category-icon {
+    width: 32px;
+    height: 32px;
+}
+
+.converter-category {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+


### PR DESCRIPTION
## Summary
- Display length and weight category icons in converter
- Style icons in global CSS
- Add SVG assets for length and weight

## Testing
- `CI=true npx jest __tests__/converter.test.tsx`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2b738308328aa7616552b2a10f6