### PR TITLE
feat(nessus): add accessible host bubble chart

### DIFF
--- a/components/apps/nessus/filter.worker.js
+++ b/components/apps/nessus/filter.worker.js
@@ -1,0 +1,13 @@
+const scaleRadius = (cvss) => cvss * 5;
+
+self.onmessage = (e) => {
+  const { hosts = [], filter = 'All' } = e.data || {};
+  const filtered =
+    filter === 'All' ? hosts : hosts.filter((h) => h.severity === filter);
+  const processed = filtered.map((h, i) => ({
+    ...h,
+    radius: scaleRadius(h.cvss),
+    index: i,
+  }));
+  self.postMessage(processed);
+};


### PR DESCRIPTION
## Summary
- add Web Worker powered host bubble chart for Nessus data
- filter by severity with accessible pills and live region updates
- respect reduced motion preferences and color contrast

## Testing
- `npm test -- __tests__/calculator.app.test.js` (fails: TextEncoder is not defined)
- `npm test -- __tests__/snake.config.test.ts` (fails: CandyCrushApp is not defined)
- `npm test -- __tests__/frogger.config.test.ts` (fails: CandyCrushApp is not defined)
- `npm run lint` (errors: react-hooks/rules-of-hooks in useGameControls.js)

------
https://chatgpt.com/codex/tasks/task_e_68aecb03e7648328a8c2b9f24d13ffeb