### PR TITLE
feat(qr): add device choice and design tab

### DIFF
--- a/components/apps/qr_tool/scan.worker.js
+++ b/components/apps/qr_tool/scan.worker.js
@@ -1,8 +1,24 @@
 import jsQR from 'jsqr';
 
+const flipHorizontal = (data, width, height) => {
+  const flipped = new Uint8ClampedArray(data.length);
+  const bytes = 4;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const src = (y * width + x) * bytes;
+      const dst = (y * width + (width - x - 1)) * bytes;
+      for (let i = 0; i < bytes; i += 1) {
+        flipped[dst + i] = data[src + i];
+      }
+    }
+  }
+  return flipped;
+};
+
 self.onmessage = (e) => {
-  const { data, width, height } = e.data;
-  const code = jsQR(data, width, height);
+  const { data, width, height, flip } = e.data;
+  const input = flip ? flipHorizontal(data, width, height) : data;
+  const code = jsQR(input, width, height);
   self.postMessage(code ? code.data : null);
 };
 


### PR DESCRIPTION
## Summary
- allow choosing camera and toggling torch when scanning QR codes
- add design tab for QR colors, eye shapes, logo overlay and PNG/SVG export
- flip frames in worker to respect selected device orientation

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68af2847fa348328abdb006ef24a7558