### PR TITLE
feat: add virtual desktop switching

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,8 +10,11 @@ import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import ReactGA from 'react-ga4';
+import VirtualDesktopSwitcher from '../ui/VirtualDesktopSwitcher';
+import { VirtualDesktopContext } from '../../hooks/useVirtualDesktops';
 
 export class Desktop extends Component {
+    static contextType = VirtualDesktopContext;
     constructor() {
         super();
         this.app_stack = [];
@@ -285,8 +288,10 @@ export class Desktop extends Component {
 
     renderWindows = () => {
         let windowsJsx = [];
-        apps.forEach((app, index) => {
-            if (this.state.closed_windows[app.id] === false) {
+        const { activeDesktop, assignments } = this.context;
+        apps.forEach((app) => {
+            const desktopIndex = assignments[app.id] ?? 0;
+            if (this.state.closed_windows[app.id] === false && desktopIndex === activeDesktop) {
 
                 const props = {
                     title: app.title,
@@ -437,6 +442,7 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
+                this.context.assignWindow(objId, this.context.activeDesktop);
                 this.setState({ closed_windows, favourite_apps, allAppsView: false }, this.focus(objId));
                 this.app_stack.push(objId);
             }, 200);
@@ -458,6 +464,7 @@ export class Desktop extends Component {
 
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
+        this.context.removeWindow(objId);
 
         this.setState({ closed_windows, favourite_apps });
     }
@@ -641,6 +648,8 @@ export class Desktop extends Component {
                         games={games}
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
+
+                <VirtualDesktopSwitcher />
 
             </div>
         )

--- a/components/ui/VirtualDesktopSwitcher.tsx
+++ b/components/ui/VirtualDesktopSwitcher.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useVirtualDesktops } from '../../hooks/useVirtualDesktops';
+
+export default function VirtualDesktopSwitcher() {
+  const { activeDesktop, desktops, switchDesktop } = useVirtualDesktops();
+  const [visible, setVisible] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.altKey) {
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          e.preventDefault();
+          const delta = e.key === 'ArrowLeft' ? -1 : 1;
+          switchDesktop(activeDesktop + delta);
+          setVisible(true);
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = setTimeout(() => setVisible(false), 800);
+        }
+      }
+    },
+    [activeDesktop, switchDesktop]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <div
+      className={`fixed inset-0 flex items-center justify-center transition-opacity duration-300 pointer-events-none ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div className="flex space-x-4 bg-black/60 p-4 rounded-lg">
+        {Array.from({ length: desktops }).map((_, idx) => (
+          <div
+            key={idx}
+            className={`h-4 w-8 sm:h-6 sm:w-12 rounded-sm transition-transform duration-300 ${
+              idx === activeDesktop ? 'bg-white scale-125' : 'bg-gray-400'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/hooks/useVirtualDesktops.tsx
+++ b/hooks/useVirtualDesktops.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+interface VirtualDesktopContextValue {
+  activeDesktop: number;
+  assignments: Record<string, number>;
+  desktops: number;
+  switchDesktop: (index: number) => void;
+  assignWindow: (id: string, desktop: number) => void;
+  removeWindow: (id: string) => void;
+}
+
+export const VirtualDesktopContext = createContext<VirtualDesktopContextValue>({
+  activeDesktop: 0,
+  assignments: {},
+  desktops: 1,
+  switchDesktop: () => {},
+  assignWindow: () => {},
+  removeWindow: () => {},
+});
+
+export function VirtualDesktopProvider({ children, count = 4 }: { children: ReactNode; count?: number }) {
+  const [activeDesktop, setActiveDesktop] = useState(0);
+  const [assignments, setAssignments] = useState<Record<string, number>>({});
+
+  const desktops = count;
+
+  const switchDesktop = useCallback(
+    (index: number) => {
+      setActiveDesktop(() => {
+        const next = ((index % desktops) + desktops) % desktops;
+        return next;
+      });
+    },
+    [desktops]
+  );
+
+  const assignWindow = useCallback((id: string, desktop: number) => {
+    setAssignments((prev) => ({ ...prev, [id]: desktop }));
+  }, []);
+
+  const removeWindow = useCallback((id: string) => {
+    setAssignments((prev) => {
+      const { [id]: _removed, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
+  return (
+    <VirtualDesktopContext.Provider
+      value={{ activeDesktop, assignments, desktops, switchDesktop, assignWindow, removeWindow }}
+    >
+      {children}
+    </VirtualDesktopContext.Provider>
+  );
+}
+
+export const useVirtualDesktops = () => useContext(VirtualDesktopContext);
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,7 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { VirtualDesktopProvider } from '../hooks/useVirtualDesktops';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -40,8 +41,10 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <Component {...pageProps} />
-      <Analytics />
+      <VirtualDesktopProvider>
+        <Component {...pageProps} />
+        <Analytics />
+      </VirtualDesktopProvider>
     </SettingsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add VirtualDesktopContext and provider for managing active desktops and window assignments
- implement VirtualDesktopSwitcher overlay with Ctrl+Alt+Arrow shortcuts and animations
- integrate desktop UI to respect active workspace

## Testing
- `npm test` (fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)
- `npm run lint` (fails: components/apps/Chrome/index.tsx parse error)


------
https://chatgpt.com/codex/tasks/task_e_68b073405380832882eb23fec830f4d1