### PR TITLE
feat(games): add share helpers

### DIFF
--- a/components/apps/Games/common/share/index.ts
+++ b/components/apps/Games/common/share/index.ts
@@ -1,0 +1,2 @@
+export { recordCanvas } from './record';
+export { shareBlob } from './share';

--- a/components/apps/Games/common/share/record.ts
+++ b/components/apps/Games/common/share/record.ts
@@ -1,0 +1,43 @@
+export async function recordCanvas(
+  canvas: HTMLCanvasElement,
+  duration = 1000,
+  options: MediaRecorderOptions = { mimeType: 'video/webm' }
+): Promise<Blob> {
+  // Fallback to PNG snapshot when MediaRecorder is unavailable
+  if (typeof window === 'undefined' || typeof MediaRecorder === 'undefined') {
+    return new Promise((resolve, reject) =>
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Snapshot failed'))),
+        'image/png'
+      )
+    );
+  }
+
+  const stream = canvas.captureStream();
+  return new Promise((resolve, reject) => {
+    try {
+      const chunks: BlobPart[] = [];
+      const recorder = new MediaRecorder(stream, options);
+      recorder.ondataavailable = (e: BlobEvent) => {
+        if (e.data && e.data.size > 0) chunks.push(e.data);
+      };
+      recorder.onerror = () => {
+        // On error, fallback to snapshot
+        canvas.toBlob(
+          (blob) => (blob ? resolve(blob) : reject(new Error('Snapshot failed'))),
+          'image/png'
+        );
+      };
+      recorder.onstop = () => {
+        resolve(new Blob(chunks, { type: options.mimeType || 'video/webm' }));
+      };
+      recorder.start();
+      setTimeout(() => recorder.stop(), duration);
+    } catch {
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('Snapshot failed'))),
+        'image/png'
+      );
+    }
+  });
+}

--- a/components/apps/Games/common/share/share.ts
+++ b/components/apps/Games/common/share/share.ts
@@ -1,0 +1,22 @@
+export async function shareBlob(blob: Blob, fileName: string): Promise<void> {
+  const file = new File([blob], fileName, { type: blob.type });
+  const shareData: ShareData = { files: [file] };
+
+  if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
+    try {
+      await navigator.share(shareData);
+      return;
+    } catch {
+      // fall back to download if sharing fails
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add canvas recording helper with snapshot fallback
- add share helper around Web Share API

## Testing
- `npm test` *(fails: SyntaxError and localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeca5b7dc8328a7d29d0d21d694a7