### PR TITLE
Add font scale setting with clamp-based typography

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -80,6 +80,18 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Font Size:</label>
+                <input
+                    type="range"
+                    min="0.75"
+                    max="1.5"
+                    step="0.05"
+                    value={fontScale}
+                    onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                    className="ubuntu-slider"
+                />
+            </div>
+            <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
@@ -134,7 +146,14 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
+                    onClick={async () => {
+                        await resetSettings();
+                        setAccent(defaults.accent);
+                        setWallpaper(defaults.wallpaper);
+                        setDensity(defaults.density);
+                        setReducedMotion(defaults.reducedMotion);
+                        setFontScale(defaults.fontScale);
+                    }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -8,6 +8,8 @@ import {
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
+  getFontScale as loadFontScale,
+  setFontScale as saveFontScale,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -17,10 +19,12 @@ interface SettingsContextValue {
   wallpaper: string;
   density: Density;
   reducedMotion: boolean;
+  fontScale: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
+  setFontScale: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -28,10 +32,12 @@ export const SettingsContext = createContext<SettingsContextValue>({
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
+  fontScale: defaults.fontScale,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
+  setFontScale: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -39,6 +45,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
+  const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
 
   useEffect(() => {
     (async () => {
@@ -46,6 +53,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
+      setFontScale(await loadFontScale());
     })();
   }, []);
 
@@ -89,8 +97,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
 
+  useEffect(() => {
+    document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
+    saveFontScale(fontScale);
+  }, [fontScale]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, setAccent, setWallpaper, setDensity, setReducedMotion }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,9 @@
 @import './globals.css';
 
+html {
+    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+}
+
 body{
     font-family: var(--font-family-base);
     font-display: swap;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -47,6 +47,7 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+  --font-multiplier: 1;
 }
 
 /* High contrast theme */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -5,6 +5,7 @@ const DEFAULT_SETTINGS = {
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,
+  fontScale: 1,
 };
 
 export async function getAccent() {
@@ -47,6 +48,17 @@ export async function setReducedMotion(value) {
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
+export async function getFontScale() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
+  const stored = window.localStorage.getItem('font-scale');
+  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+}
+
+export async function setFontScale(scale) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-scale', String(scale));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -55,6 +67,7 @@ export async function resetSettings() {
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
+  window.localStorage.removeItem('font-scale');
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add font size slider to settings with persistent storage
- apply `clamp()`-based font sizing via CSS variable
- expose `fontScale` through settings context

## Testing
- `npm test` *(fails: memoryGame, autopsy, beef, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0879b0e4c8328909214020bed525b