### PR TITLE
Add demo banner and accessible mock terminal

### DIFF
--- a/components/DemoBanner.tsx
+++ b/components/DemoBanner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const DemoBanner: React.FC = () => (
+  <div className="bg-red-600 text-white text-center py-2 font-bold" data-testid="demo-banner">
+    Demo Only
+  </div>
+);
+
+export default DemoBanner;

--- a/components/MockTerminal.tsx
+++ b/components/MockTerminal.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface LogEntry {
+  annotation: string;
+  message: string;
+}
+
+const initialLogs: LogEntry[] = [
+  { annotation: 'INFO', message: 'Initializing demo environment...' },
+  { annotation: 'WARN', message: 'This terminal is for demonstration purposes only.' },
+  { annotation: 'SUCCESS', message: 'Simulation ready.' },
+];
+
+const MockTerminal: React.FC = () => {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let i = 0;
+    const interval = setInterval(() => {
+      setLogs((prev) => [...prev, initialLogs[i]]);
+      i += 1;
+      if (i >= initialLogs.length) clearInterval(interval);
+    }, 800);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [logs]);
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      className="bg-black text-green-400 font-mono p-4 h-48 overflow-y-auto outline-none focus:ring-2 focus:ring-green-500"
+      aria-label="Mock terminal"
+    >
+      {logs.map((log, idx) => (
+        <div key={idx}>
+          [{log.annotation}] {log.message}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MockTerminal;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import DemoBanner from '../components/DemoBanner';
 
 function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -22,6 +23,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
   return (
     <SettingsProvider>
+      <DemoBanner />
       <Component {...pageProps} />
       <Analytics />
     </SettingsProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
+import MockTerminal from '../components/MockTerminal';
 
 const App: React.FC = () => (
   <>
     <Meta />
     <Ubuntu />
     <InstallButton />
+    <div className="p-4">
+      <MockTerminal />
+    </div>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add a prominent "Demo Only" banner across the app
- introduce an accessible mock terminal that simulates console events

## Testing
- `yarn test` (fails: __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/a11y.spec.ts)
- `yarn lint` (fails: React hooks rule violations and duplicate props)


------
https://chatgpt.com/codex/tasks/task_e_68af191485f4832882d9e0300d81f73b