### PR TITLE
feat: add nikto command preview demo

### DIFF
--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,193 +1,106 @@
-import React, { useState, useRef, useEffect } from 'react';
-
-const MAX_TARGET_LENGTH = 2048;
-const MAX_TEXT_SIZE = 500000; // ~500kb
-
-const RadarChart = ({ data }) => {
-  const labels = Object.keys(data);
-  const counts = labels.map((l) => data[l] || 0);
-  const max = Math.max(...counts, 1);
-  const points = labels
-    .map((label, i) => {
-      const angle = (Math.PI * 2 * i) / labels.length - Math.PI / 2;
-      const radius = (counts[i] / max) * 40;
-      const x = 50 + radius * Math.cos(angle);
-      const y = 50 + radius * Math.sin(angle);
-      return `${x},${y}`;
-    })
-    .join(' ');
-
-  const altText =
-    labels.length > 0
-      ? labels.map((l) => `${l}: ${data[l] || 0}`).join(', ')
-      : 'no data';
-
-  return (
-    <svg
-      viewBox="0 0 100 100"
-      role="img"
-      aria-label={`Nikto findings radar chart showing ${altText}`}
-      className="w-full h-full"
-    >
-      <title>Nikto findings</title>
-      <desc>{`Radar chart of categories with counts: ${altText}`}</desc>
-      <polygon
-        points={points}
-        fill="rgba(34,197,94,0.4)"
-        stroke="#22c55e"
-        strokeWidth="2"
-      />
-      {labels.map((label, i) => {
-        const angle = (Math.PI * 2 * i) / labels.length - Math.PI / 2;
-        const x = 50 + 45 * Math.cos(angle);
-        const y = 50 + 45 * Math.sin(angle);
-        return (
-          <text
-            key={label}
-            x={x}
-            y={y}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            className="fill-white text-[8px]"
-          >
-            {label}
-          </text>
-        );
-      })}
-    </svg>
-  );
-};
+import React, { useEffect, useRef, useState } from 'react';
 
 const NiktoApp = () => {
-  const [target, setTarget] = useState('');
-  const [clusters, setClusters] = useState({});
-  const [loading, setLoading] = useState(false);
+  const [target, setTarget] = useState('example.com');
   const [status, setStatus] = useState('');
-  const [animProgress, setAnimProgress] = useState(1);
+  const [results, setResults] = useState({});
   const workerRef = useRef(null);
-  const prefersReducedMotion = useRef(false);
 
   useEffect(() => {
     workerRef.current = new Worker(new URL('./nikto.worker.js', import.meta.url));
     workerRef.current.onmessage = (e) => {
-      const { clusters: c, error } = e.data || {};
+      const { clusters, error } = e.data || {};
       if (error) {
         setStatus(error);
-        setClusters({});
-      } else if (c) {
-        setClusters(c);
+        setResults({});
+      } else if (clusters) {
+        setResults(clusters);
         setStatus('Scan complete');
       }
     };
     workerRef.current.onerror = () => {
       setStatus('Worker error');
-      setLoading(false);
     };
-    prefersReducedMotion.current = window.matchMedia(
-      '(prefers-reduced-motion: reduce)'
-    ).matches;
     return () => workerRef.current?.terminate();
   }, []);
 
-  useEffect(() => {
-    if (!Object.keys(clusters).length) return;
-    if (prefersReducedMotion.current) {
-      setAnimProgress(1);
-      return;
-    }
-    setAnimProgress(0);
-    let start;
-    const step = (ts) => {
-      if (!start) start = ts;
-      const progress = Math.min((ts - start) / 500, 1);
-      setAnimProgress(progress);
-      if (progress < 1) requestAnimationFrame(step);
-    };
-    requestAnimationFrame(step);
-  }, [clusters]);
-
-  const runScan = async () => {
-    if (!target) return;
-    if (target.length > MAX_TARGET_LENGTH) {
-      setStatus('Target too long');
-      return;
-    }
-    setLoading(true);
-    setStatus('Running scan');
-    setClusters({});
+  const runDemo = async () => {
+    setStatus('Running scan...');
+    setResults({});
     try {
-      const res = await fetch(`/api/nikto?target=${encodeURIComponent(target)}`);
+      const res = await fetch('/demo/nikto-output.txt');
       const text = await res.text();
-      if (text.length > MAX_TEXT_SIZE) {
-        setStatus('Scan result too large to analyze');
-        return;
-      }
+      setStatus('Parsing results...');
       workerRef.current?.postMessage({ text });
-    } catch (err) {
-      setStatus(`Error: ${err.message}`);
-    } finally {
-      setLoading(false);
+    } catch (e) {
+      setStatus(`Error: ${e.message}`);
     }
   };
 
-  const scaledClusters = Object.fromEntries(
-    Object.entries(clusters).map(([k, v]) => [k, v.count * animProgress])
-  );
+  const command = `nikto -h ${target}`;
 
   return (
-    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 overflow-auto">
-      <h1 className="text-lg mb-4 font-bold">Nikto Scanner</h1>
-      <div className="flex mb-4">
+    <div className="h-full w-full flex flex-col md:flex-row text-white">
+      <div className="md:w-1/2 p-4 bg-ub-dark overflow-y-auto">
+        <h1 className="text-lg mb-4">Nikto Demo</h1>
+        <label htmlFor="target" className="block text-sm mb-1">
+          Target
+        </label>
         <input
-          type="text"
+          id="target"
           value={target}
-          onChange={(e) => setTarget(e.target.value.slice(0, MAX_TARGET_LENGTH))}
-          placeholder="http://example.com"
-          className="flex-1 p-2 rounded-l text-black"
+          onChange={(e) => setTarget(e.target.value)}
+          className="w-full p-2 mb-4 text-black"
         />
+        <pre className="bg-black text-green-400 p-2 rounded mb-4 overflow-auto">
+          {command}
+        </pre>
         <button
           type="button"
-          onClick={runScan}
-          className="px-4 bg-ubt-blue rounded-r focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+          onClick={runDemo}
+          className="px-4 py-2 bg-ubt-blue rounded focus:outline-none focus:ring-2 focus:ring-ubt-blue"
         >
-          Scan
+          Run Demo
         </button>
-      </div>
-      <div aria-live="polite" className="sr-only">
-        {status}
-      </div>
-      {loading ? (
-        <p>Running scan...</p>
-      ) : Object.keys(clusters).length > 0 ? (
-        <div className="flex flex-col md:flex-row gap-4 flex-1">
-          <div className="md:w-1/2 flex justify-center items-center">
-            <RadarChart data={scaledClusters} />
-          </div>
-          <ul
-            className="md:w-1/2 list-disc pl-4 text-sm overflow-auto"
-            aria-live="polite"
+        {status && <p className="mt-4 text-sm">{status}</p>}
+        <div aria-live="polite" className="sr-only">
+          {status}
+        </div>
+        <p className="mt-4 text-sm">
+          <a
+            href="https://cirt.net/Nikto2"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-ubt-blue"
           >
-            {Object.entries(clusters).map(([cat, { proofs }]) => (
-              <li key={cat} className="mb-2">
-                <span className="font-bold text-white">{cat}</span>
-                <ul className="list-disc pl-4 mt-1">
+            Official documentation
+          </a>
+        </p>
+      </div>
+      <div className="md:w-1/2 p-4 bg-black overflow-y-auto">
+        <h2 className="text-lg mb-4">Demo results</h2>
+        {Object.keys(results).length === 0 ? (
+          <p>No results</p>
+        ) : (
+          <div className="grid gap-4">
+            {Object.entries(results).map(([cat, { proofs }]) => (
+              <div key={cat} className="bg-ub-cool-grey p-4 rounded shadow">
+                <h3 className="font-bold mb-2">{cat}</h3>
+                <ul className="list-disc pl-4 text-sm">
                   {proofs.map((p, i) => (
-                    <li key={i} className="text-gray-100 mb-1">
+                    <li key={i} className="mb-1">
                       {p}
                     </li>
                   ))}
                 </ul>
-              </li>
+              </div>
             ))}
-          </ul>
-        </div>
-      ) : (
-        <p>No results</p>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };
 
 export default NiktoApp;
-
 export const displayNikto = () => <NiktoApp />;

--- a/public/demo/nikto-output.txt
+++ b/public/demo/nikto-output.txt
@@ -1,0 +1,5 @@
++ Server: Apache/2.4.41 (Ubuntu)
++ The X-XSS-Protection header is not defined. This can allow XSS.
++ /login.php: Database error reveals SQL injection vulnerability.
++ /etc/passwd: Local File Inclusion vulnerability.
++ http://example.com/remote.txt: Remote File Inclusion vulnerability.


### PR DESCRIPTION
## Summary
- add Nikto demo UI with command preview and worker-driven status
- display parsed results as cards
- include link to official Nikto docs

## Testing
- `npm test` *(fails: calc, memoryGame, BeEF, autopsy)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b06367393c832884e5a56e084f73f4