### PR TITLE
Reduce default audio volume

### DIFF
--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -204,7 +204,7 @@ const Asteroids = () => {
       osc.connect(gain);
       gain.connect(ctxAudio.destination);
       osc.start();
-      gain.gain.setValueAtTime(0.2, ctxAudio.currentTime);
+      gain.gain.setValueAtTime(0.1, ctxAudio.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.0001, ctxAudio.currentTime + 0.3);
       osc.stop(ctxAudio.currentTime + 0.3);
     };

--- a/components/apps/blackjack.js
+++ b/components/apps/blackjack.js
@@ -98,7 +98,7 @@ const Blackjack = () => {
     osc.connect(gain);
     gain.connect(ctx.destination);
     osc.frequency.value = 440;
-    gain.gain.value = 0.1;
+    gain.gain.value = 0.05;
     osc.start();
     osc.stop(ctx.currentTime + 0.1);
   };
@@ -111,7 +111,7 @@ const Blackjack = () => {
     osc.connect(gain);
     gain.connect(ctx.destination);
     osc.frequency.value = 600 + Math.random() * 400; // pitch jitter
-    gain.gain.value = 0.15;
+    gain.gain.value = 0.075;
     osc.start();
     osc.stop(ctx.currentTime + 0.05);
   };

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -144,6 +144,7 @@ const BreakoutGame = ({ levels }) => {
       osc.frequency.value = freq;
       osc.connect(gain);
       gain.connect(audioCtx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       osc.stop(audioCtx.currentTime + 0.1);
     };

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -70,7 +70,7 @@ const CarRacer = () => {
     const gain = ctx.createGain();
     osc.connect(gain);
     gain.connect(ctx.destination);
-    gain.gain.value = 0.1;
+    gain.gain.value = 0.05;
     osc.frequency.value = 440;
     osc.start();
     osc.stop(ctx.currentTime + 0.1);

--- a/components/apps/checkers.js
+++ b/components/apps/checkers.js
@@ -96,9 +96,12 @@ const Checkers = () => {
     try {
       const ctx = new (window.AudioContext || window.webkitAudioContext)();
       const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
       osc.type = 'square';
       osc.frequency.value = 500;
-      osc.connect(ctx.destination);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       osc.stop(ctx.currentTime + 0.1);
     } catch (e) {

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -269,8 +269,11 @@ const getBestMove = (board, side, depth) => {
 const playBeep = () => {
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
   const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
   osc.frequency.value = 400;
-  osc.connect(ctx.destination);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  gain.gain.value = 0.5;
   osc.start();
   osc.stop(ctx.currentTime + 0.1);
 };

--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -88,7 +88,7 @@ const ConnectFour = () => {
       osc.connect(gain);
       gain.connect(ac.destination);
       osc.start();
-      gain.gain.setValueAtTime(0.2, ac.currentTime);
+      gain.gain.setValueAtTime(0.1, ac.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.0001, ac.currentTime + 0.1);
       osc.stop(ac.currentTime + 0.1);
     } catch (e) {

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -194,7 +194,7 @@ const Frogger = () => {
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.frequency.value = freq;
-    gain.gain.setValueAtTime(0.1, ctx.currentTime);
+    gain.gain.setValueAtTime(0.05, ctx.currentTime);
     osc.connect(gain);
     gain.connect(ctx.destination);
     osc.start();

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -106,6 +106,7 @@ const Hangman = () => {
         osc.frequency.value = freq;
         osc.connect(gain);
         gain.connect(ctx.destination);
+        gain.gain.value = 0.5;
         osc.start();
         gain.gain.exponentialRampToValueAtTime(
           0.0001,

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -45,9 +45,12 @@ const Memory = () => {
     try {
       const ctx = new (window.AudioContext || window.webkitAudioContext)();
       const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
       osc.type = 'sine';
       osc.frequency.value = 600;
-      osc.connect(ctx.destination);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       setTimeout(() => {
         osc.stop();

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -343,6 +343,7 @@ const Minesweeper = () => {
       type === 'boom' ? 120 : type === 'flag' ? 330 : 440;
     osc.connect(gain);
     gain.connect(ctx.destination);
+    gain.gain.value = 0.5;
     osc.start();
     osc.stop(ctx.currentTime + 0.15);
   };

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -69,8 +69,11 @@ const Nonogram = () => {
     try {
       const ctx = new (window.AudioContext || window.webkitAudioContext)();
       const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
       osc.frequency.value = 880;
-      osc.connect(ctx.destination);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       osc.stop(ctx.currentTime + 0.05);
     } catch {

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -140,6 +140,7 @@ const Pacman = () => {
       osc.frequency.value = freq;
       osc.connect(gain);
       gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       osc.stop(ctx.currentTime + 0.1);
     } catch {

--- a/components/apps/phaser-template.js
+++ b/components/apps/phaser-template.js
@@ -70,7 +70,7 @@ class GameScene extends Phaser.Scene {
     this.input.on('pointerdown', () => this.handleAction());
 
     // Howler audio example
-    this.jumpSound = new Howl({ src: ['jump.mp3'], volume: 0.5 });
+    this.jumpSound = new Howl({ src: ['jump.mp3'], volume: 0.25 });
   }
 
   togglePause() {

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -19,6 +19,7 @@ function playCoinSound() {
     osc.frequency.value = 800;
     osc.connect(gain);
     gain.connect(ac.destination);
+    gain.gain.value = 0.5;
     osc.start();
     gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 0.2);
     osc.stop(ac.currentTime + 0.2);

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -71,6 +71,7 @@ const Pong = () => {
           osc.frequency.value = freq;
           osc.connect(gain);
           gain.connect(ctx.destination);
+          gain.gain.value = 0.5;
           osc.start();
           osc.stop(ctx.currentTime + 0.1);
         } catch {

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -93,7 +93,7 @@ const Reversi = () => {
     gain.connect(ctx.destination);
     osc.frequency.value = 500;
     osc.start();
-    gain.gain.setValueAtTime(0.3, ctx.currentTime);
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
     gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.1);
     osc.stop(ctx.currentTime + 0.1);
   };

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -137,7 +137,7 @@ const Simon = () => {
     oscillator.connect(gain);
     gain.connect(ctx.destination);
     gain.gain.setValueAtTime(0.0001, startTime);
-    gain.gain.exponentialRampToValueAtTime(0.5, startTime + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.25, startTime + 0.01);
     gain.gain.exponentialRampToValueAtTime(0.0001, startTime + duration);
     oscillator.start(startTime);
     oscillator.stop(startTime + duration + 0.05);

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -76,7 +76,7 @@ const Snake = () => {
         osc.frequency.value = freq;
         osc.connect(gain);
         gain.connect(ctx.destination);
-        gain.gain.setValueAtTime(0.2, ctx.currentTime);
+        gain.gain.setValueAtTime(0.1, ctx.currentTime);
         gain.gain.exponentialRampToValueAtTime(
           0.001,
           ctx.currentTime + 0.15,

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -107,6 +107,7 @@ const Sokoban = () => {
       const gain = ctx.createGain();
       osc.connect(gain);
       gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.frequency.value = 440;
       osc.start();
       osc.stop(ctx.currentTime + 0.05);

--- a/components/apps/solitaire.js
+++ b/components/apps/solitaire.js
@@ -63,7 +63,10 @@ const Solitaire = () => {
     if (!sound) return;
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
     const osc = ctx.createOscillator();
-    osc.connect(ctx.destination);
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    gain.gain.value = 0.5;
     osc.start();
     osc.stop(ctx.currentTime + 0.05);
   };

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -68,7 +68,7 @@ const SpaceInvaders = () => {
     osc.frequency.value = freq;
     osc.connect(gain);
     gain.connect(audioCtx.current.destination);
-    gain.gain.value = 0.1;
+    gain.gain.value = 0.05;
     osc.start();
     osc.stop(audioCtx.current.currentTime + 0.1);
   };
@@ -84,7 +84,7 @@ const SpaceInvaders = () => {
       end,
       audioCtx.current.currentTime + duration
     );
-    gain.gain.setValueAtTime(0.1, audioCtx.current.currentTime);
+    gain.gain.setValueAtTime(0.05, audioCtx.current.currentTime);
     gain.gain.linearRampToValueAtTime(
       0,
       audioCtx.current.currentTime + duration

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -25,8 +25,11 @@ export default function SpotifyApp() {
     analyser.fftSize = 256;
 
     const source = audioCtx.createMediaElementSource(audioEl);
+    const gain = audioCtx.createGain();
+    gain.gain.value = 0.5;
     source.connect(analyser);
-    analyser.connect(audioCtx.destination);
+    analyser.connect(gain);
+    gain.connect(audioCtx.destination);
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -147,9 +147,12 @@ const Tetris = () => {
           new (window.AudioContext || window.webkitAudioContext)();
         audioCtxRef.current = ctx;
         const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
         osc.type = 'square';
         osc.frequency.value = freq;
-        osc.connect(ctx.destination);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        gain.gain.value = 0.5;
         osc.start();
         osc.stop(ctx.currentTime + duration);
       } catch {

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -120,9 +120,12 @@ const TicTacToe = () => {
     if (sound) {
       const ctx = new (window.AudioContext || window.webkitAudioContext)();
       const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
       osc.type = 'sine';
       osc.frequency.value = 440;
-      osc.connect(ctx.destination);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.start();
       osc.stop(ctx.currentTime + 0.1);
     }
@@ -200,9 +203,12 @@ const TicTacToe = () => {
           if (sound) {
             const ctx = new (window.AudioContext || window.webkitAudioContext)();
             const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
             osc.type = 'sine';
             osc.frequency.value = 660;
-            osc.connect(ctx.destination);
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            gain.gain.value = 0.5;
             osc.start();
             osc.stop(ctx.currentTime + 0.1);
           }

--- a/components/apps/tower-defense.js
+++ b/components/apps/tower-defense.js
@@ -168,7 +168,7 @@ function TowerDefense() {
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.frequency.value = 440;
-      gain.gain.value = 0.05;
+      gain.gain.value = 0.025;
       osc.connect(gain).connect(ctx.destination);
       osc.start();
       osc.stop(ctx.currentTime + 0.1);

--- a/components/apps/word-search.js
+++ b/components/apps/word-search.js
@@ -189,6 +189,7 @@ const WordSearch = () => {
       const gain = ctx.createGain();
       osc.connect(gain);
       gain.connect(ctx.destination);
+      gain.gain.value = 0.5;
       osc.frequency.value = 600;
       osc.start();
       setTimeout(() => {

--- a/components/util-components/status_card.js
+++ b/components/util-components/status_card.js
@@ -26,7 +26,7 @@ export class StatusCard extends Component {
                 super();
                 this.wrapperRef = React.createRef();
                 this.state = {
-                        sound_level: 75, // better of setting default values from localStorage
+                        sound_level: 37, // better of setting default values from localStorage
                         brightness_level: 100 // setting default value to 100 so that by default its always full.
                 };
         }
@@ -35,7 +35,7 @@ export class StatusCard extends Component {
         };
         componentDidMount() {
                 this.setState({
-                        sound_level: localStorage.getItem('sound-level') || 75,
+                        sound_level: localStorage.getItem('sound-level') || 37,
                         brightness_level: localStorage.getItem('brightness-level') || 100
                 }, () => {
                         document.getElementById('monitor-screen').style.filter = `brightness(${3 / 400 * this.state.brightness_level +

--- a/hooks/useGameAudio.js
+++ b/hooks/useGameAudio.js
@@ -23,7 +23,7 @@ export default function useGameAudio() {
   // Global mute is persisted across the portfolio, but per‑game volume lives
   // only for the lifetime of the hook instance.
   const [muted, setMuted] = usePersistedState('settings:audioMuted', false);
-  const [gameVolume, setGameVolume] = useState(1);
+  const [gameVolume, setGameVolume] = useState(0.5);
   const [ready, setReady] = useState(false);
 
   // Create the audio graph after the first user interaction to comply with

--- a/public/apps/asteroids/main.js
+++ b/public/apps/asteroids/main.js
@@ -13,7 +13,7 @@ function ping(freq = 880) {
     osc.frequency.value = freq;
     osc.connect(gain);
     gain.connect(audioCtx.destination);
-    gain.gain.value = 0.1;
+    gain.gain.value = 0.05;
     osc.start();
     osc.stop(audioCtx.currentTime + 0.1);
   } catch {}

--- a/public/apps/platformer/main.js
+++ b/public/apps/platformer/main.js
@@ -88,6 +88,7 @@ function playCoinSound() {
     osc.frequency.value = 800;
     osc.connect(gain);
     gain.connect(ac.destination);
+    gain.gain.value = 0.5;
     osc.start();
     gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 0.2);
     osc.stop(ac.currentTime + 0.2);

--- a/public/apps/pong/main.js
+++ b/public/apps/pong/main.js
@@ -137,7 +137,7 @@ function playBeep(freq = 440) {
     osc.type = 'square';
     osc.connect(gain);
     gain.connect(audioCtx.destination);
-    gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
+    gain.gain.setValueAtTime(0.05, audioCtx.currentTime);
     gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.2);
     osc.start();
     osc.stop(audioCtx.currentTime + 0.2);


### PR DESCRIPTION
## Summary
- Set global game audio hook default volume to 50%
- Lower status panel default sound level
- Halve sound effect volumes across portfolio apps

## Testing
- `npm test` *(fails: memoryGame, BeEF app, Autopsy, Reader, NmapNSE, Calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b03e4f5fe0832889ff85b0336c6082