### PR TITLE
Specify GameLayout file extension in games

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import useGameControls from './useGameControls';
 import { findHint } from '../../apps/games/_2048/ai';
 

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -11,7 +11,7 @@ import {
   createSeededRNG,
 } from './asteroids-utils';
 import useGameControls from './useGameControls';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 
 // Arcade-style tuning constants
 const THRUST = 0.1;

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -2,7 +2,7 @@
 
 import React, { useRef, useEffect, useState } from "react";
 import levelsData from "./breakout-levels.json";
-import GameLayout from "./GameLayout";
+import GameLayout from "./GameLayout.js";
 
 // Base logical canvas size (used if container size is unavailable)
 const WIDTH = 640;

--- a/components/apps/checkers.js
+++ b/components/apps/checkers.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import {
   createBoard,
   getPieceMoves,

--- a/components/apps/game.js
+++ b/components/apps/game.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 
 const lines = [
   [0, 1, 2],

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import { createDeck } from './memory_utils';
 
 const SIZE = 4;

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Howl } from 'howler';
 import seedrandom from 'seedrandom';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import usePersistentState from '../usePersistentState';
 
 const padStyles = [

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import useGameControls from './useGameControls';
 import useGameHaptics from '../../hooks/useGameHaptics';
 import usePersistentState from '../../hooks/usePersistentState';

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import useGameControls from './useGameControls';
 import levelPack from './sokoban_levels.json';
 

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 import useAssetLoader from '../../hooks/useAssetLoader';
 
 const EXTRA_LIFE_THRESHOLDS = [1000, 5000, 10000];

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import ReactGA from 'react-ga4';
 import confetti from 'canvas-confetti';
-import GameLayout from './GameLayout';
+import GameLayout from './GameLayout.js';
 
 const winningLines = [
   [0, 1, 2],


### PR DESCRIPTION
## Summary
- explicitly import `GameLayout.js` in assorted game components to clarify module resolution

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, nmapNse tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b00e82e9a88328978c8d5d5befbfe9