### PR TITLE
Add resource monitor tiles for FPS, network and resource timings

### DIFF
--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,10 +1,15 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const ResourceMonitor = () => {
   const cpuRef = useRef(null);
   const memoryRef = useRef(null);
   const networkRef = useRef(null);
   const liveRef = useRef(null);
+  const [fps, setFps] = useState(0);
+  const [netInfo, setNetInfo] = useState({ type: '', downlink: 0 });
+  const [resources, setResources] = useState([]);
+  const [resourceSupported, setResourceSupported] = useState(true);
+  const [memoryInfo, setMemoryInfo] = useState(null);
 
   useEffect(() => {
     if (
@@ -33,11 +38,75 @@ const ResourceMonitor = () => {
     worker.onmessage = (e) => {
       const { cpu, memory, down, up } = e.data || {};
       if (liveRef.current) {
-        liveRef.current.textContent =
-          `CPU ${cpu.toFixed(1)}%, Memory ${memory.toFixed(1)}%, Download ${down.toFixed(1)} Mbps, Upload ${up.toFixed(1)} Mbps`;
+        const memText = memory === null ? 'Memory N/A' : `Memory ${memory.toFixed(1)}%`;
+        liveRef.current.textContent = `CPU ${cpu.toFixed(1)}%, ${memText}, Download ${down.toFixed(1)} Mbps, Upload ${up.toFixed(1)} Mbps`;
       }
     };
     return () => worker.terminate();
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let frame = 0;
+    let last = performance.now();
+    let raf;
+    const loop = (now) => {
+      frame++;
+      const delta = now - last;
+      if (delta >= 1000) {
+        setFps((frame * 1000) / delta);
+        frame = 0;
+        last = now;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    const update = () => {
+      if (!conn) {
+        setNetInfo({ type: 'N/A', downlink: 0 });
+        return;
+      }
+      setNetInfo({ type: conn.effectiveType || 'unknown', downlink: conn.downlink || 0 });
+    };
+    update();
+    conn && conn.addEventListener('change', update);
+    return () => conn && conn.removeEventListener('change', update);
+  }, []);
+
+  useEffect(() => {
+    if (typeof performance === 'undefined') return;
+    const update = () => {
+      if (performance && performance.memory) {
+        const { usedJSHeapSize, totalJSHeapSize } = performance.memory;
+        setMemoryInfo({ used: usedJSHeapSize, total: totalJSHeapSize });
+      } else {
+        setMemoryInfo(null);
+      }
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (typeof PerformanceObserver === 'undefined' || !PerformanceObserver.supportedEntryTypes?.includes('resource')) {
+      setResourceSupported(false);
+      return;
+    }
+    const observer = new PerformanceObserver((list) => {
+      const newEntries = list
+        .getEntries()
+        .map(({ name, duration }) => ({ name, duration }));
+      setResources((prev) => [...prev, ...newEntries].slice(-5));
+    });
+    observer.observe({ type: 'resource', buffered: true });
+    return () => observer.disconnect();
   }, []);
 
   return (
@@ -67,6 +136,40 @@ const ResourceMonitor = () => {
           aria-label="Network usage chart"
           className="bg-ub-dark-grey"
         />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-4 text-center text-sm">
+        <div className="bg-ub-dark-grey p-2" role="img" aria-label="Frames per second">
+          FPS: {fps.toFixed(1)}
+        </div>
+        <div className="bg-ub-dark-grey p-2" role="img" aria-label="Network status">
+          {netInfo.type ? `${netInfo.type} ${netInfo.downlink.toFixed(1)} Mbps` : 'Network: N/A'}
+        </div>
+        <div className="bg-ub-dark-grey p-2" role="img" aria-label="Memory usage">
+          {memoryInfo
+            ? `${(memoryInfo.used / 1048576).toFixed(1)} / ${(memoryInfo.total / 1048576).toFixed(1)} MB`
+            : 'Memory: N/A'}
+        </div>
+        <div
+          className="bg-ub-dark-grey p-2 overflow-y-auto"
+          role="img"
+          aria-label="Recent resource timings"
+        >
+          {resourceSupported ? (
+            resources.length ? (
+              <ul className="text-left">
+                {resources.map((r, i) => (
+                  <li key={i} className="truncate">
+                    {r.name} {r.duration.toFixed(1)}ms
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <span>No recent resources</span>
+            )
+          ) : (
+            <span>Resource timing unsupported</span>
+          )}
+        </div>
       </div>
       <div ref={liveRef} className="sr-only" aria-live="polite" role="status" />
     </div>

--- a/components/apps/resource_monitor.worker.js
+++ b/components/apps/resource_monitor.worker.js
@@ -28,7 +28,7 @@ function startSampling() {
     last = now;
     const cpu = Math.min(100, Math.max(0, (delay / 1000) * 100));
 
-    let memory = 0;
+    let memory = null;
     if (performance && performance.memory) {
       const { usedJSHeapSize, totalJSHeapSize } = performance.memory;
       memory = (usedJSHeapSize / totalJSHeapSize) * 100;
@@ -38,7 +38,7 @@ function startSampling() {
     const down = connection.downlink || 0;
     const up = connection.uplink || connection.upload || 0;
 
-    push(cpu, memory, down, up);
+    push(cpu, memory ?? 0, down, up);
     if (reduceMotion) draw();
     self.postMessage({ cpu, memory, down, up });
   }, 1000);


### PR DESCRIPTION
## Summary
- show FPS, network connection, memory and recent resource timings in resource monitor
- handle unsupported performance APIs and connection changes gracefully

## Testing
- `npm test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*
- `npm run lint` *(fails: React hook rules violations in useGameControls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aedcc9eb7c8328a28811fcc3886f99