### PR TITLE
feat: enable PWA share target for Sticky Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ This project supports static export. Serverless API routes will not be available
 yarn export        # outputs to ./out
 ```
 
+### Install as PWA for Sharing
+
+To send text or links directly into the Sticky Notes app:
+
+1. Open the site in a supported browser (Chrome, Edge, etc.).
+2. Use the browser's **Install** or **Add to Home screen** option.
+3. After installation, use the system **Share** action and select "Kali Linux Portfolio".
+4. The shared content will appear as a new note.
+
 ---
 
 ## Tech Stack

--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -89,10 +89,10 @@ function createNoteElement(note) {
   notesContainer.appendChild(el);
 }
 
-function addNote() {
+function addNote(content = '') {
   const note = {
     id: Date.now(),
-    content: '',
+    content,
     x: 50,
     y: 50,
     color: '#fffa65',
@@ -143,6 +143,13 @@ async function init() {
     }
 
     notes.forEach(createNoteElement);
+
+    const params = new URLSearchParams(location.search);
+    const sharedText = params.get('text');
+    if (sharedText) {
+      addNote(sharedText);
+      history.replaceState(null, '', location.pathname);
+    }
   } catch (err) {
     console.error('Failed to load notes', err);
     try {

--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,0 +1,14 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const { text, url, title } = req.body || {};
+  const content = text || url || title || '';
+  const params = new URLSearchParams();
+  if (content) {
+    params.set('text', content);
+  }
+  res.redirect(307, `/apps/sticky_notes/?${params.toString()}`);
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -17,6 +17,16 @@
       "type": "image/png"
     }
   ],
+  "share_target": {
+    "action": "/api/share",
+    "method": "POST",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "shortcuts": [
     {
       "name": "Open Terminal",


### PR DESCRIPTION
## Summary
- add Web Share Target metadata to manifest
- handle shared text via `/api/share` and redirect to Sticky Notes
- document installing the PWA for sharing

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b07357622883289cf04af2648d6737