### PR TITLE
feat: add severity filtering and export to Nessus report

### DIFF
--- a/__tests__/nessus-report.test.tsx
+++ b/__tests__/nessus-report.test.tsx
@@ -13,4 +13,16 @@ describe('Nessus sample report', () => {
       screen.getByText(/Disclaimer: This sample report is for demonstration/)
     ).toBeInTheDocument();
   });
+
+  test('filters by severity', () => {
+    render(<NessusReport />);
+    fireEvent.change(screen.getByLabelText('Filter severity'), {
+      target: { value: 'High' },
+    });
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(2); // header + 1 finding
+    expect(
+      screen.getByText('Apache HTTP Server Privilege Escalation')
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- show severity chips for Nessus findings
- filter findings by severity and export to CSV
- add tests for severity filtering

## Testing
- `yarn test __tests__/nessus-report.test.tsx`
- `yarn lint` *(fails: React hook rule violations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68af190c4dc08328b5a904e058c3739f