### PR TITLE
feat: enable scroll snapping in gallery

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -495,3 +495,12 @@ textarea:focus-visible {
     outline: 2px solid #3B82F6;
     outline-offset: 2px;
 }
+
+/* Enable scroll snapping for gallery containers */
+.gallery-container {
+    scroll-snap-type: x mandatory;
+}
+
+.gallery-container > * {
+    scroll-snap-align: start;
+}


### PR DESCRIPTION
## Summary
- enable scroll-snap behavior on gallery containers and items

## Testing
- `npm test` *(fails: memoryGame, BeEF, Chrome config suites)*
- `npm run lint` *(fails: parsing error in components/apps/Chrome/index.tsx)*
- `npx jest __tests__/projectGallery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b073602b408328aeee17659c1a6ac9