### PR TITLE
refactor HelpOverlay rendering

### DIFF
--- a/components/apps/HelpOverlay.jsx
+++ b/components/apps/HelpOverlay.jsx
@@ -2,18 +2,7 @@ import React from 'react';
 import InputRemap from './Games/common/input-remap/InputRemap';
 import useInputMapping from './Games/common/input-remap/useInputMapping';
 
-interface HelpOverlayProps {
-  gameId: string;
-  onClose: () => void;
-}
-
-interface Instruction {
-  objective: string;
-  controls: string;
-  actions?: Record<string, string>;
-}
-
-export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
+export const GAME_INSTRUCTIONS = {
   '2048': {
     objective: 'Reach the 2048 tile by merging numbers.',
     controls: 'Use the arrow keys to slide and combine tiles.',
@@ -154,11 +143,11 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
   },
 };
 
-const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
+const HelpOverlay = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
-  if (!info) return null;
-  const [mapping, setKey] = useInputMapping(gameId, info.actions || {});
-  return (
+  const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
+
+  return info ? (
     <div
       className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
       role="dialog"
@@ -193,7 +182,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         </button>
       </div>
     </div>
-  );
+  ) : null;
 };
 
 export default HelpOverlay;


### PR DESCRIPTION
## Summary
- convert HelpOverlay to JSX and remove TypeScript types
- move input mapping hook before null check and render overlay conditionally

## Testing
- `npm test` *(fails: combo meter increments and resets, BeEF app updates hook list, BeEF app streams module output to UI, Autopsy plugins and timeline filters artifacts by type, NmapNSEApp shows example output for selected script, NmapNSEApp copies command to clipboard)*
- `npm run lint` *(fails: react/no-unescaped-entities, react-hooks/rules-of-hooks, others)*

------
https://chatgpt.com/codex/tasks/task_e_68afbab6afb08328a3b85d1119f53071