### PR TITLE
feat: add accessible drag-and-drop Todoist board

### DIFF
--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,12 +1,135 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react';
+
+const initialGroups = {
+  'To Do': [
+    { id: 1, title: 'Write docs', priority: 'high' },
+    { id: 2, title: 'Design UI', priority: 'medium' },
+  ],
+  'In Progress': [
+    { id: 3, title: 'Set up CI', priority: 'low' },
+  ],
+  Done: [],
+};
+
+const priorityColors = {
+  high: 'bg-red-700 text-white',
+  medium: 'bg-yellow-600 text-black',
+  low: 'bg-green-700 text-white',
+};
 
 export default function Todoist() {
-    return (
-        <iframe src="https://todoist.com/showProject?id=220474322" frameBorder="0" title="Todoist" className="h-full w-full"></iframe>
-        // just to bypass the headers 🙃
-    )
+  const [groups, setGroups] = useState(initialGroups);
+  const [animating, setAnimating] = useState('');
+  const dragged = useRef({ group: '', id: null });
+  const liveRef = useRef(null);
+  const workerRef = useRef(null);
+  const prefersReducedMotion = useRef(
+    typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+
+  const announce = (task, group) => {
+    if (liveRef.current) {
+      liveRef.current.textContent = `Moved ${task} to ${group}`;
+    }
+  };
+
+  const finalizeMove = (newGroups, taskTitle, to) => {
+    setGroups(newGroups);
+    announce(taskTitle, to);
+    if (!prefersReducedMotion.current) {
+      requestAnimationFrame(() => {
+        setAnimating(to);
+        setTimeout(() => setAnimating(''), 500);
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+      workerRef.current = new Worker(
+        new URL('./todoist.worker.js', import.meta.url)
+      );
+      workerRef.current.onmessage = (e) => {
+        const { groups: newGroups, taskTitle, to } = e.data || {};
+        finalizeMove(newGroups, taskTitle, to);
+      };
+    }
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  const handleDragStart = (group, task) => (e) => {
+    dragged.current = { group, id: task.id, title: task.title };
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDrop = (group) => (e) => {
+    e.preventDefault();
+    const { group: from, id, title } = dragged.current;
+    if (from === group || !id) return;
+    if (workerRef.current) {
+      workerRef.current.postMessage({ groups, from, to: group, id });
+    } else {
+      const newGroups = moveTask(groups, from, group, id);
+      finalizeMove(newGroups, title, group);
+    }
+  };
+
+  const handleDragOver = (e) => e.preventDefault();
+
+  const moveTask = (data, from, to, id) => {
+    const newGroups = {
+      ...data,
+      [from]: [...data[from]],
+      [to]: [...data[to]],
+    };
+    const index = newGroups[from].findIndex((t) => t.id === id);
+    if (index > -1) {
+      const [task] = newGroups[from].splice(index, 1);
+      newGroups[to].push(task);
+    }
+    return newGroups;
+  };
+
+  return (
+    <div className="flex h-full w-full" role="application">
+      <div aria-live="polite" className="sr-only" ref={liveRef} />
+      {Object.keys(groups).map((name) => (
+        <div
+          key={name}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop(name)}
+          className={`flex-1 p-2 border-r last:border-r-0 border-gray-300 overflow-y-auto ${
+            !prefersReducedMotion.current ? 'transition-colors' : ''
+          } ${animating === name ? 'bg-blue-200' : ''}`}
+          role="list"
+          aria-label={name}
+        >
+          <h2 className="mb-2 font-bold text-lg text-gray-800">{name}</h2>
+          {groups[name].map((task) => (
+            <div
+              key={task.id}
+              draggable
+              onDragStart={handleDragStart(name, task)}
+              className={`mb-2 p-2 rounded shadow ${
+                priorityColors[task.priority]
+              } ${
+                !prefersReducedMotion.current
+                  ? 'transition-transform duration-300'
+                  : ''
+              }`}
+              role="listitem"
+            >
+              {task.title}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export const displayTodoist = () => {
-    return <Todoist />;
+  return <Todoist />;
 };
+

--- a/components/apps/todoist.worker.js
+++ b/components/apps/todoist.worker.js
@@ -1,0 +1,17 @@
+self.onmessage = (e) => {
+  const { groups, from, to, id } = e.data || {};
+  const newGroups = {
+    ...groups,
+    [from]: [...groups[from]],
+    [to]: [...groups[to]],
+  };
+  const index = newGroups[from].findIndex((t) => t.id === id);
+  if (index > -1) {
+    const [task] = newGroups[from].splice(index, 1);
+    newGroups[to].push(task);
+    self.postMessage({ groups: newGroups, taskTitle: task.title, to });
+  } else {
+    self.postMessage({ groups: newGroups });
+  }
+};
+


### PR DESCRIPTION
## Summary
- replace iframe Todoist with in-app drag-and-drop board
- color-code task priorities and animate column transitions respecting motion preferences
- offload moves to a Web Worker and announce updates via ARIA live region

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aeaeb2c81c83289aab5999ef98bd9a