### PR TITLE
refactor(window): use Web Animations API

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -127,23 +127,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
 }
 
-.closed-window {
-    animation: closeWindow 200ms 1 forwards;
-}
-
-@keyframes closeWindow {
-    0% {
-        opacity: 1;
-        transform: translate(var(--window-transform-x), var(--window-transform-y)) scale(1);
-        visibility: visible;
-    }
-
-    100% {
-        opacity: 0;
-        transform: translate(var(--window-transform-x), var(--window-transform-y)) scale(0.85);
-        visibility: hidden;
-    }
-}
 
 .windowMainScreen::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- replace CSS keyframes with Web Animations API in window component
- add easing presets and cancel animations on interaction
- remove unused closeWindow keyframes from global styles

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0735a2f5c8328afedb9f3b3fc748c