### PR TITLE
Add combo meter and card flip transitions to Memory game

### DIFF
--- a/__tests__/memoryGame.test.tsx
+++ b/__tests__/memoryGame.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import Memory from '../components/apps/memory';
+
+jest.mock('../components/apps/memory_utils', () => ({
+  createDeck: () => [
+    { id: 0, value: 'A' },
+    { id: 1, value: 'A' },
+    { id: 2, value: 'B' },
+    { id: 3, value: 'B' },
+    { id: 4, value: 'C' },
+    { id: 5, value: 'C' },
+    { id: 6, value: 'D' },
+    { id: 7, value: 'D' },
+    { id: 8, value: 'E' },
+    { id: 9, value: 'E' },
+    { id: 10, value: 'F' },
+    { id: 11, value: 'F' },
+    { id: 12, value: 'G' },
+    { id: 13, value: 'G' },
+    { id: 14, value: 'H' },
+    { id: 15, value: 'H' },
+  ],
+}));
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  // minimal matchMedia polyfill
+  window.matchMedia = window.matchMedia || ((query: string) => ({
+    matches: false,
+    media: query,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+  // requestAnimationFrame using timers
+  window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+  };
+  window.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({ data: [] })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => []),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    fillText: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    transform: jest.fn(),
+    rect: jest.fn(),
+    clip: jest.fn(),
+    createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
+  }));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('combo meter increments and resets', () => {
+  const { getAllByRole, getByTestId } = render(<Memory />);
+  const cards = getAllByRole('button');
+  const combo = getByTestId('combo-meter');
+
+  expect(combo.textContent).toContain('0');
+
+  fireEvent.click(cards[0]);
+  fireEvent.click(cards[1]);
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  expect(combo.textContent).toContain('1');
+
+  fireEvent.click(cards[2]);
+  fireEvent.click(cards[3]);
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  expect(combo.textContent).toContain('2');
+
+  fireEvent.click(cards[4]);
+  fireEvent.click(cards[6]);
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  expect(combo.textContent).toContain('0');
+});
+
+test('card flip applies transform style', () => {
+  const { getAllByRole } = render(<Memory />);
+  const card = getAllByRole('button')[0];
+  const inner = card.querySelector('[data-testid="card-inner"]') as HTMLElement;
+  expect(inner.style.transform).toBe('rotateY(0deg)');
+  fireEvent.click(card);
+  expect(inner.style.transform).toBe('rotateY(180deg)');
+});
+

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -191,6 +191,7 @@ const Memory = () => {
                   className={`relative w-full aspect-square [perspective:600px] rounded transform ${isHighlighted ? 'ring-4 ring-green-600' : ''} ${reduceMotion.current ? '' : 'transition-transform duration-200'} ${isHighlighted && !reduceMotion.current ? 'scale-105' : ''}`}
                 >
                   <div
+                    data-testid="card-inner"
                     className={`w-full h-full transition-transform ${reduceMotion.current ? '' : 'duration-500'} [transform-style:preserve-3d]`}
                     style={{ transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)' }}
                   >
@@ -221,6 +222,7 @@ const Memory = () => {
           <div>Moves: {moves}</div>
           <div>Rating: {'★'.repeat(stars)}{'☆'.repeat(3 - stars)}</div>
           {best.moves != null && <div>Best: {best.moves}m/{best.time}s</div>}
+          <div data-testid="combo-meter">Combo: {streak}</div>
         </div>
         <div className="flex space-x-2">
           <button onClick={reset} className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded">Reset</button>


### PR DESCRIPTION
## Summary
- Display combo meter in Memory game and track consecutive matches
- Mark card inner element for flip transitions and testing
- Add tests for combo meter behavior and card flipping

## Testing
- `npm test __tests__/memoryGame.test.tsx`
- `npm test` *(fails: jest unable to parse react-cytoscapejs; cannot find module fake-indexeddb/auto; cannot find module ../../hooks/useTheme)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa18c6008328b8f6051e4e3ea991