### PR TITLE
feat(hashcat): add gpu usage gauge

### DIFF
--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -37,11 +37,8 @@ export const generateWordlist = (pattern) => {
 const Gauge = ({ value }) => (
   <div className="w-48">
     <div className="text-sm mb-1">GPU Usage: {value}%</div>
-    <div className="w-full h-4 bg-gray-700 rounded">
-      <div
-        className="h-4 bg-green-500 rounded"
-        style={{ width: `${value}%` }}
-      />
+    <div className="gpu-bar">
+      <div className="gpu-bar-fill" style={{ width: `${value}%` }} />
     </div>
   </div>
 );

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,18 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Hashcat GPU usage bar */
+.gpu-bar {
+    width: 100%;
+    height: 1rem;
+    background: var(--color-ub-dark-grey);
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.gpu-bar-fill {
+    height: 100%;
+    background: linear-gradient(to right, var(--color-ubt-green), var(--color-ubt-gedit-blue));
+    transition: width 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- add GPU usage bar to Hashcat app
- style gauge with gradient fill

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c6fe8483288d7e85dfc08fb243