### PR TITLE
Load JS modules for Sokoban and Word Search pages

### DIFF
--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const Sokoban = dynamic(() => import('../../apps/sokoban'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Sokoban = dynamic<{ getDailySeed?: () => Promise<string> }>(
+  () => import('../../components/apps/sokoban'),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+);
 
 const SokobanPage: React.FC = () => (
   <Sokoban getDailySeed={() => getDailySeed('sokoban')} />

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
 const WordSearch = dynamic<{ getDailySeed?: () => Promise<string> }>(
-  () => import('../../apps/word_search'),
+  () => import('../../components/apps/word-search'),
   { ssr: false },
 );
 


### PR DESCRIPTION
## Summary
- switch Word Search page to use restored `components/apps/word-search` module
- load Sokoban from its JS module and type its dynamic import

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, nmapNse.test.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b00b2bc5ac8328ac3e6676d047671b