### PR TITLE
Remove demo banner from top bar

### DIFF
--- a/components/DemoBanner.tsx
+++ b/components/DemoBanner.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-const DemoBanner: React.FC = () => (
-  <div className="bg-red-600 text-white text-center py-2 font-bold" data-testid="demo-banner">
-    Demo Only
-  </div>
-);
-
-export default DemoBanner;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,7 +7,6 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
-import DemoBanner from '../components/DemoBanner';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -26,7 +25,6 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <DemoBanner />
       <Component {...pageProps} />
       <Analytics />
     </SettingsProvider>


### PR DESCRIPTION
## Summary
- remove demo banner top bar from global app
- delete unused DemoBanner component

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, nmapNse)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68afdb1da1f48328b2c8f283975b14df