### PR TITLE
feat: add figlet text color and animation

### DIFF
--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -5,6 +5,7 @@ const fonts = ['Standard', 'Slant'];
 const FigletApp = () => {
   const [text, setText] = useState('');
   const [font, setFont] = useState(fonts[0]);
+  const [color, setColor] = useState('#ffffff');
   const [output, setOutput] = useState('');
   const workerRef = useRef(null);
 
@@ -41,8 +42,20 @@ const FigletApp = () => {
           value={text}
           onChange={(e) => setText(e.target.value)}
         />
+        <input
+          type="color"
+          className="w-8 h-8 p-0 border-none bg-gray-700"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+        />
       </div>
-      <pre className="flex-1 overflow-auto p-2 whitespace-pre">{output}</pre>
+      <pre
+        key={`${output}-${color}`}
+        className="flex-1 overflow-auto p-2 whitespace-pre fade-in"
+        style={{ color }}
+      >
+        {output}
+      </pre>
     </div>
   );
 };

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,12 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.fade-in {
+    animation: fadeIn 0.5s ease-in;
+}


### PR DESCRIPTION
## Summary
- allow choosing text color in figlet app and animate output
- define fade-in keyframes in global styles

## Testing
- `yarn test __tests__/calc.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c1614883288c39bb3ae6a4e43d