### PR TITLE
Improve ARIA navigation with roving tabindex

### DIFF
--- a/__tests__/aboutAccessibility.test.tsx
+++ b/__tests__/aboutAccessibility.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AboutApp from '../components/apps/About';
+
+describe('AboutApp accessibility', () => {
+  it('supports roving tabindex for navigation tabs', async () => {
+    const user = userEvent.setup();
+    render(<AboutApp />);
+    const tablist = screen.getAllByRole('tablist')[0];
+    const tabs = within(tablist).getAllByRole('tab');
+    expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
+    tabs[0].focus();
+    await user.keyboard('{ArrowDown}');
+    const updatedTabs = within(tablist).getAllByRole('tab');
+    expect(updatedTabs[1]).toHaveFocus();
+    expect(updatedTabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
+});
+

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -54,7 +54,9 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
         <div
           key={section.id}
           id={section.id}
-          tabIndex={0}
+          role="tab"
+          aria-selected={this.state.active_screen === section.id}
+          tabIndex={this.state.active_screen === section.id ? 0 : -1}
           onFocus={this.changeScreen}
           className={
             (this.state.active_screen === section.id
@@ -77,6 +79,24 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
     </>
   );
 
+  handleNavKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const tabs = Array.from(
+      e.currentTarget.querySelectorAll<HTMLElement>('[role="tab"]')
+    );
+    let index = tabs.indexOf(document.activeElement as HTMLElement);
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      index = (index + 1) % tabs.length;
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      index = (index - 1 + tabs.length) % tabs.length;
+    } else {
+      return;
+    }
+    tabs.forEach((tab, i) => (tab.tabIndex = i === index ? 0 : -1));
+    tabs[index].focus();
+  };
+
   render() {
     const structured = {
       '@context': 'https://schema.org',
@@ -91,7 +111,12 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
           <title>About</title>
           <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }} />
         </Head>
-        <div className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black">
+        <div
+          className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black"
+          role="tablist"
+          aria-orientation="vertical"
+          onKeyDown={this.handleNavKeyDown}
+        >
           {this.renderNavLinks()}
         </div>
         <div
@@ -106,6 +131,9 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
               (this.state.navbar ? ' visible animateShow z-30 ' : ' invisible ') +
               ' md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20'
             }
+            role="tablist"
+            aria-orientation="vertical"
+            onKeyDown={this.handleNavKeyDown}
           >
             {this.renderNavLinks()}
           </div>

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 import * as pdfjsLib from 'pdfjs-dist';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
@@ -16,6 +17,9 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const [thumbs, setThumbs] = useState<HTMLCanvasElement[]>([]);
   const [query, setQuery] = useState('');
   const [matches, setMatches] = useState<number[]>([]);
+  const thumbListRef = useRef<HTMLDivElement | null>(null);
+
+  useRovingTabIndex(thumbListRef, thumbs.length > 0, 'horizontal');
 
   useEffect(() => {
     const loadPdf = async () => {
@@ -86,12 +90,21 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
         <button onClick={search}>Search</button>
       </div>
       <canvas ref={canvasRef} data-testid="pdf-canvas" />
-      <div className="flex gap-2 overflow-x-auto mt-2">
+      <div
+        className="flex gap-2 overflow-x-auto mt-2"
+        role="listbox"
+        aria-orientation="horizontal"
+        ref={thumbListRef}
+      >
         {thumbs.map((t, i) => (
           <canvas
             key={i + 1}
+            role="option"
+            tabIndex={page === i + 1 ? 0 : -1}
+            aria-selected={page === i + 1}
             data-testid={`thumb-${i + 1}`}
             onClick={() => setPage(i + 1)}
+            onFocus={() => setPage(i + 1)}
             ref={(el) => {
               if (el) el.getContext('2d')?.drawImage(t, 0, 0);
             }}

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -2,8 +2,9 @@ import { useEffect } from 'react';
 
 /**
  * Enables roving tab index and arrow key navigation within a container.
- * Elements inside the container that have role="tab" or role="menuitem"
- * will participate in the roving behaviour.
+ * Elements inside the container that have role="tab", role="menuitem",
+ * or role="option" will participate in the roving behaviour. This covers
+ * common patterns such as tabs, menus and listboxes.
  */
 export default function useRovingTabIndex(
   ref: React.RefObject<HTMLElement>,
@@ -15,7 +16,9 @@ export default function useRovingTabIndex(
     if (!node || !active) return;
 
     const items = Array.from(
-      node.querySelectorAll<HTMLElement>('[role="tab"], [role="menuitem"]')
+      node.querySelectorAll<HTMLElement>(
+        '[role="tab"], [role="menuitem"], [role="option"]'
+      )
     );
     if (items.length === 0) return;
 


### PR DESCRIPTION
## Summary
- extend roving tabindex hook to support listbox options
- add ARIA roles and keyboard navigation to About and PdfViewer components
- cover new behavior with focused accessibility tests

## Testing
- `yarn test __tests__/aboutAccessibility.test.tsx __tests__/pdfviewer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b08703f2d4832881053f04e7cc07e0