### PR TITLE
feat: add pixel-aware canvas utility

### DIFF
--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -1,0 +1,70 @@
+import React, {
+  useRef,
+  useEffect,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
+
+export interface CanvasHandle {
+  getInputCoords: (
+    e: MouseEvent | TouchEvent
+  ) => { x: number; y: number };
+}
+
+interface CanvasProps {
+  width: number;
+  height: number;
+  className?: string;
+}
+
+const Canvas = forwardRef<CanvasHandle, CanvasProps>(
+  ({ width, height, className }, ref) => {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const resize = () => {
+        const dpr = window.devicePixelRatio || 1;
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+        canvas.width = Math.floor(width * dpr);
+        canvas.height = Math.floor(height * dpr);
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      };
+
+      resize();
+      window.addEventListener('resize', resize);
+      return () => window.removeEventListener('resize', resize);
+    }, [width, height]);
+
+    useImperativeHandle(ref, () => ({
+      getInputCoords(e) {
+        const canvas = canvasRef.current;
+        if (!canvas) return { x: 0, y: 0 };
+        const rect = canvas.getBoundingClientRect();
+        const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+        const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+        return {
+          x: ((clientX - rect.left) * width) / rect.width,
+          y: ((clientY - rect.top) * height) / rect.height,
+        };
+      },
+    }));
+
+    return (
+      <canvas
+        ref={canvasRef}
+        className={className}
+        style={{ imageRendering: 'pixelated' }}
+      />
+    );
+  }
+);
+
+Canvas.displayName = 'Canvas';
+
+export default Canvas;


### PR DESCRIPTION
## Summary
- add reusable canvas component that scales with `devicePixelRatio`
- expose helper to convert pointer events to canvas coordinates
- enable pixelated rendering for retro-style games

## Testing
- `npm test` *(fails: Unexpected token in react-cytoscapejs; localStorage unavailable; CandyCrushApp undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68aeec9e55c083288e950417e529caf2