### PR TITLE
feat: add density and motion settings

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { theme, setTheme, accent, setAccent, wallpaper, setWallpaper } = useSettings();
+    const { theme, setTheme, accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -81,6 +81,28 @@ export function Settings() {
                 />
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Density:</label>
+                <select
+                    value={density}
+                    onChange={(e) => setDensity(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="regular">Regular</option>
+                    <option value="compact">Compact</option>
+                </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={reducedMotion}
+                        onChange={(e) => setReducedMotion(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Reduced Motion
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
                     style={{ backgroundColor: theme === 'dark' ? '#000000' : '#ffffff', color: theme === 'dark' ? '#ffffff' : '#000000' }}
@@ -124,7 +146,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={async () => { await resetSettings(); setTheme(defaults.theme); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); }}
+                    onClick={async () => { await resetSettings(); setTheme(defaults.theme); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -6,39 +6,56 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getDensity as loadDensity,
+  setDensity as saveDensity,
+  getReducedMotion as loadReducedMotion,
+  setReducedMotion as saveReducedMotion,
   defaults,
 } from '../utils/settingsStore';
 
 type Theme = 'light' | 'dark' | 'system';
+type Density = 'regular' | 'compact';
 
 interface SettingsContextValue {
   theme: Theme;
   accent: string;
   wallpaper: string;
+  density: Density;
+  reducedMotion: boolean;
   setTheme: (theme: Theme) => void;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setDensity: (density: Density) => void;
+  setReducedMotion: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
   theme: defaults.theme,
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  density: defaults.density,
+  reducedMotion: defaults.reducedMotion,
   setTheme: () => {},
   setAccent: () => {},
   setWallpaper: () => {},
+  setDensity: () => {},
+  setReducedMotion: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(defaults.theme);
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [density, setDensity] = useState<Density>(defaults.density);
+  const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
 
   useEffect(() => {
     (async () => {
       setTheme((await loadTheme()) as Theme);
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setDensity((await loadDensity()) as Density);
+      setReducedMotion(await loadReducedMotion());
     })();
   }, []);
 
@@ -70,8 +87,39 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
 
+  useEffect(() => {
+    const spacing: Record<Density, Record<string, string>> = {
+      regular: {
+        '--space-1': '0.25rem',
+        '--space-2': '0.5rem',
+        '--space-3': '0.75rem',
+        '--space-4': '1rem',
+        '--space-5': '1.5rem',
+        '--space-6': '2rem',
+      },
+      compact: {
+        '--space-1': '0.125rem',
+        '--space-2': '0.25rem',
+        '--space-3': '0.5rem',
+        '--space-4': '0.75rem',
+        '--space-5': '1rem',
+        '--space-6': '1.5rem',
+      },
+    };
+    const vars = spacing[density];
+    Object.entries(vars).forEach(([key, value]) => {
+      document.documentElement.style.setProperty(key, value);
+    });
+    saveDensity(density);
+  }, [density]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('reduced-motion', reducedMotion);
+    saveReducedMotion(reducedMotion);
+  }, [reducedMotion]);
+
   return (
-    <SettingsContext.Provider value={{ theme, accent, wallpaper, setTheme, setAccent, setWallpaper }}>
+    <SettingsContext.Provider value={{ theme, accent, wallpaper, density, reducedMotion, setTheme, setAccent, setWallpaper, setDensity, setReducedMotion }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -4,6 +4,8 @@ const DEFAULT_SETTINGS = {
   theme: 'system',
   accent: '#E95420',
   wallpaper: 'wall-2',
+  density: 'regular',
+  reducedMotion: false,
 };
 
 export async function getTheme() {
@@ -36,6 +38,26 @@ export async function setWallpaper(wallpaper) {
   await set('bg-image', wallpaper);
 }
 
+export async function getDensity() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
+  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+}
+
+export async function setDensity(density) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('density', density);
+}
+
+export async function getReducedMotion() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  return window.localStorage.getItem('reduced-motion') === 'true';
+}
+
+export async function setReducedMotion(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -43,6 +65,8 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
+  window.localStorage.removeItem('density');
+  window.localStorage.removeItem('reduced-motion');
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add persistent density and reduced-motion settings
- allow toggling spacing scale and motion reduction
- extend settings UI to manage density and motion

## Testing
- `yarn test`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68af190160648328928add0b531c7b47