### PR TITLE
Ensure Hydra temp files cleaned up

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -1,0 +1,39 @@
+const randomUUIDMock = jest
+  .fn()
+  .mockReturnValueOnce('u')
+  .mockReturnValueOnce('p');
+
+jest.mock('crypto', () => ({
+  randomUUID: randomUUIDMock,
+}));
+
+jest.mock('child_process', () => ({
+  execFile: (cmd, args, options, callback) => {
+    if (typeof options === 'function') {
+      callback = options;
+    }
+    callback(null, 'done', '');
+  },
+}));
+
+const handler = require('../pages/api/hydra').default;
+const fs = require('fs').promises;
+
+test('removes temp files after hydra execution', async () => {
+  const req = {
+    method: 'POST',
+    body: { target: 'target', service: 'ssh', userList: 'u', passList: 'p' },
+  };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  const userPath = '/tmp/hydra-users-u.txt';
+  const passPath = '/tmp/hydra-pass-p.txt';
+
+  await handler(req, res);
+
+  await expect(fs.access(userPath)).rejects.toBeTruthy();
+  await expect(fs.access(passPath)).rejects.toBeTruthy();
+});

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -33,8 +33,10 @@ export default async function handler(req, res) {
   try {
     await execFileAsync('which', ['hydra']);
   } catch {
-    await fs.unlink(userPath).catch(() => {});
-    await fs.unlink(passPath).catch(() => {});
+    await Promise.all([
+      fs.unlink(userPath).catch(() => {}),
+      fs.unlink(passPath).catch(() => {}),
+    ]);
     res.status(500).json({ error: 'Hydra not installed' });
     return;
   }
@@ -48,7 +50,9 @@ export default async function handler(req, res) {
     const msg = error.stderr?.toString() || error.message;
     res.status(500).json({ error: msg });
   } finally {
-    fs.unlink(userPath).catch(() => {});
-    fs.unlink(passPath).catch(() => {});
+    await Promise.all([
+      fs.unlink(userPath).catch(() => {}),
+      fs.unlink(passPath).catch(() => {}),
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- Clean up Hydra API temp files concurrently
- Verify cleanup with new API test

## Testing
- `npm test __tests__/hydra-api.test.js __tests__/hydra.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b03f19d8508328ae8db2e84ebf3c33