### PR TITLE
Guard service worker registration in production

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,10 +17,22 @@ function MyApp({ Component, pageProps }) {
     if (trackingId) {
       ReactGA.initialize(trackingId);
     }
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js').catch(() => {
-        // ignore registration errors
-      });
+    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+      fetch('/service-worker.js')
+        .then((response) => {
+          if (response.ok) {
+            navigator.serviceWorker
+              .register('/service-worker.js')
+              .catch((error) => {
+                console.error('Service worker registration failed', error);
+              });
+          } else {
+            console.error('Service worker file not found');
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to fetch service worker', error);
+        });
     }
   }, []);
   return (


### PR DESCRIPTION
## Summary
- Only register service worker in production and verify its existence

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, calc)*
- `yarn build` *(fails: File '/workspace/kali-linux-portfolio/apps/sticky_notes/main.js' is not a module)*
- `yarn dev`

------
https://chatgpt.com/codex/tasks/task_e_68b03f23c1f083288a40fa41e7d482a8