### PR TITLE
feat(memory): apply 3D flip styles

### DIFF
--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -158,24 +158,14 @@ const Memory = () => {
           return (
             <div key={card.id} className="aspect-square" onClick={() => handleFlip(idx)}>
               <div
-                className={`relative w-full h-full transform-gpu ${
+                className={`relative w-full h-full transform-gpu memory-card ${
                   prefersReducedMotion ? '' : 'transition-transform duration-500'
-                }`}
-                style={{
-                  transformStyle: 'preserve-3d',
-                  transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
-                }}
+                } ${isFlipped ? 'flipped' : ''}`}
               >
-                <div
-                  className="absolute inset-0 bg-gray-700 rounded flex items-center justify-center text-2xl"
-                  style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
-                >
+                <div className="memory-card-front absolute inset-0 bg-gray-700 rounded flex items-center justify-center text-2xl">
                   {card.value}
                 </div>
-                <div
-                  className="absolute inset-0 bg-gray-600 rounded"
-                  style={{ backfaceVisibility: 'hidden' }}
-                />
+                <div className="memory-card-back absolute inset-0 bg-gray-600 rounded" />
               </div>
             </div>
           );

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Memory game card flipping */
+.memory-card {
+    transform-style: preserve-3d;
+}
+
+.memory-card.flipped {
+    transform: rotateY(180deg);
+}
+
+.memory-card-front,
+.memory-card-back {
+    backface-visibility: hidden;
+}
+
+.memory-card-front {
+    transform: rotateY(180deg);
+}


### PR DESCRIPTION
## Summary
- add 3D flip classes for Memory game cards
- use CSS classes to apply front/back faces and flipping

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea2d3e0c88328a6139649369e23e5