### PR TITLE
feat: add progress circle for volatility

### DIFF
--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -36,14 +36,19 @@ const VolatilityApp = () => {
         <button
           onClick={analyze}
           disabled={!file || loading}
-          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50 flex items-center justify-center gap-2"
         >
+          {loading && <div className="progress-circle" />}
           {loading ? 'Analyzing...' : 'Analyze'}
         </button>
       </div>
-      <pre className="flex-1 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap">
-        {output}
-      </pre>
+      <div className="flex-1 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap flex items-center justify-center">
+        {loading ? (
+          <div className="progress-circle" />
+        ) : (
+          <pre className="w-full whitespace-pre-wrap">{output}</pre>
+        )}
+      </div>
     </div>
   );
 };

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,19 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Volatility progress circle */
+.progress-circle {
+    width: 40px;
+    height: 40px;
+    border: 4px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: progress-rotate 1s linear infinite;
+}
+
+@keyframes progress-rotate {
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
## Summary
- show animated progress circle in Volatility app during analysis
- add CSS animation for progress circle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c6041883288fbc883df69f1050