### PR TITLE
feat: add nessus summary and responsive report

### DIFF
--- a/__tests__/nessus-dashboard.test.tsx
+++ b/__tests__/nessus-dashboard.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import NessusDashboard from '../pages/nessus-dashboard';
+
+describe('Nessus dashboard summary', () => {
+  test('displays severity cards', () => {
+    render(<NessusDashboard />);
+    expect(screen.getByText('Nessus Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('Low')).toBeInTheDocument();
+  });
+});

--- a/__tests__/nessus-report.test.tsx
+++ b/__tests__/nessus-report.test.tsx
@@ -2,13 +2,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import NessusReport from '../pages/nessus-report';
 
 describe('Nessus sample report', () => {
-  test('shows findings and drawer with disclaimer', () => {
+  test('shows findings and detail panel with disclaimer', () => {
     render(<NessusReport />);
     expect(screen.getByText('Sample Nessus Report')).toBeInTheDocument();
-    const rows = screen.getAllByRole('row');
-    expect(rows.length).toBe(5); // header + 4 findings
-    fireEvent.click(screen.getByText('Weak SSH Cipher'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const items = screen.getAllByRole('button');
+    expect(items.length).toBe(4);
+    fireEvent.click(screen.getByRole('button', { name: /Weak SSH Cipher/ }));
     expect(
       screen.getByText(/Disclaimer: This sample report is for demonstration/)
     ).toBeInTheDocument();

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,33 +1,42 @@
-import React, { useEffect, useState } from 'react';
-import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
+import React, { useMemo } from 'react';
+import data from '../components/apps/nessus/sample-report.json';
 
+const severityColors: Record<string, string> = {
+  Critical: '#b91c1c',
+  High: '#c2410c',
+  Medium: '#b45309',
+  Low: '#1d4ed8',
+};
 const NessusDashboard: React.FC = () => {
-  const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });
+  const findings = data as { severity: keyof typeof severityColors }[];
 
-  useEffect(() => {
-    const jobs = loadJobDefinitions();
-    const fps = loadFalsePositives();
-    setTotals({ jobs: jobs.length, falsePositives: fps.length });
-  }, []);
-
-  const max = Math.max(totals.jobs, totals.falsePositives, 1);
+  const counts = useMemo(() => {
+    return findings.reduce<Record<string, number>>((acc, f) => {
+      acc[f.severity] = (acc[f.severity] || 0) + 1;
+      return acc;
+    }, {});
+  }, [findings]);
 
   return (
     <div className="p-4 bg-gray-900 min-h-screen text-white">
       <h1 className="text-2xl mb-4">Nessus Dashboard</h1>
-      <div className="flex items-end space-x-4 h-48">
-        <div
-          className="bg-blue-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.jobs / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">Jobs {totals.jobs}</span>
-        </div>
-        <div
-          className="bg-green-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.falsePositives / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">False {totals.falsePositives}</span>
-        </div>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
+        {Object.entries(counts).map(([sev, count]) => (
+          <div
+            key={sev}
+            className="bg-gray-800 p-4 rounded flex items-center justify-between"
+          >
+            <div className="flex items-center space-x-2">
+              <span
+                aria-hidden="true"
+                className="w-4 h-4 rounded-full ring-2 ring-white"
+                style={{ backgroundColor: severityColors[sev] }}
+              />
+              <span className="text-sm">{sev}</span>
+            </div>
+            <span className="text-xl font-semibold">{count}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -2,10 +2,10 @@ import React, { useMemo, useState } from 'react';
 import data from '../components/apps/nessus/sample-report.json';
 
 const severityColors: Record<string, string> = {
-  Critical: '#991b1b',
-  High: '#b45309',
-  Medium: '#a16207',
-  Low: '#1e40af',
+  Critical: '#b91c1c',
+  High: '#c2410c',
+  Medium: '#b45309',
+  Low: '#1d4ed8',
 };
 
 interface Finding {
@@ -65,54 +65,56 @@ const NessusReport: React.FC = () => {
       >
         {segments}
       </svg>
-      <table className="w-full mb-4 text-sm">
-        <thead>
-          <tr className="text-left border-b border-gray-700">
-            <th className="py-1">ID</th>
-            <th className="py-1">Finding</th>
-            <th className="py-1">CVSS</th>
-            <th className="py-1">Severity</th>
-          </tr>
-        </thead>
-        <tbody>
+      <div className="flex flex-col md:flex-row gap-4">
+        <ul className="md:w-1/2 space-y-2">
           {findings.map((f) => (
-            <tr
-              key={f.id}
-              className="border-b border-gray-800 cursor-pointer hover:bg-gray-800"
-              onClick={() => setSelected(f)}
-            >
-              <td className="py-1">{f.id}</td>
-              <td className="py-1">{f.name}</td>
-              <td className="py-1">{f.cvss}</td>
-              <td className="py-1">{f.severity}</td>
-            </tr>
+            <li key={f.id}>
+              <button
+                onClick={() => setSelected(f)}
+                className="w-full text-left p-2 rounded bg-gray-800 hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
+              >
+                <div className="flex justify-between">
+                  <span className="font-medium">{f.name}</span>
+                  <span className="text-sm">{f.cvss}</span>
+                </div>
+                <div className="flex items-center space-x-2 mt-1">
+                  <span
+                    aria-hidden="true"
+                    className="w-3 h-3 rounded-full ring-2 ring-white"
+                    style={{ backgroundColor: severityColors[f.severity] }}
+                  />
+                  <span className="text-xs">{f.severity}</span>
+                </div>
+              </button>
+            </li>
           ))}
-        </tbody>
-      </table>
-      {selected && (
-        <div
-          role="dialog"
-          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
-        >
-          <button
-            type="button"
-            onClick={() => setSelected(null)}
-            className="mb-2 text-sm bg-red-600 px-2 py-1 rounded"
-          >
-            Close
-          </button>
-          <h2 className="text-xl mb-2">{selected.name}</h2>
-          <p className="text-sm mb-2">
-            CVSS {selected.cvss} ({selected.severity})
-          </p>
-          <p className="mb-4 text-sm whitespace-pre-wrap">
-            {selected.description}
-          </p>
-          <p className="text-xs text-gray-400">
-            Disclaimer: This sample report is for demonstration purposes only.
-          </p>
+        </ul>
+        <div className="md:flex-1">
+          {selected ? (
+            <section className="bg-gray-800 p-4 rounded h-full">
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="mb-2 text-sm bg-red-600 px-2 py-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-400"
+              >
+                Close
+              </button>
+              <h2 className="text-xl mb-2">{selected.name}</h2>
+              <p className="text-sm mb-2">
+                CVSS {selected.cvss} ({selected.severity})
+              </p>
+              <p className="mb-4 text-sm whitespace-pre-wrap">
+                {selected.description}
+              </p>
+              <p className="text-xs text-gray-400">
+                Disclaimer: This sample report is for demonstration purposes only.
+              </p>
+            </section>
+          ) : (
+            <p className="text-sm text-gray-400">Select a finding to view details.</p>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add severity summary cards to Nessus dashboard
- implement responsive list-detail view for Nessus report
- cover dashboard and report with tests

## Testing
- `npm test` (fails: __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/a11y.spec.ts)
- `npm run lint` (fails: react-hooks/rules-of-hooks in useGameControls.js)


------
https://chatgpt.com/codex/tasks/task_e_68af190ce8d48328944726b71460644d