### PR TITLE
feat(word-search): offload grid generation to worker

### DIFF
--- a/apps/word_search/worker.ts
+++ b/apps/word_search/worker.ts
@@ -1,0 +1,14 @@
+import { generateGrid } from './generator';
+import type { WordPlacement } from './types';
+
+interface Message {
+  words: string[];
+  size: number;
+  seed: string;
+}
+
+self.onmessage = (e: MessageEvent<Message>) => {
+  const { words, size, seed } = e.data;
+  const result = generateGrid(words, size, seed);
+  (self as any).postMessage(result);
+};


### PR DESCRIPTION
## Summary
- move word search grid generation to a dedicated Web Worker
- send generated grid back to main thread and reset puzzle state on receipt
- show a loading indicator while puzzles are being generated

## Testing
- `yarn test __tests__/wordSearch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b063203900832883bb519c5ac4ee09