### PR TITLE
fix: escape apostrophe in About text

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -38,7 +38,7 @@ export default function AboutApp() {
       />
       <h2 id="about-heading" className="text-2xl font-bold mb-4">About</h2>
       <p className="mb-6 max-w-[60ch] leading-relaxed">
-        I'm Alex Unnippillil, a security engineer focused on building accessible
+        I&apos;m Alex Unnippillil, a security engineer focused on building accessible
         security tooling and exploring new web technologies.
       </p>
       <section aria-labelledby="now-heading" className="mb-6 max-w-[60ch]">


### PR DESCRIPTION
## Summary
- escape apostrophe in About app text to satisfy react/no-unescaped-entities

## Testing
- `yarn test` (fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, nmapNse.test.tsx)
- `yarn lint components/apps/About/index.tsx` (fails: couldn't find any `pages` or `app` directory)


------
https://chatgpt.com/codex/tasks/task_e_68afbab5500883289dea316ca4c4870f