### PR TITLE
Define global spacing tokens and replace hard-coded spacing

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -90,7 +90,7 @@ export class AboutAlex extends Component {
                 </div>
                 <div onClick={this.showNavBar} className="md:hidden flex flex-col items-center justify-center absolute bg-ub-cool-grey rounded w-6 h-6 top-1 left-1">
                     <div className=" w-3.5 border-t border-white"></div>
-                    <div className=" w-3.5 border-t border-white" style={{ marginTop: "2pt", marginBottom: "2pt" }}></div>
+                    <div className=" w-3.5 border-t border-white" style={{ marginTop: "var(--space-1)", marginBottom: "var(--space-1)" }}></div>
                     <div className=" w-3.5 border-t border-white"></div>
                     <div className={(this.state.navbar ? " visible animateShow z-30 " : " invisible ") + " md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20"}>
                         {this.renderNavLinks()}

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -132,10 +132,10 @@ const ReconNG = () => {
         },
       },
       {
-        selector: '$node > node',
-        style: {
-          'padding': '10px',
-          'background-opacity': 0.1,
+          selector: '$node > node',
+          style: {
+            'padding': 'var(--space-3)',
+            'background-opacity': 0.1,
           'border-color': '#555',
           label: 'data(label)',
           color: '#fff',

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
+import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -19,7 +19,7 @@ const InfoFrame = ({ title, link, description }: FrameProps) => (
 
 const SecurityEducation = () => (
   <main>
-    <div style={{ backgroundColor: '#fcd34d', padding: '1rem', textAlign: 'center', fontWeight: 'bold' }}>
+    <div style={{ backgroundColor: '#fcd34d', padding: 'var(--space-4)', textAlign: 'center', fontWeight: 'bold' }}>
       Use Kali Linux and related tools legally and ethically with proper authorization.
     </div>
     <div className="grid gap-4 p-4 md:grid-cols-2">

--- a/pages/sekurlsa_logonpasswords.tsx
+++ b/pages/sekurlsa_logonpasswords.tsx
@@ -72,7 +72,7 @@ const SekurlsaLogonpasswords = () => {
   return (
     <>
       <Meta />
-      <div style={{ backgroundColor: '#fcd34d', padding: '1rem', textAlign: 'center', fontWeight: 'bold' }}>
+        <div style={{ backgroundColor: '#fcd34d', padding: 'var(--space-4)', textAlign: 'center', fontWeight: 'bold' }}>
         Sanitized credential data for educational use only.
       </div>
       <main className="grid gap-4 p-4 md:grid-cols-2">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,13 @@
+:root {
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --line-height-base: 1.5;
+}
+
+body {
+  line-height: var(--line-height-base);
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,14 +26,6 @@
   --color-bg: #111111;
   --color-text: #F6F6F5;
 
-  /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
-
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;


### PR DESCRIPTION
## Summary
- add `styles/globals.css` with spacing scale and default line-height
- import new globals and use spacing tokens instead of inline values in components

## Testing
- `npm test -- --ci` *(fails: __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/a11y.spec.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af1922c58c83288bf4d3082b8bc21e