### PR TITLE
Switch key pages to JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ yarn export        # outputs to ./out
 
 ```
 pages/
-  _app.tsx               # global providers (Legal banner, GA init, Vercel Analytics)
-  _document.tsx
-  index.tsx              # mounts <Ubuntu />
+  _app.jsx               # global providers (Legal banner, GA init, Vercel Analytics)
+  _document.jsx
+  index.jsx              # mounts <Ubuntu />
   api/                   # (dev/server) stub routes for demo-only features
   apps/                  # a few example pages
 

--- a/docs/pip-portal.md
+++ b/docs/pip-portal.md
@@ -28,7 +28,7 @@ function HudButton() {
   );
 }
 
-// in _app.tsx
+// in _app.jsx
 export default function App({ Component, pageProps }) {
   return (
     <PipPortalProvider>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,3 @@
-import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
@@ -10,7 +9,10 @@ import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import DemoBanner from '../components/DemoBanner';
 
-function MyApp({ Component, pageProps }: AppProps) {
+/**
+ * @param {import('next/app').AppProps} props
+ */
+function MyApp({ Component, pageProps }) {
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
     if (trackingId) {

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,7 +1,10 @@
-import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+  /**
+   * @param {import('next/document').DocumentContext} ctx
+   */
+  static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
     return { ...initialProps };
   }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
 import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
 import MockTerminal from '../components/MockTerminal';
 
-const App: React.FC = () => (
+/**
+ * @returns {JSX.Element}
+ */
+const App = () => (
   <>
     <Meta />
     <Ubuntu />


### PR DESCRIPTION
## Summary
- convert core Next pages to `.jsx` extensions
- drop type-only imports and annotate component props with JSDoc
- update docs to reference new filenames

## Testing
- `npm run smoke` *(fails: Missing script "smoke")*

------
https://chatgpt.com/codex/tasks/task_e_68af3ef3ba4883288221d6a282263ba7