### PR TITLE
feat(phaser): add parallax background and checkpoint flags

### DIFF
--- a/__tests__/phaserMatter.test.ts
+++ b/__tests__/phaserMatter.test.ts
@@ -1,4 +1,5 @@
 import { GameState } from '../apps/phaser_matter/gameLogic';
+import level from '../public/apps/phaser_matter/level1.json';
 
 describe('phaser matter platformer', () => {
   test('falling off map resets to spawn', () => {
@@ -12,5 +13,15 @@ describe('phaser matter platformer', () => {
     gs.setCheckpoint({ x: 100, y: 200 });
     const pos = gs.respawnIfOutOfBounds({ x: 5, y: 2000 }, 1000);
     expect(pos).toEqual({ x: 100, y: 200 });
+  });
+
+  test('level data defines parallax layers', () => {
+    expect(Array.isArray((level as any).parallaxLayers)).toBe(true);
+    expect((level as any).parallaxLayers.length).toBeGreaterThan(0);
+  });
+
+  test('level data defines checkpoints', () => {
+    expect(Array.isArray((level as any).checkpoints)).toBe(true);
+    expect((level as any).checkpoints.length).toBeGreaterThan(0);
   });
 });

--- a/public/apps/phaser_matter/level1.json
+++ b/public/apps/phaser_matter/level1.json
@@ -1,5 +1,9 @@
 {
   "spawn": { "x": 100, "y": 100 },
+  "parallaxLayers": [
+    { "color": "#99ccff", "scrollFactor": 0.2 },
+    { "color": "#6699cc", "scrollFactor": 0.5 }
+  ],
   "platforms": [
     { "x": 400, "y": 580, "width": 800, "height": 40 },
     { "x": 400, "y": 400, "width": 200, "height": 20 }


### PR DESCRIPTION
## Summary
- add parallax layers to Phaser Matter demo level
- show checkpoint flags that activate on touch
- test level includes parallax layers and checkpoints

## Testing
- `npm test __tests__/phaserMatter.test.ts`
- `npm test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*


------
https://chatgpt.com/codex/tasks/task_e_68aefa1a89408328b85f506f7cbf3bf4