### PR TITLE
feat: add design tokens

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1,43 +1,7 @@
-/* Theme variables */
-:root {
-    --color-ub-grey: #111111;
-    --color-ub-warm-grey: #AEA79F;
-    --color-ub-cool-grey: #333333;
-    --color-ub-orange: #E95420;
-    --color-ub-lite-abrgn: #77216F;
-    --color-ub-med-abrgn: #5E2750;
-    --color-ub-drk-abrgn: #2C001E;
-    --color-ub-window-title: #201f1f;
-    --color-ub-gedit-dark: #021B33;
-    --color-ub-gedit-light: #003B70;
-    --color-ub-gedit-darker: #010D1A;
-    --color-ubt-grey: #F6F6F5;
-    --color-ubt-warm-grey: #AEA79F;
-    --color-ubt-cool-grey: #333333;
-    --color-ubt-blue: #3465A4;
-    --color-ubt-green: #4E9A06;
-    --color-ubt-gedit-orange: #F39A21;
-    --color-ubt-gedit-blue: #50B6C6;
-    --color-ubt-gedit-dark: #003B70;
-    --color-ub-border-orange: #E95420;
-    --color-ub-dark-grey: #555555;
-    --color-bg: #111111;
-    --color-text: #F6F6F5;
-}
-
-[data-theme='light'] {
-    --color-ub-grey: #ffffff;
-    --color-ub-warm-grey: #666666;
-    --color-ub-cool-grey: #e5e5e5;
-    --color-ub-window-title: #f0f0f0;
-    --color-ubt-grey: #111111;
-    --color-ubt-cool-grey: #4a4a4a;
-    --color-bg: #ffffff;
-    --color-text: #333333;
-}
+@import './tokens.css';
 
 body{
-    font-family: 'Ubuntu', sans-serif;
+    font-family: var(--font-family-base);
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,110 @@
+/* Design tokens */
+
+:root {
+  /* Theme colors */
+  --color-ub-grey: #111111;
+  --color-ub-warm-grey: #AEA79F;
+  --color-ub-cool-grey: #333333;
+  --color-ub-orange: #E95420;
+  --color-ub-lite-abrgn: #77216F;
+  --color-ub-med-abrgn: #5E2750;
+  --color-ub-drk-abrgn: #2C001E;
+  --color-ub-window-title: #201f1f;
+  --color-ub-gedit-dark: #021B33;
+  --color-ub-gedit-light: #003B70;
+  --color-ub-gedit-darker: #010D1A;
+  --color-ubt-grey: #F6F6F5;
+  --color-ubt-warm-grey: #AEA79F;
+  --color-ubt-cool-grey: #333333;
+  --color-ubt-blue: #3465A4;
+  --color-ubt-green: #4E9A06;
+  --color-ubt-gedit-orange: #F39A21;
+  --color-ubt-gedit-blue: #50B6C6;
+  --color-ubt-gedit-dark: #003B70;
+  --color-ub-border-orange: #E95420;
+  --color-ub-dark-grey: #555555;
+  --color-bg: #111111;
+  --color-text: #F6F6F5;
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+
+  /* Radius */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 8px;
+  --radius-round: 9999px;
+
+  /* Motion durations */
+  --motion-fast: 150ms;
+  --motion-medium: 300ms;
+  --motion-slow: 500ms;
+
+  /* Fonts */
+  --font-family-base: 'Ubuntu', sans-serif;
+}
+
+/* Light theme */
+[data-theme='light'] {
+  --color-ub-grey: #ffffff;
+  --color-ub-warm-grey: #666666;
+  --color-ub-cool-grey: #e5e5e5;
+  --color-ub-window-title: #f0f0f0;
+  --color-ubt-grey: #111111;
+  --color-ubt-cool-grey: #4a4a4a;
+  --color-bg: #ffffff;
+  --color-text: #333333;
+}
+
+/* High contrast theme */
+.high-contrast {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-ub-grey: #000000;
+  --color-ub-cool-grey: #000000;
+  --color-ubt-grey: #ffffff;
+  --color-ubt-cool-grey: #ffffff;
+  --color-ub-orange: #ffff00;
+  --color-ub-lite-abrgn: #00ffff;
+  --color-ub-border-orange: #ffff00;
+}
+
+/* Dyslexia-friendly fonts */
+.dyslexia {
+  --font-family-base: 'OpenDyslexic', 'Comic Sans MS', Arial, sans-serif;
+}
+
+/* Reduced motion */
+.reduced-motion {
+  --motion-fast: 0ms;
+  --motion-medium: 0ms;
+  --motion-slow: 0ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-fast: 0ms;
+    --motion-medium: 0ms;
+    --motion-slow: 0ms;
+  }
+}
+
+/* Optional high contrast via media query */
+@media (prefers-contrast: more) {
+  :root {
+    --color-bg: #000000;
+    --color-text: #ffffff;
+    --color-ub-grey: #000000;
+    --color-ub-cool-grey: #000000;
+    --color-ubt-grey: #ffffff;
+    --color-ubt-cool-grey: #ffffff;
+    --color-ub-orange: #ffff00;
+    --color-ub-lite-abrgn: #00ffff;
+    --color-ub-border-orange: #ffff00;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize theme values and spacing, radius, and motion durations in new `tokens.css`
- support accessibility themes including high-contrast, dyslexia-friendly fonts, and reduced motion
- load design tokens globally and reference font family token

## Testing
- `npm test` (fails: TextEncoder is not defined; CandyCrushApp is not defined)
- `npm run lint` (fails: React Hooks called conditionally)


------
https://chatgpt.com/codex/tasks/task_e_68aeddc50bd8832895aac93e8e3f2e41