### PR TITLE
Add game performance overlay with exportable reports

### DIFF
--- a/components/apps/GameLayout.js
+++ b/components/apps/GameLayout.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PerfOverlay from './Games/common/perf';
 
 const GameLayout = ({ children, stage, lives, score, highScore }) => (
   <div className="h-full w-full relative text-white">
@@ -9,6 +10,7 @@ const GameLayout = ({ children, stage, lives, score, highScore }) => (
       {highScore !== undefined && <div>High: {highScore}</div>}
     </div>
     {children}
+    <PerfOverlay />
 
   </div>
 );

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
+import PerfOverlay from './Games/common/perf';
 
 interface GameLayoutProps {
   gameId: string;
@@ -81,6 +82,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
         ?
       </button>
       {children}
+      <PerfOverlay />
     </div>
   );
 };

--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef } from 'react';
+
+interface PerfSample {
+  t: number;
+  dt: number;
+}
+
+const MAX_SAMPLES = 120;
+const MAX_MS = 50; // cap graph at 50ms (20 FPS)
+
+export const exportPerfReport = (samples: PerfSample[]) => {
+  if (!samples.length || typeof document === 'undefined') return;
+  const avgDt = samples.reduce((a, s) => a + s.dt, 0) / samples.length;
+  const avgFps = 1000 / avgDt;
+  const report = {
+    avgFps,
+    avgFrameMs: avgDt,
+    samples: samples.map((s) => ({ t: Math.round(s.t), dt: +s.dt.toFixed(2) })),
+  };
+  const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'perf-report.json';
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+const PerfOverlay: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const samplesRef = useRef<PerfSample[]>([]);
+  const lastRef = useRef<number>(0);
+  const rafRef = useRef<number>();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    let mounted = true;
+
+    const loop = (now: number) => {
+      if (!mounted) return;
+      if (lastRef.current) {
+        const dt = now - lastRef.current;
+        const samples = samplesRef.current;
+        samples.push({ t: now, dt });
+        if (samples.length > MAX_SAMPLES) samples.shift();
+        if (ctx && canvas) {
+          const w = canvas.width;
+          const h = canvas.height;
+          ctx.clearRect(0, 0, w, h);
+          ctx.strokeStyle = '#00ff00';
+          ctx.beginPath();
+          samples.forEach((s, i) => {
+            const x = (i / (samples.length - 1 || 1)) * w;
+            const clamped = Math.min(s.dt, MAX_MS);
+            const y = h - (clamped / MAX_MS) * h;
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+          });
+          ctx.stroke();
+          const latest = samples[samples.length - 1];
+          const fps = latest ? (1000 / latest.dt).toFixed(1) : '0';
+          ctx.fillStyle = '#ffffff';
+          ctx.font = '12px sans-serif';
+          ctx.fillText(`${fps} FPS`, 4, 12);
+        }
+      }
+      lastRef.current = now;
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      mounted = false;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  const handleExport = () => exportPerfReport(samplesRef.current);
+
+  return (
+    <div className="absolute bottom-2 left-2 z-50 bg-black bg-opacity-50 text-white p-1 text-xs space-y-1">
+      <canvas ref={canvasRef} width={150} height={60} className="block" />
+      <button type="button" onClick={handleExport} className="underline">
+        Export JSON
+      </button>
+    </div>
+  );
+};
+
+export default PerfOverlay;

--- a/components/apps/Games/common/perf/index.ts
+++ b/components/apps/Games/common/perf/index.ts
@@ -1,0 +1,1 @@
+export { default, exportPerfReport } from './PerfOverlay';


### PR DESCRIPTION
## Summary
- add FPS/frame-time overlay component for games
- expose JSON performance report export
- integrate overlay into existing game layouts

## Testing
- `npm test` *(fails: __tests__/beef.test.tsx, __tests__/frogger.test.ts, __tests__/calculator.app.test.js, __tests__/frogger.config.test.ts, __tests__/snake.config.test.ts)*
- `npm run lint` *(fails: React hook rule violations and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeca6ac98832894b00e71268d3af4