### PR TITLE
Add command palette with shared registry

### DIFF
--- a/components/common/CommandPalette.tsx
+++ b/components/common/CommandPalette.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect, useRef } from 'react';
+import { useCommands } from '../../hooks/useCommands';
+
+function fuzzyMatch(query: string, text: string) {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  let qi = 0;
+  for (let i = 0; i < t.length && qi < q.length; i++) {
+    if (t[i] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}
+
+export default function CommandPalette() {
+  const { commands } = useCommands();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [index, setIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = query
+    ? commands.filter((c) =>
+        fuzzyMatch(query, c.name + ' ' + (c.keywords?.join(' ') || ''))
+      )
+    : commands;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      } else if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIndex((i) => (i + 1) % filtered.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setIndex((i) => (i - 1 + filtered.length) % filtered.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const cmd = filtered[index];
+      if (cmd) {
+        cmd.action();
+        setOpen(false);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-start justify-center p-4" role="dialog" aria-modal="true">
+      <div className="bg-white text-black rounded shadow max-w-md w-full">
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIndex(0);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="Type a command..."
+          className="w-full p-2 border-b outline-none"
+        />
+        <ul role="menu">
+          {filtered.map((cmd, i) => (
+            <li key={cmd.id}>
+              <button
+                className={`w-full text-left px-2 py-1 ${i === index ? 'bg-gray-200' : ''}`}
+                onMouseDown={() => {
+                  cmd.action();
+                  setOpen(false);
+                }}
+                role="menuitem"
+              >
+                {cmd.name}
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="px-2 py-1 text-sm text-gray-500">No results</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/hooks/useCommands.ts
+++ b/hooks/useCommands.ts
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
+
+export interface Command {
+  id: string;
+  name: string;
+  keywords?: string[];
+  action: () => void;
+}
+
+interface CommandsContextValue {
+  commands: Command[];
+  register: (command: Command) => void;
+  unregister: (id: string) => void;
+}
+
+const CommandsContext = createContext<CommandsContextValue>({
+  commands: [],
+  register: () => {},
+  unregister: () => {},
+});
+
+export function CommandsProvider({ children }: { children: ReactNode }) {
+  const [commands, setCommands] = useState<Command[]>([]);
+
+  const register = useCallback((command: Command) => {
+    setCommands((prev) => {
+      const without = prev.filter((c) => c.id !== command.id);
+      return [...without, command];
+    });
+  }, []);
+
+  const unregister = useCallback((id: string) => {
+    setCommands((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  return (
+    <CommandsContext.Provider value={{ commands, register, unregister }}>
+      {children}
+    </CommandsContext.Provider>
+  );
+}
+
+export function useCommands() {
+  return useContext(CommandsContext);
+}
+
+export function useCommand(command: Command, deps: unknown[] = []) {
+  const { register, unregister } = useCommands();
+  useEffect(() => {
+    register(command);
+    return () => unregister(command.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,8 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { CommandsProvider } from '../hooks/useCommands';
+import CommandPalette from '../components/common/CommandPalette';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -40,7 +42,10 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <Component {...pageProps} />
+      <CommandsProvider>
+        <Component {...pageProps} />
+        <CommandPalette />
+      </CommandsProvider>
       <Analytics />
     </SettingsProvider>
   );


### PR DESCRIPTION
## Summary
- add CommandPalette component opened via Ctrl/⌘+K with fuzzy search
- introduce shared command registry hook for registering app actions
- mount command palette and provider in app layout

## Testing
- `yarn test` (fails: Parsing error in components/apps/Chrome/index.tsx)
- `yarn lint` (fails: Parsing error in components/apps/Chrome/index.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b07341bdc48328bfed807e51c38202