### PR TITLE
feat(blackjack): add card flip and chip stacks

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -251,7 +251,35 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Blackjack animations */
 .card {
-    transition: transform 0.3s ease, opacity 0.3s ease;
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.6s ease, opacity 0.3s ease;
+}
+
+.card-face {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+}
+
+.card-front {
+    background: #ffffff;
+    color: #000000;
+    transform: rotateY(180deg);
+}
+
+.card-back {
+    background: #1f2937;
+    color: #ffffff;
+}
+
+.card.flipped {
+    transform: rotateY(180deg);
 }
 
 .animate-deal {
@@ -267,8 +295,50 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
 }
 
+.chip-stack {
+    position: relative;
+}
+
+.chip {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid #000;
+    position: absolute;
+    left: 0;
+    transition: transform 0.3s;
+}
+
+.chip-pop {
+    animation: chipPop 0.3s ease-out forwards;
+}
+
+@keyframes chipPop {
+    from { transform: translateY(10px) scale(0.5); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+}
+
 .shuffle {
     animation: shuffleDeck 0.5s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .card,
+    .chip {
+        transition: none;
+    }
+    .card.flipped {
+        transform: none;
+    }
+    .chip-pop,
+    .animate-deal {
+        animation: none;
+        transform: none;
+        opacity: 1;
+    }
 }
 
 @keyframes shuffleDeck {


### PR DESCRIPTION
## Summary
- add flip animation component with reduced-motion and requestAnimationFrame
- display bets as stackable chips with ARIA live regions
- style cards and chips for high contrast and reduced-motion support

## Testing
- `yarn test`
- `yarn lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68aeaeca6ac88328b87304e00171f99f