### PR TITLE
feat: add radare2 basic block graph

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Radare2 graph styling */
+.radare2-graph {
+    --r2-node-color: #4E9A06;
+    --r2-link-color: #E95420;
+}
+
+.radare2-graph canvas {
+    background-color: #000;
+}


### PR DESCRIPTION
## Summary
- add toggleable graph view with arrows to visualize radare2 analysis
- style graph nodes and edges for better visibility

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c5742483288e0f1ae939e05399