### PR TITLE
feat: add seeded word search generator

### DIFF
--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -55,39 +55,83 @@ export interface GenerateResult {
 export function generateGrid(
   words: string[],
   size = 12,
-  seed = 'seed'
+  seed = 'seed',
+  { unique = false }: { unique?: boolean } = {},
 ): GenerateResult {
   const rng = createRNG(seed);
   const grid: string[][] = Array.from({ length: size }, () => Array(size).fill(''));
   const placements: WordPlacement[] = [];
-  words.forEach((w) => {
-    const word = w.toUpperCase();
-    for (let attempt = 0; attempt < 200; attempt += 1) {
-      const dir = DIRECTIONS[Math.floor(rng() * DIRECTIONS.length)];
-      const maxRow = dir.dy > 0 ? size - word.length : dir.dy < 0 ? word.length - 1 : size - 1;
-      const maxCol = dir.dx > 0 ? size - word.length : dir.dx < 0 ? word.length - 1 : size - 1;
-      const startRow = Math.floor(rng() * (maxRow + 1));
-      const startCol = Math.floor(rng() * (maxCol + 1));
-      let ok = true;
-      const positions: Position[] = [];
-      for (let i = 0; i < word.length; i += 1) {
-        const r = startRow + dir.dy * i;
-        const c = startCol + dir.dx * i;
-        const existing = grid[r][c];
-        if (existing && existing !== word[i]) {
-          ok = false;
-          break;
-        }
-        positions.push({ row: r, col: c });
-      }
-      if (!ok) continue;
-      positions.forEach((p, i) => {
-        grid[p.row][p.col] = word[i];
-      });
-      placements.push({ word, positions });
-      return;
+
+  // place longer words first for better success rate
+  const sorted = words
+    .map((w) => w.toUpperCase())
+    .sort((a, b) => b.length - a.length);
+
+  function shuffle<T>(arr: T[]): void {
+    for (let i = arr.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(rng() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
     }
-  });
+  }
+
+  function getOptions(word: string) {
+    const opts: { positions: Position[]; overlap: number }[] = [];
+    DIRECTIONS.forEach((dir) => {
+      const rowStart = dir.dy === 1 ? 0 : dir.dy === -1 ? word.length - 1 : 0;
+      const rowEnd = dir.dy === 1 ? size - word.length : dir.dy === -1 ? size - 1 : size - 1;
+      const colStart = dir.dx === 1 ? 0 : dir.dx === -1 ? word.length - 1 : 0;
+      const colEnd = dir.dx === 1 ? size - word.length : dir.dx === -1 ? size - 1 : size - 1;
+      for (let r = rowStart; r <= rowEnd; r += 1) {
+        for (let c = colStart; c <= colEnd; c += 1) {
+          let ok = true;
+          let overlap = 0;
+          const pos: Position[] = [];
+          for (let i = 0; i < word.length; i += 1) {
+            const rr = r + dir.dy * i;
+            const cc = c + dir.dx * i;
+            const existing = grid[rr][cc];
+            if (existing && existing !== word[i]) {
+              ok = false;
+              break;
+            }
+            if (existing === word[i]) overlap += 1;
+            pos.push({ row: rr, col: cc });
+          }
+          if (ok) opts.push({ positions: pos, overlap });
+        }
+      }
+    });
+    shuffle(opts);
+    opts.sort((a, b) => b.overlap - a.overlap);
+    return opts;
+  }
+
+  function placeWord(index: number): boolean {
+    if (index >= sorted.length) return true;
+    const word = sorted[index];
+    const options = getOptions(word);
+    for (const opt of options) {
+      const overwritten: Position[] = [];
+      opt.positions.forEach((p, i) => {
+        if (!grid[p.row][p.col]) {
+          grid[p.row][p.col] = word[i];
+          overwritten.push(p);
+        }
+      });
+      placements.push({ word, positions: opt.positions });
+      if (placeWord(index + 1)) return true;
+      placements.pop();
+      overwritten.forEach((p) => {
+        grid[p.row][p.col] = '';
+      });
+    }
+    return false;
+  }
+
+  if (!placeWord(0)) {
+    throw new Error('Unable to place all words');
+  }
+
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   for (let r = 0; r < size; r += 1) {
     for (let c = 0; c < size; c += 1) {
@@ -96,5 +140,48 @@ export function generateGrid(
       }
     }
   }
+
+  if (unique && !validateGrid(sorted, grid, true)) {
+    throw new Error('Puzzle does not have a unique solution');
+  }
+
   return { grid, placements };
+}
+
+export function validateGrid(
+  words: string[],
+  grid: string[][],
+  unique = false,
+): boolean {
+  const upper = words.map((w) => w.toUpperCase());
+  const size = grid.length;
+  const countWord = (word: string) => {
+    let count = 0;
+    for (let r = 0; r < size; r += 1) {
+      for (let c = 0; c < size; c += 1) {
+        for (const dir of DIRECTIONS) {
+          let ok = true;
+          for (let i = 0; i < word.length; i += 1) {
+            const rr = r + dir.dy * i;
+            const cc = c + dir.dx * i;
+            if (rr < 0 || rr >= size || cc < 0 || cc >= size) {
+              ok = false;
+              break;
+            }
+            if (grid[rr][cc] !== word[i]) {
+              ok = false;
+              break;
+            }
+          }
+          if (ok) count += 1;
+        }
+      }
+    }
+    return count;
+  };
+
+  return upper.every((w) => {
+    const cnt = countWord(w);
+    return cnt > 0 && (!unique || cnt === 1);
+  });
 }

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -1,11 +1,29 @@
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const WordSearch = dynamic<{ getDailySeed?: () => Promise<string> }>(
+const WordSearch = dynamic<{ seed: string }>(
   () => import('../../apps/word_search'),
   { ssr: false },
 );
 
 export default function WordSearchPage(): JSX.Element {
-  return <WordSearch getDailySeed={() => getDailySeed('word_search')} />;
+  const { query } = useRouter();
+  const [seed, setSeed] = useState<string | null>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      const s =
+        typeof query.seed === 'string'
+          ? query.seed
+          : await getDailySeed('word_search');
+      setSeed(s);
+    };
+    void init();
+  }, [query.seed]);
+
+  if (!seed) return <></>;
+
+  return <WordSearch seed={seed} />;
 }


### PR DESCRIPTION
## Summary
- add backtracking word search generator with deterministic seeding and density heuristics
- validate grids with optional unique-solution checks
- allow passing puzzle seeds from page for repeatable word searches

## Testing
- `npm test` *(fails: memoryGame, BeEF, autopsy, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68af281e21008328882dd581e4a84b41