### PR TITLE
feat: apply inert attribute to root on overlay

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -283,3 +283,44 @@ describe('Window keyboard dragging', () => {
     expect(handle).toHaveAttribute('aria-grabbed', 'false');
   });
 });
+
+describe('Window overlay inert behaviour', () => {
+  it('sets and removes inert on #root restoring focus', () => {
+    const ref = React.createRef<Window>();
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+      const opener = document.createElement('button');
+      document.body.appendChild(opener);
+      opener.focus();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />,
+      { container: root }
+    );
+
+    act(() => {
+      ref.current!.activateOverlay();
+    });
+
+    expect(root).toHaveAttribute('inert');
+
+    act(() => {
+      ref.current!.closeWindow();
+    });
+
+    expect(root).not.toHaveAttribute('inert');
+
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -28,6 +28,7 @@ export class Window extends Component {
         }
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
+        this._menuOpener = null;
     }
 
     componentDidMount() {
@@ -128,6 +129,25 @@ export class Window extends Component {
             });
         };
         shrink();
+    }
+
+    activateOverlay = () => {
+        const root = document.getElementById('root');
+        if (root) {
+            root.setAttribute('inert', '');
+        }
+        this._menuOpener = document.activeElement;
+    }
+
+    deactivateOverlay = () => {
+        const root = document.getElementById('root');
+        if (root) {
+            root.removeAttribute('inert');
+        }
+        if (this._menuOpener && typeof this._menuOpener.focus === 'function') {
+            this._menuOpener.focus();
+        }
+        this._menuOpener = null;
     }
 
     changeCursorToMove = () => {
@@ -315,6 +335,7 @@ export class Window extends Component {
     closeWindow = () => {
         this.setWinowsPosition();
         this.setState({ closed: true }, () => {
+            this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
             setTimeout(() => {
                 this.props.closed(this.id)


### PR DESCRIPTION
## Summary
- add overlay helpers in window base component to set/remove inert and restore focus
- test root inert removal when overlay closes

## Testing
- `npm test __tests__/window.test.tsx`
- `npm test` *(fails: combo meter increments and resets, card flip applies transform style, BeEF app updates hook list, BeEF app streams module output, Autopsy plugins and timeline filters artifacts by type, UnitConverter UI keeps sliders synchronized, Snake config, Frogger config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0735f793c8328a63402879a2c993f