### PR TITLE
Add skeleton loading and external open link for iframe

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -10,6 +10,13 @@ describe('VsCode app', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
+  it('has an external link', () => {
+    render(<VsCode />);
+    const link = screen.getByRole('link', { name: /open externally/i });
+    expect(link).toHaveAttribute('href', 'https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
   it('shows banner when cookies are blocked', async () => {
     const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
     Object.defineProperty(document, 'cookie', {

--- a/apps.config.js
+++ b/apps.config.js
@@ -575,6 +575,8 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayVsCode,
+    defaultWidth: 85,
+    defaultHeight: 85,
   },
   {
     id: 'x',

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -11,9 +11,10 @@ const isAllowed = (src) => {
   }
 };
 
-export default function ExternalFrame({ src, title, prefetch = false, ...props }) {
+export default function ExternalFrame({ src, title, prefetch = false, onLoad: onLoadProp, ...props }) {
   const [cookiesBlocked, setCookiesBlocked] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     try {
@@ -39,14 +40,34 @@ export default function ExternalFrame({ src, title, prefetch = false, ...props }
           </button>
         </div>
       )}
-      <iframe
-        src={src}
-        title={title}
-        sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
-        referrerPolicy="no-referrer"
-        {...props}
-      />
+      <div className="relative flex-1">
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute top-2 right-2 z-10 px-2 py-1 text-xs bg-white text-black rounded opacity-0 focus-visible:opacity-100"
+        >
+          Open Externally
+        </a>
+        <iframe
+          src={src}
+          title={title}
+          sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
+          referrerPolicy="no-referrer"
+          onLoad={(e) => {
+            setLoaded(true);
+            onLoadProp?.(e);
+          }}
+          className={`w-full h-full ${loaded ? '' : 'invisible'}`}
+          {...props}
+        />
+        {!loaded && (
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-200 animate-pulse" aria-hidden="true">
+            <span className="sr-only">Loading...</span>
+          </div>
+        )}
+      </div>
       {showDialog && (
         <dialog open>
           <p>Enable third-party cookies in your browser settings to use this app.</p>


### PR DESCRIPTION
## Summary
- show a pulsing skeleton until external frames finish loading
- add an "Open Externally" link that appears when focused
- set VS Code window default dimensions to 85x85

## Testing
- `yarn test __tests__/vscode.test.tsx`
- `yarn test __tests__/frogger.config.test.ts`
- `yarn test __tests__/snake.config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af18fb5bf083288336a12f0a288dd2