### PR TITLE
feat: add color scheme toggle

### DIFF
--- a/components/util-components/status_card.js
+++ b/components/util-components/status_card.js
@@ -27,7 +27,8 @@ export class StatusCard extends Component {
                 this.wrapperRef = React.createRef();
                 this.state = {
                         sound_level: 75, // better of setting default values from localStorage
-                        brightness_level: 100 // setting default value to 100 so that by default its always full.
+                        brightness_level: 100, // setting default value to 100 so that by default its always full.
+                        color_scheme: 'system'
                 };
         }
         handleClickOutside = () => {
@@ -36,10 +37,12 @@ export class StatusCard extends Component {
         componentDidMount() {
                 this.setState({
                         sound_level: localStorage.getItem('sound-level') || 75,
-                        brightness_level: localStorage.getItem('brightness-level') || 100
+                        brightness_level: localStorage.getItem('brightness-level') || 100,
+                        color_scheme: localStorage.getItem('color-scheme') || 'system'
                 }, () => {
                         document.getElementById('monitor-screen').style.filter = `brightness(${3 / 400 * this.state.brightness_level +
                                 0.25})`;
+                        this.applyScheme(this.state.color_scheme);
                 })
         }
 
@@ -55,9 +58,23 @@ export class StatusCard extends Component {
                 localStorage.setItem('sound-level', e.target.value);
         };
 
-        // theme toggling removed for Kali theme
+        applyScheme = (scheme) => {
+                if (scheme === 'system') {
+                        document.documentElement.removeAttribute('data-color-scheme');
+                        localStorage.removeItem('color-scheme');
+                } else {
+                        document.documentElement.dataset.colorScheme = scheme;
+                        localStorage.setItem('color-scheme', scheme);
+                }
+        };
 
-	render() {
+        handleScheme = (e) => {
+                const scheme = e.target.value;
+                this.setState({ color_scheme: scheme });
+                this.applyScheme(scheme);
+        };
+
+        render() {
 		return (
 			<div
 				ref={this.wrapperRef}
@@ -96,7 +113,7 @@ export class StatusCard extends Component {
                                                         alt="ubuntu brightness"
                                                         sizes="16px"
                                                 />
-					</div>
+                                        </div>
                                         <Slider
                                                 onChange={this.handleBrightness}
                                                 className="ubuntu-slider w-2/3"
@@ -105,7 +122,27 @@ export class StatusCard extends Component {
                                                 aria-label="Screen brightness"
                                         />
                                 </div>
-                                {/* Theme toggle removed for fixed Kali theme */}
+                                <div className="w-64 py-1.5 flex items-center justify-center bg-ub-cool-grey hover:bg-ub-warm-grey hover:bg-opacity-20">
+                                        <div className="w-8">
+                                                <Image
+                                                        width={16}
+                                                        height={16}
+                                                        src="/themes/Yaru/status/weather-clear-night-symbolic.svg"
+                                                        alt="color scheme"
+                                                        sizes="16px"
+                                                />
+                                        </div>
+                                        <select
+                                                onChange={this.handleScheme}
+                                                value={this.state.color_scheme}
+                                                className="bg-ub-cool-grey text-gray-400 w-2/3 border border-ubt-cool-grey rounded"
+                                                aria-label="Color scheme"
+                                        >
+                                                <option value="system">System</option>
+                                                <option value="light">Light</option>
+                                                <option value="dark">Dark</option>
+                                        </select>
+                                </div>
                                 <div className="w-64 flex content-center justify-center">
                                         <div className="w-2/4 border-black border-opacity-50 border-b my-2 border-solid" />
                                 </div>

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -16,6 +16,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <meta name="color-scheme" content="dark light" />
           <Script src="/theme.js" strategy="beforeInteractive" />
         </Head>
         <body>

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,5 +1,9 @@
 (function () {
   try {
     document.documentElement.dataset.theme = 'kali';
+    var scheme = localStorage.getItem('color-scheme');
+    if (scheme) {
+      document.documentElement.dataset.colorScheme = scheme;
+    }
   } catch (e) {}
 })();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,3 +17,47 @@
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
 }
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: #f5f5f5;
+    --color-text: #0f1317;
+    --color-primary: #1793d1;
+    --color-secondary: #e5e5e5;
+    --color-accent: #1793d1;
+    --color-muted: #d0d0d0;
+    --color-surface: #ffffff;
+    --color-inverse: #ffffff;
+    --color-border: #d0d0d0;
+    --color-terminal: #00ff00;
+    --color-dark: #e0e0e0;
+  }
+}
+
+html[data-color-scheme='dark'] {
+  --color-bg: #0f1317;
+  --color-text: #f5f5f5;
+  --color-primary: #1793d1;
+  --color-secondary: #1a1f26;
+  --color-accent: #1793d1;
+  --color-muted: #2a2e36;
+  --color-surface: #1a1f26;
+  --color-inverse: #000000;
+  --color-border: #2a2e36;
+  --color-terminal: #00ff00;
+  --color-dark: #0c0f12;
+}
+
+html[data-color-scheme='light'] {
+  --color-bg: #f5f5f5;
+  --color-text: #0f1317;
+  --color-primary: #1793d1;
+  --color-secondary: #e5e5e5;
+  --color-accent: #1793d1;
+  --color-muted: #d0d0d0;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d0d0d0;
+  --color-terminal: #00ff00;
+  --color-dark: #e0e0e0;
+}


### PR DESCRIPTION
## Summary
- declare supported color schemes in document metadata
- switch global colors based on `prefers-color-scheme` and allow manual overrides
- add Quick Settings option to choose light or dark mode

## Testing
- `npm test` *(fails: memoryGame, beef, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0735c310c8328929a9bf6b012f5b7