### PR TITLE
Add WebHID demo app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -66,6 +66,7 @@ const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
 const BluetoothApp = createDynamicApp('bluetooth', 'Bluetooth Tools');
+const HidDemoApp = createDynamicApp('hid-demo', 'HID Demo');
 const DsniffApp = createDynamicApp('dsniff', 'dsniff');
 const BeefApp = createDynamicApp('beef', 'BeEF');
 const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
@@ -146,6 +147,7 @@ const displayAutopsy = createDisplay(AutopsyApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBluetooth = createDisplay(BluetoothApp);
+const displayHidDemo = createDisplay(HidDemoApp);
 const displayBeef = createDisplay(BeefApp);
 const displayMetasploit = createDisplay(MetasploitApp);
 const displayDsniff = createDisplay(DsniffApp);
@@ -676,6 +678,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayBluetooth,
+  },
+  {
+    id: 'hid-demo',
+    title: 'HID Demo',
+    icon: './themes/Yaru/apps/game.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHidDemo,
   },
   {
     id: 'metasploit',

--- a/components/apps/hid-demo.tsx
+++ b/components/apps/hid-demo.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+
+interface HidLog {
+  device: HIDDevice;
+  reportId: number;
+  data: string;
+}
+
+const HIDDemo: React.FC = () => {
+  const supported = typeof navigator !== 'undefined' && 'hid' in navigator;
+  const [devices, setDevices] = useState<HIDDevice[]>([]);
+  const [logs, setLogs] = useState<HidLog[]>([]);
+
+  useEffect(() => {
+    if (!supported) return;
+    navigator.hid.getDevices().then(setDevices).catch(() => {});
+  }, [supported]);
+
+  const requestDevices = async () => {
+    if (!supported) return;
+    try {
+      const requested = await navigator.hid.requestDevice({ filters: [] });
+      setDevices((prev) => [...prev, ...requested]);
+    } catch {
+      // user cancelled
+    }
+  };
+
+  const connect = async (device: HIDDevice) => {
+    if (!device.opened) await device.open();
+    device.addEventListener('inputreport', (e: HIDInputReportEvent) => {
+      const bytes = new Uint8Array(e.data.buffer);
+      const data = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(' ');
+      setLogs((prev) => [{ device, reportId: e.reportId, data }, ...prev].slice(0, 20));
+    });
+  };
+
+  return (
+    <div className="h-full w-full bg-black p-4 text-white">
+      {!supported && (
+        <p className="mb-4 text-yellow-400">WebHID is not supported in this browser.</p>
+      )}
+      <button
+        onClick={requestDevices}
+        disabled={!supported}
+        className="rounded bg-blue-600 px-3 py-1 disabled:opacity-50"
+      >
+        Request Device
+      </button>
+      <ul className="my-4 max-h-48 space-y-2 overflow-auto">
+        {devices.map((d) => (
+          <li
+            key={`${d.vendorId}-${d.productId}-${d.productName}`}
+            className="flex items-center justify-between border-b border-gray-700 pb-1"
+          >
+            <span>
+              {d.productName || 'Unknown'} ({d.vendorId.toString(16)}:{' '}
+              {d.productId.toString(16)})
+            </span>
+            <button
+              onClick={() => connect(d)}
+              className="rounded bg-gray-700 px-2 py-0.5 text-xs"
+            >
+              Listen
+            </button>
+          </li>
+        ))}
+      </ul>
+      {logs.length > 0 && (
+        <div>
+          <p className="mb-2 font-bold">Last Input Report</p>
+          <pre className="max-h-40 overflow-auto rounded bg-gray-800 p-2 text-xs">
+            {`Device: ${logs[0].device.productName || 'Unknown'}\nReport ${logs[0].reportId}: ${logs[0].data}`}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HIDDemo;
+export const displayHidDemo = () => <HIDDemo />;


### PR DESCRIPTION
## Summary
- add HIDDemo component using WebHID to list devices and read input reports
- register HID Demo in the application configuration

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07364c3c08328b59e2380f2775bbd