### PR TITLE
feat: add HUD overlay and delta time loops

### DIFF
--- a/__tests__/asteroids-utils.test.ts
+++ b/__tests__/asteroids-utils.test.ts
@@ -25,7 +25,7 @@ describe('bullet pool', () => {
   it('reuses bullets after they expire', () => {
     const pool = createBulletPool(1);
     const first = spawnBullet(pool, 0, 0, 0, 0, 1);
-    updateBullets(pool); // bullet expires
+    updateBullets(pool, 1); // bullet expires
     const second = spawnBullet(pool, 0, 0, 0, 0, 1);
     expect(second).toBe(first);
   });

--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -1,9 +1,9 @@
-const { JSDOM } = require('jsdom');
 const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
 
 function setupDom() {
-  global.TextEncoder = TextEncoder;
-  global.TextDecoder = TextDecoder;
   const dom = new JSDOM(
     `<!DOCTYPE html><html><body>
       <input id="display" />

--- a/apps.config.js
+++ b/apps.config.js
@@ -50,6 +50,7 @@ const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
 const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
+const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
+import HUD from './Games/common/HUD';
 
 interface GameLayoutProps {
   gameId: string;
@@ -9,6 +10,7 @@ interface GameLayoutProps {
 const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
   const [showHelp, setShowHelp] = useState(false);
   const [paused, setPaused] = useState(false);
+  const [muted, setMuted] = useState(false);
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
@@ -54,6 +56,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
 
   return (
     <div className="relative h-full w-full">
+      <HUD paused={paused} muted={muted} onPause={setPaused} onMute={setMuted} />
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div

--- a/components/apps/Games/common/HUD.tsx
+++ b/components/apps/Games/common/HUD.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface HUDProps {
+  paused?: boolean;
+  muted?: boolean;
+  onPause?: (v: boolean) => void;
+  onMute?: (v: boolean) => void;
+}
+
+const HUD: React.FC<HUDProps> = ({ paused = false, muted = false, onPause, onMute }) => {
+  const [fps, setFps] = useState(0);
+
+  // FPS counter
+  useEffect(() => {
+    let raf: number;
+    let frames = 0;
+    let last = performance.now();
+    const loop = (time: number) => {
+      frames += 1;
+      if (time - last >= 1000) {
+        setFps(frames);
+        frames = 0;
+        last = time;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const togglePause = useCallback(() => onPause?.(!paused), [onPause, paused]);
+  const toggleMute = useCallback(() => onMute?.(!muted), [onMute, muted]);
+
+  // keyboard shortcuts
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'p' || e.key === 'P') {
+        e.preventDefault();
+        togglePause();
+      }
+      if (e.key === 'm' || e.key === 'M') {
+        e.preventDefault();
+        toggleMute();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [togglePause, toggleMute]);
+
+  const fireKey = (key: string, type: 'keydown' | 'keyup') => {
+    const codeMap: Record<string, string> = {
+      ArrowUp: 'ArrowUp',
+      ArrowDown: 'ArrowDown',
+      ArrowLeft: 'ArrowLeft',
+      ArrowRight: 'ArrowRight',
+      ' ': 'Space',
+      h: 'KeyH',
+    };
+    const event = new KeyboardEvent(type, { key, code: codeMap[key] || key });
+    window.dispatchEvent(event);
+  };
+
+  const bindButton = (key: string) => ({
+    onMouseDown: () => fireKey(key, 'keydown'),
+    onMouseUp: () => fireKey(key, 'keyup'),
+    onTouchStart: (e: React.TouchEvent) => {
+      e.preventDefault();
+      fireKey(key, 'keydown');
+    },
+    onTouchEnd: (e: React.TouchEvent) => {
+      e.preventDefault();
+      fireKey(key, 'keyup');
+    },
+  });
+
+  const isTouch = typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+
+  return (
+    <div className="pointer-events-none select-none absolute inset-0 z-40">
+      <div className="absolute top-2 left-2 text-white text-xs bg-black bg-opacity-50 px-2 py-1 rounded">
+        FPS: {fps}
+      </div>
+      <div className="absolute top-2 right-2 flex gap-2 pointer-events-auto">
+        <button type="button" onClick={togglePause} className="px-2 py-1 bg-gray-700 text-white rounded">
+          {paused ? 'Resume' : 'Pause'} [P]
+        </button>
+        <button type="button" onClick={toggleMute} className="px-2 py-1 bg-gray-700 text-white rounded">
+          {muted ? 'Unmute' : 'Mute'} [M]
+        </button>
+      </div>
+      {isTouch && (
+        <>
+          <div className="absolute bottom-4 left-4 grid grid-cols-3 grid-rows-3 gap-1 pointer-events-auto">
+            <div />
+            <button className="w-10 h-10 bg-gray-700 text-white rounded" {...bindButton('ArrowUp')}>
+              ▲
+            </button>
+            <div />
+            <button className="w-10 h-10 bg-gray-700 text-white rounded" {...bindButton('ArrowLeft')}>
+              ◀
+            </button>
+            <div className="w-10 h-10" />
+            <button className="w-10 h-10 bg-gray-700 text-white rounded" {...bindButton('ArrowRight')}>
+              ▶
+            </button>
+            <div />
+            <button className="w-10 h-10 bg-gray-700 text-white rounded" {...bindButton('ArrowDown')}>
+              ▼
+            </button>
+            <div />
+          </div>
+          <div className="absolute bottom-4 right-4 flex gap-2 pointer-events-auto">
+            <button className="w-12 h-12 bg-gray-700 text-white rounded-full" {...bindButton(' ')}>
+              A
+            </button>
+            <button className="w-12 h-12 bg-gray-700 text-white rounded-full" {...bindButton('h')}>
+              B
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default HUD;

--- a/components/apps/asteroids-utils.js
+++ b/components/apps/asteroids-utils.js
@@ -33,12 +33,12 @@ export function spawnBullet(pool, x, y, dx, dy, life = 60) {
   return null;
 }
 
-export function updateBullets(pool) {
+export function updateBullets(pool, dt = 1) {
   for (const b of pool) {
     if (!b.active) continue;
-    b.x += b.dx;
-    b.y += b.dy;
-    b.life -= 1;
+    b.x += b.dx * dt;
+    b.y += b.dy * dt;
+    b.life -= dt;
     if (b.life <= 0) b.active = false;
   }
 }
@@ -78,10 +78,10 @@ export function spawnPowerUp(list, x, y) {
   list.push({ type, x, y, r: 12, life: 600 });
 }
 
-export function updatePowerUps(list) {
+export function updatePowerUps(list, dt = 1) {
   for (let i = list.length - 1; i >= 0; i -= 1) {
     const p = list[i];
-    p.life -= 1;
+    p.life -= dt;
     if (p.life <= 0) list.splice(i, 1);
   }
 }

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -314,11 +314,15 @@ const Asteroids = () => {
       multiplierTimer = MULTIPLIER_TIMEOUT;
     }
 
-    const update = () => {
+    let last = performance.now();
+    const update = (time) => {
       if (pausedRef.current) {
         requestRef.current = requestAnimationFrame(update);
+        last = time;
         return;
       }
+      const dt = (time - last) / (1000 / 60);
+      last = time;
       pollGamepad();
       const { keys, joystick, fire, hyperspace: hyper } = controlsRef.current;
       const turn =
@@ -341,10 +345,10 @@ const Asteroids = () => {
       if (padState.fire) fireBullet();
       if (padState.hyperspace) hyperspace();
 
-      ship.angle += turn * 0.05;
+      ship.angle += turn * 0.05 * dt;
       if (thrust > 0) {
-        ship.velX += Math.cos(ship.angle) * THRUST * thrust;
-        ship.velY += Math.sin(ship.angle) * THRUST * thrust;
+        ship.velX += Math.cos(ship.angle) * THRUST * thrust * dt;
+        ship.velY += Math.sin(ship.angle) * THRUST * thrust * dt;
         spawnParticles(
           ship.x - Math.cos(ship.angle) * 12,
           ship.y - Math.sin(ship.angle) * 12,
@@ -352,31 +356,31 @@ const Asteroids = () => {
           'orange',
         );
       }
-      ship.velX *= INERTIA;
-      ship.velY *= INERTIA;
-      ship.x = wrap(ship.x + ship.velX, canvas.width, ship.r);
-      ship.y = wrap(ship.y + ship.velY, canvas.height, ship.r);
-      ship.cooldown = Math.max(0, ship.cooldown - 1);
-      ship.rapidFire = Math.max(0, ship.rapidFire - 1);
-      ship.shield = Math.max(0, ship.shield - 1);
-      ship.hitCooldown = Math.max(0, ship.hitCooldown - 1);
+      ship.velX *= INERTIA ** dt;
+      ship.velY *= INERTIA ** dt;
+      ship.x = wrap(ship.x + ship.velX * dt, canvas.width, ship.r);
+      ship.y = wrap(ship.y + ship.velY * dt, canvas.height, ship.r);
+      ship.cooldown = Math.max(0, ship.cooldown - dt);
+      ship.rapidFire = Math.max(0, ship.rapidFire - dt);
+      ship.shield = Math.max(0, ship.shield - dt);
+      ship.hitCooldown = Math.max(0, ship.hitCooldown - dt);
 
-      if (multiplierTimer > 0) multiplierTimer -= 1;
+      if (multiplierTimer > 0) multiplierTimer -= dt;
       else multiplier = 1;
 
-      updateBullets(bullets);
-      updatePowerUps(powerUps);
+      updateBullets(bullets, dt);
+      updatePowerUps(powerUps, dt);
 
       asteroids.forEach((a) => {
-        a.x = wrap(a.x + a.dx, canvas.width, a.r);
-        a.y = wrap(a.y + a.dy, canvas.height, a.r);
+        a.x = wrap(a.x + a.dx * dt, canvas.width, a.r);
+        a.y = wrap(a.y + a.dy * dt, canvas.height, a.r);
       });
 
       // UFO logic
       if (ufo.active) {
-        ufo.x += ufo.dx;
-        ufo.y += ufo.dy;
-        ufo.cooldown -= 1;
+        ufo.x += ufo.dx * dt;
+        ufo.y += ufo.dy * dt;
+        ufo.cooldown -= dt;
         if (ufo.cooldown <= 0) {
           const angle = Math.atan2(ship.y - ufo.y, ship.x - ufo.x);
           ufoBullets.push({ x: ufo.x, y: ufo.y, dx: Math.cos(angle) * 3, dy: Math.sin(angle) * 3, r: 2, life: 120 });
@@ -384,7 +388,7 @@ const Asteroids = () => {
           playSound(660);
         }
         if (ufo.x < -50 || ufo.x > canvas.width + 50) ufo.active = false;
-      } else if (ufoTimer-- <= 0) {
+      } else if ((ufoTimer -= dt) <= 0) {
         ufo.active = true;
         ufo.y = Math.random() * canvas.height;
         ufo.x = Math.random() < 0.5 ? -20 : canvas.width + 20;
@@ -394,17 +398,17 @@ const Asteroids = () => {
         ufoTimer = Math.max(300, 900 - level * 60);
       }
       ufoBullets.forEach((b) => {
-        b.x += b.dx;
-        b.y += b.dy;
-        b.life -= 1;
+        b.x += b.dx * dt;
+        b.y += b.dy * dt;
+        b.life -= dt;
       });
       for (let i = ufoBullets.length - 1; i >= 0; i -= 1) if (ufoBullets[i].life <= 0) ufoBullets.splice(i, 1);
 
       particles.forEach((p) => {
         if (!p.active) return;
-        p.x += p.dx;
-        p.y += p.dy;
-        p.life -= 1;
+        p.x += p.dx * dt;
+        p.y += p.dy * dt;
+        p.life -= dt;
         if (p.life <= 0) p.active = false;
       });
 


### PR DESCRIPTION
## Summary
- add reusable HUD with pause, mute, FPS, and touch controls
- wire HUD into GameLayout
- normalize Asteroids game loop to use requestAnimationFrame delta

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aedcd8efbc8328a55b15dc7d0ba5ea