### PR TITLE
Adjust game window defaults and overrides

### DIFF
--- a/__tests__/frogger.config.test.ts
+++ b/__tests__/frogger.config.test.ts
@@ -7,8 +7,8 @@ describe('frogger config', () => {
   test('frogger game is registered with defaults', () => {
     const frogger = games.find((g) => g.id === 'frogger');
     expect(frogger).toBeDefined();
-    expect(frogger?.defaultWidth).toBe(50);
-    expect(frogger?.defaultHeight).toBe(60);
+    expect(frogger?.defaultWidth).toBe(58);
+    expect(frogger?.defaultHeight).toBe(72);
     expect(typeof frogger?.screen).toBe('function');
   });
 });

--- a/__tests__/snake.config.test.ts
+++ b/__tests__/snake.config.test.ts
@@ -6,8 +6,8 @@ describe('snake app config', () => {
   it('includes snake with default sizing and dynamic screen', () => {
     const snake = games.find((g) => g.id === 'snake');
     expect(snake).toBeDefined();
-    expect(snake?.defaultWidth).toBe(50);
-    expect(snake?.defaultHeight).toBe(60);
+    expect(snake?.defaultWidth).toBe(58);
+    expect(snake?.defaultHeight).toBe(72);
     expect(typeof snake?.screen).toBe('function');
   });
 });

--- a/apps.config.js
+++ b/apps.config.js
@@ -215,8 +215,8 @@ export const utilities = utilityList;
 
 // Default window sizing for games to prevent oversized frames
 export const gameDefaults = {
-  defaultWidth: 50,
-  defaultHeight: 60,
+  defaultWidth: 58,
+  defaultHeight: 72,
 };
 
 // Games list used for the "Games" folder on the desktop
@@ -304,6 +304,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayChess,
+    defaultWidth: 64,
+    defaultHeight: 79,
   },
   {
     id: 'connect-four',
@@ -421,6 +423,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySolitaire,
+    defaultWidth: 64,
+    defaultHeight: 79,
   },
   {
     id: 'tictactoe',
@@ -449,6 +453,8 @@ const gameList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayTowerDefense,
+    defaultWidth: 64,
+    defaultHeight: 79,
   },
   {
     id: 'word-search',


### PR DESCRIPTION
## Summary
- increase baseline game window size
- enlarge tall games like Chess, Solitaire, and Tower Defense
- align snake and frogger config tests with new defaults

## Testing
- `npm test` *(fails: BeEF app, Autopsy, a11y.spec)*
- `npm run lint` *(fails: React hooks / duplicate prop errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af191bb9308328b9f374f2c6ccf44c