### PR TITLE
feat(nmap-nse): add filter search

### DIFF
--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 interface Script {
   name: string;
@@ -12,6 +17,8 @@ type ScriptData = Record<string, Script[]>;
 
 const NmapNSE: React.FC = () => {
   const [data, setData] = useState<ScriptData>({});
+  const [filter, setFilter] = useState('');
+  const [debouncedFilter, setDebouncedFilter] = useState('');
   const copyExample = useCallback((text: string) => {
     if (typeof window !== 'undefined') {
       try {
@@ -30,6 +37,43 @@ const NmapNSE: React.FC = () => {
       );
     }
   }, []);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedFilter(filter), 300);
+    return () => clearTimeout(handler);
+  }, [filter]);
+
+  const filteredEntries = useMemo(() => {
+    if (!debouncedFilter) return Object.entries(data);
+    const lower = debouncedFilter.toLowerCase();
+    return Object.entries(data)
+      .map(([category, scripts]) => [
+        category,
+        scripts.filter((script) =>
+          [script.name, script.description, script.example].some((field) =>
+            field.toLowerCase().includes(lower)
+          )
+        ),
+      ])
+      .filter(([, scripts]) => scripts.length > 0);
+  }, [data, debouncedFilter]);
+
+  const escapeRegExp = (str: string) =>
+    str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const highlightMatch = (text: string) => {
+    if (!debouncedFilter) return text;
+    const regex = new RegExp(`(${escapeRegExp(debouncedFilter)})`, 'ig');
+    return text.split(regex).map((part, i) =>
+      part.toLowerCase() === debouncedFilter.toLowerCase() ? (
+        <mark key={i} className="bg-yellow-500 text-black">
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    );
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -51,7 +95,15 @@ const NmapNSE: React.FC = () => {
         Script details use static demo data for learning purposes only. Links open
         in isolated tabs.
       </p>
-      {Object.entries(data).map(([category, scripts]) => (
+      <input
+        type="text"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        placeholder="Filter scripts..."
+        className="mb-4 w-full p-2 rounded text-black"
+        aria-label="Filter scripts"
+      />
+      {filteredEntries.map(([category, scripts]) => (
         <div key={category} className="mb-6">
           <h2 className="text-xl mb-2 capitalize">{category}</h2>
           {scripts.map((script) => (
@@ -61,11 +113,11 @@ const NmapNSE: React.FC = () => {
                 onClick={() => openScriptDoc(script.name)}
                 className="font-mono text-blue-400 underline"
               >
-                {script.name}
+                {highlightMatch(script.name)}
               </button>
-              <p className="mb-2">{script.description}</p>
+              <p className="mb-2">{highlightMatch(script.description)}</p>
               <pre className="bg-black text-green-400 p-2 rounded overflow-auto font-mono leading-[1.2]">
-                {script.example}
+                {highlightMatch(script.example)}
               </pre>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- add search input for Nmap scripts
- debounce filter updates
- highlight matched text in script fields

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b044432c4083289d8a16fc042859ee