### PR TITLE
feat: add clipboard copy toast

### DIFF
--- a/__tests__/passwordGenerator.test.tsx
+++ b/__tests__/passwordGenerator.test.tsx
@@ -11,16 +11,27 @@ describe('PasswordGenerator', () => {
     expect(value).toHaveLength(8);
   });
 
-  it('copies password to clipboard', async () => {
+  it('copies password to clipboard and shows success toast', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     // @ts-ignore
     Object.assign(navigator, { clipboard: { writeText } });
-    const { getByText, getByTestId } = render(<PasswordGenerator />);
+    const { getByText, getByTestId, findByText } = render(<PasswordGenerator />);
     fireEvent.click(getByText('Generate'));
     const value = (getByTestId('password-display') as HTMLInputElement).value;
     fireEvent.click(getByText('Copy'));
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(value);
     });
+    expect(await findByText('Password copied to clipboard')).toBeInTheDocument();
+  });
+
+  it('prompts manual copy when clipboard write fails', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    // @ts-ignore
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { getByText, findByText } = render(<PasswordGenerator />);
+    fireEvent.click(getByText('Generate'));
+    fireEvent.click(getByText('Copy'));
+    expect(await findByText('Press Ctrl+C to copy')).toBeInTheDocument();
   });
 });

--- a/apps/password_generator/index.tsx
+++ b/apps/password_generator/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import Toast from '../../components/ui/Toast';
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz';
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -17,6 +18,8 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
   const [useNumbers, setUseNumbers] = useState(true);
   const [useSymbols, setUseSymbols] = useState(false);
   const [password, setPassword] = useState('');
+  const [toast, setToast] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const generatePassword = () => {
     let chars = '';
@@ -39,9 +42,18 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
   const copyToClipboard = async () => {
     if (!password) return;
     try {
-      await navigator.clipboard?.writeText(password);
+      const permission = await navigator.permissions?.query({
+        // @ts-ignore - PermissionName may not include clipboard-write in older lib versions
+        name: 'clipboard-write',
+      });
+      if (permission && permission.state === 'denied') {
+        throw new Error('Permission denied');
+      }
+      await navigator.clipboard.writeText(password);
+      setToast('Password copied to clipboard');
     } catch (e) {
-      // ignore
+      inputRef.current?.select();
+      setToast('Press Ctrl+C to copy');
     }
   };
 
@@ -59,57 +71,66 @@ const PasswordGenerator: React.FC<PasswordGeneratorProps> = ({ getDailySeed }) =
   const { label, width, color } = strengthInfo();
 
   return (
-    <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
-      <div>
-        <label htmlFor="length" className="mr-2">Length:</label>
-        <input
-          id="length"
-          type="number"
-          min={4}
-          max={64}
-          value={length}
-          onChange={(e) => setLength(parseInt(e.target.value, 10) || 0)}
-          className="text-black px-2"
-        />
-      </div>
-      <div className="flex flex-col space-y-1">
-        <label><input type="checkbox" checked={useLower} onChange={(e) => setUseLower(e.target.checked)} /> Lowercase</label>
-        <label><input type="checkbox" checked={useUpper} onChange={(e) => setUseUpper(e.target.checked)} /> Uppercase</label>
-        <label><input type="checkbox" checked={useNumbers} onChange={(e) => setUseNumbers(e.target.checked)} /> Numbers</label>
-        <label><input type="checkbox" checked={useSymbols} onChange={(e) => setUseSymbols(e.target.checked)} /> Symbols</label>
-      </div>
-      <div className="flex space-x-2 items-center">
-        <input
-          data-testid="password-display"
-          type="text"
-          readOnly
-          value={password}
-          className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-        />
-        <button
-          type="button"
-          onClick={copyToClipboard}
-          className="px-3 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-        >
-          Copy
-        </button>
-      </div>
-      <div>
-        <div className="h-2 w-full bg-gray-700 rounded">
-          <div className={`h-full ${color} rounded`} style={{ width }} />
+    <>
+      <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col space-y-4">
+        <div>
+          <label htmlFor="length" className="mr-2">Length:</label>
+          <input
+            id="length"
+            type="number"
+            min={4}
+            max={64}
+            value={length}
+            onChange={(e) => setLength(parseInt(e.target.value, 10) || 0)}
+            className="text-black px-2"
+          />
         </div>
-        <div className="text-sm mt-1">Strength: {label}</div>
+        <div className="flex flex-col space-y-1">
+          <label><input type="checkbox" checked={useLower} onChange={(e) => setUseLower(e.target.checked)} /> Lowercase</label>
+          <label><input type="checkbox" checked={useUpper} onChange={(e) => setUseUpper(e.target.checked)} /> Uppercase</label>
+          <label><input type="checkbox" checked={useNumbers} onChange={(e) => setUseNumbers(e.target.checked)} /> Numbers</label>
+          <label><input type="checkbox" checked={useSymbols} onChange={(e) => setUseSymbols(e.target.checked)} /> Symbols</label>
+        </div>
+        <div className="flex space-x-2 items-center">
+          <input
+            ref={inputRef}
+            data-testid="password-display"
+            type="text"
+            readOnly
+            value={password}
+            className="flex-1 text-black px-2 py-1 font-mono leading-[1.2] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={copyToClipboard}
+            className="px-3 py-1 bg-blue-600 rounded focus-visible:ring-2 focus-visible-ring-offset-2 focus-visible:ring-blue-500"
+          >
+            Copy
+          </button>
+        </div>
+        <div>
+          <div className="h-2 w-full bg-gray-700 rounded">
+            <div className={`h-full ${color} rounded`} style={{ width }} />
+          </div>
+          <div className="text-sm mt-1">Strength: {label}</div>
+        </div>
+        <div className="mt-auto">
+          <button
+            type="button"
+            onClick={generatePassword}
+            className="w-full px-4 py-2 bg-green-600 rounded"
+          >
+            Generate
+          </button>
+        </div>
       </div>
-      <div className="mt-auto">
-        <button
-          type="button"
-          onClick={generatePassword}
-          className="w-full px-4 py-2 bg-green-600 rounded"
-        >
-          Generate
-        </button>
-      </div>
-    </div>
+      {toast && (
+        <Toast
+          message={toast}
+          onClose={() => setToast(null)}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- use Clipboard API to copy generated passwords
- show toast on success or prompt manual copy when clipboard access fails
- add tests for clipboard success and failure scenarios

## Testing
- `yarn lint --file apps/password_generator/index.tsx --file __tests__/passwordGenerator.test.tsx`
- `yarn test __tests__/passwordGenerator.test.tsx`
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0444775408328bf7af8a3fce50f4b