### PR TITLE
feat: add geolocation button with manual fallback

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -44,7 +44,7 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=()',
+    value: 'camera=(), microphone=(), geolocation=*',
   },
   {
     // Allow same-origin framing so the PDF resume renders in an <object>


### PR DESCRIPTION
## Summary
- allow geolocation in Permissions-Policy header
- add geolocation button with permission error messaging
- show manual city input when location access is denied

## Testing
- `npm run lint`
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b044538df08328ba3528463dcd4fea