### PR TITLE
Add window snapping and keyboard shortcuts

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -117,3 +117,47 @@ describe('Window snapping preview', () => {
     expect(screen.queryByTestId('snap-preview')).toBeNull();
   });
 });
+
+describe('Window snapping action', () => {
+  it('snaps to previewed position on drag stop', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.setState({
+        snapPreview: { left: '0', top: '0', width: '50%', height: '100%' },
+        snapPosition: 'left'
+      }, () => {
+        ref.current!.handleStop();
+      });
+    });
+
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.snapPreview).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- apply snap region on drag stop and allow unsnapping
- add Alt+Arrow keyboard shortcuts for snapping
- announce snap state changes via aria-live region

## Testing
- `npm test window.test.tsx`
- `npm run lint components/base/window.js components/screen/desktop.js` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af191911548328ac3c5990ecd9b4b2