### PR TITLE
Await hydra temp file cleanup

### DIFF
--- a/__tests__/hydra.api.test.ts
+++ b/__tests__/hydra.api.test.ts
@@ -1,0 +1,71 @@
+// @jest-environment node
+import { promises as fs } from 'fs';
+
+const USER_PATH = '/tmp/hydra-users-test-uuid.txt';
+const PASS_PATH = '/tmp/hydra-pass-test-uuid.txt';
+
+async function cleanup() {
+  await fs.unlink(USER_PATH).catch(() => {});
+  await fs.unlink(PASS_PATH).catch(() => {});
+}
+
+describe('Hydra API temp file cleanup', () => {
+  afterEach(async () => {
+    jest.resetModules();
+    jest.dontMock('child_process');
+    jest.dontMock('crypto');
+    await cleanup();
+  });
+
+  it('removes temp files after successful run', async () => {
+    jest.doMock('crypto', () => ({ randomUUID: () => 'test-uuid' }));
+    const execFileMock = jest.fn((cmd: string, args: any, options: any, cb: any) => {
+      if (typeof options === 'function') {
+        cb = options;
+      }
+      cb(null, '', '');
+    });
+    jest.doMock('child_process', () => ({ execFile: execFileMock }));
+
+    const handler = (await import('../pages/api/hydra')).default;
+
+    const req: any = {
+      method: 'POST',
+      body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
+    };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    await expect(fs.access(USER_PATH)).rejects.toThrow();
+    await expect(fs.access(PASS_PATH)).rejects.toThrow();
+  });
+
+  it('removes temp files if hydra missing', async () => {
+    jest.doMock('crypto', () => ({ randomUUID: () => 'test-uuid' }));
+    const execFileMock = jest.fn((cmd: string, args: any, options: any, cb: any) => {
+      if (typeof options === 'function') {
+        cb = options;
+      }
+      if (cmd === 'which') {
+        cb(new Error('missing'), '', '');
+      } else {
+        cb(null, '', '');
+      }
+    });
+    jest.doMock('child_process', () => ({ execFile: execFileMock }));
+
+    const handler = (await import('../pages/api/hydra')).default;
+
+    const req: any = {
+      method: 'POST',
+      body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
+    };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    await expect(fs.access(USER_PATH)).rejects.toThrow();
+    await expect(fs.access(PASS_PATH)).rejects.toThrow();
+  });
+});

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -33,8 +33,10 @@ export default async function handler(req, res) {
   try {
     await execFileAsync('which', ['hydra']);
   } catch {
-    await fs.unlink(userPath).catch(() => {});
-    await fs.unlink(passPath).catch(() => {});
+    await Promise.all([
+      fs.unlink(userPath).catch(() => {}),
+      fs.unlink(passPath).catch(() => {}),
+    ]);
     res.status(500).json({ error: 'Hydra not installed' });
     return;
   }
@@ -48,7 +50,9 @@ export default async function handler(req, res) {
     const msg = error.stderr?.toString() || error.message;
     res.status(500).json({ error: msg });
   } finally {
-    fs.unlink(userPath).catch(() => {});
-    fs.unlink(passPath).catch(() => {});
+    await Promise.all([
+      fs.unlink(userPath).catch(() => {}),
+      fs.unlink(passPath).catch(() => {}),
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- use `Promise.all` to await temporary file removal in `hydra` API
- add regression tests ensuring temp files are deleted

## Testing
- `yarn test __tests__/hydra.api.test.ts`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03e27110c8328a56471c6f08506fb