### PR TITLE
feat: add VSCode editor with monaco

### DIFF
--- a/__mocks__/monaco-editor.js
+++ b/__mocks__/monaco-editor.js
@@ -1,0 +1,6 @@
+const editorInstance = { dispose: jest.fn() };
+export const editor = {
+  create: jest.fn(() => editorInstance),
+  setTheme: jest.fn(),
+};
+export default { editor };

--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -19,6 +19,7 @@ function setupDom() {
       <div id="paren-indicator"></div>
       <button id="print-tape"></button>
     </body></html>`
+  , { url: "http://localhost" }
   );
   global.window = dom.window;
   global.document = dom.window.document;

--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -1,30 +1,38 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import VsCode from '../components/apps/vscode';
+import { ThemeProvider } from '../hooks/useTheme';
 
-describe('VsCode app', () => {
-  it('renders external frame', () => {
-    render(<VsCode />);
-    const frame = screen.getByTitle('VsCode');
-    expect(frame.tagName).toBe('IFRAME');
-    expect(screen.queryByRole('alert')).toBeNull();
-  });
+jest.mock('monaco-editor');
 
-  it('shows banner when cookies are blocked', async () => {
-    const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
-    Object.defineProperty(document, 'cookie', {
-      configurable: true,
-      get: () => '',
-      set: () => {},
-    });
-
-    render(<VsCode />);
-    const alert = await screen.findByRole('alert');
-    expect(alert).toBeInTheDocument();
-
-    if (original) {
-      Object.defineProperty(document, 'cookie', original);
-    }
-  });
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ text: () => Promise.resolve('file content') })
+  ) as any;
 });
 
+afterEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+});
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('VsCode app', () => {
+  it('renders file tree from samples', () => {
+    renderWithTheme(<VsCode />);
+    expect(screen.getByText('hello.ts')).toBeInTheDocument();
+    expect(screen.getByText('README.md')).toBeInTheDocument();
+  });
+
+  it('opens multiple files in tabs', async () => {
+    renderWithTheme(<VsCode />);
+    fireEvent.click(screen.getByText('hello.ts'));
+    await waitFor(() => screen.getByRole('tab', { name: 'hello.ts' }));
+    fireEvent.click(screen.getByText('README.md'));
+    await waitFor(() => screen.getByRole('tab', { name: 'README.md' }));
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(2);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -50,6 +50,7 @@ const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
 const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
+const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 

--- a/components/apps/VSCode/Editor.tsx
+++ b/components/apps/VSCode/Editor.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import { useTheme } from '../../../hooks/useTheme';
+
+interface EditorProps {
+  path: string;
+  content: string;
+}
+
+export default function Editor({ path, content }: EditorProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const monacoRef = useRef<any>(null);
+  const editorRef = useRef<any>(null);
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    let disposed = false;
+    async function load() {
+      const monaco = await import('monaco-editor');
+      monacoRef.current = monaco;
+      if (disposed || !containerRef.current) return;
+      editorRef.current = monaco.editor.create(containerRef.current, {
+        value: content,
+        language: languageFromPath(path),
+        readOnly: true,
+        automaticLayout: true,
+        theme: theme === 'dark' ? 'vs-dark' : 'vs-light',
+      });
+    }
+    load();
+    return () => {
+      disposed = true;
+      if (editorRef.current) {
+        editorRef.current.dispose();
+      }
+    };
+  }, [path, content]);
+
+  useEffect(() => {
+    if (monacoRef.current) {
+      monacoRef.current.editor.setTheme(theme === 'dark' ? 'vs-dark' : 'vs-light');
+    }
+  }, [theme]);
+
+  return <div className="h-full w-full" ref={containerRef} />;
+}
+
+function languageFromPath(path: string) {
+  const ext = path.split('.').pop();
+  switch (ext) {
+    case 'ts':
+      return 'typescript';
+    case 'js':
+      return 'javascript';
+    case 'json':
+      return 'json';
+    case 'md':
+      return 'markdown';
+    case 'html':
+      return 'html';
+    case 'css':
+      return 'css';
+    default:
+      return 'plaintext';
+  }
+}

--- a/components/apps/VSCode/index.tsx
+++ b/components/apps/VSCode/index.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import Editor from './Editor';
+
+interface TreeNode {
+  name: string;
+  path?: string;
+  children?: TreeNode[];
+}
+
+function loadSamplePaths(): string[] {
+  // Browser build using webpack context
+  if (typeof window !== 'undefined' && (require as any).context) {
+    try {
+      const req = (require as any).context('../../../public/samples', true, /.+/);
+      return req.keys().map((k: string) => k.replace('./', ''));
+    } catch {
+      return [];
+    }
+  }
+  // Node/test environment
+  try {
+    const fs = eval('require')('fs');
+    const path = eval('require')('path');
+    const base = path.join(process.cwd(), 'public', 'samples');
+    if (!fs.existsSync(base)) return [];
+    const walk = (dir: string): string[] =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry: any) => {
+        const res = path.join(dir, entry.name);
+        return entry.isDirectory() ? walk(res) : [res];
+      });
+    return walk(base).map((p) => p.replace(base + path.sep, ''));
+  } catch {
+    return [];
+  }
+}
+
+const samplePaths = loadSamplePaths();
+
+function buildTree(paths: string[]): TreeNode[] {
+  const root: TreeNode[] = [];
+  for (const file of paths) {
+    const parts = file.split('/');
+    let current = root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      let node = current.find((n) => n.name === part);
+      if (!node) {
+        node = { name: part };
+        if (i === parts.length - 1) {
+          node.path = file;
+        } else {
+          node.children = [];
+        }
+        current.push(node);
+      }
+      if (node.children) {
+        current = node.children;
+      }
+    }
+  }
+  return root;
+}
+
+const fileTree = buildTree(samplePaths);
+
+export default function VSCode() {
+  const [openFiles, setOpenFiles] = useState<{ path: string; content: string }[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+
+  async function openFile(path: string) {
+    const existing = openFiles.find((f) => f.path === path);
+    if (existing) {
+      setActive(path);
+      return;
+    }
+    const res = await fetch(`/samples/${path}`);
+    const text = await res.text();
+    setOpenFiles([...openFiles, { path, content: text }]);
+    setActive(path);
+  }
+
+  return (
+    <div className="flex h-full w-full">
+      <aside className="w-48 overflow-auto border-r border-gray-300 dark:border-gray-700 text-xs">
+        <FileTree nodes={fileTree} onOpen={openFile} />
+      </aside>
+      <section className="flex-1 flex flex-col">
+        <div className="flex space-x-2 border-b border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800" role="tablist">
+          {openFiles.map((file) => (
+            <button role="tab"
+              key={file.path}
+              className={`px-2 py-1 ${active === file.path ? 'bg-white dark:bg-gray-900' : ''}`}
+              onClick={() => setActive(file.path)}
+            >
+              {file.path.split('/').pop()}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1">
+          {active && (
+            <Editor
+              key={active}
+              path={active}
+              content={openFiles.find((f) => f.path === active)?.content || ''}
+            />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function FileTree({ nodes, onOpen }: { nodes: TreeNode[]; onOpen: (path: string) => void }) {
+  return (
+    <ul className="pl-2">
+      {nodes.map((node) => (
+        <li key={node.name} className="my-1">
+          {node.children ? (
+            <details open>
+              <summary>{node.name}</summary>
+              <FileTree nodes={node.children} onOpen={onOpen} />
+            </details>
+          ) : (
+            <button className="hover:underline" onClick={() => node.path && onOpen(node.path)}>
+              {node.name}
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,21 +1,10 @@
 import React from 'react';
-import ExternalFrame from '../ExternalFrame';
+import VSCode from './VSCode';
 
 export default function VsCode() {
-    return (
-        <ExternalFrame
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-            frameBorder="0"
-            prefetch={false}
-        />
-    );
+  return <VSCode />;
 }
 
 export const displayVsCode = () => {
-    return <VsCode />;
+  return <VsCode />;
 };
-

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(globalThis as any).TextEncoder = TextEncoder;
+(globalThis as any).TextDecoder = TextDecoder;
 
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jsqr": "^1.4.0",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
+    "monaco-editor": "^0.52.2",
     "next": "^15.0.0",
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",

--- a/public/samples/README.md
+++ b/public/samples/README.md
@@ -1,0 +1,1 @@
+# Sample File\nThis is a sample.

--- a/public/samples/hello.ts
+++ b/public/samples/hello.ts
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,6 +6078,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:^0.52.2":
+  version: 0.52.2
+  resolution: "monaco-editor@npm:0.52.2"
+  checksum: 10c0/5a92da64f1e2ab375c0ce99364137f794d057c97bed10ecc65a08d6e6846804b8ecbd377eacf01e498f7dfbe1b21e8be64f728256681448f0484df90e767b435
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -8273,6 +8280,7 @@ __metadata:
     jsqr: "npm:^1.4.0"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
+    monaco-editor: "npm:^0.52.2"
     next: "npm:^15.0.0"
     pdfjs-dist: "npm:^5.4.54"
     phaser: "npm:3.70.0"


### PR DESCRIPTION
## Summary
- integrate monaco-editor and dynamic theme-aware Editor
- build read-only file tree and multi-tab interface for `/public/samples`
- add sample files and tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aedcc841a083288741f153495839ec