### PR TITLE
feat: add jump buffer and remappable controls

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -1,10 +1,96 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Phaser from 'phaser';
 import { GameState } from './gameLogic';
+import usePersistedState from '../../hooks/usePersistedState';
+
+type Action = 'left' | 'right' | 'jump';
 
 const PhaserMatter: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const controls = useRef({ left: false, right: false, jump: false });
+  const controls = useRef({
+    left: false,
+    right: false,
+    jumpHeld: false,
+    jumpPressed: false,
+  });
+
+  const [keyMap, setKeyMap] = usePersistedState<Record<Action, string>>('phaser-keys', {
+    left: 'ArrowLeft',
+    right: 'ArrowRight',
+    jump: 'Space',
+  });
+  const [padMap, setPadMap] = usePersistedState<Record<Action, number>>('phaser-pad', {
+    left: 14,
+    right: 15,
+    jump: 0,
+  });
+  const [bufferWindow, setBufferWindow] = usePersistedState<number>('phaser-buffer', 100);
+  const bufferRef = useRef(bufferWindow);
+  useEffect(() => {
+    bufferRef.current = bufferWindow;
+  }, [bufferWindow]);
+  const keyMapRef = useRef(keyMap);
+  useEffect(() => {
+    keyMapRef.current = keyMap;
+  }, [keyMap]);
+  const padMapRef = useRef(padMap);
+  useEffect(() => {
+    padMapRef.current = padMap;
+  }, [padMap]);
+  const [waiting, setWaiting] = useState<
+    null | { device: 'key' | 'pad'; action: Action }
+  >(null);
+
+  // Keyboard input and remapping
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (waiting?.device === 'key' && e.type === 'keydown') {
+        setKeyMap((prev) => ({ ...prev, [waiting.action]: e.code }));
+        setWaiting(null);
+        return;
+      }
+      const pressed = e.type === 'keydown';
+      const action = (Object.keys(keyMapRef.current) as Action[]).find(
+        (a) => keyMapRef.current[a] === e.code,
+      );
+      if (action) {
+        if (action === 'jump') {
+          if (pressed && !controls.current.jumpHeld) controls.current.jumpPressed = true;
+          controls.current.jumpHeld = pressed;
+        } else {
+          controls.current[action] = pressed;
+        }
+      }
+    };
+    window.addEventListener('keydown', handle);
+    window.addEventListener('keyup', handle);
+    return () => {
+      window.removeEventListener('keydown', handle);
+      window.removeEventListener('keyup', handle);
+    };
+  }, [waiting, setKeyMap]);
+
+  // Gamepad remapping polling when waiting
+  useEffect(() => {
+    if (!waiting || waiting.device !== 'pad') return;
+    let raf: number;
+    const poll = () => {
+      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+      for (const gp of pads) {
+        if (!gp) continue;
+        for (let i = 0; i < gp.buttons.length; i++) {
+          if (gp.buttons[i].pressed) {
+            setPadMap((prev) => ({ ...prev, [waiting.action]: i }));
+            setWaiting(null);
+            return;
+          }
+        }
+      }
+      raf = requestAnimationFrame(poll);
+    };
+    raf = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(raf);
+  }, [waiting, setPadMap]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -14,6 +100,9 @@ const PhaserMatter: React.FC = () => {
       state!: GameState;
       lastGrounded = 0;
       coyoteTime = 100; // ms
+      jumpBufferTimer = 0;
+      buffered = false;
+      padJumpWasPressed = false;
 
       constructor() {
         super('level');
@@ -73,18 +162,57 @@ const PhaserMatter: React.FC = () => {
         });
       }
 
-      update(time: number) {
+      update(time: number, delta: number) {
         const ctrl = controls.current;
         const speed = 5;
+
+        // Poll gamepad for input
+        if (this.input.gamepad.total > 0) {
+          const pad = this.input.gamepad.getPad(0);
+          const pm = padMapRef.current;
+          ctrl.left = pad.buttons[pm.left]?.pressed;
+          ctrl.right = pad.buttons[pm.right]?.pressed;
+          const jp = pad.buttons[pm.jump]?.pressed;
+          if (jp && !this.padJumpWasPressed) {
+            ctrl.jumpPressed = true;
+            ctrl.jumpHeld = true;
+          } else if (!jp) {
+            ctrl.jumpHeld = false;
+          }
+          this.padJumpWasPressed = jp;
+        }
+
         if (ctrl.left) this.player.setVelocityX(-speed);
         else if (ctrl.right) this.player.setVelocityX(speed);
         else this.player.setVelocityX(0);
 
         const onGround = Math.abs(this.player.body.velocity.y) < 0.01;
         if (onGround) this.lastGrounded = time;
-        if (ctrl.jump && (onGround || time - this.lastGrounded < this.coyoteTime)) {
+
+        if (ctrl.jumpPressed) {
+          this.jumpBufferTimer = bufferRef.current;
+          const canJump = onGround || time - this.lastGrounded < this.coyoteTime;
+          this.buffered = !canJump;
+          ctrl.jumpPressed = false;
+          if (canJump) {
+            this.player.setVelocityY(-10);
+            ctrl.jumpHeld = false;
+            this.buffered = false;
+          }
+        }
+
+        if (this.jumpBufferTimer > 0) this.jumpBufferTimer -= delta;
+
+        const canJump = onGround || time - this.lastGrounded < this.coyoteTime;
+        if (canJump && this.jumpBufferTimer > 0) {
           this.player.setVelocityY(-10);
-          ctrl.jump = false; // consume jump
+          this.jumpBufferTimer = 0;
+          ctrl.jumpHeld = false;
+          if (this.buffered) {
+            this.player.setTintFill(0xffff00);
+            this.time.delayedCall(100, () => this.player.clearTint());
+          }
+          this.buffered = false;
         }
 
         const data = this.cache.json.get('level');
@@ -110,18 +238,109 @@ const PhaserMatter: React.FC = () => {
     };
   }, []);
 
-  const bind = (key: 'left' | 'right' | 'jump') => ({
-    onMouseDown: () => (controls.current[key] = true),
-    onMouseUp: () => (controls.current[key] = false),
-    onTouchStart: () => (controls.current[key] = true),
-    onTouchEnd: () => (controls.current[key] = false),
-  });
+  const bind = (key: Action) =>
+    key === 'jump'
+      ? {
+          onMouseDown: () => {
+            controls.current.jumpPressed = true;
+            controls.current.jumpHeld = true;
+          },
+          onMouseUp: () => (controls.current.jumpHeld = false),
+          onTouchStart: () => {
+            controls.current.jumpPressed = true;
+            controls.current.jumpHeld = true;
+          },
+          onTouchEnd: () => (controls.current.jumpHeld = false),
+        }
+      : {
+          onMouseDown: () => (controls.current[key] = true),
+          onMouseUp: () => (controls.current[key] = false),
+          onTouchStart: () => (controls.current[key] = true),
+          onTouchEnd: () => (controls.current[key] = false),
+        };
 
   return (
     <div ref={containerRef} className="relative">
-      <button className="absolute left-4 bottom-4" {...bind('left')}>◀</button>
-      <button className="absolute left-20 bottom-4" {...bind('right')}>▶</button>
-      <button className="absolute right-4 bottom-4" {...bind('jump')}>⇧</button>
+      <button className="absolute left-4 bottom-4" {...bind('left')}>
+        ◀
+      </button>
+      <button className="absolute left-20 bottom-4" {...bind('right')}>
+        ▶
+      </button>
+      <button className="absolute right-4 bottom-4" {...bind('jump')}>
+        ⇧
+      </button>
+      <div className="absolute top-4 left-4 bg-white bg-opacity-80 p-2 rounded text-xs space-y-1">
+        {waiting && <div>Press a {waiting.device === 'key' ? 'key' : 'button'}...</div>}
+        <div>Keyboard</div>
+        <div>
+          Left:
+          <button
+            onClick={() => setWaiting({ device: 'key', action: 'left' })}
+            className="ml-1 border px-1"
+          >
+            {keyMap.left}
+          </button>
+        </div>
+        <div>
+          Right:
+          <button
+            onClick={() => setWaiting({ device: 'key', action: 'right' })}
+            className="ml-1 border px-1"
+          >
+            {keyMap.right}
+          </button>
+        </div>
+        <div>
+          Jump:
+          <button
+            onClick={() => setWaiting({ device: 'key', action: 'jump' })}
+            className="ml-1 border px-1"
+          >
+            {keyMap.jump}
+          </button>
+        </div>
+        <div className="pt-2">Gamepad</div>
+        <div>
+          Left:
+          <button
+            onClick={() => setWaiting({ device: 'pad', action: 'left' })}
+            className="ml-1 border px-1"
+          >
+            {padMap.left}
+          </button>
+        </div>
+        <div>
+          Right:
+          <button
+            onClick={() => setWaiting({ device: 'pad', action: 'right' })}
+            className="ml-1 border px-1"
+          >
+            {padMap.right}
+          </button>
+        </div>
+        <div>
+          Jump:
+          <button
+            onClick={() => setWaiting({ device: 'pad', action: 'jump' })}
+            className="ml-1 border px-1"
+          >
+            {padMap.jump}
+          </button>
+        </div>
+        <div className="pt-2">
+          Buffer:
+          <input
+            type="range"
+            min={0}
+            max={300}
+            value={bufferWindow}
+            onChange={(e) => setBufferWindow(Number(e.target.value))}
+            className="mx-1"
+          />
+          {bufferWindow}ms
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- support buffered jumps with coyote time and sprite flash
- allow keyboard and gamepad remapping with adjustable jump buffer window

## Testing
- `yarn test __tests__/phaserMatter.test.ts --runInBand`
- `yarn test` *(fails: SyntaxError in react-cytoscapejs and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecb42d648328a13a29c7a0b25c63