### PR TITLE
Add window edge snapping preview and quarter snapping

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -42,7 +42,7 @@ describe('Window lifecycle', () => {
   });
 });
 
-describe('Window snapping preview', () => {
+  describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
     const ref = React.createRef<Window>();
     render(
@@ -63,13 +63,13 @@ describe('Window snapping preview', () => {
     // Simulate being near the left edge
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -78,6 +78,43 @@ describe('Window snapping preview', () => {
     });
 
     expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+  });
+
+  it('shows preview when dragged near bottom-right corner', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: window.innerWidth - 105,
+      top: window.innerHeight - 110,
+      right: window.innerWidth - 5,
+      bottom: window.innerHeight - 10,
+      width: 100,
+      height: 100,
+      x: window.innerWidth - 105,
+      y: window.innerHeight - 110,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+    expect(ref.current!.state.snapPosition).toBe('bottom-right');
   });
 
   it('hides preview when away from edge', () => {
@@ -138,13 +175,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -158,6 +195,47 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
     expect(ref.current!.state.width).toBe(50);
     expect(ref.current!.state.height).toBe(96.3);
+  });
+
+  it('snaps window on drag stop near bottom-right corner', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: window.innerWidth - 105,
+      top: window.innerHeight - 110,
+      right: window.innerWidth - 5,
+      bottom: window.innerHeight - 10,
+      width: 100,
+      height: 100,
+      x: window.innerWidth - 105,
+      y: window.innerHeight - 110,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.snapped).toBe('bottom-right');
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.height).toBe(50);
   });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
@@ -179,13 +257,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -226,13 +304,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 

--- a/components/base/window.tsx
+++ b/components/base/window.tsx
@@ -200,17 +200,42 @@ export class Window extends Component {
         var rect = r.getBoundingClientRect();
         const threshold = 30;
         let snap = null;
-        if (rect.left <= threshold) {
+        const nearLeft = rect.left <= threshold;
+        const nearRight = rect.right >= window.innerWidth - threshold;
+        const nearTop = rect.top <= threshold;
+        const nearBottom = rect.bottom >= window.innerHeight - threshold;
+
+        if (nearLeft && nearTop) {
+            snap = { left: '0', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-left' });
+        }
+        else if (nearRight && nearTop) {
+            snap = { left: '50%', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-right' });
+        }
+        else if (nearLeft && nearBottom) {
+            snap = { left: '0', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-left' });
+        }
+        else if (nearRight && nearBottom) {
+            snap = { left: '50%', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-right' });
+        }
+        else if (nearLeft) {
             snap = { left: '0', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'left' });
         }
-        else if (rect.right >= window.innerWidth - threshold) {
+        else if (nearRight) {
             snap = { left: '50%', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
-        else if (rect.top <= threshold) {
+        else if (nearTop) {
             snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (nearBottom) {
+            snap = { left: '0', top: '50%', width: '100%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -243,6 +268,26 @@ export class Window extends Component {
                 newWidth = 100.2;
                 newHeight = 50;
                 transform = 'translate(-1pt,-2pt)';
+            } else if (snapPos === 'bottom') {
+                newWidth = 100.2;
+                newHeight = 50;
+                transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+            } else if (snapPos === 'top-left') {
+                newWidth = 50;
+                newHeight = 50;
+                transform = 'translate(-1pt,-2pt)';
+            } else if (snapPos === 'top-right') {
+                newWidth = 50;
+                newHeight = 50;
+                transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+            } else if (snapPos === 'bottom-left') {
+                newWidth = 50;
+                newHeight = 50;
+                transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+            } else if (snapPos === 'bottom-right') {
+                newWidth = 50;
+                newHeight = 50;
+                transform = `translate(${window.innerWidth / 2}px,${window.innerHeight / 2}px)`;
             }
             var r = document.querySelector("#" + this.id);
             if (r && transform) {


### PR DESCRIPTION
## Summary
- Support snapping windows to screen edges and corners with preview hints
- Update drag handling to snap dropped windows to halves or quarters
- Expand window tests for new corner snapping behavior

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0872b1afc8328a1e9c1837e1177a8