### PR TITLE
Wrap vanilla apps in React wrappers

### DIFF
--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { useEffect } from 'react';
+import './styles.css';
+
+export default function Calculator() {
+  useEffect(() => {
+    const load = async () => {
+      if (typeof window !== 'undefined' && !(window as any).math) {
+        await new Promise((resolve) => {
+          const script = document.createElement('script');
+          script.src = 'https://cdn.jsdelivr.net/npm/mathjs@13.2.3/lib/browser/math.js';
+          script.onload = resolve;
+          document.body.appendChild(script);
+        });
+      }
+      await import('./main');
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="calculator">
+      <input id="display" className="display" />
+      <button id="toggle-precise" className="toggle" aria-pressed="false">Precise Mode: Off</button>
+      <button id="toggle-scientific" className="toggle" aria-pressed="false">Scientific</button>
+      <button id="toggle-programmer" className="toggle" aria-pressed="false">Programmer</button>
+      <button id="toggle-history" className="toggle" aria-pressed="false">History</button>
+      <div className="buttons">
+        <button className="btn" data-value="7">7</button>
+        <button className="btn" data-value="8">8</button>
+        <button className="btn" data-value="9">9</button>
+        <button className="btn" data-value="/">&divide;</button>
+        <button className="btn" data-value="4">4</button>
+        <button className="btn" data-value="5">5</button>
+        <button className="btn" data-value="6">6</button>
+        <button className="btn" data-value="*">&times;</button>
+        <button className="btn" data-value="1">1</button>
+        <button className="btn" data-value="2">2</button>
+        <button className="btn" data-value="3">3</button>
+        <button className="btn" data-value="-">&minus;</button>
+        <button className="btn" data-value="0">0</button>
+        <button className="btn" data-value=".">.</button>
+        <button className="btn" data-action="equals">=</button>
+        <button className="btn" data-value="+">+</button>
+        <button className="btn span-two" data-action="clear">C</button>
+      </div>
+      <div id="scientific" className="scientific hidden">
+        <button className="btn" data-value="sin(">sin</button>
+        <button className="btn" data-value="cos(">cos</button>
+        <button className="btn" data-value="tan(">tan</button>
+        <button className="btn" data-value="sqrt(">√</button>
+        <button className="btn" data-value="(">(</button>
+        <button className="btn" data-value=")">)</button>
+      </div>
+      <div id="programmer" className="programmer hidden">
+        <select id="base-select" defaultValue="10">
+          <option value="2">Bin</option>
+          <option value="8">Oct</option>
+          <option value="10">Dec</option>
+          <option value="16">Hex</option>
+        </select>
+        <button className="btn" data-value="&amp;">&amp;</button>
+        <button className="btn" data-value="|">|</button>
+        <button className="btn" data-value="^">^</button>
+        <button className="btn" data-value="~">~</button>
+        <button className="btn" data-value="<<">&lt;&lt;</button>
+        <button className="btn" data-value=">>">&gt;&gt;</button>
+        <button className="btn" data-action="ans">Ans</button>
+        <button id="print-tape" className="btn" data-action="print">Print</button>
+        <div id="paren-indicator" />
+      </div>
+      <div id="history" className="history hidden" aria-live="polite" />
+    </div>
+  );
+}
+

--- a/apps/sticky_notes/index.tsx
+++ b/apps/sticky_notes/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useEffect } from 'react';
+import './styles.css';
+
+export default function StickyNotes() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      import('./main');
+    }
+  }, []);
+
+  return (
+    <div>
+      <button id="add-note">Add Note</button>
+      <div id="notes" />
+    </div>
+  );
+}
+

--- a/apps/timer_stopwatch/index.tsx
+++ b/apps/timer_stopwatch/index.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect } from 'react';
+import './styles.css';
+
+export default function TimerStopwatch() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      import('./main');
+    }
+  }, []);
+
+  return (
+    <div>
+      <div>
+        <button id="modeTimer">Timer</button>
+        <button id="modeStopwatch">Stopwatch</button>
+      </div>
+      <div id="timerControls">
+        <div>
+          <input type="number" id="minutes" min="0" defaultValue="0" /> :
+          <input type="number" id="seconds" min="0" max="59" defaultValue="30" />
+        </div>
+        <div className="display" id="timerDisplay">00:30</div>
+        <div>
+          <button id="startTimer">Start</button>
+          <button id="stopTimer">Stop</button>
+          <button id="resetTimer">Reset</button>
+        </div>
+      </div>
+      <div id="stopwatchControls" style={{ display: 'none' }}>
+        <div className="display" id="stopwatchDisplay">00:00</div>
+        <div>
+          <button id="startWatch">Start</button>
+          <button id="stopWatch">Stop</button>
+          <button id="resetWatch">Reset</button>
+          <button id="lapWatch">Lap</button>
+        </div>
+        <ul id="laps" />
+      </div>
+    </div>
+  );
+}
+

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -1,0 +1,39 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  margin-top: 50px;
+  background: #f0f0f0;
+}
+.display {
+  font-size: 4rem;
+  font-family: 'Courier New', monospace;
+  margin: 20px 0;
+}
+button {
+  margin: 5px;
+  padding: 10px 20px;
+  font-size: 1rem;
+}
+input {
+  width: 60px;
+  text-align: center;
+  font-size: 1rem;
+  padding: 5px;
+}
+ul {
+  list-style: none;
+  padding: 0;
+  margin-top: 10px;
+  width: 100%;
+  max-width: 300px;
+}
+li {
+  background: #fff;
+  margin: 2px 0;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+}

