### PR TITLE
Add image preview and adjustable ASCII rendering controls

### DIFF
--- a/components/apps/ascii_art/worker.js
+++ b/components/apps/ascii_art/worker.js
@@ -1,5 +1,5 @@
 self.onmessage = async (e) => {
-  const { bitmap, charSet, cellSize, useColor, palette } = e.data;
+  const { bitmap, charSet, cellSize, useColor, palette, contrast = 1 } = e.data;
   const chars = charSet.split('');
   const width = Math.floor(bitmap.width / cellSize);
   const height = Math.floor(bitmap.height / cellSize);
@@ -21,7 +21,9 @@ self.onmessage = async (e) => {
     const r = data[idx];
     const g = data[idx + 1];
     const b = data[idx + 2];
-    gray[i] = 0.299 * r + 0.587 * g + 0.114 * b;
+    let val = 0.299 * r + 0.587 * g + 0.114 * b;
+    val = (val - 128) * contrast + 128;
+    gray[i] = Math.max(0, Math.min(255, val));
   }
   let plain = '';
   let html = '';


### PR DESCRIPTION
## Summary
- add contrast and character density sliders to ASCII art app
- preview uploaded image alongside ASCII output
- improve worker to apply contrast adjustment and update via requestAnimationFrame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeaeb70d9c8328bf4771f4bb278d57