### PR TITLE
fix: load theme script asynchronously

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 class MyDocument extends Document {
   /**
@@ -15,7 +16,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#000000" />
-          <script src="/theme.js" />
+          <Script src="/theme.js" strategy="beforeInteractive" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Summary
- use Next.js `Script` with `strategy="beforeInteractive"` to load theme.js

## Testing
- `yarn lint` *(fails: next lint deprecated, couldn't find pages directory)*
- `yarn test` *(fails: memoryGame, beef, autopsy, nmapNse)*
- `yarn test __tests__/terminal.test.tsx`
- `yarn build` *(partial: build hung while collecting build traces)*

------
https://chatgpt.com/codex/tasks/task_e_68afee933d2c8328a9994a809df3598d