### PR TITLE
Guard NSE documentation link against SSR

### DIFF
--- a/pages/apps/nmap-nse.tsx
+++ b/pages/apps/nmap-nse.tsx
@@ -18,11 +18,13 @@ const NmapNSEPage: React.FC = () => {
     }
   }, []);
   const openScriptDoc = useCallback((name: string) => {
-    window.open(
-      `https://nmap.org/nsedoc/scripts/${name}.html`,
-      '_blank',
-      'noopener,noreferrer'
-    );
+    if (typeof window !== 'undefined') {
+      window.open(
+        `https://nmap.org/nsedoc/scripts/${name}.html`,
+        '_blank',
+        'noopener,noreferrer'
+      );
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- guard nmap NSE doc links for server-side rendering by checking for `window`

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse)*
- `npm run lint` *(fails: React hook rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e551d348328bea62b99b4807cbe