### PR TITLE
feat: add chip stacks and dealer peek animation

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -324,6 +324,15 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
 }
 
+.peek {
+    animation: dealerPeek 0.6s ease-in-out;
+}
+
+@keyframes dealerPeek {
+    0%, 100% { transform: rotateY(0); }
+    50% { transform: rotateY(-20deg); }
+}
+
 .chip-stack {
     position: relative;
 }
@@ -364,6 +373,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
     .chip-pop,
     .animate-deal,
+    .peek,
     .shuffle {
         animation: none;
         transform: none;


### PR DESCRIPTION
## Summary
- show chip stacks for each player's wager
- animate dealer's hidden card peeking when up card is ten or ace

## Testing
- `npm test` *(fails: Jest encountered unexpected token and localStorage SecurityError)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecffae1c832887ab550a3b9fb712