### PR TITLE
feat(vscode): add file selector and external link

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -12,9 +12,13 @@ describe('VsCode app', () => {
 
   it('has an external link', () => {
     render(<VsCode />);
-    const link = screen.getByRole('link', { name: /open externally/i });
-    expect(link).toHaveAttribute('href', 'https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md');
-    expect(link).toHaveAttribute('target', '_blank');
+    const links = screen.getAllByRole('link', { name: /open externally/i });
+    const hasCorrectLink = links.some((link) =>
+      link.getAttribute('href') ===
+        'https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md' &&
+      link.getAttribute('target') === '_blank'
+    );
+    expect(hasCorrectLink).toBe(true);
   });
 
   it('shows banner when cookies are blocked', async () => {

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,16 +1,46 @@
 import React, { useState } from 'react';
 import ExternalFrame from '../ExternalFrame';
 
+const FILE_OPTIONS = [
+    { label: 'README.md', value: 'README.md' },
+    { label: 'pages/index.tsx', value: 'pages/index.tsx' },
+    { label: 'components/apps/vscode.js', value: 'components/apps/vscode.js' },
+];
+
 export default function VsCode() {
     const [loaded, setLoaded] = useState(false);
+    const [path, setPath] = useState('README.md');
+
+    const src = `https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=${encodeURIComponent(path)}`;
 
     return (
         <div className="relative h-full w-full">
+            <div className="absolute top-2 left-2 z-10 flex gap-2">
+                <select
+                    value={path}
+                    onChange={(e) => setPath(e.target.value)}
+                    className="text-xs bg-white text-black p-1 rounded"
+                >
+                    {FILE_OPTIONS.map((f) => (
+                        <option key={f.value} value={f.value}>
+                            {f.label}
+                        </option>
+                    ))}
+                </select>
+                <a
+                    href={src}
+                    target="_blank"
+                    rel="noopener"
+                    className="px-2 py-1 text-xs bg-white text-black rounded"
+                >
+                    Open externally
+                </a>
+            </div>
             {!loaded && (
                 <div className="absolute inset-0 animate-pulse bg-ub-cool-grey" />
             )}
             <ExternalFrame
-                src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+                src={src}
                 title="VsCode"
                 className={`h-full w-full bg-ub-cool-grey ${loaded ? 'block' : 'hidden'}`}
                 sandbox="allow-scripts allow-same-origin"


### PR DESCRIPTION
## Summary
- add dropdown to view README, pages and component files in embedded VS Code
- update iframe when selection changes and provide an external link button
- adjust VsCode tests for multiple external links

## Testing
- `yarn test`
- `yarn test __tests__/vscode.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68af283a770c8328904a47da961b0b9c