### PR TITLE
feat: add worker hook with auto cleanup

### DIFF
--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import useWorker from '../../../utils/worker';
 
 // Font list must match those parsed in worker.js
 const fonts = ['Standard', 'Slant', 'Big', 'Ghost', 'Small'];
@@ -9,23 +10,20 @@ const FigletApp = () => {
   const [output, setOutput] = useState('');
   const [inverted, setInverted] = useState(false);
   const [announce, setAnnounce] = useState('');
-  const workerRef = useRef(null);
+  const worker = useWorker('./worker.js', (e) => setOutput(e.data));
   const frameRef = useRef(null);
   const announceTimer = useRef(null);
 
   useEffect(() => {
-    workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
-    workerRef.current.onmessage = (e) => setOutput(e.data);
     return () => {
-      workerRef.current?.terminate();
       if (frameRef.current) cancelAnimationFrame(frameRef.current);
       clearTimeout(announceTimer.current);
     };
   }, []);
 
   const updateFiglet = () => {
-    if (workerRef.current) {
-      workerRef.current.postMessage({ text, font });
+    if (worker) {
+      worker.postMessage({ text, font });
     }
   };
 

--- a/utils/worker.ts
+++ b/utils/worker.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export const useWorker = <In = unknown, Out = unknown>(
+  path: string,
+  onMessage?: (e: MessageEvent<Out>) => void,
+) => {
+  const [worker, setWorker] = useState<
+    (Worker & { postMessage(data: In): void }) | null
+  >(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('Worker' in window)) return;
+    const w = new Worker(new URL(path, import.meta.url));
+    if (onMessage) w.onmessage = onMessage as (e: MessageEvent) => void;
+    setWorker(w as typeof worker);
+    return () => {
+      w.terminate();
+    };
+  }, [path, onMessage]);
+
+  return worker;
+};
+
+export default useWorker;


### PR DESCRIPTION
## Summary
- add `useWorker` hook to standardize web worker creation with auto cleanup
- update checkers, figlet and car-racer apps to use the hook
- pause car racer loop on tab visibility changes and leverage OffscreenCanvas

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*

------
https://chatgpt.com/codex/tasks/task_e_68af07f1d6ac83288f14b3827dc310f2