### PR TITLE
feat: expand figlet fonts and ascii export

### DIFF
--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -366,8 +366,9 @@ export default function AsciiArt() {
           type="button"
           onClick={downloadAscii}
           className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded"
+          aria-label="Export ASCII as .txt"
         >
-          TXT
+          Export TXT
         </button>
         <button
           type="button"

--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useRef } from 'react';
 
 const FigletApp = () => {
   const [text, setText] = useState('');
-  const [fonts, setFonts] = useState(['Standard']);
-  const [font, setFont] = useState('Standard');
+  const [fonts, setFonts] = useState([]);
+  const [font, setFont] = useState('');
   const [output, setOutput] = useState('');
   const [inverted, setInverted] = useState(false);
   const [announce, setAnnounce] = useState('');
@@ -16,7 +16,7 @@ const FigletApp = () => {
     workerRef.current.onmessage = (e) => {
       if (e.data?.type === 'fonts') {
         setFonts(e.data.fonts);
-        setFont(e.data.fonts[0]);
+        setFont(e.data.fonts[0] || '');
       } else if (e.data?.type === 'render') {
         setOutput(e.data.output);
         setAnnounce('Preview updated');
@@ -32,7 +32,7 @@ const FigletApp = () => {
   }, []);
 
   const updateFiglet = () => {
-    if (workerRef.current) {
+    if (workerRef.current && font) {
       workerRef.current.postMessage({ text, font });
     }
   };
@@ -61,11 +61,17 @@ const FigletApp = () => {
           onChange={(e) => setFont(e.target.value)}
           aria-label="Select font"
         >
-          {fonts.map((f) => (
-            <option key={f} value={f}>
-              {f}
+          {fonts.length === 0 ? (
+            <option value="" disabled>
+              Loading...
             </option>
-          ))}
+          ) : (
+            fonts.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))
+          )}
         </select>
         <input
           type="text"


### PR DESCRIPTION
## Summary
- fetch Figlet font list from CDN and use async text rendering
- populate Figlet font dropdown dynamically
- add accessible TXT export button to ASCII Art app

## Testing
- `npm test` *(fails: memoryGame.test.tsx, nmapNse.test.tsx, beef.test.tsx, autopsy.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2853f6908328a2e84d554228e4a8