### PR TITLE
chore: improve accessibility

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -32,8 +32,9 @@ export class SideBarApp extends Component {
 
     render() {
         return (
-            <div
-                tabIndex="0"
+            <button
+                type="button"
+                aria-label={this.props.title}
                 onClick={this.openApp}
                 onMouseEnter={() => {
                     this.setState({ showTitle: true });
@@ -75,7 +76,7 @@ export class SideBarApp extends Component {
                 >
                     {this.props.title}
                 </div>
-            </div>
+            </button>
         );
     }
 }

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -17,9 +17,12 @@ export class UbuntuApp extends Component {
     render() {
         return (
             <div
+                role="button"
+                aria-label={this.props.name}
                 className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={0}
             >
                 <Image

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -247,7 +247,12 @@ export class WindowXBorder extends Component {
 export function WindowEditButtons(props) {
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center">
-            <span className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.minimize}>
+            <button
+                type="button"
+                aria-label="Window minimize"
+                className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
+                onClick={props.minimize}
+            >
                 <NextImage
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
                     alt="Kali window minimize"
@@ -256,11 +261,16 @@ export function WindowEditButtons(props) {
                     height={20}
                     sizes="20px"
                 />
-            </span>
+            </button>
             {props.allowMaximize && (
                 props.isMaximised
                     ? (
-                        <span className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.maximize}>
+                        <button
+                            type="button"
+                            aria-label="Window restore"
+                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
+                            onClick={props.maximize}
+                        >
                             <NextImage
                                 src="/themes/Yaru/window/window-restore-symbolic.svg"
                                 alt="Kali window restore"
@@ -269,9 +279,14 @@ export function WindowEditButtons(props) {
                                 height={20}
                                 sizes="20px"
                             />
-                        </span>
+                        </button>
                     ) : (
-                        <span className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.maximize}>
+                        <button
+                            type="button"
+                            aria-label="Window maximize"
+                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
+                            onClick={props.maximize}
+                        >
                             <NextImage
                                 src="/themes/Yaru/window/window-maximize-symbolic.svg"
                                 alt="Kali window maximize"
@@ -280,10 +295,16 @@ export function WindowEditButtons(props) {
                                 height={20}
                                 sizes="20px"
                             />
-                        </span>
+                        </button>
                     )
             )}
-            <button tabIndex="-1" id={`close-${props.id}`} className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center mt-1 h-5 w-5 items-center" onClick={props.close}>
+            <button
+                type="button"
+                id={`close-${props.id}`}
+                aria-label="Window close"
+                className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
+                onClick={props.close}
+            >
                 <NextImage
                     src="/themes/Yaru/window/window-close-symbolic.svg"
                     alt="Kali window close"

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -43,34 +43,69 @@ function DesktopMenu(props) {
     }
 
     return (
-        <div id="desktop-menu" className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}>
-            <button onClick={props.addNewFolder} type="button" className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+        <div
+            id="desktop-menu"
+            role="menu"
+            aria-label="Desktop context menu"
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+        >
+            <button
+                onClick={props.addNewFolder}
+                type="button"
+                role="menuitem"
+                aria-label="New Folder"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
                 <span className="ml-5">New Folder</span>
             </button>
             <Devider />
-            <div className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
-            <button onClick={openTerminal} type="button" className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <button
+                onClick={openTerminal}
+                type="button"
+                role="menuitem"
+                aria-label="Open in Terminal"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
                 <span className="ml-5">Open in Terminal</span>
             </button>
             <Devider />
-            <button onClick={openSettings} type="button" className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <button
+                onClick={openSettings}
+                type="button"
+                role="menuitem"
+                aria-label="Change Background"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
                 <span className="ml-5">Change Background...</span>
             </button>
             <Devider />
-            <div className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Display Settings</span>
             </div>
-            <button onClick={openSettings} type="button" className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <button
+                onClick={openSettings}
+                type="button"
+                role="menuitem"
+                aria-label="Settings"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
                 <span className="ml-5">Settings</span>
             </button>
             <Devider />
-            <button onClick={goFullScreen} type="button" className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5">
+            <button
+                onClick={goFullScreen}
+                type="button"
+                role="menuitem"
+                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
         </div>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,33 +14,31 @@ export default class Navbar extends Component {
 	render() {
 		return (
 			<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-				<div
-					tabIndex="0"
-					className={
-						'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-					}
-				>
-					Activities
-				</div>
-				<div
-					tabIndex="0"
-					className={
-						'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1'
-					}
-				>
-					<Clock />
-				</div>
-				<div
-					id="status-bar"
-					tabIndex="0"
-					onFocus={() => {
-						this.setState({ status_card: true });
-					}}
-					// removed onBlur from here
-					className={
-						'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-					}
-				>
+                                <div
+                                        className={
+                                                'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '
+                                        }
+                                >
+                                        Activities
+                                </div>
+                                <div
+                                        className={
+                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                        }
+                                >
+                                        <Clock />
+                                </div>
+                                <button
+                                        type="button"
+                                        id="status-bar"
+                                        aria-label="System status"
+                                        onClick={() => {
+                                                this.setState({ status_card: !this.state.status_card });
+                                        }}
+                                        className={
+                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                        }
+                                >
 					<Status />
 					<StatusCard
 						shutDown={this.props.shutDown}
@@ -51,7 +49,7 @@ export default class Navbar extends Component {
 							this.setState({ status_card: false });
 						}}
 					/>
-				</div>
+                                </button>
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary
- improve window controls with labeled buttons
- convert sidebar icons and app tiles into accessible buttons
- add menu roles and better keyboard support for desktop menu and navbar

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddc746fc83288c3ab4a9f16eae0e