### PR TITLE
Add browser smoke test script and record failures

### DIFF
--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -1,12 +1,15 @@
-import { chromium } from 'playwright';
+import { chromium, firefox, webkit } from 'playwright';
 import fs from 'fs';
 import path from 'path';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
 (async () => {
-  const browser = await chromium.launch();
-  const context = await browser.newContext();
+  const browsers = [
+    { name: 'chromium', type: chromium },
+    { name: 'firefox', type: firefox },
+    { name: 'webkit', type: webkit },
+  ];
 
   const pagesDir = path.join(process.cwd(), 'pages', 'apps');
   const files = fs.readdirSync(pagesDir, { withFileTypes: true })
@@ -15,25 +18,52 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
   const routes = files.map((file) => `/apps/${file.replace(/\.(jsx?|tsx?)$/, '')}`);
 
-  for (const route of routes) {
-    const page = await context.newPage();
-    const consoleErrors = [];
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') {
-        consoleErrors.push(msg.text());
+  let hadError = false;
+  const results = [];
+
+  for (const { name, type } of browsers) {
+    const browser = await type.launch();
+    const context = await browser.newContext();
+
+    for (const route of routes) {
+      const page = await context.newPage();
+      const consoleErrors = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+      console.log(`[${name}] Visiting ${route}`);
+      let error = '';
+      try {
+        const response = await page.goto(`${BASE_URL}${route}`);
+        if (!response || !response.ok()) {
+          error = `HTTP ${response ? response.status() : 'no response'}`;
+        } else if (consoleErrors.length > 0) {
+          error = consoleErrors.join('\n');
+        }
+      } catch (err) {
+        error = err.message;
       }
-    });
-    console.log(`Visiting ${route}`);
-    const response = await page.goto(`${BASE_URL}${route}`);
-    if (!response || !response.ok()) {
-      throw new Error(`Failed to load ${route}: ${response ? response.status() : 'no response'}`);
+      if (error) {
+        hadError = true;
+        console.error(`[${name}] Error on ${route}: ${error}`);
+      }
+      results.push({ browser: name, route, error });
+      await page.close();
     }
-    if (consoleErrors.length > 0) {
-      throw new Error(`Console errors on ${route}:\n${consoleErrors.join('\n')}`);
-    }
-    await page.close();
+
+    await browser.close();
   }
 
-  await browser.close();
-  console.log('All app routes loaded without console errors.');
+  if (hadError) {
+    console.error('Completed with errors');
+  } else {
+    console.log('All app routes loaded without console errors.');
+  }
+
+  // Write results to log file if TEST_LOG env variable provided
+  if (process.env.SMOKE_LOG) {
+    fs.writeFileSync(process.env.SMOKE_LOG, JSON.stringify(results, null, 2));
+  }
 })();

--- a/test-log.md
+++ b/test-log.md
@@ -1,0 +1,22 @@
+# Test Log
+
+## pages/apps routes console error check
+
+Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All requests returned HTTP 500 responses, so console errors could not be verified.
+
+| Route | Chromium | Firefox | WebKit |
+|-------|----------|---------|--------|
+| /apps/2048 | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/blackjack | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/calculator | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/checkers | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/connect-four | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/minesweeper | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/nmap-nse | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/password_generator | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/phaser_matter | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/sokoban | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/sticky_notes | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/timer_stopwatch | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/weather_widget | HTTP 500 | HTTP 500 | HTTP 500 |
+| /apps/word_search | HTTP 500 | HTTP 500 | HTTP 500 |


### PR DESCRIPTION
## Summary
- extend smoke-all-apps script to scan Chromium, Firefox, and WebKit and optionally log results
- add `test-log.md` documenting `/apps` routes returning HTTP 500 across browsers

## Testing
- `SMOKE_LOG=/tmp/smoke-results.json npm run smoke` (HTTP 500 errors for all routes)
- `npm test` (fail: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b0632489a483288a8c3552e24e3aff