### PR TITLE
feat: highlight credentials in msf-post output

### DIFF
--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -1,5 +1,26 @@
 import React, { useEffect, useState } from 'react';
 
+// Regex patterns to detect potential credentials or tokens in log lines
+const credentialRegex = /(password|passwd|pwd|secret|credential|user|username|login|passphrase)/i;
+const tokenRegex = /(token|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|bearer)/i;
+
+// Convert raw output into React elements with highlighted sensitive info
+const renderHighlightedOutput = (text) =>
+  text.split('\n').map((line, idx) => {
+    let className = '';
+    if (credentialRegex.test(line)) {
+      className = 'credential-highlight';
+    } else if (tokenRegex.test(line)) {
+      className = 'token-highlight';
+    }
+    return (
+      <span key={idx} className={className}>
+        {line}
+        {'\n'}
+      </span>
+    );
+  });
+
 const MsfPostApp = () => {
   const [modules, setModules] = useState([]);
   const [selected, setSelected] = useState('');
@@ -59,7 +80,7 @@ const MsfPostApp = () => {
         </button>
       </div>
       <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">
-        {output}
+        {renderHighlightedOutput(output)}
       </pre>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,20 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Highlighted log entries */
+.credential-highlight,
+.token-highlight {
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
+.credential-highlight {
+    background-color: rgba(239, 68, 68, 0.4);
+    color: #fff;
+}
+
+.token-highlight {
+    background-color: rgba(234, 179, 8, 0.4);
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- highlight credential or token lines in msf-post log output
- add CSS classes for sensitive output highlights

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c7bcb48328b8c4ce713d2f4bda