### PR TITLE
feat: add filtered Metasploit post module catalog

### DIFF
--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -1,10 +1,26 @@
 import React, { useEffect, useState } from 'react';
 
-const SAMPLE_MODULES = [
-  'post/multi/recon/local_exploit_suggester',
-  'post/windows/manage/enable_rdp',
-  'post/linux/gather/enum_network',
+// Sample module catalog for demo purposes only
+const MODULE_CATALOG = [
+  {
+    name: 'post/multi/recon/local_exploit_suggester',
+    platform: 'multi',
+    session: 'meterpreter',
+  },
+  {
+    name: 'post/windows/manage/enable_rdp',
+    platform: 'windows',
+    session: 'meterpreter',
+  },
+  {
+    name: 'post/linux/gather/enum_network',
+    platform: 'linux',
+    session: 'shell',
+  },
 ];
+
+const PLATFORMS = ['multi', 'windows', 'linux'];
+const SESSION_TYPES = ['meterpreter', 'shell'];
 
 const escapeText = (text) =>
   text
@@ -16,8 +32,9 @@ const escapeText = (text) =>
 
 const MsfPostApp = () => {
   const [modules, setModules] = useState([]);
-  const [selected, setSelected] = useState('');
   const [output, setOutput] = useState('');
+  const [platform, setPlatform] = useState('');
+  const [sessionType, setSessionType] = useState('');
   const [steps, setSteps] = useState([
     { label: 'Gather System Info', done: false },
     { label: 'Escalate Privileges', done: false },
@@ -28,7 +45,7 @@ const MsfPostApp = () => {
   const [reduceMotion, setReduceMotion] = useState(false);
 
   useEffect(() => {
-    setModules(SAMPLE_MODULES);
+    setModules(MODULE_CATALOG);
   }, []);
 
   useEffect(() => {
@@ -38,6 +55,12 @@ const MsfPostApp = () => {
     mq.addEventListener('change', handleChange);
     return () => mq.removeEventListener('change', handleChange);
   }, []);
+
+  const filteredModules = modules.filter(
+    (m) =>
+      (!platform || m.platform === platform) &&
+      (!sessionType || m.session === sessionType)
+  );
 
   const animateSteps = () => {
     setSteps((prev) => prev.map((s) => ({ ...s, done: false })));
@@ -60,9 +83,9 @@ const MsfPostApp = () => {
     update();
   };
 
-  const runModule = () => {
-    if (!selected) return;
-    setOutput(`# Running ${selected}\nSample output line 1\nSample output line 2`);
+  const runModule = (mod) => {
+    if (!mod) return;
+    setOutput(`# Running ${mod}\nSample output line 1\nSample output line 2`);
     animateSteps();
   };
 
@@ -82,32 +105,61 @@ const MsfPostApp = () => {
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
       <h2 className="text-lg mb-2">Metasploit Post Modules</h2>
-      <div className="flex mb-4">
+      <div className="flex mb-4 space-x-2">
         <select
-          className="flex-1 bg-gray-800 p-2 rounded"
-          value={selected}
-          onChange={(e) => setSelected(e.target.value)}
+          className="bg-gray-800 p-2 rounded"
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value)}
         >
-          <option value="">Select a module</option>
-          {modules.map((m) => (
-            <option key={m} value={m}>
-              {m}
+          <option value="">All Platforms</option>
+          {PLATFORMS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          className="bg-gray-800 p-2 rounded"
+          value={sessionType}
+          onChange={(e) => setSessionType(e.target.value)}
+        >
+          <option value="">All Sessions</option>
+          {SESSION_TYPES.map((s) => (
+            <option key={s} value={s}>
+              {s}
             </option>
           ))}
         </select>
         <button
-          onClick={runModule}
-          className="ml-2 px-4 py-2 bg-blue-600 rounded"
-        >
-          Run
-        </button>
-        <button
           onClick={copyAsCode}
-          className="ml-2 px-4 py-2 bg-green-600 rounded"
+          className="px-4 py-2 bg-green-600 rounded"
         >
           Copy as code
         </button>
       </div>
+      <ul className="mb-4 flex-1 overflow-auto">
+        {filteredModules.map((m) => (
+          <li key={m.name} className="mb-2 flex items-center">
+            <button
+              onClick={() => runModule(m.name)}
+              className="mr-2 px-2 py-1 bg-blue-600 rounded"
+            >
+              Run
+            </button>
+            <a
+              href={`https://www.rapid7.com/db/modules/${m.name}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-400 hover:underline"
+            >
+              {m.name}
+            </a>
+            <span className="ml-2 text-xs text-gray-400">
+              [{m.platform} / {m.session}]
+            </span>
+          </li>
+        ))}
+      </ul>
       <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">
         {output}
       </pre>


### PR DESCRIPTION
## Summary
- add demo catalog of Metasploit post modules with platform and session metadata
- filter catalog by platform and required session
- link each module entry to official Metasploit documentation

## Testing
- `yarn test components/apps/msf-post/index.js` *(fails: No tests found)*
- `yarn lint components/apps/msf-post/index.js` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0636528648328ae8cd621d32acdbe