### PR TITLE
feat: add pseudocode and disassembly viewer

### DIFF
--- a/components/apps/ghidra/PseudoDisasmViewer.js
+++ b/components/apps/ghidra/PseudoDisasmViewer.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+const SNIPPET = [
+  { pseudo: 'int square(int x) {', asm: 'square:' },
+  { pseudo: '  return x * x;', asm: '  imul eax, edi, edi' },
+  { pseudo: '}', asm: '  ret' },
+];
+
+export default function PseudoDisasmViewer() {
+  const [hover, setHover] = useState(null);
+
+  const handleCopy = (text) => {
+    if (navigator && navigator.clipboard) {
+      navigator.clipboard.writeText(text);
+    }
+  };
+
+  const renderColumn = (key, label) => (
+    <pre
+      aria-label={label}
+      className="w-1/2 overflow-auto p-2 whitespace-pre-wrap"
+    >
+      {SNIPPET.map((line, idx) => (
+        <div
+          key={`${key}-${idx}`}
+          onMouseEnter={() => setHover(idx)}
+          onMouseLeave={() => setHover(null)}
+          onClick={() => handleCopy(line[key])}
+          className={`cursor-pointer ${
+            hover === idx ? 'bg-yellow-700' : ''
+          }`}
+        >
+          {line[key]}
+        </div>
+      ))}
+    </pre>
+  );
+
+  return (
+    <div className="w-full h-48 flex border-t border-gray-700 bg-gray-800 text-sm text-gray-100">
+      {renderColumn('pseudo', 'Pseudocode')}
+      {renderColumn('asm', 'Disassembly')}
+    </div>
+  );
+}
+

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import PseudoDisasmViewer from './PseudoDisasmViewer';
 
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
@@ -159,29 +160,32 @@ export default function GhidraApp() {
   const selectedBlock = BLOCKS.find((b) => b.id === selected);
 
   return (
-    <div className="w-full h-full flex bg-gray-900 text-gray-100">
-      <div className="w-1/3 border-r border-gray-700">
-        <ControlFlowGraph
-          blocks={BLOCKS}
-          selected={selected}
-          onSelect={setSelected}
-          prefersReducedMotion={prefersReducedMotion}
-        />
+    <div className="w-full h-full flex flex-col bg-gray-900 text-gray-100">
+      <div className="flex flex-1">
+        <div className="w-1/3 border-r border-gray-700">
+          <ControlFlowGraph
+            blocks={BLOCKS}
+            selected={selected}
+            onSelect={setSelected}
+            prefersReducedMotion={prefersReducedMotion}
+          />
+        </div>
+        <pre
+          ref={decompileRef}
+          aria-label="Decompiled code"
+          className="w-1/3 overflow-auto p-2 whitespace-pre-wrap"
+        >
+          {selectedBlock.code.join('\n')}
+        </pre>
+        <pre
+          ref={hexRef}
+          aria-label="Hexadecimal representation"
+          className="w-1/3 overflow-auto p-2 whitespace-pre-wrap"
+        >
+          {hexMap[selected] || ''}
+        </pre>
       </div>
-      <pre
-        ref={decompileRef}
-        aria-label="Decompiled code"
-        className="w-1/3 overflow-auto p-2 whitespace-pre-wrap"
-      >
-        {selectedBlock.code.join('\n')}
-      </pre>
-      <pre
-        ref={hexRef}
-        aria-label="Hexadecimal representation"
-        className="w-1/3 overflow-auto p-2 whitespace-pre-wrap"
-      >
-        {hexMap[selected] || ''}
-      </pre>
+      <PseudoDisasmViewer />
       <div aria-live="polite" role="status" className="sr-only">
         {liveMessage}
       </div>


### PR DESCRIPTION
## Summary
- add pseudocode/disassembly viewer component with synchronized hover and copy
- integrate viewer into Ghidra app layout

## Testing
- `yarn lint` *(fails: react-hooks warnings, parsing errors in existing files)*
- `yarn test` *(fails: module parse errors and missing references in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aee3ae4bac83289af9c1e2e3cdcadd