### PR TITLE
feat(openvas): group findings and export

### DIFF
--- a/components/apps/openvas/openvas.worker.js
+++ b/components/apps/openvas/openvas.worker.js
@@ -6,13 +6,23 @@ self.onmessage = (e) => {
   const sevReg = /Severity:\s*(Low|Medium|High|Critical)/i;
   const impactReg = /Impact:\s*(Low|Medium|High|Critical)/i;
   const likelihoodReg = /Likelihood:\s*(Low|Medium|High|Critical)/i;
+  const hostReg = /Host:\s*(\S+)/i;
+  let currentHost = '';
+
   lines.forEach((line) => {
+    const hostMatch = line.match(hostReg);
+    if (hostMatch) {
+      currentHost = hostMatch[1];
+      return;
+    }
+
     const severityMatch = line.match(sevReg);
     const impactMatch = line.match(impactReg);
     const likelihoodMatch = line.match(likelihoodReg);
     if (severityMatch || impactMatch || likelihoodMatch) {
       const sev = severityMatch ? severityMatch[1].toLowerCase() : 'low';
       findings.push({
+        host: currentHost,
         severity: sev,
         impact: impactMatch ? impactMatch[1].toLowerCase() : sev,
         likelihood: likelihoodMatch ? likelihoodMatch[1].toLowerCase() : sev,


### PR DESCRIPTION
## Summary
- parse host info from OpenVAS output and include in findings
- group findings by host and severity, and export visible rows to CSV

## Testing
- `yarn test` *(fails: react-cytoscapejs module parse error; frogger & calculator tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68aeecf749e08328a317dcc67ebe4753