### PR TITLE
Animate merges and score popup in 2048 game

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,25 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+@keyframes tile-merge {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.tile-merge {
+    animation: tile-merge 0.2s ease-out;
+}
+
+@keyframes score-popup {
+    from { opacity: 1; transform: translateY(0); }
+    to { opacity: 0; transform: translateY(-20px); }
+}
+
+.score-popup {
+    position: absolute;
+    left: 100%;
+    margin-left: 0.5rem;
+    animation: score-popup 0.6s ease-out;
+}


### PR DESCRIPTION
## Summary
- animate 2048 tile merges and track scoring
- show score increments with popup and style animations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2cb1edc83289fe8861973b99981