### PR TITLE
feat: show snap preview on window drag

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -41,3 +41,79 @@ describe('Window lifecycle', () => {
     jest.useRealTimers();
   });
 });
+
+describe('Window snapping preview', () => {
+  it('shows preview when dragged near left edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Simulate being near the left edge
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+  });
+
+  it('hides preview when away from edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Position far from edges
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: 200,
+      right: 300,
+      bottom: 300,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: 200,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.queryByTestId('snap-preview')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- detect when windows are dragged near screen edges
- show a ghost snap preview rectangle during drag
- test preview visibility logic

## Testing
- `npx jest __tests__/window.test.tsx --runTestsByPath`


------
https://chatgpt.com/codex/tasks/task_e_68aefad4e67c83289c6fdba810884d79