### PR TITLE
Include apps and hooks in Tailwind content scan

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   mode: 'jit',
-  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './apps/**/*.{js,ts,jsx,tsx}',
+    './hooks/**/*.{js,ts,jsx,tsx}',
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- include app and hook directories in Tailwind content paths so purge covers these sources

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `yarn build` *(fails: components/apps/Chrome/index.tsx parse error)*
- `npx tailwindcss -c tailwind.config.js -i /tmp/input.css -o /tmp/tailwind.css`


------
https://chatgpt.com/codex/tasks/task_e_68b0726674f48328ae3f001175e9ae12