### PR TITLE
feat(breakout): add power-up icons

### DIFF
--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -98,6 +98,14 @@ const BreakoutGame = ({ levels }) => {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
 
+    // Load power-up icons
+    const powerupImgs = {
+      expand: new Image(),
+      multi: new Image(),
+    };
+    powerupImgs.expand.src = "/apps/breakout/expand.svg";
+    powerupImgs.multi.src = "/apps/breakout/multi.svg";
+
     // Fit canvas to its container and device pixel ratio
     const fit = () => {
       const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
@@ -197,6 +205,7 @@ const BreakoutGame = ({ levels }) => {
                 y: brick.y + brick.h / 2,
                 type,
                 vy: 100,
+                angle: 0,
               });
             }
             break;
@@ -213,6 +222,7 @@ const BreakoutGame = ({ levels }) => {
       for (let i = powerUps.length - 1; i >= 0; i -= 1) {
         const p = powerUps[i];
         p.y += p.vy * dt;
+        p.angle += dt * 5;
         if (p.y + 8 > paddle.y && p.x > paddle.x && p.x < paddle.x + paddle.w) {
           if (p.type === "multi") {
             balls.push({
@@ -261,8 +271,17 @@ const BreakoutGame = ({ levels }) => {
 
       // Power-ups
       for (const p of powerUps) {
-        ctx.fillStyle = p.type === "multi" ? "red" : "blue";
-        ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
+        const img = powerupImgs[p.type];
+        if (img && img.complete) {
+          ctx.save();
+          ctx.translate(p.x, p.y);
+          ctx.rotate(p.angle);
+          ctx.drawImage(img, -8, -8, 16, 16);
+          ctx.restore();
+        } else {
+          ctx.fillStyle = p.type === "multi" ? "red" : "blue";
+          ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
+        }
       }
 
       // HUD

--- a/public/apps/breakout/expand.svg
+++ b/public/apps/breakout/expand.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="7" y="3" width="2" height="10" fill="#fff"/>
+  <rect x="3" y="7" width="10" height="2" fill="#fff"/>
+</svg>

--- a/public/apps/breakout/multi.svg
+++ b/public/apps/breakout/multi.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="5" cy="8" r="3" fill="#fff"/>
+  <circle cx="11" cy="5" r="3" fill="#fff"/>
+  <circle cx="11" cy="11" r="3" fill="#fff"/>
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,26 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Breakout power-up sprite animations */
+.breakout-powerup {
+    width: 16px;
+    height: 16px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    animation: breakout-float 1s ease-in-out infinite;
+}
+
+.breakout-powerup.expand {
+    background-image: url('/apps/breakout/expand.svg');
+}
+
+.breakout-powerup.multi {
+    background-image: url('/apps/breakout/multi.svg');
+}
+
+@keyframes breakout-float {
+    0% { transform: translateY(0); }
+    50% { transform: translateY(-2px); }
+    100% { transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- render Breakout power-ups using dedicated sprite icons that rotate while falling
- add CSS sprite classes and float animation for power-ups
- include SVG assets for expand and multi-ball boosts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea2ce68c48328a1e1b34847f81f3c