### PR TITLE
Add Nonogram line solver with backtracking

### DIFF
--- a/__tests__/nonogram.test.ts
+++ b/__tests__/nonogram.test.ts
@@ -1,4 +1,12 @@
-import { validateSolution, findHint, getPuzzleBySeed, generateLinePatterns, lineToClues } from '../components/apps/nonogramUtils';
+import {
+  validateSolution,
+  findHint,
+  getPuzzleBySeed,
+  generateLinePatterns,
+  lineToClues,
+  puzzles,
+} from '../components/apps/nonogramUtils';
+import { solveNonogram } from '../components/apps/nonogram';
 
 describe('nonogram utilities', () => {
   test('validateSolution confirms grid matches clues', () => {
@@ -51,5 +59,15 @@ describe('nonogram utilities', () => {
     const a = getPuzzleBySeed('2024-01-01');
     const b = getPuzzleBySeed('2024-01-01');
     expect(a).toEqual(b);
+  });
+
+  test('standard puzzles solve without guesses', () => {
+    puzzles.forEach(({ rows, cols }) => {
+      const res = solveNonogram(rows, cols);
+      expect(res).not.toBeNull();
+      if (!res) return;
+      expect(res.usedGuess).toBe(false);
+      expect(validateSolution(res.grid, rows, cols)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add iterative line solver with backtracking
- Highlight row/column contradictions when clues conflict
- Ensure sample puzzles solve logically without guesses

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68af281f631083288e8a46a7430b3941