### PR TITLE
Render Mimikatz credentials in sortable table

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,24 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Credentials table styling */
+.credentials-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.credentials-table th,
+.credentials-table td {
+    padding: 0.5rem;
+    text-align: left;
+}
+
+.credentials-table th {
+    background-color: var(--color-ub-warm-grey);
+    cursor: pointer;
+}
+
+.credentials-table tr:nth-child(even) {
+    background-color: var(--color-ub-cool-grey);
+}


### PR DESCRIPTION
## Summary
- Parse Mimikatz command output into credential entries and render them in a sortable table.
- Add reusable table styles for headers and striped rows.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c328248328b678545b4ceecf94