### PR TITLE
feat(radare2): offload analysis to worker

### DIFF
--- a/components/apps/radare2/analysisWorker.js
+++ b/components/apps/radare2/analysisWorker.js
@@ -1,0 +1,23 @@
+import { parseGraph, convertAnalysisToGhidra } from './utils';
+
+let paused = false;
+
+self.onmessage = (e) => {
+  const { type, analysis } = e.data || {};
+  if (type === 'pause') {
+    paused = true;
+    return;
+  }
+  if (type === 'resume') {
+    paused = false;
+    return;
+  }
+  if (paused) return;
+  if (type === 'graph') {
+    const graphData = parseGraph(analysis || '');
+    postMessage({ type: 'graph', graphData });
+  } else if (type === 'export') {
+    const ghidra = convertAnalysisToGhidra(analysis || '');
+    postMessage({ type: 'export', ghidra });
+  }
+};

--- a/components/apps/radare2/hexWorker.js
+++ b/components/apps/radare2/hexWorker.js
@@ -1,5 +1,17 @@
+let paused = false;
+
 self.onmessage = (e) => {
-  const hex = (e.data || '').replace(/[^0-9a-fA-F]/g, '');
+  const data = e.data || {};
+  if (data.type === 'pause') {
+    paused = true;
+    return;
+  }
+  if (data.type === 'resume') {
+    paused = false;
+    return;
+  }
+  if (paused) return;
+  const hex = (data.hex || '').replace(/[^0-9a-fA-F]/g, '');
   const bytes = hex.match(/.{1,2}/g) || [];
   postMessage(bytes);
 };


### PR DESCRIPTION
## Summary
- move analysis parsing and export logic to a dedicated web worker
- add visibility-based pausing for analysis and hex workers
- avoid unnecessary hex editor drawing when tab is hidden

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in react-cytoscapejs; missing module '../../hooks/useTheme')*
- `npm run lint` *(fails: react-hooks/rules-of-hooks errors in HelpOverlay and useGameControls)*

------
https://chatgpt.com/codex/tasks/task_e_68af0881cd2c8328a500b7e66075cd09