### PR TITLE
feat(beef): add replay controls and graph tooltips

### DIFF
--- a/__tests__/beef.test.tsx
+++ b/__tests__/beef.test.tsx
@@ -1,85 +1,43 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 jest.mock('react-cytoscapejs', () => () => null);
 jest.mock('../components/apps/beef/HookGraph', () => () => null);
-beforeAll(() => {
-  (global as any).URL.createObjectURL = () => '';
-});
-import { TextEncoder, TextDecoder } from 'util';
-import { ReadableStream } from 'stream/web';
+
 import Beef from '../components/apps/beef';
 
 describe('BeEF app', () => {
   beforeEach(() => {
-    // hide help overlay
     window.localStorage.setItem('beefHelpDismissed', 'true');
     (global as any).fetch = jest.fn();
-    (global as any).TextDecoder = TextDecoder;
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('updates hook list when new hooks arrive', async () => {
-    jest.useFakeTimers();
+  it('refreshes hooks and runs modules from demo data', async () => {
     const hookResponses = [
       { hooked_browsers: [{ id: '1' }] },
       { hooked_browsers: [{ id: '1' }, { id: '2' }] },
     ];
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
-      if (url.endsWith('/api/hooks')) {
+      if (url.endsWith('/demo-data/beef/hooks.json')) {
         const data = hookResponses.shift();
         return Promise.resolve({ json: () => Promise.resolve(data) });
       }
-      if (url.endsWith('/api/modules')) {
-        return Promise.resolve({ json: () => Promise.resolve({ modules: [] }) });
+      if (url.endsWith('/demo-data/beef/modules.json')) {
+        return Promise.resolve({ json: () => Promise.resolve({ modules: [{ id: 'mod1', name: 'Module 1', output: 'out' }] }) });
+      }
+      if (url.endsWith('/demo-data/beef/events.json')) {
+        return Promise.resolve({ json: () => Promise.resolve({ events: [] }) });
       }
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 
     render(<Beef />);
-    // initial hooks fetch
     expect(await screen.findByText('1')).toBeInTheDocument();
-    expect(screen.queryByText('2')).toBeNull();
-
-    await act(async () => {
-      jest.advanceTimersByTime(5000);
-    });
-
+    fireEvent.click(screen.getByText('Refresh'));
     expect(await screen.findByText('2')).toBeInTheDocument();
-  });
 
-  it('streams module output to UI', async () => {
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(encoder.encode('chunk1'));
-        controller.enqueue(encoder.encode('chunk2'));
-        controller.close();
-      },
-    });
-
-    (global.fetch as jest.Mock).mockImplementation((url: string, opts?: any) => {
-      if (url.endsWith('/api/hooks')) {
-        return Promise.resolve({ json: () => Promise.resolve({ hooked_browsers: [{ id: '1' }] }) });
-      }
-      if (url.endsWith('/api/modules') && (!opts || opts.method === 'GET')) {
-        return Promise.resolve({ json: () => Promise.resolve({ modules: [{ id: 'mod1', name: 'Module 1' }] }) });
-      }
-      if (url.includes('/api/modules/mod1/1')) {
-        return Promise.resolve({ body: stream });
-      }
-      return Promise.resolve({ json: () => Promise.resolve({}) });
-    });
-
-    render(<Beef />);
-    // select hook
-    fireEvent.click(await screen.findByText('1'));
-    // choose module
+    fireEvent.click(screen.getByText('1'));
     fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'mod1' } });
     fireEvent.click(screen.getByText('Run Module'));
-
-    expect(await screen.findByText('chunk1chunk2')).toBeInTheDocument();
+    expect(await screen.findByText('out')).toBeInTheDocument();
   });
 });

--- a/public/demo-data/beef/events.json
+++ b/public/demo-data/beef/events.json
@@ -1,0 +1,9 @@
+{
+  "events": [
+    { "type": "hook", "hook": { "id": "demo1", "name": "Demo Client 1", "status": "online" } },
+    { "type": "hook", "hook": { "id": "demo2", "name": "Demo Client 2", "status": "offline" } },
+    { "type": "module", "hook": "demo1", "module": "alert" },
+    { "type": "module", "hook": "demo1", "module": "get-cookie" },
+    { "type": "module", "hook": "demo2", "module": "alert" }
+  ]
+}


### PR DESCRIPTION
## Summary
- load BeEF demo events and add playback with play/pause controls
- enhance hook graph with Cytoscape tooltips for nodes
- include sample event data for demo replay

## Testing
- `npm test` *(fails: memoryGame combo meter, autopsy filter, nmapNse app)*

------
https://chatgpt.com/codex/tasks/task_e_68af28502d8c832890d26b9fa59ef8e6