### PR TITLE
feat: add serial terminal

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -62,6 +62,7 @@ const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
+const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -138,6 +139,7 @@ const displayAsciiArt = createDisplay(AsciiArtApp);
 const displayQuoteGenerator = createDisplay(QuoteGeneratorApp);
 const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
+const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 
 const displayGhidra = createDisplay(GhidraApp);
@@ -855,6 +857,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayWeatherWidget,
+  },
+  {
+    id: 'serial-terminal',
+    title: 'Serial Terminal',
+    icon: './themes/Yaru/apps/bash.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySerialTerminal,
   },
   {
     id: 'radare2',

--- a/components/apps/serial-terminal.tsx
+++ b/components/apps/serial-terminal.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState, useRef } from 'react';
+import FormError from '../../ui/FormError';
+
+const SerialTerminalApp: React.FC = () => {
+  const supported = typeof navigator !== 'undefined' && 'serial' in navigator;
+  const [port, setPort] = useState<SerialPort | null>(null);
+  const [logs, setLogs] = useState('');
+  const [error, setError] = useState('');
+  const readerRef = useRef<ReadableStreamDefaultReader<string> | null>(null);
+
+  useEffect(() => {
+    if (!supported) return;
+    const handleDisconnect = (e: unknown) => {
+      if ((e as { target?: SerialPort }).target === port) {
+        setError('Device disconnected.');
+        setPort(null);
+      }
+    };
+    navigator.serial.addEventListener('disconnect', handleDisconnect);
+    return () => {
+      navigator.serial.removeEventListener('disconnect', handleDisconnect);
+    };
+  }, [supported, port]);
+
+  const readLoop = async (p: SerialPort) => {
+    const textDecoder = new TextDecoderStream();
+    const readableClosed = p.readable?.pipeTo(textDecoder.writable);
+    const reader = textDecoder.readable.getReader();
+    readerRef.current = reader;
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) setLogs((l) => l + value);
+      }
+    } catch {
+      // ignored
+    } finally {
+      reader.releaseLock();
+      await readableClosed?.catch(() => {});
+    }
+  };
+
+  const connect = async () => {
+    if (!supported) return;
+    setError('');
+    try {
+      const p = await navigator.serial.requestPort();
+      await p.open({ baudRate: 9600 });
+      setPort(p);
+      readLoop(p);
+    } catch (err) {
+      const e = err as DOMException;
+      if (e.name === 'NotAllowedError') {
+        setError('Permission to access serial port was denied.');
+      } else if (e.name === 'NotFoundError') {
+        setError('No port selected.');
+      } else {
+        setError(e.message || 'Failed to open serial port.');
+      }
+    }
+  };
+
+  const disconnect = async () => {
+    try {
+      await readerRef.current?.cancel();
+      await port?.close();
+    } catch {
+      // ignore
+    } finally {
+      setPort(null);
+    }
+  };
+
+  return (
+    <div className="relative h-full w-full bg-black p-4 text-green-400 font-mono">
+      <div className="mb-4 flex gap-2">
+        {!port ? (
+          <button
+            onClick={connect}
+            disabled={!supported}
+            className="rounded bg-gray-700 px-2 py-1 text-white disabled:opacity-50"
+          >
+            Connect
+          </button>
+        ) : (
+          <button
+            onClick={disconnect}
+            className="rounded bg-red-700 px-2 py-1 text-white"
+          >
+            Disconnect
+          </button>
+        )}
+      </div>
+      {!supported && (
+        <p className="mb-2 text-sm text-yellow-400">
+          Web Serial API not supported in this browser.
+        </p>
+      )}
+      {error && <FormError className="mb-2 mt-0">{error}</FormError>}
+      <pre className="h-[calc(100%-4rem)] overflow-auto whitespace-pre-wrap break-words">
+        {logs || 'No data'}
+      </pre>
+    </div>
+  );
+};
+
+export default SerialTerminalApp;
+export const displaySerialTerminal = () => <SerialTerminalApp />;
+


### PR DESCRIPTION
## Summary
- add serial terminal component for streaming microcontroller logs
- register serial terminal in app configuration

## Testing
- `yarn lint --file components/apps/serial-terminal.tsx --file apps.config.js`
- `yarn test __tests__/memoryGame.test.tsx` *(fails: Unable to find or mismatched elements)*

------
https://chatgpt.com/codex/tasks/task_e_68b0736704348328ba43ebee6168b36f