### PR TITLE
feat: improve modal focus management

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,8 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(null);
+  const modalRef = useRef(null);
+  const lastFocused = useRef(null);
+  useFocusTrap(modalRef, !!selected);
+
+  const openBadge = (badge) => {
+    lastFocused.current = document.activeElement;
+    setSelected(badge);
+  };
+
+  const closeModal = () => {
+    setSelected(null);
+    lastFocused.current?.focus();
+  };
 
   const filteredBadges = badges.filter((badge) =>
     badge.label.toLowerCase().includes(filter.toLowerCase())
@@ -27,7 +41,7 @@ const BadgeList = ({ badges, className = '' }) => {
             key={idx}
             type="button"
             className="m-1 hover:scale-110 transition-transform cursor-pointer"
-            onClick={() => setSelected(badge)}
+            onClick={() => openBadge(badge)}
             aria-label={badge.label}
           >
             <img
@@ -41,9 +55,10 @@ const BadgeList = ({ badges, className = '' }) => {
       {selected && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-          onClick={() => setSelected(null)}
+          onClick={closeModal}
           role="dialog"
           aria-modal="true"
+          ref={modalRef}
         >
           <div
             className="bg-white text-black p-4 rounded shadow max-w-sm"
@@ -53,7 +68,8 @@ const BadgeList = ({ badges, className = '' }) => {
             <div className="text-sm">{selected.description}</div>
             <button
               className="mt-4 px-2 py-1 bg-blue-600 text-white rounded"
-              onClick={() => setSelected(null)}
+              onClick={closeModal}
+              autoFocus
             >
               Close
             </button>

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import InputRemap from './Games/common/input-remap/InputRemap';
 import useInputMapping from './Games/common/input-remap/useInputMapping';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface HelpOverlayProps {
   gameId: string;
@@ -158,8 +159,19 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
   if (!info) return null;
   const [mapping, setKey] = useInputMapping(gameId, info.actions || {});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastFocused = useRef<HTMLElement | null>(null);
+  useFocusTrap(containerRef);
+  useEffect(() => {
+    lastFocused.current = document.activeElement as HTMLElement;
+  }, []);
+  const handleClose = () => {
+    lastFocused.current?.focus();
+    onClose();
+  };
   return (
     <div
+      ref={containerRef}
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
       role="dialog"
       aria-modal="true"
@@ -185,7 +197,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
           </p>
         )}
         <button
-          onClick={onClose}
+          onClick={handleClose}
           className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
           autoFocus
         >

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useFocusTrap from '../../../hooks/useFocusTrap';
 
 const STORAGE_KEY = 'beefHelpDismissed';
 
@@ -17,8 +18,11 @@ export default function GuideOverlay({ onClose }) {
   const [step, setStep] = useState(0);
   const [dontShow, setDontShow] = useState(false);
   const containerRef = useRef(null);
+  const lastFocused = useRef(null);
+  useFocusTrap(containerRef);
 
   useEffect(() => {
+    lastFocused.current = document.activeElement;
     containerRef.current?.focus();
   }, []);
 
@@ -30,6 +34,7 @@ export default function GuideOverlay({ onClose }) {
         /* ignore storage errors */
       }
     }
+    lastFocused.current?.focus();
     onClose();
   };
 


### PR DESCRIPTION
## Summary
- trap focus in help and guide overlays and return focus on close
- maintain focus order in game layout and badge list modals
- refine trash app buttons and dialog focus handling

## Testing
- `yarn test` *(fails: BeEF app updates hook list, BeEF app streams module output to UI, Autopsy plugins and timeline filters artifacts by type, a11y.spec.ts suite)*

------
https://chatgpt.com/codex/tasks/task_e_68af1926ffc48328a702339ffce9f9b0