### PR TITLE
feat(wordle): add hard mode rules and daily seed

### DIFF
--- a/__tests__/wordle.test.tsx
+++ b/__tests__/wordle.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import wordList from '../components/apps/wordle_words.json';
+import { getDailySeed } from '../utils/dailyChallenge';
 import type { ComponentType } from 'react';
 
 let Wordle: ComponentType;
@@ -26,13 +27,28 @@ describe('Wordle', () => {
 
   test('solves puzzle and shares result', async () => {
     render(<Wordle />);
-    const todayKey = new Date().toISOString().split('T')[0];
-    const solution = wordList[hash(todayKey) % wordList.length];
+    const seed = getDailySeed('wordle-common', new Date('2024-01-01T00:00:00Z'));
+    const solution = wordList[hash(seed) % wordList.length];
     const input = screen.getByPlaceholderText('Guess');
     fireEvent.change(input, { target: { value: solution } });
     fireEvent.submit(input.closest('form')!);
     const shareBtn = await screen.findByText('Share');
     fireEvent.click(shareBtn);
     expect((navigator as any).clipboard.writeText).toHaveBeenCalled();
+  });
+
+  test('enforces hard mode rules', async () => {
+    render(<Wordle />);
+    const hardToggle = screen.getByLabelText('Hard Mode');
+    fireEvent.click(hardToggle);
+
+    const input = screen.getByPlaceholderText('Guess');
+    fireEvent.change(input, { target: { value: 'ABDOM' } });
+    fireEvent.submit(input.closest('form')!);
+
+    fireEvent.change(input, { target: { value: 'ABASE' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(await screen.findByText(/Hard mode:/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- enforce standard Wordle hard mode constraints
- seed daily puzzle using shared daily seed utility
- update tests and add coverage for hard mode

## Testing
- `yarn test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*


------
https://chatgpt.com/codex/tasks/task_e_68aefa22e5e883288f2d8bfd89214185