### PR TITLE
feat: add accessible hydra credential stepper

### DIFF
--- a/components/apps/hydra/Stepper.js
+++ b/components/apps/hydra/Stepper.js
@@ -24,7 +24,16 @@ const Stepper = ({
       window.matchMedia &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    let delay = prefersReducedMotion ? 0 : 500;
+    if (prefersReducedMotion) {
+      const final = Math.min(lockoutThreshold, totalAttempts);
+      setAttempt(final);
+      if (final >= lockoutThreshold) {
+        setLocked(true);
+      }
+      return;
+    }
+
+    let delay = 500;
 
     const tick = () => {
       requestAnimationFrame(() => {
@@ -37,7 +46,7 @@ const Stepper = ({
             }
             return final;
           }
-          if (!prefersReducedMotion && next >= backoffThreshold) {
+          if (next >= backoffThreshold) {
             delay = Math.min(delay * 2, 4000);
           }
           timerRef.current = setTimeout(tick, delay);
@@ -63,12 +72,12 @@ const Stepper = ({
           <div
             key={i}
             className={`w-4 h-4 rounded ${
-              i < attempt ? 'bg-green-400' : 'bg-gray-600'
+              i < attempt ? 'bg-green-400' : 'bg-gray-500'
             }`}
           />
         ))}
       </div>
-      <div className="sr-only" aria-live="polite">
+      <div className="sr-only" role="status" aria-live="polite">
         {locked ? 'Locked out' : `Attempt ${attempt} of ${lockoutThreshold}`}
       </div>
       {locked ? (


### PR DESCRIPTION
## Summary
- enhance hydra stepper to respect reduced motion
- improve contrast and aria live updates for lockout/backoff visualization

## Testing
- `npm test` *(fails: ReferenceError: TextEncoder is not defined; CandyCrushApp not defined)*
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb05b0d483288e0989c2a26b6d6a