### PR TITLE
feat(john): add workload progress bar

### DIFF
--- a/components/apps/john/progress.worker.js
+++ b/components/apps/john/progress.worker.js
@@ -1,0 +1,16 @@
+let total = 0;
+let completed = 0;
+
+onmessage = (e) => {
+  const { type, total: t, amount = 1, phase } = e.data;
+  if (type === 'init') {
+    total = t || 0;
+    completed = 0;
+    postMessage({ percent: 0, phase: 'wordlist' });
+  } else if (type === 'increment') {
+    completed += amount;
+    let percent = total ? (completed / total) * 100 : 0;
+    if (percent > 100) percent = 100;
+    postMessage({ percent, phase });
+  }
+};


### PR DESCRIPTION
## Summary
- add Web Worker-powered progress tracking to John interface
- show accessible progress bar with wordlist/rules phases

## Testing
- `yarn test`
- `yarn lint` (warns deprecated next lint)


------
https://chatgpt.com/codex/tasks/task_e_68aeaec59bd08328b55528f0c3b11b5f