### PR TITLE
Add calculator tape, keyboard input, and memory functions

### DIFF
--- a/__tests__/calc.test.tsx
+++ b/__tests__/calc.test.tsx
@@ -20,5 +20,30 @@ describe('Calc component', () => {
     fireEvent.click(getByText('='));
     expect(getByTestId('calc-display').textContent).toBe('Invalid Expression');
   });
+
+  it('logs to tape and supports memory functions', () => {
+    const { getByText, getByTestId } = render(<Calc />);
+    fireEvent.click(getByText('5'));
+    fireEvent.click(getByText('M+'));
+    fireEvent.click(getByText('C'));
+    fireEvent.click(getByText('MR'));
+    expect(getByTestId('calc-display').textContent).toBe('5');
+
+    fireEvent.click(getByText('+'));
+    fireEvent.click(getByText('1'));
+    fireEvent.click(getByText('='));
+    expect(getByTestId('calc-tape').textContent).toContain('5+1 = 6');
+  });
+
+  it('handles keyboard input', () => {
+    const { getByTestId } = render(<Calc />);
+    fireEvent.keyDown(window, { key: '1' });
+    fireEvent.keyDown(window, { key: '+' });
+    fireEvent.keyDown(window, { key: '1' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(getByTestId('calc-display').textContent).toBe('2');
+    fireEvent.keyDown(window, { key: 'Backspace' });
+    expect(getByTestId('calc-display').textContent).toBe('');
+  });
 });
 

--- a/components/apps/calc/Tape.tsx
+++ b/components/apps/calc/Tape.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface TapeEntry {
+  expr: string;
+  result: string;
+}
+
+interface Props {
+  entries: TapeEntry[];
+  onClear: () => void;
+}
+
+const Tape: React.FC<Props> = ({ entries, onClear }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [entries]);
+
+  return (
+    <div className="w-48 ml-4 flex flex-col">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-bold">Tape</span>
+        <button
+          aria-label="clear tape"
+          onClick={onClear}
+          className="px-2 py-1 bg-gray-800 hover:bg-gray-700 rounded text-sm"
+        >
+          Clear
+        </button>
+      </div>
+      <div
+        ref={ref}
+        data-testid="calc-tape"
+        className="flex-1 overflow-y-auto bg-gray-800 rounded p-2 text-sm"
+      >
+        {entries.map((entry, idx) => (
+          <div key={idx} className="mb-1">
+            {entry.expr} = {entry.result}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Tape;


### PR DESCRIPTION
## Summary
- add `Tape` side panel component that auto-scrolls and records expression/result pairs
- support keyboard input for digits, operations, Enter, and Backspace
- introduce persistent M+, M-, MR memory buttons

## Testing
- `npx jest __tests__/calc.test.tsx --verbose`
- `npx jest __tests__/calc.test.ts --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68aedcc75058832899f6740f4da76244