### PR TITLE
Escape apostrophe in About app text

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -38,7 +38,7 @@ export default function AboutApp() {
       />
       <h2 id="about-heading" className="text-2xl font-bold mb-4">About</h2>
       <p className="mb-6 max-w-[60ch] leading-relaxed">
-        I'm Alex Unnippillil, a security engineer focused on building accessible
+        I&apos;m Alex Unnippillil, a security engineer focused on building accessible
         security tooling and exploring new web technologies.
       </p>
       <section aria-labelledby="now-heading" className="mb-6 max-w-[60ch]">


### PR DESCRIPTION
## Summary
- escape apostrophe in About app copy to avoid raw `'`
- scan JSX/TSX files to confirm no other unescaped apostrophes remain

## Testing
- `yarn lint` *(fails: React Hook rule violations in unrelated files)*
- `yarn test` *(fails: memoryGame, BeEF, Autopsy, NmapNSE test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ce1cd6c83288876b766ab7dd6cb