### PR TITLE
Add car racer dashboard overlay

### DIFF
--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -482,8 +482,6 @@ const CarRacer = () => {
             Restart
           </button>
         </div>
-        <div>Laps: {laps}</div>
-        <div>Speed: {Math.round(speed)}</div>
         <div>Lap Time: {lapTime.toFixed(2)}s</div>
         {lastLap !== null && <div>Last Lap: {lastLap.toFixed(2)}s</div>}
         {bestLap !== null && <div>Best Lap: {bestLap.toFixed(2)}s</div>}
@@ -497,6 +495,10 @@ const CarRacer = () => {
             </ol>
           </div>
         )}
+      </div>
+      <div className="car-dashboard">
+        <div className="car-dashboard-item">Speed: {Math.round(speed)}</div>
+        <div className="car-dashboard-item">Lap: {laps}</div>
       </div>
       {control === 'wheel' && (
         <div

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Car racer dashboard styling */
+.car-dashboard {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    display: flex;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+}
+
+.car-dashboard-item {
+    margin: 0;
+}


### PR DESCRIPTION
## Summary
- add dashboard overlay to car racer game showing speed and lap count
- style dashboard elements with new CSS classes

## Testing
- `CI=true yarn test > /tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68aea2cf0b3483289972de591e710c9e