### PR TITLE
feat: add accessible theme palette

### DIFF
--- a/pa11yci.json
+++ b/pa11yci.json
@@ -2,6 +2,13 @@
   "defaults": {
     "chromeLaunchConfig": {
       "args": ["--no-sandbox"]
+    },
+    "runners": ["axe", "htmlcs"],
+    "standard": "WCAG2AA",
+    "axe": {
+      "rules": {
+        "color-contrast": { "enabled": true }
+      }
     }
   },
   "urls": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "export": "next export",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "next lint"
+    "lint": "next lint",
+    "a11y": "pa11y-ci --config pa11yci.json"
   },
   "engines": {
     "node": "20.x"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
+import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,19 @@
+@import './tokens.css';
+
+/* Accessible theme color palette meeting WCAG AA contrast ratios */
+:root {
+  /* Base colors */
+  --color-bg: #121212; /* background, 17.18:1 vs --color-text */
+  --color-text: #f5f5f5; /* text on dark backgrounds */
+  /* Brand accents */
+  --color-primary: #e95420; /* 5.13:1 on --color-bg */
+  --color-secondary: #77216f; /* 8.63:1 vs --color-text */
+  --color-accent: #00a36c; /* 5.76:1 on --color-bg */
+  /* Utility colors */
+  --color-muted: #333333; /* 11.59:1 vs --color-text */
+  --color-surface: #ffffff; /* light surfaces, 15.3:1 vs --color-bg */
+  --color-inverse: #000000; /* inverse of text */
+  --color-border: #d3d7cf; /* subtle borders */
+  --color-terminal: #00ff00; /* terminal green, 15.3:1 on --color-inverse */
+  --color-dark: #1f2937; /* card back */
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,4 @@
-@import './tokens.css';
+@import './globals.css';
 
 body{
     font-family: var(--font-family-base);
@@ -12,13 +12,13 @@ body{
 .top-arrow-up {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 5px solid #333333;
+    border-bottom: 5px solid var(--color-muted);
 }
 
 .arrow-custom {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 5px solid white;
+    border-bottom: 5px solid var(--color-text);
 }
 
 .animateShow {
@@ -55,7 +55,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
     -webkit-appearance: none;
-    background-color: #fff;
+    background-color: var(--color-surface);
     pointer-events: none;
     border-radius: 50%;
     width: 12px;
@@ -67,28 +67,28 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .arrow-custom-up {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 5px solid white;
+    border-bottom: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-down {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 5px solid white;
+    border-top: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-left {
     border-bottom: 5px solid transparent;
     border-top: 5px solid transparent;
-    border-right: 5px solid white;
+    border-right: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-right {
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-left: 5px solid white;
+    border-left: 5px solid var(--color-text);
     width: 0;
 }
 
@@ -150,7 +150,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .windowMainScreen::-webkit-scrollbar-thumb {
-    background-color: #D3D7CF;
+    background-color: var(--color-border);
     border-radius: 5px;
 }
 
@@ -165,9 +165,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Terminal enhancements */
 .crt-terminal {
-    background: #000000;
-    color: #00ff00;
-    text-shadow: 0 0 2px #00ff00;
+    background: var(--color-inverse);
+    color: var(--color-terminal);
+    text-shadow: 0 0 2px var(--color-terminal);
     box-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
 }
 
@@ -261,14 +261,14 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .card-front {
-    background: #ffffff;
-    color: #000000;
+    background: var(--color-surface);
+    color: var(--color-inverse);
     transform: rotateY(180deg);
 }
 
 .card-back {
-    background: #1f2937;
-    color: #ffffff;
+    background: var(--color-dark);
+    color: var(--color-surface);
 }
 
 .card.flipped {
@@ -308,7 +308,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 2px solid #000;
+    border: 2px solid var(--color-inverse);
     position: absolute;
     left: 0;
     transition: transform 0.3s;

--- a/styles/resume-print.css
+++ b/styles/resume-print.css
@@ -3,13 +3,13 @@
     margin: 1in;
   }
   body {
-    background: #fff;
-    color: #000;
+    background: var(--color-surface);
+    color: var(--color-inverse);
   }
   .no-print {
     display: none !important;
   }
   .windowMainScreen {
-    background: #fff !important;
+    background: var(--color-surface) !important;
   }
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,7 +2,7 @@ import { get, set, del } from 'idb-keyval';
 
 const DEFAULT_SETTINGS = {
   theme: 'system',
-  accent: '#E95420',
+  accent: 'var(--color-primary)',
   wallpaper: 'wall-2',
 };
 


### PR DESCRIPTION
## Summary
- add WCAG AA compliant theme palette and variables
- replace hard-coded colors with CSS variables
- enforce color contrast checks with Pa11y in CI

## Testing
- `yarn lint` *(fails: React hook usage, duplicate props)*
- `yarn test` *(fails: BeEF app and Autopsy tests, Playwright a11y suite misconfigured)*
- `yarn a11y` *(fails: missing libatk-1.0.so.0 for Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68af192859388328be37e505373920f8