### PR TITLE
feat: add tabbed window component and integrate in apps

### DIFF
--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import LegalInterstitial from '../../components/ui/LegalInterstitial';
+import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
 
-const HTTPPreview: React.FC = () => {
-  const [accepted, setAccepted] = useState(false);
+const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
-
   const command = `curl -X ${method} ${url}`.trim();
 
-  if (!accepted) {
-    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
-  }
-
   return (
-    <div className="min-h-screen bg-gray-900 p-4 text-white">
+    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
       <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Build a curl command without sending any requests. Learn more at{' '}
@@ -66,6 +61,28 @@ const HTTPPreview: React.FC = () => {
         </pre>
       </div>
     </div>
+  );
+};
+
+const HTTPPreview: React.FC = () => {
+  const [accepted, setAccepted] = useState(false);
+  const countRef = useRef(1);
+
+  if (!accepted) {
+    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
+  }
+
+  const createTab = (): TabDefinition => {
+    const id = Date.now().toString();
+    return { id, title: `Request ${countRef.current++}`, content: <HTTPBuilder /> };
+  };
+
+  return (
+    <TabbedWindow
+      className="min-h-screen bg-gray-900 text-white"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
   );
 };
 

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,22 +1,17 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import LegalInterstitial from '../../components/ui/LegalInterstitial';
+import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
 
-const SSHPreview: React.FC = () => {
-  const [accepted, setAccepted] = useState(false);
+const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('');
-
   const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
 
-  if (!accepted) {
-    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
-  }
-
   return (
-    <div className="min-h-screen bg-gray-900 p-4 text-white">
+    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
       <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Generate an SSH command without executing it. Learn more at{' '}
@@ -75,6 +70,28 @@ const SSHPreview: React.FC = () => {
         </pre>
       </div>
     </div>
+  );
+};
+
+const SSHPreview: React.FC = () => {
+  const [accepted, setAccepted] = useState(false);
+  const countRef = useRef(1);
+
+  if (!accepted) {
+    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
+  }
+
+  const createTab = (): TabDefinition => {
+    const id = Date.now().toString();
+    return { id, title: `Session ${countRef.current++}`, content: <SSHBuilder /> };
+  };
+
+  return (
+    <TabbedWindow
+      className="min-h-screen bg-gray-900 text-white"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
   );
 };
 

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
+
+export interface TabDefinition {
+  id: string;
+  title: string;
+  content: React.ReactNode;
+  closable?: boolean;
+  onActivate?: () => void;
+  onDeactivate?: () => void;
+  onClose?: () => void;
+}
+
+interface TabbedWindowProps {
+  initialTabs: TabDefinition[];
+  onNewTab?: () => TabDefinition;
+  onTabsChange?: (tabs: TabDefinition[]) => void;
+  className?: string;
+}
+
+interface TabContextValue {
+  id: string;
+  active: boolean;
+  close: () => void;
+}
+
+const TabContext = createContext<TabContextValue>({ id: '', active: false, close: () => {} });
+export const useTab = () => useContext(TabContext);
+
+const TabbedWindow: React.FC<TabbedWindowProps> = ({
+  initialTabs,
+  onNewTab,
+  onTabsChange,
+  className = '',
+}) => {
+  const [tabs, setTabs] = useState<TabDefinition[]>(initialTabs);
+  const [activeId, setActiveId] = useState<string>(initialTabs[0]?.id || '');
+  const prevActive = useRef<string>('');
+  const dragSrc = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (prevActive.current !== activeId) {
+      const prev = tabs.find((t) => t.id === prevActive.current);
+      const next = tabs.find((t) => t.id === activeId);
+      if (prev && prev.onDeactivate) prev.onDeactivate();
+      if (next && next.onActivate) next.onActivate();
+      prevActive.current = activeId;
+    }
+  }, [activeId, tabs]);
+
+  const updateTabs = useCallback(
+    (updater: (prev: TabDefinition[]) => TabDefinition[]) => {
+      setTabs((prev) => {
+        const next = updater(prev);
+        onTabsChange?.(next);
+        return next;
+      });
+    },
+    [onTabsChange],
+  );
+
+  const setActive = useCallback(
+    (id: string) => {
+      setActiveId(id);
+    },
+    [],
+  );
+
+  const closeTab = useCallback(
+    (id: string) => {
+      updateTabs((prev) => {
+        const idx = prev.findIndex((t) => t.id === id);
+        const removed = prev[idx];
+        const next = prev.filter((t) => t.id !== id);
+        if (removed && removed.onClose) removed.onClose();
+        if (id === activeId && next.length > 0) {
+          const fallback = next[idx] || next[idx - 1];
+          setActiveId(fallback.id);
+        } else if (next.length === 0 && onNewTab) {
+          const tab = onNewTab();
+          next.push(tab);
+          setActiveId(tab.id);
+        }
+        return next;
+      });
+    },
+    [activeId, onNewTab, updateTabs],
+  );
+
+  const addTab = useCallback(() => {
+    if (!onNewTab) return;
+    const tab = onNewTab();
+    updateTabs((prev) => [...prev, tab]);
+    setActiveId(tab.id);
+  }, [onNewTab, updateTabs]);
+
+  const handleDragStart = (index: number) => (e: React.DragEvent) => {
+    dragSrc.current = index;
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (index: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (index: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const src = dragSrc.current;
+    if (src === null || src === index) return;
+    updateTabs((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(src, 1);
+      next.splice(index, 0, moved);
+      return next;
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.ctrlKey && e.key.toLowerCase() === 'w') {
+      e.preventDefault();
+      closeTab(activeId);
+      return;
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      setTabs((prev) => {
+        if (prev.length === 0) return prev;
+        const idx = prev.findIndex((t) => t.id === activeId);
+        const nextIdx =
+          e.key === 'ArrowLeft'
+            ? (idx - 1 + prev.length) % prev.length
+            : (idx + 1) % prev.length;
+        const nextTab = prev[nextIdx];
+        setActiveId(nextTab.id);
+        return prev;
+      });
+    }
+  };
+
+  return (
+    <div
+      className={`flex flex-col w-full h-full ${className}`.trim()}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+    >
+      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+        {tabs.map((t, i) => (
+          <div
+            key={t.id}
+            className={`flex items-center px-2 py-1 cursor-pointer select-none ${
+              t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
+            }`}
+            draggable
+            onDragStart={handleDragStart(i)}
+            onDragOver={handleDragOver(i)}
+            onDrop={handleDrop(i)}
+            onClick={() => setActive(t.id)}
+          >
+            <span className="mr-2 truncate" style={{ maxWidth: 150 }}>
+              {t.title}
+            </span>
+            {t.closable !== false && tabs.length > 1 && (
+              <button
+                className="ml-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeTab(t.id);
+                }}
+                aria-label="Close Tab"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+        {onNewTab && (
+          <button
+            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            onClick={addTab}
+            aria-label="New Tab"
+          >
+            +
+          </button>
+        )}
+      </div>
+      <div className="flex-grow relative overflow-hidden">
+        {tabs.map((t) => (
+          <TabContext.Provider
+            key={t.id}
+            value={{ id: t.id, active: t.id === activeId, close: () => closeTab(t.id) }}
+          >
+            <div
+              className={`absolute inset-0 w-full h-full ${
+                t.id === activeId ? 'block' : 'hidden'
+              }`}
+            >
+              {t.content}
+            </div>
+          </TabContext.Provider>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TabbedWindow;


### PR DESCRIPTION
## Summary
- add reusable TabbedWindow component with draggable headers, keyboard nav and tab context
- switch HTTP and SSH builders to TabbedWindow for multi-session layouts

## Testing
- `npm test` (fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)
- `npm run lint` (fails: components/apps/Chrome/index.tsx parsing error)


------
https://chatgpt.com/codex/tasks/task_e_68b0733f29d88328a08bb4c9f6f1eaf6