### PR TITLE
Add accessible help overlay controls

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -29,6 +29,24 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
 
+  // Keyboard shortcut to toggle help overlay
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+      if (isInput) return;
+      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+        e.preventDefault();
+        setShowHelp((h) => !h);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   // Show tutorial overlay on first visit
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary
- trap focus in HelpOverlay and restore focus after closing
- add keyboard shortcut `?` to toggle help overlay

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b044337a048328afd3de4ab8698fa8