### PR TITLE
feat: add backdrop blur to overlays

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -79,7 +79,7 @@ const BadgeList = ({ badges, className = '' }) => {
       </div>
       {selected && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 overlay-bg flex items-center justify-center z-50"
           onClick={closeModal}
           role="dialog"
           aria-modal="true"

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -348,7 +348,7 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
         ))}
       </div>
       {selected && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50" onClick={() => setSelected(null)}>
+        <div className="fixed inset-0 flex items-center justify-center overlay-bg z-50" onClick={() => setSelected(null)}>
           <div className="bg-ub-cool-grey p-4 rounded max-w-xs" onClick={(e) => e.stopPropagation()}>
             <div className="font-bold mb-2 text-center">{selected.alt}</div>
             <p className="text-sm text-center">{selected.description}</p>

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -96,7 +96,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div
-          className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
+          className="absolute inset-0 overlay-bg z-50 flex items-center justify-center"
           role="dialog"
           aria-modal="true"
         >

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -199,7 +199,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   return (
     <div
       ref={overlayRef}
-      className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
+      className="absolute inset-0 overlay-bg text-white flex items-center justify-center z-50"
       role="dialog"
       aria-modal="true"
     >

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -320,7 +320,7 @@ const SkillSection = ({ title, badges }) => {
       </div>
       {selected && (
         <div
-          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+          className="fixed inset-0 flex items-center justify-center overlay-bg z-50"
           onClick={() => setSelected(null)}
         >
           <div

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -45,7 +45,7 @@ export default function GuideOverlay({ onClose }) {
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
+      className="absolute inset-0 overlay-bg text-white flex items-center justify-center z-50"
       role="dialog"
       aria-modal="true"
       tabIndex={-1}

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -369,7 +369,7 @@ const CarRacer = () => {
       </div>
       {!runningRef.current && (
         <div
-          className="absolute inset-0 bg-black bg-opacity-60 flex items-center justify-center z-20"
+          className="absolute inset-0 overlay-bg flex items-center justify-center z-20"
           role="alert"
         >
           <div className="text-center">

--- a/components/apps/project-gallery.js
+++ b/components/apps/project-gallery.js
@@ -293,7 +293,7 @@ export default function ProjectGallery() {
           </div>
           {selected && (
             <div
-              className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
+              className="fixed inset-0 overlay-bg flex items-center justify-center p-4"
               role="dialog"
             >
               <div className="bg-ub-cool-grey text-white p-4 rounded w-full max-w-md">

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -263,7 +263,7 @@ const Snake = () => {
           />
           {gameOver && (
             <div
-              className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
+              className="absolute inset-0 flex items-center justify-center overlay-bg"
               role="alert"
               aria-live="assertive"
             >

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -507,7 +507,7 @@ const Solitaire = () => {
       </div>
       {paused && (
         <div
-          className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
+          className="absolute inset-0 overlay-bg z-50 flex items-center justify-center"
           role="dialog"
           aria-modal="true"
         >
@@ -545,7 +545,7 @@ const Solitaire = () => {
         ))}
       {won && (
         <div
-          className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-80 text-2xl"
+          className="absolute inset-0 flex items-center justify-center overlay-bg text-2xl"
           role="alert"
         >
           You win!

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -570,7 +570,7 @@ const Tetris = () => {
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-4xl">Paused</div>
       )}
       {showSettings && (
-        <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div className="absolute inset-0 overlay-bg flex items-center justify-center">
           <div className="bg-gray-800 p-4 rounded">
             <h2 className="mb-2 text-center">Settings</h2>
             <div className="mb-2 flex items-center">

--- a/components/apps/trash.js
+++ b/components/apps/trash.js
@@ -328,7 +328,7 @@ export class Trash extends Component {
                     {this.state.empty ? this.emptyScreen() : this.showTrashItems()}
                 </div>
                 {showEmptyModal && (
-                    <div className="absolute inset-0 bg-black bg-opacity-80 flex flex-col items-center justify-center p-4">
+                    <div className="absolute inset-0 overlay-bg flex flex-col items-center justify-center p-4">
                         <div
                             ref={this.modalRef}
                             role="dialog"
@@ -345,7 +345,7 @@ export class Trash extends Component {
                     </div>
                 )}
                 {confirmDelete && (
-                    <div className="absolute inset-0 bg-black bg-opacity-80 flex flex-col items-center justify-center p-4">
+                    <div className="absolute inset-0 overlay-bg flex flex-col items-center justify-center p-4">
                         <div className="bg-ub-warm-grey p-4 rounded shadow-md max-w-full">
                             <p className="mb-2">Delete {this.state.fileHandle?.name}?</p>
                             {this.state.filePreview?.type === 'image' ? (

--- a/components/ui/LegalInterstitial.tsx
+++ b/components/ui/LegalInterstitial.tsx
@@ -7,7 +7,7 @@ interface LegalInterstitialProps {
 }
 
 const LegalInterstitial: React.FC<LegalInterstitialProps> = ({ onAccept }) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 text-white">
+  <div className="fixed inset-0 z-50 flex items-center justify-center overlay-bg text-white">
     <div className="max-w-md rounded bg-gray-900 p-6 text-center">
       <h2 className="mb-4 text-xl font-bold">Legal Use Only</h2>
       <p className="mb-6 text-sm">

--- a/styles/index.css
+++ b/styles/index.css
@@ -361,7 +361,26 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Context Menu */
 .context-menu-bg {
-    background-color: rgb(43, 43, 43);
+    background-color: rgba(43, 43, 43, 0.9);
+}
+
+@supports (backdrop-filter: blur(8px)) {
+    .context-menu-bg {
+        background-color: rgba(43, 43, 43, 0.5);
+        backdrop-filter: blur(8px);
+    }
+}
+
+/* Overlay */
+.overlay-bg {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+@supports (backdrop-filter: blur(8px)) {
+    .overlay-bg {
+        background-color: rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(8px);
+    }
 }
 
 .emoji-list>li {


### PR DESCRIPTION
## Summary
- add backdrop blur with fallback to context menu background
- introduce reusable overlay class for modal dialogs
- apply blurred overlay styling across dialogs and games

## Testing
- `npm test` *(fails: memoryGame, beef, converter, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0873930188328918690a3b54fbdef