### PR TITLE
Add progress fixtures and disclaimers for security tools

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -27,8 +27,12 @@ describe('HashcatApp', () => {
 
   it('shows progress info from JSON', () => {
     const { getByText } = render(<HashcatApp />);
-    expect(getByText(`Hash rate: ${progressInfo.hashRate}`)).toBeInTheDocument();
-    expect(getByText(`ETA: ${progressInfo.eta}`)).toBeInTheDocument();
+    const first = progressInfo.steps[0];
+    expect(
+      getByText(`Attempts/sec: ${first.attemptsPerSec}`)
+    ).toBeInTheDocument();
+    expect(getByText(`ETA: ${first.eta}`)).toBeInTheDocument();
     expect(getByText(`Mode: ${progressInfo.mode}`)).toBeInTheDocument();
+    expect(getByText(progressInfo.disclaimer)).toBeInTheDocument();
   });
 });

--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -30,7 +30,7 @@ describe('Hydra wordlists', () => {
   });
 });
 
-describe('Hydra pause and resume', () => {
+describe('Hydra progress', () => {
   beforeEach(() => {
     localStorage.setItem(
       'hydraUserLists',
@@ -42,40 +42,15 @@ describe('Hydra pause and resume', () => {
     );
   });
 
-  it('pauses and resumes cracking progress', async () => {
-    let runResolve: Function = () => {};
-    // @ts-ignore
-    global.fetch = jest.fn((url, options) => {
-      if (options && options.body && options.body.includes('action')) {
-        return Promise.resolve({ json: async () => ({}) });
-      }
-      return new Promise((resolve) => {
-        runResolve = () => resolve({ json: async () => ({ output: '' }) });
-      });
-    });
-
+  it('shows fixture progress and results', async () => {
     render(<HydraApp />);
     fireEvent.change(screen.getByPlaceholderText('192.168.0.1'), {
       target: { value: '1.1.1.1' },
     });
     fireEvent.click(screen.getByText('Run Hydra'));
 
-    const pauseBtn = await screen.findByTestId('pause-button');
-    fireEvent.click(pauseBtn);
-    expect(global.fetch).toHaveBeenCalledWith(
-      '/api/hydra',
-      expect.objectContaining({ body: JSON.stringify({ action: 'pause' }) })
-    );
-
-    const resumeBtn = await screen.findByTestId('resume-button');
-    fireEvent.click(resumeBtn);
-    expect(global.fetch).toHaveBeenCalledWith(
-      '/api/hydra',
-      expect.objectContaining({ body: JSON.stringify({ action: 'resume' }) })
-    );
-
-    await act(async () => {
-      runResolve();
-    });
+    await screen.findByText(/Attempts\/sec:/i);
+    await screen.findByText('admin:password123', {}, { timeout: 5000 });
+    expect(await screen.findByText(/Simulation only/)).toBeInTheDocument();
   });
 });

--- a/components/apps/hashcat/progress.json
+++ b/components/apps/hashcat/progress.json
@@ -1,6 +1,11 @@
 {
-  "progress": 42,
-  "hashRate": "123 H/s",
-  "eta": "00:00:42",
-  "mode": "Brute-force"
+  "mode": "Brute-force",
+  "disclaimer": "Simulation only. Do not use for unauthorized access.",
+  "steps": [
+    { "percent": 25, "attemptsPerSec": "100 H/s", "eta": "00:00:30" },
+    { "percent": 75, "attemptsPerSec": "120 H/s", "eta": "00:00:10" },
+    { "percent": 100, "attemptsPerSec": "0 H/s", "eta": "00:00:00", "cracked": [
+        { "hash": "5f4dcc3b5aa765d61d8327deb882cf99", "password": "password" }
+    ] }
+  ]
 }

--- a/components/apps/hydra/progress.json
+++ b/components/apps/hydra/progress.json
@@ -1,0 +1,10 @@
+{
+  "disclaimer": "Simulation only. Do not use for unauthorized access.",
+  "steps": [
+    { "percent": 25, "attemptsPerSec": "50 attempts/s", "eta": "00:00:30" },
+    { "percent": 75, "attemptsPerSec": "55 attempts/s", "eta": "00:00:10" },
+    { "percent": 100, "attemptsPerSec": "0 attempts/s", "eta": "00:00:00", "cracked": [
+        { "user": "admin", "password": "password123" }
+    ] }
+  ]
+}

--- a/components/apps/john/progress.json
+++ b/components/apps/john/progress.json
@@ -1,0 +1,10 @@
+{
+  "disclaimer": "Simulation only. Do not use for unauthorized access.",
+  "steps": [
+    { "percent": 30, "attemptsPerSec": "80 H/s", "eta": "00:00:20", "phase": "wordlist" },
+    { "percent": 60, "attemptsPerSec": "90 H/s", "eta": "00:00:10", "phase": "rules" },
+    { "percent": 100, "attemptsPerSec": "0 H/s", "eta": "00:00:00", "phase": "done", "cracked": [
+        { "hash": "5f4dcc3b5aa765d61d8327deb882cf99", "password": "password" }
+    ] }
+  ]
+}


### PR DESCRIPTION
## Summary
- simulate Hashcat with fixture progress, attempts/sec and cracked hash output
- add Hydra progress bar using fixture data and disclaimers
- drive John the Ripper UI from fixture steps with ETA and attempt rate

## Testing
- `yarn lint` *(fails: react-hooks rules in existing files)*
- `yarn test` *(fails: TextEncoder not defined in calculator.app.test.js; CandyCrushApp not defined in snake.config.test.ts & frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aedcd78d488328a25e0694d10fc1c4