### PR TITLE
Validate timer inputs before starting

### DIFF
--- a/apps/timer_stopwatch/index.html
+++ b/apps/timer_stopwatch/index.html
@@ -44,6 +44,10 @@
       border-radius: 4px;
       font-family: 'Courier New', monospace;
     }
+    .error {
+      color: red;
+      margin-top: 5px;
+    }
   </style>
 </head>
 <body>
@@ -57,6 +61,7 @@
       <input type="number" id="minutes" min="0" value="0" /> :
       <input type="number" id="seconds" min="0" max="59" value="30" />
     </div>
+    <div id="timerError" class="error"></div>
     <div class="display" id="timerDisplay">00:30</div>
     <div>
       <button id="startTimer">Start</button>

--- a/apps/timer_stopwatch/index.tsx
+++ b/apps/timer_stopwatch/index.tsx
@@ -20,6 +20,7 @@ export default function TimerStopwatch() {
           <input type="number" id="minutes" min="0" defaultValue="0" /> :
           <input type="number" id="seconds" min="0" max="59" defaultValue="30" />
         </div>
+        <div id="timerError" className="error" />
         <div className="display" id="timerDisplay">00:30</div>
         <div>
           <button id="startTimer">Start</button>

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -12,6 +12,38 @@ const stopwatchControls = document.getElementById('stopwatchControls');
 const minutesInput = document.getElementById('minutes');
 const secondsInput = document.getElementById('seconds');
 const lapsList = document.getElementById('laps');
+const startTimerBtn = document.getElementById('startTimer');
+const timerError = document.getElementById('timerError');
+
+function validateTimerInputs() {
+  const minsStr = minutesInput.value.trim();
+  const secsStr = secondsInput.value.trim();
+
+  const minsValid = /^\d+$/.test(minsStr);
+  const secsValid = /^\d+$/.test(secsStr);
+  const mins = minsValid ? parseInt(minsStr, 10) : NaN;
+  const secs = secsValid ? parseInt(secsStr, 10) : NaN;
+
+  let msg = '';
+  if (!minsValid || !secsValid) {
+    msg = 'Use numbers only.';
+  } else if (mins < 0 || secs < 0 || secs > 59) {
+    msg = 'Minutes >= 0 and seconds 0-59.';
+  }
+
+  if (msg) {
+    timerError.textContent = msg;
+    startTimerBtn.disabled = true;
+    return false;
+  }
+
+  timerError.textContent = '';
+  startTimerBtn.disabled = false;
+  return true;
+}
+
+minutesInput.addEventListener('input', validateTimerInputs);
+secondsInput.addEventListener('input', validateTimerInputs);
 
 function formatTime(seconds) {
   const m = Math.floor(seconds / 60)
@@ -41,6 +73,7 @@ function updateTimerDisplay() {
 
 function startTimer() {
   if (timerInterval) return;
+  if (!validateTimerInputs()) return;
   const mins = parseInt(minutesInput.value, 10) || 0;
   const secs = parseInt(secondsInput.value, 10) || 0;
   timerRemaining = mins * 60 + secs;
@@ -117,7 +150,7 @@ function playSound() {
   }
 }
 
-document.getElementById('startTimer').addEventListener('click', startTimer);
+startTimerBtn.addEventListener('click', startTimer);
 document.getElementById('stopTimer').addEventListener('click', stopTimer);
 document.getElementById('resetTimer').addEventListener('click', resetTimer);
 
@@ -129,3 +162,4 @@ document.getElementById('lapWatch').addEventListener('click', lapWatch);
 // Initialize displays
 updateTimerDisplay();
 updateStopwatchDisplay();
+validateTimerInputs();

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -37,3 +37,8 @@ li {
   border-radius: 4px;
   font-family: 'Courier New', monospace;
 }
+
+.error {
+  color: red;
+  margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- validate minutes and seconds, disabling start until numbers are within range
- display inline timer input errors with red styling

## Testing
- `yarn test apps/timer_stopwatch --passWithNoTests`
- `yarn lint apps/timer_stopwatch` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b044514f3483288eb908d80518d8ee