### PR TITLE
Add tabbed volatility tables with demo data

### DIFF
--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -1,11 +1,84 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MemoryHeatmap from './MemoryHeatmap';
 
+const demoPslist = [
+  { pid: 4, ppid: 0, name: 'System' },
+  { pid: 248, ppid: 4, name: 'smss.exe' },
+  { pid: 612, ppid: 248, name: 'csrss.exe' },
+];
+
+const demoNetscan = [
+  { proto: 'TCP', local: '0.0.0.0:80', foreign: '0.0.0.0:0', state: 'LISTENING' },
+  { proto: 'UDP', local: '127.0.0.1:53', foreign: '0.0.0.0:0', state: 'NONE' },
+  {
+    proto: 'TCP',
+    local: '192.168.1.5:445',
+    foreign: '192.168.1.10:51234',
+    state: 'ESTABLISHED',
+  },
+];
+
+const demoMalfind = [
+  { pid: 612, address: '0x7f12a000', protection: 'RWX', description: 'Injected Code' },
+  { pid: 700, address: '0x401000', protection: 'RWX', description: 'Suspicious Section' },
+];
+
+const SortableTable = ({ columns, data }) => {
+  const [sort, setSort] = useState({ key: null, dir: 'asc' });
+
+  const sorted = React.useMemo(() => {
+    if (!sort.key) return data;
+    const sortedData = [...data].sort((a, b) => {
+      if (a[sort.key] < b[sort.key]) return sort.dir === 'asc' ? -1 : 1;
+      if (a[sort.key] > b[sort.key]) return sort.dir === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sortedData;
+  }, [data, sort]);
+
+  const toggleSort = (key) => {
+    setSort((prev) => ({
+      key,
+      dir: prev.key === key && prev.dir === 'asc' ? 'desc' : 'asc',
+    }));
+  };
+
+  return (
+    <table className="w-full text-xs table-auto">
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th
+              key={col.key}
+              onClick={() => toggleSort(col.key)}
+              className="cursor-pointer px-2 py-1 text-left bg-gray-700"
+            >
+              {col.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row, i) => (
+          <tr key={i} className="odd:bg-gray-800">
+            {columns.map((col) => (
+              <td key={col.key} className="px-2 py-1 whitespace-nowrap">
+                {row[col.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
 const VolatilityApp = () => {
   const [file, setFile] = useState(null);
   const [output, setOutput] = useState('');
   const [loading, setLoading] = useState(false);
   const [heatmapData, setHeatmapData] = useState([]);
+  const [activeTab, setActiveTab] = useState('pslist');
   const workerRef = useRef(null);
 
   useEffect(() => {
@@ -54,9 +127,60 @@ const VolatilityApp = () => {
         </button>
       </div>
       <MemoryHeatmap data={heatmapData} />
-      <pre className="flex-1 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap">
-        {output}
-      </pre>
+      <div className="flex-1 flex flex-col">
+        <div className="flex space-x-2 px-2 bg-gray-900">
+          {['pslist', 'netscan', 'malfind'].map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-2 py-1 text-sm rounded ${
+                activeTab === tab ? 'bg-gray-700' : 'bg-gray-800'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 overflow-auto p-2">
+          {activeTab === 'pslist' && (
+            <SortableTable
+              columns={[
+                { key: 'pid', label: 'PID' },
+                { key: 'ppid', label: 'PPID' },
+                { key: 'name', label: 'Name' },
+              ]}
+              data={demoPslist}
+            />
+          )}
+          {activeTab === 'netscan' && (
+            <SortableTable
+              columns={[
+                { key: 'proto', label: 'Proto' },
+                { key: 'local', label: 'LocalAddr' },
+                { key: 'foreign', label: 'ForeignAddr' },
+                { key: 'state', label: 'State' },
+              ]}
+              data={demoNetscan}
+            />
+          )}
+          {activeTab === 'malfind' && (
+            <SortableTable
+              columns={[
+                { key: 'pid', label: 'PID' },
+                { key: 'address', label: 'Address' },
+                { key: 'protection', label: 'Protection' },
+                { key: 'description', label: 'Description' },
+              ]}
+              data={demoMalfind}
+            />
+          )}
+        </div>
+      </div>
+      {output && (
+        <pre className="h-32 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap">
+          {output}
+        </pre>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add sortable table component with demo pslist, netscan, and malfind datasets
- expose these datasets via tabbed interface in volatility app

## Testing
- `yarn test` *(fails: SyntaxError and SecurityError, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecfa76f083288d539e73fbaf6e4f