### PR TITLE
feat: add zoomable timeline to autopsy

### DIFF
--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,4 +1,91 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+function Timeline({ events }) {
+  const canvasRef = useRef(null);
+  const workerRef = useRef(null);
+  const [sorted, setSorted] = useState([]);
+  const [zoom, setZoom] = useState(0.5); // pixels per minute
+
+  useEffect(() => {
+    workerRef.current = new Worker(
+      new URL('./timelineWorker.js', import.meta.url)
+    );
+    workerRef.current.onmessage = (e) => setSorted(e.data);
+    return () => workerRef.current.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (workerRef.current) workerRef.current.postMessage({ events });
+  }, [events]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || sorted.length === 0) return;
+    const ctx = canvas.getContext('2d');
+    const times = sorted.map((e) => new Date(e.timestamp).getTime());
+    const min = Math.min(...times);
+    const max = Math.max(...times);
+    const rangeMin = (max - min) / 60000 || 1;
+    const width = Math.max(rangeMin * zoom, 600);
+    canvas.width = width;
+    canvas.height = 80;
+    const height = canvas.height;
+    const prefersReduced = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    const render = () => {
+      ctx.fillStyle = '#1f1f1f';
+      ctx.fillRect(0, 0, width, height);
+      ctx.strokeStyle = '#ffffff';
+      ctx.beginPath();
+      ctx.moveTo(0, height / 2);
+      ctx.lineTo(width, height / 2);
+      ctx.stroke();
+      ctx.fillStyle = '#ffa500';
+      sorted.forEach((ev) => {
+        const t = new Date(ev.timestamp).getTime();
+        const x = ((t - min) / 60000) * zoom;
+        ctx.fillRect(x, height / 2 - 10, 2, 20);
+      });
+    };
+    if (prefersReduced) {
+      render();
+    } else {
+      requestAnimationFrame(render);
+    }
+  }, [sorted, zoom]);
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <div className="flex space-x-2 mb-1">
+        <button
+          onClick={() => setZoom((z) => Math.min(z * 2, 10))}
+          className="bg-ub-orange text-black px-2 py-1 rounded"
+          aria-label="Zoom in"
+        >
+          +
+        </button>
+        <button
+          onClick={() => setZoom((z) => Math.max(z / 2, 0.25))}
+          className="bg-ub-orange text-black px-2 py-1 rounded"
+          aria-label="Zoom out"
+        >
+          -
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        className="bg-ub-grey"
+        role="img"
+        aria-label="File event timeline"
+      />
+    </div>
+  );
+}
 
 function Autopsy() {
   const [caseName, setCaseName] = useState('');
@@ -7,6 +94,7 @@ function Autopsy() {
   const [artifacts, setArtifacts] = useState([]);
   const [plugins, setPlugins] = useState([]);
   const [selectedPlugin, setSelectedPlugin] = useState('');
+  const [announcement, setAnnouncement] = useState('');
 
   useEffect(() => {
     fetch('/plugin-marketplace.json')
@@ -62,8 +150,20 @@ function Autopsy() {
     URL.revokeObjectURL(url);
   };
 
+  useEffect(() => {
+    if (artifacts.length > 0) {
+      const a = artifacts[artifacts.length - 1];
+      setAnnouncement(
+        `${a.name} analyzed at ${new Date(a.timestamp).toLocaleString()}`
+      );
+    }
+  }, [artifacts]);
+
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 space-y-4">
+      <div aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
       <div className="flex space-x-2">
         <input
           type="text"
@@ -114,19 +214,10 @@ function Autopsy() {
       {artifacts.length > 0 && (
         <div className="space-y-2">
           <div className="text-sm font-bold">Timeline</div>
-          <ul className="space-y-1 text-xs">
-            {artifacts.map((a, idx) => (
-              <li key={idx} className="bg-ub-grey p-1 rounded">
-                <div>{new Date(a.timestamp).toLocaleString()}</div>
-                <div>
-                  {a.name} ({a.plugin})
-                </div>
-              </li>
-            ))}
-          </ul>
+          <Timeline events={artifacts} />
           <button
             onClick={downloadReport}
-            className="bg-ub-orange px-3 py-1 rounded text-sm"
+            className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
           >
             Download Report
           </button>

--- a/components/apps/autopsy/timelineWorker.js
+++ b/components/apps/autopsy/timelineWorker.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-restricted-globals */
+self.onmessage = (e) => {
+  const { events = [] } = e.data || {};
+  const sorted = events.slice().sort(
+    (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+  );
+  self.postMessage(sorted);
+};


### PR DESCRIPTION
## Summary
- add canvas-based timeline with day-to-minute zoom controls
- process timeline data in a Web Worker and animate with requestAnimationFrame
- announce new artifacts via ARIA live region for accessibility

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aeaebd9750832892b9d4c6e51cf454