### PR TITLE
feat(beef): visualize hooks and attack steps

### DIFF
--- a/components/apps/beef/Graph.js
+++ b/components/apps/beef/Graph.js
@@ -1,0 +1,88 @@
+import React, { useRef, useEffect } from 'react';
+import cytoscape from 'cytoscape';
+
+export default function BeefGraph({ hooks, steps }) {
+  const containerRef = useRef(null);
+  const cyRef = useRef(null);
+  const liveRef = useRef(null);
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  useEffect(() => {
+    if (!containerRef.current || containerRef.current.offsetHeight === 0) return;
+    if (!cyRef.current) {
+      cyRef.current = cytoscape({
+        container: containerRef.current,
+        style: [
+          {
+            selector: 'node',
+            style: {
+              'background-color': '#ffffff',
+              label: 'data(label)',
+              color: '#000000',
+              'text-outline-color': '#ffffff',
+              'text-outline-width': 1,
+              'font-size': 10,
+            },
+          },
+          {
+            selector: 'edge',
+            style: {
+              width: 2,
+              'line-color': '#00ff00',
+              'target-arrow-color': '#00ff00',
+              'target-arrow-shape': 'triangle',
+            },
+          },
+        ],
+        layout: { name: 'grid', animate: false },
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+
+    cy.batch(() => {
+      cy.elements().remove();
+      hooks.forEach((hook) => {
+        const id = hook.session || hook.id;
+        cy.add({ data: { id, label: hook.name || id } });
+      });
+      steps.forEach((step, idx) => {
+        const moduleNodeId = `${step.module}-${idx}`;
+        cy.add({ data: { id: moduleNodeId, label: step.module } });
+        cy.add({
+          data: {
+            id: `${step.hook}-${moduleNodeId}`,
+            source: step.hook,
+            target: moduleNodeId,
+          },
+        });
+      });
+    });
+
+    window.requestAnimationFrame(() => {
+      cy.layout({ name: 'cose', animate: !prefersReducedMotion }).run();
+    });
+
+    if (liveRef.current) {
+      liveRef.current.textContent = `Graph updated with ${hooks.length} hooks and ${steps.length} steps`;
+    }
+  }, [hooks, steps, prefersReducedMotion]);
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        className="w-full h-64 bg-black"
+        role="img"
+        aria-label="Hooks and attack steps graph"
+      />
+      <div ref={liveRef} className="sr-only" aria-live="polite" />
+    </>
+  );
+}

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import GuideOverlay from './GuideOverlay';
+import BeefGraph from './Graph';
 
 export default function Beef() {
   const [hooks, setHooks] = useState([]);
@@ -8,6 +9,7 @@ export default function Beef() {
   const [modules, setModules] = useState([]);
   const [output, setOutput] = useState('');
   const [showHelp, setShowHelp] = useState(false);
+  const [steps, setSteps] = useState([]);
 
   const baseUrl = process.env.NEXT_PUBLIC_BEEF_URL || 'http://127.0.0.1:3000';
 
@@ -73,6 +75,7 @@ export default function Beef() {
     } catch (e) {
       setOutput(e.toString());
     }
+    setSteps((prev) => [...prev, { hook: selected, module: moduleId }]);
   };
 
   return (
@@ -104,6 +107,9 @@ export default function Beef() {
         </ul>
       </div>
       <div className="flex-1 p-4 overflow-y-auto">
+        <div className="mb-4">
+          <BeefGraph hooks={hooks} steps={steps} />
+        </div>
         {selected ? (
           <>
             <div className="mb-2">

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
     "chess.js": "^1.0.0",
+    "cytoscape": "3.30.0",
     "expr-eval": "^2.0.2",
     "figlet": "^1.8.2",
     "howler": "^2.2.4",
@@ -41,7 +42,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",
-
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cytoscape@npm:3.30.0":
+  version: 3.30.0
+  resolution: "cytoscape@npm:3.30.0"
+  checksum: 10c0/ffd463f27975b7d979c6f1a8c3472d95cbe2d75dc820aac27ad3e253eaa877da4c7ed4632a341394d911ba1804c5786a292a56387bbb34fcf0c9db69286e123e
+  languageName: node
+  linkType: hard
+
 "d3-array@npm:1 - 3, d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
@@ -6669,7 +6676,6 @@ __metadata:
   linkType: hard
 
 "react-force-graph@npm:^1.45.0":
-
   version: 1.48.0
   resolution: "react-force-graph@npm:1.48.0"
   dependencies:
@@ -8023,6 +8029,7 @@ __metadata:
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
     chess.js: "npm:^1.0.0"
+    cytoscape: "npm:3.30.0"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:^15.0.0"
     expr-eval: "npm:^2.0.2"
@@ -8043,7 +8050,6 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"
-
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"


### PR DESCRIPTION
## Summary
- add Cytoscape graph to display hooked browsers and executed modules
- respect motion preferences, provide high-contrast nodes/edges, and announce graph updates via ARIA live region
- track module executions for replay visualization

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aeaeb982e483289e1617e144d9087f