### PR TITLE
feat(metasploit): rely on bundled modules for offline search

### DIFF
--- a/__tests__/metasploit.test.tsx
+++ b/__tests__/metasploit.test.tsx
@@ -4,29 +4,10 @@ import MetasploitApp from '../components/apps/metasploit';
 
 describe('Metasploit app', () => {
   beforeEach(() => {
-    // @ts-ignore
-    global.fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve({}) })
-    );
     localStorage.clear();
   });
 
-  it('refreshes modules on mount', () => {
-    render(<MetasploitApp />);
-    expect(global.fetch).toHaveBeenCalledWith('/api/metasploit');
-  });
-
   it('persists command history', async () => {
-    // @ts-ignore
-    (global.fetch as jest.Mock).mockImplementation((url, options) => {
-      if (options && options.method === 'POST') {
-        return Promise.resolve({
-          json: () => Promise.resolve({ output: 'res' }),
-        });
-      }
-      return Promise.resolve({ json: () => Promise.resolve({}) });
-    });
-
     const { unmount } = render(<MetasploitApp />);
     const input = screen.getByPlaceholderText('msfconsole command');
     fireEvent.change(input, { target: { value: 'search test' } });

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -33,11 +33,6 @@ const MetasploitApp = () => {
   const moduleRaf = useRef();
   const progressRaf = useRef();
 
-  // Refresh modules list in the background on mount
-  useEffect(() => {
-    fetch('/api/metasploit').catch(() => {});
-  }, []);
-
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     const handler = () => setReduceMotion(mq.matches);
@@ -80,23 +75,31 @@ const MetasploitApp = () => {
     return () => cancelAnimationFrame(moduleRaf.current);
   }, [selectedSeverity, reduceMotion]);
 
-  const runCommand = async () => {
+  const runCommand = () => {
     const cmd = command.trim();
     if (!cmd) return;
     setLoading(true);
-    try {
-      const res = await fetch('/api/metasploit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ command: cmd }),
-      });
-      const data = await res.json();
-      setOutput((prev) => `${prev}\nmsf6 > ${cmd}\n${data.output || ''}`);
-    } catch (e) {
-      setOutput((prev) => `${prev}\nError: ${e.message}`);
-    } finally {
+    setTimeout(() => {
+      let result = '';
+      if (cmd.toLowerCase().startsWith('search ')) {
+        const q = cmd.slice(7).toLowerCase();
+        const matches = modules.filter(
+          (m) =>
+            m.name.toLowerCase().includes(q) ||
+            m.description.toLowerCase().includes(q)
+        );
+        result = matches.length
+          ? matches
+              .map((m) => `${m.name} - ${m.description}`)
+              .join('\n')
+          : 'No matching modules found.';
+      } else {
+        result = 'Command not supported in this demo.';
+      }
+      setOutput((prev) => `${prev}\nmsf6 > ${cmd}\n${result}`);
       setLoading(false);
-    }
+      setCommand('');
+    }, 300);
   };
 
   const runDemo = () => {

--- a/components/apps/metasploit/modules.json
+++ b/components/apps/metasploit/modules.json
@@ -33,5 +33,26 @@
     "severity": "medium",
     "type": "post",
     "tags": ["ssh", "credentials"]
+  },
+  {
+    "name": "exploit/windows/http/atlassian_crowd_deserialization",
+    "description": "Atlassian Crowd Java deserialization RCE",
+    "severity": "high",
+    "type": "exploit",
+    "tags": ["http", "deserialization"]
+  },
+  {
+    "name": "auxiliary/scanner/ssh/ssh_version",
+    "description": "SSH version scanner",
+    "severity": "low",
+    "type": "auxiliary",
+    "tags": ["ssh", "scanner"]
+  },
+  {
+    "name": "post/windows/gather/enum_domain",
+    "description": "Windows domain enumeration",
+    "severity": "medium",
+    "type": "post",
+    "tags": ["windows", "recon"]
   }
 ]


### PR DESCRIPTION
## Summary
- remove background fetch and handle `search` command locally
- expand bundled Metasploit modules list
- update Metasploit tests for offline behaviour

## Testing
- `npm test`
- `npm test __tests__/metasploit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af0876312483289b27be3ee285d4e3