### PR TITLE
Add gamepad polling hook and integrate with game controls

### DIFF
--- a/hooks/useGamepad.ts
+++ b/hooks/useGamepad.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { pollTwinStick, TwinStickState } from '../utils/gamepad';
+
+export default function useGamepad(deadzone: number = 0.25): TwinStickState {
+  const [state, setState] = useState<TwinStickState>(() => pollTwinStick(deadzone));
+
+  useEffect(() => {
+    let raf: number;
+    const read = () => {
+      setState(pollTwinStick(deadzone));
+      raf = requestAnimationFrame(read);
+    };
+    raf = requestAnimationFrame(read);
+    return () => cancelAnimationFrame(raf);
+  }, [deadzone]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- add `useGamepad` hook that polls controllers with deadzone filtering
- wire gamepad input into existing game control helper for directional and advanced games

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b07361f0148328aeb41602a00371ba