### PR TITLE
feat: responsive canvas and reduced motion

### DIFF
--- a/components/apps/GameLayout.js
+++ b/components/apps/GameLayout.js
@@ -1,18 +1,1 @@
-import React from 'react';
-import PerfOverlay from './Games/common/perf';
-
-const GameLayout = ({ children, stage, lives, score, highScore }) => (
-  <div className="h-full w-full relative text-white">
-    <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
-      <div>Stage: {stage}</div>
-      <div>Lives: {lives}</div>
-      {score !== undefined && <div>Score: {score}</div>}
-      {highScore !== undefined && <div>High: {highScore}</div>}
-    </div>
-    {children}
-    <PerfOverlay />
-
-  </div>
-);
-
-export default GameLayout;
+export { default } from './GameLayout.tsx';

--- a/hooks/useCanvasResize.ts
+++ b/hooks/useCanvasResize.ts
@@ -16,16 +16,27 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
       const { clientWidth, clientHeight } = parent;
       const scale = Math.min(
         clientWidth / baseWidth,
-        clientHeight / baseHeight
+        clientHeight / baseHeight,
       );
-      canvas.width = baseWidth * scale;
-      canvas.height = baseHeight * scale;
-      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      const width = baseWidth * scale;
+      const height = baseHeight * scale;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      ctx.setTransform(dpr * scale, 0, 0, dpr * scale, 0, 0);
     };
 
     resize();
+    const ro = new ResizeObserver(resize);
+    const parent = canvas.parentElement;
+    if (parent) ro.observe(parent);
     window.addEventListener('resize', resize);
-    return () => window.removeEventListener('resize', resize);
+    return () => {
+      window.removeEventListener('resize', resize);
+      ro.disconnect();
+    };
   }, [baseWidth, baseHeight]);
 
   return canvasRef;

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export default function usePrefersReducedMotion() {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setPrefersReduced(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  return prefersReduced;
+}


### PR DESCRIPTION
## Summary
- add hook to detect `prefers-reduced-motion`
- make canvas resize with parent and preserve aspect ratio
- pause games and show help overlay via updated `GameLayout`
- refactor Snake to use responsive canvas and layout

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, a11y.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af1915974083288c292e88f9724a1b