### PR TITLE
feat: secure contact form and API

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,17 +1,60 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+const sanitize = (str: string) =>
+  String(str).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]!));
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+const rateLimit = new Map<string, { count: number; start: number }>();
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ ok: false });
     return;
   }
 
-  const { name, email, message, honeypot } = req.body || {};
-  if (honeypot || !/\S+@\S+\.\S+/.test(email || '')) {
-    res.status(400).json({ ok: false });
+  const ip =
+    (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  const now = Date.now();
+  const entry = rateLimit.get(ip) || { count: 0, start: now };
+  if (now - entry.start > RATE_LIMIT_WINDOW_MS) {
+    entry.count = 0;
+    entry.start = now;
+  }
+  entry.count += 1;
+  rateLimit.set(ip, entry);
+  if (entry.count > RATE_LIMIT_MAX) {
+    res.status(429).json({ ok: false, error: 'Too many requests' });
     return;
   }
 
-  console.log('contact message', { name, email, message });
+  const { name = '', email = '', message = '', honeypot = '' } = req.body || {};
+  const trimmedName = name.trim();
+  const trimmedEmail = email.trim();
+  const trimmedMessage = message.trim();
+
+  if (
+    honeypot ||
+    !trimmedName ||
+    trimmedName.length > 100 ||
+    !/\S+@\S+\.\S+/.test(trimmedEmail) ||
+    !trimmedMessage ||
+    trimmedMessage.length > 1000
+  ) {
+    res.status(400).json({ ok: false, error: 'Invalid input' });
+    return;
+  }
+
+  console.log('contact message', {
+    name: sanitize(trimmedName),
+    email: sanitize(trimmedEmail),
+    message: sanitize(trimmedMessage),
+  });
   res.status(200).json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- validate and sanitize client contact form inputs before submission
- add rate limiting and server-side validation for contact API
- sanitize logged strings to mitigate injection

## Testing
- `yarn lint` *(fails: React Hook "useEffect" is called conditionally)*
- `yarn test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*

------
https://chatgpt.com/codex/tasks/task_e_68af086ad6988328a0a855a7957431ae