### PR TITLE
feat: add patterns and BPM control to Simon

### DIFF
--- a/__tests__/simonSeed.test.ts
+++ b/__tests__/simonSeed.test.ts
@@ -1,0 +1,16 @@
+import { generateSequence } from '../components/apps/simon';
+
+describe('generateSequence', () => {
+  test('uses seed for deterministic sequences', () => {
+    const seq1 = generateSequence(5, 'abc');
+    const seq2 = generateSequence(5, 'abc');
+    expect(seq1).toEqual(seq2);
+  });
+
+  test('different seeds give different sequences', () => {
+    const seq1 = generateSequence(5, 'a');
+    const seq2 = generateSequence(5, 'b');
+    expect(seq1).not.toEqual(seq2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add optional stripe patterns and thick outlines to Simon pads
- introduce audio-only practice mode
- replace speed select with BPM slider and seedable sequence generator for versus play

## Testing
- `npm test` *(fails: beef.test.tsx parsing error, frogger.test.ts syntax error, frogger.config.test.ts CandyCrushApp undefined, snake.config.test.ts CandyCrushApp undefined)*
- `npm run lint` *(fails: parsing error in frogger.js and hooks rule violations in useGameControls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecb6c4048328b5879e34710cb321