### PR TITLE
Respect reduced motion in 2048 game

### DIFF
--- a/apps/2048/index.tsx
+++ b/apps/2048/index.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
 const SIZE = 4;
 
@@ -119,6 +120,7 @@ const Page2048 = () => {
   const [won, setWon] = useState(false);
   const [lost, setLost] = useState(false);
   const [history, setHistory] = useState<number[][][]>([]);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     const seed = todaySeed();
@@ -278,7 +280,9 @@ const Page2048 = () => {
           row.map((cell, cIdx) => (
             <div
               key={`${rIdx}-${cIdx}`}
-              className="w-full aspect-square transition-transform transition-opacity"
+              className={`w-full aspect-square ${
+                prefersReducedMotion ? '' : 'transition-transform transition-opacity'
+              }`}
             >
               <div
                 className={`h-full w-full flex items-center justify-center text-2xl font-bold rounded ${


### PR DESCRIPTION
## Summary
- honour `prefers-reduced-motion` in 2048 board
- conditionally remove transition effects when reduced motion is requested

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b087adf7f88328b7ac54b2f17b1548