### PR TITLE
feat: add keyboard shortcut overlay

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import { registerShortcut, clearShortcuts } from '../utils/shortcutRegistry';
+
+describe('ShortcutOverlay', () => {
+  beforeEach(() => {
+    clearShortcuts();
+  });
+
+  it('lists shortcuts and highlights conflicts', () => {
+    registerShortcut({ keys: 'a', description: 'Action A' });
+    registerShortcut({ keys: 'a', description: 'Action B' });
+    render(<ShortcutOverlay />);
+    fireEvent.keyDown(window, { key: '?', shiftKey: true });
+    expect(screen.getByText('Action A')).toBeInTheDocument();
+    expect(screen.getByText('Action B')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveAttribute('data-conflict', 'true');
+    expect(items[1]).toHaveAttribute('data-conflict', 'true');
+  });
+});

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  getShortcuts,
+  registerShortcut,
+  subscribe,
+  Shortcut,
+} from '../../utils/shortcutRegistry';
+
+const ShortcutOverlay: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [shortcuts, setShortcuts] = useState<Shortcut[]>(getShortcuts());
+
+  useEffect(() => {
+    // register help shortcut
+    registerShortcut({ keys: '?', description: 'Show keyboard shortcuts' });
+    const unsub = subscribe(setShortcuts);
+    return () => unsub();
+  }, []);
+
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        (target as HTMLElement).isContentEditable;
+      if (isInput) return;
+      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+        e.preventDefault();
+        toggle();
+      } else if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, toggle]);
+
+  const handleExport = () => {
+    const data = JSON.stringify(shortcuts, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'shortcuts.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (!open) return null;
+
+  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
+    map.set(s.keys, (map.get(s.keys) || 0) + 1);
+    return map;
+  }, new Map());
+  const conflicts = new Set(
+    Array.from(keyCounts.entries())
+      .filter(([, count]) => count > 1)
+      .map(([key]) => key)
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="max-w-lg w-full space-y-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="text-sm underline"
+          >
+            Close
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="px-2 py-1 bg-gray-700 rounded text-sm"
+        >
+          Export JSON
+        </button>
+        <ul className="space-y-1">
+          {shortcuts.map((s, i) => (
+            <li
+              key={i}
+              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
+              className={
+                conflicts.has(s.keys)
+                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
+                  : 'flex justify-between px-2 py-1'
+              }
+            >
+              <span className="font-mono mr-4">{s.keys}</span>
+              <span className="flex-1">{s.description}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ShortcutOverlay;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,7 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import ShortcutOverlay from '../components/common/ShortcutOverlay';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -41,6 +42,7 @@ function MyApp({ Component, pageProps }) {
   return (
     <SettingsProvider>
       <Component {...pageProps} />
+      <ShortcutOverlay />
       <Analytics />
     </SettingsProvider>
   );

--- a/utils/shortcutRegistry.ts
+++ b/utils/shortcutRegistry.ts
@@ -1,0 +1,30 @@
+export interface Shortcut {
+  keys: string;
+  description: string;
+}
+
+export type ShortcutListener = (shortcuts: Shortcut[]) => void;
+
+const shortcuts: Shortcut[] = [];
+const listeners = new Set<ShortcutListener>();
+
+export function registerShortcut(shortcut: Shortcut) {
+  shortcuts.push(shortcut);
+  listeners.forEach((l) => l([...shortcuts]));
+}
+
+export function getShortcuts(): Shortcut[] {
+  return [...shortcuts];
+}
+
+export function subscribe(listener: ShortcutListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function clearShortcuts() {
+  shortcuts.length = 0;
+  listeners.forEach((l) => l([]));
+}


### PR DESCRIPTION
## Summary
- add global `ShortcutOverlay` toggled with `?`
- central registry to collect and export shortcuts
- list shortcuts and highlight conflicts

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0734998208328ad3de0c00cba6006