### PR TITLE
feat: add web vitals analytics opt-out

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, analytics, setAnalytics } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -91,6 +91,17 @@ export function Settings() {
                 </label>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={analytics}
+                        onChange={(e) => setAnalytics(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Enable Analytics
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
                     style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
@@ -134,7 +145,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
+                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); setAnalytics(defaults.analytics); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -8,6 +8,8 @@ import {
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
+  getAnalytics as loadAnalytics,
+  setAnalytics as saveAnalytics,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -17,10 +19,12 @@ interface SettingsContextValue {
   wallpaper: string;
   density: Density;
   reducedMotion: boolean;
+  analytics: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
+  setAnalytics: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -28,10 +32,12 @@ export const SettingsContext = createContext<SettingsContextValue>({
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
+  analytics: defaults.analytics,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
+  setAnalytics: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -39,6 +45,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
+  const [analytics, setAnalytics] = useState<boolean>(defaults.analytics);
 
   useEffect(() => {
     (async () => {
@@ -46,6 +53,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
+      setAnalytics(await loadAnalytics());
     })();
   }, []);
 
@@ -89,8 +97,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
 
+  useEffect(() => {
+    saveAnalytics(analytics);
+  }, [analytics]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, setAccent, setWallpaper, setDensity, setReducedMotion }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, analytics, setAccent, setWallpaper, setDensity, setReducedMotion, setAnalytics }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/lib/web-vitals.js
+++ b/lib/web-vitals.js
@@ -1,0 +1,12 @@
+import { onCLS, onFID, onLCP, onFCP, onTTFB, onINP } from 'web-vitals';
+
+export const registerWebVitals = (onPerfEntry) => {
+  if (onPerfEntry && typeof onPerfEntry === 'function') {
+    onCLS(onPerfEntry);
+    onFID(onPerfEntry);
+    onLCP(onPerfEntry);
+    onFCP(onPerfEntry);
+    onTTFB(onPerfEntry);
+    onINP(onPerfEntry);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
     "turndown": "^7.2.1",
+    "web-vitals": "^5.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,7 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { registerWebVitals } from '../lib/web-vitals';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -14,8 +15,39 @@ import { SettingsProvider } from '../hooks/useSettings';
 function MyApp({ Component, pageProps }) {
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
-    if (trackingId) {
+    const analyticsEnabled = window.localStorage.getItem('analytics') !== 'false';
+    if (trackingId && analyticsEnabled) {
       ReactGA.initialize(trackingId);
+    }
+
+    if (analyticsEnabled) {
+      registerWebVitals((metric) => {
+        if (trackingId) {
+          ReactGA.event({
+            category: 'Web Vitals',
+            action: metric.name,
+            value: Math.round(metric.name === 'CLS' ? metric.value * 1000 : metric.value),
+            label: metric.id,
+            nonInteraction: true,
+          });
+        } else if (process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ID) {
+          const body = JSON.stringify({
+            dsn: process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ID,
+            id: metric.id,
+            page: window.location.pathname,
+            href: window.location.href,
+            event_name: metric.name,
+            value: metric.value.toString(),
+            speed: metric.navigationEntry ? metric.navigationEntry.type : undefined,
+          });
+          const url = 'https://vitals.vercel-insights.com/v1/vitals';
+          if (navigator.sendBeacon) {
+            navigator.sendBeacon(url, body);
+          } else {
+            fetch(url, { body, method: 'POST', keepalive: true });
+          }
+        }
+      });
     }
     if (
       process.env.NODE_ENV === 'production' &&

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -5,6 +5,7 @@ const DEFAULT_SETTINGS = {
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,
+  analytics: true,
 };
 
 export async function getAccent() {
@@ -47,6 +48,16 @@ export async function setReducedMotion(value) {
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
+export async function getAnalytics() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.analytics;
+  return window.localStorage.getItem('analytics') !== 'false';
+}
+
+export async function setAnalytics(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('analytics', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -55,6 +66,7 @@ export async function resetSettings() {
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
+  window.localStorage.removeItem('analytics');
 }
 
 export const defaults = DEFAULT_SETTINGS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9684,6 +9684,7 @@ __metadata:
     turndown: "npm:^7.2.1"
     typescript: "npm:^5.9.2"
     wait-on: "npm:^8.0.4"
+    web-vitals: "npm:^5.1.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -9844,6 +9845,13 @@ __metadata:
   dependencies:
     makeerror: "npm:1.0.12"
   checksum: 10c0/a17e037bccd3ca8a25a80cb850903facdfed0de4864bd8728f1782370715d679fa72e0a0f5da7c1c1379365159901e5935f35be531229da53bbfc0efdabdb48e
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "web-vitals@npm:5.1.0"
+  checksum: 10c0/1af22ddbe2836ba880fcb492cfba24c3349f4760ebb5e92f38324ea67bca3c4dbb9c86f1a32af4795b6115cdaf98b90000cf3a7402bffef6e8c503f0d1b2e706
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add web vitals helper registering core metrics
- allow users to opt out of analytics in settings
- send web vitals to GA4 or Vercel only when analytics enabled

## Testing
- `yarn lint` *(fails: Parsing error: ')' expected)*
- `yarn test` *(fails: memoryGame, beef, snake.config, frogger.config tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b073523d588328bbf6413b4b431200