### PR TITLE
feat: add global focus outline

### DIFF
--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -35,7 +35,6 @@ body {
   border: none;
   background: transparent;
   resize: none;
-  outline: none;
 }
 
 .note .controls {

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -57,7 +57,7 @@ const PopularModules: React.FC = () => {
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
-          className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+          className={`px-2 py-1 text-sm rounded  focus:ring-2 focus:ring-blue-400 ${
             filter === '' ? 'bg-blue-600' : 'bg-gray-700'
           }`}
         >
@@ -67,7 +67,7 @@ const PopularModules: React.FC = () => {
           <button
             key={t}
             onClick={() => setFilter(t)}
-            className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+            className={`px-2 py-1 text-sm rounded  focus:ring-2 focus:ring-blue-400 ${
               filter === t ? 'bg-blue-600' : 'bg-gray-700'
             }`}
           >
@@ -80,7 +80,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => setSelected(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="p-3 text-left bg-ub-grey rounded border border-gray-700  focus:ring-2 focus:ring-blue-400"
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -65,7 +65,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded  focus:ring"
             autoFocus
           >
             Resume
@@ -77,7 +77,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({ gameId, children }) => {
         aria-label="Help"
         aria-expanded={showHelp}
         onClick={toggle}
-        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center  focus:ring"
       >
         ?
       </button>

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -32,7 +32,7 @@ const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
           <button
             type="button"
             onClick={() => capture(action)}
-            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 rounded  focus:ring"
           >
             {waiting === action ? 'Press key...' : mapping[action]}
           </button>

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -186,7 +186,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded  focus:ring"
           autoFocus
         >
           Close

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -65,7 +65,7 @@ export class AboutAlex extends Component {
                         id={section.id}
                         tabIndex="0"
                         onFocus={this.changeScreen}
-                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
+                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default  py-1.5  duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
                     >
                         <Image
                             className=" w-3 md:w-4"

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -62,7 +62,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50  focus:ring"
           >
             Prev
           </button>
@@ -71,7 +71,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50  focus:ring"
           >
             Next
           </button>
@@ -86,7 +86,7 @@ export default function GuideOverlay({ onClose }) {
         </label>
         <button
           onClick={handleClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded  focus:ring"
         >
           Close
         </button>

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -343,25 +343,25 @@ const CarRacer = () => {
       </div>
       <div className="absolute bottom-2 left-2 space-x-2 z-10 text-sm">
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2  focus:ring-2 focus:ring-white"
           onClick={reset}
         >
           Reset
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2  focus:ring-2 focus:ring-white"
           onClick={togglePause}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2  focus:ring-2 focus:ring-white"
           onClick={toggleSound}
         >
           {sound ? 'Sound: on' : 'Sound: off'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2  focus:ring-2 focus:ring-white"
           onClick={triggerBoost}
         >
           Boost

--- a/components/apps/chrome.js
+++ b/components/apps/chrome.js
@@ -114,7 +114,7 @@ export class Chrome extends Component {
                 {this.state.tabs.map((tab, idx) => {
                     if (!this.thumbRefs[idx]) this.thumbRefs[idx] = createRef();
                     return (
-                        <button key={idx} ref={this.thumbRefs[idx]} onClick={() => this.selectTab(idx)} className="relative focus:outline-none border border-white" aria-label={`Open tab ${idx + 1}`}>
+                        <button key={idx} ref={this.thumbRefs[idx]} onClick={() => this.selectTab(idx)} className="relative  border border-white" aria-label={`Open tab ${idx + 1}`}>
                             <iframe
                                 src={tab.url}
                                 title={`Tab ${idx + 1}`}
@@ -153,8 +153,8 @@ export class Chrome extends Component {
                         sizes="20px"
                     />
                 </div>
-                <input onKeyDown={this.checkKey} onChange={this.handleDisplayUrl} value={this.state.display_url} id="chrome-url-bar" className="outline-none bg-ub-grey rounded-full pl-3 py-0.5 mr-3 w-5/6 text-gray-300 focus:text-white" type="url" spellCheck={false} autoComplete="off" />
-                <button onClick={this.openGrid} className="mr-2 px-2 py-0.5 bg-gray-800 text-white rounded focus:outline-none focus:ring" aria-label="Show all tabs">Tabs</button>
+                <input onKeyDown={this.checkKey} onChange={this.handleDisplayUrl} value={this.state.display_url} id="chrome-url-bar" className=" bg-ub-grey rounded-full pl-3 py-0.5 mr-3 w-5/6 text-gray-300 focus:text-white" type="url" spellCheck={false} autoComplete="off" />
+                <button onClick={this.openGrid} className="mr-2 px-2 py-0.5 bg-gray-800 text-white rounded  focus:ring" aria-label="Show all tabs">Tabs</button>
             </div>
         );
     }

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -196,7 +196,7 @@ export default function FileExplorer() {
         </div>
         <div className="flex-1 flex flex-col">
           {currentFile && (
-            <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
+            <textarea className="flex-1 p-2 bg-ub-cool-grey " value={content} onChange={onChange} />
           )}
           <div className="p-2 border-t border-gray-600">
             <input

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -136,18 +136,18 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light  font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject  text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen  tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                         <p id="message-status" className={`text-xs mt-1 ${messageInvalid ? 'text-red-400' : messageValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {messageInvalid ? 'Message must not be empty' : messageValid ? 'Looks good' : ''}

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -189,7 +189,7 @@ const MetasploitApp = () => {
                 key={s}
                 onClick={() => setSelectedSeverity(s)}
                 aria-pressed={selectedSeverity === s}
-                className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus:outline-none ${severityStyles[s]} ${
+                className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2  ${severityStyles[s]} ${
                   selectedSeverity === s
                     ? 'ring-2 ring-white motion-safe:transition-transform motion-safe:duration-300 motion-safe:scale-110 motion-reduce:transition-none motion-reduce:scale-100'
                     : ''

--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -62,7 +62,7 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
             key={level}
             onClick={() => setFilter(level)}
             aria-pressed={filter === level}
-            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+            className={`px-3 py-1 rounded-full text-sm border  focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
               filter === level
                 ? 'bg-white text-black border-gray-300'
                 : 'bg-gray-800 text-white border-gray-600'

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -148,7 +148,7 @@ const NiktoApp = () => {
         <button
           type="button"
           onClick={runScan}
-          className="px-4 bg-ubt-blue rounded-r focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+          className="px-4 bg-ubt-blue rounded-r  focus:ring-2 focus:ring-ubt-blue"
         >
           Scan
         </button>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -226,7 +226,7 @@ const OpenVASApp = () => {
                       type="button"
                       onClick={() => handleCellClick(likelihood, impact)}
                       disabled={count === 0}
-                      className={`p-2 ${color(i, j)} text-white focus:outline-none w-full ${
+                      className={`p-2 ${color(i, j)} text-white  w-full ${
                         reduceMotion.current ? '' : 'transition-transform hover:scale-105'
                       } ${
                         filter &&
@@ -254,7 +254,7 @@ const OpenVASApp = () => {
                 key={level}
                 onClick={() => handleSeverityChange(level)}
                 aria-pressed={severity === level}
-                className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                className={`px-3 py-1 rounded-full text-sm  focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
                   severity === level
                     ? 'bg-white text-black'
                     : 'bg-gray-800 text-white'

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -191,7 +191,7 @@ export default function ProjectGallery() {
           <div className="mb-4 flex flex-wrap gap-2">
             <button
               onClick={() => setFilter('')}
-              className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+              className={`px-3 py-1 rounded-full text-sm  focus:ring-2 focus:ring-blue-400 ${
                 filter === ''
                   ? 'bg-blue-600 text-white'
                   : 'bg-gray-700 text-white'
@@ -204,7 +204,7 @@ export default function ProjectGallery() {
               <button
                 key={t}
                 onClick={() => setFilter(t)}
-                className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+                className={`px-3 py-1 rounded-full text-sm  focus:ring-2 focus:ring-blue-400 ${
                   filter === t
                     ? 'bg-blue-600 text-white'
                     : 'bg-gray-700 text-white'
@@ -263,7 +263,7 @@ export default function ProjectGallery() {
                         href={project.live}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-500  focus:ring-2 focus:ring-blue-400"
                         onClick={(e) => e.stopPropagation()}
                       >
                         Live Demo
@@ -274,7 +274,7 @@ export default function ProjectGallery() {
                         href={project.repo}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="px-3 py-1 text-sm border border-blue-600 rounded text-white hover:bg-blue-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        className="px-3 py-1 text-sm border border-blue-600 rounded text-white hover:bg-blue-600 hover:text-white  focus:ring-2 focus:ring-blue-400"
                         onClick={(e) => e.stopPropagation()}
                       >
                         Repo
@@ -282,7 +282,7 @@ export default function ProjectGallery() {
                     )}
                     <button
                       onClick={() => setSelected(project)}
-                      className="px-3 py-1 text-sm border border-gray-500 rounded text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                      className="px-3 py-1 text-sm border border-gray-500 rounded text-white hover:bg-gray-700  focus:ring-2 focus:ring-blue-400"
                     >
                       Details
                     </button>

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -123,7 +123,7 @@ const HexEditor = ({ hex }) => {
                   key={i}
                   onMouseDown={() => handleMouseDown(i)}
                   onMouseEnter={() => handleMouseEnter(i)}
-                  className={`w-6 h-6 flex items-center justify-center rounded focus:outline-none focus:ring-2 focus:ring-yellow-300 ${
+                  className={`w-6 h-6 flex items-center justify-center rounded  focus:ring-2 focus:ring-yellow-300 ${
                     selected ? 'bg-yellow-300 text-black' : 'bg-gray-800'
                   }`}
                   style={{ minWidth: '1.5rem' }}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -116,7 +116,7 @@ export function Settings() {
                                 }
                             }}
                             data-path={name}
-                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
+                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10  border-4 border-opacity-80"}
                             style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
                         ></div>
                     ))

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -514,7 +514,7 @@ const Sudoku = () => {
                 } ${shimmer ? 'shimmer' : ''} ${isHint ? 'ring-2 ring-yellow-400' : ''}`}
               >
                 <input
-                  className={`w-full h-full text-center outline-none bg-transparent ${
+                  className={`w-full h-full text-center  bg-transparent ${
                     conflict ? 'text-white' : wrong ? 'text-red-500' : 'text-black'
                   }`}
                   aria-label={`Row ${r + 1} Column ${c + 1}`}

--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -192,7 +192,7 @@ export class Trash extends Component {
                                 onFocus={this.focusFile}
                                 onBlur={this.focusFile}
                                 onClick={() => this.toggleSelect(index)}
-                                className={`trash-item flex flex-col items-center text-sm outline-none w-16 my-2 mx-4 ${selected ? 'opacity-60' : ''}`}
+                                className={`trash-item flex flex-col items-center text-sm  w-16 my-2 mx-4 ${selected ? 'opacity-60' : ''}`}
                             >
                                 <div className="w-16 h-16 flex items-center justify-center">
                                     <Image

--- a/components/apps/volatility/MemoryHeatmap.js
+++ b/components/apps/volatility/MemoryHeatmap.js
@@ -114,7 +114,7 @@ const MemoryHeatmap = ({ data }) => {
             key={key}
             onClick={() => toggle(key)}
             aria-pressed={filters[key]}
-            className={`px-3 py-1 rounded-full text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            className={`px-3 py-1 rounded-full text-sm font-medium  focus:ring-2 focus:ring-offset-2 ${
               filters[key]
                 ? `${chipColors[key]} text-white focus:ring-white`
                 : 'bg-gray-200 text-gray-800 focus:ring-black'
@@ -131,7 +131,7 @@ const MemoryHeatmap = ({ data }) => {
         tabIndex={0}
         role="img"
         aria-label="Heatmap of memory regions. Use arrow keys to pan."
-        className="border border-gray-500 w-full h-40 focus:outline-none"
+        className="border border-gray-500 w-full h-40 "
       />
       <div className="sr-only" aria-live="polite">
         {announcement}

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -44,7 +44,7 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") + " w-auto p-2 outline-none relative transition hover:bg-white hover:bg-opacity-10 rounded m-1"}
+                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") + " w-auto p-2  relative transition hover:bg-white hover:bg-opacity-10 rounded m-1"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -21,7 +21,7 @@ export class UbuntuApp extends Component {
                 aria-label={this.props.name}
                 data-context="app"
                 data-app-id={this.props.id}
-                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
+                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent  rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -359,7 +359,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
+                className="mx-1.5  cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center mt-1 h-5 w-5 items-center"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -55,7 +55,7 @@ class AllApplications extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white "
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -14,7 +14,7 @@ function BootingScreen(props) {
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
+            <div className="w-10 h-10 flex justify-center items-center rounded-full  cursor-pointer" onClick={props.turnOn} >
                 {(props.isShutDown
                     ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
                     : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -574,7 +574,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className=" mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <div onClick={addFolder} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Create</div>

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -12,7 +12,7 @@ export default function LockScreen(props) {
     };
 
     return (
-        <div id="ubuntu-lock-screen" style={{ zIndex: "100" }} className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
+        <div id="ubuntu-lock-screen" style={{ zIndex: "100" }} className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute  bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <div style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPositionX: "center" }} className="absolute top-0 left-0 w-full h-full transform z-20 blur-md "></div>
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -16,14 +16,14 @@ export default class Navbar extends Component {
 			<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div
                                         className={
-                                                'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '
+                                                'pl-3 pr-3  transition duration-100 ease-in-out border-b-2 border-transparent py-1 '
                                         }
                                 >
                                         Activities
                                 </div>
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'pl-2 pr-2 text-xs md:text-sm  transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
                                         <Clock />
@@ -36,7 +36,7 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative pr-3 pl-3  transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
 					<Status />

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -55,7 +55,7 @@ class ShortcutSelector extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white "
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -36,7 +36,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline "
         >
           {actionLabel}
         </button>

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -12,7 +12,7 @@ const ToolTile = ({ title, link, children }: TileProps) => (
     href={link}
     target="_blank"
     rel="noopener noreferrer"
-    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
+    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black  focus:ring"
   >
     <h2 className="text-xl mb-2">{title}</h2>
     {children}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,11 @@
 @import './tokens.css';
 
+/* Global focus style */
+:focus-visible {
+    outline: 2px solid var(--focus-color);
+    outline-offset: 2px;
+}
+
 body{
     font-family: var(--font-family-base);
     font-display: swap;
@@ -38,7 +44,6 @@ body{
 }
 
 input[type=range].ubuntu-slider {
-    outline: none;
     -webkit-appearance: none;
     background: linear-gradient(to right, rgba(175, 175, 175, 0.3) 0%, rgba(175, 175, 175, 0.3) 100%);
     background-position: center;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,6 +25,7 @@
   --color-ub-dark-grey: #555555;
   --color-bg: #111111;
   --color-text: #F6F6F5;
+  --focus-color: var(--color-ubt-blue);
 
   /* Spacing scale */
   --space-1: 0.25rem;


### PR DESCRIPTION
## Summary
- define `--focus-color` design token and add global `:focus-visible` outline reset
- remove outline suppression from components so interactive elements display focus

## Testing
- `yarn lint` *(fails: React Hook lint errors and duplicate prop warnings)*
- `yarn test` *(fails: BeEF, Autopsy, a11y Playwright tests)*
- `yarn dev`

------
https://chatgpt.com/codex/tasks/task_e_68af192131788328a74f6edcf42fe380