### PR TITLE
Add guesses line chart to John app

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,35 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* John app chart styling */
+.john-chart {
+    width: 100%;
+    height: 150px;
+}
+
+.john-chart svg {
+    width: 100%;
+    height: 100%;
+}
+
+.john-chart-line {
+    fill: none;
+    stroke: #21c5c7;
+    stroke-width: 2;
+}
+
+.john-legend {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: #fff;
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+}
+
+.john-legend-color {
+    width: 12px;
+    height: 12px;
+    background-color: #21c5c7;
+}


### PR DESCRIPTION
## Summary
- Add simulated guesses-over-time line chart to John app
- Style chart and legend for John interface

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aea2c969808328900fa5851531c755