### PR TITLE
feat(volatility): demo heatmap and plugin browser

### DIFF
--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import plugins from '../../../public/demo-data/volatility/plugins.json';
+
+const PluginBrowser = () => (
+  <div className="space-y-3">
+    {plugins.map((p) => (
+      <div key={p.name} className="bg-gray-800 p-3 rounded">
+        <h3 className="font-semibold text-sm">{p.name}</h3>
+        <p className="text-xs mb-1">{p.description}</p>
+        <a
+          href={p.doc}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-blue-400 underline"
+        >
+          Volatility 3 docs
+        </a>
+      </div>
+    ))}
+  </div>
+);
+
+export default PluginBrowser;

--- a/components/apps/volatility/heatmap.worker.js
+++ b/components/apps/volatility/heatmap.worker.js
@@ -4,19 +4,28 @@ self.onmessage = ({ data }) => {
     cellSize = 10,
     cols = 100,
     rows = 60,
+    segments = [],
   } = data || {};
-  const types = ['process', 'dll', 'socket'];
+
+  let segIndex = 0;
+  let segCount = 0;
 
   for (let y = 0; y < rows; y++) {
     for (let x = 0; x < cols; x++) {
+      if (segments[segIndex] && segCount >= segments[segIndex].size) {
+        segIndex = Math.min(segIndex + 1, segments.length - 1);
+        segCount = 0;
+      }
+      const type = segments[segIndex]?.type || 'process';
       cells.push({
         x: x * cellSize,
         y: y * cellSize,
         width: cellSize,
         height: cellSize,
         value: Math.random(),
-        type: types[Math.floor(Math.random() * types.length)],
+        type,
       });
+      segCount++;
     }
   }
 

--- a/public/demo-data/volatility/memory.json
+++ b/public/demo-data/volatility/memory.json
@@ -1,0 +1,7 @@
+{
+  "segments": [
+    { "size": 2000, "type": "process" },
+    { "size": 2000, "type": "dll" },
+    { "size": 2000, "type": "socket" }
+  ]
+}

--- a/public/demo-data/volatility/plugins.json
+++ b/public/demo-data/volatility/plugins.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "pslist",
+    "description": "List running processes.",
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html"
+  },
+  {
+    "name": "netscan",
+    "description": "Scan for network connections.",
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/netscan.html"
+  },
+  {
+    "name": "malfind",
+    "description": "Find hidden or injected code sections.",
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/malfind.html"
+  }
+]


### PR DESCRIPTION
## Summary
- load demo memory plugin output and map segments to heatmap in worker
- add plugin browser with descriptions and Volatility 3 doc links
- simulate analysis using static demo data

## Testing
- `yarn lint`
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0637280c48328b67e98fd5de00a50