### PR TITLE
feat: add Input Lab utility app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -59,6 +59,7 @@ const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
 const QuoteGeneratorApp = createDynamicApp('quote_generator', 'Quote Generator');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
+const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -139,6 +140,7 @@ const displayQuoteGenerator = createDisplay(QuoteGeneratorApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
+const displayInputLab = createDisplay(InputLabApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -217,6 +219,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayProjectGallery,
+  },
+  {
+    id: 'input-lab',
+    title: 'Input Lab',
+    icon: './themes/Yaru/apps/input-lab.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayInputLab,
   },
 ];
 

--- a/apps/input-lab/index.tsx
+++ b/apps/input-lab/index.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+const SAVE_KEY = 'input-lab:text';
+
+const schema = z.object({
+  text: z.string().min(1, 'Text is required'),
+});
+
+export default function InputLab() {
+  const [text, setText] = useState('');
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState('');
+
+  // Load saved text on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = window.localStorage.getItem(SAVE_KEY);
+    if (saved) setText(saved);
+  }, []);
+
+  // Validate and autosave
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handle = setTimeout(() => {
+      const result = schema.safeParse({ text });
+      if (!result.success) {
+        const msg = result.error.issues[0].message;
+        setError(msg);
+        setStatus(`Error: ${msg}`);
+        return;
+      }
+      setError('');
+      window.localStorage.setItem(SAVE_KEY, text);
+      setStatus('Saved');
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [text]);
+
+  return (
+    <div className="min-h-screen bg-gray-900 p-4 text-white">
+      <h1 className="mb-4 text-2xl">Input Lab</h1>
+      <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
+        <div>
+          <label htmlFor="input-lab-text" className="mb-1 block text-sm font-medium">
+            Text
+          </label>
+          <input
+            id="input-lab-text"
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+          />
+          {error && <p className="mt-1 text-sm text-red-400">{error}</p>}
+        </div>
+      </form>
+      <div role="status" aria-live="polite" className="mt-4 text-sm text-green-400">
+        {status}
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/input-lab/index.tsx
+++ b/components/apps/input-lab/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/input-lab';

--- a/pages/apps/input-lab.tsx
+++ b/pages/apps/input-lab.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
+
+export default function InputLabPage() {
+  return <InputLab />;
+}

--- a/public/themes/Yaru/apps/input-lab.svg
+++ b/public/themes/Yaru/apps/input-lab.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#4b5563"/>
+  <rect x="15" y="40" width="70" height="20" rx="4" fill="#ffffff"/>
+  <circle cx="30" cy="50" r="5" fill="#9ca3af"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Input Lab utility with autosave, validation and live status
- wire Input Lab into dynamic app registry and pages
- include Input Lab icon and utilities listing entry

## Testing
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `yarn lint` *(fails: components/apps/Chrome/index.tsx parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68b072973fd88328960cddee2f69a4cb