### PR TITLE
feat(hangman): add accessible letter grid

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -361,22 +361,27 @@ const Hangman = () => {
           Hint
         </button>
       </div>
-      <div className="grid grid-cols-13 gap-1 text-xs mb-2">
-        {letters.map((l) => {
-          const intensity =
-            frequencies.max ? frequencies.counts[l] / frequencies.max : 0;
-          const color = `rgba(255,0,0,${intensity})`;
-          return (
-            <span
-              key={l}
-              style={{ backgroundColor: color }}
-              className="px-1 rounded"
-            >
-              {l}
-            </span>
-          );
-        })}
-      </div>
+        <div className="flex flex-wrap justify-center gap-1 text-xs mb-2">
+          {letters.map((l) => {
+            const intensity =
+              frequencies.max ? frequencies.counts[l] / frequencies.max : 0;
+            const color = `rgba(255,0,0,${intensity})`;
+            const guessedAlready = guessed.includes(l);
+            return (
+              <button
+                key={l}
+                type="button"
+                onClick={() => handleGuess(l)}
+                style={{ backgroundColor: color }}
+                className={`px-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${guessedAlready ? 'opacity-50' : ''}`}
+                aria-pressed={guessedAlready}
+                disabled={guessedAlready || wrong >= maxWrong || won || paused}
+              >
+                {l}
+              </button>
+            );
+          })}
+        </div>
       <canvas
         ref={canvasRef}
         width={400}


### PR DESCRIPTION
## Summary
- add responsive alphabet button grid with aria-pressed states and focus styles

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b064c6c7b08328a4389f248162a554