### PR TITLE
feat(games): add common overlay and input utilities

### DIFF
--- a/components/apps/Games/common/Overlay.tsx
+++ b/components/apps/Games/common/Overlay.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Heads up display for games. Provides pause/resume, sound toggle and
+ * frames-per-second counter. Can be dropped into any game component.
+ */
+export default function Overlay({
+  onPause,
+  onResume,
+  muted: externalMuted,
+  onToggleSound,
+}: {
+  onPause?: () => void;
+  onResume?: () => void;
+  muted?: boolean;
+  onToggleSound?: (muted: boolean) => void;
+}) {
+  const [paused, setPaused] = useState(false);
+  const [muted, setMuted] = useState(externalMuted ?? false);
+  const [fps, setFps] = useState(0);
+  const frame = useRef(performance.now());
+  const count = useRef(0);
+
+  // track fps using requestAnimationFrame
+  useEffect(() => {
+    let raf: number;
+    const measure = (now: number) => {
+      count.current += 1;
+      if (now - frame.current >= 1000) {
+        setFps(count.current);
+        count.current = 0;
+        frame.current = now;
+      }
+      raf = requestAnimationFrame(measure);
+    };
+    raf = requestAnimationFrame(measure);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const togglePause = useCallback(() => {
+    setPaused((p) => {
+      const np = !p;
+      np ? onPause?.() : onResume?.();
+      return np;
+    });
+  }, [onPause, onResume]);
+
+  const toggleSound = useCallback(() => {
+    setMuted((m) => {
+      const nm = !m;
+      onToggleSound?.(nm);
+      return nm;
+    });
+  }, [onToggleSound]);
+
+  useEffect(() => {
+    if (externalMuted !== undefined) {
+      setMuted(externalMuted);
+    }
+  }, [externalMuted]);
+
+  return (
+    <div className="game-overlay">
+      <button onClick={togglePause} aria-label={paused ? 'Resume' : 'Pause'}>
+        {paused ? 'Resume' : 'Pause'}
+      </button>
+      <button onClick={toggleSound} aria-label={muted ? 'Unmute' : 'Mute'}>
+        {muted ? 'Sound' : 'Mute'}
+      </button>
+      <span className="fps">{fps} FPS</span>
+    </div>
+  );
+}

--- a/components/apps/Games/common/VirtualPad.tsx
+++ b/components/apps/Games/common/VirtualPad.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface PadProps {
+  onDirection?: (dir: { x: number; y: number }) => void;
+  onButton?: (button: string) => void;
+}
+
+/**
+ * Simple on screen D-pad and two action buttons (A/B).
+ * Designed primarily for touch devices but clickable with a mouse.
+ */
+export default function VirtualPad({ onDirection, onButton }: PadProps) {
+  const handleDir = (x: number, y: number) => () => onDirection?.({ x, y });
+  const handleBtn = (b: string) => () => onButton?.(b);
+
+  return (
+    <div className="virtual-pad">
+      <div className="dpad">
+        <button className="up" onPointerDown={handleDir(0, -1)} />
+        <div className="middle">
+          <button className="left" onPointerDown={handleDir(-1, 0)} />
+          <button className="right" onPointerDown={handleDir(1, 0)} />
+        </div>
+        <button className="down" onPointerDown={handleDir(0, 1)} />
+      </div>
+      <div className="actions">
+        <button className="btn-a" onPointerDown={handleBtn('A')}>
+          A
+        </button>
+        <button className="btn-b" onPointerDown={handleBtn('B')}>
+          B
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/apps/Games/common/index.ts
+++ b/components/apps/Games/common/index.ts
@@ -1,0 +1,6 @@
+export { default as Overlay } from './Overlay';
+export { default as VirtualPad } from './VirtualPad';
+export { default as useGamepad } from './useGamepad';
+export { default as useGameLoop } from './useGameLoop';
+export { default as useSaveSlots } from './useSaveSlots';
+export { default as useLeaderboard } from './useLeaderboard';

--- a/components/apps/Games/common/useGameLoop.ts
+++ b/components/apps/Games/common/useGameLoop.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Simple game loop helper that provides frame-time delta in seconds to the
+ * callback. The loop runs only while `running` is true.
+ */
+export default function useGameLoop(
+  callback: (delta: number) => void,
+  running = true,
+) {
+  const cb = useRef(callback);
+  cb.current = callback;
+
+  useEffect(() => {
+    if (!running) return undefined;
+    let raf: number;
+    let last = performance.now();
+    const loop = (now: number) => {
+      const delta = (now - last) / 1000;
+      last = now;
+      cb.current(delta);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [running]);
+}

--- a/components/apps/Games/common/useGamepad.ts
+++ b/components/apps/Games/common/useGamepad.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+export interface GamepadState {
+  buttons: number[];
+  axes: number[];
+}
+
+/**
+ * React hook wrapper around the Gamepad API. Polls at animation frame rate
+ * and returns button/axis state. Only the first connected gamepad is used.
+ */
+export default function useGamepad(): GamepadState {
+  const [state, setState] = useState<GamepadState>({ buttons: [], axes: [] });
+
+  useEffect(() => {
+    let raf: number;
+    const read = () => {
+      const pads = navigator.getGamepads?.();
+      const pad = pads && pads[0];
+      if (pad) {
+        setState({
+          buttons: pad.buttons.map((b) => b.value),
+          axes: Array.from(pad.axes),
+        });
+      }
+      raf = requestAnimationFrame(read);
+    };
+    raf = requestAnimationFrame(read);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return state;
+}

--- a/components/apps/Games/common/useLeaderboard.ts
+++ b/components/apps/Games/common/useLeaderboard.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface ScoreEntry {
+  name: string;
+  score: number;
+  date: number;
+}
+
+const prefix = 'leaderboard:';
+
+/**
+ * Maintains a simple local leaderboard using localStorage.
+ */
+export default function useLeaderboard(gameId: string, size = 10) {
+  const key = `${prefix}${gameId}`;
+  const [scores, setScores] = useState<ScoreEntry[]>([]);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(key);
+    if (raw) setScores(JSON.parse(raw));
+  }, [key]);
+
+  const addScore = useCallback(
+    (name: string, score: number) => {
+      const next = [...scores, { name, score, date: Date.now() }]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, size);
+      setScores(next);
+      localStorage.setItem(key, JSON.stringify(next));
+    },
+    [scores, key, size],
+  );
+
+  return { scores, addScore };
+}

--- a/components/apps/Games/common/useSaveSlots.ts
+++ b/components/apps/Games/common/useSaveSlots.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+
+const prefix = 'game-slot:';
+
+/**
+ * Helper for saving and loading named save slots using localStorage.
+ */
+export default function useSaveSlots(gameId: string) {
+  const makeKey = useCallback((name: string) => `${prefix}${gameId}:${name}`, [gameId]);
+
+  const save = useCallback(
+    (name: string, data: unknown) => {
+      localStorage.setItem(makeKey(name), JSON.stringify(data));
+    },
+    [makeKey],
+  );
+
+  const load = useCallback(
+    (name: string) => {
+      const raw = localStorage.getItem(makeKey(name));
+      return raw ? JSON.parse(raw) : null;
+    },
+    [makeKey],
+  );
+
+  const remove = useCallback(
+    (name: string) => {
+      localStorage.removeItem(makeKey(name));
+    },
+    [makeKey],
+  );
+
+  const list = useCallback(() => {
+    const keys = Object.keys(localStorage).filter((k) => k.startsWith(`${prefix}${gameId}:`));
+    return keys.map((k) => k.split(':').pop() as string);
+  }, [gameId]);
+
+  return { save, load, remove, list };
+}


### PR DESCRIPTION
## Summary
- add reusable game overlay with pause, sound toggle, and FPS counter
- provide virtual D-pad with action buttons for touch controls
- include hooks for Gamepad API, delta-time loops, save slots, and local leaderboard

## Testing
- `yarn test` (fails: SyntaxError in beef and frogger tests, SecurityError in calculator tests)
- `yarn lint` (fails: parsing errors and hook order issues in existing app files)


------
https://chatgpt.com/codex/tasks/task_e_68aeecfc50d083288ff82c452623d05c