### PR TITLE
feat: enhance battleship AI with heatmap and new modes

### DIFF
--- a/components/apps/battleship/GameLayout.js
+++ b/components/apps/battleship/GameLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats, showHeatmap, onToggleHeatmap }) => {
+const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats, showHeatmap, onToggleHeatmap, salvo, onToggleSalvo, fog, onToggleFog }) => {
   return (
     <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
       <div className="flex items-center space-x-2 mb-2">
@@ -20,6 +20,12 @@ const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats
         </button>
         <button className="px-2 py-1 bg-gray-700" onClick={onToggleHeatmap}>
           {showHeatmap ? 'Hide' : 'Show'} Heatmap
+        </button>
+        <button className="px-2 py-1 bg-gray-700" onClick={onToggleSalvo}>
+          {salvo ? 'Salvo: On' : 'Salvo: Off'}
+        </button>
+        <button className="px-2 py-1 bg-gray-700" onClick={onToggleFog}>
+          {fog ? 'Reveal Board' : 'Fog of War'}
         </button>
         {stats && (
           <div className="ml-4 text-sm">


### PR DESCRIPTION
## Summary
- add probability-based hunt-target AI and optimal enemy ship placement
- support salvo mode and fog-of-war options in Battleship
- visualize AI shot probabilities with heatmap

## Testing
- `node --input-type=module <simulation>`
- `npm test` *(fails: combo meter increments and resets, card flip applies transform style, BeEF app, Autopsy app, NmapNSEApp)*

------
https://chatgpt.com/codex/tasks/task_e_68af24d2765c832881d599fa97387c0e