### PR TITLE
feat: add copy buttons and monospace styling

### DIFF
--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -79,12 +79,12 @@ const PasswordGenerator: React.FC = () => {
           type="text"
           readOnly
           value={password}
-          className="flex-1 text-black px-2 py-1"
+          className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
         />
         <button
           type="button"
           onClick={copyToClipboard}
-          className="px-3 py-1 bg-blue-600 rounded"
+          className="px-3 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
         >
           Copy
         </button>

--- a/pages/apps/nmap-nse.tsx
+++ b/pages/apps/nmap-nse.tsx
@@ -10,6 +10,13 @@ type ScriptData = Record<string, Script[]>;
 
 const NmapNSEPage: React.FC = () => {
   const [data, setData] = useState<ScriptData>({});
+  const copyExample = useCallback((text: string) => {
+    try {
+      navigator.clipboard?.writeText(text);
+    } catch (e) {
+      // ignore copy errors
+    }
+  }, []);
   const openScriptDoc = useCallback((name: string) => {
     window.open(
       `https://nmap.org/nsedoc/scripts/${name}.html`,
@@ -51,7 +58,16 @@ const NmapNSEPage: React.FC = () => {
                 {script.name}
               </button>
               <p className="mb-2">{script.description}</p>
-              <pre className="bg-black text-green-400 p-2 rounded overflow-auto">{script.example}</pre>
+              <pre className="bg-black text-green-400 p-2 rounded overflow-auto font-mono leading-[1.2]">
+                {script.example}
+              </pre>
+              <button
+                type="button"
+                onClick={() => copyExample(script.example)}
+                className="mt-2 px-2 py-1 bg-blue-700 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+              >
+                Copy
+              </button>
             </div>
           ))}
         </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -470,3 +470,17 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: word-found-highlight 0.6s forwards;
     display: inline-block;
 }
+
+/* Ensure monospace layout for app outputs */
+textarea,
+pre {
+    font-family: monospace;
+    line-height: 1.2;
+}
+
+/* Visible focus rings for copy buttons and text areas */
+button:focus-visible,
+textarea:focus-visible {
+    outline: 2px solid #3B82F6;
+    outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add copy button for Nmap script examples
- use monospace font and tighter line height for app outputs
- show visible focus ring on copy buttons and text fields

## Testing
- `yarn lint` *(fails: React Hook useEffect has a missing dependency... and more)*
- `yarn test __tests__/beef.test.tsx __tests__/autopsy.test.tsx __tests__/a11y.spec.ts` *(fails: BeEF app › updates hook list when new hooks arrive; Autopsy plugins and timeline › filters artifacts by type; Test suite failed to run)*
- `yarn test __tests__/passwordGenerator.test.tsx __tests__/nmapNse.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af1907ac5c832888bf1cba0f462b74