### PR TITLE
feat: add parallax and landing effects to platformer

### DIFF
--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -5,6 +5,7 @@ import {
   updatePhysics,
   collectCoin,
   movePlayer,
+  GRAVITY,
 } from '../../public/apps/platformer/engine.js';
 
 const TILE_SIZE = 16;
@@ -29,11 +30,13 @@ function playCoinSound() {
 const Platformer = () => {
   const canvasRef = useRef(null);
   const resetRef = useRef(() => {});
+  const reduceMotion = useRef(false);
 
   const [levels, setLevels] = useState([]);
   const [levelData, setLevelData] = useState(null);
   const [paused, setPaused] = useState(false);
   const [sound, setSound] = useState(true);
+  const [ariaMsg, setAriaMsg] = useState('');
 
   const [progress, setProgress] = usePersistentState(
     'platformer-progress',
@@ -60,6 +63,16 @@ const Platformer = () => {
       .then((data) => setLevelData(data));
   }, [levels, progress.level]);
 
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduceMotion.current = mq.matches;
+    const handler = () => {
+      reduceMotion.current = mq.matches;
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
   // main game loop
   useEffect(() => {
     if (!levelData) return;
@@ -73,6 +86,21 @@ const Platformer = () => {
     player.x = spawn.x;
     player.y = spawn.y;
     let score = 0;
+    let wasOnGround = true;
+    let particles = [];
+    const bgLayers = [
+      { speed: 15, stars: [] },
+      { speed: 30, stars: [] },
+    ];
+    const bgOffsets = [0, 0];
+    const genStars = (count) =>
+      Array.from({ length: count }, () => ({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        size: Math.random() * 2 + 1,
+      }));
+    bgLayers[0].stars = genStars(40);
+    bgLayers[1].stars = genStars(20);
 
     const keys = {};
     const handleDown = (e) => {
@@ -108,8 +136,42 @@ const Platformer = () => {
         right: keys['ArrowRight'],
         jump: keys['Space'],
       };
+      const vyBefore = player.vy;
       updatePhysics(player, input, dt);
       movePlayer(player, tiles, TILE_SIZE, dt);
+
+      if (
+        player.onGround &&
+        !wasOnGround &&
+        vyBefore > 200 &&
+        !reduceMotion.current
+      ) {
+        for (let i = 0; i < 6; i++) {
+          particles.push({
+            x: player.x + player.w / 2,
+            y: player.y + player.h,
+            vx: (Math.random() - 0.5) * 100,
+            vy: -Math.random() * 100,
+            life: 0.3,
+          });
+        }
+      }
+      wasOnGround = player.onGround;
+
+      if (!reduceMotion.current) {
+        particles = particles
+          .map((p) => ({
+            ...p,
+            life: p.life - dt,
+            x: p.x + p.vx * dt,
+            y: p.y + p.vy * dt,
+            vy: p.vy + GRAVITY * dt * 0.5,
+          }))
+          .filter((p) => p.life > 0);
+        bgOffsets.forEach((o, i) => {
+          bgOffsets[i] = (o + bgLayers[i].speed * dt) % canvas.width;
+        });
+      }
 
       // fall out of world
       if (player.y > levelData.height * TILE_SIZE) respawn();
@@ -119,6 +181,7 @@ const Platformer = () => {
 
       if (collectCoin(tiles, cx, cy)) {
         score++;
+        setAriaMsg(`Score ${score}`);
         if (sound) playCoinSound();
         if (score > progress.highscore)
           setProgress((p) => ({ ...p, highscore: score }));
@@ -135,6 +198,17 @@ const Platformer = () => {
 
     const draw = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      if (!reduceMotion.current) {
+        bgLayers.forEach((layer, i) => {
+          ctx.fillStyle = i === 0 ? '#111' : '#222';
+          layer.stars.forEach((star) => {
+            const x = (star.x - bgOffsets[i] + canvas.width) % canvas.width;
+            ctx.fillRect(x, star.y, star.size, star.size);
+          });
+        });
+      }
       for (let y = 0; y < levelData.height; y++) {
         for (let x = 0; x < levelData.width; x++) {
           const t = tiles[y][x];
@@ -157,6 +231,13 @@ const Platformer = () => {
       }
       ctx.fillStyle = 'white';
       ctx.fillRect(player.x, player.y, player.w, player.h);
+      if (!reduceMotion.current) {
+        particles.forEach((p) => {
+          ctx.globalAlpha = p.life / 0.3;
+          ctx.fillRect(p.x, p.y, 4, 4);
+          ctx.globalAlpha = 1;
+        });
+      }
       ctx.fillStyle = 'white';
       ctx.font = '12px monospace';
       ctx.fillText(`Score: ${score} Hi: ${progress.highscore || 0}`, 4, 12);
@@ -214,6 +295,7 @@ const Platformer = () => {
           Sound: {sound ? 'On' : 'Off'}
         </button>
       </div>
+      <div aria-live="polite" className="sr-only">{ariaMsg}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add parallax starfield background with reduced-motion fallbacks
- create dust puff particles when the player lands
- announce score changes via ARIA live region for assistive tech

## Testing
- `yarn lint` *(fails: React Hook errors in unrelated files)*
- `yarn test` *(fails: TextEncoder not defined; CandyCrushApp not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb1ab7108328a286aa0a04d7e2a4