### PR TITLE
feat(simon): add accessibility animations

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -346,3 +346,30 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: tile-pop 0.15s ease-out;
 
 }
+
+@keyframes pad-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.6); }
+    50% { box-shadow: 0 0 20px 5px rgba(255, 255, 255, 0.2); }
+}
+
+.pad-pulse {
+    animation: pad-pulse 0.5s ease-in-out;
+}
+
+@keyframes buzz {
+    10%, 90% { transform: translateX(-2px); }
+    20%, 80% { transform: translateX(2px); }
+    30%, 50%, 70% { transform: translateX(-4px); }
+    40%, 60% { transform: translateX(4px); }
+}
+
+.buzz {
+    animation: buzz 0.6s linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pad-pulse,
+    .buzz {
+        animation: none;
+    }
+}


### PR DESCRIPTION
## Summary
- add pad pulse glow with reduced-motion support
- buzz UI on Simon errors and announce with aria-live

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeaed3ca648328ba6e37ed5e1308e4