### PR TITLE
feat: flash winning connect four discs

### DIFF
--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -247,7 +247,9 @@ const ConnectFour = () => {
                     <div
                       className={`h-8 w-8 rounded-full ${
                         cell === 'red' ? 'bg-red-500' : 'bg-yellow-400'
-                      } ${isWin ? 'ring-4 ring-white' : ''}`}
+                      } ${
+                        isWin ? (cell === 'red' ? 'flash-red' : 'flash-yellow') : ''
+                      }`}
                     />
                   )}
                 </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,27 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Connect Four winning disc animations */
+@keyframes flash {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+@keyframes redFlash {
+    0%, 100% { background-color: #ef4444; }
+    50% { background-color: #f87171; }
+}
+
+@keyframes yellowFlash {
+    0%, 100% { background-color: #facc15; }
+    50% { background-color: #fde047; }
+}
+
+.flash-red {
+    animation: flash 1s infinite, redFlash 1s infinite;
+}
+
+.flash-yellow {
+    animation: flash 1s infinite, yellowFlash 1s infinite;
+}


### PR DESCRIPTION
## Summary
- animate winning Connect Four discs with flashing color transitions
- add CSS keyframes for red and yellow win effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aea2d1be2c832885c920ad4112423e