### PR TITLE
feat: add haptic feedback utility

### DIFF
--- a/components/apps/Games/common/haptics/index.ts
+++ b/components/apps/Games/common/haptics/index.ts
@@ -1,0 +1,61 @@
+export type HapticPattern = number | number[];
+
+const supportsVibration = () =>
+  typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+
+const supportsGamepadVibration = () => {
+  if (typeof navigator === 'undefined' || !('getGamepads' in navigator)) return false;
+  const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+  return Array.from(pads).some(
+    (p) => p && p.vibrationActuator && typeof p.vibrationActuator.playEffect === 'function'
+  );
+};
+
+const triggerGamepad = (duration: number) => {
+  if (!supportsGamepadVibration()) return;
+  try {
+    const pads = navigator.getGamepads();
+    for (const pad of pads) {
+      if (pad && pad.vibrationActuator) {
+        pad.vibrationActuator.playEffect('dual-rumble', {
+          duration,
+          strongMagnitude: 1.0,
+          weakMagnitude: 1.0,
+        });
+      }
+    }
+  } catch {
+    // ignore errors
+  }
+};
+
+export const vibrate = (pattern: HapticPattern) => {
+  const duration = Array.isArray(pattern)
+    ? pattern.reduce((sum, n) => sum + (n > 0 ? n : 0), 0)
+    : pattern;
+
+  try {
+    if (supportsVibration()) navigator.vibrate(pattern);
+    triggerGamepad(duration);
+  } catch {
+    // ignore unsupported devices
+  }
+};
+
+export const patterns = {
+  score: [20],
+  danger: [40, 80, 40],
+  gameOver: [100, 30, 100],
+};
+
+export const score = () => vibrate(patterns.score);
+export const danger = () => vibrate(patterns.danger);
+export const gameOver = () => vibrate(patterns.gameOver);
+
+export default {
+  vibrate,
+  score,
+  danger,
+  gameOver,
+  patterns,
+};

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import useGameControls from './useGameControls';
+import useGameHaptics from '../../hooks/useGameHaptics';
 
 const GRID_SIZE = 20;
 const CELL_SIZE = 16; // pixels
@@ -30,6 +31,7 @@ const Snake = () => {
   const lastRef = useRef(0);
   const runningRef = useRef(true);
   const audioCtx = useRef(null);
+  const haptics = useGameHaptics();
   const prefersReducedMotion = useRef(false);
 
   const [running, setRunning] = useState(true);
@@ -145,6 +147,7 @@ const Snake = () => {
       head.x >= GRID_SIZE ||
       head.y >= GRID_SIZE
     ) {
+      haptics.danger();
       setGameOver(true);
       setRunning(false);
       beep(120);
@@ -152,6 +155,7 @@ const Snake = () => {
     }
 
     if (snake.some((s) => s.x === head.x && s.y === head.y)) {
+      haptics.danger();
       setGameOver(true);
       setRunning(false);
       beep(120);
@@ -161,6 +165,7 @@ const Snake = () => {
     snake.unshift(head);
     if (head.x === foodRef.current.x && head.y === foodRef.current.y) {
       setScore((s) => s + 1);
+      haptics.score();
       beep(440);
       foodRef.current = randomFood(snake);
       if (!prefersReducedMotion.current) head.scale = 0;
@@ -205,6 +210,10 @@ const Snake = () => {
       }
     }
   }, [gameOver, score, highScore]);
+
+  useEffect(() => {
+    if (gameOver) haptics.gameOver();
+  }, [gameOver, haptics]);
 
   const reset = useCallback(() => {
     snakeRef.current = [
@@ -270,6 +279,12 @@ const Snake = () => {
           onClick={() => setSound((s) => !s)}
         >
           {sound ? 'Sound On' : 'Sound Off'}
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-700 rounded"
+          onClick={haptics.toggle}
+        >
+          {haptics.enabled ? 'Haptics On' : 'Haptics Off'}
         </button>
       </div>
     </div>

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -1,12 +1,27 @@
 import { useCallback } from 'react';
+import usePersistedState from './usePersistedState';
+import {
+  vibrate as vibrateNative,
+  patterns,
+} from '../components/apps/Games/common/haptics';
 
-// Provides a simple wrapper around the Vibration API if available.
+// Exposes helpers for triggering game haptics with an on/off toggle.
 export default function useGameHaptics() {
-  const vibrate = useCallback((pattern) => {
-    if (typeof navigator !== 'undefined' && navigator.vibrate) {
-      navigator.vibrate(pattern);
-    }
-  }, []);
+  const [enabled, setEnabled] = usePersistedState('game:haptics', true);
 
-  return { vibrate };
+  const vibrate = useCallback(
+    (pattern) => {
+      if (!enabled) return;
+      vibrateNative(pattern);
+    },
+    [enabled]
+  );
+
+  const score = useCallback(() => vibrate(patterns.score), [vibrate]);
+  const danger = useCallback(() => vibrate(patterns.danger), [vibrate]);
+  const gameOver = useCallback(() => vibrate(patterns.gameOver), [vibrate]);
+
+  const toggle = useCallback(() => setEnabled((e) => !e), [setEnabled]);
+
+  return { enabled, toggle, vibrate, score, danger, gameOver };
 }


### PR DESCRIPTION
## Summary
- add haptics module wrapping vibration APIs with score, danger, and game over patterns
- expose hook with persistent toggle and convenience helpers
- wire haptic events and HUD toggle into Snake game

## Testing
- `npm test` *(fails: Jest encountered unexpected token, CandyCrushApp undefined, localStorage SecurityError)*

------
https://chatgpt.com/codex/tasks/task_e_68aeec9c9c888328a147de892203665b