### PR TITLE
feat: focus trap overlay components

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 const BadgeList = ({ badges, className = '' }) => {
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(null);
   const triggerRef = useRef(null);
   const modalRef = useRef(null);
+  useFocusTrap(modalRef, selected !== null);
 
   const closeModal = () => {
     setSelected(null);
@@ -16,21 +18,15 @@ const BadgeList = ({ badges, className = '' }) => {
 
     const focusableSelectors =
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    const focusable = modalRef.current?.querySelectorAll(focusableSelectors);
-    const elements = Array.from(focusable ?? []);
-
+    const elements = Array.from(
+      modalRef.current?.querySelectorAll(focusableSelectors) ?? []
+    );
     elements[0]?.focus();
 
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
         e.preventDefault();
         closeModal();
-      } else if (e.key === 'Tab' && elements.length > 0) {
-        e.preventDefault();
-        const index = elements.indexOf(document.activeElement);
-        const next =
-          (index + (e.shiftKey ? -1 : 1) + elements.length) % elements.length;
-        elements[next].focus();
       }
     };
 

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import InputRemap from './Games/common/input-remap/InputRemap';
 import useInputMapping from './Games/common/input-remap/useInputMapping';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface HelpOverlayProps {
   gameId: string;
@@ -159,35 +160,24 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
   const overlayRef = useRef<HTMLDivElement>(null);
   const prevFocus = useRef<HTMLElement | null>(null);
+  useFocusTrap(overlayRef, true);
 
   useEffect(() => {
-    if (!overlayRef.current) return;
+    const node = overlayRef.current;
+    if (!node) return;
     prevFocus.current = document.activeElement as HTMLElement | null;
     const selectors =
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
     const focusables = Array.from(
-      overlayRef.current.querySelectorAll<HTMLElement>(selectors)
+      node.querySelectorAll<HTMLElement>(selectors)
     );
     focusables[0]?.focus();
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Tab' && focusables.length > 0) {
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
-        if (e.shiftKey) {
-          if (document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          }
-        } else if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      } else if (e.key === 'Escape') {
+      if (e.key === 'Escape') {
         e.preventDefault();
         onClose();
       }
     };
-    const node = overlayRef.current;
     node.addEventListener('keydown', handleKey);
     return () => {
       node.removeEventListener('keydown', handleKey);

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useFocusTrap from '../../../hooks/useFocusTrap';
 
 const STORAGE_KEY = 'beefHelpDismissed';
 
@@ -17,9 +18,20 @@ export default function GuideOverlay({ onClose }) {
   const [step, setStep] = useState(0);
   const [dontShow, setDontShow] = useState(false);
   const containerRef = useRef(null);
+  const prevFocus = useRef(null);
+  useFocusTrap(containerRef, true);
 
   useEffect(() => {
-    containerRef.current?.focus();
+    prevFocus.current = document.activeElement;
+    const selectors =
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const focusables = containerRef.current
+      ? containerRef.current.querySelectorAll(selectors)
+      : [];
+    focusables[0]?.focus();
+    return () => {
+      prevFocus.current && prevFocus.current.focus();
+    };
   }, []);
 
   const handleClose = () => {

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,14 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import logger from '../../utils/logger'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -48,6 +53,8 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button


### PR DESCRIPTION
## Summary
- use existing focus trap hooks in desktop context menu
- enforce focus trapping in Help and BeEF overlays
- apply focus trap to badge list modal

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, config suites)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b08705959083289381b91d64a189f5