### PR TITLE
feat(figlet): add real-time font previewer

### DIFF
--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -1,24 +1,44 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-const fonts = ['Standard', 'Slant'];
+// Font list must match those parsed in worker.js
+const fonts = ['Standard', 'Slant', 'Big', 'Ghost', 'Small'];
 
 const FigletApp = () => {
   const [text, setText] = useState('');
   const [font, setFont] = useState(fonts[0]);
   const [output, setOutput] = useState('');
+  const [inverted, setInverted] = useState(false);
+  const [announce, setAnnounce] = useState('');
   const workerRef = useRef(null);
+  const frameRef = useRef(null);
 
   useEffect(() => {
     workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
     workerRef.current.onmessage = (e) => setOutput(e.data);
-    return () => workerRef.current?.terminate();
+    return () => {
+      workerRef.current?.terminate();
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    };
   }, []);
 
-  useEffect(() => {
+  const updateFiglet = () => {
     if (workerRef.current) {
       workerRef.current.postMessage({ text, font });
     }
+  };
+
+  useEffect(() => {
+    if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(updateFiglet);
+    return () => cancelAnimationFrame(frameRef.current);
   }, [text, font]);
+
+  const copyOutput = () => {
+    if (output) {
+      navigator.clipboard.writeText(output);
+      setAnnounce('Copied to clipboard');
+    }
+  };
 
   return (
     <div className="flex flex-col h-full w-full bg-ub-cool-grey text-white font-mono">
@@ -27,6 +47,7 @@ const FigletApp = () => {
           className="bg-gray-700 text-white px-1"
           value={font}
           onChange={(e) => setFont(e.target.value)}
+          aria-label="Select font"
         >
           {fonts.map((f) => (
             <option key={f} value={f}>
@@ -40,9 +61,34 @@ const FigletApp = () => {
           placeholder="Type here"
           value={text}
           onChange={(e) => setText(e.target.value)}
+          aria-label="Text to convert"
         />
+        <button
+          onClick={copyOutput}
+          className="px-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
+          aria-label="Copy ASCII art"
+        >
+          Copy
+        </button>
+        <button
+          onClick={() => setInverted((i) => !i)}
+          className="px-2 bg-gray-700 hover:bg-gray-600 rounded text-white"
+          aria-label="Invert colors"
+        >
+          Invert
+        </button>
       </div>
-      <pre className="flex-1 overflow-auto p-2 whitespace-pre">{output}</pre>
+      <pre
+        aria-live="polite"
+        className={`flex-1 overflow-auto p-2 whitespace-pre transition-colors motion-reduce:transition-none ${
+          inverted ? 'bg-white text-black' : 'bg-black text-white'
+        }`}
+      >
+        {output}
+      </pre>
+      <div aria-live="polite" className="sr-only">
+        {announce}
+      </div>
     </div>
   );
 };

--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -1,9 +1,15 @@
 import figlet from 'figlet';
 import standard from 'figlet/importable-fonts/Standard.js';
 import slant from 'figlet/importable-fonts/Slant.js';
+import big from 'figlet/importable-fonts/Big.js';
+import ghost from 'figlet/importable-fonts/Ghost.js';
+import small from 'figlet/importable-fonts/Small.js';
 
 figlet.parseFont('Standard', standard);
 figlet.parseFont('Slant', slant);
+figlet.parseFont('Big', big);
+figlet.parseFont('Ghost', ghost);
+figlet.parseFont('Small', small);
 
 self.onmessage = (e) => {
   const { text, font } = e.data;


### PR DESCRIPTION
## Summary
- add real-time figlet font previewer with selectable fonts
- add copy-to-clipboard and invert display controls
- improve accessibility with aria-live updates and reduced motion support

## Testing
- `yarn lint`
- `yarn test figlet --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aeaeb7bba083288dbab0f75b9272e5