### PR TITLE
Add cancelable hashcat progress simulation

### DIFF
--- a/components/apps/hashcat/progress.worker.js
+++ b/components/apps/hashcat/progress.worker.js
@@ -1,4 +1,5 @@
 self.onmessage = (e) => {
+  if (e.data?.cancel) return;
   const target = e.data?.target ?? 100;
   let current = 0;
   const tick = () => {


### PR DESCRIPTION
## Summary
- Add start/stop controls to simulate hash cracking progress
- Block wordlist uploads and clarify with UI messaging
- Allow worker to halt when canceling progress

## Testing
- `yarn lint`
- `yarn test components/apps/hashcat` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68af088378888328b405d5e9c26cafce