### PR TITLE
feat: compute ball spin from contact

### DIFF
--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import useGameControls from './useGameControls';
+import { computeBallSpin } from '../../utils/physics';
 
 // Basic timing constants so the simulation is consistent across refresh rates
 const FRAME_TIME = 1000 / 60; // ideal frame time in ms
@@ -365,11 +366,14 @@ const Pong = () => {
       }
 
       const paddleCollision = (pad, dir) => {
-        const padCenter = pad.y + paddleHeight / 2;
-        const relative = (ball.y - padCenter) / (paddleHeight / 2);
-        // add spin based on paddle velocity and impact point
+        const { spin, relative } = computeBallSpin(
+          ball.y,
+          pad.y,
+          paddleHeight,
+          pad.vy
+        );
         ball.vx = Math.abs(ball.vx) * dir;
-        ball.vy += pad.vy * 0.1 + relative * 200;
+        ball.vy += spin;
         if (!prefersReducedMotion) {
           pad.scale = 1.2;
           pad.widthScale = 0.8;

--- a/public/apps/pong/main.js
+++ b/public/apps/pong/main.js
@@ -11,6 +11,13 @@ const player = { x: 10, y: canvas.height / 2 - paddleHeight / 2, vy: 0 };
 const opponent = { x: canvas.width - paddleWidth - 10, y: canvas.height / 2 - paddleHeight / 2, vy: 0 };
 const ball = { x: canvas.width / 2, y: canvas.height / 2, vx: 200, vy: 120, size: 8 };
 
+function computeBallSpin(ballY, paddleY, paddleHeight, paddleVy, spinFactor = 300, velocityFactor = 0.5) {
+  const padCenter = paddleY + paddleHeight / 2;
+  const relative = (ballY - padCenter) / (paddleHeight / 2);
+  const spin = paddleVy * velocityFactor + relative * spinFactor;
+  return { spin, relative };
+}
+
 const keys = {};
 document.addEventListener('keydown', (e) => (keys[e.code] = true));
 document.addEventListener('keyup', (e) => (keys[e.code] = false));
@@ -90,10 +97,14 @@ function update(dt) {
 }
 
 function paddleBounce(pad, dir) {
-  const padCenter = pad.y + paddleHeight / 2;
-  const relative = (ball.y - padCenter) / (paddleHeight / 2);
+  const { spin } = computeBallSpin(
+    ball.y,
+    pad.y,
+    paddleHeight,
+    pad.vy
+  );
   ball.vx = Math.abs(ball.vx) * dir;
-  ball.vy += pad.vy * 0.5 + relative * 300; // spin effect
+  ball.vy += spin;
   playBeep();
   rumble();
 }

--- a/utils/physics.js
+++ b/utils/physics.js
@@ -1,0 +1,27 @@
+/**
+ * Calculate spin-induced velocity change for a ball hitting a paddle.
+ * The spin is proportional to how far from the paddle's centre the ball
+ * makes contact and to the paddle's vertical velocity.
+ *
+ * @param {number} ballY - The y position of the ball at impact.
+ * @param {number} paddleY - The top y position of the paddle.
+ * @param {number} paddleHeight - The height of the paddle.
+ * @param {number} paddleVy - The vertical velocity of the paddle.
+ * @param {number} [spinFactor=200] - Multiplier for contact based spin.
+ * @param {number} [velocityFactor=0.1] - Multiplier for paddle velocity influence.
+ * @returns {{ spin: number, relative: number }} Spin amount to add to the ball's
+ * vertical velocity and the relative impact position (-1 to 1).
+ */
+export function computeBallSpin(
+  ballY,
+  paddleY,
+  paddleHeight,
+  paddleVy,
+  spinFactor = 200,
+  velocityFactor = 0.1
+) {
+  const padCenter = paddleY + paddleHeight / 2;
+  const relative = (ballY - padCenter) / (paddleHeight / 2);
+  const spin = paddleVy * velocityFactor + relative * spinFactor;
+  return { spin, relative };
+}


### PR DESCRIPTION
## Summary
- encapsulate paddle contact spin logic in `computeBallSpin`
- apply spin utility in React and static Pong implementations

## Testing
- `npm test` *(fails: Cannot find module 'fake-indexeddb/auto' in __tests__/saveSlots.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa1af6e483288888402df17f60ab