### PR TITLE
feat: add content usage optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Heavy apps are wrapped with **dynamic import** and most games share a `GameLayou
 | `NEXT_PUBLIC_BEEF_URL` | Optional URL for the BeEF demo iframe (if used). |
 | `NEXT_PUBLIC_GHIDRA_URL` | Optional URL for a remote Ghidra Web interface. |
 | `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |
+| `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
 
 > In production (Vercel/GitHub Actions), set these as **environment variables or repo secrets**. See **CI/CD** below.
 


### PR DESCRIPTION
## Summary
- tweak window component to monitor content area usage
- shrink windows if usage stays low for 200ms
- document NEXT_PUBLIC_UI_EXPERIMENTS flag for enabling heuristics

## Testing
- `npm test` *(fails: __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/a11y.spec.ts)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks, react/jsx-no-duplicate-props)*

------
https://chatgpt.com/codex/tasks/task_e_68af191c76c08328b2570817b456ac41