### PR TITLE
Improve accessibility with roles and keyboard navigation

### DIFF
--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -1,9 +1,9 @@
-const { JSDOM } = require('jsdom');
 const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
 
 function setupDom() {
-  global.TextEncoder = TextEncoder;
-  global.TextDecoder = TextDecoder;
   const dom = new JSDOM(
     `<!DOCTYPE html><html><body>
       <input id="display" />

--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -61,7 +61,7 @@ describe('YouTubeApp', () => {
     const user = userEvent.setup();
     render(<YouTubeApp initialVideos={mockVideos} />);
     expect(screen.getAllByTestId('video-card')).toHaveLength(3);
-    await user.click(screen.getByRole('button', { name: 'Dev' }));
+    await user.click(screen.getByRole('tab', { name: 'Dev' }));
     expect(screen.getAllByTestId('video-card')).toHaveLength(2);
     expect(screen.queryByText('Cooking with React')).not.toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe('YouTubeApp', () => {
     render(<YouTubeApp initialVideos={mockVideos} />);
 
     // Filter to a category with multiple videos then change sort order
-    await user.click(screen.getByRole('button', { name: 'Dev' }));
+    await user.click(screen.getByRole('tab', { name: 'Dev' }));
     const getTitles = () =>
       screen.getAllByRole('link').map((a) => a.textContent);
 
@@ -139,7 +139,7 @@ describe('YouTubeApp', () => {
   it('category buttons include transition-colors class', () => {
     render(<YouTubeApp initialVideos={mockVideos} />);
     screen
-      .getAllByRole('button')
+      .getAllByRole('tab')
       .forEach((btn) => expect(btn).toHaveClass('transition-colors'));
   });
 

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 const CHANNEL_HANDLE = 'Alex-Unnippillil';
 
@@ -27,6 +28,7 @@ export default function YouTubeApp({ initialVideos = [] }) {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const playerRef = useRef(null);
   const containerRef = useRef(null);
+  const tabListRef = useRef(null);
   const progressRaf = useRef();
   const scrollRaf = useRef();
 
@@ -187,6 +189,8 @@ export default function YouTubeApp({ initialVideos = [] }) {
       player?.destroy();
     };
   }, [currentVideo, prefersReducedMotion]);
+
+  useRovingTabIndex(tabListRef, true, 'horizontal');
 
   // Dock the player as a mini version when scrolled out of view
   useEffect(() => {
@@ -362,11 +366,18 @@ export default function YouTubeApp({ initialVideos = [] }) {
           </div>
 
           {/* Category tabs */}
-          <div className="overflow-x-auto px-3 pb-2 flex flex-wrap gap-2">
+          <div
+            className="overflow-x-auto px-3 pb-2 flex flex-wrap gap-2"
+            role="tablist"
+            ref={tabListRef}
+          >
             {categories.map((cat) => (
               <button
                 key={cat}
                 onClick={() => handleCategoryClick(cat)}
+                role="tab"
+                aria-selected={activeCategory === cat}
+                tabIndex={activeCategory === cat ? 0 : -1}
                 className={`px-3 py-1 rounded-full text-sm whitespace-nowrap transition-colors ${
                   activeCategory === cat
                     ? 'bg-red-600 text-white'

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -165,6 +165,14 @@ export class Window extends Component {
         });
     }
 
+    handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            this.closeWindow();
+        } else if (e.key === 'Tab') {
+            this.focusWindow();
+        }
+    }
+
     render() {
         return (
             <Draggable
@@ -179,9 +187,14 @@ export class Window extends Component {
                 defaultPosition={{ x: this.startX, y: this.startY }}
                 bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
             >
-                <div style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                <div
+                    style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
                     className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                     id={this.id}
+                    role="dialog"
+                    aria-label={this.props.title}
+                    tabIndex={0}
+                    onKeyDown={this.handleKeyDown}
                 >
                     {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                     {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,9 +1,17 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)
     useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
 
     return (
         <div
@@ -11,6 +19,7 @@ function DefaultMenu(props) {
             role="menu"
             aria-hidden={!props.active}
             ref={menuRef}
+            onKeyDown={handleKeyDown}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -534,7 +534,7 @@ export class Desktop extends Component {
 
                 {/* Context Menus */}
                 <DesktopMenu active={this.state.context_menus.desktop} openApp={this.openApp} addNewFolder={this.addNewFolder} />
-                <DefaultMenu active={this.state.context_menus.default} />
+                <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
 
                 {/* Folder Input Name Bar */}
                 {

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+/**
+ * Enables roving tab index and arrow key navigation within a container.
+ * Elements inside the container that have role="tab" or role="menuitem"
+ * will participate in the roving behaviour.
+ */
+export default function useRovingTabIndex(
+  ref: React.RefObject<HTMLElement>,
+  active: boolean = true,
+  orientation: 'horizontal' | 'vertical' = 'horizontal'
+) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || !active) return;
+
+    const items = Array.from(
+      node.querySelectorAll<HTMLElement>('[role="tab"], [role="menuitem"]')
+    );
+    if (items.length === 0) return;
+
+    let index = items.findIndex((el) => el.tabIndex === 0);
+    if (index === -1) index = 0;
+    items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+
+    const handleKey = (e: KeyboardEvent) => {
+      const forward = orientation === 'horizontal' ? ['ArrowRight', 'ArrowDown'] : ['ArrowDown'];
+      const backward = orientation === 'horizontal' ? ['ArrowLeft', 'ArrowUp'] : ['ArrowUp'];
+      if (forward.includes(e.key)) {
+        e.preventDefault();
+        index = (index + 1) % items.length;
+        items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+        items[index].focus();
+      } else if (backward.includes(e.key)) {
+        e.preventDefault();
+        index = (index - 1 + items.length) % items.length;
+        items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+        items[index].focus();
+      }
+    };
+
+    node.addEventListener('keydown', handleKey);
+    return () => {
+      node.removeEventListener('keydown', handleKey);
+    };
+  }, [ref, active, orientation]);
+}


### PR DESCRIPTION
## Summary
- add reusable roving tab index hook for keyboard arrow navigation
- mark windows and menus with appropriate roles and escape handling
- convert YouTube category buttons into accessible tablist

## Testing
- `npm test` *(fails: localStorage unavailable in calculator.app.test.js; CandyCrushApp is not defined in frogger.config.test.ts and snake.config.test.ts)*
- `npm run lint` *(fails: React hook rule violations in useGameControls.js)*
- `npx -y lighthouse http://localhost:3000 --only-categories=accessibility --quiet --chrome-flags="--headless"` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2c86c248328af12592710cd559a