### PR TITLE
Prune stale IPs from contact rate limiter

### DIFF
--- a/__tests__/contact.api.test.ts
+++ b/__tests__/contact.api.test.ts
@@ -1,0 +1,48 @@
+import handler, { rateLimit, RATE_LIMIT_WINDOW_MS } from '../pages/api/contact';
+
+type Res = ReturnType<typeof mockRes>;
+
+function mockRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn();
+  res.end = jest.fn();
+  return res;
+}
+
+describe('contact api rate limiter', () => {
+  afterEach(() => {
+    rateLimit.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('removes stale ip entries', async () => {
+    const currentTime = 1_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(currentTime);
+    rateLimit.set('1.1.1.1', {
+      count: 1,
+      start: currentTime - RATE_LIMIT_WINDOW_MS - 1,
+    });
+
+    const req: any = {
+      method: 'POST',
+      headers: {},
+      socket: { remoteAddress: '2.2.2.2' },
+      body: {
+        name: 'Alex',
+        email: 'alex@example.com',
+        message: 'Hello',
+        honeypot: '',
+      },
+    };
+    const res: Res = mockRes();
+
+    await handler(req, res);
+
+    expect(rateLimit.has('1.1.1.1')).toBe(false);
+    expect(rateLimit.has('2.2.2.2')).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
+// Simple in-memory rate limiter. Not suitable for distributed environments.
+export const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
-const rateLimit = new Map<string, { count: number; start: number }>();
+export const rateLimit = new Map<string, { count: number; start: number }>();
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -20,6 +21,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
   entry.count += 1;
   rateLimit.set(ip, entry);
+  for (const [key, value] of rateLimit) {
+    if (now - value.start > RATE_LIMIT_WINDOW_MS) {
+      rateLimit.delete(key);
+    }
+  }
   if (entry.count > RATE_LIMIT_MAX) {
     res.status(429).json({ ok: false, error: 'Too many requests' });
     return;


### PR DESCRIPTION
## Summary
- prune rate limiter map entries older than the window
- note that limiter is in-memory
- add test ensuring stale IP entries are removed

## Testing
- `npm test __tests__/contact.api.test.ts`
- `npm test` *(fails: memoryGame, BeEF app, Autopsy, NmapNSE, Reader, Calc, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b03e287d508328877d0a1e053aba05