### PR TITLE
feat(hashcat): add mode filter and demo wordlists

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -38,7 +38,7 @@ describe('HashcatApp', () => {
       getByText(`Attempts/sec: ${progressInfo.hashRate[1]}`)
     ).toBeInTheDocument();
     expect(getByText(`ETA: ${progressInfo.eta[1]}`)).toBeInTheDocument();
-    expect(getByText(`Mode: ${progressInfo.mode}`)).toBeInTheDocument();
+    expect(getByText('Mode: MD5')).toBeInTheDocument();
     jest.useRealTimers();
   });
 
@@ -47,7 +47,7 @@ describe('HashcatApp', () => {
     fireEvent.change(getByLabelText('Hash Type:'), { target: { value: '100' } });
     expect(
       getByText(
-        'Example hash: da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        'Example hash: 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8'
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add hash mode filter with examples and expected outputs
- simulate cracking progress and reveal demo result
- introduce conceptual wordlist selection with link to official resources

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, calc.test.tsx)*
- `npx jest __tests__/hashcat.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0635d763c8328a089d8011c2bc762