--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+import './styles.css';
+
+export default function WeatherWidget() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      import('./main');
+    }
+  }, []);
+
+  return (
+    <div>
+      <div className="controls">
+        <select id="city-picker"></select>
+        <select id="unit-toggle">
+          <option value="metric">°C</option>
+          <option value="imperial">°F</option>
+        </select>
+        <input type="text" id="api-key-input" placeholder="API Key (optional)" />
+        <button id="save-api-key">Save</button>
+      </div>
+      <div id="weather" className="weather">
+        <div className="temp">--°C</div>
+        <img className="icon" src="" alt="Weather icon" />
+        <div className="forecast">Loading...</div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -1,109 +1,101 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const widget = document.getElementById('weather');
-  const tempEl = widget.querySelector('.temp');
-  const iconEl = widget.querySelector('.icon');
-  const forecastEl = widget.querySelector('.forecast');
-  const cityPicker = document.getElementById('city-picker');
-  const unitToggle = document.getElementById('unit-toggle');
-  const apiKeyInput = document.getElementById('api-key-input');
-  const saveApiKeyBtn = document.getElementById('save-api-key');
+import cities from './cities.json';
 
-  let apiKey = localStorage.getItem('weatherApiKey') || '';
-  if (apiKey) apiKeyInput.value = apiKey;
+const widget = document.getElementById('weather');
+const tempEl = widget.querySelector('.temp');
+const iconEl = widget.querySelector('.icon');
+const forecastEl = widget.querySelector('.forecast');
+const cityPicker = document.getElementById('city-picker');
+const unitToggle = document.getElementById('unit-toggle');
+const apiKeyInput = document.getElementById('api-key-input');
+const saveApiKeyBtn = document.getElementById('save-api-key');
 
-  let cities = [];
-  let unit = unitToggle.value;
+let apiKey = localStorage.getItem('weatherApiKey') || '';
+if (apiKey) apiKeyInput.value = apiKey;
 
-  async function loadCities() {
-    try {
-      const res = await fetch('cities.json');
-      cities = await res.json();
-      cityPicker.innerHTML = cities
-        .map((c) => `<option value="${c.name}">${c.name}</option>`)
-        .join('');
-    } catch (err) {
-      console.error('Failed to load city list', err);
-    }
-  }
+let unit = unitToggle.value;
 
-  function convertTemp(celsius) {
-    return unit === 'metric' ? celsius : celsius * 9 / 5 + 32;
-  }
+function loadCities() {
+  cityPicker.innerHTML = cities
+    .map((c) => `<option value="${c.name}">${c.name}</option>`)
+    .join('');
+}
 
-  function renderWeather(data) {
-    widget.classList.remove('fade-in');
-    widget.classList.add('fade-out');
-    widget.addEventListener(
-      'animationend',
-      function handler() {
-        widget.classList.remove('fade-out');
-        const temp = convertTemp(data.tempC);
-        tempEl.textContent = `${Math.round(temp)}°${unit === 'metric' ? 'C' : 'F'}`;
-        if (data.icon) {
-          iconEl.src = `https://openweathermap.org/img/wn/${data.icon}@2x.png`;
-          iconEl.alt = data.condition;
-        }
-        forecastEl.textContent = data.condition;
-        widget.classList.add('fade-in');
-        widget.removeEventListener('animationend', handler);
-      },
-      { once: true }
-    );
-  }
+function convertTemp(celsius) {
+  return unit === 'metric' ? celsius : (celsius * 9) / 5 + 32;
+}
 
-  async function fetchLiveWeather(city) {
-    const response = await fetch(
-      `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
-    );
-    if (!response.ok) throw new Error('Failed to fetch weather');
-    const data = await response.json();
-    return {
-      tempC: data.main.temp,
-      condition: data.weather[0].description,
-      icon: data.weather[0].icon,
-    };
-  }
-
-  async function updateWeather() {
-    const city = cityPicker.value;
-    try {
-      let data;
-      if (apiKey) {
-        data = await fetchLiveWeather(city);
-      } else {
-        data = cities.find((c) => c.name === city);
+function renderWeather(data) {
+  widget.classList.remove('fade-in');
+  widget.classList.add('fade-out');
+  widget.addEventListener(
+    'animationend',
+    function handler() {
+      widget.classList.remove('fade-out');
+      const temp = convertTemp(data.tempC);
+      tempEl.textContent = `${Math.round(temp)}°${unit === 'metric' ? 'C' : 'F'}`;
+      if (data.icon) {
+        iconEl.src = `https://openweathermap.org/img/wn/${data.icon}@2x.png`;
+        iconEl.alt = data.condition;
       }
-      if (data) {
-        renderWeather(data);
-      }
-    } catch (err) {
-      console.error(err);
-    }
-  }
+      forecastEl.textContent = data.condition;
+      widget.classList.add('fade-in');
+      widget.removeEventListener('animationend', handler);
+    },
+    { once: true }
+  );
+}
 
