### PR TITLE
Add packet waterfall visualization with burst controls

### DIFF
--- a/components/apps/wireshark/Waterfall.js
+++ b/components/apps/wireshark/Waterfall.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react';
+import { protocolName, getRowColor } from './utils';
+
+const protocolColors = {
+  TCP: 'bg-blue-400',
+  UDP: 'bg-green-400',
+  ICMP: 'bg-purple-400',
+  default: 'bg-gray-400',
+};
+
+const Waterfall = ({ packets, colorRules, viewIndex, prefersReducedMotion }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    if (prefersReducedMotion) {
+      node.style.transform = `translateX(-${viewIndex * 8}px)`;
+      return;
+    }
+    const raf = requestAnimationFrame(() => {
+      node.style.transform = `translateX(-${viewIndex * 8}px)`;
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [viewIndex, prefersReducedMotion]);
+
+  return (
+    <div className="relative h-16 bg-black overflow-hidden border-t border-gray-800" role="group" aria-label="Packet waterfall">
+      <div ref={containerRef} className="flex absolute top-0 left-0 h-full will-change-transform">
+        {packets.map((p, idx) => {
+          const ruleColor = getRowColor(p, colorRules);
+          const protoColor = protocolColors[protocolName(p.protocol)] || protocolColors.default;
+          const colorClass = ruleColor || protoColor;
+          return (
+            <div
+              key={idx}
+              className={`w-2 h-full ${colorClass} ${p.burstStart ? 'ml-1' : ''}`}
+              title={`${protocolName(p.protocol)} packet at ${p.timestamp}`}
+              aria-label={`${protocolName(p.protocol)} packet at ${p.timestamp}`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Waterfall;

--- a/components/apps/wireshark/burstWorker.js
+++ b/components/apps/wireshark/burstWorker.js
@@ -1,0 +1,13 @@
+let last = 0;
+let timeline = [];
+self.onmessage = (e) => {
+  const pkt = e.data;
+  const ts = Number(pkt.timestamp);
+  const burstStart = !last || ts - last > 1000;
+  timeline = [...timeline, { ...pkt, burstStart }].slice(-500);
+  if (burstStart) {
+    self.postMessage({ type: 'burst', start: ts });
+  }
+  last = ts;
+  self.postMessage({ type: 'timeline', timeline });
+};

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,17 +1,6 @@
-import React, { useEffect, useState } from 'react';
-
-const protocolName = (proto) => {
-  switch (proto) {
-    case 6:
-      return 'TCP';
-    case 17:
-      return 'UDP';
-    case 1:
-      return 'ICMP';
-    default:
-      return proto;
-  }
-};
+import React, { useEffect, useRef, useState } from 'react';
+import Waterfall from './Waterfall';
+import { protocolName, getRowColor } from './utils';
 
 // Determine if a packet matches the active filter expression
 const matchesFilter = (packet, filter) => {
@@ -26,17 +15,6 @@ const matchesFilter = (packet, filter) => {
   );
 };
 
-// Determine the color class for a packet based on user rules
-export const getRowColor = (packet, rules) => {
-  const proto = protocolName(packet.protocol);
-  const rule = rules.find(
-    (r) =>
-      (r.protocol && r.protocol === proto) ||
-      (r.ip && (packet.src === r.ip || packet.dest === r.ip))
-  );
-  return rule ? rule.color : '';
-};
-
 const WiresharkApp = ({ initialPackets = [] }) => {
   const [packets, setPackets] = useState(initialPackets);
   const [socket, setSocket] = useState(null);
@@ -44,14 +22,51 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   const [filter, setFilter] = useState('');
   const [colorRuleText, setColorRuleText] = useState('[]');
   const [colorRules, setColorRules] = useState([]);
+  const [paused, setPaused] = useState(false);
+  const [timeline, setTimeline] = useState([]);
+  const [viewIndex, setViewIndex] = useState(0);
+  const [announcement, setAnnouncement] = useState('');
+  const workerRef = useRef(null);
+  const pausedRef = useRef(false);
+  const prefersReducedMotion = useRef(false);
+  const VISIBLE = 100;
 
   // Load persisted filter on mount
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const saved = window.localStorage.getItem('wireshark-filter');
       if (saved) setFilter(saved);
+      prefersReducedMotion.current = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
     }
   }, []);
+
+  // instantiate worker for burst grouping
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof Worker === 'undefined') return;
+    const worker = new Worker(new URL('./burstWorker.js', import.meta.url));
+    worker.onmessage = (e) => {
+      if (e.data.type === 'burst') {
+        setAnnouncement(`Burst starting at ${e.data.start}`);
+      }
+      if (e.data.type === 'timeline') {
+        setTimeline(e.data.timeline);
+      }
+    };
+    workerRef.current = worker;
+    return () => worker.terminate();
+  }, []);
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
+
+  useEffect(() => {
+    if (!paused) {
+      setViewIndex(Math.max(0, timeline.length - VISIBLE));
+    }
+  }, [timeline, paused]);
 
   const handleFilterChange = (e) => {
     const val = e.target.value;
@@ -86,6 +101,9 @@ const WiresharkApp = ({ initialPackets = [] }) => {
       try {
         const pkt = JSON.parse(event.data);
         setPackets((prev) => [pkt, ...prev].slice(0, 500));
+        if (!pausedRef.current) {
+          workerRef.current?.postMessage(pkt);
+        }
       } catch (e) {
         // ignore malformed packets
       }
@@ -136,7 +154,29 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           placeholder='Color rules JSON'
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
+        <button
+          onClick={() => setPaused((p) => !p)}
+          className="px-3 py-1 bg-gray-700 rounded"
+          aria-pressed={paused}
+        >
+          {paused ? 'Resume' : 'Pause'}
+        </button>
+        <input
+          type="range"
+          min="0"
+          max={Math.max(0, timeline.length - VISIBLE)}
+          value={viewIndex}
+          onChange={(e) => setViewIndex(parseInt(e.target.value, 10))}
+          aria-label="Scrub timeline"
+          className="flex-1"
+        />
       </div>
+      <Waterfall
+        packets={timeline}
+        colorRules={colorRules}
+        viewIndex={viewIndex}
+        prefersReducedMotion={prefersReducedMotion.current}
+      />
       <div className="flex-1 overflow-auto">
         <table className="min-w-full text-xs">
           <thead className="bg-gray-800">
@@ -166,6 +206,9 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             ))}
           </tbody>
         </table>
+      </div>
+      <div aria-live="polite" className="sr-only">
+        {announcement}
       </div>
     </div>
   );

--- a/components/apps/wireshark/utils.js
+++ b/components/apps/wireshark/utils.js
@@ -1,0 +1,23 @@
+export const protocolName = (proto) => {
+  switch (proto) {
+    case 6:
+      return 'TCP';
+    case 17:
+      return 'UDP';
+    case 1:
+      return 'ICMP';
+    default:
+      return proto;
+  }
+};
+
+// Determine the color class for a packet based on user rules
+export const getRowColor = (packet, rules) => {
+  const proto = protocolName(packet.protocol);
+  const rule = rules.find(
+    (r) =>
+      (r.protocol && r.protocol === proto) ||
+      (r.ip && (packet.src === r.ip || packet.dest === r.ip))
+  );
+  return rule ? rule.color : '';
+};


### PR DESCRIPTION
## Summary
- add color-coded packet waterfall with pause and scrub controls
- use Web Worker to group bursts and announce via ARIA live region
- respect reduced motion preferences and render with requestAnimationFrame

## Testing
- `CI=true yarn test`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68aeaebbf57c8328accef6d3a0d9cdd4