### PR TITLE
test: polyfill fetch for tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,16 @@ global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder as any;
 
+// Ensure a global `fetch` exists for tests. Jest's jsdom environment
+// doesn't provide one on the Node `global` object, which causes
+// `jest.spyOn(global, 'fetch')` to fail. Providing a simple stub allows
+// tests to spy on and mock `fetch` as needed.
+// @ts-ignore
+if (!global.fetch) {
+  // @ts-ignore
+  global.fetch = () => Promise.reject(new Error('fetch not implemented'));
+}
+
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient
 // for our tests because we only rely on the instance existing.


### PR DESCRIPTION
## Summary
- polyfill global `fetch` in Jest setup so tests can spy on it

## Testing
- `yarn test __tests__/nmapNse.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b03d0b841c8328ad6e66a9ff16cd70