### PR TITLE
Add demo-only BeEF overlay and local data

### DIFF
--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -1,49 +1,94 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const STORAGE_KEY = 'beefHelpDismissed';
 
+const STEPS = [
+  'S1: Refresh to load demo hooks.',
+  'S2: Select a hooked browser.',
+  'S3: Pick a module from the list.',
+  'S4: Run the chosen module.',
+  'S5: Review the module output.',
+  'S6: Inspect the hook/module graph.',
+  'S7: Remember this is a safe demo.',
+  'S8: Close the guide and explore.'
+];
+
 export default function GuideOverlay({ onClose }) {
+  const [step, setStep] = useState(0);
   const [dontShow, setDontShow] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
 
   const handleClose = () => {
     if (dontShow) {
       try {
         localStorage.setItem(STORAGE_KEY, 'true');
-      } catch (e) {
-        // ignore storage errors
+      } catch {
+        /* ignore storage errors */
       }
     }
     onClose();
   };
 
+  const prev = () => setStep((s) => Math.max(0, s - 1));
+  const next = () => setStep((s) => Math.min(STEPS.length - 1, s + 1));
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape') handleClose();
+    if (e.key === 'ArrowRight') next();
+    if (e.key === 'ArrowLeft') prev();
+  };
+
   return (
     <div
+      ref={containerRef}
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
       role="dialog"
       aria-modal="true"
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
     >
       <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+        <div className="mb-2 text-center font-bold">
+          Demo data, no live scanning
+        </div>
         <h2 className="text-xl font-bold mb-2">BeEF Workflow</h2>
-        <ul className="list-disc pl-5 mb-4 space-y-1">
-          <li>Use <strong>Refresh</strong> to load hooked browsers.</li>
-          <li>Select a browser from the list to target.</li>
-          <li>Enter a <strong>Module ID</strong> and click <strong>Run Module</strong> to execute it.</li>
-          <li>View the module output below the controls.</li>
-        </ul>
+        <p className="mb-4">{STEPS[step]}</p>
+        <div className="flex justify-between mb-4">
+          <button
+            type="button"
+            onClick={prev}
+            disabled={step === 0}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+          >
+            Prev
+          </button>
+          <span>{step + 1} / {STEPS.length}</span>
+          <button
+            type="button"
+            onClick={next}
+            disabled={step === STEPS.length - 1}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+          >
+            Next
+          </button>
+        </div>
         <label className="flex items-center space-x-2">
           <input
             type="checkbox"
             checked={dontShow}
             onChange={(e) => setDontShow(e.target.checked)}
           />
-            <span>Don&apos;t show again</span>
-          </label>
+          <span>Don&apos;t show again</span>
+        </label>
         <button
           onClick={handleClose}
           className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
-          autoFocus
         >
-          Got it
+          Close
         </button>
       </div>
     </div>

--- a/public/demo-data/beef/hooks.json
+++ b/public/demo-data/beef/hooks.json
@@ -1,0 +1,6 @@
+{
+  "hooked_browsers": [
+    { "id": "demo1", "name": "Demo Client 1", "status": "online" },
+    { "id": "demo2", "name": "Demo Client 2", "status": "offline" }
+  ]
+}

--- a/public/demo-data/beef/modules.json
+++ b/public/demo-data/beef/modules.json
@@ -1,0 +1,14 @@
+{
+  "modules": [
+    {
+      "id": "alert",
+      "name": "Alert Dialog",
+      "output": "Alert executed on target."
+    },
+    {
+      "id": "get-cookie",
+      "name": "Get Cookies",
+      "output": "sessionid=demo123; csrftoken=demo456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Replace remote BeEF calls with local demo JSON
- Add keyboard-navigable step-through overlay with S1-S8 steps
- Show persistent "Demo data, no live scanning" banner

## Testing
- `yarn test components/apps/beef --passWithNoTests`
- `yarn lint --file components/apps/beef/index.js --file components/apps/beef/GuideOverlay.js --file components/apps/beef/HookGraph.js`


------
https://chatgpt.com/codex/tasks/task_e_68af0872e4f4832893d50b2b783bea88