### PR TITLE
Extend converter with temperature and cached currency rates

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -8,7 +8,11 @@ describe('Unit conversion', () => {
   });
 
   it('converts kilograms to pounds', () => {
-    expect(convertUnit('weight', 'kilogram', 'pound', 1)).toBeCloseTo(2.20462, 5);
+    expect(convertUnit('mass', 'kilogram', 'pound', 1)).toBeCloseTo(2.20462, 5);
+  });
+
+  it('converts celsius to fahrenheit', () => {
+    expect(convertUnit('temperature', 'celsius', 'fahrenheit', 100)).toBeCloseTo(212);
   });
 
   it('respects precision when provided', () => {

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -10,11 +10,16 @@ const unitMap = {
     mile: 'mi',
     foot: 'ft',
   },
-  weight: {
+  mass: {
     gram: 'g',
     kilogram: 'kg',
     pound: 'lb',
     ounce: 'oz',
+  },
+  temperature: {
+    celsius: 'degC',
+    fahrenheit: 'degF',
+    kelvin: 'K',
   },
 };
 
@@ -170,7 +175,8 @@ const UnitConverter = () => {
           onChange={(e) => setCategory(e.target.value)}
         >
           <option value="length">Length</option>
-          <option value="weight">Weight</option>
+          <option value="mass">Mass</option>
+          <option value="temperature">Temperature</option>
         </select>
       </label>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-2">


### PR DESCRIPTION
## Summary
- add mass and temperature unit mappings using math.js
- switch currency converter to exchangerate.host with base/quote selectors
- cache exchange rates with last-updated timestamps

## Testing
- `yarn test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*
- `yarn lint` *(fails: React Hooks called conditionally in useGameControls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aedcd15c9083288ef537d4be2b53ac