### PR TITLE
Add optional capture rule for checkers

### DIFF
--- a/apps/checkers/index.tsx
+++ b/apps/checkers/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { pointerHandlers } from '../../utils/pointer';
+import usePersistentState from '../../hooks/usePersistentState';
 import {
   Board,
   Move,
@@ -19,7 +20,7 @@ const getAllMovesNoForce = (board: Board, color: 'red' | 'black'): Move[] => {
   for (let r = 0; r < 8; r++) {
     for (let c = 0; c < 8; c++) {
       if (board[r][c]?.color === color) {
-        const moves = getPieceMoves(board, r, c);
+        const moves = getPieceMoves(board, r, c, false);
         if (moves.length) result = result.concat(moves);
       }
     }
@@ -32,7 +33,7 @@ export default function CheckersPage() {
   const [turn, setTurn] = useState<'red' | 'black'>('red');
   const [selected, setSelected] = useState<[number, number] | null>(null);
   const [moves, setMoves] = useState<Move[]>([]);
-  const [rule, setRule] = useState<'forced' | 'relaxed'>('forced');
+  const [rule, setRule] = usePersistentState<'forced' | 'relaxed'>('checkersRule', 'forced');
   const [algorithm, setAlgorithm] = useState<'alphabeta' | 'mcts'>('alphabeta');
   const [difficulty, setDifficulty] = useState(3);
   const [winner, setWinner] = useState<string | null>(null);
@@ -103,7 +104,7 @@ export default function CheckersPage() {
   const selectPiece = (r: number, c: number) => {
     const piece = board[r][c];
     if (winner || !piece || piece.color !== turn) return;
-    const pieceMoves = getPieceMoves(board, r, c);
+    const pieceMoves = getPieceMoves(board, r, c, rule === 'forced');
     const mustCapture = rule === 'forced' && allMoves.some((m) => m.captured);
     const filtered = mustCapture ? pieceMoves.filter((m) => m.captured) : pieceMoves;
     if (filtered.length) {

--- a/components/apps/checkers/engine.ts
+++ b/components/apps/checkers/engine.ts
@@ -41,7 +41,12 @@ export interface Move {
 export const cloneBoard = (board: Board): Board =>
   board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
 
-export const getPieceMoves = (board: Board, r: number, c: number): Move[] => {
+export const getPieceMoves = (
+  board: Board,
+  r: number,
+  c: number,
+  enforceCapture = true,
+): Move[] => {
   const piece = board[r][c];
   if (!piece) return [];
   const dirs = [...directions[piece.color]];
@@ -65,25 +70,32 @@ export const getPieceMoves = (board: Board, r: number, c: number): Move[] => {
       }
     }
   }
-  return captures.length ? captures : moves;
+  return enforceCapture && captures.length ? captures : [...captures, ...moves];
 };
 
-export const getAllMoves = (board: Board, color: Color): Move[] => {
+export const getAllMoves = (
+  board: Board,
+  color: Color,
+  enforceCapture = true,
+): Move[] => {
   let result: Move[] = [];
   for (let r = 0; r < 8; r++) {
     for (let c = 0; c < 8; c++) {
       if (board[r][c]?.color === color) {
-        const moves = getPieceMoves(board, r, c);
+        const moves = getPieceMoves(board, r, c, enforceCapture);
         if (moves.length) result = result.concat(moves);
       }
     }
   }
   const anyCapture = result.some((m) => m.captured);
-  return anyCapture ? result.filter((m) => m.captured) : result;
+  return enforceCapture && anyCapture ? result.filter((m) => m.captured) : result;
 };
 
-export const hasMoves = (board: Board, color: Color): boolean =>
-  getAllMoves(board, color).length > 0;
+export const hasMoves = (
+  board: Board,
+  color: Color,
+  enforceCapture = true,
+): boolean => getAllMoves(board, color, enforceCapture).length > 0;
 
 export const applyMove = (
   board: Board,


### PR DESCRIPTION
## Summary
- add optional enforce-capture parameter to checkers engine
- add persisted "Require capture" toggle and update AI/move logic
- store rule preference on the Checkers page

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, calc.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0443b1108832886bd0ee98db92395