### PR TITLE
chore: expand pa11y coverage

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -2,6 +2,8 @@ name: Accessibility
 
 on:
   pull_request:
+  push:
+    branches: [master]
 
 jobs:
   a11y:

--- a/pa11yci.json
+++ b/pa11yci.json
@@ -2,10 +2,39 @@
   "defaults": {
     "chromeLaunchConfig": {
       "args": ["--no-sandbox"]
-    }
+    },
+    "runners": ["axe"],
+    "axe": {
+      "runOnly": {
+        "type": "rule",
+        "values": ["color-contrast", "label"]
+      }
+    },
+    "includeNotices": false,
+    "includeWarnings": false
   },
   "urls": [
     "http://localhost:3000",
-    "http://localhost:3000/apps"
+    "http://localhost:3000/apps",
+    "http://localhost:3000/apps/2048",
+    "http://localhost:3000/apps/blackjack",
+    "http://localhost:3000/apps/checkers",
+    "http://localhost:3000/apps/connect-four",
+    "http://localhost:3000/apps/minesweeper",
+    "http://localhost:3000/apps/nmap-nse",
+    "http://localhost:3000/apps/password_generator",
+    "http://localhost:3000/apps/phaser_matter",
+    "http://localhost:3000/apps/sokoban",
+    "http://localhost:3000/apps/word_search",
+    "http://localhost:3000/video-gallery",
+    "http://localhost:3000/security-education",
+    "http://localhost:3000/nessus-dashboard",
+    "http://localhost:3000/nessus-report",
+    "http://localhost:3000/nikto-report",
+    "http://localhost:3000/popular-modules",
+    "http://localhost:3000/post_exploitation",
+    "http://localhost:3000/sekurlsa_logonpasswords",
+    "http://localhost:3000/spoofing",
+    "http://localhost:3000/dummy-form"
   ]
 }


### PR DESCRIPTION
## Summary
- run Pa11y against key desktop apps like Nmap NSE, video gallery, and security education
- alert on color contrast or missing label issues only
- ensure accessibility checks run on pushes and pull requests

## Testing
- `yarn test` *(fails: BeEF app, Autopsy plugins and timeline, a11y.spec.ts)*
- `npx pa11y-ci --config pa11yci.json` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68af191ab5a883289f5e47b2aa7044d8