### PR TITLE
Explain OpenWeather key usage in weather widget

### DIFF
--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -17,8 +17,27 @@ export default function WeatherWidget() {
           <option value="metric">°C</option>
           <option value="imperial">°F</option>
         </select>
-        <input type="text" id="api-key-input" placeholder="API Key (optional)" />
+        <input
+          type="text"
+          id="api-key-input"
+          placeholder="OpenWeather API Key"
+          title="OpenWeather API key required for live data"
+        />
         <button id="save-api-key">Save</button>
+      </div>
+      <small className="api-note">
+        Requires an{' '}
+        <a
+          href="https://openweathermap.org/appid"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          OpenWeather API key
+        </a>
+        . Leave blank to use demo data.
+      </small>
+      <div id="demo-message" className="demo-message" style={{ display: 'none' }}>
+        Showing demo weather data. Add an API key for live updates.
       </div>
       <div id="weather" className="weather">
         <div className="temp">--°C</div>

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -8,11 +8,21 @@ const cityPicker = document.getElementById('city-picker');
 const unitToggle = document.getElementById('unit-toggle');
 const apiKeyInput = document.getElementById('api-key-input');
 const saveApiKeyBtn = document.getElementById('save-api-key');
+const demoMessage = document.getElementById('demo-message');
 
 let apiKey = localStorage.getItem('weatherApiKey') || '';
 if (apiKey) apiKeyInput.value = apiKey;
+updateDemoMessage();
 
 let unit = unitToggle.value;
+
+function updateDemoMessage() {
+  if (apiKey) {
+    demoMessage.style.display = 'none';
+  } else {
+    demoMessage.style.display = 'block';
+  }
+}
 
 function loadCities() {
   cityPicker.innerHTML = cities
@@ -90,6 +100,7 @@ saveApiKeyBtn.addEventListener('click', () => {
     localStorage.removeItem('weatherApiKey');
   }
   updateWeather();
+  updateDemoMessage();
 });
 
 loadCities();

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -41,6 +41,18 @@ body {
   text-transform: capitalize;
 }
 
+.api-note,
+.demo-message {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  margin-top: 10px;
+}
+
+.demo-message {
+  color: #555;
+}
+
 .fade-in {
   animation: fadeIn 0.5s forwards;
 }


### PR DESCRIPTION
## Summary
- document OpenWeather API key requirement and add setup link
- show a demo data banner when no API key is saved

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04454e8608328a1ca23f9ff545d21