### PR TITLE
Add Nessus sample report viewer with CVSS donut

### DIFF
--- a/__tests__/nessus-report.test.tsx
+++ b/__tests__/nessus-report.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import NessusReport from '../pages/nessus-report';
+
+describe('Nessus sample report', () => {
+  test('shows findings and drawer with disclaimer', () => {
+    render(<NessusReport />);
+    expect(screen.getByText('Sample Nessus Report')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(5); // header + 4 findings
+    fireEvent.click(screen.getByText('Weak SSH Cipher'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Disclaimer: This sample report is for demonstration/)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/apps/nessus/sample-report.json
+++ b/components/apps/nessus/sample-report.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "1",
+    "name": "OpenSSL Heartbeat Information Disclosure",
+    "cvss": 5.0,
+    "severity": "Medium",
+    "description": "OpenSSL 1.0.1 Heartbeat extension allows remote attackers to obtain sensitive information."
+  },
+  {
+    "id": "2",
+    "name": "Apache HTTP Server Privilege Escalation",
+    "cvss": 7.5,
+    "severity": "High",
+    "description": "Apache may allow local users to escalate privileges."
+  },
+  {
+    "id": "3",
+    "name": "Weak SSH Cipher",
+    "cvss": 9.8,
+    "severity": "Critical",
+    "description": "The SSH server is configured to allow weak ciphers."
+  },
+  {
+    "id": "4",
+    "name": "Outdated Software",
+    "cvss": 2.5,
+    "severity": "Low",
+    "description": "Installed software is outdated."
+  }
+]

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -1,0 +1,120 @@
+import React, { useMemo, useState } from 'react';
+import data from '../components/apps/nessus/sample-report.json';
+
+const severityColors: Record<string, string> = {
+  Critical: '#991b1b',
+  High: '#b45309',
+  Medium: '#a16207',
+  Low: '#1e40af',
+};
+
+interface Finding {
+  id: string;
+  name: string;
+  cvss: number;
+  severity: keyof typeof severityColors;
+  description: string;
+}
+
+const radius = 60;
+const circumference = 2 * Math.PI * radius;
+
+const NessusReport: React.FC = () => {
+  const [selected, setSelected] = useState<Finding | null>(null);
+  const findings = data as Finding[];
+
+  const counts = useMemo(() => {
+    return findings.reduce<Record<string, number>>((acc, f) => {
+      acc[f.severity] = (acc[f.severity] || 0) + 1;
+      return acc;
+    }, {});
+  }, [findings]);
+
+  const segments = useMemo(() => {
+    const total = findings.length;
+    let offset = 0;
+    return Object.entries(counts).map(([sev, count]) => {
+      const dash = (count / total) * circumference;
+      const segment = (
+        <circle
+          key={sev}
+          r={radius}
+          cx={radius + 20}
+          cy={radius + 20}
+          fill="transparent"
+          stroke={severityColors[sev]}
+          strokeWidth="30"
+          strokeDasharray={`${dash} ${circumference - dash}`}
+          strokeDashoffset={-offset}
+          transform={`rotate(-90 ${radius + 20} ${radius + 20})`}
+        />
+      );
+      offset += dash;
+      return segment;
+    });
+  }, [counts, findings.length]);
+
+  return (
+    <div className="p-4 bg-gray-900 text-white min-h-screen">
+      <h1 className="text-2xl mb-4">Sample Nessus Report</h1>
+      <svg
+        width={(radius + 20) * 2}
+        height={(radius + 20) * 2}
+        aria-label="CVSS severity distribution"
+        className="mx-auto mb-4"
+      >
+        {segments}
+      </svg>
+      <table className="w-full mb-4 text-sm">
+        <thead>
+          <tr className="text-left border-b border-gray-700">
+            <th className="py-1">ID</th>
+            <th className="py-1">Finding</th>
+            <th className="py-1">CVSS</th>
+            <th className="py-1">Severity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {findings.map((f) => (
+            <tr
+              key={f.id}
+              className="border-b border-gray-800 cursor-pointer hover:bg-gray-800"
+              onClick={() => setSelected(f)}
+            >
+              <td className="py-1">{f.id}</td>
+              <td className="py-1">{f.name}</td>
+              <td className="py-1">{f.cvss}</td>
+              <td className="py-1">{f.severity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selected && (
+        <div
+          role="dialog"
+          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
+        >
+          <button
+            type="button"
+            onClick={() => setSelected(null)}
+            className="mb-2 text-sm bg-red-600 px-2 py-1 rounded"
+          >
+            Close
+          </button>
+          <h2 className="text-xl mb-2">{selected.name}</h2>
+          <p className="text-sm mb-2">
+            CVSS {selected.cvss} ({selected.severity})
+          </p>
+          <p className="mb-4 text-sm whitespace-pre-wrap">
+            {selected.description}
+          </p>
+          <p className="text-xs text-gray-400">
+            Disclaimer: This sample report is for demonstration purposes only.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NessusReport;


### PR DESCRIPTION
## Summary
- add sample Nessus findings JSON
- display CVSS donut and findings table with detail drawer and disclaimer
- test drawer rendering and disclaimer presence

## Testing
- `yarn test` *(fails: react-cytoscapejs ESM parse, calculator localStorage, CandyCrushApp reference)*
- `yarn lint pages/nessus-report.tsx __tests__/nessus-report.test.tsx components/apps/nessus/sample-report.json` *(fails: Could not find pages or app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aee3ad36b08328a4bb216c13e27247