### PR TITLE
Add smoke test for app routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,4 +341,19 @@ See [`LICENSE`](./LICENSE).
 - `test` → `jest`
 - `test:watch` → `jest --watch`
 - `lint` → `next lint`
+- `smoke` → `node scripts/smoke-all-apps.mjs`
+
+### Smoke Tests
+
+Start the development server in one terminal:
+
+```bash
+npm run dev
+```
+
+In another terminal, run the Playwright smoke test which visits every `/apps/*` route and fails on console errors:
+
+```bash
+npm run smoke
+```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "next lint",
-    "a11y": "pa11y-ci --config pa11yci.json"
+    "a11y": "pa11y-ci --config pa11yci.json",
+    "smoke": "node scripts/smoke-all-apps.mjs"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -1,0 +1,39 @@
+import { chromium } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+
+  const pagesDir = path.join(process.cwd(), 'pages', 'apps');
+  const files = fs.readdirSync(pagesDir, { withFileTypes: true })
+    .filter((d) => d.isFile() && /\.(jsx?|tsx?)$/.test(d.name))
+    .map((d) => d.name);
+
+  const routes = files.map((file) => `/apps/${file.replace(/\.(jsx?|tsx?)$/, '')}`);
+
+  for (const route of routes) {
+    const page = await context.newPage();
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    console.log(`Visiting ${route}`);
+    const response = await page.goto(`${BASE_URL}${route}`);
+    if (!response || !response.ok()) {
+      throw new Error(`Failed to load ${route}: ${response ? response.status() : 'no response'}`);
+    }
+    if (consoleErrors.length > 0) {
+      throw new Error(`Console errors on ${route}:\n${consoleErrors.join('\n')}`);
+    }
+    await page.close();
+  }
+
+  await browser.close();
+  console.log('All app routes loaded without console errors.');
+})();


### PR DESCRIPTION
## Summary
- add Playwright smoke test visiting every `/apps/*` route and failing on console errors
- expose test via `npm run smoke`
- document smoke test usage

## Testing
- `npm test` *(fails: memoryGame, BeEF, autopsy, nmapNse)*
- `npm run smoke` *(fails: console error on /apps/2048)*

------
https://chatgpt.com/codex/tasks/task_e_68af3ef7db9483289e99668174c816e5