### PR TITLE
Improve BadgeList accessibility with focus-trapped modal

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,8 +1,44 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(null);
+  const triggerRef = useRef(null);
+  const modalRef = useRef(null);
+
+  const closeModal = () => {
+    setSelected(null);
+    triggerRef.current && triggerRef.current.focus();
+  };
+
+  useEffect(() => {
+    if (!selected) return;
+
+    const focusableSelectors =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusable = modalRef.current?.querySelectorAll(focusableSelectors);
+    const elements = Array.from(focusable ?? []);
+
+    elements[0]?.focus();
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeModal();
+      } else if (e.key === 'Tab' && elements.length > 0) {
+        e.preventDefault();
+        const index = elements.indexOf(document.activeElement);
+        const next =
+          (index + (e.shiftKey ? -1 : 1) + elements.length) % elements.length;
+        elements[next].focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selected]);
 
   const filteredBadges = badges.filter((badge) =>
     badge.label.toLowerCase().includes(filter.toLowerCase())
@@ -27,7 +63,10 @@ const BadgeList = ({ badges, className = '' }) => {
             key={badge.label}
             type="button"
             className="m-1 hover:scale-110 transition-transform cursor-pointer"
-            onClick={() => setSelected(badge)}
+            onClick={(e) => {
+              triggerRef.current = e.currentTarget;
+              setSelected(badge);
+            }}
             aria-label={badge.label}
           >
             <img
@@ -41,11 +80,12 @@ const BadgeList = ({ badges, className = '' }) => {
       {selected && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-          onClick={() => setSelected(null)}
+          onClick={closeModal}
           role="dialog"
           aria-modal="true"
         >
           <div
+            ref={modalRef}
             className="bg-white text-black p-4 rounded shadow max-w-sm"
             onClick={(e) => e.stopPropagation()}
           >
@@ -53,7 +93,7 @@ const BadgeList = ({ badges, className = '' }) => {
             <div className="text-sm">{selected.description}</div>
             <button
               className="mt-4 px-2 py-1 bg-blue-600 text-white rounded"
-              onClick={() => setSelected(null)}
+              onClick={closeModal}
             >
               Close
             </button>


### PR DESCRIPTION
## Summary
- add focus-trapped modal to BadgeList with escape-to-close and returning focus to the trigger

## Testing
- `npm test` (fails: memoryGame, beef, autopsy, calc and others)
- `npx next lint --file components/BadgeList.js`


------
https://chatgpt.com/codex/tasks/task_e_68b04439f9848328889a449a5cc02e8d