### PR TITLE
feat(settings): add accessible theme preview

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
 
 export function Settings(props) {
     const { theme, setTheme } = useTheme();
+    const [accent, setAccent] = useState('#4f46e5');
+    const [contrast, setContrast] = useState(0);
+    const liveRegion = useRef(null);
 
     const wallpapers = {
         "wall-1": "./images/wallpapers/wall-1.webp",
@@ -19,6 +22,46 @@ export function Settings(props) {
         props.changeBackgroundImage(e.target.dataset.path);
     }
 
+    let hexToRgb = (hex) => {
+        hex = hex.replace('#', '');
+        let bigint = parseInt(hex, 16);
+        return {
+            r: (bigint >> 16) & 255,
+            g: (bigint >> 8) & 255,
+            b: bigint & 255,
+        };
+    };
+
+    let luminance = ({ r, g, b }) => {
+        let a = [r, g, b].map(v => {
+            v = v / 255;
+            return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+        });
+        return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+    };
+
+    let contrastRatio = (hex1, hex2) => {
+        let l1 = luminance(hexToRgb(hex1)) + 0.05;
+        let l2 = luminance(hexToRgb(hex2)) + 0.05;
+        return l1 > l2 ? l1 / l2 : l2 / l1;
+    };
+
+    let accentText = () => {
+        return contrastRatio(accent, '#000000') > contrastRatio(accent, '#ffffff') ? '#000000' : '#ffffff';
+    };
+
+    useEffect(() => {
+        let raf = requestAnimationFrame(() => {
+            let ratio = contrastRatio(accent, accentText());
+            setContrast(ratio);
+            if (liveRegion.current) {
+                const msg = `Contrast ratio ${ratio.toFixed(2)}:1 ${ratio >= 4.5 ? 'passes' : 'fails'}`;
+                liveRegion.current.textContent = msg;
+            }
+        });
+        return () => cancelAnimationFrame(raf);
+    }, [accent, theme]);
+
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
@@ -33,6 +76,34 @@ export function Settings(props) {
                     <option value="dark">Dark</option>
                     <option value="light">Light</option>
                 </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Accent:</label>
+                <input
+                    type="color"
+                    aria-label="Accent color picker"
+                    value={accent}
+                    onChange={(e) => setAccent(e.target.value)}
+                    className="w-10 h-10 border border-ubt-cool-grey bg-ub-cool-grey"
+                />
+            </div>
+            <div className="flex justify-center my-4">
+                <div
+                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
+                    style={{ backgroundColor: theme === 'dark' ? '#000000' : '#ffffff', color: theme === 'dark' ? '#ffffff' : '#000000' }}
+                >
+                    <p className="mb-2 text-center">Preview</p>
+                    <button
+                        className="px-2 py-1 rounded"
+                        style={{ backgroundColor: accent, color: accentText() }}
+                    >
+                        Accent
+                    </button>
+                    <p className={`mt-2 text-sm text-center ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>
+                        {`Contrast ${contrast.toFixed(2)}:1 ${contrast >= 4.5 ? 'Pass' : 'Fail'}`}
+                    </p>
+                    <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
+                </div>
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {


### PR DESCRIPTION
## Summary
- add accent color picker and live theme preview
- validate color contrast in real time and announce results for screen readers
- respect motion preferences with reduced animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeaeb0eb8483288ef35f1ad178973c