### PR TITLE
Improve game accessibility and layout

### DIFF
--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -243,6 +243,33 @@ const Checkers = () => {
     workerRef.current?.postMessage({ board, color: turn, maxDepth: 8 });
   };
 
+  const focusCell = (r: number, c: number) => {
+    document.getElementById(`cell-${r}-${c}`)?.focus();
+  };
+
+  const handleKey = (
+    r: number,
+    c: number,
+    e: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (e.key === 'ArrowUp' && r > 0) {
+      e.preventDefault();
+      focusCell(r - 1, c);
+    } else if (e.key === 'ArrowDown' && r < 7) {
+      e.preventDefault();
+      focusCell(r + 1, c);
+    } else if (e.key === 'ArrowLeft' && c > 0) {
+      e.preventDefault();
+      focusCell(r, c - 1);
+    } else if (e.key === 'ArrowRight' && c < 7) {
+      e.preventDefault();
+      focusCell(r, c + 1);
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      selected ? tryMove(r, c) : selectPiece(r, c);
+    }
+  };
+
   return (
     <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
       <div aria-live="polite" className="sr-only">
@@ -250,7 +277,10 @@ const Checkers = () => {
       </div>
       {winner && <div className="mb-2 text-xl">{winner} wins!</div>}
       {draw && <div className="mb-2 text-xl">Draw!</div>}
-      <div className="grid grid-cols-8 gap-0">
+      <div
+        className="grid grid-cols-8 gap-0"
+        style={{ width: 'clamp(384px, 90vw, 560px)' }}
+      >
         {board.map((row, r) =>
           row.map((cell, c) => {
             const isDark = (r + c) % 2 === 1;
@@ -262,11 +292,14 @@ const Checkers = () => {
             const isCrowned = crowned && crowned[0] === r && crowned[1] === c;
             return (
               <div
+                id={`cell-${r}-${c}`}
+                tabIndex={0}
+                onKeyDown={(e) => handleKey(r, c, e)}
                 key={`${r}-${c}`}
                 {...pointerHandlers(() =>
                   selected ? tryMove(r, c) : selectPiece(r, c)
                 )}
-                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center ${
+                className={`aspect-square flex items-center justify-center ${
                   isDark ? 'bg-gray-700' : 'bg-gray-400'
                 } ${
                   isMove
@@ -282,7 +315,7 @@ const Checkers = () => {
               >
                 {cell && (
                   <div
-                    className={`w-10 h-10 md:w-12 md:h-12 rounded-full flex items-center justify-center ${
+                    className={`w-5/6 h-5/6 rounded-full flex items-center justify-center ${
                       cell.color === 'red' ? 'bg-red-500' : 'bg-black'
                     } ${cell.king ? 'border-4 border-yellow-300' : ''} ${
                       isCrowned ? 'motion-safe:animate-flourish' : ''

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -20,6 +20,7 @@ const Memory = () => {
   const [streak, setStreak] = useState(0);
   const [particles, setParticles] = useState([]);
   const [nudge, setNudge] = useState(false);
+  const [dragging, setDragging] = useState(null);
 
   const runningRef = useRef(false);
   const startRef = useRef(0);
@@ -188,7 +189,11 @@ const Memory = () => {
                   onClick={() => handleCardClick(i)}
                   aria-label={isFlipped ? `Card ${card.value}` : 'Hidden card'}
                   disabled={flipped.includes(i) || matched.includes(i) || paused}
-                  className={`relative w-full aspect-square [perspective:600px] rounded transform ${isHighlighted ? 'ring-4 ring-green-600' : ''} ${reduceMotion.current ? '' : 'transition-transform duration-200'} ${isHighlighted && !reduceMotion.current ? 'scale-105' : ''}`}
+                  onPointerDown={() => setDragging(i)}
+                  onPointerUp={() => setDragging(null)}
+                  onPointerLeave={() => setDragging(null)}
+                  className={`relative w-full aspect-square min-w-[64px] min-h-[64px] [perspective:600px] rounded transform ${isHighlighted ? 'ring-4 ring-green-600' : ''} ${dragging === i ? 'ring-4 ring-blue-400 scale-105' : ''} ${reduceMotion.current ? '' : 'transition-transform duration-200'} ${isHighlighted && !reduceMotion.current ? 'scale-105' : ''}`}
+                  style={{ touchAction: 'none' }}
                 >
                   <div
                     data-testid="card-inner"

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -478,7 +478,10 @@ const Sudoku = () => {
           </span>
         )}
       </div>
-      <div className="grid grid-cols-9" style={{ gap: '2px' }}>
+      <div
+        className="grid grid-cols-9"
+        style={{ gap: '2px', height: '60vh', maxHeight: '72vh' }}
+      >
         {board.map((row, r) =>
           row.map((val, c) => {
             const original = puzzle[r][c] !== 0;
@@ -509,13 +512,13 @@ const Sudoku = () => {
                   conflict
                     ? 'bg-red-700 error-pulse'
                     : wrong
-                    ? 'bg-red-200'
+                    ? 'bg-red-600'
                     : ''
                 } ${shimmer ? 'shimmer' : ''} ${isHint ? 'ring-2 ring-yellow-400' : ''}`}
               >
                 <input
                   className={`w-full h-full text-center outline-none bg-transparent ${
-                    conflict ? 'text-white' : wrong ? 'text-red-500' : 'text-black'
+                    conflict || wrong ? 'text-white' : 'text-black'
                   }`}
                   aria-label={`Row ${r + 1} Column ${c + 1}`}
                   value={val === 0 ? '' : val}

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -522,7 +522,11 @@ const Tetris = () => {
           width={WIDTH * CELL_SIZE}
           height={HEIGHT * CELL_SIZE}
           className="border border-gray-700 transition-transform"
-          style={{ transform: shake ? 'translateY(2px)' : 'none' }}
+          style={{
+            transform: shake ? 'translateY(2px)' : 'none',
+            height: '60vh',
+            maxHeight: '72vh',
+          }}
         />
         <div className="flex flex-col text-sm">
           <div className="mb-4">


### PR DESCRIPTION
## Summary
- Clamp checkers board width and add keyboard navigation between cells
- Enlarge memory card hit targets and show drag feedback
- Increase error contrast and set playfield height for Sudoku and Tetris

## Testing
- `npm test` *(failing: __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/a11y.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af1928ac98832893d573674588a4c5