### PR TITLE
Add merge ripple and score animation to 2048

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -446,6 +446,38 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 }
 
+@keyframes merge-ripple {
+    from { transform: scale(0); opacity: 0.5; }
+    to { transform: scale(3); opacity: 0; }
+}
+
+.merge-ripple {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: rgba(255, 255, 255, 0.5);
+    pointer-events: none;
+    animation: merge-ripple 0.4s ease-out;
+}
+
+@keyframes score-pop {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+}
+
+.score-pop {
+    display: inline-block;
+    animation: score-pop 0.3s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .merge-ripple,
+    .tile-pop,
+    .score-pop {
+        animation: none;
+    }
+}
+
 @keyframes pad-pulse {
     0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.6); }
     50% { box-shadow: 0 0 20px 5px rgba(255, 255, 255, 0.2); }


### PR DESCRIPTION
## Summary
- add ripple effect on tile merges
- animate score changes and track score with ARIA live updates
- honor motion preferences and use requestAnimationFrame for animation cleanup

## Testing
- `npm test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb0f49188328b0142d6f78fdc6ef