### PR TITLE
feat: add app pinning context menu

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -35,6 +35,8 @@ export class SideBarApp extends Component {
             <button
                 type="button"
                 aria-label={this.props.title}
+                data-context="app"
+                data-app-id={this.props.id}
                 onClick={this.openApp}
                 onMouseEnter={() => {
                     this.setState({ showTitle: true });

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -19,6 +19,8 @@ export class UbuntuApp extends Component {
             <div
                 role="button"
                 aria-label={this.props.name}
+                data-context="app"
+                data-app-id={this.props.id}
                 className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,0 +1,46 @@
+import React, { useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+
+function AppMenu(props) {
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
+
+    const handlePin = () => {
+        if (props.pinned) {
+            props.unpinApp && props.unpinApp()
+        } else {
+            props.pinApp && props.pinApp()
+        }
+    }
+
+    return (
+        <div
+            id="app-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        >
+            <button
+                type="button"
+                onClick={handlePin}
+                role="menuitem"
+                aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+            </button>
+        </div>
+    )
+}
+
+export default AppMenu


### PR DESCRIPTION
## Summary
- add app-specific context menu with pin/unpin actions
- persist pinned apps in localStorage and initialize from it
- mark app icons for context menu targeting

## Testing
- `yarn test` *(fails: missing react-cytoscapejs transform; hooks/useTheme module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefad778388328b13291e3da3a7624