### PR TITLE
Animate hangman drawing

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -37,16 +37,74 @@ const HangmanDrawing = ({ wrong }) => (
     <line x1="120" y1="20" x2="120" y2="40" strokeWidth="4" />
     {/* head */}
     {wrong > 0 && (
-      <circle cx="120" cy="60" r="20" strokeWidth="4" fill="transparent" />
+      <circle
+        cx="120"
+        cy="60"
+        r="20"
+        strokeWidth="4"
+        fill="transparent"
+        className="hangman-part"
+        pathLength="100"
+      />
     )}
     {/* body */}
-    {wrong > 1 && <line x1="120" y1="80" x2="120" y2="140" strokeWidth="4" />}
+    {wrong > 1 && (
+      <line
+        x1="120"
+        y1="80"
+        x2="120"
+        y2="140"
+        strokeWidth="4"
+        className="hangman-part"
+        pathLength="100"
+      />
+    )}
     {/* arms */}
-    {wrong > 2 && <line x1="120" y1="100" x2="90" y2="120" strokeWidth="4" />}
-    {wrong > 3 && <line x1="120" y1="100" x2="150" y2="120" strokeWidth="4" />}
+    {wrong > 2 && (
+      <line
+        x1="120"
+        y1="100"
+        x2="90"
+        y2="120"
+        strokeWidth="4"
+        className="hangman-part"
+        pathLength="100"
+      />
+    )}
+    {wrong > 3 && (
+      <line
+        x1="120"
+        y1="100"
+        x2="150"
+        y2="120"
+        strokeWidth="4"
+        className="hangman-part"
+        pathLength="100"
+      />
+    )}
     {/* legs */}
-    {wrong > 4 && <line x1="120" y1="140" x2="100" y2="170" strokeWidth="4" />}
-    {wrong > 5 && <line x1="120" y1="140" x2="140" y2="170" strokeWidth="4" />}
+    {wrong > 4 && (
+      <line
+        x1="120"
+        y1="140"
+        x2="100"
+        y2="170"
+        strokeWidth="4"
+        className="hangman-part"
+        pathLength="100"
+      />
+    )}
+    {wrong > 5 && (
+      <line
+        x1="120"
+        y1="140"
+        x2="140"
+        y2="170"
+        strokeWidth="4"
+        className="hangman-part"
+        pathLength="100"
+      />
+    )}
   </svg>
 );
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+@keyframes hangman-draw {
+    from { stroke-dashoffset: 100; }
+    to { stroke-dashoffset: 0; }
+}
+
+.hangman-part {
+    stroke-dasharray: 100;
+    stroke-dashoffset: 100;
+    animation: hangman-draw 0.5s ease-out forwards;
+}


### PR DESCRIPTION
## Summary
- draw each hangman body part with stroke animation as mistakes accumulate
- add SVG/CSS animation rules for hangman segments

## Testing
- `npm test --silent >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68aea2d31c388328abf383d1b8032d78