### PR TITLE
Use fixture data for dsniff

### DIFF
--- a/__tests__/dsniff.test.tsx
+++ b/__tests__/dsniff.test.tsx
@@ -1,45 +1,18 @@
 import React from 'react';
-import { render, fireEvent, screen, act } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import Dsniff from '../components/apps/dsniff';
 
 describe('Dsniff component', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ text: () => Promise.resolve('') }) as any;
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-    jest.resetAllMocks();
-  });
-
-  it('toggles simulation mode', () => {
+  it('shows fixture logs', async () => {
     render(<Dsniff />);
-    expect(screen.getByText('No data')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText('Simulation'));
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-    expect(screen.queryByText('No data')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText('Simulation'));
-    act(() => {
-      jest.advanceTimersByTime(0);
-    });
-    expect(screen.getByText('No data')).toBeInTheDocument();
+    expect(await screen.findByText('example.com')).toBeInTheDocument();
+    expect(await screen.findByText('test.com')).toBeInTheDocument();
   });
 
-  it('applies host filter', () => {
+  it('applies host filter', async () => {
     render(<Dsniff />);
-    fireEvent.click(screen.getByLabelText('Simulation'));
-    act(() => {
-      jest.advanceTimersByTime(2000);
-    });
+    await screen.findByText('example.com');
 
-    // Apply host filter
     fireEvent.change(screen.getByPlaceholderText('Value'), {
       target: { value: 'example.com' },
     });

--- a/public/demo-data/dsniff/arpspoof.json
+++ b/public/demo-data/dsniff/arpspoof.json
@@ -1,0 +1,4 @@
+[
+  "ARP reply 192.168.0.1 is-at 00:11:22:33:44:55",
+  "ARP reply 192.168.0.2 is-at aa:bb:cc:dd:ee:ff"
+]

--- a/public/demo-data/dsniff/urlsnarf.json
+++ b/public/demo-data/dsniff/urlsnarf.json
@@ -1,0 +1,4 @@
+[
+  "HTTP example.com /index.html",
+  "HTTPS test.com /login"
+]


### PR DESCRIPTION
## Summary
- load urlsnarf and arpspoof logs from JSON fixtures
- remove packet capture fetching and simulation toggle
- add lab-use disclaimer and adapt tests

## Testing
- `npm test __tests__/dsniff.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af0884f5dc83289316d41c54a8fe8a