### PR TITLE
Enhance Wordle share and accessibility

### DIFF
--- a/__tests__/wordle.test.tsx
+++ b/__tests__/wordle.test.tsx
@@ -18,13 +18,14 @@ describe('Wordle', () => {
     Object.assign(navigator, {
       clipboard: { writeText: jest.fn() },
     });
+    delete (navigator as any).share;
     Wordle = require('../components/apps/wordle').default;
   });
   afterEach(() => {
     jest.clearAllTimers();
   });
 
-  test('solves puzzle and shares result', async () => {
+  test('falls back to clipboard share when navigator.share unavailable', async () => {
     render(<Wordle />);
     const todayKey = new Date().toISOString().split('T')[0];
     const solution = wordList[hash(todayKey) % wordList.length];
@@ -34,5 +35,18 @@ describe('Wordle', () => {
     const shareBtn = await screen.findByText('Share');
     fireEvent.click(shareBtn);
     expect((navigator as any).clipboard.writeText).toHaveBeenCalled();
+  });
+
+  test('uses native share when available', async () => {
+    (navigator as any).share = jest.fn().mockResolvedValue(undefined);
+    render(<Wordle />);
+    const todayKey = new Date().toISOString().split('T')[0];
+    const solution = wordList[hash(todayKey) % wordList.length];
+    const input = screen.getByPlaceholderText('Guess');
+    fireEvent.change(input, { target: { value: solution } });
+    fireEvent.submit(input.closest('form')!);
+    const shareBtn = await screen.findByText('Share');
+    fireEvent.click(shareBtn);
+    expect((navigator as any).share).toHaveBeenCalled();
   });
 });

--- a/styles/index.css
+++ b/styles/index.css
@@ -447,6 +447,17 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 }
 
+@keyframes tile-flip {
+    0% { transform: rotateX(0); }
+    50% { transform: rotateX(-90deg); }
+    100% { transform: rotateX(0); }
+}
+
+.tile-flip {
+    animation: tile-flip 0.6s ease;
+    transform-style: preserve-3d;
+}
+
 @keyframes hangman-draw {
     from { stroke-dashoffset: 100; }
     to { stroke-dashoffset: 0; }


### PR DESCRIPTION
## Summary
- support native navigator.share with clipboard fallback for Wordle results
- sequential tile flip cascade and new tile-flip animation
- add shape indicators for colorblind mode and test native/clipboard sharing

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in react-cytoscapejs)*


------
https://chatgpt.com/codex/tasks/task_e_68aeecbd5e088328938944e52600d48d