### PR TITLE
chore: remove duplicate referrer policy

### DIFF
--- a/components/apps/YouTube/index.tsx
+++ b/components/apps/YouTube/index.tsx
@@ -111,7 +111,6 @@ export default function YouTubeApp({ initialVideos = [] as Video[] }) {
               referrerPolicy="no-referrer"
               allowFullScreen
               loading="lazy"
-              referrerPolicy="strict-origin-when-cross-origin"
             />
             <div className="absolute inset-x-0 bottom-0 flex justify-between p-1 bg-black/60 text-xs">
               <button


### PR DESCRIPTION
## Summary
- fix YouTube iframe to use a single referrerPolicy attribute

## Testing
- `yarn lint --file components/apps/YouTube/index.tsx`
- `yarn test` *(fails: `memoryGame.test.tsx`, `beef.test.tsx`, `autopsy.test.tsx`, `nmapNse.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ce5a5748328bcbac9bec6c44c6d