### PR TITLE
feat: add radare2 tour

### DIFF
--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -1,8 +1,24 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import HexEditor from './HexEditor';
-import { saveSnippet, loadSnippets } from './utils';
-import FormError from '../../ui/FormError';
+
+// Pre-baked data for the tour
+const demoSections = [
+  { name: '.text', addr: '0x1000', size: '0x200' },
+  { name: '.data', addr: '0x2000', size: '0x80' },
+  { name: '.bss', addr: '0x2080', size: '0x40' },
+];
+
+const demoSymbols = [
+  { name: 'sym.main', addr: '0x1000' },
+  { name: 'sym.helper', addr: '0x1050' },
+  { name: 'sym.exit', addr: '0x1100' },
+];
+
+// Sample call graph input for the worker
+const demoAnalysis = `
+main -> sym.helper
+sym.helper -> sym.exit
+`;
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
@@ -10,23 +26,11 @@ const ForceGraph2D = dynamic(
 );
 
 const Radare2 = () => {
-  const [hex, setHex] = useState('');
-  const [disasm, setDisasm] = useState('');
-  const [file, setFile] = useState(null);
-  const [analysis, setAnalysis] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [snippets, setSnippets] = useState([]);
-  const [snippetName, setSnippetName] = useState('');
-  const [snippetCommand, setSnippetCommand] = useState('');
-  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
   const workerRef = useRef(null);
-  const visibleRef = useRef(true);
+  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
 
-  useEffect(() => {
-    setSnippets(loadSnippets());
-  }, []);
-
+  // Kick off the worker with the pre-baked analysis so no real
+  // analysis runs in the browser.
   useEffect(() => {
     if (typeof Worker !== 'undefined') {
       workerRef.current = new Worker(
@@ -35,200 +39,71 @@ const Radare2 = () => {
       workerRef.current.onmessage = (e) => {
         if (e.data.type === 'graph') {
           setGraphData(e.data.graphData);
-        } else if (e.data.type === 'export') {
-          const ghidra = e.data.ghidra;
-          const blob = new Blob([JSON.stringify(ghidra, null, 2)], {
-            type: 'application/json',
-          });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'analysis.ghidra.json';
-          a.click();
-          URL.revokeObjectURL(url);
         }
       };
+      workerRef.current.postMessage({ type: 'graph', analysis: demoAnalysis });
       return () => workerRef.current.terminate();
     }
     return undefined;
   }, []);
 
-  useEffect(() => {
-    const handleVis = () => {
-      const isVisible = document.visibilityState === 'visible';
-      visibleRef.current = isVisible;
-      workerRef.current?.postMessage({ type: isVisible ? 'resume' : 'pause' });
-      if (isVisible && analysis) {
-        workerRef.current?.postMessage({ type: 'graph', analysis });
-      }
-    };
-    document.addEventListener('visibilitychange', handleVis);
-    return () => document.removeEventListener('visibilitychange', handleVis);
-  }, [analysis]);
-
-  useEffect(() => {
-    if (workerRef.current && analysis && visibleRef.current) {
-      workerRef.current.postMessage({ type: 'graph', analysis });
-    }
-  }, [analysis]);
-
-  const handleSaveSnippet = () => {
-    if (!snippetName || !snippetCommand) return;
-    const updated = saveSnippet(snippetName, snippetCommand);
-    setSnippets(updated);
-    setSnippetName('');
-    setSnippetCommand('');
-  };
-
-  const handleExport = () => {
-    if (!analysis) return;
-    workerRef.current?.postMessage({ type: 'export', analysis });
-  };
-
-  const handleDisasm = async () => {
-    setError('');
-    setDisasm('');
-    if (!hex) return;
-    setLoading(true);
-    try {
-      const res = await fetch('/api/radare2', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'disasm', hex }),
-      });
-      const data = await res.json();
-      if (data.error) setError(data.error);
-      else setDisasm(data.result);
-    } catch (err) {
-      setError('Failed to reach backend');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleAnalyze = () => {
-    setError('');
-    setAnalysis('');
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = async () => {
-      const base64 = reader.result.split(',')[1];
-      setLoading(true);
-      try {
-        const res = await fetch('/api/radare2', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'analyze', file: base64 }),
-        });
-        const data = await res.json();
-        if (data.error) setError(data.error);
-        else setAnalysis(data.result);
-      } catch (err) {
-        setError('Failed to reach backend');
-      } finally {
-        setLoading(false);
-      }
-    };
-    reader.readAsDataURL(file);
-  };
-
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-4 overflow-auto">
-      <h1 className="text-xl mb-4">Radare2 Toolkit</h1>
+      <h1 className="text-xl mb-4">Radare2 Tour</h1>
 
