### PR TITLE
Add chart viewer app and fetch utilities

### DIFF
--- a/__mocks__/react-cytoscapejs.js
+++ b/__mocks__/react-cytoscapejs.js
@@ -1,0 +1,3 @@
+module.exports = function ReactCytoscape() {
+  return null;
+};

--- a/apps.config.js
+++ b/apps.config.js
@@ -14,6 +14,7 @@ import { displayConverter } from './components/apps/converter';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayNikto } from './components/apps/nikto';
+import { displayChartViewer } from './components/apps/chart-viewer';
 
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
@@ -808,6 +809,16 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeather,
+  },
+  {
+    id: 'chart-viewer',
+    title: 'Charts',
+    icon: './themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayChartViewer,
+    movable: true,
   },
   {
     id: 'radare2',

--- a/components/apps/chart-viewer/index.tsx
+++ b/components/apps/chart-viewer/index.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Tabs from '../../ui/Tabs';
+import Toast from '../../ui/Toast';
+import Modal from '../../ui/Modal';
+import { getJson } from '../../../lib/api';
+
+type DataSet = { labels: string[]; data: number[] };
+
+const ChartViewer: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [tab, setTab] = useState<'line' | 'bar'>('line');
+  const [dataset, setDataset] = useState<DataSet | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showData, setShowData] = useState(false);
+  const [Chart, setChart] = useState<any>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getJson<DataSet>('/data/sample-chart.json');
+        setDataset(data);
+        const mod = await import('../../../lib/chart');
+        setChart(() => mod.default);
+      } catch (e: any) {
+        setError(e.message || 'Failed to load data');
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!dataset || !canvasRef.current || !Chart) return;
+    const ctx = canvasRef.current.getContext('2d');
+    if (!ctx) return;
+    const chart = new Chart(ctx, {
+      type: tab,
+      data: {
+        labels: dataset.labels,
+        datasets: [
+          {
+            label: 'Sample',
+            data: dataset.data,
+            borderColor: 'rgb(75, 192, 192)',
+            backgroundColor: 'rgba(75, 192, 192, 0.4)',
+          },
+        ],
+      },
+    });
+    return () => chart.destroy();
+  }, [dataset, tab, Chart]);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white flex flex-col items-center p-4">
+      <Tabs
+        tabs={[{ id: 'line', label: 'Line' }, { id: 'bar', label: 'Bar' }]}
+        active={tab}
+        onChange={(id) => setTab(id as 'line' | 'bar')}
+      />
+      <canvas ref={canvasRef} width={300} height={150} />
+      <button
+        onClick={() => setShowData(true)}
+        className="mt-4 px-2 py-1 bg-gray-700 rounded"
+      >
+        Show Data
+      </button>
+      {error && (
+        <Toast message={error} onClose={() => setError(null)} />
+      )}
+      <Modal open={showData} onClose={() => setShowData(false)} title="Data">
+        <pre className="text-xs whitespace-pre-wrap">
+          {JSON.stringify(dataset, null, 2)}
+        </pre>
+      </Modal>
+    </div>
+  );
+};
+
+export default ChartViewer;
+export const displayChartViewer = () => <ChartViewer />;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -66,6 +66,7 @@ export class Window extends Component {
     }
 
     changeCursorToMove = () => {
+        if (this.props.movable === false) return;
         this.focusWindow();
         if (this.state.maximized) {
             this.restoreWindow();
@@ -186,6 +187,7 @@ export class Window extends Component {
                 allowAnyClick={false}
                 defaultPosition={{ x: this.startX, y: this.startY }}
                 bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
+                disabled={this.props.movable === false}
             >
                 <div
                     style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -280,6 +280,7 @@ export class Desktop extends Component {
                     allowMaximize: app.allowMaximize,
                     defaultWidth: app.defaultWidth,
                     defaultHeight: app.defaultHeight,
+                    movable: app.movable,
                 }
 
                 windowsJsx.push(

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ open, onClose, title, children }) => {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-ub-cool-grey text-white p-4 rounded shadow-lg min-w-[300px]">
+        {title && <h2 className="text-lg mb-2">{title}</h2>}
+        {children}
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-700 rounded focus:outline-none"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/components/ui/Tabs.tsx
+++ b/components/ui/Tabs.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface TabItem {
+  id: string;
+  label: string;
+}
+
+interface TabsProps {
+  tabs: TabItem[];
+  active: string;
+  onChange: (id: string) => void;
+}
+
+const Tabs: React.FC<TabsProps> = ({ tabs, active, onChange }) => {
+  return (
+    <div className="flex border-b border-gray-700 mb-4">
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          className={`px-3 py-1 text-sm focus:outline-none ${
+            t.id === active ? 'border-b-2 border-white' : ''
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState('default');
+  return { theme, setTheme } as const;
+};
+
+export default useTheme;

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
+    'react-cytoscapejs': '<rootDir>/__mocks__/react-cytoscapejs.js',
   },
 };
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -99,6 +99,12 @@ if (typeof window !== 'undefined' && !window.localStorage) {
   } as Storage;
 }
 
+// Stub URL.createObjectURL for environments without implementation
+if (typeof URL !== 'undefined' && !URL.createObjectURL) {
+  // @ts-ignore
+  URL.createObjectURL = () => '';
+}
+
 // Minimal Worker mock for tests
 class WorkerMock {
   postMessage() {}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,26 @@
+export async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const getJson = <T>(url: string, options?: RequestInit) =>
+  request<T>(url, { ...options, method: 'GET' });
+
+export const postJson = <T>(url: string, body: unknown, options?: RequestInit) =>
+  request<T>(url, { ...options, method: 'POST', body: JSON.stringify(body) });
+
+export const putJson = <T>(url: string, body: unknown, options?: RequestInit) =>
+  request<T>(url, { ...options, method: 'PUT', body: JSON.stringify(body) });
+
+export const deleteJson = <T>(url: string, options?: RequestInit) =>
+  request<T>(url, { ...options, method: 'DELETE' });

--- a/lib/chart.ts
+++ b/lib/chart.ts
@@ -1,0 +1,3 @@
+import Chart from 'chart.js/auto';
+export default Chart;
+export type { ChartConfiguration, ChartData, ChartType } from 'chart.js';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
+    "chart.js": "^4.4.1",
     "chess.js": "^1.0.0",
     "cytoscape": "^3.33.1",
     "cytoscape-cose-bilkent": "^4.1.0",

--- a/public/data/sample-chart.json
+++ b/public/data/sample-chart.json
@@ -1,0 +1,4 @@
+{
+  "labels": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+  "data": [12, 19, 3, 5, 2, 3, 7]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kurkle/color@npm:^0.3.0":
+  version: 0.3.4
+  resolution: "@kurkle/color@npm:0.3.4"
+  checksum: 10c0/0e9fd55c614b005c5f0c4c755bca19ec0293bc7513b4ea3ec1725234f9c2fa81afbc78156baf555c8b9cb0d305619253c3f5bca016067daeebb3d00ebb4ea683
+  languageName: node
+  linkType: hard
+
 "@mixmark-io/domino@npm:^2.2.0":
   version: 2.2.0
   resolution: "@mixmark-io/domino@npm:2.2.0"
@@ -2841,6 +2848,15 @@ __metadata:
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
   checksum: 10c0/57a09a86371331e0be35d9083ba429e86c4f4648ecbe27455dbfb343037c16ee6fdc7f6b61f433a57cc5ded5561d71c56a150e018f40c2ffb7bc93a26dae341e
+  languageName: node
+  linkType: hard
+
+"chart.js@npm:^4.4.1":
+  version: 4.5.0
+  resolution: "chart.js@npm:4.5.0"
+  dependencies:
+    "@kurkle/color": "npm:^0.3.0"
+  checksum: 10c0/f12c7f9a238ee7ce6d3f7111628e9daba86bb8ff8e54cfe63525fde6ded9003c72c4c8d2c7d5702539dc0aff7e682dfec058660ade8d03a970da002656d4ac91
   languageName: node
   linkType: hard
 
@@ -8265,6 +8281,7 @@ __metadata:
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
+    chart.js: "npm:^4.4.1"
     chess.js: "npm:^1.0.0"
     cytoscape: "npm:^3.33.1"
     cytoscape-cose-bilkent: "npm:^4.1.0"


### PR DESCRIPTION
## Summary
- add generic fetch helpers and chart.js wrapper
- introduce reusable Tabs and Modal components
- register new Chart Viewer app with movable window support

## Testing
- `yarn lint` *(fails: React Hook rule violations)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aefadafea88328aaaa65f331b2be80