### PR TITLE
feat: add notification center and hook

### DIFF
--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,0 +1,81 @@
+import React, { createContext, useCallback, useEffect, useState } from 'react';
+
+export interface AppNotification {
+  id: string;
+  message: string;
+  date: number;
+}
+
+interface NotificationsContextValue {
+  notifications: Record<string, AppNotification[]>;
+  pushNotification: (appId: string, message: string) => void;
+  clearNotifications: (appId?: string) => void;
+}
+
+export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+
+  const pushNotification = useCallback((appId: string, message: string) => {
+    setNotifications(prev => {
+      const list = prev[appId] ?? [];
+      const next = {
+        ...prev,
+        [appId]: [
+          ...list,
+          {
+            id: `${Date.now()}-${Math.random()}`,
+            message,
+            date: Date.now(),
+          },
+        ],
+      };
+      return next;
+    });
+  }, []);
+
+  const clearNotifications = useCallback((appId?: string) => {
+    setNotifications(prev => {
+      if (!appId) return {};
+      const next = { ...prev };
+      delete next[appId];
+      return next;
+    });
+  }, []);
+
+  const totalCount = Object.values(notifications).reduce(
+    (sum, list) => sum + list.length,
+    0
+  );
+
+  useEffect(() => {
+    const nav: any = navigator;
+    if (nav && nav.setAppBadge) {
+      if (totalCount > 0) nav.setAppBadge(totalCount).catch(() => {});
+      else nav.clearAppBadge?.().catch(() => {});
+    }
+  }, [totalCount]);
+
+  return (
+    <NotificationsContext.Provider
+      value={{ notifications, pushNotification, clearNotifications }}
+    >
+      {children}
+      <div className="notification-center">
+        {Object.entries(notifications).map(([appId, list]) => (
+          <section key={appId} className="notification-group">
+            <h3>{appId}</h3>
+            <ul>
+              {list.map(n => (
+                <li key={n.id}>{n.message}</li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </NotificationsContext.Provider>
+  );
+};
+
+export default NotificationCenter;

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { NotificationsContext } from '../components/common/NotificationCenter';
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) {
+    throw new Error('useNotifications must be used within NotificationCenter');
+  }
+  return ctx;
+};
+
+export default useNotifications;


### PR DESCRIPTION
## Summary
- add NotificationCenter component to track per-app messages and show lists
- update PWA badge using the Badging API when notification counts change
- expose useNotifications hook so apps can push or clear notifications

## Testing
- `npm test` *(fails: memoryGame, BeEF, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b073437c808328bbc2d187f585b991