### PR TITLE
feat: replace img tags with next image

### DIFF
--- a/apps/weather_widget/index.tsx
+++ b/apps/weather_widget/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect } from 'react';
+import Image from 'next/image';
 import './styles.css';
 
 export default function WeatherWidget() {
@@ -23,7 +24,7 @@ export default function WeatherWidget() {
       <div id="error-message"></div>
       <div id="weather" className="weather">
         <div className="temp">--°C</div>
-        <img className="icon" src="" alt="Weather icon" />
+        <Image className="icon" src="" alt="Weather icon" width={100} height={100} />
         <div className="forecast">Loading...</div>
       </div>
     </div>

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
@@ -69,10 +70,12 @@ const BadgeList = ({ badges, className = '' }) => {
             }}
             aria-label={badge.label}
           >
-            <img
+            <Image
               src={badge.src}
               alt={badge.alt}
               title={badge.description || badge.label}
+              width={120}
+              height={40}
             />
           </button>
         ))}

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import Head from 'next/head';
+import Image from 'next/image';
 import usePrefersReducedMotion from './hooks/usePrefersReducedMotion';
 
 // Basic YouTube player with keyboard shortcuts, playback rate cycling,
@@ -159,11 +160,13 @@ export default function YouTubePlayer({ videoId }) {
               onClick={loadPlayer}
               className="relative w-full h-full flex items-center justify-center"
             >
-              <img
+              <Image
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
                 alt=""
                 loading="lazy"
                 className="absolute inset-0 w-full h-full object-cover"
+                width={480}
+                height={360}
               />
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -337,12 +337,14 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
-          <img
+          <Image
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
+            width={120}
+            height={40}
             onClick={() => setSelected(badge)}
           />
         ))}

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -308,12 +308,14 @@ const SkillSection = ({ title, badges }) => {
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map(badge => (
-          <img
+          <Image
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
+            width={120}
+            height={40}
             onClick={() => setSelected(badge)}
           />
         ))}
@@ -371,10 +373,12 @@ function Skills({ skills }) {
       <div className="w-full md:w-10/12 flex flex-col items-center mt-8">
         <div className="font-bold text-sm md:text-base mb-2 text-center">GitHub Contributions</div>
         <div className="bg-ub-gedit-light bg-opacity-20 p-1 md:p-2 rounded-md shadow-md">
-          <img
+          <Image
             src="https://ghchart.rshah.org/Alex-Unnippillil"
             alt="Alex Unnippillil's GitHub contribution graph"
             className="w-full rounded"
+            width={720}
+            height={144}
           />
         </div>
       </div>

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import Image from 'next/image';
 import GuideOverlay from './GuideOverlay';
 import HookGraph from './HookGraph';
 
@@ -118,10 +119,12 @@ export default function Beef() {
                   selected === id ? 'bg-ub-gray-50 text-black' : ''
                 }`}
               >
-                <img
+                <Image
                   src={`/themes/Yaru/apps/beef-${status}.svg`}
                   alt={status}
                   className="w-12 h-12 mb-1"
+                  width={48}
+                  height={48}
                 />
                 <span className="text-xs text-center truncate w-full">
                   {hook.name || id}

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 
 const Certs = () => {
   const certBadges = [
@@ -42,11 +43,11 @@ const Certs = () => {
       </ul>
       <div className="w-full md:w-10/12 flex flex-wrap justify-center items-center mt-4">
         <a href="https://data.typeracer.com/pit/profile?user=ulexa&ref=badge" target="_blank" rel="noopener noreferrer" className="m-2">
-          <img src="https://data.typeracer.com/misc/badge?user=ulexa" alt="TypeRacer.com scorecard for user ulexa" />
+          <Image src="https://data.typeracer.com/misc/badge?user=ulexa" alt="TypeRacer.com scorecard for user ulexa" width={120} height={36} />
         </a>
         {certBadges.map((badge) => (
           <a key={badge.href} href={badge.href} target="_blank" rel="noopener noreferrer" className="m-2">
-            <img src={badge.src} alt={badge.alt} className="w-24 h-24 md:w-28 md:h-28" />
+            <Image src={badge.src} alt={badge.alt} className="w-24 h-24 md:w-28 md:h-28" width={112} height={112} />
           </a>
         ))}
       </div>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -158,10 +158,13 @@ export class Gedit extends Component {
                     this.state.location &&
                     <div className="bg-ub-gedit-dark border-t border-b border-ubt-gedit-blue p-2">
                         <h2 className="font-bold text-sm mb-1">Your Local Time</h2>
-                        <img
+                        <Image
                             src={`https://staticmap.openstreetmap.de/staticmap.php?center=${this.state.location.latitude},${this.state.location.longitude}&zoom=3&size=300x150&markers=${this.state.location.latitude},${this.state.location.longitude},red-dot`}
                             alt="Map showing your approximate location"
-                            className="w-full rounded" width="300" height="150" />
+                            className="w-full rounded"
+                            width={300}
+                            height={150}
+                        />
                         <p className="text-center mt-2" aria-live="polite">{this.state.localTime}</p>
                     </div>
                 }

--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+import Image from 'next/image';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 const CHANNEL_HANDLE = 'Alex-Unnippillil';
@@ -430,11 +431,13 @@ export default function YouTubeApp({ initialVideos = [] }) {
                   }}
                 >
                   {video.thumbnail && (
-                    <img
+                    <Image
                       src={video.thumbnail}
                       alt={video.title}
                       className="w-full"
                       loading="lazy"
+                      width={320}
+                      height={180}
                     />
                   )}
                   <div

--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,19 @@ const securityHeaders = [
 
 module.exports = {
   images: {
-    domains: ['opengraph.githubassets.com', 'raw.githubusercontent.com', 'avatars.githubusercontent.com'],
+    domains: [
+      'opengraph.githubassets.com',
+      'raw.githubusercontent.com',
+      'avatars.githubusercontent.com',
+      'openweathermap.org',
+      'img.youtube.com',
+      'ghchart.rshah.org',
+      'img.shields.io',
+      'i.ytimg.com',
+      'staticmap.openstreetmap.de',
+      'images.credly.com',
+      'data.typeracer.com',
+    ],
   },
   async headers() {
     return [

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 
 interface Video {
   id: string;
@@ -66,10 +67,12 @@ const VideoGallery: React.FC = () => {
             className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
             onClick={() => setPlaying(video.id)}
           >
-            <img
+            <Image
               src={`https://img.youtube.com/vi/${video.id}/hqdefault.jpg`}
               alt={video.title}
               className="w-full"
+              width={480}
+              height={360}
             />
             <p className="mt-2 text-sm" style={{ maxInlineSize: '60ch' }}>{video.title}</p>
           </button>


### PR DESCRIPTION
## Summary
- swap img tags for next/image across weather widget, galleries, apps, and misc components
- allow new remote hosts in next.config.js for optimized image loading

## Testing
- `npm test` *(fails: Invalid URL: thumb2.jpg and other issues)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b072955f6c8328a4629b35c2929d70