### PR TITLE
feat: remove light/dark modes for kali theme

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -17,7 +17,7 @@ export default function Meta() {
             <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
             <meta name="language" content="English" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#E95420" />
+            <meta name="theme-color" content="#0f1317" />
 
             {/* Search Engine */}
             <meta name="image" content="images/logos/fevicon.png" />

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { theme, setTheme, accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -52,23 +52,11 @@ export function Settings() {
             }
         });
         return () => cancelAnimationFrame(raf);
-    }, [accent, theme, accentText, contrastRatio]);
+    }, [accent, accentText, contrastRatio]);
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
-            </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
-                <select
-                    value={theme}
-                    onChange={(e) => setTheme(e.target.value)}
-                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-                >
-                    <option value="system">System</option>
-                    <option value="dark">Dark</option>
-                    <option value="light">Light</option>
-                </select>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
@@ -105,7 +93,7 @@ export function Settings() {
             <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: theme === 'dark' ? '#000000' : '#ffffff', color: theme === 'dark' ? '#ffffff' : '#000000' }}
+                    style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
                 >
                     <p className="mb-2 text-center">Preview</p>
                     <button
@@ -146,7 +134,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={async () => { await resetSettings(); setTheme(defaults.theme); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
+                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,12 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useSettings } from '../../hooks/useSettings';
 
 const MAX_CHARS = 280;
 const RADIUS = 18;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export default function XApp() {
-  const { theme } = useSettings();
+  const theme = 'dark';
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [timelineKey, setTimelineKey] = useState(0);
@@ -128,7 +127,7 @@ export default function XApp() {
       clearTimeout(timeout);
       script && script.removeEventListener('error', handleError);
     };
-  }, [theme, timelineKey, shouldLoadTimeline]);
+  }, [timelineKey, shouldLoadTimeline]);
 
   return (
     <div className="h-full w-full overflow-auto bg-ub-cool-grey flex flex-col tweet-container">

--- a/components/util-components/status_card.js
+++ b/components/util-components/status_card.js
@@ -27,8 +27,7 @@ export class StatusCard extends Component {
                 this.wrapperRef = React.createRef();
                 this.state = {
                         sound_level: 75, // better of setting default values from localStorage
-                        brightness_level: 100, // setting default value to 100 so that by default its always full.
-                        theme: 'dark'
+                        brightness_level: 100 // setting default value to 100 so that by default its always full.
                 };
         }
         handleClickOutside = () => {
@@ -37,8 +36,7 @@ export class StatusCard extends Component {
         componentDidMount() {
                 this.setState({
                         sound_level: localStorage.getItem('sound-level') || 75,
-                        brightness_level: localStorage.getItem('brightness-level') || 100,
-                        theme: document.documentElement.dataset.theme || 'dark'
+                        brightness_level: localStorage.getItem('brightness-level') || 100
                 }, () => {
                         document.getElementById('monitor-screen').style.filter = `brightness(${3 / 400 * this.state.brightness_level +
                                 0.25})`;
@@ -57,16 +55,7 @@ export class StatusCard extends Component {
                 localStorage.setItem('sound-level', e.target.value);
         };
 
-        setTheme = (theme) => {
-                this.setState({ theme });
-                localStorage.setItem('theme', theme);
-                document.documentElement.dataset.theme = theme;
-        };
-
-        toggleTheme = () => {
-                const next = this.state.theme === 'dark' ? 'light' : 'dark';
-                this.setTheme(next);
-        };
+        // theme toggling removed for Kali theme
 
 	render() {
 		return (
@@ -116,24 +105,7 @@ export class StatusCard extends Component {
                                                 aria-label="Screen brightness"
                                         />
                                 </div>
-                                <div
-                                        className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20"
-                                        onClick={this.toggleTheme}
-                                >
-                                        <div className="w-8">
-                                                <Image
-                                                        width={16}
-                                                        height={16}
-                                                        src="/themes/Yaru/status/display-brightness-symbolic.svg"
-                                                        alt="theme toggle"
-                                                        sizes="16px"
-                                                />
-                                        </div>
-                                        <div className="w-2/3 flex items-center justify-between">
-                                                <span>Theme</span>
-                                                <span>{this.state.theme === 'dark' ? 'Dark' : 'Light'}</span>
-                                        </div>
-                                </div>
+                                {/* Theme toggle removed for fixed Kali theme */}
                                 <div className="w-64 flex content-center justify-center">
                                         <div className="w-2/4 border-black border-opacity-50 border-b my-2 border-solid" />
                                 </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,7 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import {
-  getTheme as loadTheme,
-  setTheme as saveTheme,
   getAccent as loadAccent,
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
@@ -12,17 +10,13 @@ import {
   setReducedMotion as saveReducedMotion,
   defaults,
 } from '../utils/settingsStore';
-
-type Theme = 'light' | 'dark' | 'system';
 type Density = 'regular' | 'compact';
 
 interface SettingsContextValue {
-  theme: Theme;
   accent: string;
   wallpaper: string;
   density: Density;
   reducedMotion: boolean;
-  setTheme: (theme: Theme) => void;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -30,12 +24,10 @@ interface SettingsContextValue {
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
-  theme: defaults.theme as Theme,
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
-  setTheme: () => {},
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -43,7 +35,6 @@ export const SettingsContext = createContext<SettingsContextValue>({
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(defaults.theme as Theme);
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
@@ -51,32 +42,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     (async () => {
-      setTheme((await loadTheme()) as Theme);
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
     })();
   }, []);
-
-  useEffect(() => {
-    const applyTheme = () => {
-      const resolved = theme === 'system'
-        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-        : theme;
-      document.documentElement.dataset.theme = resolved;
-    };
-
-    applyTheme();
-    saveTheme(theme);
-
-    let media: MediaQueryList | undefined;
-    if (theme === 'system') {
-      media = window.matchMedia('(prefers-color-scheme: dark)');
-      media.addEventListener('change', applyTheme);
-      return () => media?.removeEventListener('change', applyTheme);
-    }
-  }, [theme]);
 
   useEffect(() => {
     document.documentElement.style.setProperty('--color-ub-orange', accent);
@@ -119,7 +90,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [reducedMotion]);
 
   return (
-    <SettingsContext.Provider value={{ theme, accent, wallpaper, density, reducedMotion, setTheme, setAccent, setWallpaper, setDensity, setReducedMotion }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, setAccent, setWallpaper, setDensity, setReducedMotion }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,1 +1,1 @@
-export const useTheme = () => ({ theme: 'light', setTheme: () => {} });
+export const useTheme = () => ({ theme: 'kali', setTheme: () => {} });

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -15,7 +15,7 @@ class MyDocument extends Document {
       <Html lang="en">
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
-          <meta name="theme-color" content="#000000" />
+          <meta name="theme-color" content="#0f1317" />
           <Script src="/theme.js" strategy="beforeInteractive" />
         </Head>
         <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "KaliPortfolio",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#000000",
-  "theme_color": "#000000",
+  "background_color": "#0f1317",
+  "theme_color": "#0f1317",
   "icons": [
     {
       "src": "/images/logos/fevicon.png",

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,7 +1,5 @@
 (function () {
   try {
-    var stored = window.localStorage.getItem('theme');
-    var theme = stored ? stored : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    document.documentElement.dataset.theme = theme;
+    document.documentElement.dataset.theme = 'kali';
   } catch (e) {}
 })();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,17 +3,17 @@
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
   /* Base colors */
-  --color-bg: #121212; /* background, 17.18:1 vs --color-text */
+  --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
   /* Brand accents */
-  --color-primary: #e95420; /* 5.13:1 on --color-bg */
-  --color-secondary: #77216f; /* 8.63:1 vs --color-text */
-  --color-accent: #00a36c; /* 5.76:1 on --color-bg */
+  --color-primary: #1793d1; /* kali blue accent */
+  --color-secondary: #1a1f26; /* complementary dark */
+  --color-accent: #1793d1; /* accent matches primary */
   /* Utility colors */
-  --color-muted: #333333; /* 11.59:1 vs --color-text */
-  --color-surface: #ffffff; /* light surfaces, 15.3:1 vs --color-bg */
+  --color-muted: #2a2e36; /* muted surfaces */
+  --color-surface: #1a1f26; /* panel surfaces */
   --color-inverse: #000000; /* inverse of text */
-  --color-border: #d3d7cf; /* subtle borders */
-  --color-terminal: #00ff00; /* terminal green, 15.3:1 on --color-inverse */
-  --color-dark: #1f2937; /* card back */
+  --color-border: #2a2e36; /* subtle borders */
+  --color-terminal: #00ff00; /* terminal green */
+  --color-dark: #0c0f12; /* card back */
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -2,14 +2,14 @@
 
 :root {
   /* Theme colors */
-  --color-ub-grey: #111111;
-  --color-ub-warm-grey: #AEA79F;
-  --color-ub-cool-grey: #333333;
-  --color-ub-orange: #E95420;
-  --color-ub-lite-abrgn: #77216F;
-  --color-ub-med-abrgn: #5E2750;
-  --color-ub-drk-abrgn: #2C001E;
-  --color-ub-window-title: #201f1f;
+  --color-ub-grey: #0f1317;
+  --color-ub-warm-grey: #7d7f83;
+  --color-ub-cool-grey: #1a1f26;
+  --color-ub-orange: #1793d1;
+  --color-ub-lite-abrgn: #22262c;
+  --color-ub-med-abrgn: #1b1f24;
+  --color-ub-drk-abrgn: #13171b;
+  --color-ub-window-title: #0c0f12;
   --color-ub-gedit-dark: #021B33;
   --color-ub-gedit-light: #003B70;
   --color-ub-gedit-darker: #010D1A;
@@ -21,10 +21,10 @@
   --color-ubt-gedit-orange: #F39A21;
   --color-ubt-gedit-blue: #50B6C6;
   --color-ubt-gedit-dark: #003B70;
-  --color-ub-border-orange: #E95420;
-  --color-ub-dark-grey: #555555;
-  --color-bg: #111111;
-  --color-text: #F6F6F5;
+  --color-ub-border-orange: #1793d1;
+  --color-ub-dark-grey: #2a2e36;
+  --color-bg: #0f1317;
+  --color-text: #F5F5F5;
 
   /* Spacing scale */
   --space-1: 0.25rem;
@@ -47,18 +47,6 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
-}
-
-/* Light theme */
-[data-theme='light'] {
-  --color-ub-grey: #ffffff;
-  --color-ub-warm-grey: #666666;
-  --color-ub-cool-grey: #e5e5e5;
-  --color-ub-window-title: #f0f0f0;
-  --color-ubt-grey: #111111;
-  --color-ubt-cool-grey: #4a4a4a;
-  --color-bg: #ffffff;
-  --color-text: #333333;
 }
 
 /* High contrast theme */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,22 +1,11 @@
 import { get, set, del } from 'idb-keyval';
 
 const DEFAULT_SETTINGS = {
-  theme: 'system',
-  accent: 'var(--color-primary)',
+  accent: '#1793d1',
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,
 };
-
-export async function getTheme() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.theme;
-  return (await get('theme')) || DEFAULT_SETTINGS.theme;
-}
-
-export async function setTheme(theme) {
-  if (typeof window === 'undefined') return;
-  await set('theme', theme);
-}
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
@@ -61,7 +50,6 @@ export async function setReducedMotion(value) {
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
-    del('theme'),
     del('accent'),
     del('bg-image'),
   ]);


### PR DESCRIPTION
## Summary
- drop light/dark mode toggling and stick with Kali look
- style defaults and metadata to match Kali colors
- simplify settings context and status card

## Testing
- `npm test` *(fails: memoryGame, beef app, autopsy, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68b00bc042b083289cfaa218c57f8f7a