### PR TITLE
Add Wireshark demo capture and quick search

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ yarn lint
 | Reaver | /apps/reaver | Security Tool (simulated) |
 | Recon-ng | /apps/reconng | Security Tool (simulated) |
 | Volatility | /apps/volatility | Security Tool (simulated) |
-| Wireshark | /apps/wireshark | Security Tool (simulated) |
+| Wireshark | /apps/wireshark | Security Tool (simulated, lab use only) |
 
 > All security apps are **non-operational simulations** intended for education/demos. They **do not** execute exploits and should not be used for any unauthorized activity.
 

--- a/__tests__/wireshark.test.tsx
+++ b/__tests__/wireshark.test.tsx
@@ -16,7 +16,7 @@ describe('WiresharkApp', () => {
     const user = userEvent.setup();
     const { unmount } = render(<WiresharkApp initialPackets={packets} />);
 
-    const filterInput = screen.getByPlaceholderText(/filter expression/i);
+    const filterInput = screen.getByPlaceholderText(/quick search/i);
     await user.type(filterInput, 'bar');
 
     // Only packets matching the filter should remain
@@ -27,7 +27,7 @@ describe('WiresharkApp', () => {
     // Unmount and remount to ensure the filter persists
     unmount();
     render(<WiresharkApp initialPackets={packets} />);
-    expect(screen.getByPlaceholderText(/filter expression/i)).toHaveValue('bar');
+    expect(screen.getByPlaceholderText(/quick search/i)).toHaveValue('bar');
     expect(screen.getByText('bar')).toBeInTheDocument();
     expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
@@ -87,6 +87,16 @@ describe('WiresharkApp', () => {
 
     expect(await screen.findByText(/decrypted/i)).toBeInTheDocument();
     expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('provides quick search and docs link', () => {
+    render(<WiresharkApp initialPackets={[]} />);
+    expect(screen.getByPlaceholderText(/quick search/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /display filter docs/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.wireshark.org/docs/dfref/'
+    );
   });
 });
 

--- a/apps/wireshark/index.tsx
+++ b/apps/wireshark/index.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+import WiresharkApp from '../../components/apps/wireshark';
+import tinyCapture from './tinyCapture.json';
+
+const WiresharkPage: React.FC = () => {
+  return <WiresharkApp initialPackets={tinyCapture} />;
+};
+
+export default WiresharkPage;

--- a/apps/wireshark/tinyCapture.json
+++ b/apps/wireshark/tinyCapture.json
@@ -1,0 +1,5 @@
+[
+  {"timestamp":"1000","src":"10.0.0.1","dest":"10.0.0.2","protocol":6,"info":"TCP handshake"},
+  {"timestamp":"1500","src":"10.0.0.2","dest":"10.0.0.1","protocol":6,"info":"TCP response"},
+  {"timestamp":"3000","src":"10.0.0.1","dest":"10.0.0.2","protocol":17,"info":"UDP packet"}
+]

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -55,9 +55,11 @@ const WiresharkApp = ({ initialPackets = [] }) => {
         setTimeline(e.data.timeline);
       }
     };
+    // seed worker with any bundled packets
+    initialPackets.forEach((pkt) => worker.postMessage(pkt));
     workerRef.current = worker;
     return () => worker.terminate();
-  }, []);
+  }, [initialPackets]);
 
   useEffect(() => {
     pausedRef.current = paused;
@@ -149,6 +151,9 @@ const WiresharkApp = ({ initialPackets = [] }) => {
 
   return (
     <div className="w-full h-full flex flex-col bg-black text-green-400 [container-type:inline-size]">
+      <p className="text-yellow-300 text-xs p-2 bg-gray-900">
+        Bundled capture for lab use only. No live traffic.
+      </p>
       <div className="p-2 flex space-x-2 bg-gray-900 flex-wrap">
         <button
           onClick={startCapture}
@@ -174,9 +179,18 @@ const WiresharkApp = ({ initialPackets = [] }) => {
         <input
           value={filter}
           onChange={handleFilterChange}
-          placeholder="Filter expression"
+          placeholder="Quick search (e.g. tcp)"
+          aria-label="Quick search"
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
+        <a
+          href="https://www.wireshark.org/docs/dfref/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 underline whitespace-nowrap"
+        >
+          Display filter docs
+        </a>
         <input
           value={colorRuleText}
           onChange={handleColorRulesChange}

--- a/pages/apps/wireshark.tsx
+++ b/pages/apps/wireshark.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const Wireshark = dynamic(() => import('../../apps/wireshark'), { ssr: false });
+
+export default function WiresharkPage() {
+  return <Wireshark />;
+}


### PR DESCRIPTION
## Summary
- bundle tiny capture and render it with existing Wireshark components
- add quick search box with link to Wireshark display filter docs
- flag Wireshark demo for lab-only use

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0637490f08328abf216cac34a017b