### PR TITLE
feat: type install prompt event

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from 'react';
 
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+
 const InstallButton: React.FC = () => {
-  const [prompt, setPrompt] = useState<any>(null);
+  const [prompt, setPrompt] = useState<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
-    const handler = (e: any) => {
+    const handler = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
       setPrompt(e);
     };
@@ -14,7 +20,7 @@ const InstallButton: React.FC = () => {
 
   const handleInstall = async () => {
     if (!prompt) return;
-    prompt.prompt();
+    await prompt.prompt();
     await prompt.userChoice;
     setPrompt(null);
   };


### PR DESCRIPTION
## Summary
- add BeforeInstallPromptEvent interface
- type InstallButton state and handlers

## Testing
- `yarn lint`
- `yarn test` *(fails: __tests__/memoryGame.test.tsx, __tests__/beef.test.tsx, __tests__/autopsy.test.tsx, __tests__/nmapNse.test.tsx, __tests__/calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b036eef3d4832896a0773568688178