### PR TITLE
feat: add accessible context menu

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -39,6 +39,9 @@ export class Window extends Component {
 
         // on window resize, resize boundary
         window.addEventListener('resize', this.resizeBoundries);
+        // Listen for context menu events to toggle inert background
+        window.addEventListener('context-menu-open', this.setInertBackground);
+        window.addEventListener('context-menu-close', this.removeInertBackground);
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
@@ -48,6 +51,8 @@ export class Window extends Component {
         ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
         window.removeEventListener('resize', this.resizeBoundries);
+        window.removeEventListener('context-menu-open', this.setInertBackground);
+        window.removeEventListener('context-menu-close', this.removeInertBackground);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
@@ -191,6 +196,20 @@ export class Window extends Component {
         }
         else {
             this.props.hideSideBar(this.id, false);
+        }
+    }
+
+    setInertBackground = () => {
+        const root = document.getElementById(this.id);
+        if (root) {
+            root.setAttribute('inert', '');
+        }
+    }
+
+    removeInertBackground = () => {
+        const root = document.getElementById(this.id);
+        if (root) {
+            root.removeAttribute('inert');
         }
     }
 

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useRef, useEffect } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+export interface MenuItem {
+  label: React.ReactNode;
+  onSelect: () => void;
+}
+
+interface ContextMenuProps {
+  /** Element that triggers this context menu */
+  targetRef: React.RefObject<HTMLElement>;
+  /** Menu items to render */
+  items: MenuItem[];
+}
+
+/**
+ * Accessible context menu that supports right click and Shift+F10
+ * activation. Uses roving tab index for keyboard navigation and
+ * dispatches global events when opened/closed so backgrounds can
+ * be made inert.
+ */
+const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(menuRef, open);
+  useRovingTabIndex(menuRef, open, 'vertical');
+
+  useEffect(() => {
+    const node = targetRef.current;
+    if (!node) return;
+
+    const handleContextMenu = (e: MouseEvent) => {
+      e.preventDefault();
+      setPos({ x: e.pageX, y: e.pageY });
+      setOpen(true);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.shiftKey && e.key === 'F10') {
+        e.preventDefault();
+        const rect = node.getBoundingClientRect();
+        setPos({ x: rect.left, y: rect.bottom });
+        setOpen(true);
+      }
+    };
+
+    node.addEventListener('contextmenu', handleContextMenu);
+    node.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      node.removeEventListener('contextmenu', handleContextMenu);
+      node.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [targetRef]);
+
+  useEffect(() => {
+    if (open) {
+      window.dispatchEvent(new CustomEvent('context-menu-open'));
+    } else {
+      window.dispatchEvent(new CustomEvent('context-menu-close'));
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  return (
+    <div
+      role="menu"
+      ref={menuRef}
+      aria-hidden={!open}
+      style={{ left: pos.x, top: pos.y }}
+      className={(open ? 'block ' : 'hidden ') +
+        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+    >
+      {items.map((item, i) => (
+        <button
+          key={i}
+          role="menuitem"
+          tabIndex={-1}
+          onClick={() => {
+            item.onSelect();
+            setOpen(false);
+          }}
+          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ContextMenu;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -90,11 +90,14 @@ export class Desktop extends Component {
         document.addEventListener('contextmenu', this.checkContextMenu);
         // on click, anywhere, hide all menus
         document.addEventListener('click', this.hideAllContextMenu);
+        // allow keyboard activation of context menus
+        document.addEventListener('keydown', this.handleContextKey);
     }
 
     removeContextListeners = () => {
         document.removeEventListener("contextmenu", this.checkContextMenu);
         document.removeEventListener("click", this.hideAllContextMenu);
+        document.removeEventListener('keydown', this.handleContextKey);
     }
 
     checkContextMenu = (e) => {
@@ -124,6 +127,30 @@ export class Desktop extends Component {
                     action: `Opened Default Context Menu`
                 });
                 this.showContextMenu(e, "default");
+        }
+    }
+
+    handleContextKey = (e) => {
+        if (!(e.shiftKey && e.key === 'F10')) return;
+        e.preventDefault();
+        this.hideAllContextMenu();
+        const target = e.target.closest('[data-context]');
+        const context = target ? target.dataset.context : null;
+        const appId = target ? target.dataset.appId : null;
+        const rect = target ? target.getBoundingClientRect() : { left: 0, top: 0, height: 0 };
+        const fakeEvent = { pageX: rect.left, pageY: rect.top + rect.height };
+        switch (context) {
+            case "desktop-area":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Desktop Context Menu` });
+                this.showContextMenu(fakeEvent, "desktop");
+                break;
+            case "app":
+                ReactGA.event({ category: `Context Menu`, action: `Opened App Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "app"));
+                break;
+            default:
+                ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
+                this.showContextMenu(fakeEvent, "default");
         }
     }
 


### PR DESCRIPTION
## Summary
- add reusable ContextMenu component with roving tab index and keyboard trigger
- inert window background when context menu opens
- allow Shift+F10 to open desktop context menus

## Testing
- `npm test __tests__/window.test.tsx`
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0734519048328b17e5415b5bbe547