### PR TITLE
fix: mark game modules as client

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';

--- a/components/games/GameShell.jsx
+++ b/components/games/GameShell.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useCallback } from 'react';
 import useOrientationGuard from '../../hooks/useOrientationGuard';
 

--- a/components/games/VirtualControls.jsx
+++ b/components/games/VirtualControls.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import useGameInput from '../../hooks/useGameInput';
 

--- a/hooks/useGameAudio.js
+++ b/hooks/useGameAudio.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useCallback, useState } from 'react';
 import usePersistedState from './usePersistedState';
 

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback } from 'react';
 import usePersistedState from './usePersistedState';
 import {

--- a/hooks/useGameInput.js
+++ b/hooks/useGameInput.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 
 // Basic keyboard input handler. Works even when no touch or gamepad is present.

--- a/hooks/useOrientationGuard.js
+++ b/hooks/useOrientationGuard.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 // Tracks the device orientation. Useful for games that require landscape mode.

--- a/hooks/usePersistedState.js
+++ b/hooks/usePersistedState.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 // Stores state in localStorage, falling back when unavailable.


### PR DESCRIPTION
## Summary
- ensure game-related components and hooks run on the client by adding the `"use client"` directive

## Testing
- `yarn test` *(fails: memoryGame, BeEF, Autopsy, NmapNse, Calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b0347e86d083288b69f48573314225