### PR TITLE
feat: add Sokoban ghost path and deadlock warnings

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -1,5 +1,5 @@
 import { defaultLevels } from '../apps/sokoban/levels';
-import { loadLevel, move, undo, isSolved, findHint } from '../apps/sokoban/engine';
+import { loadLevel, move, undo, isSolved, findHint, wouldDeadlock } from '../apps/sokoban/engine';
 
 describe('sokoban engine', () => {
   test('simple level solvable', () => {
@@ -27,5 +27,17 @@ describe('sokoban engine', () => {
     const state = loadLevel(defaultLevels[0]);
     const hint = findHint(state);
     expect(hint).toBe('ArrowRight');
+  });
+
+  test('preflight corner deadlock', () => {
+    const level = ['#####', '#@$ #', '#  ##', '#####'];
+    const state = loadLevel(level);
+    expect(wouldDeadlock(state, 'ArrowRight')).toBe(true);
+  });
+
+  test('preflight edge deadlock', () => {
+    const level = ['#####', '#   #', '# $ #', '# @ #', '#####'];
+    const state = loadLevel(level);
+    expect(wouldDeadlock(state, 'ArrowUp')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- show preview path when hovering reachable cells in Sokoban
- add dust puff animation when crates move
- warn before pushes that would deadlock by preflight detection

## Testing
- `npm test` *(fails: CandyCrushApp is not defined, module parse errors)*
- `npm test __tests__/sokoban.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aeecb939448328b99352d07213c234