### PR TITLE
Add SSH and HTTP command preview modules with legal interstitial

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -90,7 +90,9 @@ const NmapNSEApp = createDynamicApp('nmap-nse', 'Nmap NSE');
 const OpenVASApp = createDynamicApp('openvas', 'OpenVAS');
 const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
- 
+const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
+const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+
 
 
 const displayTerminal = createDisplay(TerminalApp);
@@ -162,6 +164,8 @@ const displayNmapNSE = createDisplay(NmapNSEApp);
 const displayOpenVAS = createDisplay(OpenVASApp);
 const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
+const displaySSH = createDisplay(SSHApp);
+const displayHTTP = createDisplay(HTTPApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -797,6 +801,24 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMimikatz,
+  },
+  {
+    id: 'ssh',
+    title: 'SSH Builder',
+    icon: './themes/Yaru/apps/ssh.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySSH,
+  },
+  {
+    id: 'http',
+    title: 'HTTP Builder',
+    icon: './themes/Yaru/apps/http.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHTTP,
   },
   {
     id: 'hydra',

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState } from 'react';
+import LegalInterstitial from '../../components/ui/LegalInterstitial';
+
+const HTTPPreview: React.FC = () => {
+  const [accepted, setAccepted] = useState(false);
+  const [method, setMethod] = useState('GET');
+  const [url, setUrl] = useState('');
+
+  const command = `curl -X ${method} ${url}`.trim();
+
+  if (!accepted) {
+    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 p-4 text-white">
+      <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
+      <p className="mb-4 text-sm text-yellow-300">
+        Build a curl command without sending any requests. Learn more at{' '}
+        <a
+          href="https://curl.se/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          the curl project page
+        </a>
+        .
+      </p>
+      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
+        <div>
+          <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
+            Method
+          </label>
+          <select
+            id="http-method"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={method}
+            onChange={(e) => setMethod(e.target.value)}
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="DELETE">DELETE</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
+            URL
+          </label>
+          <input
+            id="http-url"
+            type="text"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+        </div>
+      </form>
+      <div>
+        <h2 className="mb-2 text-lg">Command Preview</h2>
+        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+          {command || '# Fill in the form to generate a command'}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default HTTPPreview;

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useState } from 'react';
+import LegalInterstitial from '../../components/ui/LegalInterstitial';
+
+const SSHPreview: React.FC = () => {
+  const [accepted, setAccepted] = useState(false);
+  const [user, setUser] = useState('');
+  const [host, setHost] = useState('');
+  const [port, setPort] = useState('');
+
+  const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
+
+  if (!accepted) {
+    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 p-4 text-white">
+      <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
+      <p className="mb-4 text-sm text-yellow-300">
+        Generate an SSH command without executing it. Learn more at{' '}
+        <a
+          href="https://www.openssh.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          the OpenSSH project page
+        </a>
+        .
+      </p>
+      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
+        <div>
+          <label htmlFor="ssh-user" className="mb-1 block text-sm font-medium">
+            Username
+          </label>
+          <input
+            id="ssh-user"
+            type="text"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="ssh-host" className="mb-1 block text-sm font-medium">
+            Host
+          </label>
+          <input
+            id="ssh-host"
+            type="text"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="ssh-port" className="mb-1 block text-sm font-medium">
+            Port (optional)
+          </label>
+          <input
+            id="ssh-port"
+            type="number"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+          />
+        </div>
+      </form>
+      <div>
+        <h2 className="mb-2 text-lg">Command Preview</h2>
+        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+          {command || '# Fill in the form to generate a command'}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default SSHPreview;

--- a/components/ui/LegalInterstitial.tsx
+++ b/components/ui/LegalInterstitial.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+interface LegalInterstitialProps {
+  onAccept: () => void;
+}
+
+const LegalInterstitial: React.FC<LegalInterstitialProps> = ({ onAccept }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 text-white">
+    <div className="max-w-md rounded bg-gray-900 p-6 text-center">
+      <h2 className="mb-4 text-xl font-bold">Legal Use Only</h2>
+      <p className="mb-6 text-sm">
+        This demo is for educational purposes only. Only interact with systems you own or have explicit permission to test.
+      </p>
+      <button
+        type="button"
+        onClick={onAccept}
+        className="rounded bg-blue-600 px-4 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+      >
+        I Understand
+      </button>
+    </div>
+  </div>
+);
+
+export default LegalInterstitial;

--- a/pages/apps/http.tsx
+++ b/pages/apps/http.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const HTTPPreview = dynamic(() => import('../../apps/http'), { ssr: false });
+
+export default function HTTPPage() {
+  return <HTTPPreview />;
+}

--- a/pages/apps/ssh.tsx
+++ b/pages/apps/ssh.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const SSHPreview = dynamic(() => import('../../apps/ssh'), { ssr: false });
+
+export default function SSHPage() {
+  return <SSHPreview />;
+}

--- a/public/themes/Yaru/apps/http.svg
+++ b/public/themes/Yaru/apps/http.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#2e3440"/>
+  <text x="32" y="37" font-size="24" text-anchor="middle" fill="#eceff4" font-family="Arial, Helvetica, sans-serif">HTTP</text>
+</svg>

--- a/public/themes/Yaru/apps/ssh.svg
+++ b/public/themes/Yaru/apps/ssh.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#2e3440"/>
+  <text x="32" y="37" font-size="24" text-anchor="middle" fill="#eceff4" font-family="Arial, Helvetica, sans-serif">SSH</text>
+</svg>


### PR DESCRIPTION
## Summary
- add reusable legal-use interstitial overlay
- create SSH and HTTP command builder apps with read-only previews and project links
- register new modules and icons in app catalogue

## Testing
- `yarn lint`
- `yarn test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b0635e8114832887c9c5dcc4d29728