### PR TITLE
feat: add app badge for pending notifications or tasks

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -13,7 +13,35 @@ export class SideBarApp extends Component {
 
     componentDidMount() {
         this.id = this.props.id;
+        this.updateBadge();
     }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.notifications !== this.props.notifications || prevProps.tasks !== this.props.tasks) {
+            this.updateBadge();
+        }
+    }
+
+    updateBadge = () => {
+        if (typeof navigator === 'undefined') return;
+        const hasSet = 'setAppBadge' in navigator;
+        const hasClear = 'clearAppBadge' in navigator;
+        if (!hasSet && !hasClear) return;
+
+        const notifications = Array.isArray(this.props.notifications)
+            ? this.props.notifications.length
+            : (typeof this.props.notifications === 'number' ? this.props.notifications : 0);
+        const tasks = Array.isArray(this.props.tasks)
+            ? this.props.tasks.length
+            : (typeof this.props.tasks === 'number' ? this.props.tasks : 0);
+        const count = notifications + tasks;
+
+        if (count > 0 && hasSet) {
+            navigator.setAppBadge(count).catch(() => {});
+        } else if (hasClear) {
+            navigator.clearAppBadge().catch(() => {});
+        }
+    };
 
     scaleImage = () => {
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- set or clear app badges in `SideBarApp` when notifications or tasks are pending

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm run lint` *(fails: Parse error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0735775408328a289d441a09510b8