### PR TITLE
feat(youtube): add oEmbed paste support and privacy mode embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Heavy apps are wrapped with **dynamic import** and most games share a `GameLayou
 | `NEXT_PUBLIC_TEMPLATE_ID` | EmailJS template id. |
 | `NEXT_PUBLIC_USER_ID` | EmailJS public key / user id. |
 | `NEXT_PUBLIC_YOUTUBE_API_KEY` | Used by the YouTube app for search/embed enhancements. |
-| `NEXT_PUBLIC_PRIVACY_MODE` | Use `youtube-nocookie.com` for embeds when set to `true`. |
+| `NEXT_PUBLIC_PRIVACY_MODE` | Use `youtube-nocookie.com` for embeds when set to `true`; playback still sets storage. |
 | `NEXT_PUBLIC_BEEF_URL` | Optional URL for the BeEF demo iframe (if used). |
 | `NEXT_PUBLIC_GHIDRA_URL` | Optional URL for a remote Ghidra Web interface. |
 | `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |


### PR DESCRIPTION
## Summary
- ensure YouTube embeds use privacy-enhanced mode and official parameters
- support pasting YouTube links with optional oEmbed lookup
- document that even privacy mode sets storage once playback starts

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b0634b308083288a8d03dffed64f56