### PR TITLE
feat: guard nikto scan input and improve chart accessibility

### DIFF
--- a/components/apps/nikto/nikto.worker.js
+++ b/components/apps/nikto/nikto.worker.js
@@ -1,3 +1,6 @@
+const MAX_TEXT_SIZE = 500000; // ~500kb
+const MAX_LINES = 10000;
+
 const categories = {
   SQLi: /sql|database/i,
   XSS: /xss|cross|script/i,
@@ -7,8 +10,16 @@ const categories = {
 };
 
 self.onmessage = (e) => {
-  const { text } = e.data;
+  const text = e.data?.text;
+  if (typeof text !== 'string' || text.length > MAX_TEXT_SIZE) {
+    postMessage({ error: 'Input too large' });
+    return;
+  }
   const lines = text.split(/\r?\n/).filter((l) => l.trim());
+  if (lines.length > MAX_LINES) {
+    postMessage({ error: 'Input too large' });
+    return;
+  }
   const clusters = {};
 
   lines.forEach((line) => {


### PR DESCRIPTION
## Summary
- limit Nikto scan target size and reject oversized results
- handle worker errors and keep parsing inside the worker
- render radar chart with dynamic descriptive alt text

## Testing
- `npm test` (fails: Cannot use import statement outside a module; Cannot find module '../../hooks/useTheme')
- `npm run lint` (fails: React Hook "useInputMapping" is called conditionally)

------
https://chatgpt.com/codex/tasks/task_e_68af087a7b708328bc9c1cdd176e2d07