### PR TITLE
Add Battleship hit ripple and guess heat map

### DIFF
--- a/components/hooks/usePrefersReducedMotion.js
+++ b/components/hooks/usePrefersReducedMotion.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+// Hook to respect the user's reduced motion preference
+export default function usePrefersReducedMotion() {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = () => setPrefersReduced(media.matches);
+    handleChange();
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReduced;
+}


### PR DESCRIPTION
## Summary
- Add animated hit ripple respecting reduced motion settings
- Overlay AI and player guess heat maps with high-contrast colors
- Improve accessibility with ARIA live region and labeled firing controls

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aeaec9e3dc8328bedc399b422a4d6a