### PR TITLE
feat: add customizable game input mapping

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -252,7 +252,7 @@ const Game2048 = () => {
     [board, won, lost, hardMode, score, setBoard, setLost, setWon],
   );
 
-  useGameControls(handleDirection);
+  useGameControls(handleDirection, '2048');
 
   useEffect(() => {
     const esc = (e) => {

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+interface Props {
+  mapping: Record<string, string>;
+  setKey: (action: string, key: string) => string | null;
+  actions: Record<string, string>;
+}
+
+const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
+  const [waiting, setWaiting] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const capture = (action: string) => {
+    setWaiting(action);
+    setMessage(null);
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      const conflict = setKey(action, e.key);
+      if (conflict) setMessage(`Replaced ${conflict}`);
+      else setMessage(null);
+      setWaiting(null);
+      window.removeEventListener('keydown', handler);
+    };
+    window.addEventListener('keydown', handler);
+  };
+
+  return (
+    <div className="space-y-2">
+      {Object.keys(actions).map((action) => (
+        <div key={action} className="flex items-center justify-between">
+          <span className="mr-2 capitalize">{action}</span>
+          <button
+            type="button"
+            onClick={() => capture(action)}
+            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          >
+            {waiting === action ? 'Press key...' : mapping[action]}
+          </button>
+        </div>
+      ))}
+      {message && <div className="text-sm text-yellow-300">{message}</div>}
+    </div>
+  );
+};
+
+export default InputRemap;

--- a/components/apps/Games/common/input-remap/useInputMapping.js
+++ b/components/apps/Games/common/input-remap/useInputMapping.js
@@ -1,0 +1,33 @@
+import usePersistedState from '../../../../../hooks/usePersistedState';
+
+export const getMapping = (gameId, defaults = {}) => {
+  if (typeof window === 'undefined') return defaults;
+  try {
+    const raw = window.localStorage.getItem(`controls:${gameId}`);
+    return raw ? { ...defaults, ...JSON.parse(raw) } : defaults;
+  } catch {
+    return defaults;
+  }
+};
+
+export default function useInputMapping(gameId, defaults = {}) {
+  const [mapping, setMapping] = usePersistedState(`controls:${gameId}`, getMapping(gameId, defaults));
+
+  const setKey = (action, key) => {
+    let conflict = null;
+    setMapping((prev) => {
+      const next = { ...prev };
+      Object.keys(next).forEach((a) => {
+        if (a !== action && next[a] === key) {
+          conflict = a;
+          delete next[a];
+        }
+      });
+      next[action] = key;
+      return next;
+    });
+    return conflict;
+  };
+
+  return [mapping, setKey];
+}

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import InputRemap from './Games/common/input-remap/InputRemap';
+import useInputMapping from './Games/common/input-remap/useInputMapping';
 
 interface HelpOverlayProps {
   gameId: string;
@@ -8,12 +10,19 @@ interface HelpOverlayProps {
 interface Instruction {
   objective: string;
   controls: string;
+  actions?: Record<string, string>;
 }
 
 export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
   '2048': {
     objective: 'Reach the 2048 tile by merging numbers.',
     controls: 'Use the arrow keys to slide and combine tiles.',
+    actions: {
+      up: 'ArrowUp',
+      down: 'ArrowDown',
+      left: 'ArrowLeft',
+      right: 'ArrowRight',
+    },
   },
   asteroids: {
     objective: 'Destroy asteroids without crashing your ship.',
@@ -148,6 +157,7 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
 const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
   if (!info) return null;
+  const [mapping, setKey] = useInputMapping(gameId, info.actions || {});
   return (
     <div
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
@@ -157,7 +167,23 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
       <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
         <h2 className="text-xl font-bold mb-2">{gameId} Help</h2>
         <p className="mb-2"><strong>Objective:</strong> {info.objective}</p>
-        <p><strong>Controls:</strong> {info.controls}</p>
+        {info.actions ? (
+          <>
+            <p>
+              <strong>Controls:</strong>{' '}
+              {Object.entries(mapping)
+                .map(([a, k]) => `${a}: ${k}`)
+                .join(', ')}
+            </p>
+            <div className="mt-2">
+              <InputRemap mapping={mapping} setKey={setKey} actions={info.actions} />
+            </div>
+          </>
+        ) : (
+          <p>
+            <strong>Controls:</strong> {info.controls}
+          </p>
+        )}
         <button
           onClick={onClose}
           className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { getMapping } from './Games/common/input-remap/useInputMapping';
 
 /**
  * Multifunctional game control hook.
@@ -7,21 +8,31 @@ import { useEffect, useRef } from 'react';
  * invoke the callback with a direction object.
  * If a ref is provided, an object describing input state is returned.
  */
-const useGameControls = (arg) => {
+const defaultMap = {
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  fire: ' ',
+  hyperspace: 'h',
+};
+
+const useGameControls = (arg, gameId = 'default') => {
   if (typeof arg === 'function') {
     const onDirection = arg;
 
     // keyboard controls
     useEffect(() => {
       const handleKey = (e) => {
-        if (e.key === 'ArrowUp') onDirection({ x: 0, y: -1 });
-        if (e.key === 'ArrowDown') onDirection({ x: 0, y: 1 });
-        if (e.key === 'ArrowLeft') onDirection({ x: -1, y: 0 });
-        if (e.key === 'ArrowRight') onDirection({ x: 1, y: 0 });
+        const map = getMapping(gameId, defaultMap);
+        if (e.key === map.up) onDirection({ x: 0, y: -1 });
+        if (e.key === map.down) onDirection({ x: 0, y: 1 });
+        if (e.key === map.left) onDirection({ x: -1, y: 0 });
+        if (e.key === map.right) onDirection({ x: 1, y: 0 });
       };
       window.addEventListener('keydown', handleKey);
       return () => window.removeEventListener('keydown', handleKey);
-    }, [onDirection]);
+    }, [onDirection, gameId]);
 
     // touch swipe controls
     useEffect(() => {
@@ -67,13 +78,15 @@ const useGameControls = (arg) => {
 
   useEffect(() => {
     const handleDown = (e) => {
-      if (e.code === 'Space') stateRef.current.fire = true;
-      else if (e.key === 'h' || e.key === 'H') stateRef.current.hyperspace = true;
+      const map = getMapping(gameId, defaultMap);
+      if (e.key === map.fire) stateRef.current.fire = true;
+      else if (e.key === map.hyperspace) stateRef.current.hyperspace = true;
       else stateRef.current.keys[e.key] = true;
     };
     const handleUp = (e) => {
-      if (e.code === 'Space') stateRef.current.fire = false;
-      else if (e.key === 'h' || e.key === 'H') stateRef.current.hyperspace = false;
+      const map = getMapping(gameId, defaultMap);
+      if (e.key === map.fire) stateRef.current.fire = false;
+      else if (e.key === map.hyperspace) stateRef.current.hyperspace = false;
       else stateRef.current.keys[e.key] = false;
     };
     window.addEventListener('keydown', handleDown);
@@ -82,7 +95,7 @@ const useGameControls = (arg) => {
       window.removeEventListener('keydown', handleDown);
       window.removeEventListener('keyup', handleUp);
     };
-  }, []);
+  }, [gameId]);
 
   useEffect(() => {
     const canvas = canvasRef?.current;


### PR DESCRIPTION
## Summary
- add persisted input mapping hook with conflict resolution and live capturing
- expose mapping UI and integrate with help overlay for per-game controls
- respect remapped keys in shared game control hook

## Testing
- `npm test` *(fails: SyntaxError in `beef.test.tsx`; SyntaxError in `frogger.test.ts`; ReferenceError in `frogger.config.test.ts`, `snake.config.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeca2d7488328a18a4a908ae954c7