### PR TITLE
Add scroll-linked animation for section headers

### DIFF
--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -26,7 +26,7 @@ const steps: Step[] = [
 
 const WorkflowCard: React.FC = () => (
   <section className="p-4 rounded bg-ub-grey text-white">
-    <h2 className="text-xl font-bold mb-2">Workflow</h2>
+    <h2 className="section-header text-xl font-bold mb-2">Workflow</h2>
     <ul>
       {steps.map((s) => (
         <li key={s.title} className="mb-2">

--- a/styles/index.css
+++ b/styles/index.css
@@ -495,3 +495,27 @@ textarea:focus-visible {
     outline: 2px solid #3B82F6;
     outline-offset: 2px;
 }
+
+/* Scroll-linked animations for section headers */
+@scroll-timeline myTimeline {
+    source: auto;
+    orientation: block;
+}
+
+.section-header {
+    animation: section-fade linear both;
+    animation-timeline: myTimeline;
+    animation-range: entry 0% exit 100%;
+}
+
+@keyframes section-fade {
+    from {
+        opacity: 0;
+        transform: translateY(1rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Define `@scroll-timeline` and fade animation for section headers in global CSS
- Apply new `section-header` class to WorkflowCard heading with scroll-linked animation

## Testing
- `npm test` *(fails: combo meter increments and resets, card flip applies transform style, updates hook list when new hooks arrive, streams module output to UI, filters artifacts by type, keeps sliders synchronized, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07358769c832884a0cc369dad2636