### PR TITLE
feat: add container queries for app windows

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -15,6 +15,7 @@ body {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 240px;
+  container-type: inline-size;
 }
 
 .display {
@@ -46,7 +47,7 @@ body {
   gap: 0.5rem;
 }
 
-@media (max-width: 480px) {
+@container (max-width: 200px) {
   .button-grid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -18,6 +18,7 @@ body {
   position: relative;
   width: 100%;
   height: 100%;
+  container-type: inline-size;
 }
 
 .note {
@@ -50,4 +51,11 @@ body {
   background: transparent;
   border: none;
   cursor: pointer;
+}
+
+@container (max-width: 400px) {
+  .note {
+    width: 150px;
+    min-height: 150px;
+  }
 }

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -46,3 +46,12 @@ li {
   border-radius: 4px;
   font-family: 'Courier New', monospace;
 }
+
+@container (max-width: 300px) {
+  .display {
+    font-size: 2rem;
+  }
+  button {
+    width: 100%;
+  }
+}

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -18,6 +18,7 @@ body {
   gap: 20px;
   width: 100%;
   max-width: 400px;
+  container-type: inline-size;
 }
 
 .controls {
@@ -36,7 +37,7 @@ body {
   text-align: center;
 }
 
-@media (min-width: 600px) {
+@container (min-width: 600px) {
   .widget-container {
     flex-direction: row;
     align-items: flex-start;

--- a/styles/index.css
+++ b/styles/index.css
@@ -145,6 +145,10 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
 }
 
+.windowMainScreen {
+    container-type: inline-size;
+}
+
 .windowMainScreen::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
     background-color: transparent;


### PR DESCRIPTION
## Summary
- enable `windowMainScreen` as a container for layout queries
- add container query rules for calculator, sticky notes, weather widget, and timer/stopwatch apps

## Testing
- `npm test` *(fails: combo meter increments and resets, card flip applies transform style, BeEF app, Autopsy plugins, UnitConverter UI, frogger config transform)*

------
https://chatgpt.com/codex/tasks/task_e_68b07351325c83288188ee8bba8a6fea