### PR TITLE
refactor: restore contact app to JavaScript

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -6,7 +6,7 @@ import { displayVsCode } from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/Chrome';
 import { displayTrash } from './components/apps/trash';
-import { displayGedit } from './components/apps/gedit';
+import { displayContact } from './components/apps/contact';
 import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
 import { displayWeather } from './components/apps/weather';
@@ -711,7 +711,7 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
-    screen: displayGedit,
+    screen: displayContact,
   },
   {
     id: 'converter',

--- a/components/apps/contact.js
+++ b/components/apps/contact.js
@@ -1,21 +1,18 @@
 import React, { useState } from 'react';
-import FormError from '../../ui/FormError';
+import FormError from '../ui/FormError';
 
-export const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
+export const isValidEmail = (email) => /\S+@\S+\.\S+/.test(email);
 
-const sanitize = (str: string) =>
+const sanitize = (str) =>
   str.replace(/[&<>"']/g, (c) => ({
     '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
     "'": '&#39;',
-  }[c]!));
+  }[c]));
 
-export const processContactForm = async (
-  data: { name: string; email: string; message: string; honeypot: string },
-  fetchImpl: typeof fetch = fetch
-) => {
+export const processContactForm = async (data, fetchImpl = fetch) => {
   const name = data.name.trim();
   const email = data.email.trim();
   const message = data.message.trim();
@@ -52,7 +49,7 @@ const ContactApp = () => {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     const result = await processContactForm({ name, email, message, honeypot });
     if (!result.success) {
@@ -113,4 +110,6 @@ const ContactApp = () => {
 };
 
 export default ContactApp;
+
+export const displayContact = () => <ContactApp />;
 


### PR DESCRIPTION
## Summary
- replace contact TypeScript component with previous JavaScript version and export displayContact helper
- update apps.config.js to use displayContact for the Contact Me shortcut

## Testing
- `npm test __tests__/contact.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b00b1c77a88328b5ba0e31239f1346