### PR TITLE
feat(chess): add accessible evaluation bar

### DIFF
--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -281,6 +281,8 @@ const ChessGame = () => {
   const [evalScore, setEvalScore] = useState(0);
   const [displayEval, setDisplayEval] = useState(0);
   const reduceMotionRef = useRef(false);
+  const evalPercent =
+    (1 / (1 + Math.exp(-displayEval / 200))) * 100;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -497,10 +499,16 @@ const ChessGame = () => {
       </div>
       <div className="mt-2">{status}</div>
       <div className="mt-2 w-full max-w-xs" aria-label="Evaluation">
-        <div className="h-4 bg-gray-700">
+        <div
+          className="h-4 bg-gray-700"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={evalPercent.toFixed(0)}
+        >
           <div
-            className={`h-full ${displayEval >= 0 ? 'bg-green-500' : 'bg-red-500'}`}
-            style={{ width: `${(1 / (1 + Math.exp(-displayEval / 200))) * 100}%` }}
+            className={`h-full ${displayEval >= 0 ? 'bg-green-600' : 'bg-red-600'}`}
+            style={{ width: `${evalPercent}%` }}
           />
         </div>
         <div className="mt-1 text-sm" aria-live="polite">


### PR DESCRIPTION
## Summary
- add progressbar semantics and higher-contrast colors to chess evaluation bar
- animate evaluation updates with requestAnimationFrame while respecting reduced-motion prefs

## Testing
- `npm test` *(fails: CandyCrushApp is not defined, TextEncoder is not defined)*
- `npm run lint` *(fails: React Hook useEffect is called conditionally, missing dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb14c9ec8328873ba2d3604958ae