### PR TITLE
Improve accessibility for search fields and modals

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 interface Props {
   highScore?: number;
@@ -9,6 +10,9 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const [theme, setThemeState] = useState(getTheme());
   const unlocked = getUnlockedThemes(highScore);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(dialogRef, open);
 
   const changeTheme = (t: string) => {
     setThemeState(t);
@@ -21,7 +25,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
         Settings
       </button>
       {open && (
-        <div role="dialog">
+        <div ref={dialogRef} role="dialog" aria-modal="true">
           <label>
             Theme
             <select

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface GameLayoutProps {
   gameId?: string;
@@ -28,6 +29,8 @@ const GameLayout: React.FC<GameLayoutProps> = ({
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
+  const pauseRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(pauseRef, paused);
 
   // Keyboard shortcut to toggle help overlay
   useEffect(() => {
@@ -96,6 +99,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div
+          ref={pauseRef}
           className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
           role="dialog"
           aria-modal="true"

--- a/components/apps/YouTube/index.jsx
+++ b/components/apps/YouTube/index.jsx
@@ -87,7 +87,11 @@ export default function YouTubeApp({ initialVideos = [] }) {
   return (
     <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white p-4">
       <div className="mb-4">
+        <label htmlFor="yt-index-search" className="sr-only">
+          Search videos
+        </label>
         <input
+          id="yt-index-search"
           type="text"
           placeholder="Search"
           value={search}

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useFocusTrap from '../../../hooks/useFocusTrap';
 
 const STORAGE_KEY = 'beefHelpDismissed';
 
@@ -21,6 +22,8 @@ export default function GuideOverlay({ onClose }) {
   useEffect(() => {
     containerRef.current?.focus();
   }, []);
+
+  useFocusTrap(containerRef, true);
 
   const handleClose = () => {
     if (dontShow) {

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -291,6 +291,7 @@ const Dsniff = () => {
         <input
           className="w-full text-black p-1"
           placeholder="Search logs"
+          aria-label="Search logs"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -192,6 +192,7 @@ const MetasploitApp = ({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search modules"
+            aria-label="Search modules"
             spellCheck={false}
           />
           <select

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -666,6 +666,7 @@ const Pacman = () => {
         <input
           type="text"
           placeholder="Search level..."
+          aria-label="Search level"
           className="w-full px-2 py-1 text-black"
           value={search}
           onChange={(e) => {

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 const GITHUB_USER = 'Alex-Unnippillil';
 
@@ -16,6 +17,8 @@ export default function ProjectGallery() {
   const [columns, setColumns] = useState(1);
   const itemRefs = useRef([]);
   itemRefs.current = [];
+  const modalRef = useRef(null);
+  useFocusTrap(modalRef, Boolean(selected));
 
   useEffect(() => {
     ReactGA.event({ category: 'Application', action: 'Loaded Project Gallery' });
@@ -293,8 +296,10 @@ export default function ProjectGallery() {
           </div>
           {selected && (
             <div
+              ref={modalRef}
               className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
               role="dialog"
+              aria-modal="true"
             >
               <div className="bg-ub-cool-grey text-white p-4 rounded w-full max-w-md">
                 <button

--- a/components/apps/quote_generator.js
+++ b/components/apps/quote_generator.js
@@ -305,6 +305,7 @@ const QuoteGenerator = () => {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search"
+            aria-label="Search quotes"
             className="px-2 py-1 rounded text-black"
           />
           <select

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -154,6 +154,7 @@ export default function SecurityTools() {
         value={query}
         onChange={e => setQuery(e.target.value)}
         placeholder="Search all tools"
+        aria-label="Search all tools"
         className="w-full mb-2 p-1 text-black text-xs"
       />
       {query ? (

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import ReactGA from 'react-ga4';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import useFocusTrap from '../../hooks/useFocusTrap';
 import {
   initializeGame,
   drawFromStock,
@@ -72,6 +73,8 @@ const Solitaire = () => {
   const tableauRefs = useRef<(HTMLDivElement | null)[]>([]);
   const wasteRef = useRef<HTMLDivElement | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const pauseRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(pauseRef, paused);
   const [flying, setFlying] = useState<AnimatedCard[]>([]);
   const [autoCompleting, setAutoCompleting] = useState(false);
   const [winnableOnly, setWinnableOnly] = useState(false);
@@ -507,6 +510,7 @@ const Solitaire = () => {
       </div>
       {paused && (
         <div
+          ref={pauseRef}
           className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
           role="dialog"
           aria-modal="true"

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -249,6 +249,7 @@ export default function Todoist() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search"
+          aria-label="Search tasks"
           className="border p-1"
         />
       </div>

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -365,7 +365,11 @@ export default function YouTubeApp({ initialVideos = [] }) {
         <>
           {/* Search + sorting */}
           <div className="p-3 flex flex-wrap items-center gap-2">
+            <label htmlFor="yt-search" className="sr-only">
+              Search
+            </label>
             <input
+              id="yt-search"
               placeholder="Search"
               className="flex-1 min-w-[150px] text-black px-3 py-2 rounded"
               value={search}

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -78,7 +78,11 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   return (
     <div>
       <div className="flex gap-2 mb-2">
+        <label htmlFor="pdf-search" className="sr-only">
+          Search document
+        </label>
         <input
+          id="pdf-search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search"

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -57,6 +57,7 @@ class AllApplications extends React.Component {
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
+                    aria-label="Search applications"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -57,6 +57,7 @@ class ShortcutSelector extends React.Component {
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
+                    aria-label="Search applications"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />

--- a/hooks/useFocusTrap.ts
+++ b/hooks/useFocusTrap.ts
@@ -16,6 +16,9 @@ export default function useFocusTrap(ref: React.RefObject<HTMLElement>, active: 
   useEffect(() => {
     const node = ref.current;
     if (!node || !active) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const focusable = getFocusableElements(node);
+    (focusable[0] || node).focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
@@ -50,6 +53,7 @@ export default function useFocusTrap(ref: React.RefObject<HTMLElement>, active: 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('focusin', handleFocus);
+      previouslyFocused?.focus();
     };
   }, [ref, active]);
 }

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import data from '../components/apps/nessus/sample-report.json';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 const severityColors: Record<string, string> = {
   Critical: '#991b1b',
@@ -27,6 +28,9 @@ const NessusReport: React.FC = () => {
   const [host, setHost] = useState<string>('All');
   const [family, setFamily] = useState<string>('All');
   const [findings, setFindings] = useState<Finding[]>(data as Finding[]);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(dialogRef, Boolean(selected));
 
   const hosts = useMemo(
     () => Array.from(new Set(findings.map((f) => f.host))).sort(),
@@ -246,7 +250,9 @@ const NessusReport: React.FC = () => {
       </table>
       {selected && (
         <div
+          ref={dialogRef}
           role="dialog"
+          aria-modal="true"
           className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
         >
           <button

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -80,7 +80,11 @@ export default function PostExploitation() {
             explains that these modules run on an active session to help operators gather deeper
             information, escalate privileges, pivot within the network, or maintain persistence.
           </p>
+          <label htmlFor="postex-search" className="sr-only">
+            Search modules
+          </label>
           <input
+            id="postex-search"
             type="text"
             placeholder="Search modules..."
             value={query}

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -38,7 +38,11 @@ const VideoGallery: React.FC = () => {
 
   return (
     <main className="p-4">
+      <label htmlFor="video-gallery-search" className="sr-only">
+        Search videos
+      </label>
       <input
+        id="video-gallery-search"
         type="text"
         placeholder="Search videos..."
         value={query}


### PR DESCRIPTION
## Summary
- add missing labels and aria labels to search inputs
- manage modal focus with new focus trap and restore functionality
- mark dialogs as `aria-modal` and ensure initial focus

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0729056708328bba2394f071ad44a