### PR TITLE
feat: add strict mode and faster sequence generation

### DIFF
--- a/__tests__/simonSeed.test.ts
+++ b/__tests__/simonSeed.test.ts
@@ -12,5 +12,10 @@ describe('generateSequence', () => {
     const seq2 = generateSequence(5, 'b');
     expect(seq1).not.toEqual(seq2);
   });
+
+  test('generates values between 0 and 3 without seed', () => {
+    const seq = generateSequence(100);
+    expect(seq.every((n) => n >= 0 && n < 4)).toBe(true);
+  });
 });
 


### PR DESCRIPTION
## Summary
- speed up Simon sequence generation using `crypto.getRandomValues`
- add a strict mode checkbox to let players retry sequences
- adjust error handling to replay sequence when strict mode is off

## Testing
- `npm test` *(fails: react-cytoscapejs ESM parse error, missing ../../hooks/useTheme in components/apps/x.js)*
- `npm run lint` *(fails: React Hooks rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa1be29c832881a802a290744524