### PR TITLE
feat: highlight word search selection path

### DIFF
--- a/apps/word_search/index.tsx
+++ b/apps/word_search/index.tsx
@@ -404,7 +404,7 @@ const WordSearchInner: React.FC<WordSearchInnerProps> = ({ getDailySeed }) => {
                 onMouseDown={() => handleMouseDown(r, c)}
                 onMouseEnter={() => handleMouseEnter(r, c)}
                 onMouseUp={handleMouseUp}
-                className={`w-8 h-8 flex items-center justify-center border text-sm font-bold cursor-pointer select-none ${isFound ? 'bg-green-300' : isSelected ? 'bg-yellow-300' : isHint ? 'bg-blue-200' : 'bg-white'}`}
+                className={`w-8 h-8 flex items-center justify-center border text-sm font-bold cursor-pointer select-none ${isFound ? 'bg-green-300' : isSelected ? 'selection' : isHint ? 'bg-blue-200' : 'bg-white'}`}
                 aria-label={`row ${r + 1} column ${c + 1} letter ${letter}`}
               >
                 {letter}
@@ -415,11 +415,8 @@ const WordSearchInner: React.FC<WordSearchInnerProps> = ({ getDailySeed }) => {
       </div>
       <ul className="mt-4 columns-2 md:columns-3">
         {words.map((w) => (
-          <li
-            key={w}
-            className={`relative overflow-hidden w-fit ${found.has(w) ? 'line-through text-gray-500' : ''}`}
-          >
-            <span className={found.has(w) ? 'word-found' : ''}>{w}</span>
+          <li key={w} className="relative overflow-hidden w-fit">
+            <span className={found.has(w) ? 'line-through text-gray-500 word-found' : ''}>{w}</span>
           </li>
         ))}
       </ul>

--- a/styles/index.css
+++ b/styles/index.css
@@ -477,6 +477,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     display: inline-block;
 }
 
+/* Highlight currently selected cells in word search */
+.selection {
+    background-color: #fde68a;
+}
+
 /* Ensure monospace layout for app outputs */
 textarea,
 pre {


### PR DESCRIPTION
## Summary
- apply `line-through` to found words in word search list
- add CSS class to highlight current selection cells

## Testing
- `yarn lint`
- `yarn test __tests__/wordSearch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b064cf6e508328b672d5214bfca275