### PR TITLE
Use local Nessus sample data

### DIFF
--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import sampleData from './sample-report.json';
 
 const severityLevels = ['All', 'Critical', 'High', 'Medium', 'Low'];
 const severityColors = {
@@ -8,14 +9,14 @@ const severityColors = {
   Low: '#1e40af',
 };
 
-const sampleHosts = [
-  { id: 1, host: '192.168.0.1', cvss: 9.8, severity: 'Critical' },
-  { id: 2, host: '192.168.0.2', cvss: 7.5, severity: 'High' },
-  { id: 3, host: '192.168.0.3', cvss: 5.0, severity: 'Medium' },
-  { id: 4, host: '192.168.0.4', cvss: 2.5, severity: 'Low' },
-];
+const defaultHosts = sampleData.map((d, i) => ({
+  id: d.id ?? i,
+  host: d.host ?? d.name,
+  cvss: d.cvss,
+  severity: d.severity,
+}));
 
-const HostBubbleChart = ({ hosts = sampleHosts }) => {
+const HostBubbleChart = ({ hosts = defaultHosts }) => {
   const [filter, setFilter] = useState('All');
   const [displayData, setDisplayData] = useState(hosts);
   const workerRef = useRef(null);
@@ -78,6 +79,7 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
         role="img"
         aria-label="Host vulnerabilities bubble chart"
         className="mx-auto"
+        tabIndex={0}
       >
         {displayData.map((host) => {
           const x = ((host.index + 1) * 400) / (displayData.length + 1);
@@ -88,6 +90,7 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
                 r={host.radius}
                 fill={severityColors[host.severity]}
                 aria-label={`${host.host} severity ${host.severity} CVSS ${host.cvss}`}
+                tabIndex={0}
                 style={{
                   transition: prefersReducedMotion ? 'none' : 'all 0.3s ease',
                 }}

--- a/components/apps/nessus/sample-report.json
+++ b/components/apps/nessus/sample-report.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "1",
+    "host": "192.168.0.1",
     "name": "OpenSSL Heartbeat Information Disclosure",
     "cvss": 5.0,
     "severity": "Medium",
@@ -8,6 +9,7 @@
   },
   {
     "id": "2",
+    "host": "192.168.0.2",
     "name": "Apache HTTP Server Privilege Escalation",
     "cvss": 7.5,
     "severity": "High",
@@ -15,6 +17,7 @@
   },
   {
     "id": "3",
+    "host": "192.168.0.3",
     "name": "Weak SSH Cipher",
     "cvss": 9.8,
     "severity": "Critical",
@@ -22,6 +25,7 @@
   },
   {
     "id": "4",
+    "host": "192.168.0.4",
     "name": "Outdated Software",
     "cvss": 2.5,
     "severity": "Low",

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  return { theme, setTheme };
+};
+

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,36 +1,51 @@
-import React, { useEffect, useState } from 'react';
-import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
+import React, { useMemo } from 'react';
+import data from '../components/apps/nessus/sample-report.json';
+
+const severityColors: Record<string, string> = {
+  Critical: 'bg-red-700',
+  High: 'bg-orange-600',
+  Medium: 'bg-yellow-600',
+  Low: 'bg-blue-700',
+};
+
+const severities = ['Critical', 'High', 'Medium', 'Low'];
 
 const NessusDashboard: React.FC = () => {
-  const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });
-
-  useEffect(() => {
-    const jobs = loadJobDefinitions();
-    const fps = loadFalsePositives();
-    setTotals({ jobs: jobs.length, falsePositives: fps.length });
+  const counts = useMemo(() => {
+    return (data as any[]).reduce<Record<string, number>>((acc, item) => {
+      const sev = item.severity as string;
+      acc[sev] = (acc[sev] || 0) + 1;
+      return acc;
+    }, {});
   }, []);
 
-  const max = Math.max(totals.jobs, totals.falsePositives, 1);
+  const max = Math.max(...severities.map((s) => counts[s] || 0), 1);
 
   return (
     <div className="p-4 bg-gray-900 min-h-screen text-white">
       <h1 className="text-2xl mb-4">Nessus Dashboard</h1>
-      <div className="flex items-end space-x-4 h-48">
-        <div
-          className="bg-blue-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.jobs / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">Jobs {totals.jobs}</span>
-        </div>
-        <div
-          className="bg-green-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.falsePositives / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">False {totals.falsePositives}</span>
-        </div>
+      <div
+        className="flex items-end space-x-4 h-48"
+        role="img"
+        aria-label="Vulnerability counts by severity"
+      >
+        {severities.map((sev) => (
+          <div
+            key={sev}
+            className={`${severityColors[sev]} w-24 text-center flex flex-col justify-end`}
+            style={{ height: `${((counts[sev] || 0) / max) * 100}%` }}
+            tabIndex={0}
+            aria-label={`${sev} findings ${counts[sev] || 0}`}
+          >
+            <span className="pb-2 text-sm">
+              {sev} {counts[sev] || 0}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );
 };
 
 export default NessusDashboard;
+


### PR DESCRIPTION
## Summary
- Load Nessus dashboard charts from bundled sample-report.json
- Make host bubble chart and bars keyboard-focusable
- Stub useTheme hook to support XApp tests

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in react-cytoscapejs)*

------
https://chatgpt.com/codex/tasks/task_e_68af087d0b28832880c676d1f5b1eb5e