### PR TITLE
refactor terminal commands into registry

### DIFF
--- a/components/apps/Terminal/commands/cd.ts
+++ b/components/apps/Terminal/commands/cd.ts
@@ -1,0 +1,15 @@
+import type { Command } from '..';
+
+const cd: Command = {
+  name: 'cd',
+  help: 'Change directory (mock)',
+  run: (argv, term) => {
+    const target = argv[0] || '';
+    term.term.writeln('');
+    term.writeLine(`bash: cd: ${target}: No such file or directory`);
+    term.prompt();
+  },
+};
+
+export default cd;
+

--- a/components/apps/Terminal/commands/clear.ts
+++ b/components/apps/Terminal/commands/clear.ts
@@ -1,0 +1,13 @@
+import type { Command } from '..';
+
+const clear: Command = {
+  name: 'clear',
+  help: 'Clear the terminal',
+  run: (_argv, term) => {
+    term.clear();
+    term.prompt();
+  },
+};
+
+export default clear;
+

--- a/components/apps/Terminal/commands/demo-hashcat.ts
+++ b/components/apps/Terminal/commands/demo-hashcat.ts
@@ -1,0 +1,26 @@
+import type { Command } from '..';
+
+const demoHashcat: Command = {
+  name: 'demo hashcat',
+  help: 'Show sample hashcat output',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    [
+      'hashcat (v6.2.6) starting in benchmark mode...',
+      'OpenCL API (OpenCL 2.1) - Platform #1 [MockGPU]',
+      '* Device #1: Example GPU, 4096/8192 MB (1024 MB allocatable), 64MCU',
+      'Benchmark relevant options:',
+      '==========================',
+      '* --optimized-kernel-enable',
+      '--------------------------',
+      'Hashmode: 0 - MD5',
+      'Speed.#1.........: 12345.0 MH/s (10.00ms) @ Accel:32 Loops:1024 Thr:256 Vec:8',
+      'Started: Fri Mar 15 12:00:00 2024',
+      'Stopped: Fri Mar 15 12:00:01 2024',
+    ].forEach(term.writeLine);
+    term.prompt();
+  },
+};
+
+export default demoHashcat;
+

--- a/components/apps/Terminal/commands/demo-nmap.ts
+++ b/components/apps/Terminal/commands/demo-nmap.ts
@@ -1,0 +1,23 @@
+import type { Command } from '..';
+
+const demoNmap: Command = {
+  name: 'demo nmap',
+  help: 'Show sample nmap output',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    [
+      'Starting Nmap 7.93 ( https://nmap.org ) at 2024-03-15 12:00 UTC',
+      'Nmap scan report for example.com (93.184.216.34)',
+      'Host is up (0.013s latency).',
+      'Not shown: 998 filtered tcp ports',
+      'PORT   STATE SERVICE',
+      '80/tcp open  http',
+      '443/tcp open https',
+      'Nmap done: 1 IP address (1 host up) scanned in 0.20 seconds',
+    ].forEach(term.writeLine);
+    term.prompt();
+  },
+};
+
+export default demoNmap;
+

--- a/components/apps/Terminal/commands/exit.ts
+++ b/components/apps/Terminal/commands/exit.ts
@@ -1,0 +1,15 @@
+import type { Command } from '..';
+
+const exitCmd: Command = {
+  name: 'exit',
+  help: 'Close current pane',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    term.writeLine('Closed pane');
+    term.exit();
+    term.prompt();
+  },
+};
+
+export default exitCmd;
+

--- a/components/apps/Terminal/commands/help.ts
+++ b/components/apps/Terminal/commands/help.ts
@@ -1,0 +1,19 @@
+import type { Command } from '..';
+
+const help: Command = {
+  name: 'help',
+  help: 'List available commands',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    const cmds = Object.keys(term.registry).sort();
+    term.writeLine('Available commands:');
+    cmds.forEach((name) => {
+      const cmd = term.registry[name];
+      term.writeLine(`${name} - ${cmd.help}`);
+    });
+    term.prompt();
+  },
+};
+
+export default help;
+

--- a/components/apps/Terminal/commands/history.ts
+++ b/components/apps/Terminal/commands/history.ts
@@ -1,0 +1,15 @@
+import type { Command } from '..';
+
+const history: Command = {
+  name: 'history',
+  help: 'Show command history',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    const historyText = term.history.join('\n');
+    term.writeLine(historyText);
+    term.prompt();
+  },
+};
+
+export default history;
+

--- a/components/apps/Terminal/commands/man.ts
+++ b/components/apps/Terminal/commands/man.ts
@@ -1,0 +1,24 @@
+import type { Command } from '..';
+
+const man: Command = {
+  name: 'man',
+  help: 'Show command usage',
+  run: (argv, term) => {
+    term.term.writeln('');
+    if (argv.length === 0) {
+      term.writeLine('Usage: man <command>');
+    } else {
+      const name = argv.join(' ');
+      const cmd = term.registry[name];
+      if (cmd) {
+        term.writeLine(`${name} - ${cmd.help}`);
+      } else {
+        term.writeLine(`No manual entry for ${name}`);
+      }
+    }
+    term.prompt();
+  },
+};
+
+export default man;
+

--- a/components/apps/Terminal/commands/pwd.ts
+++ b/components/apps/Terminal/commands/pwd.ts
@@ -1,0 +1,14 @@
+import type { Command } from '..';
+
+const pwd: Command = {
+  name: 'pwd',
+  help: 'Print current directory',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    term.writeLine('/home/alex');
+    term.prompt();
+  },
+};
+
+export default pwd;
+

--- a/components/apps/Terminal/commands/simulate.ts
+++ b/components/apps/Terminal/commands/simulate.ts
@@ -1,0 +1,20 @@
+import type { Command } from '..';
+
+const simulate: Command = {
+  name: 'simulate',
+  help: 'Run heavy simulation',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    if (term.worker) {
+      term.writeLine('Running heavy simulation...');
+      term.worker.postMessage({ command: 'simulate' });
+    } else {
+      const msg = 'Web Workers are not supported in this environment.';
+      term.writeLine(msg);
+      term.prompt();
+    }
+  },
+};
+
+export default simulate;
+

--- a/components/apps/Terminal/commands/split.ts
+++ b/components/apps/Terminal/commands/split.ts
@@ -1,0 +1,15 @@
+import type { Command } from '..';
+
+const split: Command = {
+  name: 'split',
+  help: 'Open new pane',
+  run: (_argv, term) => {
+    term.term.writeln('');
+    term.writeLine('Opened new pane');
+    term.split();
+    term.prompt();
+  },
+};
+
+export default split;
+


### PR DESCRIPTION
## Summary
- introduce `Command` interface and registry for terminal commands
- move mock commands into `components/apps/Terminal/commands` modules
- add `help` and `man` commands for usage information

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af283c27908328a27d643cb80da613