### PR TITLE
feat: add practice and wind effects to flappy bird

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -128,8 +128,8 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
     controls: 'Click a cell then type a number.',
   },
   'flappy-bird': {
-    objective: 'Fly through gaps between pipes.',
-    controls: 'Press space or click to flap.',
+    objective: 'Fly through gaps between pipes. Practice gates and easy mode available.',
+    controls: 'Space/click to flap. P: practice, G: easy gravity, M: reduced motion.',
   },
   'candy-crush': {
     objective: 'Match three candies to clear them.',


### PR DESCRIPTION
## Summary
- add wind gusts that sway foliage and speed clouds with reduced motion toggle
- introduce practice gates and optional easy gravity mode in flappy bird
- document new controls in help overlay

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/frogger.js and hook rule violations)*
- `yarn test` *(fails: react-cytoscape import syntax error and CandyCrushApp undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecc083c08328a1ba298d80531a7c