### PR TITLE
feat: simulate mimikatz with sample data

### DIFF
--- a/components/apps/mimikatz/CredentialLocator.js
+++ b/components/apps/mimikatz/CredentialLocator.js
@@ -1,9 +1,10 @@
+// Simulator: displays sample credential artifacts. For educational use only.
 import React, { useState, useEffect } from 'react';
 
 const artifacts = [
-  { label: 'SAM Database (simulation)', found: true },
-  { label: 'LSA Secrets (simulation)', found: true },
-  { label: 'DPAPI Master Keys (simulation)', found: false },
+  { label: 'SAM Database (sample)', found: true },
+  { label: 'LSA Secrets (sample)', found: true },
+  { label: 'DPAPI Master Keys (sample)', found: false },
 ];
 
 const CredentialArtifactLocator = () => {
@@ -47,6 +48,7 @@ const CredentialArtifactLocator = () => {
   return (
     <div className="mt-4 p-2 bg-ub-dark text-white rounded">
       <h2 className="text-lg mb-2">Credential Artifact Locator</h2>
+      <p className="text-xs mb-2 italic">Sample data only; no real credentials.</p>
       <button
         className="bg-green-600 rounded px-2 py-1 mb-2"
         onClick={handleScan}

--- a/components/apps/mimikatz/index.js
+++ b/components/apps/mimikatz/index.js
@@ -1,8 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import CredentialArtifactLocator from './CredentialLocator';
+import modulesData from './modules.json';
+
+// Mimikatz simulator: displays sample data only. Uploads and real credential handling are disabled.
+const sampleOutputs = {
+  sekurlsa: 'Sample output: dumped credentials (not real).',
+  lsadump: 'Sample output: LSASS secrets (not real).',
+  misc: 'Sample output: miscellaneous helper command.',
+};
 
 const MimikatzApp = () => {
-  const [modules, setModules] = useState([]);
+  const [modules] = useState(modulesData);
   const [output, setOutput] = useState('');
   const [history, setHistory] = useState([]);
   const [templates, setTemplates] = useState(() => {
@@ -16,12 +24,6 @@ const MimikatzApp = () => {
   const [templateName, setTemplateName] = useState('');
   const [templateScript, setTemplateScript] = useState('');
 
-  useEffect(() => {
-    fetch('/api/mimikatz')
-      .then((res) => res.json())
-      .then((data) => setModules(data.modules || []));
-  }, []);
-
   const addHistory = (command, text) => {
     setHistory((h) => [
       { timestamp: new Date().toISOString(), command, output: text },
@@ -29,19 +31,10 @@ const MimikatzApp = () => {
     ]);
   };
 
-  const runCommand = async (cmd) => {
-    try {
-      const res = await fetch(
-        `/api/mimikatz?command=${encodeURIComponent(cmd)}`
-      );
-      const data = await res.json();
-      setOutput(data.output || '');
-      addHistory(cmd, data.output || '');
-    } catch (err) {
-      const msg = `Error: ${err.message}`;
-      setOutput(msg);
-      addHistory(cmd, msg);
-    }
+  const runCommand = (cmd) => {
+    const text = sampleOutputs[cmd] || 'Unknown command';
+    setOutput(text);
+    addHistory(cmd, text);
   };
 
   const saveTemplate = () => {
@@ -55,21 +48,10 @@ const MimikatzApp = () => {
     setTemplateScript('');
   };
 
-  const runTemplate = async (script) => {
-    try {
-      const res = await fetch('/api/mimikatz', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ script }),
-      });
-      const data = await res.json();
-      setOutput(data.output || '');
-      addHistory(script, data.output || '');
-    } catch (err) {
-      const msg = `Error: ${err.message}`;
-      setOutput(msg);
-      addHistory(script, msg);
-    }
+  const runTemplate = (script) => {
+    const msg = 'Template execution disabled. Uploads are not permitted.';
+    setOutput(msg);
+    addHistory(script, msg);
   };
 
   return (
@@ -88,6 +70,7 @@ const MimikatzApp = () => {
             </li>
           ))}
         </ul>
+        <p className="text-xs italic mt-2">Sample modules only. No real credentials are processed.</p>
         <h2 className="text-lg mt-4">Templates</h2>
         <ul>
           {templates.map((t, idx) => (
@@ -123,7 +106,8 @@ const MimikatzApp = () => {
         </div>
       </div>
       <div className="flex-1 p-4 bg-ub-cool-grey overflow-auto">
-        <h1 className="text-lg mb-4">Mimikatz</h1>
+        <h1 className="text-lg mb-4">Mimikatz (Sample Simulator)</h1>
+        <p className="text-sm mb-4 italic">All outputs are sample data. Uploads are disabled.</p>
         <pre className="whitespace-pre-wrap mb-4">{output}</pre>
         <CredentialArtifactLocator />
         <h2 className="text-lg mb-2">History</h2>

--- a/components/apps/mimikatz/modules.json
+++ b/components/apps/mimikatz/modules.json
@@ -1,5 +1,5 @@
 [
-  { "name": "sekurlsa", "description": "Retrieve credentials from memory" },
-  { "name": "lsadump", "description": "Dump LSASS secrets" },
-  { "name": "misc", "description": "Miscellaneous helper commands" }
+  { "name": "sekurlsa", "description": "Sample: retrieve credentials from memory" },
+  { "name": "lsadump", "description": "Sample: dump LSASS secrets" },
+  { "name": "misc", "description": "Sample helper commands only" }
 ]


### PR DESCRIPTION
## Summary
- Replace network-backed mimikatz app with local sample simulator
- Mark credential artifacts and modules as sample data
- Disable script uploads and note that outputs are mock

## Testing
- `npm test` *(fails: /usr/bin/npm not found)*
- `apt-get update` *(fails: repository not signed, gpg not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af087eec5c832888802028e5a95cdf