### PR TITLE
Refine Sudoku solver utilities

### DIFF
--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ratePuzzle, getHint } from '../../workers/sudokuSolver';
 
+// Interactive Sudoku game with puzzle generation and solving utilities.
 const SIZE = 9;
 const range = (n) => Array.from({ length: n }, (_, i) => i);
 
@@ -84,6 +85,14 @@ const getCandidates = (board, r, c) => {
   return cand;
 };
 
+const HOLES_BY_DIFFICULTY = { easy: 35, medium: 45, hard: 55 };
+
+/**
+ * Generates a Sudoku puzzle and its solution.
+ * @param {'easy'|'medium'|'hard'} difficulty - Desired puzzle difficulty.
+ * @param {number} seed - Seed for deterministic generation.
+ * @returns {{puzzle: number[][], solution: number[][]}}
+ */
 const generateSudoku = (difficulty = 'easy', seed = Date.now()) => {
   const rng = createRNG(seed);
   const board = Array(SIZE)
@@ -92,8 +101,7 @@ const generateSudoku = (difficulty = 'easy', seed = Date.now()) => {
   solveBoard(board, 0, rng);
   const solution = board.map((row) => row.slice());
   const puzzle = board.map((row) => row.slice());
-  const holesByDiff = { easy: 35, medium: 45, hard: 55 };
-  let holes = holesByDiff[difficulty] || holesByDiff.easy;
+  let holes = HOLES_BY_DIFFICULTY[difficulty] || HOLES_BY_DIFFICULTY.easy;
   const positions = shuffle(range(SIZE * SIZE), rng);
   for (const pos of positions) {
     if (holes === 0) break;

--- a/workers/sudokuSolver.ts
+++ b/workers/sudokuSolver.ts
@@ -1,3 +1,4 @@
+// Utilities for solving Sudoku puzzles and generating hints.
 const digits = '123456789';
 const rows = 'ABCDEFGHI';
 const cols = digits;
@@ -152,6 +153,11 @@ const boardToString = (board: number[][]): string => board.flat().map((n) => (n 
 
 const squareToIndices = (s: string): [number, number] => [rows.indexOf(s[0]), cols.indexOf(s[1])];
 
+/**
+ * Solves a Sudoku board.
+ * @param board - 9x9 puzzle grid where 0 represents an empty cell.
+ * @returns The solved board and the steps taken to reach the solution.
+ */
 export const solve = (board: number[][]): { solution: number[][]; steps: Step[] } => {
   const grid = boardToString(board);
   const steps: Step[] = [];
@@ -162,6 +168,11 @@ export const solve = (board: number[][]): { solution: number[][]; steps: Step[] 
   return { solution: stringToBoard(squares.map((s) => result[s]).join('')), steps };
 };
 
+/**
+ * Rates a puzzle based on the number of guesses required.
+ * @param board - Puzzle to evaluate.
+ * @returns Difficulty rating and the solving steps.
+ */
 export const ratePuzzle = (board: number[][]): { difficulty: string; steps: Step[] } => {
   const { steps } = solve(board);
   const guesses = steps.filter((s) => s.technique === 'guess').length;
@@ -172,6 +183,11 @@ export const ratePuzzle = (board: number[][]): { difficulty: string; steps: Step
   return { difficulty, steps };
 };
 
+/**
+ * Provides a hint for the given board.
+ * @param board - Current puzzle state.
+ * @returns A hint describing a single move or pair, or null if none found.
+ */
 export const getHint = (
   board: number[][],
 ):
@@ -237,4 +253,5 @@ export const getHint = (
 
 export const utils = { boardToString, stringToBoard };
 
-export default { solve, ratePuzzle, getHint };
+const sudokuSolver = { solve, ratePuzzle, getHint };
+export default sudokuSolver;


### PR DESCRIPTION
## Summary
- document sudoku generator with difficulty constants
- add jsdoc comments and named export for solver utilities

## Testing
- `npx -y eslint@8.56.0 components/apps/sudoku.js workers/sudokuSolver.ts`
- `npm test` *(fails: cannot parse HookGraph.js, module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af08a876c4832884b0e3e8b0492925