-      <div className="mb-6">
-        <h2 className="text-lg mb-2">Disassemble Hex</h2>
-        <textarea
-          className="w-full p-2 rounded text-black mb-2"
-          rows={3}
-          value={hex}
-          onChange={(e) => setHex(e.target.value)}
-          placeholder="9090"
-        />
-        <HexEditor hex={hex} />
-        <button onClick={handleDisasm} className="px-4 py-2 bg-blue-600 rounded">
-          Disassemble
-        </button>
-        {disasm && (
-          <pre className="whitespace-pre-wrap bg-black p-2 mt-2 rounded">
-            {disasm}
-          </pre>
-        )}
-      </div>
-
-      <div className="mb-6">
-        <h2 className="text-lg mb-2">Analyze Binary</h2>
-        <input
-          type="file"
-          onChange={(e) => setFile(e.target.files[0])}
-          className="mb-2"
-        />
-        <button onClick={handleAnalyze} className="px-4 py-2 bg-green-600 rounded">
-          Analyze
-        </button>
-        {analysis && (
-          <>
-            <pre className="whitespace-pre-wrap bg-black p-2 mt-2 rounded">
-              {analysis}
-            </pre>
-            <button
-              onClick={handleExport}
-              className="mt-2 px-4 py-2 bg-purple-600 rounded"
-            >
-              Export Ghidra
-            </button>
-          </>
-        )}
-      </div>
-
-      <div className="mb-6">
-        <h2 className="text-lg mb-2">Snippets</h2>
-        <div className="flex flex-col sm:flex-row gap-2 mb-2">
-          <input
-            type="text"
-            value={snippetName}
-            onChange={(e) => setSnippetName(e.target.value)}
-            placeholder="Name"
-            className="p-2 rounded text-black flex-1"
-          />
-          <input
-            type="text"
-            value={snippetCommand}
-            onChange={(e) => setSnippetCommand(e.target.value)}
-            placeholder="Command"
-            className="p-2 rounded text-black flex-1"
-          />
-          <button
-            onClick={handleSaveSnippet}
-            className="px-4 py-2 bg-blue-600 rounded"
-          >
-            Save
-          </button>
-        </div>
-        <ul>
-          {snippets.map((s, idx) => (
-            <li key={idx} className="mb-1">
-              <button
-                onClick={() => setHex(s.command)}
-                className="px-2 py-1 bg-gray-700 rounded w-full text-left"
-              >
-                {s.name}: {s.command}
-              </button>
+      <section className="mb-6">
+        <h2 className="text-lg mb-2">Sections</h2>
+        <ul className="bg-black rounded p-2">
+          {demoSections.map((s) => (
+            <li key={s.name}>
+              {s.name} - {s.addr} - {s.size}
             </li>
           ))}
         </ul>
-      </div>
+      </section>
 
-      {graphData.nodes.length > 0 && (
+      <section className="mb-6">
+        <h2 className="text-lg mb-2">Symbols</h2>
+        <ul className="bg-black rounded p-2">
+          {demoSymbols.map((sym) => (
+            <li key={sym.name}>
+              {sym.name} - {sym.addr}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-lg mb-2">Call Graph</h2>
         <div className="h-64 bg-black rounded">
           <ForceGraph2D graphData={graphData} />
         </div>
-      )}
+      </section>
 
-      {loading && <p>Running...</p>}
-      {error && <FormError className="mt-2">{error}</FormError>}
+      <p>
+        Learn more from the{' '}
+        <a
+          href="https://book.rada.re"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          official radare2 book
+        </a>{' '}
+        and the{' '}
+        <a
+          href="https://rada.re"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          project site
+        </a>
+        .
+      </p>
     </div>
   );
 };
 
 export default Radare2;
+


### PR DESCRIPTION
## Summary
- add read-only Radare2 tour with sections, symbols, and pre-baked graph

## Testing
- `yarn lint`
- `yarn test` *(fails: combo meter increments and resets, card flip applies transform style, BeEF app tests, Autopsy tests, Calc component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0636bab3c83288094e5d29d47725a