### PR TITLE
Enhance Sudoku gameplay with smarter hints and notes

### DIFF
--- a/__tests__/sudokuSolver.test.ts
+++ b/__tests__/sudokuSolver.test.ts
@@ -30,7 +30,11 @@ describe('sudokuSolver', () => {
     const hint = getHint(puzzle);
     expect(hint).not.toBeNull();
     if (hint) {
-      expect(hint.value).toBeGreaterThan(0);
+      if ('value' in hint) {
+        expect(hint.value).toBeGreaterThan(0);
+      } else {
+        expect(hint.values.length).toBe(2);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- Highlight related cells when focused and glow matching digits
- Auto-update pencil notes while respecting manual overrides
- Provide hints for singles, hidden singles, and naked pairs

## Testing
- `npm test` *(fails: beef.test.tsx, frogger.test.ts, frogger.config.test.ts, snake.config.test.ts, calculator tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecbf4f5883288217b9c51ed93dfd