### PR TITLE
Add Nikto static report viewer

### DIFF
--- a/__tests__/niktoReport.test.tsx
+++ b/__tests__/niktoReport.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NiktoReport from '../pages/nikto-report';
+
+describe('NiktoReport', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            {
+              path: '/admin',
+              finding: 'admin portal',
+              references: ['OSVDB-1'],
+              severity: 'High',
+              details: 'details',
+            },
+            {
+              path: '/cgi-bin',
+              finding: 'cgi script',
+              references: ['CVE-1'],
+              severity: 'Medium',
+              details: 'details',
+            },
+          ]),
+      })
+    ) as any;
+  });
+
+  it('filters by path and severity and shows details', async () => {
+    const user = userEvent.setup();
+    render(<NiktoReport />);
+
+    await screen.findByText('/admin');
+    expect(screen.getAllByRole('row')).toHaveLength(3);
+
+    await user.type(screen.getByPlaceholderText(/filter by path/i), 'cgi');
+    expect(screen.queryByText('/admin')).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText(/filter by path/i));
+    await user.selectOptions(screen.getByDisplayValue('All'), 'High');
+    expect(screen.getByText('/admin')).toBeInTheDocument();
+    expect(screen.queryByText('/cgi-bin')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('/admin'));
+    expect(await screen.findByText(/Severity:/i)).toBeInTheDocument();
+  });
+});

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+interface NiktoFinding {
+  path: string;
+  finding: string;
+  references: string[];
+  severity: string;
+  details: string;
+}
+
+const NiktoReport: React.FC = () => {
+  const [findings, setFindings] = useState<NiktoFinding[]>([]);
+  const [severity, setSeverity] = useState('All');
+  const [pathFilter, setPathFilter] = useState('');
+  const [selected, setSelected] = useState<NiktoFinding | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/demo-data/nikto/report.json');
+        const data = await res.json();
+        setFindings(data);
+      } catch {
+        // ignore errors
+      }
+    };
+    load();
+  }, []);
+
+  const filtered = useMemo(
+    () =>
+      findings.filter(
+        (f) =>
+          (severity === 'All' || f.severity.toLowerCase() === severity.toLowerCase()) &&
+          f.path.toLowerCase().includes(pathFilter.toLowerCase())
+      ),
+    [findings, severity, pathFilter]
+  );
+
+  return (
+    <div className="p-4 bg-gray-900 text-white min-h-screen">
+      <h1 className="text-xl mb-4">Nikto Report</h1>
+      <div className="flex space-x-2 mb-4">
+        <input
+          placeholder="Filter by path"
+          className="p-2 rounded text-black"
+          value={pathFilter}
+          onChange={(e) => setPathFilter(e.target.value)}
+        />
+        <select
+          className="p-2 rounded text-black"
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+        >
+          {['All', 'Info', 'Low', 'Medium', 'High'].map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="bg-gray-700">
+            <th className="p-2">Path</th>
+            <th className="p-2">Finding</th>
+            <th className="p-2">References</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((f, idx) => (
+            <tr
+              key={idx}
+              className="odd:bg-gray-800 cursor-pointer hover:bg-gray-700"
+              onClick={() => setSelected(f)}
+            >
+              <td className="p-2">{f.path}</td>
+              <td className="p-2">{f.finding}</td>
+              <td className="p-2">{f.references.join(', ')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selected && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+          onClick={() => setSelected(null)}
+        >
+          <div
+            className="bg-gray-800 p-4 rounded max-w-lg w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg mb-2">{selected.path}</h2>
+            <p className="mb-2">
+              <span className="font-bold">Severity:</span> {selected.severity}
+            </p>
+            <p className="mb-2">{selected.finding}</p>
+            <p className="mb-2">
+              <span className="font-bold">References:</span>{' '}
+              {selected.references.join(', ')}
+            </p>
+            <p>{selected.details}</p>
+            <button
+              className="mt-4 px-4 py-2 bg-blue-600 rounded"
+              onClick={() => setSelected(null)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NiktoReport;

--- a/public/demo-data/nikto/report.json
+++ b/public/demo-data/nikto/report.json
@@ -1,0 +1,23 @@
+[
+  {
+    "path": "/admin",
+    "finding": "Potential administration portal found.",
+    "references": ["OSVDB-1234"],
+    "severity": "High",
+    "details": "The /admin path is accessible and may expose administrative functions."
+  },
+  {
+    "path": "/cgi-bin/test",
+    "finding": "CGI script found; may be vulnerable.",
+    "references": ["CVE-2012-1823", "OSVDB-5678"],
+    "severity": "Medium",
+    "details": "The /cgi-bin/test script reveals server information."
+  },
+  {
+    "path": "/",
+    "finding": "Server leaks inodes via ETags, header found with file /",
+    "references": ["OSVDB-3092"],
+    "severity": "Info",
+    "details": "ETag header found; may help fingerprinting."
+  }
+]


### PR DESCRIPTION
## Summary
- add static Nikto report page with filtering and details drawer
- include sample Nikto report data
- test filtering and detail drawer behavior

## Testing
- `yarn test __tests__/niktoReport.test.tsx --runInBand`
- `yarn lint` *(fails: React Hook warnings/errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68aedddb7f7c8328a7bc9e286a083cdc