### PR TITLE
Use logger for fullscreen errors

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import logger from '../../utils/logger'
 
 function DesktopMenu(props) {
 
@@ -38,7 +39,7 @@ function DesktopMenu(props) {
             }
         }
         catch (e) {
-            console.log(e)
+            logger.error(e)
         }
     }
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,28 @@
+const loggedMessages = new Set()
+
+const formatKey = (args) => args
+  .map(a => {
+    if (a instanceof Error) {
+      return a.stack || a.message
+    }
+    if (typeof a === 'object') {
+      try {
+        return JSON.stringify(a)
+      } catch {
+        return String(a)
+      }
+    }
+    return String(a)
+  })
+  .join(' ')
+
+const logger = {
+  error: (...args) => {
+    const key = formatKey(args)
+    if (loggedMessages.has(key)) return
+    loggedMessages.add(key)
+    console.error(...args)
+  }
+}
+
+export default logger


### PR DESCRIPTION
## Summary
- use deduplicating logger for fullscreen errors in desktop context menu
- add lightweight logger utility that avoids duplicate messages

## Testing
- `npm run smoke` *(fails: Missing script "smoke")*

------
https://chatgpt.com/codex/tasks/task_e_68af3efa41548328b648ca48a3f0794f