### PR TITLE
Add CSRF and reCAPTCHA protection to contact form

### DIFF
--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -4,7 +4,14 @@ describe('contact form', () => {
   it('invalid email blocked', async () => {
     const fetchMock = jest.fn();
     const result = await processContactForm(
-      { name: 'A', email: 'invalid', message: 'Hi', honeypot: '' },
+      {
+        name: 'A',
+        email: 'invalid',
+        message: 'Hi',
+        honeypot: '',
+        csrfToken: 'csrf',
+        recaptchaToken: 'rc',
+      },
       fetchMock
     );
     expect(result.success).toBe(false);
@@ -14,12 +21,22 @@ describe('contact form', () => {
   it('success posts to api', async () => {
     const fetchMock = jest.fn().mockResolvedValue({ ok: true });
     const result = await processContactForm(
-      { name: 'Alex', email: 'alex@example.com', message: 'Hello', honeypot: '' },
+      {
+        name: 'Alex',
+        email: 'alex@example.com',
+        message: 'Hello',
+        honeypot: '',
+        csrfToken: 'csrf',
+        recaptchaToken: 'rc',
+      },
       fetchMock
     );
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/contact',
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'csrf' }),
+      })
     );
     expect(result.success).toBe(true);
   });

--- a/__tests__/contactRateLimit.test.ts
+++ b/__tests__/contactRateLimit.test.ts
@@ -4,25 +4,38 @@ describe('contact api rate limiter', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     rateLimit.clear();
+    delete (global as any).fetch;
+    delete process.env.RECAPTCHA_SECRET_KEY;
   });
 
