### PR TITLE
feat(blackjack): add hover flip preview

### DIFF
--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -12,6 +12,7 @@ const CHIP_COLORS = {
 
 const Card = ({ card, faceDown, peeking }) => {
   const [flipped, setFlipped] = useState(false);
+  const [hovered, setHovered] = useState(false);
   const prefersReduced = useRef(false);
 
   useEffect(() => {
@@ -32,9 +33,13 @@ const Card = ({ card, faceDown, peeking }) => {
 
   return (
     <div
-      className={`h-16 w-12 card ${flipped ? 'flipped' : ''} ${peeking ? 'peek' : ''} animate-deal`}
+      className={`h-16 w-12 card ${flipped ? 'flipped' : ''} ${
+        peeking || (faceDown && hovered) ? 'peek' : ''
+      } animate-deal`}
       aria-label={faceDown ? 'Hidden card' : `${card.value}${card.suit}`}
       role="img"
+      onMouseEnter={() => faceDown && setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <div className="card-face card-front" aria-hidden="true">{`${card.value}${card.suit}`}</div>
       <div className="card-face card-back" aria-hidden="true">?</div>


### PR DESCRIPTION
## Summary
- peek at facedown blackjack cards by hovering

## Testing
- `yarn test` *(fails: Cannot find module 'fake-indexeddb/auto', Cannot find module '../../hooks/useTheme', Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa1b4df8832888f3d7f8bf0d924e