### PR TITLE
feat: animate sidebar icons and expose attention API

### DIFF
--- a/utils/attention.js
+++ b/utils/attention.js
@@ -1,0 +1,7 @@
+export const requestAttention = (appId, badge = 1) => {
+  window.dispatchEvent(new CustomEvent('app-attention', { detail: { appId, badge } }))
+}
+
+export const clearAttention = (appId) => {
+  window.dispatchEvent(new CustomEvent('app-attention', { detail: { appId, badge: 0 } }))
+}


### PR DESCRIPTION
## Summary
- animate sidebar apps and show badges when tasks complete
- add PWA badge integration via `navigator.setAppBadge`
- expose utility to request or clear sidebar attention

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b07348845883288915d9d6ce756e1a