### PR TITLE
feat(games): add accessibility settings

### DIFF
--- a/components/apps/Games/common/settings/index.tsx
+++ b/components/apps/Games/common/settings/index.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useEffect } from 'react';
+import usePersistedState from '../../../../../hooks/usePersistedState';
+
+type Settings = {
+  colorBlind: boolean;
+  setColorBlind: (v: boolean) => void;
+  highContrast: boolean;
+  setHighContrast: (v: boolean) => void;
+  reduceMotion: boolean;
+  setReduceMotion: (v: boolean) => void;
+  textScale: number;
+  setTextScale: (v: number) => void;
+};
+
+const GameSettingsContext = createContext<Settings | undefined>(undefined);
+
+export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [colorBlind, setColorBlind] = usePersistedState('settings:colorBlind', false);
+  const [highContrast, setHighContrast] = usePersistedState('settings:highContrast', false);
+  const [reduceMotion, setReduceMotion] = usePersistedState('settings:reduceMotion', () => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+    return false;
+  });
+  const [textScale, setTextScale] = usePersistedState('settings:textScale', 1);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReduceMotion(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [setReduceMotion]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.toggle('colorblind', colorBlind);
+    root.classList.toggle('high-contrast', highContrast);
+    root.classList.toggle('reduce-motion', reduceMotion);
+    root.style.setProperty('--game-text-scale', String(textScale));
+  }, [colorBlind, highContrast, reduceMotion, textScale]);
+
+  return (
+    <GameSettingsContext.Provider
+      value={{
+        colorBlind,
+        setColorBlind,
+        highContrast,
+        setHighContrast,
+        reduceMotion,
+        setReduceMotion,
+        textScale,
+        setTextScale,
+      }}
+    >
+      {children}
+    </GameSettingsContext.Provider>
+  );
+};
+
+export const useGameSettings = () => {
+  const ctx = useContext(GameSettingsContext);
+  if (!ctx) throw new Error('useGameSettings must be used within GameSettingsProvider');
+  return ctx;
+};
+
+export default GameSettingsContext;


### PR DESCRIPTION
## Summary
- add game-wide settings for colorblind palette, high contrast, reduced motion, and text scaling
- respect `prefers-reduced-motion` and apply toggles immediately across HUD and tiles
- wire 2048 to new settings and honor reduced-motion for animations

## Testing
- `npm test` *(fails: SyntaxError in beef.test.tsx; localStorage SecurityError in calculator.app.test.js; ReferenceError CandyCrushApp in snake.config.test.ts and frogger.config.test.ts; etc.)*
- `npm run lint` *(fails: React Hooks rules-of-hooks in useGameControls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeca506988328bf1df437b7e9bea0