### PR TITLE
fix: ensure HelpOverlay hook initialized

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HelpOverlay from '../components/apps/HelpOverlay';
+
+describe('HelpOverlay', () => {
+  it('returns null when no instructions exist for the game', () => {
+    const { container } = render(<HelpOverlay gameId="unknown" onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders instructions when available', () => {
+    render(<HelpOverlay gameId="2048" onClose={() => {}} />);
+    expect(screen.getByText('2048 Help')).toBeInTheDocument();
+    expect(
+      screen.getByText('Reach the 2048 tile by merging numbers.')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/up: ArrowUp/i)).toBeInTheDocument();
+  });
+});

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -156,8 +156,8 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
 
 const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
+  const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
   if (!info) return null;
-  const [mapping, setKey] = useInputMapping(gameId, info.actions || {});
   return (
     <div
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"


### PR DESCRIPTION
## Summary
- move useInputMapping hook above early-return in HelpOverlay
- add tests covering HelpOverlay rendering with and without instructions

## Testing
- `yarn test __tests__/HelpOverlay.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afbad0a5bc8328be1a0c866edbdeb0