### PR TITLE
feat: add accessible game theme

### DIFF
--- a/__tests__/games-theme.test.ts
+++ b/__tests__/games-theme.test.ts
@@ -1,0 +1,31 @@
+import {
+  getThemePalette,
+  validateContrast,
+  contrastRatio,
+  defaultPalette,
+  colorBlindPalette,
+} from '../components/apps/Games/common/theme';
+
+describe('game theme accessibility', () => {
+  test('default palette meets WCAG AA contrast', () => {
+    expect(validateContrast(defaultPalette)).toBe(true);
+  });
+
+  test('colorblind palette meets WCAG AA contrast', () => {
+    expect(validateContrast(colorBlindPalette)).toBe(true);
+  });
+
+  test('high contrast mode exceeds WCAG AAA contrast', () => {
+    const high = getThemePalette({ highContrast: true });
+    Object.values(high).forEach(({ fg, bg }) => {
+      expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(7);
+    });
+  });
+
+  test('palettes provide non-color cues', () => {
+    const palette = getThemePalette();
+    Object.values(palette).forEach((entry) => {
+      expect(entry.icon).toBeTruthy();
+    });
+  });
+});

--- a/components/apps/Games/common/theme/index.ts
+++ b/components/apps/Games/common/theme/index.ts
@@ -1,0 +1,45 @@
+import { Palette, PaletteColor, defaultPalette, colorBlindPalette } from './palette';
+
+// Calculate relative luminance according to WCAG 2.1
+const luminance = (hex: string): number => {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const [lr, lg, lb] = [r, g, b].map(toLinear);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+};
+
+// Compute contrast ratio per WCAG formula
+export const contrastRatio = (fg: string, bg: string): number => {
+  const l1 = luminance(fg);
+  const l2 = luminance(bg);
+  const [light, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (light + 0.05) / (dark + 0.05);
+};
+
+// Validate that all palette entries meet a minimum contrast ratio
+export const validateContrast = (palette: Palette, minRatio = 4.5): boolean =>
+  Object.values(palette).every(({ fg, bg }) => contrastRatio(fg, bg) >= minRatio);
+
+// Generate a high contrast variant of a palette using black backgrounds and white text
+const toHighContrast = (palette: Palette): Palette =>
+  Object.fromEntries(
+    Object.entries(palette).map(([k, v]) => [k, { ...v, bg: '#000000', fg: '#ffffff' }]),
+  ) as Palette;
+
+// Retrieve the appropriate palette based on color blindness and contrast settings
+export const getThemePalette = (
+  opts: { colorBlind?: boolean; highContrast?: boolean } = {},
+): Palette => {
+  let base: Palette = opts.colorBlind ? colorBlindPalette : defaultPalette;
+  if (opts.highContrast) base = toHighContrast(base);
+  return base;
+};
+
+export type { Palette, PaletteColor } from './palette';
+export { defaultPalette, colorBlindPalette } from './palette';

--- a/components/apps/Games/common/theme/palette.ts
+++ b/components/apps/Games/common/theme/palette.ts
@@ -1,0 +1,26 @@
+export interface PaletteColor {
+  bg: string; // background color in hex
+  fg: string; // foreground/text color in hex
+  icon: string; // non-color indicator
+}
+
+export type Palette = Record<string, PaletteColor>;
+
+// Default palette using colors with sufficient contrast
+export const defaultPalette: Palette = {
+  primary: { bg: '#f3f4f6', fg: '#111827', icon: '●' }, // gray-100 / gray-900
+  secondary: { bg: '#1d4ed8', fg: '#ffffff', icon: '▲' }, // blue-700
+  success: { bg: '#15803d', fg: '#ffffff', icon: '✔' }, // green-700
+  warning: { bg: '#d97706', fg: '#111827', icon: '!' }, // amber-600
+  danger: { bg: '#b91c1c', fg: '#ffffff', icon: '✖' }, // red-700
+};
+
+// Colorblind-friendly palette based on Okabe-Ito colors
+export const colorBlindPalette: Palette = {
+  primary: { bg: '#f3f4f6', fg: '#111827', icon: '●' },
+  secondary: { bg: '#0072b2', fg: '#ffffff', icon: '▲' },
+  success: { bg: '#009e73', fg: '#111827', icon: '✔' },
+  warning: { bg: '#d55e00', fg: '#111827', icon: '!' },
+  danger: { bg: '#cc79a7', fg: '#111827', icon: '✖' },
+};
+


### PR DESCRIPTION
## Summary
- add shared game theme with colorblind palette and icons
- provide high contrast toggle and contrast validation utilities
- test theme contrast meets WCAG guidelines

## Testing
- `yarn test __tests__/games-theme.test.ts __tests__/game2048.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aeeca03d08832893d7689c3cd065c9