### PR TITLE
feat: constrain long-form text with text-block class

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -21,7 +21,7 @@ export default function AboutApp() {
   };
 
   return (
-    <main className="p-4 w-full h-full overflow-y-auto bg-ub-cool-grey text-white">
+    <main className="p-4 w-full h-full overflow-y-auto bg-ub-cool-grey text-white text-block">
       <Head>
         <title>About</title>
         <script

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -67,7 +67,7 @@ const ContactApp = () => {
   };
 
   return (
-    <div className="p-4 text-black">
+    <div className="p-4 text-black text-block">
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <input
           className="p-1 border"

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -244,7 +244,7 @@ export default function ProjectGallery() {
                 </div>
                 <div className="p-3 flex flex-col flex-grow">
                   <h3 className="text-lg font-semibold">{project.title}</h3>
-                  <p className="text-sm text-gray-200 mt-1 flex-grow">
+                  <p className="text-sm text-gray-200 mt-1 flex-grow text-block">
                     {project.description}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-1">
@@ -304,7 +304,7 @@ export default function ProjectGallery() {
                   Close
                 </button>
                 <h2 className="text-xl font-semibold mb-2">{selected.title}</h2>
-                <p className="mb-2">{selected.description}</p>
+                <p className="mb-2 text-block">{selected.description}</p>
                 <div className="flex flex-wrap gap-1 mb-2">
                   {selected.tech.map((t, i) => (
                     <span

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -55,7 +55,7 @@ export function Settings() {
     }, [accent, theme]);
 
     return (
-        <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
+        <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey text-block"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
+import '../styles/globals.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
 

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -105,7 +105,7 @@ const NessusReport: React.FC = () => {
           <p className="text-sm mb-2">
             CVSS {selected.cvss} ({selected.severity})
           </p>
-          <p className="mb-4 text-sm whitespace-pre-wrap">
+          <p className="mb-4 text-sm whitespace-pre-wrap text-block">
             {selected.description}
           </p>
           <p className="text-xs text-gray-400">

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -87,7 +87,7 @@ const NiktoReport: React.FC = () => {
           onClick={() => setSelected(null)}
         >
           <div
-            className="bg-gray-800 p-4 rounded max-w-lg w-full"
+            className="bg-gray-800 p-4 rounded w-full text-block"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-lg mb-2">{selected.path}</h2>

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -5,7 +5,7 @@ export default function PostExploitation() {
   return (
     <>
       <Meta />
-      <main className="prose mx-auto p-4">
+      <main className="prose mx-auto p-4 text-block">
         <h1>Metasploit Post-Exploitation Modules</h1>
         <p>
           Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s <a href="https://docs.rapid7.com/metasploit/about-post-exploitation/" target="_blank" rel="noopener noreferrer">Metasploit documentation</a> explains that these modules run on an active session to help operators gather deeper information, escalate privileges, pivot within the network, or maintain persistence.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,4 @@
+.text-block {
+  max-inline-size: clamp(40ch, 60ch, 70ch);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
- add `text-block` class to restrict long-form content to 40-70ch with comfortable line-height
- apply new class across apps and pages with paragraphs or descriptions

## Testing
- `npm test` *(fails: beEF app, autopsy, a11y.spec)*

------
https://chatgpt.com/codex/tasks/task_e_68af19209f04832885b90db4332af35b