### PR TITLE
Replace img with Next.js Image component in apps

### DIFF
--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import Image from 'next/image';
 import GuideOverlay from './GuideOverlay';
 import HookGraph from './HookGraph';
 
@@ -118,10 +119,13 @@ export default function Beef() {
                   selected === id ? 'bg-ub-gray-50 text-black' : ''
                 }`}
               >
-                <img
+                <Image
                   src={`/themes/Yaru/apps/beef-${status}.svg`}
                   alt={status}
                   className="w-12 h-12 mb-1"
+                  width={48}
+                  height={48}
+                  sizes="48px"
                 />
                 <span className="text-xs text-center truncate w-full">
                   {hook.name || id}

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 
 const Certs = () => {
   const certBadges = [
@@ -42,11 +43,24 @@ const Certs = () => {
       </ul>
       <div className="w-full md:w-10/12 flex flex-wrap justify-center items-center mt-4">
         <a href="https://data.typeracer.com/pit/profile?user=ulexa&ref=badge" target="_blank" rel="noopener noreferrer" className="m-2">
-          <img src="https://data.typeracer.com/misc/badge?user=ulexa" alt="TypeRacer.com scorecard for user ulexa" />
+          <Image
+            src="https://data.typeracer.com/misc/badge?user=ulexa"
+            alt="TypeRacer.com scorecard for user ulexa"
+            width={120}
+            height={240}
+            sizes="120px"
+          />
         </a>
         {certBadges.map((badge) => (
           <a key={badge.href} href={badge.href} target="_blank" rel="noopener noreferrer" className="m-2">
-            <img src={badge.src} alt={badge.alt} className="w-24 h-24 md:w-28 md:h-28" />
+            <Image
+              src={badge.src}
+              alt={badge.alt}
+              className="w-24 h-24 md:w-28 md:h-28"
+              width={112}
+              height={112}
+              sizes="(max-width: 768px) 96px, 112px"
+            />
           </a>
         ))}
       </div>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -158,10 +158,14 @@ export class Gedit extends Component {
                     this.state.location &&
                     <div className="bg-ub-gedit-dark border-t border-b border-ubt-gedit-blue p-2">
                         <h2 className="font-bold text-sm mb-1">Your Local Time</h2>
-                        <img
+                        <Image
                             src={`https://staticmap.openstreetmap.de/staticmap.php?center=${this.state.location.latitude},${this.state.location.longitude}&zoom=3&size=300x150&markers=${this.state.location.latitude},${this.state.location.longitude},red-dot`}
                             alt="Map showing your approximate location"
-                            className="w-full rounded" width="300" height="150" />
+                            className="w-full rounded"
+                            width={300}
+                            height={150}
+                            sizes="(max-width: 300px) 100vw, 300px"
+                        />
                         <p className="text-center mt-2" aria-live="polite">{this.state.localTime}</p>
                     </div>
                 }


### PR DESCRIPTION
## Summary
- Use Next.js `Image` for static map in Gedit with responsive sizing
- Swap BeEF hook icons to `Image` with fixed dimensions
- Render certification badges via Next.js `Image`

## Testing
- `npm test` *(fails: memoryGame combo meter increments and resets)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07350caec8328a3b0485657bc63e3