### PR TITLE
Add accessible progress gauge to Hashcat app

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import HashcatApp, { detectHashType } from '../components/apps/hashcat';
+import progressInfo from '../components/apps/hashcat/progress.json';
 
 describe('HashcatApp', () => {
   it('auto-detects hash types', () => {
@@ -22,5 +23,12 @@ describe('HashcatApp', () => {
     await waitFor(() => {
       expect(getByTestId('benchmark-output').textContent).toMatch(/GPU0/);
     });
+  });
+
+  it('shows progress info from JSON', () => {
+    const { getByText } = render(<HashcatApp />);
+    expect(getByText(`Hash rate: ${progressInfo.hashRate}`)).toBeInTheDocument();
+    expect(getByText(`ETA: ${progressInfo.eta}`)).toBeInTheDocument();
+    expect(getByText(`Mode: ${progressInfo.mode}`)).toBeInTheDocument();
   });
 });

--- a/components/apps/hashcat/progress.json
+++ b/components/apps/hashcat/progress.json
@@ -1,0 +1,6 @@
+{
+  "progress": 42,
+  "hashRate": "123 H/s",
+  "eta": "00:00:42",
+  "mode": "Brute-force"
+}

--- a/components/apps/hashcat/progress.worker.js
+++ b/components/apps/hashcat/progress.worker.js
@@ -1,0 +1,12 @@
+self.onmessage = (e) => {
+  const target = e.data?.target ?? 100;
+  let current = 0;
+  const tick = () => {
+    current += 1;
+    self.postMessage(current);
+    if (current < target) {
+      setTimeout(tick, 100);
+    }
+  };
+  tick();
+};


### PR DESCRIPTION
## Summary
- show hash rate, ETA and mode from static JSON
- animate progress with requestAnimationFrame and a Web Worker
- respect reduced motion settings and announce updates via ARIA

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeaec3f24083288dd2777f20f33184