### PR TITLE
feat: load Ubuntu font locally

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -47,17 +47,6 @@ export default function Meta() {
             <link rel="canonical" href="https://unnippillil.com/" />
             <link rel="icon" href="images/logos/fevicon.svg" />
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <link
-                rel="preload"
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                as="style"
-                crossOrigin="anonymous"
-            />
-            <link
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                rel="stylesheet"
-
-            />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{

--- a/next.config.js
+++ b/next.config.js
@@ -11,12 +11,12 @@ const ContentSecurityPolicy = [
   "object-src 'none'",
   // Allow external images and data URIs for badges/icons
   "img-src 'self' https: data:",
-  // Permit inline styles and Google Fonts
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  // Permit inline styles
+  "style-src 'self' 'unsafe-inline'",
   // Explicitly allow external stylesheets
-  "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  // Allow loading fonts from Google
-  "font-src 'self' https://fonts.gstatic.com",
+  "style-src-elem 'self' 'unsafe-inline'",
+  // Allow loading fonts
+  "font-src 'self'",
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com",
   // Allow outbound connections for embeds and the in-browser Chrome app

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,12 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { Ubuntu } from 'next/font/google';
+
+const ubuntu = Ubuntu({
+  weight: ['300', '400', '500', '700'],
+  subsets: ['latin'],
+});
 
 /**
  * @param {import('next/app').AppProps} props
@@ -40,7 +46,9 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <Component {...pageProps} />
+      <main className={ubuntu.className}>
+        <Component {...pageProps} />
+      </main>
       <Analytics />
     </SettingsProvider>
   );


### PR DESCRIPTION
## Summary
- replace Google Fonts link with `next/font`-powered Ubuntu in `_app`
- remove external font links from SEO meta component
- drop Google Fonts domains from Content Security Policy

## Testing
- `npm test` *(fails: memoryGame, BeEF, autopsy, converter, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `npm run build` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0734fee58832897143ed0e5f22514