### PR TITLE
feat: improve accessibility with landmarks and focus trapping

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 interface Props {
   highScore?: number;
@@ -9,6 +10,9 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const [theme, setThemeState] = useState('default');
   const unlocked = getUnlockedThemes(highScore);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(dialogRef, open);
 
   useEffect(() => {
     setThemeState(getTheme());
@@ -21,17 +25,28 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button
+        aria-label="Open settings"
+        onClick={() => setOpen(!open)}
+        className="focus-visible:outline focus-visible:ring"
+      >
         Settings
       </button>
       {open && (
-        <div role="dialog">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Settings"
+          ref={dialogRef}
+          className="p-2 bg-white"
+        >
           <label>
             Theme
             <select
-              aria-label="theme-select"
+              aria-label="Select theme"
               value={theme}
               onChange={(e) => changeTheme(e.target.value)}
+              className="focus-visible:outline focus-visible:ring"
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface GameLayoutProps {
   gameId?: string;
@@ -22,6 +23,8 @@ const GameLayout: React.FC<GameLayoutProps> = ({
 }) => {
   const [showHelp, setShowHelp] = useState(false);
   const [paused, setPaused] = useState(false);
+  const pauseRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(pauseRef, paused);
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const close = useCallback(() => setShowHelp(false), []);
@@ -72,10 +75,20 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const resume = useCallback(() => setPaused(false), []);
 
   return (
-    <div className="relative h-full w-full" data-reduced-motion={prefersReducedMotion}>
+    <main
+      id={`${gameId}-main`}
+      aria-label={`${gameId} game area`}
+      aria-describedby={`${gameId}-hotkeys`}
+      className="relative h-full w-full"
+      data-reduced-motion={prefersReducedMotion}
+    >
+      <p id={`${gameId}-hotkeys`} className="sr-only">
+        Press ? for hotkeys
+      </p>
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div
+          ref={pauseRef}
           className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
           role="dialog"
           aria-modal="true"
@@ -83,7 +96,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus-visible:outline focus-visible:ring"
             autoFocus
           >
             Resume
@@ -95,7 +108,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         aria-label="Help"
         aria-expanded={showHelp}
         onClick={toggle}
-        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus-visible:outline focus-visible:ring"
       >
         ?
       </button>
@@ -107,7 +120,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         {highScore !== undefined && <div>High: {highScore}</div>}
       </div>
       {!prefersReducedMotion && <PerfOverlay />}
-    </div>
+    </main>
   );
 };
 

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import InputRemap from './Games/common/input-remap/InputRemap';
 import useInputMapping from './Games/common/input-remap/useInputMapping';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface HelpOverlayProps {
   gameId: string;
@@ -158,11 +159,15 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
   if (!info) return null;
   const [mapping, setKey] = useInputMapping(gameId, info.actions || {});
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, true);
   return (
     <div
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
       role="dialog"
       aria-modal="true"
+      aria-label={`${gameId} instructions`}
+      ref={ref}
     >
       <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
         <h2 className="text-xl font-bold mb-2">{gameId} Help</h2>
@@ -186,7 +191,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus-visible:outline focus-visible:ring"
           autoFocus
         >
           Close

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -6,15 +6,22 @@ interface FormErrorProps {
   children: React.ReactNode;
 }
 
-const FormError = ({ id, className = '', children }: FormErrorProps) => (
-  <p
-    id={id}
-    role="alert"
-    aria-live="assertive"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
-  >
-    {children}
-  </p>
-);
+const FormError = ({ id, className = '', children }: FormErrorProps) => {
+  const label =
+    typeof children === 'string'
+      ? `Error: ${children}`
+      : 'Form error';
+  return (
+    <p
+      id={id}
+      role="alert"
+      aria-live="assertive"
+      aria-label={label}
+      className={`text-red-600 text-sm mt-2 ${className}`.trim()}
+    >
+      {children}
+    </p>
+  );
+};
 
 export default FormError;

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -30,13 +30,14 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="alert"
       aria-live="assertive"
+      aria-label={`Notification: ${message}`}
       className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-80 text-white px-4 py-2 rounded shadow-md flex items-center"
     >
       <span>{message}</span>
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline focus-visible:outline focus-visible:ring"
         >
           {actionLabel}
         </button>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,6 +24,12 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
   return (
     <SettingsProvider>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:outline focus:ring"
+      >
+        Skip to content
+      </a>
       <DemoBanner />
       <Component {...pageProps} />
       <Analytics />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,11 +7,13 @@ import MockTerminal from '../components/MockTerminal';
 const App: React.FC = () => (
   <>
     <Meta />
-    <Ubuntu />
-    <InstallButton />
-    <div className="p-4">
-      <MockTerminal />
-    </div>
+    <main id="main-content" aria-label="Main content">
+      <Ubuntu />
+      <InstallButton />
+      <div className="p-4">
+        <MockTerminal />
+      </div>
+    </main>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add global skip link and main landmark
- expose aria labels and focus-visible styles on UI components
- trap focus in dialogs and game overlays, document hotkeys

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68af28367464832899d7e8308a9cca38