### PR TITLE
feat: add reusable tutorial overlay

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import HelpOverlay from './HelpOverlay';
+import TutorialOverlay from './Games/common/tutorial';
 
 interface GameLayoutProps {
   gameId: string;
@@ -13,13 +13,12 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
 
-  // Show tutorial overlay on first visit
+  // Show tutorial overlay until user opts out
   useEffect(() => {
     try {
-      const key = `seen_tutorial_${gameId}`;
+      const key = `hide_tutorial_${gameId}`;
       if (typeof window !== 'undefined' && !window.localStorage.getItem(key)) {
         setShowHelp(true);
-        window.localStorage.setItem(key, '1');
       }
     } catch {
       // ignore storage errors
@@ -54,7 +53,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
 
   return (
     <div className="relative h-full w-full">
-      {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
+      {showHelp && <TutorialOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div
           className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"

--- a/components/apps/Games/common/tutorial/index.tsx
+++ b/components/apps/Games/common/tutorial/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import usePersistentState from '../../../../usePersistentState';
+
+interface TutorialOverlayProps {
+  gameId: string;
+  onClose: () => void;
+}
+
+const TutorialOverlay: React.FC<TutorialOverlayProps> = ({ gameId, onClose }) => {
+  const [bindings] = usePersistentState(`${gameId}-keys`, {} as Record<string, string>);
+  const entries = Object.entries(bindings as Record<string, string>);
+
+  const dontShowAgain = () => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(`hide_tutorial_${gameId}`, '1');
+      }
+    } catch {
+      // ignore
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50 transition-opacity duration-300 motion-reduce:transition-none"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+        <h2 className="text-xl font-bold mb-3">How to Play</h2>
+        {entries.length > 0 && (
+          <ul className="mb-4 space-y-1">
+            {entries.map(([action, key]) => (
+              <li key={action}>
+                <kbd className="px-1 py-0.5 bg-gray-700 rounded mr-2">{key}</kbd>
+                {action}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="flex justify-end space-x-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            autoFocus
+          >
+            Dismiss
+          </button>
+          <button
+            onClick={dontShowAgain}
+            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          >
+            Don't show again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TutorialOverlay;


### PR DESCRIPTION
## Summary
- add tutorial overlay pulling control bindings and offering dismiss and don't show again
- wire overlay into GameLayout to display until user opts out

## Testing
- `npm test` (fails: module parse errors, localStorage unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68aeeca1f0308328b62c31919fe15071