### PR TITLE
feat: add drag previews and gamepad haptics

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -3,6 +3,7 @@ import usePersistentState from '../../hooks/usePersistentState';
 import GameLayout from './GameLayout';
 import useGameControls from './useGameControls';
 import { findHint } from '../../apps/games/_2048/ai';
+import { vibrate } from './Games/common/haptics';
 
 const SIZE = 4;
 
@@ -256,7 +257,7 @@ const Game2048 = () => {
         }
         setBoard(cloneBoard(moved));
         setMoves((m) => m + 1);
-        if (merged) navigator.vibrate?.(50);
+        if (merged) vibrate(50);
         if (mergedCells.length > 1) {
           setCombo((c) => c + 1);
           if (typeof window !== 'undefined') {

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -12,6 +12,7 @@ import {
 } from './asteroids-utils';
 import useGameControls from './useGameControls';
 import GameLayout from './GameLayout';
+import { vibrate } from './Games/common/haptics';
 
 // Arcade-style tuning constants
 const THRUST = 0.1;
@@ -275,7 +276,7 @@ const Asteroids = () => {
       );
       ship.cooldown = ship.rapidFire > 0 ? 5 : 15;
       playSound(880);
-      if ('vibrate' in navigator) navigator.vibrate(10);
+      vibrate(10);
     }
 
     function destroyShip() {
@@ -288,7 +289,7 @@ const Asteroids = () => {
         lives -= 1;
         ga.death();
         playSound(110);
-        if ('vibrate' in navigator) navigator.vibrate(200);
+        vibrate(200);
         ship.x = canvas.width / 2;
         ship.y = canvas.height / 2;
         ship.velX = 0;
@@ -323,7 +324,7 @@ const Asteroids = () => {
       }
       asteroids.splice(index, 1);
       playSound(440);
-      if ('vibrate' in navigator) navigator.vibrate(50);
+      vibrate(50);
       if (rand() < 0.1) spawnPowerUp(powerUps, a.x, a.y);
       if (score >= extraLifeScore) {
         lives += 1;

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import ReactGA from 'react-ga4';
+import { vibrate } from './Games/common/haptics';
 
 const WIDTH = 7;
 const HEIGHT = 8;
@@ -207,7 +208,7 @@ const Frogger = () => {
       const x = prev.x + dx;
       const y = prev.y + dy;
       if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT) return prev;
-      if (navigator.vibrate) navigator.vibrate(50);
+      vibrate(50);
       if (dy === -1) setScore((s) => s + 10);
       playTone(440, 0.05);
       return { x, y };

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -3,6 +3,7 @@ import { Howl } from 'howler';
 import seedrandom from 'seedrandom';
 import GameLayout from './GameLayout';
 import usePersistentState from '../usePersistentState';
+import { vibrate } from './Games/common/haptics';
 
 const padStyles = [
   {
@@ -145,7 +146,7 @@ const Simon = () => {
 
   const flashPad = useCallback(
     (idx, duration) => {
-      if ('vibrate' in navigator && !prefersReducedMotion) navigator.vibrate(50);
+      if (!prefersReducedMotion) vibrate(50);
       if (audioOnly) return;
       window.requestAnimationFrame(() => setActivePad(idx));
       setTimeout(

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -4,7 +4,15 @@ import Image from 'next/image'
 export class UbuntuApp extends Component {
     constructor() {
         super();
-        this.state = { launching: false };
+        this.state = { launching: false, dragging: false };
+    }
+
+    handleDragStart = () => {
+        this.setState({ dragging: true });
+    }
+
+    handleDragEnd = () => {
+        this.setState({ dragging: false });
     }
 
     openApp = () => {
@@ -21,7 +29,10 @@ export class UbuntuApp extends Component {
                 aria-label={this.props.name}
                 data-context="app"
                 data-app-id={this.props.id}
-                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
+                draggable
+                onDragStart={this.handleDragStart}
+                onDragEnd={this.handleDragEnd}
+                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -397,7 +397,7 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}


### PR DESCRIPTION
## Summary
- fade windows and desktop icons while dragging for a semi-transparent preview
- use shared haptics helper so supported gamepads vibrate in Frogger, 2048, Asteroids, and Simon

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `yarn lint` *(fails: parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0875a3c8083289ed93da86588e060