### PR TITLE
feat: visualize nikto scan results

### DIFF
--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,24 +1,112 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
+
+const RadarChart = ({ data }) => {
+  const labels = Object.keys(data);
+  const counts = labels.map((l) => data[l] || 0);
+  const max = Math.max(...counts, 1);
+  const points = labels
+    .map((label, i) => {
+      const angle = (Math.PI * 2 * i) / labels.length - Math.PI / 2;
+      const radius = (counts[i] / max) * 40;
+      const x = 50 + radius * Math.cos(angle);
+      const y = 50 + radius * Math.sin(angle);
+      return `${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      role="img"
+      aria-label="Nikto finding categories radar chart"
+      className="w-full h-full"
+    >
+      <polygon
+        points={points}
+        fill="rgba(34,197,94,0.4)"
+        stroke="#22c55e"
+        strokeWidth="2"
+      />
+      {labels.map((label, i) => {
+        const angle = (Math.PI * 2 * i) / labels.length - Math.PI / 2;
+        const x = 50 + 45 * Math.cos(angle);
+        const y = 50 + 45 * Math.sin(angle);
+        return (
+          <text
+            key={label}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-white text-[8px]"
+          >
+            {label}
+          </text>
+        );
+      })}
+    </svg>
+  );
+};
 
 const NiktoApp = () => {
   const [target, setTarget] = useState('');
-  const [result, setResult] = useState('');
+  const [findings, setFindings] = useState([]);
+  const [clusters, setClusters] = useState({});
   const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState('');
+  const [animProgress, setAnimProgress] = useState(1);
+  const workerRef = useRef(null);
+  const prefersReducedMotion = useRef(false);
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./nikto.worker.js', import.meta.url));
+    workerRef.current.onmessage = (e) => {
+      setClusters(e.data.clusterCounts);
+      setFindings(e.data.findings);
+      setStatus('Scan complete');
+    };
+    prefersReducedMotion.current = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (!Object.keys(clusters).length) return;
+    if (prefersReducedMotion.current) {
+      setAnimProgress(1);
+      return;
+    }
+    setAnimProgress(0);
+    let start;
+    const step = (ts) => {
+      if (!start) start = ts;
+      const progress = Math.min((ts - start) / 500, 1);
+      setAnimProgress(progress);
+      if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [clusters]);
 
   const runScan = async () => {
     if (!target) return;
     setLoading(true);
-    setResult('');
+    setStatus('Running scan');
+    setFindings([]);
+    setClusters({});
     try {
       const res = await fetch(`/api/nikto?target=${encodeURIComponent(target)}`);
       const text = await res.text();
-      setResult(text);
+      workerRef.current?.postMessage({ text });
     } catch (err) {
-      setResult(`Error: ${err.message}`);
+      setStatus(`Error: ${err.message}`);
     } finally {
       setLoading(false);
     }
   };
+
+  const scaledClusters = Object.fromEntries(
+    Object.entries(clusters).map(([k, v]) => [k, v * animProgress])
+  );
 
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 overflow-auto">
@@ -34,15 +122,35 @@ const NiktoApp = () => {
         <button
           type="button"
           onClick={runScan}
-          className="px-4 bg-ubt-blue rounded-r"
+          className="px-4 bg-ubt-blue rounded-r focus:outline-none focus:ring-2 focus:ring-ubt-blue"
         >
           Scan
         </button>
       </div>
+      <div aria-live="polite" className="sr-only">
+        {status}
+      </div>
       {loading ? (
         <p>Running scan...</p>
+      ) : findings.length > 0 ? (
+        <div className="flex flex-col md:flex-row gap-4 flex-1">
+          <div className="md:w-1/2 flex justify-center items-center">
+            <RadarChart data={scaledClusters} />
+          </div>
+          <ul
+            className="md:w-1/2 list-disc pl-4 text-sm overflow-auto"
+            aria-live="polite"
+          >
+            {findings.map((f, i) => (
+              <li key={i} className="mb-1">
+                <span className="font-bold">{f.category}:</span>{' '}
+                <span className="text-gray-300">{f.line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       ) : (
-        <pre className="whitespace-pre-wrap flex-1 overflow-auto">{result}</pre>
+        <p>No results</p>
       )}
     </div>
   );
@@ -51,4 +159,3 @@ const NiktoApp = () => {
 export default NiktoApp;
 
 export const displayNikto = () => <NiktoApp />;
-

--- a/components/apps/nikto/nikto.worker.js
+++ b/components/apps/nikto/nikto.worker.js
@@ -1,0 +1,27 @@
+const categories = {
+  SQLi: /sql|database/i,
+  XSS: /xss|cross|script/i,
+  LFI: /file|path/i,
+  RFI: /remote|include/i,
+  Info: /info|header|server/i,
+};
+
+self.onmessage = (e) => {
+  const { text } = e.data;
+  const lines = text.split(/\r?\n/).filter((l) => l.trim());
+  const findings = lines.map((line) => {
+    let category = 'Other';
+    for (const [key, regex] of Object.entries(categories)) {
+      if (regex.test(line)) {
+        category = key;
+        break;
+      }
+    }
+    return { category, line };
+  });
+  const clusterCounts = findings.reduce((acc, f) => {
+    acc[f.category] = (acc[f.category] || 0) + 1;
+    return acc;
+  }, {});
+  postMessage({ findings, clusterCounts });
+};


### PR DESCRIPTION
## Summary
- Parse nikto output off the main thread and cluster findings by category
- Render clusters in an animated radar chart with ARIA live region and WCAG-friendly colors
- List proof snippets for each finding and respect reduced-motion preferences

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeaebd3b588328bb7f7522a111f44b