### PR TITLE
Add Nmap NSE script library demo

### DIFF
--- a/pages/apps/nmap-nse.tsx
+++ b/pages/apps/nmap-nse.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+
+interface Script {
+  name: string;
+  description: string;
+  example: string;
+}
+
+type ScriptData = Record<string, Script[]>;
+
+const NmapNSEPage: React.FC = () => {
+  const [data, setData] = useState<ScriptData>({});
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/demo-data/nmap/scripts.json');
+        const json = await res.json();
+        setData(json);
+      } catch (e) {
+        // ignore
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="p-4 bg-gray-900 text-white min-h-screen">
+      <h1 className="text-2xl mb-4">Nmap NSE Script Library</h1>
+      {Object.entries(data).map(([category, scripts]) => (
+        <div key={category} className="mb-6">
+          <h2 className="text-xl mb-2 capitalize">{category}</h2>
+          {scripts.map((script) => (
+            <div key={script.name} className="mb-4">
+              <a
+                href={`https://nmap.org/nsedoc/scripts/${script.name}.html`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-blue-400 underline"
+              >
+                {script.name}
+              </a>
+              <p className="mb-2">{script.description}</p>
+              <pre className="bg-black text-green-400 p-2 rounded overflow-auto">{script.example}</pre>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default NmapNSEPage;

--- a/public/demo-data/nmap/scripts.json
+++ b/public/demo-data/nmap/scripts.json
@@ -1,0 +1,33 @@
+{
+  "discovery": [
+    {
+      "name": "http-title",
+      "description": "Fetches page titles from HTTP services.",
+      "example": "80/tcp open  http\n| http-title: Example Domain\n|_Requested resource was /"
+    },
+    {
+      "name": "ssh-hostkey",
+      "description": "Retrieves the SSH host key.",
+      "example": "22/tcp open  ssh\n| ssh-hostkey:\n|   2048 SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA (RSA)\n|_  256 SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB (ED25519)"
+    }
+  ],
+  "vuln": [
+    {
+      "name": "smb-vuln-ms17-010",
+      "description": "Detects MS17-010 SMB vulnerabilities.",
+      "example": "445/tcp open  microsoft-ds\n| smb-vuln-ms17-010: VULNERABLE\n|   MS17-010: Microsoft SMBv1 Multiple Vulnerabilities\n|_  State: VULNERABLE"
+    },
+    {
+      "name": "http-vuln-cve2009-3960",
+      "description": "Checks for directory traversal vulnerability in HTTP servers.",
+      "example": "80/tcp open  http\n| http-vuln-cve2009-3960:\n|   VULNERABLE: Directory traversal\n|_  State: VULNERABLE"
+    }
+  ],
+  "safe": [
+    {
+      "name": "ftp-anon",
+      "description": "Checks for anonymous FTP access.",
+      "example": "21/tcp open  ftp\n| ftp-anon: Anonymous FTP login allowed (FTP code 230)\n|_-rw-r--r--   1 ftp      ftp            0 Jan 01 00:00 readme.txt"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add sample NSE script data grouped by category
- display script library with descriptions, terminal-styled outputs, and links to Nmap NSEDoc

## Testing
- `npm test` *(fails: TextEncoder is not defined in calculator.app.test.js; CandyCrushApp is not defined in frogger.config.test.ts and snake.config.test.ts)*
- `npm run lint` *(fails: multiple react-hooks warnings and errors; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68aedcd67d8c8328a1f64f27200c5e4d