### PR TITLE
feat: improve unit converter accessibility and tests

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -20,6 +20,16 @@ describe('Unit conversion', () => {
       convertUnit('length', 'meter', 'kilometer', 1234, 2)
     ).toBeCloseTo(1.23, 2);
   });
+
+  it('rounds to the nearest integer when precision is zero', () => {
+    expect(convertUnit('length', 'meter', 'kilometer', 1499, 0)).toBe(1);
+    expect(convertUnit('length', 'meter', 'kilometer', 1500, 0)).toBe(2);
+  });
+
+  it('rounds halves away from zero', () => {
+    expect(convertUnit('length', 'kilometer', 'kilometer', -1.5, 0)).toBe(-2);
+    expect(convertUnit('length', 'kilometer', 'kilometer', 1.5, 0)).toBe(2);
+  });
 });
 
 describe('UnitConverter UI', () => {

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -205,7 +205,11 @@ const UnitConverter = () => {
               onChange={(e) => setFromUnit(e.target.value)}
             >
               {units.map((u) => (
-                <option key={u} value={u}>
+                <option
+                  key={u}
+                  value={u}
+                  aria-label={`${u} (${unitMap[category][u]})`}
+                >
                   {u}
                 </option>
               ))}
@@ -237,7 +241,11 @@ const UnitConverter = () => {
               onChange={(e) => setToUnit(e.target.value)}
             >
               {units.map((u) => (
-                <option key={u} value={u}>
+                <option
+                  key={u}
+                  value={u}
+                  aria-label={`${u} (${unitMap[category][u]})`}
+                >
                   {u}
                 </option>
               ))}

--- a/components/apps/converter/index.js
+++ b/components/apps/converter/index.js
@@ -2,18 +2,17 @@ import React from 'react';
 import UnitConverter from './UnitConverter';
 import CurrencyConverter from './CurrencyConverter';
 
-const Converter = () => {
-  return (
-    <div className="h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
-      <div className="grid gap-4 md:grid-cols-2">
-        <UnitConverter />
-        <CurrencyConverter />
-      </div>
+const Converter = () => (
+  <div className="h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
+    <div className="grid gap-4 md:grid-cols-2">
+      <UnitConverter />
+      <CurrencyConverter />
     </div>
-  );
-};
+  </div>
+);
+
+const displayConverter = () => <Converter />;
 
 export default Converter;
-
-export const displayConverter = () => <Converter />;
+export { displayConverter };
 


### PR DESCRIPTION
## Summary
- refactor converter component to a concise arrow function and named display export
- add aria labels for unit selections to aid screen readers
- expand unit conversion tests to cover rounding rules

## Testing
- `npm test __tests__/converter.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68af086ba0108328b6355ea96d095dc3