### PR TITLE
Animate Hashcat stats and label modes

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import HashcatApp, { detectHashType } from '../components/apps/hashcat';
 import progressInfo from '../components/apps/hashcat/progress.json';
 
@@ -25,10 +25,30 @@ describe('HashcatApp', () => {
     });
   });
 
-  it('shows progress info from JSON', () => {
+  it('animates attempts/sec and ETA from JSON', () => {
+    jest.useFakeTimers();
     const { getByText } = render(<HashcatApp />);
-    expect(getByText(`Hash rate: ${progressInfo.hashRate}`)).toBeInTheDocument();
-    expect(getByText(`ETA: ${progressInfo.eta}`)).toBeInTheDocument();
+    expect(
+      getByText(`Attempts/sec: ${progressInfo.hashRate[0]}`)
+    ).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(
+      getByText(`Attempts/sec: ${progressInfo.hashRate[1]}`)
+    ).toBeInTheDocument();
+    expect(getByText(`ETA: ${progressInfo.eta[1]}`)).toBeInTheDocument();
     expect(getByText(`Mode: ${progressInfo.mode}`)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('labels hashcat modes with example hashes', () => {
+    const { getByLabelText, getByText } = render(<HashcatApp />);
+    fireEvent.change(getByLabelText('Hash Type:'), { target: { value: '100' } });
+    expect(
+      getByText(
+        'Example hash: da39a3ee5e6b4b0d3255bfef95601890afd80709'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/components/apps/hashcat/progress.json
+++ b/components/apps/hashcat/progress.json
@@ -1,6 +1,6 @@
 {
   "progress": 42,
-  "hashRate": "123 H/s",
-  "eta": "00:00:42",
+  "hashRate": ["123 H/s", "200 H/s", "321 H/s"],
+  "eta": ["00:00:42", "00:00:21", "00:00:00"],
   "mode": "Brute-force"
 }


### PR DESCRIPTION
## Summary
- Animate attempts/sec and ETA using fixture data
- Display Hashcat mode numbers with example hashes
- Test Hashcat animation and mode labels

## Testing
- `npx jest __tests__/hashcat.test.tsx`
- `yarn test` *(fails: Jest encountered an unexpected token in react-cytoscapejs and other suites)*
- `yarn lint` *(warnings and errors about existing hooks usage)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecf68fb483289dbd0d2aacaefe9c