### PR TITLE
feat(ghidra): add project grid with placeholders

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -2,8 +2,15 @@ import React, { useEffect, useState } from 'react';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
+const SAMPLE_PROJECTS = [
+  { id: 1, name: 'Firmware', image: '/themes/ghidra/placeholder-1.svg' },
+  { id: 2, name: 'Malware', image: '/themes/ghidra/placeholder-2.svg' },
+  { id: 3, name: 'Kernel', image: '/themes/ghidra/placeholder-3.svg' },
+];
+
 export default function GhidraApp() {
   const [useRemote, setUseRemote] = useState(false);
+  const [projects, setProjects] = useState([]);
 
   useEffect(() => {
     const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
@@ -12,12 +19,13 @@ export default function GhidraApp() {
       return;
     }
     WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
-      .then(() => {
-        // Placeholder for actual Ghidra WASM initialization
-      })
       .catch(() => {
         setUseRemote(true);
       });
+  }, []);
+
+  useEffect(() => {
+    setProjects(SAMPLE_PROJECTS);
   }, []);
 
   if (useRemote) {
@@ -33,8 +41,21 @@ export default function GhidraApp() {
   }
 
   return (
-    <div className="w-full h-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Ghidra WebAssembly...
+    <div className="w-full h-full overflow-y-auto p-4 bg-ub-cool-grey text-white">
+      {projects.length === 0 ? (
+        <div className="flex items-center justify-center h-full">
+          Loading Ghidra WebAssembly...
+        </div>
+      ) : (
+        <div className="ghidra-grid">
+          {projects.map((p) => (
+            <div key={p.id} className="ghidra-item">
+              <img src={p.image} alt={p.name} className="ghidra-thumb" />
+              <span className="mt-2 block text-sm">{p.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/public/themes/ghidra/placeholder-1.svg
+++ b/public/themes/ghidra/placeholder-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+  <rect width="120" height="120" fill="#555" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#fff">A</text>
+</svg>

--- a/public/themes/ghidra/placeholder-2.svg
+++ b/public/themes/ghidra/placeholder-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+  <rect width="120" height="120" fill="#777" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#fff">B</text>
+</svg>

--- a/public/themes/ghidra/placeholder-3.svg
+++ b/public/themes/ghidra/placeholder-3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+  <rect width="120" height="120" fill="#999" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#000">C</text>
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -199,6 +199,25 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: scaleAppImage 400ms 1 forwards;
 }
 
+/* Ghidra project grid */
+.ghidra-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.ghidra-item {
+    text-align: center;
+}
+
+.ghidra-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border: 1px solid var(--color-ub-dark-grey);
+    border-radius: 0.25rem;
+}
+
 @keyframes scaleAppImage {
     from {
         transform: translate(-50%, -50%) scale(1);


### PR DESCRIPTION
## Summary
- display sample project thumbnails in Ghidra app
- add placeholder images and grid styling

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aea2c2883c83289a760287ba583f82