### PR TITLE
Persist settings using IndexedDB and improve settings accessibility

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -10,7 +10,7 @@ export function Settings() {
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
     const changeBackgroundImage = (e) => {
-        const name = e.target.dataset.path;
+        const name = e.currentTarget.dataset.path;
         setWallpaper(name);
     };
 
@@ -105,9 +105,16 @@ export function Settings() {
                             key={index}
                             role="button"
                             aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
+                            aria-pressed={name === wallpaper}
                             tabIndex="0"
                             onClick={changeBackgroundImage}
                             onFocus={changeBackgroundImage}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    changeBackgroundImage(e);
+                                }
+                            }}
                             data-path={name}
                             className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
                             style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
@@ -117,7 +124,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={() => { resetSettings(); setTheme(defaults.theme); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); }}
+                    onClick={async () => { await resetSettings(); setTheme(defaults.theme); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -30,9 +30,17 @@ export const SettingsContext = createContext<SettingsContextValue>({
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => loadTheme() as Theme);
-  const [accent, setAccent] = useState<string>(() => loadAccent());
-  const [wallpaper, setWallpaper] = useState<string>(() => loadWallpaper());
+  const [theme, setTheme] = useState<Theme>(defaults.theme);
+  const [accent, setAccent] = useState<string>(defaults.accent);
+  const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+
+  useEffect(() => {
+    (async () => {
+      setTheme((await loadTheme()) as Theme);
+      setAccent(await loadAccent());
+      setWallpaper(await loadWallpaper());
+    })();
+  }, []);
 
   useEffect(() => {
     const applyTheme = () => {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,42 +1,48 @@
+import { get, set, del } from 'idb-keyval';
+
 const DEFAULT_SETTINGS = {
   theme: 'system',
   accent: '#E95420',
   wallpaper: 'wall-2',
 };
 
-export function getTheme() {
+export async function getTheme() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.theme;
-  return window.localStorage.getItem('theme') || DEFAULT_SETTINGS.theme;
+  return (await get('theme')) || DEFAULT_SETTINGS.theme;
 }
 
-export function setTheme(theme) {
+export async function setTheme(theme) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('theme', theme);
+  await set('theme', theme);
 }
 
-export function getAccent() {
+export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return window.localStorage.getItem('accent') || DEFAULT_SETTINGS.accent;
+  return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
-export function setAccent(accent) {
+export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('accent', accent);
+  await set('accent', accent);
 }
 
-export function getWallpaper() {
+export async function getWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return window.localStorage.getItem('bg-image') || DEFAULT_SETTINGS.wallpaper;
+  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
-export function setWallpaper(wallpaper) {
+export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('bg-image', wallpaper);
+  await set('bg-image', wallpaper);
 }
 
-export function resetSettings() {
+export async function resetSettings() {
   if (typeof window === 'undefined') return;
-  window.localStorage.clear();
+  await Promise.all([
+    del('theme'),
+    del('accent'),
+    del('bg-image'),
+  ]);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- store theme, accent, and wallpaper preferences in IndexedDB via idb-keyval
- load saved settings on mount and provide async reset
- expose wallpaper selection state with `aria-pressed` and keyboard support

## Testing
- `npm test` *(fails: react-cytoscapejs syntax error; module '../../hooks/useTheme' not found)*
- `npm run lint` *(fails: React Hooks must be called in the exact same order in every component render)*

------
https://chatgpt.com/codex/tasks/task_e_68af0806d1008328b8fb57f3ea61449f