### PR TITLE
Add Reaver progress bar with status colors

### DIFF
--- a/components/apps/reaver/index.js
+++ b/components/apps/reaver/index.js
@@ -23,17 +23,27 @@ export default function ReaverApp() {
   const [pin, setPin] = useState('');
   const [log, setLog] = useState('');
   const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const statusClass = (pct) => {
+    if (pct < 33) return 'low';
+    if (pct < 66) return 'medium';
+    return 'high';
+  };
 
   const startAttack = () => {
     setRunning(true);
     setLog(`Starting WPS PIN attack on ${bssid}\n`);
     let tries = 0;
+    setProgress(0);
     const interval = setInterval(() => {
       tries += 1;
       const guess = Math.floor(Math.random() * 1e8)
         .toString()
         .padStart(8, '0');
       setLog((prev) => `${prev}Trying PIN ${guess}\n`);
+      const pct = Math.min((tries / 5) * 100, 100);
+      setProgress(pct);
       if (tries >= 5) {
         clearInterval(interval);
         const result = derivePin(bssid);
@@ -67,6 +77,19 @@ export default function ReaverApp() {
       >
         Start Attack
       </button>
+      {progress > 0 && (
+        <>
+          <div className="reaver-progress-container mt-4">
+            <div
+              className={`reaver-progress-bar ${statusClass(progress)}`}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <div className={`reaver-progress-text ${statusClass(progress)}`}>
+            {Math.floor(progress)}%
+          </div>
+        </>
+      )}
       {pin && (
         <div className="mt-4">
           <div className="mb-1">Discovered WPS PIN:</div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,31 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Reaver progress bar */
+.reaver-progress-container {
+    width: 100%;
+    height: 12px;
+    background-color: #444;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.reaver-progress-bar {
+    height: 100%;
+    transition: width 0.5s ease;
+}
+
+.reaver-progress-text {
+    margin-top: 4px;
+    text-align: right;
+    font-family: monospace;
+}
+
+.reaver-progress-bar.low { background-color: #dc2626; }
+.reaver-progress-bar.medium { background-color: #f59e0b; }
+.reaver-progress-bar.high { background-color: #10b981; }
+
+.reaver-progress-text.low { color: #dc2626; }
+.reaver-progress-text.medium { color: #f59e0b; }
+.reaver-progress-text.high { color: #10b981; }


### PR DESCRIPTION
## Summary
- add progress tracking and color-coded bar to Reaver WPS attack tool
- style progress bar container and percentage text

## Testing
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68aea2bdfc68832892ef3468e75b81bc