### PR TITLE
feat: add tabbed navigation to timer/stopwatch

### DIFF
--- a/apps/timer_stopwatch/index.tsx
+++ b/apps/timer_stopwatch/index.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import './styles.css';
 
 export default function TimerStopwatch() {
+  const [mode, setMode] = useState<'timer' | 'stopwatch'>('timer');
   useEffect(() => {
     if (typeof window !== 'undefined') {
       import('./main');
@@ -11,11 +12,32 @@ export default function TimerStopwatch() {
 
   return (
     <div>
-      <div>
-        <button id="modeTimer">Timer</button>
-        <button id="modeStopwatch">Stopwatch</button>
+      <div role="tablist" className="tabs">
+        <button
+          id="modeTimer"
+          role="tab"
+          className="tab"
+          aria-selected={mode === 'timer'}
+          onClick={() => setMode('timer')}
+        >
+          Timer
+        </button>
+        <button
+          id="modeStopwatch"
+          role="tab"
+          className="tab"
+          aria-selected={mode === 'stopwatch'}
+          onClick={() => setMode('stopwatch')}
+        >
+          Stopwatch
+        </button>
       </div>
-      <div id="timerControls">
+      <div
+        id="timerControls"
+        role="tabpanel"
+        className="tab-panel"
+        hidden={mode !== 'timer'}
+      >
         <div>
           <input type="number" id="minutes" min="0" defaultValue="0" /> :
           <input type="number" id="seconds" min="0" max="59" defaultValue="30" />
@@ -27,7 +49,12 @@ export default function TimerStopwatch() {
           <button id="resetTimer">Reset</button>
         </div>
       </div>
-      <div id="stopwatchControls" style={{ display: 'none' }}>
+      <div
+        id="stopwatchControls"
+        role="tabpanel"
+        className="tab-panel"
+        hidden={mode !== 'stopwatch'}
+      >
         <div className="display" id="stopwatchDisplay">00:00</div>
         <div>
           <button id="startWatch">Start</button>

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -17,6 +17,15 @@ button {
   padding: 10px 20px;
   font-size: 1rem;
 }
+/* Tab styles */
+.tabs .tab[aria-selected='true'] {
+  background: #ddd;
+  font-weight: bold;
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
 input {
   width: 60px;
   text-align: center;


### PR DESCRIPTION
## Summary
- add stateful tab navigation for timer/stopwatch panels with `aria-selected`
- highlight active tab and hide inactive panels via CSS

## Testing
- `npm test` *(fails: 4 failing test suites)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b064cd6efc8328abccefb0f0c2a7ea