### PR TITLE
feat(vscode): secure lazy iframe

### DIFF
--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,17 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ExternalFrame from '../ExternalFrame';
 
 export default function VsCode() {
+    const [loaded, setLoaded] = useState(false);
+
     return (
-        <ExternalFrame
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            title="VsCode"
-            className="h-full w-full bg-ub-cool-grey"
-            allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-            allowFullScreen
-            frameBorder="0"
-            prefetch={false}
-        />
+        <div className="relative h-full w-full">
+            {!loaded && (
+                <div className="absolute inset-0 animate-pulse bg-ub-cool-grey" />
+            )}
+            <ExternalFrame
+                src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+                title="VsCode"
+                className={`h-full w-full bg-ub-cool-grey ${loaded ? 'block' : 'hidden'}`}
+                sandbox="allow-scripts allow-same-origin"
+                allow="clipboard-write"
+                allowFullScreen
+                frameBorder="0"
+                prefetch={false}
+                loading="lazy"
+                onLoad={() => setLoaded(true)}
+            />
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary
- lazy-load VS Code iframe with skeleton screen
- restrict iframe sandbox and permissions

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token; Cannot find module '../../hooks/useTheme')*


------
https://chatgpt.com/codex/tasks/task_e_68af07fbc2e08328a5c39de7c90f7118