### PR TITLE
feat: seedable RNG for Breakout

### DIFF
--- a/__tests__/breakoutSeed.test.ts
+++ b/__tests__/breakoutSeed.test.ts
@@ -1,0 +1,28 @@
+import { createRng } from '../components/apps/breakout';
+
+describe('breakout rng', () => {
+  test('seed produces deterministic sequence', () => {
+    const rng1 = createRng('test-seed');
+    const rng2 = createRng('test-seed');
+    const seq1 = Array.from({ length: 5 }, () => rng1());
+    const seq2 = Array.from({ length: 5 }, () => rng2());
+    expect(seq1).toEqual(seq2);
+  });
+
+  test('different seeds produce different sequences', () => {
+    const rng1 = createRng('a');
+    const rng2 = createRng('b');
+    const seq1 = Array.from({ length: 5 }, () => rng1());
+    const seq2 = Array.from({ length: 5 }, () => rng2());
+    expect(seq1).not.toEqual(seq2);
+  });
+
+  test('unseeded rng remains random', () => {
+    const rng1 = createRng();
+    const rng2 = createRng();
+    const seq1 = Array.from({ length: 5 }, () => rng1());
+    const seq2 = Array.from({ length: 5 }, () => rng2());
+    expect(seq1).not.toEqual(seq2);
+  });
+});
+

--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useEffect, useState } from "react";
+import seedrandom from "seedrandom";
 import levelsData from "./breakout-levels.json";
 import GameLayout from "./GameLayout";
 
@@ -78,7 +79,9 @@ const LevelEditor = ({ onSave, cols = 8, rows = 5 }) => {
   );
 };
 
-const BreakoutGame = ({ levels }) => {
+export const createRng = (seed) => (seed ? seedrandom(seed) : Math.random);
+
+const BreakoutGame = ({ levels, seed }) => {
   const canvasRef = useRef(null);
   const [level, setLevel] = useState(0);
   const scoreRef = useRef(0);
@@ -124,6 +127,13 @@ const BreakoutGame = ({ levels }) => {
     soundRef.current = !soundRef.current;
     setSoundOn(soundRef.current);
   };
+
+  const rngRef = useRef(createRng(seed));
+  useEffect(() => {
+    rngRef.current = createRng(seed);
+  }, [seed]);
+
+  const rand = () => rngRef.current();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -289,8 +299,8 @@ const BreakoutGame = ({ levels }) => {
             } else {
               const impactAngle = Math.atan2(ball.vy, ball.vx);
               for (let s = 0; s < 8; s += 1) {
-                const spread = (Math.random() - 0.5) * (Math.PI / 3);
-                const speed = 100 + Math.random() * 100;
+                const spread = (rand() - 0.5) * (Math.PI / 3);
+                const speed = 100 + rand() * 100;
                 shards.push({
                   x: ball.x,
                   y: ball.y,
@@ -302,8 +312,8 @@ const BreakoutGame = ({ levels }) => {
             }
 
             // 20% chance to spawn a power-up
-            if (Math.random() < 0.2) {
-              const type = Math.random() < 0.5 ? "multi" : "expand";
+            if (rand() < 0.2) {
+              const type = rand() < 0.5 ? "multi" : "expand";
               const color = type === "multi" ? "#e11d48" : "#3b82f6"; // red vs blue
               powerUps.push({
                 x: brick.x + brick.w / 2,
@@ -530,7 +540,7 @@ const BreakoutGame = ({ levels }) => {
   );
 };
 
-const Breakout = () => {
+const Breakout = ({ seed }) => {
   const [levels, setLevels] = useState(levelsData || []);
 
   useEffect(() => {
@@ -552,7 +562,7 @@ const Breakout = () => {
 
   return (
     <GameLayout editor={<LevelEditor onSave={addLevel} />}>
-      <BreakoutGame levels={levels} />
+      <BreakoutGame levels={levels} seed={seed} />
     </GameLayout>
   );
 };


### PR DESCRIPTION
## Summary
- allow Breakout game to use seedable RNG for deterministic replays
- expose seed option and helper to create RNG
- test RNG seeding behavior

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b04437158883289ff41cfdc04a6942