### PR TITLE
Add Hydra attempt rate chart

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -199,6 +199,24 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: scaleAppImage 400ms 1 forwards;
 }
 
+/* Hydra attempts chart */
+.hydra-chart-container {
+    width: 100%;
+    max-width: 600px;
+    height: 200px;
+}
+
+.hydra-chart {
+    width: 100%;
+    height: 100%;
+}
+
+@media (max-width: 640px) {
+    .hydra-chart-container {
+        height: 150px;
+    }
+}
+
 @keyframes scaleAppImage {
     from {
         transform: translate(-50%, -50%) scale(1);


### PR DESCRIPTION
## Summary
- chart Hydra attack attempts per second over time
- add responsive styles for Hydra chart

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c3ed108328add668d62e8bfae6