### PR TITLE
feat: add background sync

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,3 +1,19 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+/* global workbox */
+
+const bgSyncPlugin = new workbox.backgroundSync.Plugin('offline-queue', {
+  maxRetentionTime: 24 * 60,
+});
+
+workbox.routing.registerRoute(
+  ({ url, request }) =>
+    url.origin === self.location.origin && request.method === 'POST',
+  new workbox.strategies.NetworkOnly({
+    plugins: [bgSyncPlugin],
+  }),
+  'POST'
+);
+
 const CACHE_NAME = 'weather-cache-v1';
 
 self.addEventListener('install', () => {


### PR DESCRIPTION
## Summary
- add Workbox Background Sync to service worker to queue offline POST requests

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: memoryGame, beef, autopsy, converter tests; syntax error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07354afbc8328941b415bb5c8c337