### PR TITLE
feat: allow desktop shortcut creation

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -58,6 +58,15 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">New Folder</span>
             </button>
+            <button
+                onClick={props.openShortcutSelector}
+                type="button"
+                role="menuitem"
+                aria-label="Create Shortcut"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Create Shortcut...</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import UbuntuApp from '../base/ubuntu_app';
+
+class ShortcutSelector extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            query: '',
+            apps: [],
+            unfilteredApps: [],
+        };
+    }
+
+    componentDidMount() {
+        const { apps = [], games = [] } = this.props;
+        const combined = [...apps];
+        games.forEach((game) => {
+            if (!combined.some((app) => app.id === game.id)) combined.push(game);
+        });
+        this.setState({ apps: combined, unfilteredApps: combined });
+    }
+
+    handleChange = (e) => {
+        const value = e.target.value;
+        const { unfilteredApps } = this.state;
+        const apps =
+            value === '' || value === null
+                ? unfilteredApps
+                : unfilteredApps.filter((app) =>
+                      app.title.toLowerCase().includes(value.toLowerCase())
+                  );
+        this.setState({ query: value, apps });
+    };
+
+    selectApp = (id) => {
+        if (typeof this.props.onSelect === 'function') {
+            this.props.onSelect(id);
+        }
+    };
+
+    renderApps = () => {
+        const apps = this.state.apps || [];
+        return apps.map((app) => (
+            <UbuntuApp
+                key={app.id}
+                name={app.title}
+                id={app.id}
+                icon={app.icon}
+                openApp={() => this.selectApp(app.id)}
+            />
+        ));
+    };
+
+    render() {
+        return (
+            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+                <input
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    placeholder="Search"
+                    value={this.state.query}
+                    onChange={this.handleChange}
+                />
+                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                    {this.renderApps()}
+                </div>
+                <button
+                    className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
+                    onClick={this.props.onClose}
+                >
+                    Cancel
+                </button>
+            </div>
+        );
+    }
+}
+
+export default ShortcutSelector;


### PR DESCRIPTION
## Summary
- add "Create Shortcut" entry in desktop context menu
- support saving app shortcuts and selecting apps through a modal selector

## Testing
- `yarn test` *(fails: Test suite failed to run)*
- `yarn lint` *(fails: React Hooks must be called in the same order)*

------
https://chatgpt.com/codex/tasks/task_e_68aefad87a988328b8fea90fd7d66acd