### PR TITLE
feat(weather): add manual location and update time

### DIFF
--- a/components/apps/weather.worker.js
+++ b/components/apps/weather.worker.js
@@ -1,0 +1,14 @@
+self.onmessage = (e) => {
+  const { temps } = e.data || {};
+  if (!Array.isArray(temps) || temps.length === 0) return;
+  const maxTemp = Math.max(...temps);
+  const minTemp = Math.min(...temps);
+  const points = temps
+    .map((t, i) => {
+      const x = (i / (temps.length - 1)) * 100;
+      const y = ((maxTemp - t) / (maxTemp - minTemp || 1)) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  self.postMessage(points);
+};


### PR DESCRIPTION
## Summary
- apply S1–S8 guidelines to weather app
- allow manual city entry if geolocation fails
- show last updated time and announce updates

## Testing
- `npm test` *(fails: BeEF, Autopsy, a11y.spec)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks, react/jsx-no-duplicate-props)*

------
https://chatgpt.com/codex/tasks/task_e_68af086c61508328bb64e83fd8410099