### PR TITLE
Add F1 help popover with Esc close

### DIFF
--- a/components/ui/HelpPopover.tsx
+++ b/components/ui/HelpPopover.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface HelpPopoverProps {
+  text: string;
+  x: number;
+  y: number;
+}
+
+const HelpPopover = ({ text, x, y }: HelpPopoverProps) => (
+  <div
+    className="fixed z-50 bg-gray-800 text-white text-sm p-2 rounded shadow-lg max-w-xs"
+    style={{ top: y, left: x }}
+    role="tooltip"
+  >
+    <p>{text}</p>
+    <p className="mt-1 text-xs text-gray-300">Press Esc to close</p>
+  </div>
+);
+
+export default HelpPopover;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
@@ -7,11 +7,13 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import HelpPopover from '../components/ui/HelpPopover';
 
 /**
  * @param {import('next/app').AppProps} props
  */
 function MyApp({ Component, pageProps }) {
+  const [help, setHelp] = useState(null);
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
     if (trackingId) {
@@ -38,9 +40,32 @@ function MyApp({ Component, pageProps }) {
         });
     }
   }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'F1') {
+        e.preventDefault();
+        const target = document.activeElement;
+        if (target) {
+          const text =
+            target.getAttribute('data-help') ||
+            target.getAttribute('title') ||
+            'No help available.';
+          const rect = target.getBoundingClientRect();
+          setHelp({ text, x: rect.left + window.scrollX, y: rect.bottom + window.scrollY });
+        }
+      } else if (e.key === 'Escape') {
+        setHelp(null);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
   return (
     <SettingsProvider>
       <Component {...pageProps} />
+      {help && <HelpPopover {...help} />}
       <Analytics />
     </SettingsProvider>
   );

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -47,6 +47,7 @@ const DummyForm: React.FC = () => {
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          data-help="Enter your full name."
         />
         <label className="mb-2 block text-sm font-medium" htmlFor="email">Email</label>
         <input
@@ -55,6 +56,7 @@ const DummyForm: React.FC = () => {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          data-help="Provide a valid email address."
         />
         <label className="mb-2 block text-sm font-medium" htmlFor="message">Message</label>
         <textarea
@@ -62,8 +64,9 @@ const DummyForm: React.FC = () => {
           className="mb-4 w-full rounded border p-2"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          data-help="Type your message here."
         />
-        <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">Submit</button>
+        <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white" data-help="Submit the form">Submit</button>
         <p className="mt-4 text-xs text-gray-500">
           This form posts to a dummy endpoint. No data is stored. By submitting, you consent to this temporary processing of your information.
         </p>


### PR DESCRIPTION
## Summary
- Add HelpPopover component
- Bind global F1/Escape shortcuts to show help for focused elements
- Document sample form inputs with `data-help`

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b087a836bc83288818ff03d90e80b0