### PR TITLE
feat: add searchable command palette

### DIFF
--- a/__tests__/searchOverlay.test.tsx
+++ b/__tests__/searchOverlay.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchOverlay, { SearchItem } from '../components/SearchOverlay';
+
+describe('SearchOverlay', () => {
+  const items: SearchItem[] = [
+    { id: 'calc', title: 'Calculator', type: 'app' },
+    { id: 'help', title: 'Getting Started', type: 'help', url: '#' },
+  ];
+
+  it('filters items based on query', () => {
+    const onClose = jest.fn();
+    const openApp = jest.fn();
+    render(
+      <SearchOverlay visible items={items} openApp={openApp} onClose={onClose} />
+    );
+    const input = screen.getByPlaceholderText(/search apps, settings, help/i);
+    fireEvent.change(input, { target: { value: 'calc' } });
+    expect(screen.getByText('Calculator')).toBeInTheDocument();
+    expect(screen.queryByText('Getting Started')).toBeNull();
+  });
+});

--- a/components/SearchOverlay.tsx
+++ b/components/SearchOverlay.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface SearchItem {
+  id: string;
+  title: string;
+  type: 'app' | 'help' | 'settings';
+  url?: string;
+}
+
+interface Props {
+  visible: boolean;
+  items: SearchItem[];
+  openApp: (id: string) => void;
+  onClose: () => void;
+}
+
+const SearchOverlay: React.FC<Props> = ({ visible, items, openApp, onClose }) => {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setQuery('');
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (visible) {
+      window.addEventListener('keydown', handleKey);
+    }
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [visible, onClose]);
+
+  if (!visible) return null;
+
+  const filtered = items.filter((item) =>
+    item.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const selectItem = (item: SearchItem) => {
+    if (item.type === 'app' || item.type === 'settings') {
+      openApp(item.id);
+    } else if (item.type === 'help' && item.url) {
+      window.open(item.url, '_blank');
+    }
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-start justify-center z-50">
+      <div className="mt-24 bg-ub-grey rounded shadow-lg w-11/12 md:w-1/2 max-h-[70vh] overflow-y-auto">
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search apps, settings, help..."
+          className="w-full px-4 py-2 bg-black bg-opacity-20 text-white focus:outline-none"
+        />
+        <ul>
+          {filtered.map((item) => (
+            <li
+              key={item.id}
+              className="px-4 py-2 hover:bg-black hover:bg-opacity-40 cursor-pointer"
+              onClick={() => selectItem(item)}
+            >
+              {item.title}
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="px-4 py-2 text-ubt-grey">No results</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default SearchOverlay;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -4,10 +4,12 @@ import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
-import AllApplications from '../screen/all-applications'
+import AllApplications from '../screen/all-applications';
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import ReactGA from 'react-ga4';
+import SearchOverlay from '../SearchOverlay';
+import { helpDocs } from '../../utils/helpIndex';
 
 export class Desktop extends Component {
     constructor() {
@@ -30,6 +32,7 @@ export class Desktop extends Component {
                 default: false,
             },
             showNameBar: false,
+            searchVisible: false,
         }
     }
 
@@ -43,10 +46,12 @@ export class Desktop extends Component {
         this.setContextListeners();
         this.setEventListeners();
         this.checkForNewFolders();
+        window.addEventListener('keydown', this.handleGlobalKey);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
+        window.removeEventListener('keydown', this.handleGlobalKey);
     }
 
     checkForNewFolders = () => {
@@ -89,6 +94,17 @@ export class Desktop extends Component {
     removeContextListeners = () => {
         document.removeEventListener("contextmenu", this.checkContextMenu);
         document.removeEventListener("click", this.hideAllContextMenu);
+    }
+
+    handleGlobalKey = (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+            e.preventDefault();
+            this.setState({ searchVisible: true });
+        }
+    }
+
+    closeSearch = () => {
+        this.setState({ searchVisible: false });
     }
 
     checkContextMenu = (e) => {
@@ -504,6 +520,10 @@ export class Desktop extends Component {
     }
 
     render() {
+        const searchItems = [
+            ...apps.map(app => ({ id: app.id, title: app.title, type: app.id === 'settings' ? 'settings' : 'app' })),
+            ...helpDocs.map(doc => ({ id: doc.id, title: doc.title, type: 'help', url: doc.url }))
+        ];
         return (
             <div className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
@@ -547,6 +567,13 @@ export class Desktop extends Component {
                         games={games}
                         recentApps={this.app_stack}
                         openApp={this.openApp} /> : null}
+
+                <SearchOverlay
+                    visible={this.state.searchVisible}
+                    items={searchItems}
+                    openApp={this.openApp}
+                    onClose={this.closeSearch}
+                />
 
             </div>
         )

--- a/utils/helpIndex.ts
+++ b/utils/helpIndex.ts
@@ -1,0 +1,33 @@
+export interface HelpDoc {
+  id: string;
+  title: string;
+  url: string;
+}
+
+export const helpDocs: HelpDoc[] = [
+  {
+    id: 'architecture-doc',
+    title: 'Architecture',
+    url: 'https://github.com/unnippillil/kali-linux-portfolio/blob/main/docs/architecture.md',
+  },
+  {
+    id: 'getting-started-doc',
+    title: 'Getting Started',
+    url: 'https://github.com/unnippillil/kali-linux-portfolio/blob/main/docs/getting-started.md',
+  },
+  {
+    id: 'new-app-checklist-doc',
+    title: 'New App Checklist',
+    url: 'https://github.com/unnippillil/kali-linux-portfolio/blob/main/docs/new-app-checklist.md',
+  },
+  {
+    id: 'pip-portal-doc',
+    title: 'Pip Portal',
+    url: 'https://github.com/unnippillil/kali-linux-portfolio/blob/main/docs/pip-portal.md',
+  },
+  {
+    id: 'tasks-doc',
+    title: 'Tasks',
+    url: 'https://github.com/unnippillil/kali-linux-portfolio/blob/main/docs/tasks.md',
+  },
+];


### PR DESCRIPTION
## Summary
- add global command palette opened with Ctrl/Cmd+K
- index apps and docs for quick search
- cover search overlay with unit test

## Testing
- `yarn lint` *(fails: react-hooks/rules-of-hooks in existing files)*
- `yarn test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*

------
https://chatgpt.com/codex/tasks/task_e_68aefacdcf288328bce17d3bda242df7