### PR TITLE
feat: blur panels and menus with fallback color

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -359,9 +359,19 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     100% { transform: translateX(0); }
 }
 
-/* Context Menu */
-.context-menu-bg {
-    background-color: rgb(43, 43, 43);
+/* Context Menu & Panels */
+.context-menu-bg,
+.windowMainScreen {
+    background-color: rgba(43, 43, 43, 0.85); /* Fallback for unsupported browsers */
+}
+
+@supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
+    .context-menu-bg,
+    .windowMainScreen {
+        -webkit-backdrop-filter: blur(10px);
+        backdrop-filter: blur(10px);
+        background-color: rgba(43, 43, 43, 0.4);
+    }
 }
 
 .emoji-list>li {


### PR DESCRIPTION
## Summary
- add backdrop blur to context menus and window panels
- provide semi-transparent fallback color when blur unsupported

## Testing
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0735aabc48328bcdae673209357b3