### PR TITLE
Conditionally register service worker

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,10 +17,25 @@ function MyApp({ Component, pageProps }) {
     if (trackingId) {
       ReactGA.initialize(trackingId);
     }
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js').catch(() => {
-        // ignore registration errors
-      });
+    if (
+      process.env.NODE_ENV === 'production' &&
+      'serviceWorker' in navigator
+    ) {
+      fetch('/service-worker.js', { method: 'HEAD' })
+        .then((res) => {
+          if (res.ok) {
+            navigator.serviceWorker
+              .register('/service-worker.js')
+              .catch((err) => {
+                console.error('Service worker registration failed', err);
+              });
+          } else {
+            console.warn('Service worker file not found');
+          }
+        })
+        .catch((err) => {
+          console.error('Service worker check failed', err);
+        });
     }
   }, []);
   return (


### PR DESCRIPTION
## Summary
- Only register service worker in production and when available
- Check service worker file exists before registration and log errors

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, reader, nmapNse, calc, snake.config, frogger.config)*
- `npm run lint`
- `npm run build` *(fails: apps/sticky_notes main.js is not a module)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b03e2955748328a187e5d972dca160