### PR TITLE
feat: add document pip portal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ yarn lint
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
-- **`components/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
+- **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 
 ---
 

--- a/components/common/PipPortal.tsx
+++ b/components/common/PipPortal.tsx
@@ -1,0 +1,101 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// The Document Picture-in-Picture API is still experimental and the
+// TypeScript definitions do not ship with the DOM lib yet. Declare the
+// pieces we need so that the rest of the application can type-check.
+declare global {
+  interface Window {
+    documentPictureInPicture?: {
+      requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
+    };
+  }
+
+  interface PictureInPictureWindowOptions {
+    width?: number;
+    height?: number;
+  }
+}
+
+interface PipPortalContextValue {
+  open: (content: React.ReactNode) => Promise<void>;
+  close: () => void;
+}
+
+const PipPortalContext = createContext<PipPortalContextValue>({
+  open: async () => {},
+  close: () => {},
+});
+
+export const usePipPortal = () => useContext(PipPortalContext);
+
+/**
+ * Provider that lets children render arbitrary content inside a
+ * Document Picture-in-Picture window. The window remains controllable
+ * through the returned `open` and `close` functions.
+ */
+const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const pipWindowRef = useRef<Window | null>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [content, setContent] = useState<React.ReactNode>(null);
+
+  const close = useCallback(() => {
+    const win = pipWindowRef.current;
+    if (win && !win.closed) {
+      win.close();
+    }
+    pipWindowRef.current = null;
+    setContainer(null);
+    setContent(null);
+  }, []);
+
+  const open = useCallback(
+    async (node: React.ReactNode) => {
+      if (typeof window === 'undefined' || !window.documentPictureInPicture) return;
+
+      let win = pipWindowRef.current;
+      if (!win || win.closed) {
+        try {
+          win = await window.documentPictureInPicture.requestWindow();
+        } catch {
+          return;
+        }
+        pipWindowRef.current = win;
+        setContainer(win.document.body);
+
+        const handlePageHide = () => close();
+        window.addEventListener('pagehide', handlePageHide, { once: true });
+        win.addEventListener('pagehide', handlePageHide, { once: true });
+      }
+
+      setContent(node);
+    },
+    [close],
+  );
+
+  useEffect(() => {
+    const win = pipWindowRef.current;
+    if (!win) return;
+
+    const handleUnload = () => {
+      pipWindowRef.current = null;
+      setContainer(null);
+      setContent(null);
+    };
+
+    win.addEventListener('unload', handleUnload);
+    return () => {
+      win.removeEventListener('unload', handleUnload);
+    };
+  }, [container]);
+
+  return (
+    <PipPortalContext.Provider value={{ open, close }}>
+      {children}
+      {container && content ? createPortal(content, container) : null}
+    </PipPortalContext.Provider>
+  );
+};
+
+export default PipPortalProvider;
+

--- a/docs/pip-portal.md
+++ b/docs/pip-portal.md
@@ -9,7 +9,7 @@ Wrap your application with `PipPortalProvider` and use the `usePipPortal`
 hook to open or close the PiP window.
 
 ```tsx
-import PipPortalProvider, { usePipPortal } from '../components/PipPortal';
+import PipPortalProvider, { usePipPortal } from '../components/common/PipPortal';
 
 function HudButton() {
   const { open, close } = usePipPortal();


### PR DESCRIPTION
## Summary
- add PipPortal provider for Document PiP windows
- document PiP portal usage and path

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0870286508328a85afd37ece55013