### PR TITLE
feat(weather-widget): add responsive layout and error handling

### DIFF
--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -10,7 +10,7 @@ export default function WeatherWidget() {
   }, []);
 
   return (
-    <div>
+    <div className="widget-container">
       <div className="controls">
         <select id="city-picker"></select>
         <select id="unit-toggle">
@@ -20,6 +20,7 @@ export default function WeatherWidget() {
         <input type="text" id="api-key-input" placeholder="API Key (optional)" />
         <button id="save-api-key">Save</button>
       </div>
+      <div id="error-message"></div>
       <div id="weather" className="weather">
         <div className="temp">--°C</div>
         <img className="icon" src="" alt="Weather icon" />

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -8,6 +8,7 @@ const cityPicker = document.getElementById('city-picker');
 const unitToggle = document.getElementById('unit-toggle');
 const apiKeyInput = document.getElementById('api-key-input');
 const saveApiKeyBtn = document.getElementById('save-api-key');
+const errorMessageEl = document.getElementById('error-message');
 
 let apiKey = localStorage.getItem('weatherApiKey') || '';
 if (apiKey) apiKeyInput.value = apiKey;
@@ -69,9 +70,11 @@ async function updateWeather() {
     }
     if (data) {
       renderWeather(data);
+      errorMessageEl.textContent = '';
     }
   } catch (err) {
     console.error(err);
+    errorMessageEl.textContent = 'Unable to fetch weather data. Please try again later.';
   }
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -8,21 +8,44 @@ body {
   margin: 0;
 }
 
+.widget-container {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  max-width: 400px;
+}
+
 .controls {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
   gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .weather {
-  background: white;
-  border-radius: 8px;
-  padding: 20px;
   text-align: center;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+#error-message {
+  color: #d00;
+  text-align: center;
+}
+
+@media (min-width: 600px) {
+  .widget-container {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .temp {


### PR DESCRIPTION
## Summary
- style the weather widget with a card container and responsive flexbox
- display a friendly error message when weather data fails to load

## Testing
- `npm test apps/weather_widget -- --passWithNoTests`
- `npm run lint -- --dir apps/weather_widget`

------
https://chatgpt.com/codex/tasks/task_e_68b064ce58c483288be07659fefbd3b1