### PR TITLE
fix: address hook dependency warnings

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
 
 interface Props {
@@ -7,12 +7,8 @@ interface Props {
 
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
-  const [theme, setThemeState] = useState('default');
+  const [theme, setThemeState] = useState(getTheme());
   const unlocked = getUnlockedThemes(highScore);
-
-  useEffect(() => {
-    setThemeState(getTheme());
-  }, []);
 
   const changeTheme = (t: string) => {
     setThemeState(t);

--- a/components/apps/qr_tool/index.js
+++ b/components/apps/qr_tool/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import QRCodeStyling from 'qr-code-styling';
 
 const errorLevels = {
@@ -172,7 +172,7 @@ const QRTool = () => {
     }
   };
 
-  const stopCamera = () => {
+  const stopCamera = useCallback(() => {
     const stream = videoRef.current?.srcObject;
     if (stream) {
       stream.getTracks().forEach((t) => t.stop());
@@ -185,9 +185,9 @@ const QRTool = () => {
       workerRef.current = null;
     }
     setMessage('');
-  };
+  }, []);
 
-  useEffect(() => () => stopCamera(), []);
+  useEffect(() => () => stopCamera(), [stopCamera]);
 
   return (
     <div className="h-full w-full p-4 bg-gray-900 text-white overflow-auto">


### PR DESCRIPTION
## Summary
- initialize SettingsDrawer theme state from getTheme to remove effect dependency warning
- memoize QR tool stopCamera function and include it in effect dependencies

## Testing
- `yarn lint`
- `yarn test __tests__/memoryGame.test.tsx` *(fails: Combo meter increments and resets; card flip applies transform style)*

------
https://chatgpt.com/codex/tasks/task_e_68b037585f6c83288fdb32a1de85cbc1