### PR TITLE
Add severity chart to Nikto scanner

### DIFF
--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -2,23 +2,44 @@ import React, { useState } from 'react';
 
 const NiktoApp = () => {
   const [target, setTarget] = useState('');
-  const [result, setResult] = useState('');
+  const [findings, setFindings] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   const runScan = async () => {
     if (!target) return;
     setLoading(true);
-    setResult('');
+    setFindings([]);
+    setError('');
     try {
       const res = await fetch(`/api/nikto?target=${encodeURIComponent(target)}`);
-      const text = await res.text();
-      setResult(text);
+      const data = await res.json();
+      const items = data.findings || data;
+      setFindings(Array.isArray(items) ? items : []);
     } catch (err) {
-      setResult(`Error: ${err.message}`);
+      setError(`Error: ${err.message}`);
     } finally {
       setLoading(false);
     }
   };
+
+  const severityGroups = findings.reduce(
+    (acc, cur) => {
+      const sev = (cur.severity || 'low').toLowerCase();
+      if (!acc[sev]) acc[sev] = [];
+      acc[sev].push(cur);
+      return acc;
+    },
+    { low: [], medium: [], high: [] }
+  );
+
+  const counts = {
+    low: severityGroups.low.length,
+    medium: severityGroups.medium.length,
+    high: severityGroups.high.length,
+  };
+
+  const total = counts.low + counts.medium + counts.high;
 
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 overflow-auto">
@@ -35,14 +56,39 @@ const NiktoApp = () => {
           type="button"
           onClick={runScan}
           className="px-4 bg-ubt-blue rounded-r"
+          disabled={loading}
         >
-          Scan
+          {loading ? 'Scanning...' : 'Scan'}
         </button>
       </div>
-      {loading ? (
-        <p>Running scan...</p>
-      ) : (
-        <pre className="whitespace-pre-wrap flex-1 overflow-auto">{result}</pre>
+      {error && <pre className="whitespace-pre-wrap">{error}</pre>}
+      {!error && total > 0 && (
+        <div className="mt-4">
+          <div className="nikto-chart">
+            <div className="low" style={{ width: `${(counts.low / total) * 100}%` }} />
+            <div className="medium" style={{ width: `${(counts.medium / total) * 100}%` }} />
+            <div className="high" style={{ width: `${(counts.high / total) * 100}%` }} />
+          </div>
+          <div className="flex justify-between text-xs mt-1">
+            <span>Low ({counts.low})</span>
+            <span>Medium ({counts.medium})</span>
+            <span>High ({counts.high})</span>
+          </div>
+          <div className="mt-4 space-y-4 text-sm">
+            {Object.entries(severityGroups).map(([sev, items]) =>
+              items.length > 0 ? (
+                <div key={sev}>
+                  <h2 className="font-semibold capitalize mb-1">{sev}</h2>
+                  <ul className="list-disc ml-4">
+                    {items.map((f, idx) => (
+                      <li key={idx}>{f.message || f.desc || JSON.stringify(f)}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null
+            )}
+          </div>
+        </div>
       )}
     </div>
   );
@@ -51,4 +97,3 @@ const NiktoApp = () => {
 export default NiktoApp;
 
 export const displayNikto = () => <NiktoApp />;
-

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,23 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+/* Nikto chart styling */
+.nikto-chart {
+    display: flex;
+    width: 100%;
+    height: 1rem;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.nikto-chart .low {
+    background-color: var(--color-ubt-green);
+}
+
+.nikto-chart .medium {
+    background-color: var(--color-ubt-gedit-orange);
+}
+
+.nikto-chart .high {
+    background-color: var(--color-ub-orange);
+}


### PR DESCRIPTION
## Summary
- Group Nikto scan results by severity and show counts in a color-coded bar chart.
- Style severity bars to match the site's theme.

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aea2ba43a08328976a0c23a6eb6c79