-  cityPicker.addEventListener('change', updateWeather);
+async function fetchLiveWeather(city) {
+  const response = await fetch(
+    `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
+  );
+  if (!response.ok) throw new Error('Failed to fetch weather');
+  const data = await response.json();
+  return {
+    tempC: data.main.temp,
+    condition: data.weather[0].description,
+    icon: data.weather[0].icon,
+  };
+}
 
-  unitToggle.addEventListener('change', () => {
-    unit = unitToggle.value;
-    updateWeather();
-  });
-
-  saveApiKeyBtn.addEventListener('click', () => {
-    apiKey = apiKeyInput.value.trim();
+async function updateWeather() {
+  const city = cityPicker.value;
+  try {
+    let data;
     if (apiKey) {
-      localStorage.setItem('weatherApiKey', apiKey);
+      data = await fetchLiveWeather(city);
     } else {
-      localStorage.removeItem('weatherApiKey');
+      data = cities.find((c) => c.name === city);
     }
-    updateWeather();
-  });
-
-  loadCities().then(() => {
-    if (cities.length) {
-      cityPicker.value = cities[0].name;
-      updateWeather();
+    if (data) {
+      renderWeather(data);
     }
-  });
+  } catch (err) {
+    console.error(err);
+  }
+}
 
-  setInterval(updateWeather, 10 * 60 * 1000);
+cityPicker.addEventListener('change', updateWeather);
+
+unitToggle.addEventListener('change', () => {
+  unit = unitToggle.value;
+  updateWeather();
 });
+
+saveApiKeyBtn.addEventListener('click', () => {
+  apiKey = apiKeyInput.value.trim();
+  if (apiKey) {
+    localStorage.setItem('weatherApiKey', apiKey);
+  } else {
+    localStorage.removeItem('weatherApiKey');
+  }
+  updateWeather();
+});
+
+loadCities();
+if (cities.length) {
+  cityPicker.value = cities[0].name;
+  updateWeather();
+}
+
+setInterval(updateWeather, 10 * 60 * 1000);

--- a/pages/apps/calculator.tsx
+++ b/pages/apps/calculator.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Calculator = dynamic(() => import('../../apps/calculator'), { ssr: false });
+
+export default function CalculatorPage() {
+  return <Calculator />;
+}
+

--- a/pages/apps/sticky_notes.tsx
+++ b/pages/apps/sticky_notes.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), { ssr: false });
+
+export default function StickyNotesPage() {
+  return <StickyNotes />;
+}
+

--- a/pages/apps/timer_stopwatch.tsx
+++ b/pages/apps/timer_stopwatch.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), { ssr: false });
+
+export default function TimerStopwatchPage() {
+  return <TimerStopwatch />;
+}
+

--- a/pages/apps/weather_widget.tsx
+++ b/pages/apps/weather_widget.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), { ssr: false });
+
+export default function WeatherWidgetPage() {
+  return <WeatherWidget />;
+}
+


### PR DESCRIPTION
## Summary
- add client-side React wrappers for calculator, sticky notes, timer/stopwatch, and weather widget
- expose new wrappers as dynamic Next.js pages with SSR disabled
- adjust weather widget script to load city data directly

## Testing
- `yarn lint`
- `yarn test` *(fails: memoryGame, beef, autopsy, nmapNse, calc tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b035a3cc0883289aef24c2ac0f96cf