### PR TITLE
feat: add screen recorder app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -13,6 +13,7 @@ import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
+import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
 // Dynamic applications and games
@@ -658,6 +659,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'screen-recorder',
+    title: 'Screen Recorder',
+    icon: './themes/Yaru/apps/screen-recorder.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayScreenRecorder,
   },
   {
     id: 'ettercap',

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+function ScreenRecorder() {
+    const [recording, setRecording] = useState(false);
+    const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const recorderRef = useRef<MediaRecorder | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+    const streamRef = useRef<MediaStream | null>(null);
+
+    const startRecording = async () => {
+        try {
+            const stream = await navigator.mediaDevices.getDisplayMedia({
+                video: true,
+                audio: true,
+            });
+            streamRef.current = stream;
+            const recorder = new MediaRecorder(stream);
+            chunksRef.current = [];
+            recorder.ondataavailable = (e: BlobEvent) => {
+                if (e.data.size > 0) chunksRef.current.push(e.data);
+            };
+            recorder.onstop = () => {
+                const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+                const url = URL.createObjectURL(blob);
+                setVideoUrl(url);
+                stream.getTracks().forEach((t) => t.stop());
+            };
+            recorder.start();
+            recorderRef.current = recorder;
+            setRecording(true);
+        } catch {
+            // ignore
+        }
+    };
+
+    const stopRecording = () => {
+        recorderRef.current?.stop();
+        setRecording(false);
+    };
+
+    const saveRecording = async () => {
+        if (!videoUrl) return;
+        const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+        if ('showSaveFilePicker' in window) {
+            try {
+                const handle = await (window as any).showSaveFilePicker({
+                    suggestedName: 'recording.webm',
+                    types: [
+                        {
+                            description: 'WebM video',
+                            accept: { 'video/webm': ['.webm'] },
+                        },
+                    ],
+                });
+                const writable = await handle.createWritable();
+                await writable.write(blob);
+                await writable.close();
+            } catch {
+                // ignore
+            }
+        } else {
+            const a = document.createElement('a');
+            a.href = videoUrl;
+            a.download = 'recording.webm';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            streamRef.current?.getTracks().forEach((t) => t.stop());
+            recorderRef.current?.stop();
+        };
+    }, []);
+
+    return (
+        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
+            {!recording && (
+                <button
+                    type="button"
+                    onClick={startRecording}
+                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                >
+                    Start Recording
+                </button>
+            )}
+            {recording && (
+                <button
+                    type="button"
+                    onClick={stopRecording}
+                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
+                >
+                    Stop Recording
+                </button>
+            )}
+            {videoUrl && !recording && (
+                <>
+                    <video src={videoUrl} controls className="max-w-full" />
+                    <button
+                        type="button"
+                        onClick={saveRecording}
+                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                    >
+                        Save Recording
+                    </button>
+                </>
+            )}
+        </div>
+    );
+}
+
+export default ScreenRecorder;
+
+export const displayScreenRecorder = () => {
+    return <ScreenRecorder />;
+};
+

--- a/public/themes/Yaru/apps/screen-recorder.svg
+++ b/public/themes/Yaru/apps/screen-recorder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="15" ry="15" fill="#333"/>
+  <circle cx="50" cy="50" r="30" fill="#e52d27"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Screen Recorder app using `getDisplayMedia` and `MediaRecorder`
- enable saving recordings with the File System Access API
- register Screen Recorder in the app config with an icon

## Testing
- `yarn lint --file components/apps/screen-recorder.tsx --file apps.config.js`
- `yarn test __tests__/memoryGame.test.tsx`
- `yarn test __tests__/snake.config.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b087028c6c8328ad8f5622e1d926b5