### PR TITLE
Lazy load heavy apps with dynamic imports

### DIFF
--- a/components/apps/calculator.js
+++ b/components/apps/calculator.js
@@ -1,1 +1,9 @@
-export { default } from '../../apps/calculator';
+import dynamic from 'next/dynamic';
+
+const Calculator = dynamic(() => import('../../apps/calculator'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default Calculator;
+

--- a/components/apps/sticky_notes/index.tsx
+++ b/components/apps/sticky_notes/index.tsx
@@ -1,3 +1,8 @@
-import StickyNotes from '../../../apps/sticky_notes';
+import dynamic from 'next/dynamic';
+
+const StickyNotes = dynamic(() => import('../../../apps/sticky_notes'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default StickyNotes;

--- a/components/apps/weather_widget.js
+++ b/components/apps/weather_widget.js
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 
 export default WeatherWidget;

--- a/pages/apps/2048.tsx
+++ b/pages/apps/2048.tsx
@@ -1,5 +1,8 @@
 import dynamic from 'next/dynamic';
 
-const Page2048 = dynamic(() => import('../../apps/2048'), { ssr: false });
+const Page2048 = dynamic(() => import('../../apps/2048'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default Page2048;

--- a/pages/apps/blackjack.tsx
+++ b/pages/apps/blackjack.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const Blackjack = dynamic(() => import('../../components/apps/blackjack'), { ssr: false });
+const Blackjack = dynamic(() => import('../../components/apps/blackjack'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function BlackjackPage() {
   return <Blackjack />;

--- a/pages/apps/calculator.tsx
+++ b/pages/apps/calculator.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const Calculator = dynamic(() => import('../../apps/calculator'), { ssr: false });
+const Calculator = dynamic(() => import('../../apps/calculator'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function CalculatorPage() {
   return <Calculator />;

--- a/pages/apps/checkers.tsx
+++ b/pages/apps/checkers.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 
-const Checkers = dynamic(() => import('../../apps/checkers'), { ssr: false });
+const Checkers = dynamic(() => import('../../apps/checkers'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function CheckersPage(): React.ReactElement {
   return <Checkers />;

--- a/pages/apps/http.tsx
+++ b/pages/apps/http.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const HTTPPreview = dynamic(() => import('../../apps/http'), { ssr: false });
+const HTTPPreview = dynamic(() => import('../../apps/http'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function HTTPPage() {
   return <HTTPPreview />;

--- a/pages/apps/minesweeper.tsx
+++ b/pages/apps/minesweeper.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 
 const Minesweeper = dynamic(() => import('../../components/apps/minesweeper'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 
 export default function MinesweeperPage() {

--- a/pages/apps/nmap-nse.tsx
+++ b/pages/apps/nmap-nse.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), { ssr: false });
+const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function NmapNSEPage() {
   return <NmapNSE />;

--- a/pages/apps/password_generator.tsx
+++ b/pages/apps/password_generator.tsx
@@ -1,7 +1,10 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), { ssr: false });
+const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function PasswordGeneratorPage() {
   return <PasswordGenerator getDailySeed={() => getDailySeed('password_generator')} />;

--- a/pages/apps/phaser_matter.tsx
+++ b/pages/apps/phaser_matter.tsx
@@ -1,7 +1,10 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), { ssr: false });
+const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function PhaserMatterPage() {
   return <PhaserMatter getDailySeed={() => getDailySeed('phaser_matter')} />;

--- a/pages/apps/ssh.tsx
+++ b/pages/apps/ssh.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const SSHPreview = dynamic(() => import('../../apps/ssh'), { ssr: false });
+const SSHPreview = dynamic(() => import('../../apps/ssh'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function SSHPage() {
   return <SSHPreview />;

--- a/pages/apps/sticky_notes.tsx
+++ b/pages/apps/sticky_notes.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), { ssr: false });
+const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function StickyNotesPage() {
   return <StickyNotes />;

--- a/pages/apps/timer_stopwatch.tsx
+++ b/pages/apps/timer_stopwatch.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), { ssr: false });
+const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function TimerStopwatchPage() {
   return <TimerStopwatch />;

--- a/pages/apps/weather_widget.tsx
+++ b/pages/apps/weather_widget.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), { ssr: false });
+const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function WeatherWidgetPage() {
   return <WeatherWidget />;

--- a/pages/apps/wireshark.tsx
+++ b/pages/apps/wireshark.tsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const Wireshark = dynamic(() => import('../../apps/wireshark'), { ssr: false });
+const Wireshark = dynamic(() => import('../../apps/wireshark'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function WiresharkPage() {
   return <Wireshark />;

--- a/pages/apps/word_search.tsx
+++ b/pages/apps/word_search.tsx
@@ -4,7 +4,7 @@ import { getDailySeed } from '../../utils/dailySeed';
 
 const WordSearch = dynamic<{ getDailySeed?: () => Promise<string> }>(
   () => import('../../apps/word_search'),
-  { ssr: false },
+  { ssr: false, loading: () => <p>Loading...</p> },
 );
 
 export default function WordSearchPage(): React.ReactElement {


### PR DESCRIPTION
## Summary
- load heavy calculators and sticky notes on demand
- add loading fallbacks for dynamic game imports

## Testing
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b087ba38ec8328bb8bd090a6d4d700