### PR TITLE
feat(checkers): add minimax AI with multi-jump support

### DIFF
--- a/components/apps/checkers/engine.ts
+++ b/components/apps/checkers/engine.ts
@@ -36,58 +36,15 @@ export interface Move {
   from: [number, number];
   to: [number, number];
   captured?: [number, number];
+  next?: Move[];
 }
 
 export const cloneBoard = (board: Board): Board =>
   board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
 
-export const getPieceMoves = (board: Board, r: number, c: number): Move[] => {
-  const piece = board[r][c];
-  if (!piece) return [];
-  const dirs = [...directions[piece.color]];
-  if (piece.king) {
-    dirs.push(...directions[piece.color === 'red' ? 'black' : 'red']);
-  }
-  const moves: Move[] = [];
-  const captures: Move[] = [];
-  for (const [dr, dc] of dirs) {
-    const r1 = r + dr;
-    const c1 = c + dc;
-    if (!inBounds(r1, c1)) continue;
-    const target = board[r1][c1];
-    if (!target) {
-      moves.push({ from: [r, c], to: [r1, c1] });
-    } else if (target.color !== piece.color) {
-      const r2 = r + dr * 2;
-      const c2 = c + dc * 2;
-      if (inBounds(r2, c2) && !board[r2][c2]) {
-        captures.push({ from: [r, c], to: [r2, c2], captured: [r1, c1] });
-      }
-    }
-  }
-  return captures.length ? captures : moves;
-};
-
-export const getAllMoves = (board: Board, color: Color): Move[] => {
-  let result: Move[] = [];
-  for (let r = 0; r < 8; r++) {
-    for (let c = 0; c < 8; c++) {
-      if (board[r][c]?.color === color) {
-        const moves = getPieceMoves(board, r, c);
-        if (moves.length) result = result.concat(moves);
-      }
-    }
-  }
-  const anyCapture = result.some((m) => m.captured);
-  return anyCapture ? result.filter((m) => m.captured) : result;
-};
-
-export const hasMoves = (board: Board, color: Color): boolean =>
-  getAllMoves(board, color).length > 0;
-
 export const applyMove = (
   board: Board,
-  move: Move
+  move: Move,
 ): { board: Board; capture: boolean; king: boolean } => {
   const newBoard = cloneBoard(board);
   const piece = newBoard[move.from[0]][move.from[1]]!;
@@ -110,6 +67,52 @@ export const applyMove = (
   }
   return { board: newBoard, capture, king };
 };
+export const getPieceMoves = (board: Board, r: number, c: number): Move[] => {
+  const piece = board[r][c];
+  if (!piece) return [];
+  const dirs = [...directions[piece.color]];
+  if (piece.king) dirs.push(...directions[piece.color === 'red' ? 'black' : 'red']);
+  const moves: Move[] = [];
+  const captures: Move[] = [];
+  for (const [dr, dc] of dirs) {
+    const r1 = r + dr;
+    const c1 = c + dc;
+    if (!inBounds(r1, c1)) continue;
+    const target = board[r1][c1];
+    if (!target) {
+      moves.push({ from: [r, c], to: [r1, c1] });
+    } else if (target.color !== piece.color) {
+      const r2 = r + dr * 2;
+      const c2 = c + dc * 2;
+      if (inBounds(r2, c2) && !board[r2][c2]) {
+        const move: Move = { from: [r, c], to: [r2, c2], captured: [r1, c1] };
+        const { board: nextBoard, king } = applyMove(board, move);
+        if (!king) {
+          const further = getPieceMoves(nextBoard, r2, c2).filter((m) => m.captured);
+          if (further.length) move.next = further;
+        }
+        captures.push(move);
+      }
+    }
+  }
+  return captures.length ? captures : moves;
+};
+
+export const getAllMoves = (board: Board, color: Color): Move[] => {
+  let result: Move[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      if (board[r][c]?.color === color) {
+        const moves = getPieceMoves(board, r, c);
+        if (moves.length) result = result.concat(moves);
+      }
+    }
+  }
+  const anyCapture = result.some((m) => m.captured);
+  return anyCapture ? result.filter((m) => m.captured) : result;
+};
+export const hasMoves = (board: Board, color: Color): boolean =>
+  getAllMoves(board, color).length > 0;
 
 export const boardToBitboards = (board: Board) => {
   let red = 0n;


### PR DESCRIPTION
## Summary
- implement alpha-beta minimax worker evaluating material, mobility, advancement, and king safety
- generate multi-jump sequences with mandatory captures in checkers engine
- offload depth-8 search to web worker for responsive gameplay

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68af280dbc348328bd6985070ecd1fce