### PR TITLE
refactor: use logical properties in global css

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -16,15 +16,15 @@ button:focus-visible {
 /* Top NavBar styling */
 
 .top-arrow-up {
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-bottom: 5px solid var(--color-muted);
+    border-inline-start: 5px solid transparent;
+    border-inline-end: 5px solid transparent;
+    border-block-end: 5px solid var(--color-muted);
 }
 
 .arrow-custom {
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-bottom: 5px solid var(--color-text);
+    border-inline-start: 5px solid transparent;
+    border-inline-end: 5px solid transparent;
+    border-block-end: 5px solid var(--color-text);
 }
 
 .animateShow {
@@ -71,30 +71,30 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Window's styling */
 .arrow-custom-up {
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-bottom: 5px solid var(--color-text);
+    border-inline-start: 5px solid transparent;
+    border-inline-end: 5px solid transparent;
+    border-block-end: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-down {
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 5px solid var(--color-text);
+    border-inline-start: 5px solid transparent;
+    border-inline-end: 5px solid transparent;
+    border-block-start: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-left {
-    border-bottom: 5px solid transparent;
-    border-top: 5px solid transparent;
-    border-right: 5px solid var(--color-text);
+    border-block-end: 5px solid transparent;
+    border-block-start: 5px solid transparent;
+    border-inline-end: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-right {
-    border-top: 5px solid transparent;
-    border-bottom: 5px solid transparent;
-    border-left: 5px solid var(--color-text);
+    border-block-start: 5px solid transparent;
+    border-block-end: 5px solid transparent;
+    border-inline-start: 5px solid var(--color-text);
     width: 0;
 }
 
@@ -316,7 +316,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     justify-content: center;
     border: 2px solid var(--color-inverse);
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     transition: transform 0.3s;
 }
 
@@ -365,7 +365,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .emoji-list>li {
-    padding-left: 10px;
+    padding-inline-start: 10px;
 }
 
 .list-pc {


### PR DESCRIPTION
## Summary
- replace directional borders with logical `border-inline` and `border-block` properties in global styles
- swap `left` and `padding-left` for logical `inset-inline-start` and `padding-inline-start` to prepare for RTL layouts

## Testing
- `npm test` *(fails: combo meter increments and resets, BeEF app, autopsy plugins and timeline, UnitConverter UI, snake and frogger config tests, Chrome index parsing error)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx:391)*
- `npm run build` *(fails: Parsing error in components/apps/Chrome/index.tsx:391)*
- `npx playwright test --locale=ar` *(fails: unknown option '--locale=ar')*

------
https://chatgpt.com/codex/tasks/task_e_68b08793d0e0832882b820c21d91ea24