### PR TITLE
feat(sticky-notes): add title and color options

### DIFF
--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -1,9 +1,18 @@
 const notesContainer = document.getElementById('notes');
 const addNoteBtn = document.getElementById('add-note');
-let notes = JSON.parse(localStorage.getItem('stickyNotes') || '[]');
+const MAX_TITLE_LENGTH = 50;
+let notes = JSON.parse(localStorage.getItem('stickyNotes') || '[]').map((n) => ({
+  ...n,
+  title: n.title || '',
+}));
+
+function isValid(note) {
+  return note.title.trim().length > 0 && note.title.length <= MAX_TITLE_LENGTH;
+}
 
 function saveNotes() {
-  localStorage.setItem('stickyNotes', JSON.stringify(notes));
+  const validNotes = notes.filter(isValid);
+  localStorage.setItem('stickyNotes', JSON.stringify(validNotes));
 }
 
 function createNoteElement(note) {
@@ -17,8 +26,13 @@ function createNoteElement(note) {
   const controls = document.createElement('div');
   controls.className = 'controls';
 
+  const colorLabel = document.createElement('label');
+  colorLabel.textContent = 'Color';
+  colorLabel.setAttribute('for', `color-${note.id}`);
+
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
+  colorInput.id = `color-${note.id}`;
   colorInput.value = note.color;
   colorInput.addEventListener('input', (e) => {
     note.color = e.target.value;
@@ -35,9 +49,41 @@ function createNoteElement(note) {
     saveNotes();
   });
 
+  controls.appendChild(colorLabel);
   controls.appendChild(colorInput);
   controls.appendChild(deleteBtn);
   el.appendChild(controls);
+
+  const titleContainer = document.createElement('div');
+  titleContainer.className = 'title-wrapper';
+
+  const titleLabel = document.createElement('label');
+  titleLabel.textContent = 'Title';
+  titleLabel.setAttribute('for', `title-${note.id}`);
+
+  const titleInput = document.createElement('input');
+  titleInput.type = 'text';
+  titleInput.id = `title-${note.id}`;
+  titleInput.maxLength = MAX_TITLE_LENGTH;
+  titleInput.value = note.title;
+
+  const counter = document.createElement('span');
+  counter.className = 'char-counter';
+  counter.textContent = `${note.title.length}/${MAX_TITLE_LENGTH}`;
+
+  titleInput.addEventListener('input', (e) => {
+    note.title = e.target.value;
+    counter.textContent = `${note.title.length}/${MAX_TITLE_LENGTH}`;
+    if (e.target.checkValidity()) {
+      saveNotes();
+    }
+    e.target.classList.toggle('invalid', !e.target.checkValidity());
+  });
+
+  titleContainer.appendChild(titleLabel);
+  titleContainer.appendChild(titleInput);
+  titleContainer.appendChild(counter);
+  el.appendChild(titleContainer);
 
   const textarea = document.createElement('textarea');
   textarea.value = note.content;
@@ -51,18 +97,19 @@ function createNoteElement(note) {
   notesContainer.appendChild(el);
 }
 
-function addNote() {
-  const note = {
-    id: Date.now(),
-    content: '',
-    x: 50,
-    y: 50,
-    color: '#fffa65',
-  };
-  notes.push(note);
-  createNoteElement(note);
-  saveNotes();
-}
+  function addNote() {
+    const note = {
+      id: Date.now(),
+      content: '',
+      x: 50,
+      y: 50,
+      color: '#fffa65',
+      title: '',
+    };
+    notes.push(note);
+    createNoteElement(note);
+    saveNotes();
+  }
 
 function enableDrag(el, note) {
   let offsetX, offsetY;

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -49,3 +49,22 @@ body {
   border: none;
   cursor: pointer;
 }
+
+.note .title-wrapper {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+.note .title-wrapper input {
+  flex: 1;
+  margin: 0 4px;
+}
+
+.note .char-counter {
+  font-size: 0.8rem;
+}
+
+.note input.invalid {
+  border: 1px solid red;
+}


### PR DESCRIPTION
## Summary
- add labeled color picker to sticky notes
- add title field with 50 char limit and live counter
- validate title before persisting notes

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b0444e361083288d733b9ddb26baa1