### PR TITLE
feat: snap windows to desktop grid

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -28,6 +28,9 @@ export class Window extends Component {
         }
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
+        // desktop grid configuration
+        this.gridCols = 12;
+        this.gridRows = 8;
     }
 
     componentDidMount() {
@@ -212,6 +215,10 @@ export class Window extends Component {
             snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
         }
+        else if (rect.bottom >= window.innerHeight - threshold) {
+            snap = { left: '0', top: '50%', width: '100%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
+        }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
         }
@@ -243,6 +250,10 @@ export class Window extends Component {
                 newWidth = 100.2;
                 newHeight = 50;
                 transform = 'translate(-1pt,-2pt)';
+            } else if (snapPos === 'bottom') {
+                newWidth = 100.2;
+                newHeight = 50;
+                transform = `translate(-1pt,${window.innerHeight / 2}px)`;
             }
             var r = document.querySelector("#" + this.id);
             if (r && transform) {
@@ -258,6 +269,16 @@ export class Window extends Component {
             }, this.resizeBoundries);
         }
         else {
+            const node = document.getElementById(this.id);
+            if (node) {
+                const rect = node.getBoundingClientRect();
+                const cellWidth = window.innerWidth / this.gridCols;
+                const cellHeight = window.innerHeight / this.gridRows;
+                const x = Math.round(rect.left / cellWidth) * cellWidth;
+                const y = Math.round(rect.top / cellHeight) * cellHeight;
+                node.style.transform = `translate(${x}px,${y}px)`;
+                this.setWinowsPosition();
+            }
             this.setState({ snapPreview: null, snapPosition: null });
         }
     }
@@ -567,8 +588,10 @@ export class WindowMainScreen extends Component {
     }
     render() {
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
-                {this.props.screen(this.props.addFolder, this.props.openApp)}
+            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}> 
+                <div className="app-container">
+                    {this.props.screen(this.props.addFolder, this.props.openApp)}
+                </div>
             </div>
         )
     }

--- a/styles/index.css
+++ b/styles/index.css
@@ -495,3 +495,22 @@ textarea:focus-visible {
     outline: 2px solid #3B82F6;
     outline-offset: 2px;
 }
+/* Desktop grid and subgrid for app containers */
+:root {
+    --desktop-grid-cols: 12;
+    --desktop-grid-rows: 8;
+}
+
+.window-parent {
+    display: grid !important;
+    grid-template-columns: repeat(var(--desktop-grid-cols), 1fr);
+    grid-template-rows: repeat(var(--desktop-grid-rows), 1fr);
+}
+
+.app-container {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-template-rows: subgrid;
+    width: 100%;
+    height: 100%;
+}


### PR DESCRIPTION
## Summary
- support drag-to-edge snapping with grid-based positioning
- define desktop CSS grid and subgrid app container styles
- wrap window content with app subgrid for consistent layout

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b07342f7a08328a7602bf6328e2049