### PR TITLE
Add clipboard manager app with IndexedDB history

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -11,6 +11,7 @@ import { displayTodoist } from './components/apps/todoist';
 import { displayYouTube } from './components/apps/youtube';
 import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
+import { displayClipboardManager } from './components/apps/ClipboardManager';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayNikto } from './components/apps/nikto';
@@ -190,6 +191,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAsciiArt,
+  },
+  {
+    id: 'clipboard-manager',
+    title: 'Clipboard Manager',
+    icon: './themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayClipboardManager,
   },
   {
     id: 'figlet',

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { openDB } from 'idb';
+
+interface ClipItem {
+  id?: number;
+  text: string;
+  created: number;
+}
+
+const DB_NAME = 'clipboard-manager';
+const STORE_NAME = 'items';
+
+const dbPromise = openDB(DB_NAME, 1, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+    }
+  },
+});
+
+const ClipboardManager: React.FC = () => {
+  const [items, setItems] = useState<ClipItem[]>([]);
+
+  const loadItems = useCallback(async () => {
+    try {
+      const db = await dbPromise;
+      const all = await db.getAll(STORE_NAME);
+      setItems(all.sort((a, b) => (b.id ?? 0) - (a.id ?? 0)));
+    } catch {
+      // ignore errors
+    }
+  }, []);
+
+  const addItem = useCallback(
+    async (text: string) => {
+      if (!text) return;
+      try {
+        const db = await dbPromise;
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        await tx.store.add({ text, created: Date.now() });
+        await tx.done;
+        await loadItems();
+      } catch {
+        // ignore errors
+      }
+    },
+    [loadItems]
+  );
+
+  useEffect(() => {
+    loadItems();
+  }, [loadItems]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const perm = await (navigator.permissions as any)?.query?.({
+        name: 'clipboard-read' as any,
+      });
+      if (perm && perm.state === 'denied') return;
+      const text = await navigator.clipboard.readText();
+      if (text && (!items[0] || items[0].text !== text)) {
+        await addItem(text);
+      }
+    } catch (err) {
+      console.error('Clipboard read failed:', err);
+    }
+  }, [items, addItem]);
+
+  useEffect(() => {
+    document.addEventListener('copy', handleCopy);
+    return () => document.removeEventListener('copy', handleCopy);
+  }, [handleCopy]);
+
+  const writeToClipboard = async (text: string) => {
+    try {
+      const perm = await (navigator.permissions as any)?.query?.({
+        name: 'clipboard-write' as any,
+      });
+      if (perm && perm.state === 'denied') return;
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      console.error('Clipboard write failed:', err);
+    }
+  };
+
+  const clearHistory = async () => {
+    try {
+      const db = await dbPromise;
+      await db.clear(STORE_NAME);
+      setItems([]);
+    } catch {
+      // ignore errors
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
+      <button
+        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+        onClick={clearHistory}
+      >
+        Clear History
+      </button>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            className="cursor-pointer hover:underline"
+            onClick={() => writeToClipboard(item.text)}
+          >
+            {item.text}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const displayClipboardManager = () => <ClipboardManager />;
+
+export default ClipboardManager;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -49,10 +49,12 @@ export class Desktop extends Component {
         this.setEventListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
+        document.addEventListener('keydown', this.handleGlobalShortcut);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
+        document.removeEventListener('keydown', this.handleGlobalShortcut);
     }
 
     checkForNewFolders = () => {
@@ -95,6 +97,13 @@ export class Desktop extends Component {
     removeContextListeners = () => {
         document.removeEventListener("contextmenu", this.checkContextMenu);
         document.removeEventListener("click", this.hideAllContextMenu);
+    }
+
+    handleGlobalShortcut = (e) => {
+        if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+            e.preventDefault();
+            this.openApp('clipboard-manager');
+        }
     }
 
     checkContextMenu = (e) => {


### PR DESCRIPTION
## Summary
- add Clipboard Manager React app that persists clipboard history in IndexedDB and reads/writes via Clipboard API
- register Clipboard Manager utility and global Ctrl+Shift+V shortcut

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm run lint` *(fails: components/apps/Chrome/index.tsx parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0734616588328bd269980608076f4