### PR TITLE
feat(ettercap): add mocked tables

### DIFF
--- a/components/apps/ettercap/data.json
+++ b/components/apps/ettercap/data.json
@@ -1,0 +1,11 @@
+{
+  "arpTable": [
+    { "ip": "192.168.0.1", "mac": "aa:bb:cc:dd:ee:ff" },
+    { "ip": "192.168.0.2", "mac": "11:22:33:44:55:66" },
+    { "ip": "192.168.0.3", "mac": "77:88:99:aa:bb:cc" }
+  ],
+  "flows": [
+    { "source": "192.168.0.2", "destination": "192.168.0.3", "protocol": "HTTP" },
+    { "source": "192.168.0.3", "destination": "192.168.0.2", "protocol": "HTTP" }
+  ]
+}

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
+import data from './data.json';
 
+const { arpTable, flows } = data;
 const attackerMac = 'aa:aa:aa:aa:aa:aa';
 
 const randomMac = () =>
@@ -252,6 +254,58 @@ const EttercapApp = () => {
         {logs.map((l, i) => (
           <div key={i}>{l}</div>
         ))}
+      </div>
+      <div className="mt-4">
+        <h2 className="font-semibold">ARP Table</h2>
+        <table className="w-full text-left border-collapse mt-2">
+          <caption className="sr-only">Mock ARP entries</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="border-b px-2 py-1">
+                IP Address
+              </th>
+              <th scope="col" className="border-b px-2 py-1">
+                MAC Address
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {arpTable.map(({ ip, mac }) => (
+              <tr key={ip}>
+                <td className="px-2 py-1 font-mono">{ip}</td>
+                <td className="px-2 py-1 font-mono">{mac}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4">
+        <h2 className="font-semibold">Observed Flows</h2>
+        <table className="w-full text-left border-collapse mt-2">
+          <caption className="sr-only">Mock network flows</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="border-b px-2 py-1">
+                Source
+              </th>
+              <th scope="col" className="border-b px-2 py-1">
+                Destination
+              </th>
+              <th scope="col" className="border-b px-2 py-1">
+                Protocol
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {flows.map((f, i) => (
+              <tr key={`${f.source}-${f.destination}-${i}`}>
+                <td className="px-2 py-1 font-mono">{f.source}</td>
+                <td className="px-2 py-1 font-mono">{f.destination}</td>
+                <td className="px-2 py-1">{f.protocol}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
       <div className="mt-4 text-xs bg-gray-800 p-2 rounded">
         <p>


### PR DESCRIPTION
## Summary
- mock ARP tables and flows from local JSON
- render ARP data using semantic tables with headers

## Testing
- `yarn test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*
- `yarn lint` *(errors: React Hook "useEffect" is called conditionally)*


------
https://chatgpt.com/codex/tasks/task_e_68af0873d044832893b5c0a249ad4ad5