### PR TITLE
feat: allow resizing sticky notes

### DIFF
--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -12,6 +12,8 @@ function createNoteElement(note) {
   el.style.left = note.x + 'px';
   el.style.top = note.y + 'px';
   el.style.backgroundColor = note.color;
+  el.style.width = (note.width || 200) + 'px';
+  el.style.height = (note.height || 200) + 'px';
   el.dataset.id = note.id;
 
   const controls = document.createElement('div');
@@ -46,6 +48,11 @@ function createNoteElement(note) {
     saveNotes();
   });
   el.appendChild(textarea);
+  el.addEventListener('mouseup', () => {
+    note.width = el.offsetWidth;
+    note.height = el.offsetHeight;
+    saveNotes();
+  });
 
   enableDrag(el, note);
   notesContainer.appendChild(el);
@@ -58,6 +65,8 @@ function addNote() {
     x: 50,
     y: 50,
     color: '#fffa65',
+    width: 200,
+    height: 200,
   };
   notes.push(note);
   createNoteElement(note);

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -25,7 +25,9 @@ body {
   width: 200px;
   min-height: 200px;
   padding: 10px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+  resize: both;
+  overflow: auto;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## Summary
- allow sticky notes to be resized and scroll content
- persist note width and height and restore on load

## Testing
- `npm run lint`
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b064cc354c83288fd23348c535bb21