### PR TITLE
feat: animate blackjack dealing and card flips

### DIFF
--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -152,16 +152,18 @@ const Blackjack = () => {
       className="flex space-x-2"
       title={showProb ? `Bust chance: ${(bustProbability(hand) * 100).toFixed(1)}%` : undefined}
     >
-      {hand.cards.map((card, idx) => (
-        <div
-          key={idx}
-          className="h-16 w-12 bg-white text-black flex items-center justify-center card animate-deal"
-        >
-          {hideFirst && idx === 0 && playerHands.length > 0 && current < playerHands.length
-            ? '?'
-            : `${card.value}${card.suit}`}
-        </div>
-      ))}
+      {hand.cards.map((card, idx) => {
+        const hidden =
+          hideFirst && idx === 0 && playerHands.length > 0 && current < playerHands.length;
+        return (
+          <div key={idx} className="h-16 w-12 card-container animate-deal">
+            <div className={`card ${hidden ? '' : 'flipped'}`}>
+              <div className="card-front">{`${card.value}${card.suit}`}</div>
+              <div className="card-back">?</div>
+            </div>
+          </div>
+        );
+      })}
       <div className="ml-2 self-center">{handValue(hand.cards)}</div>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -250,8 +250,45 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 /* Blackjack animations */
+.card-container {
+    perspective: 600px;
+}
+
 .card {
-    transition: transform 0.3s ease, opacity 0.3s ease;
+    width: 100%;
+    height: 100%;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.6s ease;
+}
+
+.card.flipped {
+    transform: rotateY(180deg);
+}
+
+.card-front,
+.card-back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+}
+
+.card-front {
+    background: #ffffff;
+    color: #000000;
+    transform: rotateY(180deg);
+}
+
+.card-back {
+    background: #4b5563;
+    color: #ffffff;
 }
 
 .animate-deal {


### PR DESCRIPTION
## Summary
- Animate dealing and flip of blackjack cards using CSS transforms
- Style card fronts and backs for flipping effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2cd18a48328a66fe784a9c6390c