### PR TITLE
feat: add copy button with clipboard feedback

### DIFF
--- a/__tests__/passwordGenerator.test.tsx
+++ b/__tests__/passwordGenerator.test.tsx
@@ -21,6 +21,7 @@ describe('PasswordGenerator', () => {
     fireEvent.click(getByText('Copy'));
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(value);
+      expect(getByText('Copied to clipboard')).toBeInTheDocument();
     });
   });
 });

--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import CopyButton from '../../components/ui/CopyButton';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -34,15 +35,6 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
       pwd += chars[idx];
     }
     setPassword(pwd);
-  };
-
-  const copyToClipboard = async () => {
-    if (!password) return;
-    try {
-      await navigator.clipboard?.writeText(password);
-    } catch (e) {
-      // ignore
-    }
   };
 
   const strengthInfo = () => {
@@ -86,13 +78,10 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
           value={password}
           className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
         />
-        <button
-          type="button"
-          onClick={copyToClipboard}
+        <CopyButton
+          text={password}
           className="px-3 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-        >
-          Copy
-        </button>
+        />
       </div>
       <div>
         <div className="h-2 w-full bg-gray-700 rounded">

--- a/components/ui/CopyButton.tsx
+++ b/components/ui/CopyButton.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import Toast from './Toast';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  className?: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({
+  text,
+  label = 'Copy',
+  className = '',
+}) => {
+  const [toast, setToast] = useState<string | null>(null);
+
+  const copyText = async () => {
+    if (!text) return;
+    try {
+      await navigator.clipboard?.writeText(text);
+      setToast('Copied to clipboard');
+    } catch (error) {
+      setToast('Failed to copy');
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={copyText}
+        className={className}
+      >
+        {label}
+      </button>
+      {toast && (
+        <Toast
+          message={toast}
+          onClose={() => setToast(null)}
+        />
+      )}
+    </>
+  );
+};
+
+export default CopyButton;


### PR DESCRIPTION
## Summary
- add reusable `CopyButton` component using `navigator.clipboard.writeText`
- integrate `CopyButton` into password generator
- test copy flow and toast feedback

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04444456083288ac63b618bb3ce4c