### PR TITLE
refactor: simplify 2048 imports

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import GameLayout from './GameLayout';
 import useGameControls from './useGameControls';

--- a/pages/apps/2048.tsx
+++ b/pages/apps/2048.tsx
@@ -1,17 +1,15 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
 
 const SIZE = 4;
 
 // simple seeded PRNG
-function mulberry32(seed: number) {
-  return function() {
-    let t = (seed += 0x6D2B79F5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+const mulberry32 = (seed: number) => () => {
+  let t = (seed += 0x6d2b79f5);
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
 
 const todaySeed = () => {
   const d = new Date();
@@ -104,7 +102,7 @@ const saveReplay = (replay: any) => {
   };
 };
 
-const Page2048: React.FC = () => {
+const Page2048 = () => {
   const rngRef = useRef(mulberry32(todaySeed()));
   const [board, setBoard] = useState<number[][]>(() => {
     const b = Array.from({ length: SIZE }, () => Array(SIZE).fill(0));


### PR DESCRIPTION
## Summary
- remove unused React default imports from 2048 components
- switch seeded RNG helper to arrow function
- drop React.FC usage in 2048 page

## Testing
- `yarn test __tests__/game2048.test.tsx`
- `yarn lint components/apps/2048.js pages/apps/2048.tsx` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af088935e48328a1c12136c1d7135d