### PR TITLE
feat: add game saves and leaderboards

### DIFF
--- a/__tests__/leaderboardAntiCheat.test.ts
+++ b/__tests__/leaderboardAntiCheat.test.ts
@@ -1,0 +1,26 @@
+import { recordScore, getLeaderboard } from '../components/apps/Games/common/leaderboard';
+
+describe('per-game leaderboard with anti-cheat', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('records valid scores in order', () => {
+    recordScore('pong', 'Alice', 100);
+    recordScore('pong', 'Bob', 200);
+    const board = getLeaderboard('pong');
+    expect(board[0]).toEqual({ name: 'Bob', score: 200 });
+    expect(board[1]).toEqual({ name: 'Alice', score: 100 });
+  });
+
+  test('rejects invalid or suspicious scores', () => {
+    recordScore('pong', 'Cheater1', 1e12);
+    recordScore('pong', 'Cheater2', -5);
+    recordScore('pong', 'Cheater3', Infinity);
+    recordScore('pong', 'Legit', 50);
+    const board = getLeaderboard('pong');
+    expect(board).toHaveLength(1);
+    expect(board[0]).toEqual({ name: 'Legit', score: 50 });
+  });
+});
+

--- a/__tests__/saveSlots.test.ts
+++ b/__tests__/saveSlots.test.ts
@@ -1,0 +1,39 @@
+import 'fake-indexeddb/auto';
+
+// Provide a lightweight structuredClone polyfill for fake-indexeddb
+// in environments where it is missing.
+// @ts-ignore
+if (typeof globalThis.structuredClone !== 'function') {
+  // @ts-ignore
+  globalThis.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
+
+import {
+  saveSlot,
+  loadSlot,
+  listSlots,
+  exportSaves,
+  importSaves,
+} from '../components/apps/Games/common/save';
+
+describe('named save slots', () => {
+  test('save and load slots via IndexedDB', async () => {
+    await saveSlot('testGame', { name: 'slot1', data: { level: 1 } });
+    await saveSlot('testGame', { name: 'slot2', data: { level: 2 } });
+    const slots = await listSlots('testGame');
+    expect(slots.sort()).toEqual(['slot1', 'slot2']);
+    const loaded = await loadSlot<{ level: number }>('testGame', 'slot2');
+    expect(loaded).toEqual({ level: 2 });
+  });
+
+  test('export and import saves as JSON', async () => {
+    await saveSlot('exportGame', { name: 'a', data: { score: 10 } });
+    const exported = await exportSaves('exportGame');
+    await importSaves('importGame', exported);
+    const importedSlots = await listSlots('importGame');
+    expect(importedSlots).toEqual(['a']);
+    const data = await loadSlot<{ score: number }>('importGame', 'a');
+    expect(data).toEqual({ score: 10 });
+  });
+});
+

--- a/components/apps/Games/common/leaderboard.ts
+++ b/components/apps/Games/common/leaderboard.ts
@@ -1,0 +1,41 @@
+export interface LeaderboardEntry {
+  name: string;
+  score: number;
+}
+
+const PREFIX = 'leaderboard:';
+const MAX_SCORE = 1_000_000_000;
+
+const isValidScore = (score: number): boolean =>
+  typeof score === 'number' && Number.isFinite(score) && score >= 0 && score <= MAX_SCORE;
+
+export const getLeaderboard = (gameId: string): LeaderboardEntry[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(`${PREFIX}${gameId}`);
+    if (!raw) return [];
+    return JSON.parse(raw) as LeaderboardEntry[];
+  } catch {
+    return [];
+  }
+};
+
+export const recordScore = (
+  gameId: string,
+  name: string,
+  score: number,
+  limit = 10
+): LeaderboardEntry[] => {
+  if (!isValidScore(score)) return getLeaderboard(gameId);
+  const board = getLeaderboard(gameId);
+  board.push({ name, score });
+  board.sort((a, b) => b.score - a.score);
+  const trimmed = board.slice(0, limit);
+  try {
+    window.localStorage.setItem(`${PREFIX}${gameId}`, JSON.stringify(trimmed));
+  } catch {
+    /* ignore storage errors */
+  }
+  return trimmed;
+};
+

--- a/components/apps/Games/common/save/index.ts
+++ b/components/apps/Games/common/save/index.ts
@@ -1,0 +1,46 @@
+import { createStore, get, set, del, keys } from 'idb-keyval';
+
+export interface SaveSlot {
+  name: string;
+  data: unknown;
+}
+
+const getStore = (gameId: string) => createStore(`game:${gameId}`, 'saves');
+
+export async function saveSlot(gameId: string, slot: SaveSlot): Promise<void> {
+  const store = getStore(gameId);
+  await set(slot.name, slot.data, store);
+}
+
+export async function loadSlot<T = unknown>(gameId: string, name: string): Promise<T | undefined> {
+  const store = getStore(gameId);
+  return get<T>(name, store);
+}
+
+export async function deleteSlot(gameId: string, name: string): Promise<void> {
+  const store = getStore(gameId);
+  await del(name, store);
+}
+
+export async function listSlots(gameId: string): Promise<string[]> {
+  const store = getStore(gameId);
+  const allKeys = await keys(store);
+  return allKeys as string[];
+}
+
+export async function exportSaves(gameId: string): Promise<SaveSlot[]> {
+  const store = getStore(gameId);
+  const allKeys = await keys(store);
+  const saves: SaveSlot[] = [];
+  for (const key of allKeys) {
+    const data = await get(key, store);
+    saves.push({ name: key as string, data });
+  }
+  return saves;
+}
+
+export async function importSaves(gameId: string, saves: SaveSlot[]): Promise<void> {
+  const store = getStore(gameId);
+  await Promise.all(saves.map((slot) => set(slot.name, slot.data, store)));
+}
+

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/three": "^0.179.0",
     "eslint": "^9.13.0",
     "eslint-config-next": "^15.0.0",
+    "fake-indexeddb": "^6.1.0",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
     "typescript": "^5.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4065,6 +4065,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-indexeddb@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "fake-indexeddb@npm:6.1.0"
+  checksum: 10c0/f2bae6cf3ed38619ccc536ee1c0d72a1ba721da24d840e9c0993800c031a5c1d8e61adc00ea31f0c2a2380447c57bc953bd4128b08dabf559c7cdf03c8893239
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -8264,6 +8271,7 @@ __metadata:
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:^15.0.0"
     expr-eval: "npm:^2.0.2"
+    fake-indexeddb: "npm:^6.1.0"
     figlet: "npm:^1.8.2"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add IndexedDB save slot utilities with JSON export/import
- introduce per-game leaderboards with simple anti-cheat checks
- cover save slots and leaderboard behaviour with tests

## Testing
- `npm test __tests__/saveSlots.test.ts __tests__/leaderboardAntiCheat.test.ts`
- `npm test` *(fails: Jest encountered unexpected token in beef and frogger tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeca38e088328954a47bcffd7d7d0