### PR TITLE
feat(trash): add undo toast and restore

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react';
+
+interface ToastProps {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  onClose?: () => void;
+  duration?: number;
+}
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  actionLabel,
+  onAction,
+  onClose,
+  duration = 6000,
+}) => {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    timeoutRef.current = setTimeout(() => {
+      onClose && onClose();
+    }, duration);
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [duration, onClose]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-80 text-white px-4 py-2 rounded shadow-md flex items-center"
+    >
+      <span>{message}</span>
+      {onAction && actionLabel && (
+        <button
+          onClick={onAction}
+          className="ml-4 underline focus:outline-none"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- add reusable Toast component with optional undo support
- enhance Trash app with selection, restore, and empty confirmation modal
- move deleted files to Trash and offer 6s undo

## Testing
- `npm test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*
- `npm run lint` *(fails: React Hook errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddcdc8f08328bd175057db356e01