### PR TITLE
feat(figlet): add accessible copy reset

### DIFF
--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -11,6 +11,7 @@ const FigletApp = () => {
   const [announce, setAnnounce] = useState('');
   const workerRef = useRef(null);
   const frameRef = useRef(null);
+  const announceTimer = useRef(null);
 
   useEffect(() => {
     workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
@@ -18,6 +19,7 @@ const FigletApp = () => {
     return () => {
       workerRef.current?.terminate();
       if (frameRef.current) cancelAnimationFrame(frameRef.current);
+      clearTimeout(announceTimer.current);
     };
   }, []);
 
@@ -37,6 +39,8 @@ const FigletApp = () => {
     if (output) {
       navigator.clipboard.writeText(output);
       setAnnounce('Copied to clipboard');
+      clearTimeout(announceTimer.current);
+      announceTimer.current = setTimeout(() => setAnnounce(''), 2000);
     }
   };
 


### PR DESCRIPTION
## Summary
- reset copy announcement after 2s so repeated copy actions are announced

## Testing
- `npm test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aecafa7a288328ae1d5260b3a3896e