### PR TITLE
Add game settings window and desktop contact shortcut

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import GameSettingsWindow from './GameSettingsWindow';
+import SettingsContext from './GameSettingsContext';
 
 interface GameLayoutProps {
   gameId?: string;
@@ -21,11 +23,14 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   highScore,
 }) => {
   const [showHelp, setShowHelp] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [paused, setPaused] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
+  const settingsAvailable = useContext(SettingsContext);
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
+  const toggleSettings = useCallback(() => setShowSettings((s) => !s), []);
 
   // Show tutorial overlay on first visit
   useEffect(() => {
@@ -74,6 +79,9 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   return (
     <div className="relative h-full w-full" data-reduced-motion={prefersReducedMotion}>
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
+      {showSettings && settingsAvailable && (
+        <GameSettingsWindow onClose={() => setShowSettings(false)} />
+      )}
       {paused && (
         <div
           className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
@@ -90,6 +98,15 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           </button>
         </div>
       )}
+      <button
+        type="button"
+        aria-label="Settings"
+        aria-expanded={showSettings}
+        onClick={toggleSettings}
+        className="absolute top-2 right-12 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+      >
+        ⚙
+      </button>
       <button
         type="button"
         aria-label="Help"

--- a/components/apps/GameSettingsWindow.tsx
+++ b/components/apps/GameSettingsWindow.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useSettings } from './GameSettingsContext';
+
+interface Props {
+  onClose: () => void;
+}
+
+const GameSettingsWindow: React.FC<Props> = ({ onClose }) => {
+  const {
+    difficulty,
+    setDifficulty,
+    assists,
+    setAssists,
+    colorBlind,
+    setColorBlind,
+    highContrast,
+    setHighContrast,
+    quality,
+    setQuality,
+  } = useSettings();
+
+  return (
+    <div
+      className="absolute inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-gray-800 text-white p-4 rounded shadow-lg space-y-3 w-72">
+        <h2 className="text-xl font-bold mb-2">Settings</h2>
+        <label className="flex items-center justify-between">
+          <span className="mr-2">Difficulty</span>
+          <select
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value)}
+            className="bg-gray-700 text-white rounded px-2 py-1"
+          >
+            <option value="easy">Easy</option>
+            <option value="normal">Normal</option>
+            <option value="hard">Hard</option>
+          </select>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={assists}
+            onChange={(e) => setAssists(e.target.checked)}
+            className="mr-2"
+          />
+          <span>Assists</span>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={colorBlind}
+            onChange={(e) => setColorBlind(e.target.checked)}
+            className="mr-2"
+          />
+          <span>Color Blind Mode</span>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={highContrast}
+            onChange={(e) => setHighContrast(e.target.checked)}
+            className="mr-2"
+          />
+          <span>High Contrast</span>
+        </label>
+        <label className="flex items-center">
+          <span className="mr-2">Quality</span>
+          <input
+            type="range"
+            min="0.5"
+            max="1"
+            step="0.1"
+            value={quality}
+            onChange={(e) => setQuality(parseFloat(e.target.value))}
+          />
+        </label>
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="mt-2 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GameSettingsWindow;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -47,12 +47,14 @@ export class Desktop extends Component {
         });
         this.setContextListeners();
         this.setEventListeners();
+        this.setKeyListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
+        this.removeKeyListeners();
     }
 
     checkForNewFolders = () => {
@@ -84,6 +86,27 @@ export class Desktop extends Component {
                 this.openApp("settings");
             });
         }
+    }
+
+    setKeyListeners = () => {
+        this.keyHandler = (e) => {
+            if ((e.key === 'c' || e.key === 'C') && this.isDesktopFocused()) {
+                e.preventDefault();
+                this.openApp('gedit');
+            }
+        };
+        window.addEventListener('keydown', this.keyHandler);
+    }
+
+    removeKeyListeners = () => {
+        if (this.keyHandler) window.removeEventListener('keydown', this.keyHandler);
+    }
+
+    isDesktopFocused = () => {
+        const { focused_windows } = this.state;
+        const noWindowFocused = Object.values(focused_windows).every(v => !v);
+        const active = document.activeElement;
+        return noWindowFocused && (active === document.body || active === null);
     }
 
     setContextListeners = () => {


### PR DESCRIPTION
## Summary
- add in-game settings modal with difficulty, assist, accessibility and quality toggles
- support showing modal from GameLayout
- open Contact app from desktop when pressing `C`

## Testing
- `npm test` *(fails: memoryGame, BeEF, Autopsy, NmapNSE)*

------
https://chatgpt.com/codex/tasks/task_e_68af28458dd08328a34820754572210c