### PR TITLE
feat: add expectimax 2048 ai and hard mode tweaks

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -441,6 +441,36 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     pointer-events: none;
 }
 
+@keyframes move-left {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+@keyframes move-right {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+}
+@keyframes move-up {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+}
+@keyframes move-down {
+    from { transform: translateY(-100%); }
+    to { transform: translateY(0); }
+}
+
+.tile-move-left {
+    animation: move-left 0.2s ease-out;
+}
+.tile-move-right {
+    animation: move-right 0.2s ease-out;
+}
+.tile-move-up {
+    animation: move-up 0.2s ease-out;
+}
+.tile-move-down {
+    animation: move-down 0.2s ease-out;
+}
+
 @keyframes score-pop {
     0% { transform: scale(1); }
     50% { transform: scale(1.3); }


### PR DESCRIPTION
## Summary
- refactor 2048 move logic to single-pass compression and add expectimax AI with movement animations
- allow undo history and new hard mode with higher 4 spawn rate and AI suggestions
- expose AI hint button and hard mode toggle in 2048 page

## Testing
- `npm test __tests__/game2048.test.tsx __tests__/game2048.test.ts`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68af24cf413c8328b1ff3ba3df41004d