### PR TITLE
Animate 2048 tile merges

### DIFF
--- a/__tests__/game2048.test.tsx
+++ b/__tests__/game2048.test.tsx
@@ -20,6 +20,19 @@ test('merging two 2s creates one 4', () => {
   expect(board[0][0]).toBe(4);
 });
 
+test('merge triggers animation', () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 2, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  const { container } = render(<Game2048 />);
+  fireEvent.keyDown(window, { key: 'ArrowLeft' });
+  const firstCell = container.querySelector('.grid div');
+  expect(firstCell?.querySelector('.merge-ripple')).toBeTruthy();
+});
+
 test('undo only restores last move', () => {
   window.localStorage.setItem('2048-board', JSON.stringify([
     [2, 2, 0, 0],

--- a/styles/index.css
+++ b/styles/index.css
@@ -447,6 +447,31 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 }
 
+@keyframes merge-ripple {
+    from { transform: scale(0); opacity: 0.5; }
+    to { transform: scale(1); opacity: 0; }
+}
+
+.merge-ripple {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: rgba(255, 255, 255, 0.5);
+    animation: merge-ripple 0.4s ease-out;
+    pointer-events: none;
+}
+
+@keyframes score-pop {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.3); }
+    100% { transform: scale(1); }
+}
+
+.score-pop {
+    display: inline-block;
+    animation: score-pop 0.3s ease-out;
+}
+
 @keyframes hangman-draw {
     from { stroke-dashoffset: 100; }
     to { stroke-dashoffset: 0; }


### PR DESCRIPTION
## Summary
- animate tile merges in 2048 with ripple and score pop effects
- test merge animation and undo functionality

## Testing
- `npm test` *(fails: beef.test.tsx, frogger.test.ts, calculator.app.test.js, frogger.config.test.ts, snake.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecfd77388328886433101fd16e83