### PR TITLE
feat: introduce shared FormError component

### DIFF
--- a/components/apps/bluetooth/index.js
+++ b/components/apps/bluetooth/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import FormError from '../../ui/FormError';
 
 const mockData = [
   {
@@ -83,7 +84,7 @@ const BluetoothApp = () => {
           Use Mock Data
         </label>
       </div>
-      {error && <p className="mb-4 text-red-400">{error}</p>}
+      {error && <FormError className="mb-4 mt-0">{error}</FormError>}
       <ul className="space-y-2 overflow-auto">
         {services.map((service) => (
           <li key={service.uuid} className="border-b border-gray-700 pb-2">

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import FormError from '../../ui/FormError';
 
 export const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
 
@@ -101,11 +102,7 @@ const ContactApp = () => {
           Send
         </button>
       </form>
-      {error && (
-        <div role="alert" className="text-red-500 mt-2">
-          {error}
-        </div>
-      )}
+      {error && <FormError>{error}</FormError>}
       {success && !error && (
         <div role="status" className="text-green-600 mt-2">
           Message sent!

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -4,6 +4,7 @@ import {
   distributeTasks,
   identifyHashType,
 } from './utils';
+import FormError from '../../ui/FormError';
 
 // Enhanced John the Ripper interface that supports rule uploads,
 // basic hash analysis and mock distribution of cracking tasks.
@@ -239,11 +240,7 @@ const JohnApp = () => {
             </p>
           </>
         )}
-        {error && (
-          <p id="john-error" role="alert" className="text-red-500 text-sm">
-            {error}
-          </p>
-        )}
+        {error && <FormError id="john-error">{error}</FormError>}
       </form>
       <pre className="flex-1 overflow-auto p-4 whitespace-pre-wrap">{output}</pre>
     </div>

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import HostBubbleChart from './HostBubbleChart';
+import FormError from '../../ui/FormError';
 
 // helpers for persistent storage of jobs and false positives
 export const loadJobDefinitions = () => {
@@ -164,15 +165,7 @@ const Nessus = () => {
           <button type="submit" className="w-full bg-blue-600 py-2 rounded">
             Login
           </button>
-          {error && (
-            <p
-              id="nessus-error"
-              role="alert"
-              className="text-red-500 text-sm"
-            >
-              {error}
-            </p>
-          )}
+          {error && <FormError id="nessus-error">{error}</FormError>}
         </form>
       </div>
     );
@@ -187,7 +180,7 @@ const Nessus = () => {
         </button>
       </div>
       <HostBubbleChart hosts={hostData} />
-      {error && <div className="text-red-500 mb-2">{error}</div>}
+      {error && <FormError className="mb-2">{error}</FormError>}
       <form onSubmit={addJob} className="mb-4 space-x-2">
         <input
           className="p-1 rounded text-black"

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import HexEditor from './HexEditor';
 import { saveSnippet, loadSnippets } from './utils';
+import FormError from '../../ui/FormError';
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
@@ -225,7 +226,7 @@ const Radare2 = () => {
       )}
 
       {loading && <p>Running...</p>}
-      {error && <p className="text-red-500">{error}</p>}
+      {error && <FormError className="mt-2">{error}</FormError>}
     </div>
   );
 };

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface FormErrorProps {
+  id?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const FormError = ({ id, className = '', children }: FormErrorProps) => (
+  <p
+    id={id}
+    role="alert"
+    aria-live="assertive"
+    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
+  >
+    {children}
+  </p>
+);
+
+export default FormError;

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import FormError from '../components/ui/FormError';
 
 const DummyForm: React.FC = () => {
   const [name, setName] = useState('');
@@ -37,7 +38,7 @@ const DummyForm: React.FC = () => {
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
         <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
-        {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+        {error && <FormError className="mb-4 mt-0">{error}</FormError>}
         {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
         <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>
         <input


### PR DESCRIPTION
## Summary
- add shared `FormError` component with alert semantics
- replace inline error markup in forms with `FormError`

## Testing
- `yarn test` *(fails: BeEF app updates hook list when new hooks arrive, BeEF app streams module output to UI, Autopsy plugins and timeline filters artifacts by type, a11y.spec.ts)*
- `yarn lint` *(fails: various react hook and jsx lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af1923e218832894b16e5e16d2143d