### PR TITLE
chore: add content-visibility to hidden panels

### DIFF
--- a/apps/timer_stopwatch/index.tsx
+++ b/apps/timer_stopwatch/index.tsx
@@ -37,6 +37,7 @@ export default function TimerStopwatch() {
         role="tabpanel"
         className="tab-panel"
         hidden={mode !== 'timer'}
+        style={{ contentVisibility: 'auto' }}
       >
         <div>
           <input type="number" id="minutes" min="0" defaultValue="0" /> :
@@ -54,6 +55,7 @@ export default function TimerStopwatch() {
         role="tabpanel"
         className="tab-panel"
         hidden={mode !== 'stopwatch'}
+        style={{ contentVisibility: 'auto' }}
       >
         <div className="display" id="stopwatchDisplay">00:00</div>
         <div>

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -23,8 +23,16 @@ button {
   font-weight: bold;
 }
 
-.tab-panel[hidden] {
-  display: none;
+@supports (content-visibility: auto) {
+  .tab-panel[hidden] {
+    content-visibility: auto;
+  }
+}
+
+@supports not (content-visibility: auto) {
+  .tab-panel[hidden] {
+    display: none;
+  }
 }
 input {
   width: 60px;

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -4,7 +4,12 @@ import Image from 'next/image'
 function BootingScreen(props) {
 
     return (
-        <div style={(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" })} className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
+        <div
+            style={{
+                ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
+                contentVisibility: 'auto',
+            }}
+            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
             <Image
                 width={400}
                 height={400}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -12,7 +12,10 @@ export default function LockScreen(props) {
     };
 
     return (
-        <div id="ubuntu-lock-screen" style={{ zIndex: "100" }} className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
+        <div
+            id="ubuntu-lock-screen"
+            style={{ zIndex: "100", contentVisibility: 'auto' }}
+            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <div style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPositionX: "center" }} className="absolute top-0 left-0 w-full h-full transform z-20 blur-md "></div>
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">


### PR DESCRIPTION
## Summary
- apply `content-visibility: auto` to boot and lock screens
- ensure timer/stopwatch tab panels use `content-visibility` with fallback

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b087bea91c8328ad6d44e1264501d9