### PR TITLE
Offload word search grid generation to worker

### DIFF
--- a/apps/word_search/grid.worker.ts
+++ b/apps/word_search/grid.worker.ts
@@ -1,0 +1,15 @@
+import { generateGrid } from './generator';
+import type { GenerateResult } from './generator';
+
+self.onmessage = (e: MessageEvent) => {
+  const { words, size, seed } = e.data as {
+    words: string[];
+    size: number;
+    seed: string;
+  };
+  const result: GenerateResult = generateGrid(words, size, seed);
+  // eslint-disable-next-line no-restricted-globals
+  (self as any).postMessage(result);
+};
+
+export {};


### PR DESCRIPTION
## Summary
- Move word search grid generation into a dedicated Web Worker
- Update game to receive generated grids from worker and reset state
- Show "Generating..." indicator while worker builds the puzzle

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, calc)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b067c54a948328916bd1e1b4d3b169