### PR TITLE
feat(openvas): add severity chart and escape descriptions

### DIFF
--- a/components/apps/openvas/chart-data.json
+++ b/components/apps/openvas/chart-data.json
@@ -1,0 +1,6 @@
+{
+  "low": 4,
+  "medium": 3,
+  "high": 2,
+  "critical": 1
+}


### PR DESCRIPTION
## Summary
- visualize OpenVAS severity distribution using a local JSON-backed bar chart
- escape finding descriptions before rendering to prevent HTML injection

## Testing
- `npm test -- openvas`


------
https://chatgpt.com/codex/tasks/task_e_68af0886b3bc83288395d3af7b044e9e