### PR TITLE
Allow Google Fonts stylesheets in CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,11 +13,12 @@ const ContentSecurityPolicy = [
   "img-src 'self' https: data:",
   // Permit inline styles and Google Fonts
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  // Explicitly allow external stylesheets
+  "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
   // Allow loading fonts from Google
   "font-src 'self' https://fonts.gstatic.com",
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com",
-
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content


### PR DESCRIPTION
## Summary
- explicitly allow external stylesheets from Google Fonts in Content Security Policy

## Testing
- `yarn lint` *(fails: Synchronous scripts should not be used)*
- `yarn test` *(fails: combo meter increments and resets; card flip applies transform style; BeEF app updates hook list when new hooks arrive; Autopsy plugins filter artifacts by type; NmapNSEApp shows example output for selected script)*

------
https://chatgpt.com/codex/tasks/task_e_68afeb81f3f483288eca117452a2bf80