### PR TITLE
feat(word-search): add daily seed support

### DIFF
--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -1,13 +1,15 @@
 import type { Position, WordPlacement } from './types';
 
+type RNG = () => number;
+
 // simple seeded RNG using xmur3 and mulberry32
-function xmur3(str: string) {
+function xmur3(str: string): () => number {
   let h = 1779033703 ^ str.length;
   for (let i = 0; i < str.length; i += 1) {
     h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
     h = (h << 13) | (h >>> 19);
   }
-  return function () {
+  return function (): number {
     h = Math.imul(h ^ (h >>> 16), 2246822507);
     h = Math.imul(h ^ (h >>> 13), 3266489909);
     h ^= h >>> 16;
@@ -15,8 +17,8 @@ function xmur3(str: string) {
   };
 }
 
-function mulberry32(a: number) {
-  return function () {
+function mulberry32(a: number): RNG {
+  return function (): number {
     let t = (a += 0x6d2b79f5);
     t = Math.imul(t ^ (t >>> 15), t | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
@@ -24,12 +26,17 @@ function mulberry32(a: number) {
   };
 }
 
-export function createRNG(seed: string) {
+export function createRNG(seed: string): RNG {
   const seedFunc = xmur3(seed);
   return mulberry32(seedFunc());
 }
 
-const DIRECTIONS = [
+interface Direction {
+  readonly dx: number;
+  readonly dy: number;
+}
+
+const DIRECTIONS: readonly Direction[] = [
   { dx: 1, dy: 0 },
   { dx: -1, dy: 0 },
   { dx: 0, dy: 1 },

--- a/apps/word_search/types.ts
+++ b/apps/word_search/types.ts
@@ -1,9 +1,9 @@
 export interface Position {
-  row: number;
-  col: number;
+  readonly row: number;
+  readonly col: number;
 }
 
 export interface WordPlacement {
-  word: string;
-  positions: Position[];
+  readonly word: string;
+  readonly positions: Position[];
 }

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -1,8 +1,11 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const WordSearch = dynamic(() => import('../../apps/word_search'), { ssr: false });
+const WordSearch = dynamic<{ getDailySeed?: () => Promise<string> }>(
+  () => import('../../apps/word_search'),
+  { ssr: false },
+);
 
-export default function WordSearchPage() {
+export default function WordSearchPage(): JSX.Element {
   return <WordSearch getDailySeed={() => getDailySeed('word_search')} />;
 }


### PR DESCRIPTION
## Summary
- refactor word search RNG helper with explicit types
- enable optional daily seed integration in word search game
- type word search page dynamic import

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '../../hooks/useTheme' from 'components/apps/x.js')*

------
https://chatgpt.com/codex/tasks/task_e_68af08a666fc83288523e86b0f45e5ca