### PR TITLE
feat: add intersection observer hook

### DIFF
--- a/apps/timer_stopwatch/index.tsx
+++ b/apps/timer_stopwatch/index.tsx
@@ -1,17 +1,20 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import useIntersection from '../../hooks/useIntersection';
 import './styles.css';
 
 export default function TimerStopwatch() {
   const [mode, setMode] = useState<'timer' | 'stopwatch'>('timer');
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const isVisible = useIntersection(containerRef);
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (isVisible && typeof window !== 'undefined') {
       import('./main');
     }
-  }, []);
+  }, [isVisible]);
 
   return (
-    <div>
+    <div ref={containerRef}>
       <div role="tablist" className="tabs">
         <button
           id="modeTimer"

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useIntersection from '../hooks/useIntersection';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(null);
   const triggerRef = useRef(null);
   const modalRef = useRef(null);
+  const listRef = useRef(null);
+  const listVisible = useIntersection(listRef);
 
   const closeModal = () => {
     setSelected(null);
@@ -57,25 +60,26 @@ const BadgeList = ({ badges, className = '' }) => {
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
       />
-      <div className="flex flex-wrap justify-center items-start w-full">
-        {filteredBadges.map((badge) => (
-          <button
-            key={badge.label}
-            type="button"
-            className="m-1 hover:scale-110 transition-transform cursor-pointer"
-            onClick={(e) => {
-              triggerRef.current = e.currentTarget;
-              setSelected(badge);
-            }}
-            aria-label={badge.label}
-          >
-            <img
-              src={badge.src}
-              alt={badge.alt}
-              title={badge.description || badge.label}
-            />
-          </button>
-        ))}
+      <div ref={listRef} className="flex flex-wrap justify-center items-start w-full">
+        {listVisible &&
+          filteredBadges.map((badge) => (
+            <button
+              key={badge.label}
+              type="button"
+              className="m-1 hover:scale-110 transition-transform cursor-pointer"
+              onClick={(e) => {
+                triggerRef.current = e.currentTarget;
+                setSelected(badge);
+              }}
+              aria-label={badge.label}
+            >
+              <img
+                src={badge.src}
+                alt={badge.alt}
+                title={badge.description || badge.label}
+              />
+            </button>
+          ))}
       </div>
       {selected && (
         <div

--- a/hooks/useIntersection.ts
+++ b/hooks/useIntersection.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useIntersection observes the given element and reports whether it is
+ * currently intersecting the viewport.  It returns a boolean visibility state
+ * that updates whenever the element's intersection status changes.
+ */
+export default function useIntersection<T extends Element>(
+  ref: React.RefObject<T>,
+  options?: IntersectionObserverInit,
+) {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setIntersecting(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIntersecting(entry.isIntersecting);
+    }, options);
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref, options]);
+
+  return isIntersecting;
+}


### PR DESCRIPTION
## Summary
- add reusable `useIntersection` hook to report element visibility
- lazy render badge images until visible
- load timer/stopwatch logic only when app enters viewport

## Testing
- `yarn test` *(fails: /usr/bin/yarn: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0734f23e48328a0ed29a99d3f8fa5