-  it('removes stale IP entries', () => {
+  it('removes stale IP entries', async () => {
     const baseTime = 1_000_000;
     jest.spyOn(Date, 'now').mockReturnValue(baseTime);
 
     rateLimit.set('1.1.1.1', { count: 1, start: baseTime - RATE_LIMIT_WINDOW_MS - 1 });
 
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({ success: true }) });
+    process.env.RECAPTCHA_SECRET_KEY = 'secret';
     const req: any = {
       method: 'POST',
-      headers: {},
+      headers: { 'x-csrf-token': 'token', cookie: 'csrfToken=token' },
+      cookies: { csrfToken: 'token' },
       socket: { remoteAddress: '2.2.2.2' },
-      body: { name: 'Alex', email: 'alex@example.com', message: 'Hello', honeypot: '' },
+      body: {
+        name: 'Alex',
+        email: 'alex@example.com',
+        message: 'Hello',
+        honeypot: '',
+        recaptchaToken: 'tok',
+      },
     };
     const res: any = {};
     res.status = () => res;
     res.json = () => {};
 
-    handler(req, res);
+    await handler(req, res);
 
     expect(rateLimit.has('1.1.1.1')).toBe(false);
     expect(rateLimit.has('2.2.2.2')).toBe(true);

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import FormError from '../../ui/FormError';
-
-export const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
+import { contactSchema } from '../../../utils/contactSchema';
 
 const sanitize = (str: string) =>
   str.replace(/[&<>"']/g, (c) => ({
@@ -12,32 +11,47 @@ const sanitize = (str: string) =>
     "'": '&#39;',
   }[c]!));
 
+const errorMap: Record<string, string> = {
+  rate_limit: 'Too many requests. Please try again later.',
+  invalid_input: 'Please check your input and try again.',
+  invalid_csrf: 'Security token mismatch. Refresh and retry.',
+  invalid_recaptcha: 'Captcha verification failed. Please try again.',
+};
+
 export const processContactForm = async (
-  data: { name: string; email: string; message: string; honeypot: string },
+  data: {
+    name: string;
+    email: string;
+    message: string;
+    honeypot: string;
+    csrfToken: string;
+    recaptchaToken: string;
+  },
   fetchImpl: typeof fetch = fetch
 ) => {
-  const name = data.name.trim();
-  const email = data.email.trim();
-  const message = data.message.trim();
-
-  if (data.honeypot) return { success: false };
-  if (!name || name.length > 100) return { success: false, error: 'Invalid name' };
-  if (!isValidEmail(email)) return { success: false, error: 'Invalid email' };
-  if (!message || message.length > 1000)
-    return { success: false, error: 'Invalid message' };
-
   try {
+    const parsed = contactSchema.parse(data);
     const res = await fetchImpl('/api/contact', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': parsed.csrfToken,
+      },
       body: JSON.stringify({
-        name: sanitize(name),
-        email,
-        message: sanitize(message),
-        honeypot: '',
+        name: sanitize(parsed.name),
+        email: parsed.email,
+        message: sanitize(parsed.message),
+        honeypot: parsed.honeypot,
+        recaptchaToken: parsed.recaptchaToken,
       }),
     });
-    if (!res.ok) return { success: false, error: 'Submission failed' };
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return {
+        success: false,
+        error: errorMap[body.code as string] || 'Submission failed',
+      };
+    }
     return { success: true };
   } catch {
     return { success: false, error: 'Submission failed' };
@@ -51,10 +65,42 @@ const ContactApp = () => {
   const [honeypot, setHoneypot] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+  const [csrfToken, setCsrfToken] = useState('');
+
+  useEffect(() => {
+    fetch('/api/contact')
+      .then((res) => res.json())
+      .then((d) => setCsrfToken(d.csrfToken || ''))
+      .catch(() => {});
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+    if (siteKey) {
+      const script = document.createElement('script');
+      script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      script.async = true;
+      document.head.appendChild(script);
+    }
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const result = await processContactForm({ name, email, message, honeypot });
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+    const recaptchaToken = await new Promise<string>((resolve) => {
+      const g: any = (window as any).grecaptcha;
+      if (!g || !siteKey) return resolve('');
+      g.ready(() => {
+        g.execute(siteKey, { action: 'submit' })
+          .then((token: string) => resolve(token))
+          .catch(() => resolve(''));
+      });
+    });
+    const result = await processContactForm({
+      name,
+      email,
+      message,
+      honeypot,
+      csrfToken,
+      recaptchaToken,
+    });
     if (!result.success) {
       setError(result.error ? sanitize(result.error) : 'Submission failed');
       setSuccess(false);

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "npm run build:gamepad",
-    "dev": "next dev",
     "prebuild": "tsc -p tsconfig.gamepad.json",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "export": "next export",
@@ -65,7 +64,8 @@
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
-    "turndown": "^7.2.1"
+    "turndown": "^7.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,4 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { randomBytes } from 'crypto';
+import { contactSchema } from '../../utils/contactSchema';
 
 // Simple in-memory rate limiter. Not suitable for distributed environments.
 export const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -6,7 +8,17 @@ const RATE_LIMIT_MAX = 5;
 
 export const rateLimit = new Map<string, { count: number; start: number }>();
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const token = randomBytes(32).toString('hex');
+    res.setHeader(
+      'Set-Cookie',
+      `csrfToken=${token}; HttpOnly; Path=/; SameSite=Strict`
+    );
+    res.status(200).json({ ok: true, csrfToken: token });
+    return;
+  }
+
   if (req.method !== 'POST') {
     res.status(405).json({ ok: false });
     return;
@@ -28,24 +40,62 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     }
   }
   if (entry.count > RATE_LIMIT_MAX) {
-    res.status(429).json({ ok: false, error: 'Too many requests' });
+    console.warn('Contact submission rejected', { ip, reason: 'rate_limit' });
+    res.status(429).json({ ok: false, code: 'rate_limit' });
     return;
   }
 
-  const { name = '', email = '', message = '', honeypot = '' } = req.body || {};
-  const trimmedName = name.trim();
-  const trimmedEmail = email.trim();
-  const trimmedMessage = message.trim();
+  const csrfHeader = req.headers['x-csrf-token'];
+  const csrfCookie = req.cookies?.csrfToken;
+  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie) {
+    console.warn('Contact submission rejected', { ip, reason: 'invalid_csrf' });
+    res.status(403).json({ ok: false, code: 'invalid_csrf' });
+    return;
+  }
 
-  if (
-    honeypot ||
-    !trimmedName ||
-    trimmedName.length > 100 ||
-    !/\S+@\S+\.\S+/.test(trimmedEmail) ||
-    !trimmedMessage ||
-    trimmedMessage.length > 1000
-  ) {
-    res.status(400).json({ ok: false, error: 'Invalid input' });
+  const { recaptchaToken = '', ...rest } = req.body || {};
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!recaptchaToken || !secret) {
+    console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
+    res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
+    return;
+  }
+  try {
+    const verify = await fetch(
+      'https://www.google.com/recaptcha/api/siteverify',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          secret,
+          response: recaptchaToken,
+        }),
+      }
+    );
+    const captcha = await verify.json();
+    if (!captcha.success) {
+      console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
+      res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
+      return;
+    }
+  } catch {
+    console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
+    res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
+    return;
+  }
+
+  try {
+    const parsed = contactSchema.parse({ ...rest, csrfToken: csrfHeader, recaptchaToken });
+    if (parsed.honeypot) {
+      console.warn('Contact submission rejected', { ip, reason: 'honeypot' });
+      res.status(400).json({ ok: false, code: 'invalid_input' });
+      return;
+    }
+  } catch {
+    console.warn('Contact submission rejected', { ip, reason: 'invalid_input' });
+    res.status(400).json({ ok: false, code: 'invalid_input' });
     return;
   }
 

--- a/utils/contactSchema.ts
+++ b/utils/contactSchema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .transform((v) => v.replace(/\s+/g, ' ')),
+  email: z.string().trim().email(),
+  message: z
+    .string()
+    .trim()
+    .min(1)
+    .max(1000)
+    .transform((v) => v.replace(/\s+/g, ' ')),
+  honeypot: z.string().max(0),
+  csrfToken: z.string().min(1),
+  recaptchaToken: z.string().min(1),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9681,6 +9681,7 @@ __metadata:
     turndown: "npm:^7.2.1"
     typescript: "npm:^5.9.2"
     wait-on: "npm:^8.0.4"
+    zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
 
@@ -10214,7 +10215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.1":
+"zod@npm:^3.23.8, zod@npm:^3.24.1":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c


### PR DESCRIPTION
## Summary
- add shared Zod schema with whitespace normalization for contact form
- integrate CSRF token fetch and reCAPTCHA v3 on client; map API errors to friendly messages
- validate CSRF and reCAPTCHA on server API with logging and schema enforcement

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc, contact.api/contactRateLimit/contact: pass in targeted run)*
- `npm test __tests__/contact.test.tsx __tests__/contact.api.test.ts __tests__/contactRateLimit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b06356d4508328bebae6fe70544e03