### PR TITLE
feat: add theme and accent settings

### DIFF
--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -18,7 +18,8 @@ function setupDom() {
       <div id="history"></div>
       <div id="paren-indicator"></div>
       <button id="print-tape"></button>
-    </body></html>`
+    </body></html>`,
+    { url: 'https://example.org' }
   );
   global.window = dom.window;
   global.document = dom.window.document;

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
-import { setWallpaper, resetSettings } from '../../utils/settingsStore';
+import { setWallpaper, resetSettings, getAccent, setAccent as saveAccent } from '../../utils/settingsStore';
 
 export function Settings(props) {
     const { theme, setTheme } = useTheme();
-    const [accent, setAccent] = useState('#4f46e5');
+    const [accent, setAccent] = useState(() => getAccent());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -62,23 +62,30 @@ export function Settings(props) {
                 liveRegion.current.textContent = msg;
             }
         });
+        document.documentElement.style.setProperty('--color-accent', accent);
+        document.documentElement.style.setProperty('--color-accent-foreground', accentText());
+        saveAccent(accent);
         return () => cancelAnimationFrame(raf);
     }, [accent, theme]);
+
+    const toggleTheme = () => {
+        const order = ['light', 'dark', 'system'];
+        const next = order[(order.indexOf(theme) + 1) % order.length];
+        setTheme(next);
+    };
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(${wallpapers[props.currBgImgName]})`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
-            <div className="flex justify-center my-4">
+            <div className="flex justify-center my-4 items-center">
                 <label className="mr-2 text-ubt-grey">Theme:</label>
-                <select
-                    value={theme}
-                    onChange={(e) => setTheme(e.target.value)}
+                <button
+                    onClick={toggleTheme}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="dark">Dark</option>
-                    <option value="light">Light</option>
-                </select>
+                    {theme.charAt(0).toUpperCase() + theme.slice(1)}
+                </button>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
@@ -91,15 +98,9 @@ export function Settings(props) {
                 />
             </div>
             <div className="flex justify-center my-4">
-                <div
-                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: theme === 'dark' ? '#000000' : '#ffffff', color: theme === 'dark' ? '#ffffff' : '#000000' }}
-                >
+                <div className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none bg-white text-black dark:bg-black dark:text-white">
                     <p className="mb-2 text-center">Preview</p>
-                    <button
-                        className="px-2 py-1 rounded"
-                        style={{ backgroundColor: accent, color: accentText() }}
-                    >
+                    <button className="px-2 py-1 rounded bg-accent text-accent-foreground">
                         Accent
                     </button>
                     <p className={`mt-2 text-sm text-center ${contrast >= 4.5 ? 'text-green-400' : 'text-red-400'}`}>

--- a/hooks/useTheme.tsx
+++ b/hooks/useTheme.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, ReactNode, useState } from 'react';
-import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/settingsStore';
+import { getTheme as loadTheme, setTheme as saveTheme, getAccent } from '../utils/settingsStore';
 
-type Theme = 'light' | 'dark';
+type Theme = 'light' | 'dark' | 'system';
 
 interface ThemeContextValue {
   theme: Theme;
@@ -9,23 +9,71 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: 'dark',
+  theme: 'system',
   setTheme: () => {},
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof document !== 'undefined' && document.documentElement.dataset.theme) {
-      return document.documentElement.dataset.theme as Theme;
-    }
-    return loadTheme() as Theme;
-  });
+  const [theme, setTheme] = useState<Theme>(() => loadTheme() as Theme);
 
   useEffect(() => {
-    if (typeof document !== 'undefined') {
-      document.documentElement.dataset.theme = theme;
-    }
+    if (typeof document === 'undefined') return;
+    const accent = getAccent();
+    const root = document.documentElement;
+    const hexToRgb = (hex: string) => {
+      const h = hex.replace('#', '');
+      const bigint = parseInt(h, 16);
+      return {
+        r: (bigint >> 16) & 255,
+        g: (bigint >> 8) & 255,
+        b: bigint & 255,
+      };
+    };
+    const luminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
+      const a = [r, g, b].map(v => {
+        v = v / 255;
+        return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      });
+      return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+    };
+    const contrast = (hex1: string, hex2: string) => {
+      const l1 = luminance(hexToRgb(hex1)) + 0.05;
+      const l2 = luminance(hexToRgb(hex2)) + 0.05;
+      return l1 > l2 ? l1 / l2 : l2 / l1;
+    };
+    const accentText = contrast(accent, '#000000') > contrast(accent, '#ffffff') ? '#000000' : '#ffffff';
+    root.style.setProperty('--color-accent', accent);
+    root.style.setProperty('--color-accent-foreground', accentText);
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const apply = (t: Theme) => {
+      const resolved = t === 'system'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : t;
+      root.classList.remove('light', 'dark');
+      root.classList.add(resolved);
+      root.dataset.theme = resolved;
+    };
+    apply(theme);
     saveTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = () => {
+      if (theme === 'system') {
+        const root = document.documentElement;
+        root.classList.remove('light', 'dark');
+        root.classList.add(media.matches ? 'dark' : 'light');
+        root.dataset.theme = media.matches ? 'dark' : 'light';
+      }
+    };
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
   }, [theme]);
 
   return (

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
 
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient
@@ -14,6 +15,22 @@ class ImageMock {
 
 // @ts-ignore - allow overriding the global Image for the test env
 global.Image = ImageMock as unknown as typeof Image;
+
+// Polyfill TextEncoder/TextDecoder for node < 11
+// @ts-ignore
+if (typeof global.TextEncoder === 'undefined') global.TextEncoder = TextEncoder;
+// @ts-ignore
+if (typeof global.TextDecoder === 'undefined') global.TextDecoder = TextDecoder as any;
+
+// Ensure localStorage is available for tests that rely on it
+// @ts-ignore
+if (typeof global.localStorage === 'undefined') {
+  const { JSDOM } = require('jsdom');
+  const { window } = new JSDOM('', { url: 'https://example.org' });
+  global.window = window as any;
+  global.document = window.document as any;
+  global.localStorage = window.localStorage as any;
+}
 
 // Provide a minimal canvas mock so libraries like xterm.js can run under JSDOM
 // @ts-ignore

--- a/styles/index.css
+++ b/styles/index.css
@@ -23,6 +23,8 @@
     --color-ub-dark-grey: #555555;
     --color-bg: #111111;
     --color-text: #F6F6F5;
+    --color-accent: #4f46e5;
+    --color-accent-foreground: #ffffff;
 }
 
 [data-theme='light'] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   mode: 'jit',
+  darkMode: 'class',
   content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
@@ -25,6 +26,10 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        accent: {
+          DEFAULT: 'var(--color-accent)',
+          foreground: 'var(--color-accent-foreground)',
+        },
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,5 +1,6 @@
 const DEFAULT_SETTINGS = {
-  theme: 'dark',
+  theme: 'system',
+  accent: '#4f46e5',
   wallpaper: 'wall-2',
 };
 
@@ -11,6 +12,16 @@ export function getTheme() {
 export function setTheme(theme) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('theme', theme);
+}
+
+export function getAccent() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  return window.localStorage.getItem('accent') || DEFAULT_SETTINGS.accent;
+}
+
+export function setAccent(accent) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('accent', accent);
 }
 
 export function getWallpaper() {


### PR DESCRIPTION
## Summary
- use class-based dark mode with accent color tokens
- persist theme, accent, and wallpaper in settings store
- add settings toggle with live accent preview

## Testing
- `yarn test` *(fails: TypeError: Cannot read properties of null (reading 'addEventListener') in calculator.app.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aedcc61ea083288cb94622d53cc28b