### PR TITLE
feat(qr-tool): support drag and drop decoding

### DIFF
--- a/__tests__/qr_tool.test.tsx
+++ b/__tests__/qr_tool.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import QRTool from '../components/apps/qr_tool';
+
+describe('QRTool drag and drop', () => {
+  beforeEach(() => {
+    // Mock Worker
+    const mockPost = jest.fn();
+    // @ts-ignore
+    global.Worker = jest.fn(() => ({ postMessage: mockPost, terminate: jest.fn(), onmessage: null }));
+    // @ts-ignore
+    global.URL.createObjectURL = jest.fn(() => 'blob:');
+    // Mock Image to trigger onload immediately
+    // @ts-ignore
+    global.Image = class {
+      onload: (() => void) | null = null;
+      width = 2;
+      height = 2;
+      set src(_v: string) {
+        if (this.onload) this.onload();
+      }
+    } as any;
+    // Mock canvas context
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      drawImage: jest.fn(),
+      getImageData: () => ({ data: new Uint8ClampedArray(4), width: 2, height: 2 }),
+    }));
+  });
+
+  it('sends image data to worker when an image is dropped', async () => {
+    const { getByText, getByTestId } = render(<QRTool />);
+    fireEvent.click(getByText('Scan'));
+    const zone = getByTestId('drop-zone');
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+    // Worker mock is assigned in beforeEach
+    const mockWorker = (global.Worker as unknown as jest.Mock).mock.results[0].value;
+    await waitFor(() => expect(mockWorker.postMessage).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- allow QR Tool to accept dropped images for decoding
- add test covering drag-and-drop flow

## Testing
- `yarn test __tests__/qr_tool.test.tsx`
- `yarn lint components/apps/qr_tool/index.js __tests__/qr_tool.test.tsx` *(fails: Could not find pages or app directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b07298bc0483289e8dff5db16fe47a