### PR TITLE
Add weather effects and driving assists

### DIFF
--- a/public/apps/car-racer/index.html
+++ b/public/apps/car-racer/index.html
@@ -20,6 +20,9 @@
         <option value="aggressive">Aggressive</option>
       </select>
     </label>
+    <label>
+      <input type="checkbox" id="assist" /> Traction assist
+    </label>
     <div>Lap: <span id="lapTime">0.00</span>s Best: <span id="bestTime">--</span>s</div>
   </div>
   <script type="module" src="./main.js"></script>


### PR DESCRIPTION
## Summary
- implement day-night cycle with headlights, rain and reflections in car racer
- add low-speed auto-centering and optional traction assist

## Testing
- `npm test` *(fails: SyntaxError in react-cytoscapejs, frogger, localStorage security error, missing CandyCrushApp)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecacd7048328992e0bf645fa795b