### PR TITLE
feat: add window status announcements

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -118,6 +118,70 @@ describe('Window snapping preview', () => {
   });
 });
 
+describe('Window announcements', () => {
+  it('announces open and close actions', () => {
+    const announce = jest.fn();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        announce={announce}
+      />
+    );
+
+    expect(announce).toHaveBeenCalledWith('Test window opened');
+
+    const closeButton = screen.getByRole('button', { name: /window close/i });
+    fireEvent.click(closeButton);
+    expect(announce).toHaveBeenLastCalledWith('Test window closed');
+  });
+
+  it('announces window movement', () => {
+    const announce = jest.fn();
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        announce={announce}
+        ref={ref}
+      />
+    );
+
+    announce.mockClear();
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 50,
+      top: 60,
+      right: 150,
+      bottom: 160,
+      width: 100,
+      height: 100,
+      x: 50,
+      y: 60,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(announce).toHaveBeenCalledWith('Test window moved to 50, 60');
+  });
+});
+
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
     const ref = React.createRef<Window>();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -42,6 +42,9 @@ export class Window extends Component {
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
+        if (this.props.announce) {
+            this.props.announce(`${this.props.title} window opened`);
+        }
     }
 
     componentWillUnmount() {
@@ -260,6 +263,12 @@ export class Window extends Component {
         else {
             this.setState({ snapPreview: null, snapPosition: null });
         }
+        if (this.props.announce) {
+            const rect = document.getElementById(this.id)?.getBoundingClientRect();
+            const x = rect ? Math.round(rect.left) : 0;
+            const y = rect ? Math.round(rect.top) : 0;
+            this.props.announce(`${this.props.title} window moved to ${x}, ${y}`);
+        }
     }
 
     focusWindow = () => {
@@ -314,6 +323,9 @@ export class Window extends Component {
 
     closeWindow = () => {
         this.setWinowsPosition();
+        if (this.props.announce) {
+            this.props.announce(`${this.props.title} window closed`);
+        }
         this.setState({ closed: true }, () => {
             this.props.hideSideBar(this.id, false);
             setTimeout(() => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -35,6 +35,7 @@ export class Desktop extends Component {
             context_app: null,
             showNameBar: false,
             showShortcutSelector: false,
+            statusMessage: '',
         }
     }
 
@@ -304,6 +305,7 @@ export class Desktop extends Component {
                     allowMaximize: app.allowMaximize,
                     defaultWidth: app.defaultWidth,
                     defaultHeight: app.defaultHeight,
+                    announce: this.announce,
                 }
 
                 windowsJsx.push(
@@ -538,6 +540,10 @@ export class Desktop extends Component {
         }
     }
 
+    announce = (message) => {
+        this.setState({ statusMessage: message });
+    }
+
     addToDesktop = (folder_name) => {
         folder_name = folder_name.trim();
         let folder_id = folder_name.replace(/\s+/g, '-').toLowerCase();
@@ -641,6 +647,10 @@ export class Desktop extends Component {
                         games={games}
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
+
+                <div role="status" aria-live="polite" className="sr-only">
+                    {this.state.statusMessage}
+                </div>
 
             </div>
         )


### PR DESCRIPTION
## Summary
- add screen reader announcements when windows open, close, or move
- provide hidden live region for window status messages
- test window announcements

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b08799bfbc83288a8cf9228372c5ec