### PR TITLE
Use worker timers for clock and stopwatch

### DIFF
--- a/workers/timer.worker.js
+++ b/workers/timer.worker.js
@@ -1,0 +1,11 @@
+let intervalId = null;
+self.onmessage = ({ data }) => {
+  const { action, interval } = data || {};
+  if (action === 'start' && typeof interval === 'number') {
+    clearInterval(intervalId);
+    intervalId = setInterval(() => self.postMessage('tick'), interval);
+  } else if (action === 'stop') {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+};


### PR DESCRIPTION
## Summary
- Replace setInterval loops with Web Worker ticks for clock component
- Move timer and stopwatch intervals into a dedicated worker and adjust for tab switching
- Add shared timer worker utility

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `yarn test` *(fails: /usr/bin/yarn: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b04426985483289d27a90eebd3e595