### PR TITLE
feat: add autopsy event timeline visualization

### DIFF
--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -111,27 +111,51 @@ function Autopsy() {
           className="bg-ub-grey text-xs text-white p-2 rounded resize-none"
         />
       )}
-      {artifacts.length > 0 && (
-        <div className="space-y-2">
-          <div className="text-sm font-bold">Timeline</div>
-          <ul className="space-y-1 text-xs">
-            {artifacts.map((a, idx) => (
-              <li key={idx} className="bg-ub-grey p-1 rounded">
-                <div>{new Date(a.timestamp).toLocaleString()}</div>
-                <div>
-                  {a.name} ({a.plugin})
-                </div>
-              </li>
-            ))}
-          </ul>
-          <button
-            onClick={downloadReport}
-            className="bg-ub-orange px-3 py-1 rounded text-sm"
-          >
-            Download Report
-          </button>
-        </div>
-      )}
+      {artifacts.length > 0 && (() => {
+        const times = artifacts.map((a) => new Date(a.timestamp).getTime());
+        const minTime = Math.min(...times);
+        const maxTime = Math.max(...times);
+        const range = maxTime - minTime || 1;
+        return (
+          <div className="space-y-2">
+            <div className="text-sm font-bold">Timeline</div>
+            <div className="timeline-bar">
+              {artifacts.map((a, idx) => {
+                const pos =
+                  ((new Date(a.timestamp).getTime() - minTime) / range) * 100;
+                return (
+                  <div
+                    key={idx}
+                    className="event-marker"
+                    style={{ left: `${pos}%` }}
+                  >
+                    <div className="event-details">
+                      {new Date(a.timestamp).toLocaleString()} - {a.name} (
+                      {a.plugin})
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <ul className="space-y-1 text-xs">
+              {artifacts.map((a, idx) => (
+                <li key={idx} className="bg-ub-grey p-1 rounded">
+                  <div>{new Date(a.timestamp).toLocaleString()}</div>
+                  <div>
+                    {a.name} ({a.plugin})
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <button
+              onClick={downloadReport}
+              className="bg-ub-orange px-3 py-1 rounded text-sm"
+            >
+              Download Report
+            </button>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -199,6 +199,48 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: scaleAppImage 400ms 1 forwards;
 }
 
+/* Autopsy timeline styling */
+.timeline-bar {
+    position: relative;
+    height: 8px;
+    background: var(--color-ub-warm-grey);
+    border-radius: 4px;
+    margin-top: 8px;
+}
+
+.event-marker {
+    position: absolute;
+    top: -4px;
+    width: 8px;
+    height: 16px;
+    background: var(--color-ub-orange);
+    border-radius: 4px;
+    transform: translateX(-50%);
+    cursor: pointer;
+}
+
+.event-details {
+    position: absolute;
+    top: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-ub-grey);
+    color: var(--color-text);
+    white-space: nowrap;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    z-index: 10;
+}
+
+.event-marker:hover .event-details {
+    opacity: 1;
+    pointer-events: auto;
+}
+
 @keyframes scaleAppImage {
     from {
         transform: translate(-50%, -50%) scale(1);


### PR DESCRIPTION
## Summary
- visualize Autopsy case artifacts on a chronological bar
- style timeline markers and hover tooltips

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2bcff6c8328983f759165aca40d