### PR TITLE
feat: enhance converter with currency caching and favorites

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -50,6 +50,7 @@ const SudokuApp = createDynamicApp('sudoku', 'Sudoku');
 const SpaceInvadersApp = createDynamicApp('space-invaders', 'Space Invaders');
 const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
+const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 

--- a/components/apps/converter/CurrencyConverter.js
+++ b/components/apps/converter/CurrencyConverter.js
@@ -6,14 +6,54 @@ const CurrencyConverter = () => {
   const [to, setTo] = useState('EUR');
   const [amount, setAmount] = useState('');
   const [result, setResult] = useState('');
+  const [lastUpdated, setLastUpdated] = useState('');
+  const [favorites, setFavorites] = useState([]);
 
+  // Load cached rates and favorites, then fetch latest rates
   useEffect(() => {
-    fetch('https://open.er-api.com/v6/latest/USD')
-      .then((res) => res.json())
-      .then((data) => setRates(data.rates || {}))
-      .catch(() => setRates({}));
+    if (typeof window === 'undefined') return;
+
+    try {
+      const cached = JSON.parse(localStorage.getItem('currencyRates'));
+      if (cached?.rates) {
+        setRates(cached.rates);
+        setLastUpdated(cached.timestamp);
+      }
+    } catch {
+      /* empty */
+    }
+
+    try {
+      const favs = JSON.parse(localStorage.getItem('currencyFavorites'));
+      if (Array.isArray(favs)) setFavorites(favs);
+    } catch {
+      /* empty */
+    }
+
+    async function fetchRates() {
+      try {
+        const res = await fetch(
+          'https://api.exchangerate.host/latest?base=USD'
+        );
+        const data = await res.json();
+        if (data?.rates) {
+          setRates(data.rates);
+          const ts = new Date().toISOString();
+          setLastUpdated(ts);
+          localStorage.setItem(
+            'currencyRates',
+            JSON.stringify({ rates: data.rates, timestamp: ts })
+          );
+        }
+      } catch {
+        /* empty */
+      }
+    }
+
+    fetchRates();
   }, []);
 
+  // Convert when inputs change
   useEffect(() => {
     if (!amount || !rates[from] || !rates[to]) {
       setResult('');
@@ -25,6 +65,40 @@ const CurrencyConverter = () => {
   }, [amount, from, to, rates]);
 
   const currencyOptions = Object.keys(rates);
+
+  const handleSwap = () => {
+    const newFrom = to;
+    const newTo = from;
+    const newAmount = result || amount;
+    let newResult = '';
+    if (newAmount && rates[newFrom] && rates[newTo]) {
+      const usdAmount = parseFloat(newAmount) / rates[newFrom];
+      newResult = (usdAmount * rates[newTo]).toFixed(2);
+    }
+    setFrom(newFrom);
+    setTo(newTo);
+    setAmount(newAmount);
+    setResult(newResult);
+  };
+
+  const addFavorite = () => {
+    const pair = { from, to };
+    if (favorites.some((f) => f.from === from && f.to === to)) return;
+    const updated = [...favorites, pair];
+    setFavorites(updated);
+    localStorage.setItem('currencyFavorites', JSON.stringify(updated));
+  };
+
+  const removeFavorite = (idx) => {
+    const updated = favorites.filter((_, i) => i !== idx);
+    setFavorites(updated);
+    localStorage.setItem('currencyFavorites', JSON.stringify(updated));
+  };
+
+  const selectFavorite = (pair) => {
+    setFrom(pair.from);
+    setTo(pair.to);
+  };
 
   return (
     <div className="bg-gray-700 p-4 rounded flex flex-col gap-2">
@@ -68,9 +142,49 @@ const CurrencyConverter = () => {
           </select>
         </label>
       </div>
+      <button
+        onClick={handleSwap}
+        className="mt-1 px-2 py-1 bg-gray-600 rounded"
+        aria-label="Swap currencies"
+      >
+        Swap
+      </button>
       <div data-testid="currency-result" className="mt-2">
         {result && `${amount} ${from} = ${result} ${to}`}
       </div>
+      {lastUpdated && (
+        <div className="text-xs">Rates updated: {new Date(lastUpdated).toLocaleString()}</div>
+      )}
+      <button
+        onClick={addFavorite}
+        className="mt-2 px-2 py-1 bg-gray-600 rounded"
+      >
+        Add Favorite
+      </button>
+      {favorites.length > 0 && (
+        <div className="mt-2">
+          <h3 className="text-lg">Favorites</h3>
+          <ul className="flex flex-wrap gap-2 mt-1">
+            {favorites.map((fav, idx) => (
+              <li key={`${fav.from}-${fav.to}-${idx}`} className="flex items-center">
+                <button
+                  className="px-2 py-1 bg-gray-600 rounded"
+                  onClick={() => selectFavorite(fav)}
+                >
+                  {fav.from} → {fav.to}
+                </button>
+                <button
+                  className="ml-1 text-xs"
+                  onClick={() => removeFavorite(idx)}
+                  aria-label={`Remove ${fav.from} to ${fav.to}`}
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,11 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Polyfill TextEncoder/TextDecoder for environments that lack them
+// @ts-ignore
+global.TextEncoder = TextEncoder;
+// @ts-ignore
+global.TextDecoder = TextDecoder;
 
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient


### PR DESCRIPTION
## Summary
- fetch currency rates from exchangerate.host, cache them locally and show last update timestamp
- add swap button and favorite currency pairs to converter
- polyfill TextEncoder/TextDecoder and add missing Candy Crush app config for test stability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeddd18a948328acf34cf6802ab37b