### PR TITLE
Add simulation banner and demo command list

### DIFF
--- a/components/SimulationBanner.tsx
+++ b/components/SimulationBanner.tsx
@@ -1,0 +1,7 @@
+export default function SimulationBanner() {
+  return (
+    <div className="bg-yellow-200 text-center text-gray-800 py-2 text-sm">
+      Simulation Only – No real network calls are made.
+    </div>
+  );
+}

--- a/data/demo-commands.json
+++ b/data/demo-commands.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "List processes",
+    "command": "ps aux",
+    "description": "Shows running processes."
+  },
+  {
+    "name": "Network connections",
+    "command": "netstat -tulpn",
+    "description": "Displays active network connections."
+  },
+  {
+    "name": "System info",
+    "command": "uname -a",
+    "description": "Prints system information."
+  }
+]

--- a/docs/hookgraph.md
+++ b/docs/hookgraph.md
@@ -1,0 +1,19 @@
+# HookGraph
+
+This document explains the basics of API hooking using a local HookGraph diagram.
+
+![HookGraph Diagram](../public/hookgraph.svg)
+
+The diagram shows how an application call is intercepted by a hook that injects custom logic before passing control to the original API.
+
+```js
+// Example of intercepting a function call. This code is for illustration only
+// and is not operational.
+const originalSend = socket.send;
+socket.send = function (...args) {
+  console.log('send intercepted', args);
+  // originalSend.apply(this, args);
+};
+```
+
+Hooks should only be experimented with in controlled environments.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,47 +1,33 @@
 import { useEffect } from 'react';
-import ReactGA from 'react-ga4';
-import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import SimulationBanner from '../components/SimulationBanner';
 
 /**
  * @param {import('next/app').AppProps} props
  */
 function MyApp({ Component, pageProps }) {
   useEffect(() => {
-    const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
-    if (trackingId) {
-      ReactGA.initialize(trackingId);
-    }
-    if (
-      process.env.NODE_ENV === 'production' &&
-      'serviceWorker' in navigator
-    ) {
-      fetch('/service-worker.js', { method: 'HEAD' })
-        .then((res) => {
-          if (res.ok) {
-            navigator.serviceWorker
-              .register('/service-worker.js')
-              .catch((err) => {
-                console.error('Service worker registration failed', err);
-              });
-          } else {
-            console.warn('Service worker file not found');
-          }
-        })
-        .catch((err) => {
-          console.error('Service worker check failed', err);
-        });
+    if (typeof window !== 'undefined') {
+      const block = () =>
+        Promise.reject(new Error('Network access disabled in simulation'));
+      window.fetch = block;
+      window.XMLHttpRequest = function () {
+        throw new Error('Network access disabled in simulation');
+      };
+      window.WebSocket = function () {
+        throw new Error('Network access disabled in simulation');
+      };
     }
   }, []);
   return (
     <SettingsProvider>
+      <SimulationBanner />
       <Component {...pageProps} />
-      <Analytics />
     </SettingsProvider>
   );
 }

--- a/pages/command-list.tsx
+++ b/pages/command-list.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import commands from '../data/demo-commands.json';
+
+export default function CommandList() {
+  const [confirmed, setConfirmed] = useState(false);
+  const [query, setQuery] = useState('');
+  const filtered = commands.filter((c) =>
+    c.name.toLowerCase().includes(query.toLowerCase()) ||
+    c.command.toLowerCase().includes(query.toLowerCase())
+  );
+
+  if (!confirmed) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Command Reference</h1>
+        <p className="mb-4 text-red-600">
+          These commands are for educational use in lab environments only. Using
+          them on production systems may cause damage.
+        </p>
+        <button
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+          onClick={() => setConfirmed(true)}
+        >
+          I am in a lab
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Command Reference</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search commands..."
+        className="border p-2 mb-4 w-full"
+      />
+      <p className="mb-4 text-sm text-red-600">
+        These commands are provided for demonstration purposes only. Do not run
+        them outside a controlled environment.
+      </p>
+      <ul>
+        {filtered.map((cmd) => (
+          <li key={cmd.command} className="mb-4">
+            <div className="font-semibold">{cmd.name}</div>
+            <pre className="bg-gray-100 p-2 overflow-x-auto">
+              <code>{cmd.command}</code>
+            </pre>
+            <p className="text-sm">{cmd.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/public/hookgraph.svg
+++ b/public/hookgraph.svg
@@ -1,0 +1,15 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="10" y="10" width="120" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="70" y="35" font-size="14" text-anchor="middle">Original API</text>
+  <rect x="270" y="10" width="120" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="330" y="35" font-size="14" text-anchor="middle">Hooked Logic</text>
+  <rect x="140" y="150" width="120" height="40" fill="#e0e0e0" stroke="#000" />
+  <text x="200" y="175" font-size="14" text-anchor="middle">Application</text>
+  <path d="M70 50 L70 150" stroke="#000" marker-end="url(#arrow)" />
+  <path d="M200 150 L330 50" stroke="#000" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- document hooking with a local HookGraph diagram
- add lab-gated demo command list with search
- block network calls and display a simulation-only banner

## Testing
- `yarn lint`
- `yarn test` *(fails: memoryGame, beef, autopsy, calc)*

------
https://chatgpt.com/codex/tasks/task_e_68b063518ba0832883166db34668eca1