### PR TITLE
feat: show sortable dsniff credential table

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -40,6 +40,17 @@ const Dsniff = () => {
   const [simulate, setSimulate] = useState(false);
   const simInterval = useRef(null);
   const simIndex = useRef(0);
+  const [sortField, setSortField] = useState('protocol');
+  const [sortAsc, setSortAsc] = useState(true);
+
+  const sortBy = (field) => {
+    if (sortField === field) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortField(field);
+      setSortAsc(true);
+    }
+  };
 
   const fetchOutputs = async () => {
     try {
@@ -108,6 +119,14 @@ const Dsniff = () => {
       log[f.field].toLowerCase().includes(f.value.toLowerCase())
     );
     return searchMatch && filterMatch;
+  });
+
+  const sortedLogs = [...filteredLogs].sort((a, b) => {
+    const aVal = (a[sortField] || '').toLowerCase();
+    const bVal = (b[sortField] || '').toLowerCase();
+    if (aVal < bVal) return sortAsc ? -1 : 1;
+    if (aVal > bVal) return sortAsc ? 1 : -1;
+    return 0;
   });
 
   return (
@@ -187,12 +206,40 @@ const Dsniff = () => {
           ))}
         </div>
       </div>
-      <div className="bg-black text-green-500 p-2 h-40 overflow-auto whitespace-pre-wrap">
-        {filteredLogs.length ? (
-          filteredLogs.map((log, i) => <div key={i}>{log.raw}</div>)
-        ) : (
-          'No data'
-        )}
+      <div className="h-40 overflow-auto">
+        <table className="dsniff-table w-full">
+          <thead>
+            <tr>
+              <th onClick={() => sortBy('protocol')}>
+                Protocol {sortField === 'protocol' ? (sortAsc ? '▲' : '▼') : ''}
+              </th>
+              <th onClick={() => sortBy('host')}>
+                Host {sortField === 'host' ? (sortAsc ? '▲' : '▼') : ''}
+              </th>
+              <th>Raw</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedLogs.length ? (
+              sortedLogs.map((log, i) => (
+                <tr key={i}>
+                  <td>
+                    <span
+                      className={`status-indicator status-${log.protocol.toLowerCase()}`}
+                    ></span>
+                    {log.protocol}
+                  </td>
+                  <td>{log.host}</td>
+                  <td>{log.raw}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan="3">No data</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,53 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* dsniff table styles */
+.dsniff-table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: var(--color-ub-grey);
+    color: var(--color-ubt-green);
+    font-size: 0.875rem;
+}
+
+.dsniff-table th,
+.dsniff-table td {
+    border: 1px solid var(--color-ubt-warm-grey);
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+}
+
+.dsniff-table th {
+    cursor: pointer;
+    background-color: var(--color-ub-dark-grey);
+    color: var(--color-text);
+}
+
+.dsniff-table tbody tr:nth-child(even) {
+    background-color: var(--color-ub-cool-grey);
+}
+
+.dsniff-table tbody tr:nth-child(odd) {
+    background-color: var(--color-ub-grey);
+}
+
+.status-indicator {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 0.25rem;
+}
+
+.status-indicator.status-http {
+    background-color: var(--color-ubt-green);
+}
+
+.status-indicator.status-https {
+    background-color: var(--color-ubt-blue);
+}
+
+.status-indicator.status-arp {
+    background-color: var(--color-ub-orange);
+}


### PR DESCRIPTION
## Summary
- display dsniff logs in a sortable table with protocol status indicators
- style dsniff table and protocol status markers

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2c88bb88328b16f08aa56784470