### PR TITLE
feat: enhance weather forecast with caching

### DIFF
--- a/lib/weather/index.js
+++ b/lib/weather/index.js
@@ -1,0 +1,21 @@
+export const DEFAULT_LOCATION = {
+  name: 'New York',
+  latitude: 40.7128,
+  longitude: -74.0060,
+};
+
+export async function getForecast({ latitude, longitude }) {
+  const params = new URLSearchParams({
+    latitude: latitude.toString(),
+    longitude: longitude.toString(),
+    current_weather: 'true',
+    hourly: 'temperature_2m,precipitation_probability',
+    daily:
+      'weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_probability_max',
+    timezone: 'auto',
+  });
+  const url = `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch forecast');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add weather forecast helper using open-meteo API with default location fallback
- display richer weather data with hourly chart, sunrise/sunset, precipitation and unit toggle
- cache weather API responses through service worker for offline support

## Testing
- `yarn test` *(fails: TextEncoder is not defined; CandyCrushApp is not defined)*
- `yarn lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddd3df408328acdbef9b76c8b005