### PR TITLE
feat: add YouTube video gallery

### DIFF
--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+
+interface Video {
+  id: string;
+  title: string;
+}
+
+const CHANNEL_ID = 'UCVuVDVmnoVuCS27U5rRsI_g'; // Kali Linux Official channel
+
+const VideoGallery: React.FC = () => {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [query, setQuery] = useState('');
+  const [playing, setPlaying] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchVideos = async () => {
+      try {
+        const res = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${CHANNEL_ID}`);
+        const text = await res.text();
+        const parser = new DOMParser();
+        const xml = parser.parseFromString(text, 'application/xml');
+        const entries = Array.from(xml.getElementsByTagName('entry'));
+        const vids: Video[] = entries.map((entry) => ({
+          id: entry.getElementsByTagName('yt:videoId')[0]?.textContent || '',
+          title: entry.getElementsByTagName('title')[0]?.textContent || '',
+        }));
+        setVideos(vids);
+      } catch (e) {
+        /* ignore errors */
+      }
+    };
+    fetchVideos();
+  }, []);
+
+  const filtered = videos.filter((v) =>
+    v.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <main className="p-4">
+      <input
+        type="text"
+        placeholder="Search videos..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="mb-4 w-full max-w-md px-3 py-2 border rounded"
+      />
+      {playing && (
+        <div className="mb-4 w-full max-w-2xl aspect-video">
+          <iframe
+            title="Selected video"
+            className="w-full h-full"
+            src={`https://www.youtube.com/embed/${playing}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {filtered.map((video) => (
+          <button
+            key={video.id}
+            type="button"
+            className="text-left"
+            onClick={() => setPlaying(video.id)}
+          >
+            <img
+              src={`https://img.youtube.com/vi/${video.id}/hqdefault.jpg`}
+              alt={video.title}
+              className="w-full"
+            />
+            <p className="mt-2 text-sm">{video.title}</p>
+          </button>
+        ))}
+      </div>
+    </main>
+  );
+};
+
+export default VideoGallery;
+


### PR DESCRIPTION
## Summary
- embed channel videos using iframe feed
- show grid of video cards with inline mini player
- add client-side search to filter video titles

## Testing
- `yarn lint` *(fails: react-hooks/rules-of-hooks in existing code)*
- `CI=1 yarn test` *(fails: SyntaxError in react-cytoscapejs and other existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aedccf4bdc83288cb7279d21ce014d