### PR TITLE
feat: sync theme with system preference

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -17,4 +17,15 @@ describe('theme persistence and unlocking', () => {
     expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
     expect(unlocked).not.toContain('matrix');
   });
+
+  test('defaults to system preference when no stored theme', () => {
+    // simulate dark mode preference
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+    expect(getTheme()).toBe('dark');
+    // simulate light mode preference
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    expect(getTheme()).toBe('default');
+  });
 });

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,5 +1,9 @@
 (function () {
+  var THEME_KEY = 'app:theme';
   try {
-    document.documentElement.dataset.theme = 'kali';
+    var stored = localStorage.getItem(THEME_KEY);
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = stored || (prefersDark ? 'dark' : 'default');
+    document.documentElement.dataset.theme = theme;
   } catch (e) {}
 })();

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -11,7 +11,12 @@ export const THEME_UNLOCKS: Record<string, number> = {
 export const getTheme = (): string => {
   if (typeof window === 'undefined') return 'default';
   try {
-    return window.localStorage.getItem(THEME_KEY) || 'default';
+    const stored = window.localStorage.getItem(THEME_KEY);
+    if (stored) return stored;
+    const prefersDark = window.matchMedia?.(
+      '(prefers-color-scheme: dark)'
+    ).matches;
+    return prefersDark ? 'dark' : 'default';
   } catch {
     return 'default';
   }
@@ -21,6 +26,7 @@ export const setTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
+    document.documentElement.dataset.theme = theme;
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- use `prefers-color-scheme` to set initial theme
- allow users to override theme and save choice
- test theme preference detection

## Testing
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `yarn test __tests__/themePersistence.test.ts`
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0878e54b88328ab8b540bb7c3e74d