### PR TITLE
feat: add glow ripple to simon pads

### DIFF
--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -174,9 +174,10 @@ const Simon = () => {
     const colors = mode === 'colorblind'
       ? { base: 'bg-gray-700', active: 'bg-gray-500' }
       : pad.color;
-    return `h-32 w-32 rounded flex items-center justify-center text-3xl ${
-      activePad === idx ? colors.active : colors.base
-    }`;
+    const base =
+      'h-32 w-32 rounded flex items-center justify-center text-3xl relative overflow-hidden';
+    const activeClass = activePad === idx ? `${colors.active} glow-ripple` : colors.base;
+    return `${base} ${activeClass}`;
   };
 
   return (

--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,36 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+/* Simon game glow ripple effect */
+.glow-ripple {
+    position: relative;
+    overflow: hidden;
+}
+
+.glow-ripple::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    pointer-events: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.8);
+    transform: translate(-50%, -50%) scale(0);
+    animation: glow-ripple 0.6s ease-out;
+}
+
+@keyframes glow-ripple {
+    from {
+        opacity: 0.75;
+        box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.8);
+        transform: translate(-50%, -50%) scale(0);
+    }
+    to {
+        opacity: 0;
+        box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
+        transform: translate(-50%, -50%) scale(4);
+    }
+}


### PR DESCRIPTION
## Summary
- add glow ripple animation to Simon game pads
- define keyframe glow effect in global styles

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68aea2d82c1c8328a9b537dfdedf6334