### PR TITLE
feat(bluetooth): add mock radar sweep scanner

### DIFF
--- a/components/apps/bluetooth/worker.js
+++ b/components/apps/bluetooth/worker.js
@@ -1,0 +1,29 @@
+let deviceId = 0;
+let interval;
+
+function randomDevice() {
+  deviceId += 1;
+  const angle = Math.random() * Math.PI * 2;
+  const distance = Math.random(); // 0-1 from center
+  const strength = Math.random(); // 0-1
+  return {
+    id: deviceId,
+    name: `Device ${deviceId}`,
+    angle,
+    distance,
+    strength,
+  };
+}
+
+self.onmessage = (e) => {
+  const { command } = e.data || {};
+  if (command === 'start' && !interval) {
+    interval = setInterval(() => {
+      self.postMessage(randomDevice());
+    }, 1500);
+  }
+  if (command === 'stop' && interval) {
+    clearInterval(interval);
+    interval = null;
+  }
+};


### PR DESCRIPTION
## Summary
- add canvas-based radar sweep UI
- ping mock Bluetooth devices with web worker
- announce discovered devices via aria-live

## Testing
- `yarn lint`
- `CI=true yarn test` *(fails to exit, but all suites reported pass)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaebaf23c8328bb240df384aae0a4