### PR TITLE
Respect tab order for desktop and app grid

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -8,6 +8,7 @@ export class UbuntuApp extends Component {
     }
 
     openApp = () => {
+        if (this.props.disabled) return;
         this.setState({ launching: true }, () => {
             setTimeout(() => this.setState({ launching: false }), 300);
         });
@@ -19,13 +20,14 @@ export class UbuntuApp extends Component {
             <div
                 role="button"
                 aria-label={this.props.name}
+                aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
                 className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={0}
+                tabIndex={this.props.disabled ? -1 : 0}
             >
                 <Image
                     width={40}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -47,6 +47,7 @@ class AllApplications extends React.Component {
                 id={app.id}
                 icon={app.icon}
                 openApp={() => this.openApp(app.id)}
+                disabled={app.disabled}
             />
         ));
     };

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -272,7 +272,8 @@ export class Desktop extends Component {
                     name: app.title,
                     id: app.id,
                     icon: app.icon,
-                    openApp: this.openApp
+                    openApp: this.openApp,
+                    disabled: this.state.disabled_apps[app.id]
                 }
 
                 appsJsx.push(

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -47,6 +47,7 @@ class ShortcutSelector extends React.Component {
                 id={app.id}
                 icon={app.icon}
                 openApp={() => this.selectApp(app.id)}
+                disabled={app.disabled}
             />
         ));
     };


### PR DESCRIPTION
## Summary
- Skip disabled desktop and grid icons from keyboard navigation
- Propagate `disabled` state to desktop, all apps, and shortcut selector grids

## Testing
- `npm test` *(fails: snake.config.test.ts)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b08795b28c8328b735574a356632dd