### PR TITLE
feat(calc): add token validation and inline errors

### DIFF
--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -1,8 +1,11 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import FormField from '../../components/ui/FormField';
 import './styles.css';
 
 export default function Calculator() {
+  const [error, setError] = useState('');
+
   useEffect(() => {
     const load = async () => {
       if (typeof window !== 'undefined' && !(window as any).math) {
@@ -13,14 +16,17 @@ export default function Calculator() {
           document.body.appendChild(script);
         });
       }
-      await import('./main');
+      const mod = await import('./main');
+      if (mod.initCalculator) mod.initCalculator(setError);
     };
     load();
   }, []);
 
   return (
     <div className="calculator">
-      <input id="display" className="display" />
+      <FormField error={error}>
+        <input id="display" className="display" />
+      </FormField>
       <button id="toggle-precise" className="toggle" aria-pressed="false">Precise Mode: Off</button>
       <button id="toggle-scientific" className="toggle" aria-pressed="false">Scientific</button>
       <button id="toggle-programmer" className="toggle" aria-pressed="false">Programmer</button>

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import FormError from './FormError';
+
+interface FormFieldProps {
+  id?: string;
+  className?: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+const FormField = ({ id, className = '', error, children }: FormFieldProps) => (
+  <div id={id} className={className}>
+    {children}
+    {error && <FormError>{error}</FormError>}
+  </div>
+);
+
+export default FormField;


### PR DESCRIPTION
## Summary
- add reusable `<FormField>` for inline error display
- apply FormField to calculator and wire up error state
- add token-level input validation with caret preservation

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04438ede08328aff4d598c0ab6510