### PR TITLE
feat(nikto): add radar chart clustering

### DIFF
--- a/components/apps/nikto/nikto.worker.js
+++ b/components/apps/nikto/nikto.worker.js
@@ -9,7 +9,9 @@ const categories = {
 self.onmessage = (e) => {
   const { text } = e.data;
   const lines = text.split(/\r?\n/).filter((l) => l.trim());
-  const findings = lines.map((line) => {
+  const clusters = {};
+
+  lines.forEach((line) => {
     let category = 'Other';
     for (const [key, regex] of Object.entries(categories)) {
       if (regex.test(line)) {
@@ -17,11 +19,12 @@ self.onmessage = (e) => {
         break;
       }
     }
-    return { category, line };
+    if (!clusters[category]) {
+      clusters[category] = { count: 0, proofs: [] };
+    }
+    clusters[category].count += 1;
+    clusters[category].proofs.push(line);
   });
-  const clusterCounts = findings.reduce((acc, f) => {
-    acc[f.category] = (acc[f.category] || 0) + 1;
-    return acc;
-  }, {});
-  postMessage({ findings, clusterCounts });
+
+  postMessage({ clusters });
 };


### PR DESCRIPTION
## Summary
- cluster nikto findings in a web worker and expose proof snippets
- render radar chart of finding categories with reduced-motion animation
- list grouped proof snippets with accessible contrast and live updates

## Testing
- `yarn test` (fails: TextEncoder is not defined, CandyCrushApp is not defined)
- `yarn lint` (fails: react-hooks/rules-of-hooks)


------
https://chatgpt.com/codex/tasks/task_e_68aecb01021083289546e81ebd1275a1