### PR TITLE
feat: add swipe support for 2048

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
+import { detectSwipe } from '../games/_2048/swipe';
 
 const SIZE = 4;
 
@@ -186,6 +187,30 @@ const Page2048 = () => {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
+  }, [handleMove]);
+
+  useEffect(() => {
+    let startX = 0;
+    let startY = 0;
+    const onStart = (e: TouchEvent) => {
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+    };
+    const onEnd = (e: TouchEvent) => {
+      const dir = detectSwipe(
+        startX,
+        startY,
+        e.changedTouches[0].clientX,
+        e.changedTouches[0].clientY
+      );
+      if (dir) handleMove(dir);
+    };
+    window.addEventListener('touchstart', onStart);
+    window.addEventListener('touchend', onEnd);
+    return () => {
+      window.removeEventListener('touchstart', onStart);
+      window.removeEventListener('touchend', onEnd);
+    };
   }, [handleMove]);
 
   const reset = () => {

--- a/apps/games/_2048/swipe.ts
+++ b/apps/games/_2048/swipe.ts
@@ -1,0 +1,19 @@
+export type Direction = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
+
+export const SWIPE_THRESHOLD = 30;
+
+export const detectSwipe = (
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  threshold: number = SWIPE_THRESHOLD
+): Direction | null => {
+  const dx = endX - startX;
+  const dy = endY - startY;
+  if (Math.abs(dx) < threshold && Math.abs(dy) < threshold) return null;
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return dx > 0 ? 'ArrowRight' : 'ArrowLeft';
+  }
+  return dy > 0 ? 'ArrowDown' : 'ArrowUp';
+};


### PR DESCRIPTION
## Summary
- add utility to detect swipe direction with movement threshold
- enable touch swipe controls in 2048 game

## Testing
- `yarn lint apps/2048/index.tsx apps/games/_2048/swipe.ts` *(fails: Couldn't find any `pages` or `app` directory)*
- `yarn test` *(fails: memoryGame, beef, autopsy, calc tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0443033c8832889cf93fbc2a0125b