### PR TITLE
refactor: export haptics constant

### DIFF
--- a/components/apps/Games/common/haptics/index.ts
+++ b/components/apps/Games/common/haptics/index.ts
@@ -52,10 +52,12 @@ export const score = () => vibrate(patterns.score);
 export const danger = () => vibrate(patterns.danger);
 export const gameOver = () => vibrate(patterns.gameOver);
 
-export default {
+const haptics = {
   vibrate,
   score,
   danger,
   gameOver,
   patterns,
 };
+
+export default haptics;


### PR DESCRIPTION
## Summary
- export haptic utilities via named constant

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, nmapNse)*
- `yarn lint` *(fails: react hooks/rules-of-hooks etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af6ce355688328bf191e55d87d3faa