### PR TITLE
Highlight Reversi legal moves with translucent markers

### DIFF
--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -255,7 +255,13 @@ const Reversi = () => {
                   </div>
                 )}
                 {!cell && move && !isPreview && (
-                  <div className="w-2 h-2 rounded-full bg-white opacity-50" />
+                  <div
+                    className={`legal-move-marker ${
+                      player === 'B'
+                        ? 'legal-move-marker-black'
+                        : 'legal-move-marker-white'
+                    }`}
+                  />
                 )}
                 {!cell && isPreview && (
                   <div

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,19 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Reversi legal move marker */
+.legal-move-marker {
+    width: 50%;
+    height: 50%;
+    border-radius: 50%;
+    opacity: 0.5;
+}
+
+.legal-move-marker-black {
+    background-color: black;
+}
+
+.legal-move-marker-white {
+    background-color: white;
+}


### PR DESCRIPTION
## Summary
- show legal Reversi moves using translucent markers
- style new legal move markers in shared CSS

## Testing
- `npx jest --runInBand` *(terminated after all tests reported pass)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aea2d7983c8328b40e54a3bf230985