### PR TITLE
Pause Phaser game when tab is hidden and resume on focus

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -267,7 +267,24 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
       scene: LevelScene,
     });
 
+    const handleVisibility = () => {
+      const scene = game.scene.getScene('level') as Phaser.Scene & {
+        matter: Phaser.Physics.Matter.MatterPhysics;
+      };
+      if (document.visibilityState === 'hidden') {
+        scene.scene.pause();
+        scene.matter.world.pause();
+      } else {
+        scene.scene.resume();
+        scene.matter.world.resume();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
+
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
       game.destroy(true);
     };
   }, []);


### PR DESCRIPTION
## Summary
- auto-pause Phaser Matter scene when document becomes hidden
- resume scene and physics on visibility or focus return

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b044499f04832899b30b53ba349c03