### PR TITLE
feat(nmap-nse): add script search input

### DIFF
--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -12,6 +12,7 @@ type ScriptData = Record<string, Script[]>;
 
 const NmapNSE: React.FC = () => {
   const [data, setData] = useState<ScriptData>({});
+  const [query, setQuery] = useState('');
   const copyExample = useCallback((text: string) => {
     if (typeof window !== 'undefined') {
       try {
@@ -44,14 +45,36 @@ const NmapNSE: React.FC = () => {
     load();
   }, []);
 
+  const queryLower = query.toLowerCase();
+  const filtered = Object.entries(data).flatMap(([category, scripts]) => {
+    const categoryMatch = category.toLowerCase().includes(queryLower);
+    const matchedScripts = scripts.filter((s) =>
+      s.name.toLowerCase().includes(queryLower)
+    );
+    if (categoryMatch) {
+      return [[category, scripts]];
+    }
+    if (matchedScripts.length > 0) {
+      return [[category, matchedScripts]];
+    }
+    return [] as [string, Script[]][];
+  });
+
   return (
     <div className="p-4 bg-gray-900 text-white min-h-screen">
       <h1 className="text-2xl mb-4">Nmap NSE Script Library</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Filter scripts"
+        className="mb-4 p-2 w-full rounded text-black"
+      />
       <p className="text-sm text-yellow-300 mb-4">
         Script details use static demo data for learning purposes only. Links open
         in isolated tabs.
       </p>
-      {Object.entries(data).map(([category, scripts]) => (
+      {filtered.map(([category, scripts]) => (
         <div key={category} className="mb-6">
           <h2 className="text-xl mb-2 capitalize">{category}</h2>
           {scripts.map((script) => (


### PR DESCRIPTION
## Summary
- add stateful search input to nmap-nse app
- filter displayed categories and scripts based on query

## Testing
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn test` *(fails: memoryGame, beef, autopsy, calc)*
- `yarn lint apps/nmap-nse/index.tsx` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b064c7edfc8328b5500e5668059307