### PR TITLE
feat: centralize transition timing

### DIFF
--- a/apps/color_picker/index.html
+++ b/apps/color_picker/index.html
@@ -3,13 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Color Picker</title>
-  <style>
-    body {
-      font-family: Arial, Helvetica, sans-serif;
-      padding: 2rem;
-      background: #f4f4f4;
-    }
+    <title>Color Picker</title>
+    <style>
+      :root {
+        --transition-fast: 160ms;
+        --transition-medium: 240ms;
+        --transition-ease: cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        padding: 2rem;
+        background: #f4f4f4;
+      }
     h1 {
       margin-bottom: 1rem;
     }
@@ -20,7 +25,7 @@
       border-radius: 4px;
       cursor: pointer;
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-      transition: transform 0.2s ease;
+        transition: transform var(--transition-fast) var(--transition-ease);
     }
     #color-input:hover {
       transform: scale(1.05);
@@ -37,8 +42,8 @@
       border: 1px solid #ccc;
       border-radius: 4px;
       cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
+        transition: transform var(--transition-fast) var(--transition-ease), box-shadow var(--transition-fast) var(--transition-ease);
+      }
     .swatch:hover {
       transform: scale(1.1);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);

--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -62,7 +62,7 @@ const BadgeList = ({ badges, className = '' }) => {
           <button
             key={badge.label}
             type="button"
-            className="m-1 hover:scale-110 transition-transform cursor-pointer"
+              className="m-1 hover:scale-110 transition-transform duration-[var(--transition-fast)] ease-[var(--transition-ease)] cursor-pointer"
             onClick={(e) => {
               triggerRef.current = e.currentTarget;
               setSelected(badge);

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -222,7 +222,7 @@ const JohnApp = () => {
                       : 'repeating-linear-gradient(45deg,#1e3a8a,#1e3a8a 10px,#065f46 10px,#065f46 20px)',
                   backgroundSize: '20px 20px',
                   backgroundPosition: `${phase === 'wordlist' ? animOffset : -animOffset}px 0`,
-                  transition: prefersReducedMotion ? 'none' : 'width 0.2s ease-out',
+                    transition: prefersReducedMotion ? 'none' : 'width var(--transition-fast) var(--transition-ease)',
                 }}
                 role="progressbar"
                 aria-valuenow={Math.round(progress)}

--- a/components/apps/mimikatz/CredentialLocator.js
+++ b/components/apps/mimikatz/CredentialLocator.js
@@ -61,7 +61,7 @@ const CredentialArtifactLocator = () => {
           className="bg-blue-500 h-4"
           style={{
             width: `${progress}%`,
-            transition: prefersReducedMotion ? 'none' : 'width 0.2s',
+              transition: prefersReducedMotion ? 'none' : 'width var(--transition-fast) var(--transition-ease)',
           }}
           role="progressbar"
           aria-label="scan progress"

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -92,7 +92,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4">
                 <div
-                    className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
+                    className="p-4 rounded transition-colors duration-[var(--transition-medium)] ease-[var(--transition-ease)] motion-reduce:transition-none"
                     style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
                 >
                     <p className="mb-2 text-center">Preview</p>

--- a/styles/index.css
+++ b/styles/index.css
@@ -28,7 +28,7 @@ button:focus-visible {
 }
 
 .animateShow {
-    animation: transformDownShow 200ms 1 forwards;
+    animation: transformDownShow var(--transition-fast) var(--transition-ease) 1 forwards;
 }
 
 @keyframes transformDownShow {
@@ -252,7 +252,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .card {
     position: relative;
     transform-style: preserve-3d;
-    transition: transform 0.6s ease, opacity 0.3s ease;
+    transition: transform 0.6s var(--transition-ease), opacity var(--transition-medium) var(--transition-ease);
 }
 
 .card-face {
@@ -284,7 +284,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .animate-deal {
     transform: translateY(-20px);
     opacity: 0;
-    animation: dealCard 0.3s forwards ease-out;
+    animation: dealCard var(--transition-medium) var(--transition-ease) forwards;
 }
 
 @keyframes dealCard {
@@ -317,11 +317,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     border: 2px solid var(--color-inverse);
     position: absolute;
     left: 0;
-    transition: transform 0.3s;
+    transition: transform var(--transition-medium) var(--transition-ease);
 }
 
 .chip-pop {
-    animation: chipPop 0.3s ease-out forwards;
+    animation: chipPop var(--transition-medium) var(--transition-ease) forwards;
 }
 
 @keyframes chipPop {
@@ -414,7 +414,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .reveal {
-    animation: reveal 0.3s ease-out;
+    animation: reveal var(--transition-medium) var(--transition-ease);
 }
 
 @keyframes tile-pop {
@@ -423,7 +423,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .tile-pop {
-    animation: tile-pop 0.15s ease-out;
+    animation: tile-pop var(--transition-fast) var(--transition-ease);
 
 }
 
@@ -449,7 +449,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .score-pop {
     display: inline-block;
-    animation: score-pop 0.3s ease-out;
+    animation: score-pop var(--transition-medium) var(--transition-ease);
 }
 
 @keyframes hangman-draw {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -45,6 +45,11 @@
   --motion-medium: 300ms;
   --motion-slow: 500ms;
 
+  /* Global transition tokens */
+  --transition-fast: 160ms;
+  --transition-medium: 240ms;
+  --transition-ease: cubic-bezier(0.4, 0, 0.2, 1);
+
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,13 @@ module.exports = {
       zIndex: {
         '-10': '-10',
       },
+      transitionDuration: {
+        fast: 'var(--transition-fast)',
+        DEFAULT: 'var(--transition-medium)',
+      },
+      transitionTimingFunction: {
+        DEFAULT: 'var(--transition-ease)',
+      },
       keyframes: {
         glow: {
           '0%, 100%': { boxShadow: '0 0 0px theme("colors.amber.400")' },


### PR DESCRIPTION
## Summary
- define global CSS transition tokens for fast/medium durations and standard easing curve
- wire tokens into Tailwind defaults
- apply new transition variables to component animations

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0876aa88c8328ba289b638c80c3cd