### PR TITLE
feat(openvas): add interactive risk matrix

### DIFF
--- a/components/apps/openvas/openvas.worker.js
+++ b/components/apps/openvas/openvas.worker.js
@@ -1,0 +1,24 @@
+self.onmessage = (e) => {
+  const text = e.data || '';
+  const lines = text.split('\n');
+  const findings = [];
+  const severities = ['low', 'medium', 'high', 'critical'];
+  const sevReg = /Severity:\s*(Low|Medium|High|Critical)/i;
+  const impactReg = /Impact:\s*(Low|Medium|High|Critical)/i;
+  const likelihoodReg = /Likelihood:\s*(Low|Medium|High|Critical)/i;
+  lines.forEach((line) => {
+    const severityMatch = line.match(sevReg);
+    const impactMatch = line.match(impactReg);
+    const likelihoodMatch = line.match(likelihoodReg);
+    if (severityMatch || impactMatch || likelihoodMatch) {
+      const sev = severityMatch ? severityMatch[1].toLowerCase() : 'low';
+      findings.push({
+        severity: sev,
+        impact: impactMatch ? impactMatch[1].toLowerCase() : sev,
+        likelihood: likelihoodMatch ? likelihoodMatch[1].toLowerCase() : sev,
+        description: line.trim(),
+      });
+    }
+  });
+  self.postMessage(findings);
+};


### PR DESCRIPTION
## Summary
- parse scan results in a web worker
- add risk matrix to visualize and filter findings
- announce filter changes via ARIA live region and respect reduced motion

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeaec63258832895089ad7cc0e6ee1