### PR TITLE
feat(password-generator): add FormField validation

### DIFF
--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import FormField from '../../components/ui/FormField';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -12,6 +13,7 @@ interface PasswordGeneratorProps {
 const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) => {
   void getDailySeed;
   const [length, setLength] = useState(12);
+  const [lengthValid, setLengthValid] = useState(true);
   const [useLower, setUseLower] = useState(true);
   const [useUpper, setUseUpper] = useState(true);
   const [useNumbers, setUseNumbers] = useState(true);
@@ -58,20 +60,21 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
 
   const { label, width, color } = strengthInfo();
 
+  const canGenerate =
+    lengthValid && (useLower || useUpper || useNumbers || useSymbols);
+
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
-      <div>
-        <label htmlFor="length" className="mr-2">Length:</label>
-        <input
-          id="length"
-          type="number"
-          min={4}
-          max={64}
-          value={length}
-          onChange={(e) => setLength(parseInt(e.target.value, 10) || 0)}
-          className="text-black px-2"
-        />
-      </div>
+      <FormField
+        id="length"
+        label="Length"
+        type="number"
+        min={4}
+        max={64}
+        value={length}
+        onChange={(v) => setLength(typeof v === 'number' ? v : 0)}
+        onValidChange={setLengthValid}
+      />
       <div className="flex flex-col space-y-1">
         <label><input type="checkbox" checked={useLower} onChange={(e) => setUseLower(e.target.checked)} /> Lowercase</label>
         <label><input type="checkbox" checked={useUpper} onChange={(e) => setUseUpper(e.target.checked)} /> Uppercase</label>
@@ -104,7 +107,8 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
         <button
           type="button"
           onClick={generatePassword}
-          className="w-full px-4 py-2 bg-green-600 rounded"
+          className="w-full px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+          disabled={!canGenerate}
         >
           Generate
         </button>

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useCallback } from 'react';
+import FormError from './FormError';
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  type?: string;
+  value: string | number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: any) => void;
+  onValidChange?: (valid: boolean) => void;
+}
+
+const FormField: React.FC<FormFieldProps> = ({
+  id,
+  label,
+  type = 'text',
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  onValidChange,
+}) => {
+  const [error, setError] = useState('');
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = type === 'number' ? e.target.valueAsNumber : e.target.value;
+      onChange(val);
+      let err = '';
+      if (type === 'number') {
+        if (Number.isNaN(val)) {
+          err = 'Value required';
+        } else {
+          if (min !== undefined && val < min) err = `Minimum ${min}`;
+          else if (max !== undefined && val > max) err = `Maximum ${max}`;
+        }
+      }
+      setError(err);
+      onValidChange?.(!err);
+    },
+    [onChange, onValidChange, min, max, type]
+  );
+
+  return (
+    <div className="mb-4">
+      <label htmlFor={id} className="mr-2">
+        {label}:
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={handleChange}
+        min={min}
+        max={max}
+        step={step}
+        aria-describedby={error ? `${id}-error` : undefined}
+        className="text-black px-2"
+      />
+      {error && <FormError id={`${id}-error`}>{error}</FormError>}
+    </div>
+  );
+};
+
+export default FormField;
+


### PR DESCRIPTION
## Summary
- add reusable FormField component with built-in range validation and inline errors
- integrate FormField into password generator and disable generation until inputs valid

## Testing
- `npm test __tests__/passwordGenerator.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b044428d4883289ffbafe5f91df936