### PR TITLE
feat: add resize cursors with live size guide

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -255,6 +255,39 @@ describe('Window snapping finalize and release', () => {
   });
 });
 
+describe('Window resize guidelines', () => {
+  it('shows live size guide while resizing', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    act(() => {
+      ref.current!.state.cursorType = 'cursor-se-resize';
+      ref.current!.startResize({ clientX: 0, clientY: 0, preventDefault: () => {}, stopPropagation: () => {} } as any);
+      ref.current!.performResize({ clientX: 50, clientY: 50 } as any);
+    });
+
+    expect(screen.getByTestId('size-guides')).toBeInTheDocument();
+
+    act(() => {
+      ref.current!.stopResize();
+    });
+
+    expect(screen.queryByTestId('size-guides')).toBeNull();
+  });
+});
+
 describe('Window keyboard dragging', () => {
   it('moves window using arrow keys with grabbed state', () => {
     render(


### PR DESCRIPTION
## Summary
- enhance window component with edge and corner resize cursors
- show live width/height guide while resizing
- test that resize guide appears during drag

## Testing
- `npx jest __tests__/window.test.tsx`
- `yarn test` *(fails: TypeError in memoryGame.test.tsx; missing elements in beef.test.tsx; syntax errors in chrome component)*
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b087571e5883288a24693bb67afc11