### PR TITLE
feat: add skip link and landmark roles

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -586,10 +586,15 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <div className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
-                <div className="absolute h-full w-full bg-transparent" data-context="desktop-area">
+                <div
+                    id="window-area"
+                    role="main"
+                    className="absolute h-full w-full bg-transparent"
+                    data-context="desktop-area"
+                >
                     {this.renderWindows()}
                 </div>
 
@@ -642,7 +647,7 @@ export class Desktop extends Component {
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
 
-            </div>
+            </main>
         )
     }
 }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -27,7 +27,10 @@ export default function SideBar(props) {
 
     return (
         <>
-            <div className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-7 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}>
+            <nav
+                aria-label="Dock"
+                className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-7 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}
+            >
                 {
                     (
                         Object.keys(props.closed_windows).length !== 0
@@ -36,7 +39,7 @@ export default function SideBar(props) {
                     )
                 }
                 <AllApps showApps={props.showAllApps} />
-            </div>
+            </nav>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
         </>
     )

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -7,6 +7,9 @@ import InstallButton from '../components/InstallButton';
  */
 const App = () => (
   <>
+    <a href="#window-area" className="sr-only focus:not-sr-only">
+      Skip to content
+    </a>
     <Meta />
     <Ubuntu />
     <InstallButton />


### PR DESCRIPTION
## Summary
- add skip-to-content link
- add main landmark for desktop and window area
- mark dock navigation with nav role

## Testing
- `yarn lint` *(fails: Parsing error: ')' expected.)*
- `yarn test` *(fails: combo meter increments and resets, BeEF app updates hook list, Autopsy plugins and timeline filters artifacts by type, UnitConverter UI keeps sliders synchronized, Test suite failed to run: Unterminated regexp literal)*

------
https://chatgpt.com/codex/tasks/task_e_68b087a2eb7483288fd81cb8ba5e3c26