### PR TITLE
feat: offload autopsy parsing and escape filenames

### DIFF
--- a/components/apps/autopsy/jsonWorker.js
+++ b/components/apps/autopsy/jsonWorker.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-restricted-globals */
+self.onmessage = (e) => {
+  try {
+    const data = JSON.parse(e.data);
+    self.postMessage(data.artifacts || []);
+  } catch {
+    self.postMessage([]);
+  }
+};


### PR DESCRIPTION
## Summary
- escape artifact filenames before rendering
- parse autopsy demo JSON in a web worker with a main-thread fallback

## Testing
- `npm test` *(fails: beef.test.tsx, autopsy.test.tsx, frogger.config.test.ts, snake.config.test.ts)*
- `npm test __tests__/autopsy.test.tsx` *(fails: filters artifacts by type)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68af087cb9dc832884ce0d898dbee9b0