### PR TITLE
Offload Todoist task moves to worker and persist via idb

### DIFF
--- a/components/apps/todoist.worker.js
+++ b/components/apps/todoist.worker.js
@@ -1,5 +1,7 @@
 self.onmessage = (e) => {
-  const { groups, from, to, id } = e.data || {};
+  const { type } = e.data || {};
+  if (type !== 'move') return;
+  const { groups, from, to, id } = e.data;
   const newGroups = {
     ...groups,
     [from]: [...groups[from]],


### PR DESCRIPTION
## Summary
- use idb-keyval to load and save Todoist tasks
- offload task movement to a dedicated worker and clean it up on unmount
- gate worker messages by type

## Testing
- `npm test` *(fails: Jest encountered unexpected token and missing module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af0808e11c83288215371e04622b3e