### PR TITLE
chore: update CSP for media embeds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 // Security headers configuration for Next.js.
-// Allows external badges, inline styles, and same-origin PDF embedding.
+// Allows external badges and same-origin PDF embedding.
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -11,10 +11,10 @@ const ContentSecurityPolicy = [
   "object-src 'none'",
   // Allow external images and data URIs for badges/icons
   "img-src 'self' https: data:",
-  // Permit inline styles and Google Fonts
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  // Permit Google Fonts
+  "style-src 'self' https://fonts.googleapis.com",
   // Explicitly allow external stylesheets
-  "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "style-src-elem 'self' https://fonts.googleapis.com",
   // Allow loading fonts from Google
   "font-src 'self' https://fonts.gstatic.com",
   // External scripts required for embedded timelines
@@ -22,7 +22,7 @@ const ContentSecurityPolicy = [
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com",
+  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com",
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
   // Enforce HTTPS for all requests
@@ -55,7 +55,14 @@ const securityHeaders = [
 
 module.exports = {
   images: {
-    domains: ['opengraph.githubassets.com', 'raw.githubusercontent.com', 'avatars.githubusercontent.com'],
+    domains: [
+      'opengraph.githubassets.com',
+      'raw.githubusercontent.com',
+      'avatars.githubusercontent.com',
+      'i.ytimg.com',
+      'yt3.ggpht.com',
+      'i.scdn.co',
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary
- allow YouTube & Spotify frames
- drop unsafe-inline from style-src
- permit YouTube and Spotify image domains

## Testing
- `yarn lint` *(fails: components/apps/Chrome/index.tsx parsing error)*
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config tests)*
- `yarn build` *(fails: components/apps/Chrome/index.tsx parsing error)*
- `yarn dev` *(500 due to global CSS import in apps/calculator)*


------
https://chatgpt.com/codex/tasks/task_e_68b07294071883288bfdd5c479ef6c3b