### PR TITLE
feat(metasploit): add severity browser and exploit replay

### DIFF
--- a/components/apps/metasploit/exploit.worker.js
+++ b/components/apps/metasploit/exploit.worker.js
@@ -1,0 +1,20 @@
+onmessage = () => {
+  const steps = [
+    'Initializing exploit...',
+    'Checking target...',
+    'Sending payload...',
+    'Gaining access...',
+    'Session established.'
+  ];
+  let i = 0;
+  const sendStep = () => {
+    if (i < steps.length) {
+      postMessage({ step: steps[i] });
+      i += 1;
+      setTimeout(sendStep, 1000);
+    } else {
+      postMessage({ done: true });
+    }
+  };
+  sendStep();
+};

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -1,6 +1,16 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import modules from './modules.json';
 import usePersistentState from '../../usePersistentState';
+
+const severities = ['critical', 'high', 'medium', 'low'];
+const severityStyles = {
+  critical: 'bg-red-700 text-white',
+  high: 'bg-orange-600 text-black',
+  medium: 'bg-yellow-300 text-black',
+  low: 'bg-green-300 text-black',
+};
+
+const timelineSteps = 5;
 
 const banner = `Metasploit Framework Console (mock)\nType 'search <term>' to search modules.`;
 
@@ -9,10 +19,30 @@ const MetasploitApp = () => {
   const [output, setOutput] = usePersistentState('metasploit-history', banner);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
+  const [selectedSeverity, setSelectedSeverity] = useState(null);
+  const [animationStyle, setAnimationStyle] = useState({ opacity: 1 });
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  const [timeline, setTimeline] = useState([]);
+  const [replaying, setReplaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [liveMsg, setLiveMsg] = useState('');
+
+  const workerRef = useRef();
+  const moduleRaf = useRef();
+  const progressRaf = useRef();
 
   // Refresh modules list in the background on mount
   useEffect(() => {
     fetch('/api/metasploit').catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReduceMotion(mq.matches);
+    handler();
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
   }, []);
 
   const filtered = useMemo(() => {
@@ -24,6 +54,27 @@ const MetasploitApp = () => {
         m.description.toLowerCase().includes(q)
     );
   }, [query]);
+
+  const modulesBySeverity = useMemo(() => {
+    return modules.reduce((acc, m) => {
+      acc[m.severity] = acc[m.severity] ? [...acc[m.severity], m] : [m];
+      return acc;
+    }, {});
+  }, []);
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    setAnimationStyle({ opacity: 0 });
+    let start;
+    const step = (ts) => {
+      if (!start) start = ts;
+      const pct = Math.min((ts - start) / 300, 1);
+      setAnimationStyle({ opacity: pct });
+      if (pct < 1) moduleRaf.current = requestAnimationFrame(step);
+    };
+    moduleRaf.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(moduleRaf.current);
+  }, [selectedSeverity, reduceMotion]);
 
   const runCommand = async () => {
     const cmd = command.trim();
@@ -43,6 +94,39 @@ const MetasploitApp = () => {
       setLoading(false);
     }
   };
+
+  const startReplay = () => {
+    if (workerRef.current) workerRef.current.terminate();
+    setTimeline([]);
+    setProgress(0);
+    setReplaying(true);
+    const worker = new Worker(new URL('./exploit.worker.js', import.meta.url));
+    worker.onmessage = (e) => {
+      if (e.data.step) {
+        setTimeline((t) => [...t, e.data.step]);
+        setLiveMsg(e.data.step);
+      } else if (e.data.done) {
+        setReplaying(false);
+        worker.terminate();
+      }
+    };
+    worker.postMessage('start');
+    workerRef.current = worker;
+  };
+
+  useEffect(() => {
+    if (!replaying || reduceMotion) return;
+    let start;
+    const total = timelineSteps * 1000;
+    const step = (ts) => {
+      if (!start) start = ts;
+      const pct = Math.min(((ts - start) / total) * 100, 100);
+      setProgress(pct);
+      if (pct < 100) progressRaf.current = requestAnimationFrame(step);
+    };
+    progressRaf.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(progressRaf.current);
+  }, [replaying, reduceMotion]);
 
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white">
@@ -81,6 +165,58 @@ const MetasploitApp = () => {
             ))}
           </ul>
         )}
+        <div className="mt-4">
+          <div className="flex flex-wrap mb-2">
+            {severities.map((s) => (
+              <button
+                key={s}
+                onClick={() => setSelectedSeverity(s)}
+                className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus:outline-none ${severityStyles[s]} ${
+                  selectedSeverity === s
+                    ? 'ring-2 ring-white motion-safe:transition-transform motion-safe:duration-300 motion-safe:scale-110 motion-reduce:transition-none motion-reduce:scale-100'
+                    : ''
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+          {selectedSeverity && (
+            <ul style={animationStyle} className="max-h-40 overflow-auto text-xs">
+              {(modulesBySeverity[selectedSeverity] || []).map((m) => (
+                <li key={m.name} className="mb-1">
+                  <span className="font-mono">{m.name}</span> - {m.description}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="mt-4">
+          <button
+            onClick={startReplay}
+            className="px-2 py-1 bg-ub-orange rounded text-black"
+          >
+            Replay Mock Exploit
+          </button>
+          <div aria-live="polite" className="sr-only">
+            {liveMsg}
+          </div>
+          {timeline.length > 0 && (
+            <>
+              <ul className="mt-2 text-xs max-h-32 overflow-auto">
+                {timeline.map((t, i) => (
+                  <li key={i}>{t}</li>
+                ))}
+              </ul>
+              <div className="w-full bg-ub-grey h-2 mt-2">
+                <div
+                  className="h-full bg-ub-orange"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </>
+          )}
+        </div>
       </div>
       <pre className="flex-grow bg-black text-green-400 p-2 overflow-auto whitespace-pre-wrap">
         {loading ? 'Running...' : output}

--- a/components/apps/metasploit/modules.json
+++ b/components/apps/metasploit/modules.json
@@ -1,22 +1,27 @@
 [
   {
     "name": "exploit/windows/smb/ms17_010_eternalblue",
-    "description": "MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption"
+    "description": "MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption",
+    "severity": "critical"
   },
   {
     "name": "exploit/multi/http/struts2_content_type_ognl",
-    "description": "Apache Struts 2 Content-Type OGNL RCE"
+    "description": "Apache Struts 2 Content-Type OGNL RCE",
+    "severity": "high"
   },
   {
     "name": "exploit/unix/ftp/vsftpd_234_backdoor",
-    "description": "VSFTPD v2.3.4 Backdoor Command Execution"
+    "description": "VSFTPD v2.3.4 Backdoor Command Execution",
+    "severity": "medium"
   },
   {
     "name": "auxiliary/scanner/portscan/tcp",
-    "description": "TCP Port Scanner"
+    "description": "TCP Port Scanner",
+    "severity": "low"
   },
   {
     "name": "payload/windows/meterpreter/reverse_tcp",
-    "description": "Windows Meterpreter Reverse TCP"
+    "description": "Windows Meterpreter Reverse TCP",
+    "severity": "high"
   }
 ]


### PR DESCRIPTION
## Summary
- animate severity chips with high-contrast styles
- add mock exploit timeline replay using web worker and aria live updates
- honor reduced-motion preference and requestAnimationFrame animations

## Testing
- `yarn lint`
- `yarn test components/apps/metasploit --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aeaebbb9d4832897f25ffdbfdfea67