### PR TITLE
feat(calculator): responsive grid layout

### DIFF
--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -25,7 +25,7 @@ export default function Calculator() {
       <button id="toggle-scientific" className="toggle" aria-pressed="false">Scientific</button>
       <button id="toggle-programmer" className="toggle" aria-pressed="false">Programmer</button>
       <button id="toggle-history" className="toggle" aria-pressed="false">History</button>
-      <div className="buttons">
+      <div className="button-grid">
         <button className="btn" data-value="7">7</button>
         <button className="btn" data-value="8">8</button>
         <button className="btn" data-value="9">9</button>
@@ -44,7 +44,7 @@ export default function Calculator() {
         <button className="btn" data-value="+">+</button>
         <button className="btn span-two" data-action="clear">C</button>
       </div>
-      <div id="scientific" className="scientific hidden">
+      <div id="scientific" className="scientific hidden button-grid">
         <button className="btn" data-value="sin(">sin</button>
         <button className="btn" data-value="cos(">cos</button>
         <button className="btn" data-value="tan(">tan</button>

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -13,7 +13,8 @@ body {
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  width: 240px;
+  width: 100%;
+  max-width: 240px;
 }
 
 .display {
@@ -25,6 +26,8 @@ body {
   font-size: 1.2rem;
   border-radius: 4px;
   overflow-x: auto;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .toggle {
@@ -37,11 +40,16 @@ body {
   cursor: pointer;
 }
 
-.buttons,
-.scientific {
+.button-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .button-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- make calculator buttons responsive with a collapsible grid
- resize display input to fill its container

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b064c1eac883289ec784b4bc30531d