### PR TITLE
feat(figlet): improve offline fonts and live preview

### DIFF
--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -5,14 +5,18 @@ import big from 'figlet/importable-fonts/Big.js';
 import ghost from 'figlet/importable-fonts/Ghost.js';
 import small from 'figlet/importable-fonts/Small.js';
 
+const fonts = ['Standard', 'Slant', 'Big', 'Ghost', 'Small'];
+
 figlet.parseFont('Standard', standard);
 figlet.parseFont('Slant', slant);
 figlet.parseFont('Big', big);
 figlet.parseFont('Ghost', ghost);
 figlet.parseFont('Small', small);
 
+self.postMessage({ type: 'fonts', fonts });
+
 self.onmessage = (e) => {
   const { text, font } = e.data;
   const rendered = figlet.textSync(text || '', { font });
-  self.postMessage(rendered);
+  self.postMessage({ type: 'render', output: rendered });
 };


### PR DESCRIPTION
## Summary
- load figlet font list from worker for offline use
- announce ascii preview updates using aria-live

## Testing
- `npm test` *(fails: Cannot use import statement outside a module; Cannot find module '../../hooks/useTheme')*


------
https://chatgpt.com/codex/tasks/task_e_68af086f4c708328a8be9510634615a4