### PR TITLE
feat: add VT feed status demo with worker progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ yarn lint
 | Wireshark | /apps/wireshark | Security Tool (simulated) |
 
 > All security apps are **non-operational simulations** intended for education/demos. They **do not** execute exploits and should not be used for any unauthorized activity.
+> All reports and feed data are canned examples and not generated from live systems.
 
 ---
 

--- a/components/apps/openvas/feed-status-card.js
+++ b/components/apps/openvas/feed-status-card.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const FeedStatusCard = () => {
+  const feed = {
+    source: 'Greenbone Community Feed',
+    vtCount: 99564,
+    lastUpdate: '2024-02-01',
+    docs: 'https://docs.greenbone.net/'
+  };
+  return (
+    <div className="p-4 bg-gray-800 rounded mb-4">
+      <h3 className="text-md font-bold mb-2">VT Feed Status</h3>
+      <p className="text-sm">Source: {feed.source}</p>
+      <p className="text-sm">VTs: {feed.vtCount.toLocaleString()}</p>
+      <p className="text-sm">Last Update: {feed.lastUpdate}</p>
+      <p className="text-xs text-gray-400 mt-2">
+        Data based on <a href={feed.docs} className="underline" target="_blank" rel="noreferrer">Greenbone docs</a> (canned demo)
+      </p>
+    </div>
+  );
+};
+
+export default FeedStatusCard;

--- a/components/apps/openvas/openvas.worker.js
+++ b/components/apps/openvas/openvas.worker.js
@@ -1,12 +1,12 @@
 self.onmessage = (e) => {
-  const text = e.data || '';
+  const text = e.data?.text || '';
   const lines = text.split('\n');
   const findings = [];
-  const severities = ['low', 'medium', 'high', 'critical'];
   const sevReg = /Severity:\s*(Low|Medium|High|Critical)/i;
   const impactReg = /Impact:\s*(Low|Medium|High|Critical)/i;
   const likelihoodReg = /Likelihood:\s*(Low|Medium|High|Critical)/i;
-  lines.forEach((line) => {
+  const total = lines.length;
+  lines.forEach((line, idx) => {
     const severityMatch = line.match(sevReg);
     const impactMatch = line.match(impactReg);
     const likelihoodMatch = line.match(likelihoodReg);
@@ -19,6 +19,13 @@ self.onmessage = (e) => {
         description: line.trim(),
       });
     }
+    if (idx % 50 === 0) {
+      self.postMessage({
+        type: 'progress',
+        data: Math.round((idx / total) * 100),
+      });
+    }
   });
-  self.postMessage(findings);
+  self.postMessage({ type: 'progress', data: 100 });
+  self.postMessage({ type: 'result', data: findings });
 };

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import FeedStatusCard from './feed-status-card';
+
+const TaskOverview = () => {
+  const tasks = [
+    { name: 'Internal Network Scan', status: 'Completed' },
+    { name: 'External Perimeter', status: 'Running' },
+    { name: 'Web App Audit', status: 'Queued' }
+  ];
+
+  return (
+    <div className="mb-4">
+      <FeedStatusCard />
+      <div className="p-4 bg-gray-800 rounded">
+        <h3 className="text-md font-bold mb-2">Demo Task Overview</h3>
+        <ul className="text-sm space-y-1">
+          {tasks.map((t) => (
+            <li key={t.name} className="flex justify-between">
+              <span>{t.name}</span>
+              <span>{t.status}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-gray-400 mt-2">All task data is canned for demonstration purposes.</p>
+      </div>
+    </div>
+  );
+};
+
+export default TaskOverview;


### PR DESCRIPTION
## Summary
- add VT feed status card and task overview demo
- stream heavy OpenVAS parsing to worker with progress bar
- document that demo data and reports are canned

## Testing
- `npm test` *(fails: memoryGame, BeEF app, Autopsy, Calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b0636860508328908219228ba1996c