### PR TITLE
Add demo mode and static transcripts for Metasploit demo

### DIFF
--- a/components/apps/metasploit/modules.json
+++ b/components/apps/metasploit/modules.json
@@ -4,34 +4,39 @@
     "description": "MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption",
     "severity": "critical",
     "type": "exploit",
-    "tags": ["smb", "rce"]
+    "tags": ["smb", "rce"],
+    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] 192.168.1.100 - Connecting to target...\n[+] 192.168.1.100 - Connection established\n[*] 192.168.1.100 - Sending exploit...\n[+] 192.168.1.100 - Exploit completed, but no session was created."
   },
   {
     "name": "exploit/multi/http/struts2_content_type_ognl",
     "description": "Apache Struts 2 Content-Type OGNL RCE",
     "severity": "high",
     "type": "exploit",
-    "tags": ["http", "rce"]
+    "tags": ["http", "rce"],
+    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] http://example.com - Sending exploit payload...\n[+] http://example.com - Exploit completed"
   },
   {
     "name": "exploit/unix/ftp/vsftpd_234_backdoor",
     "description": "VSFTPD v2.3.4 Backdoor Command Execution",
     "severity": "medium",
     "type": "exploit",
-    "tags": ["ftp", "backdoor"]
+    "tags": ["ftp", "backdoor"],
+    "transcript": "[*] 10.0.0.2:21 - Connecting to server...\n[+] 10.0.0.2:21 - Backdoor service discovered\n[*] Command shell session 1 opened"
   },
   {
     "name": "auxiliary/scanner/portscan/tcp",
     "description": "TCP Port Scanner",
     "severity": "low",
     "type": "auxiliary",
-    "tags": ["scanner", "network"]
+    "tags": ["scanner", "network"],
+    "transcript": "[*] Scanning 192.168.1.0/24 ports 1-1000\n[*] 192.168.1.1:80 - open\n[*] 192.168.1.10:22 - open\n[*] Scanning completed"
   },
   {
     "name": "post/multi/gather/ssh_creds",
     "description": "SSH Credentials Gather",
     "severity": "medium",
     "type": "post",
-    "tags": ["ssh", "credentials"]
+    "tags": ["ssh", "credentials"],
+    "transcript": "[*] Gathering SSH credentials...\n[+] user:password found in /home/user/.ssh/config\n[*] Post module execution completed"
   }
 ]


### PR DESCRIPTION
## Summary
- seed Metasploit modules with demo transcripts and categorize list
- add demo mode flag preventing network calls and render module transcripts on selection
- cover demo behaviour with updated tests

## Testing
- `npm test __tests__/metasploit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af190ffb688328aeafd14e1ab8cb65