### PR TITLE
feat(converter): add container queries and shared unit data

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -1,4 +1,4 @@
-import { convertUnit } from '../components/apps/converter/UnitConverter';
+import { convertUnit } from '../components/apps/converter/unitData';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import UnitConverter from '../components/apps/converter/UnitConverter';
 

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -1,34 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { create, all } from 'mathjs';
-
-const math = create(all);
-
-const unitMap = {
-  length: {
-    meter: 'm',
-    kilometer: 'km',
-    mile: 'mi',
-    foot: 'ft',
-  },
-  mass: {
-    gram: 'g',
-    kilogram: 'kg',
-    pound: 'lb',
-    ounce: 'oz',
-  },
-  temperature: {
-    celsius: 'degC',
-    fahrenheit: 'degF',
-    kelvin: 'K',
-  },
-};
-
-export const convertUnit = (category, from, to, amount, precision) => {
-  const fromUnit = unitMap[category][from];
-  const toUnit = unitMap[category][to];
-  const result = math.unit(amount, fromUnit).toNumber(toUnit);
-  return typeof precision === 'number' ? math.round(result, precision) : result;
-};
+import { unitMap, categories, convertUnit, math } from './unitData';
 
 // A slider that displays a rounding preview bubble while dragging.
 const RoundingSlider = ({ value, precision, onChange, prefersReducedMotion }) => {
@@ -84,7 +55,7 @@ const RoundingSlider = ({ value, precision, onChange, prefersReducedMotion }) =>
 };
 
 const UnitConverter = () => {
-  const [category, setCategory] = useState('length');
+  const [category, setCategory] = useState(categories[0].value);
   const [fromUnit, setFromUnit] = useState('meter');
   const [toUnit, setToUnit] = useState('kilometer');
   const [leftVal, setLeftVal] = useState('');
@@ -174,9 +145,11 @@ const UnitConverter = () => {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
         >
-          <option value="length">Length</option>
-          <option value="mass">Mass</option>
-          <option value="temperature">Temperature</option>
+          {categories.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
         </select>
       </label>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-2">

--- a/components/apps/converter/index.js
+++ b/components/apps/converter/index.js
@@ -3,11 +3,25 @@ import UnitConverter from './UnitConverter';
 import CurrencyConverter from './CurrencyConverter';
 
 const Converter = () => (
-  <div className="h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
-    <div className="grid gap-4 md:grid-cols-2">
+  <div className="converter-container h-full w-full p-4 overflow-y-auto bg-ub-cool-grey text-white">
+    <div className="grid gap-4 converter-grid">
       <UnitConverter />
       <CurrencyConverter />
     </div>
+    <style jsx>{`
+      .converter-container {
+        container-type: inline-size;
+      }
+      .converter-grid {
+        transition: grid-template-columns 0.3s ease;
+        grid-template-columns: 1fr;
+      }
+      @container (min-width: 48rem) {
+        .converter-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+    `}</style>
   </div>
 );
 

--- a/components/apps/converter/unitData.js
+++ b/components/apps/converter/unitData.js
@@ -1,0 +1,36 @@
+import { create, all } from 'mathjs';
+
+export const math = create(all);
+
+export const unitMap = {
+  length: {
+    meter: 'm',
+    kilometer: 'km',
+    mile: 'mi',
+    foot: 'ft',
+  },
+  mass: {
+    gram: 'g',
+    kilogram: 'kg',
+    pound: 'lb',
+    ounce: 'oz',
+  },
+  temperature: {
+    celsius: 'degC',
+    fahrenheit: 'degF',
+    kelvin: 'K',
+  },
+};
+
+export const categories = Object.keys(unitMap).map((key) => ({
+  value: key,
+  label: key.charAt(0).toUpperCase() + key.slice(1),
+}));
+
+export const convertUnit = (category, from, to, amount, precision) => {
+  const fromUnit = unitMap[category][from];
+  const toUnit = unitMap[category][to];
+  const result = math.unit(amount, fromUnit).toNumber(toUnit);
+  return typeof precision === 'number' ? math.round(result, precision) : result;
+};
+


### PR DESCRIPTION
## Summary
- use container queries to place unit and currency converters side-by-side at medium widths
- centralize unit definitions and conversion logic in a shared module
- populate unit category options dynamically from shared data

## Testing
- `npm test __tests__/converter.test.tsx`
- `npm test` *(fails: BeEF app updates hook list when new hooks arrive; BeEF app streams module output to UI; Autopsy plugins and timeline filters artifacts by type; Test suite failed to run)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks and react/jsx-no-duplicate-props)*

------
https://chatgpt.com/codex/tasks/task_e_68af190633e88328acae983f75005227