### PR TITLE
refactor: use mathjs for calculator operations

### DIFF
--- a/__tests__/calc.test.tsx
+++ b/__tests__/calc.test.tsx
@@ -20,5 +20,49 @@ describe('Calc component', () => {
     fireEvent.click(getByText('='));
     expect(getByTestId('calc-display').textContent).toBe('Invalid Expression');
   });
+
+  it('performs scientific operations via mathjs', () => {
+    const { getByText, getByLabelText, getByTestId } = render(<Calc />);
+
+    fireEvent.click(getByText('Sci'));
+
+    // Percent: 50 -> 0.5
+    fireEvent.click(getByText('5'));
+    fireEvent.click(getByText('0'));
+    fireEvent.click(getByLabelText('percent'));
+    expect(getByTestId('calc-display').textContent).toBe('0.5');
+
+    // Clear display
+    fireEvent.click(getByLabelText('clear'));
+
+    // Square root: √9 -> 3
+    fireEvent.click(getByText('9'));
+    fireEvent.click(getByLabelText('square root'));
+    expect(getByTestId('calc-display').textContent).toBe('3');
+
+    // Clear display
+    fireEvent.click(getByLabelText('clear'));
+
+    // Square: 3² -> 9
+    fireEvent.click(getByText('3'));
+    fireEvent.click(getByLabelText('square'));
+    expect(getByTestId('calc-display').textContent).toBe('9');
+
+    // Clear display
+    fireEvent.click(getByLabelText('clear'));
+
+    // Reciprocal: 2 -> 0.5
+    fireEvent.click(getByText('2'));
+    fireEvent.click(getByLabelText('reciprocal'));
+    expect(getByTestId('calc-display').textContent).toBe('0.5');
+
+    // Clear display
+    fireEvent.click(getByLabelText('clear'));
+
+    // Toggle sign: 5 -> -5
+    fireEvent.click(getByText('5'));
+    fireEvent.click(getByLabelText('toggle sign'));
+    expect(getByTestId('calc-display').textContent).toBe('-5');
+  });
 });
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "npm run build:gamepad",
-    "dev": "next dev",
     "prebuild": "tsc -p tsconfig.gamepad.json",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "export": "next export",
@@ -35,7 +34,6 @@
     "cytoscape": "^3.33.1",
     "cytoscape-cose-bilkent": "^4.1.0",
     "dompurify": "^3.2.6",
-    "expr-eval": "^2.0.2",
     "figlet": "^1.8.2",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,13 +4616,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expr-eval@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expr-eval@npm:2.0.2"
-  checksum: 10c0/642f112ff28ea34574c595c3ad73ccd8e638498879a4dd28620c4dabebab2e11987a851266ba81883dae85a5800e0c93b3d06f81718b71a215f831534646e4f2
-  languageName: node
-  linkType: hard
-
 "extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
@@ -9643,7 +9636,6 @@ __metadata:
     dompurify: "npm:^3.2.6"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:^15.0.0"
-    expr-eval: "npm:^2.0.2"
     fake-indexeddb: "npm:^6.1.0"
     figlet: "npm:^1.8.2"
     howler: "npm:^2.2.4"


### PR DESCRIPTION
## Summary
- replace expr-eval based calculator parsing with mathjs
- run memory and scientific features through mathjs
- add tests for scientific calculator shortcuts

## Testing
- `yarn test --runTestsByPath __tests__/calc.test.ts`
- `yarn test --runTestsByPath __tests__/calc.test.tsx`
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b04438581c832893afe372495e836f