### PR TITLE
feat(breakout): color-coded power-up drops

### DIFF
--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -285,10 +285,12 @@ const BreakoutGame = ({ levels }) => {
             // 20% chance to spawn a power-up
             if (Math.random() < 0.2) {
               const type = Math.random() < 0.5 ? "multi" : "expand";
+              const color = type === "multi" ? "#e11d48" : "#3b82f6"; // red vs blue
               powerUps.push({
                 x: brick.x + brick.w / 2,
                 y: brick.y + brick.h / 2,
                 type,
+                color,
                 vy: 100,
               });
             }
@@ -392,8 +394,10 @@ const BreakoutGame = ({ levels }) => {
 
       // Power-ups
       for (const p of powerUps) {
-        ctx.fillStyle = p.type === "multi" ? "red" : "blue";
-        ctx.fillRect(p.x - 5, p.y - 5, 10, 10);
+        ctx.fillStyle = p.color;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 6, 0, Math.PI * 2);
+        ctx.fill();
       }
 
       // HUD


### PR DESCRIPTION
## Summary
- give breakout bricks a chance to spawn red multi-ball or blue paddle-widen power-ups
- render power-ups as colored circles

## Testing
- `yarn test` *(fails: cannot parse react-cytoscapejs, frogger collisions, calculator SecurityError, CandyCrushApp not defined)*
- `yarn lint` *(fails: React Hooks rule violations in useGameControls.js and dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed003e9883289970f12f916ffd7a