### PR TITLE
test: add axe accessibility checks

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -18,4 +18,4 @@ jobs:
           yarn dev &
           npx wait-on http://localhost:3000
       - run: npx pa11y-ci --config pa11yci.json
-      - run: npx playwright test __tests__/a11y.spec.ts
+      - run: npx playwright test playwright/a11y.spec.ts

--- a/playwright/a11y.spec.ts
+++ b/playwright/a11y.spec.ts
@@ -4,11 +4,14 @@ import AxeBuilder from '@axe-core/playwright';
 const urls = ['/', '/apps'];
 
 for (const path of urls) {
-  test(`no accessibility violations on ${path}`, async ({ page }) => {
+  test(`no critical accessibility violations on ${path}`, async ({ page }) => {
     await page.goto(`http://localhost:3000${path}`);
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa'])
       .analyze();
-    expect(results.violations).toEqual([]);
+    const critical = results.violations.filter(
+      (v) => v.impact === 'critical',
+    );
+    expect(critical).toEqual([]);
   });
 }


### PR DESCRIPTION
## Summary
- run axe-core via Playwright on key pages
- fail Playwright tests only on critical a11y violations
- hook Playwright a11y tests into CI

## Testing
- `npx playwright test playwright/a11y.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*


------
https://chatgpt.com/codex/tasks/task_e_68b063258604832898540bce59d4152a