### PR TITLE
feat: add post-exploitation module search and details

### DIFF
--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,24 +1,139 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 
+interface ModuleOption {
+  name: string;
+  required: boolean;
+  description: string;
+}
+
+interface Module {
+  name: string;
+  description: string;
+  options: ModuleOption[];
+}
+
+const modules: Module[] = [
+  {
+    name: 'getsystem',
+    description: 'Attempt to elevate your privilege to that of local system.',
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.'
+      }
+    ]
+  },
+  {
+    name: 'keyscan_start',
+    description: 'Start capturing keystrokes.',
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.'
+      }
+    ]
+  },
+  {
+    name: 'persistence_service',
+    description: 'Achieve persistence by installing a service.',
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.'
+      },
+      {
+        name: 'RPORT',
+        required: false,
+        description: 'Remote port used for callback.'
+      }
+    ]
+  }
+];
+
 export default function PostExploitation() {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<Module | null>(null);
+
+  const filtered = modules.filter((m) =>
+    m.name.toLowerCase().includes(query.toLowerCase())
+  );
+
   return (
     <>
       <Meta />
-      <main className="prose mx-auto p-4">
-        <h1>Metasploit Post-Exploitation Modules</h1>
-        <p>
-          Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s <a href="https://docs.rapid7.com/metasploit/about-post-exploitation/" target="_blank" rel="noopener noreferrer">Metasploit documentation</a> explains that these modules run on an active session to help operators gather deeper information, escalate privileges, pivot within the network, or maintain persistence.
-        </p>
-        <h2>Example Report</h2>
-        <p>The following sample shows data a post-exploitation run might collect:</p>
-        <ul>
-          <li>Host: 192.0.2.10</li>
-          <li>Session type: Meterpreter</li>
-          <li>Privilege level: Administrator</li>
-          <li>Key actions: Collected user tokens, enabled persistence, dumped credentials.</li>
-        </ul>
+      <main className="mx-auto grid gap-4 p-4 md:grid-cols-2">
+        <section className="prose">
+          <h1>Metasploit Post-Exploitation Modules</h1>
+          <p>
+            Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s{' '}
+            <a
+              href="https://docs.rapid7.com/metasploit/about-post-exploitation/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Metasploit documentation
+            </a>{' '}
+            explains that these modules run on an active session to help operators gather deeper
+            information, escalate privileges, pivot within the network, or maintain persistence.
+          </p>
+          <input
+            type="text"
+            placeholder="Search modules..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="mb-4 w-full rounded border p-2"
+          />
+          <ul className="divide-y rounded border">
+            {filtered.map((m) => (
+              <li key={m.name}>
+                <button
+                  onClick={() => setSelected(m)}
+                  className={`w-full p-2 text-left hover:bg-gray-50 ${
+                    selected?.name === m.name ? 'bg-gray-100' : ''
+                  }`}
+                >
+                  {m.name}
+                </button>
+              </li>
+            ))}
+            {filtered.length === 0 && <li className="p-2">No modules match your search.</li>}
+          </ul>
+        </section>
+        <aside className="prose">
+          {selected ? (
+            <>
+              <h2>{selected.name}</h2>
+              <p>{selected.description}</p>
+              <h3>Options</h3>
+              <ul>
+                {selected.options.map((opt) => (
+                  <li key={opt.name}>
+                    <strong>{opt.name}</strong>{' '}
+                    {opt.required ? '(required)' : '(optional)'} - {opt.description}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p>Select a module to view details.</p>
+          )}
+          <h3>Example Transcript</h3>
+          <pre className="overflow-x-auto rounded bg-black p-3 text-green-400">
+{`meterpreter > getuid
+Server username: NT AUTHORITY\\SYSTEM
+meterpreter > keyscan_start
+Starting the keystroke sniffer...
+meterpreter > run persistence_service
+[*] Creating service accomplished
+`}
+          </pre>
+        </aside>
       </main>
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- add static data for several post-exploitation modules
- add search bar to filter modules by name
- show selected module description, options and example transcript in side pane

## Testing
- `npm test` (fails: Unable to find an element with the text: 1, Unable to find an element with the text: resume.docx, Playwright Test needs to be invoked via 'npx playwright test')
- `npm run lint` (fails: React Hook "useInputMapping" is called conditionally, No duplicate props allowed)


------
https://chatgpt.com/codex/tasks/task_e_68af1910945c8328886bdeef134d5412