### PR TITLE
feat(figlet): dynamic font previews with monospace filter

### DIFF
--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -1,22 +1,55 @@
 import figlet from 'figlet';
-import standard from 'figlet/importable-fonts/Standard.js';
-import slant from 'figlet/importable-fonts/Slant.js';
-import big from 'figlet/importable-fonts/Big.js';
-import ghost from 'figlet/importable-fonts/Ghost.js';
-import small from 'figlet/importable-fonts/Small.js';
 
-const fonts = ['Standard', 'Slant', 'Big', 'Ghost', 'Small'];
+const FONT_URL = 'https://unpkg.com/figlet@1.8.2/fonts';
+const loaded = new Set();
 
-figlet.parseFont('Standard', standard);
-figlet.parseFont('Slant', slant);
-figlet.parseFont('Big', big);
-figlet.parseFont('Ghost', ghost);
-figlet.parseFont('Small', small);
+async function loadFont(name) {
+  if (loaded.has(name)) return;
+  const res = await fetch(`${FONT_URL}/${encodeURIComponent(name)}.flf`);
+  const data = await res.text();
+  figlet.parseFont(name, data);
+  loaded.add(name);
+}
 
-self.postMessage({ type: 'fonts', fonts });
+function strip(lines) {
+  return lines.map((l) => l.replace(/\s+$/, ''));
+}
 
-self.onmessage = (e) => {
-  const { text, font } = e.data;
-  const rendered = figlet.textSync(text || '', { font });
+function isMonospace(name) {
+  const chars = 'ABCDE';
+  let width;
+  for (const ch of chars) {
+    const glyph = strip(figlet.textSync(ch, { font: name }).split('\n'));
+    const w = glyph.reduce((m, line) => Math.max(m, line.length), 0);
+    if (width === undefined) width = w;
+    else if (w !== width) return false;
+  }
+  return true;
+}
+
+async function init() {
+  const meta = await fetch(`${FONT_URL}?meta`).then((r) => r.json());
+  const fonts = meta.files
+    .filter((f) => f.path.endsWith('.flf'))
+    .map((f) => f.path.split('/').pop().replace('.flf', ''));
+  for (const name of fonts) {
+    await loadFont(name);
+    const preview = figlet.textSync('Figlet', { font: name });
+    const mono = isMonospace(name);
+    self.postMessage({ type: 'font', font: name, preview, mono });
+  }
+}
+
+init();
+
+self.onmessage = async (e) => {
+  const { text = '', font } = e.data;
+  if (!font) return;
+  await loadFont(font);
+  const normalized = String(text)
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .join('\n');
+  const rendered = figlet.textSync(normalized, { font });
   self.postMessage({ type: 'render', output: rendered });
 };


### PR DESCRIPTION
## Summary
- load FIGlet fonts dynamically and show live previews
- add monospace-only filter and FIGlet reference
- normalize multiline input in worker before rendering

## Testing
- `yarn lint components/apps/figlet/index.js components/apps/figlet/worker.js` *(fails: Couldn't find any `pages` or `app` directory)*
- `npx eslint components/apps/figlet/index.js components/apps/figlet/worker.js` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: memoryGame, beef, autopsy, calc tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0634f9660832897a38ca0d4e35560