### PR TITLE
Show skeleton placeholders for slow-loading apps

### DIFF
--- a/components/AppLoader.js
+++ b/components/AppLoader.js
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+const AppLoader = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey">
+      <div className="w-2/3 space-y-4 animate-pulse">
+        <div className="h-4 bg-ub-grey rounded" />
+        <div className="h-4 bg-ub-grey rounded" />
+        <div className="h-4 bg-ub-grey rounded" />
+      </div>
+    </div>
+  );
+};
+
+export default AppLoader;

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -3,10 +3,11 @@ import dynamic from 'next/dynamic';
 import HexEditor from './HexEditor';
 import { saveSnippet, loadSnippets } from './utils';
 import FormError from '../../ui/FormError';
+import AppLoader from '../../AppLoader';
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
+  { ssr: false, loading: () => <AppLoader /> }
 );
 
 const Radare2 = () => {

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../hooks/usePersistentState';
+import AppLoader from '../../AppLoader';
 
 const CytoscapeComponent = dynamic(
   async () => {
@@ -14,7 +15,7 @@ const CytoscapeComponent = dynamic(
     cytoscape.use(coseBilkent);
     return (await import('react-cytoscapejs')).default;
   },
-  { ssr: false },
+  { ssr: false, loading: () => <AppLoader /> },
 );
 
 const modules = [

--- a/components/apps/weather_widget.js
+++ b/components/apps/weather_widget.js
@@ -1,7 +1,9 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../AppLoader';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
+  loading: () => <AppLoader />,
 });
 
 export default WeatherWidget;

--- a/pages/apps/2048.tsx
+++ b/pages/apps/2048.tsx
@@ -1,5 +1,9 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const Page2048 = dynamic(() => import('../../apps/2048'), { ssr: false });
+const Page2048 = dynamic(() => import('../../apps/2048'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default Page2048;

--- a/pages/apps/blackjack.tsx
+++ b/pages/apps/blackjack.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const Blackjack = dynamic(() => import('../../components/apps/blackjack'), { ssr: false });
+const Blackjack = dynamic(() => import('../../components/apps/blackjack'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function BlackjackPage() {
   return <Blackjack />;

--- a/pages/apps/calculator.tsx
+++ b/pages/apps/calculator.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const Calculator = dynamic(() => import('../../apps/calculator'), { ssr: false });
+const Calculator = dynamic(() => import('../../apps/calculator'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function CalculatorPage() {
   return <Calculator />;

--- a/pages/apps/checkers.tsx
+++ b/pages/apps/checkers.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const Checkers = dynamic(() => import('../../apps/checkers'), { ssr: false });
+const Checkers = dynamic(() => import('../../apps/checkers'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function CheckersPage(): React.ReactElement {
   return <Checkers />;

--- a/pages/apps/http.tsx
+++ b/pages/apps/http.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const HTTPPreview = dynamic(() => import('../../apps/http'), { ssr: false });
+const HTTPPreview = dynamic(() => import('../../apps/http'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function HTTPPage() {
   return <HTTPPreview />;

--- a/pages/apps/minesweeper.tsx
+++ b/pages/apps/minesweeper.tsx
@@ -1,7 +1,9 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
 const Minesweeper = dynamic(() => import('../../components/apps/minesweeper'), {
   ssr: false,
+  loading: () => <AppLoader />,
 });
 
 export default function MinesweeperPage() {

--- a/pages/apps/nmap-nse.tsx
+++ b/pages/apps/nmap-nse.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), { ssr: false });
+const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function NmapNSEPage() {
   return <NmapNSE />;

--- a/pages/apps/password_generator.tsx
+++ b/pages/apps/password_generator.tsx
@@ -1,7 +1,11 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), { ssr: false });
+const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function PasswordGeneratorPage() {
   return <PasswordGenerator getDailySeed={() => getDailySeed('password_generator')} />;

--- a/pages/apps/phaser_matter.tsx
+++ b/pages/apps/phaser_matter.tsx
@@ -1,7 +1,11 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), { ssr: false });
+const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function PhaserMatterPage() {
   return <PhaserMatter getDailySeed={() => getDailySeed('phaser_matter')} />;

--- a/pages/apps/sokoban.tsx
+++ b/pages/apps/sokoban.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import AppLoader from '../../components/AppLoader';
 
 const Sokoban = dynamic(() => import('../../apps/sokoban'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => <AppLoader />,
 });
 
 const SokobanPage: React.FC = () => (

--- a/pages/apps/ssh.tsx
+++ b/pages/apps/ssh.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const SSHPreview = dynamic(() => import('../../apps/ssh'), { ssr: false });
+const SSHPreview = dynamic(() => import('../../apps/ssh'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function SSHPage() {
   return <SSHPreview />;

--- a/pages/apps/sticky_notes.tsx
+++ b/pages/apps/sticky_notes.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), { ssr: false });
+const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function StickyNotesPage() {
   return <StickyNotes />;

--- a/pages/apps/timer_stopwatch.tsx
+++ b/pages/apps/timer_stopwatch.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), { ssr: false });
+const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function TimerStopwatchPage() {
   return <TimerStopwatch />;

--- a/pages/apps/weather_widget.tsx
+++ b/pages/apps/weather_widget.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), { ssr: false });
+const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function WeatherWidgetPage() {
   return <WeatherWidget />;

--- a/pages/apps/wireshark.tsx
+++ b/pages/apps/wireshark.tsx
@@ -1,6 +1,10 @@
 import dynamic from 'next/dynamic';
+import AppLoader from '../../components/AppLoader';
 
-const Wireshark = dynamic(() => import('../../apps/wireshark'), { ssr: false });
+const Wireshark = dynamic(() => import('../../apps/wireshark'), {
+  ssr: false,
+  loading: () => <AppLoader />,
+});
 
 export default function WiresharkPage() {
   return <Wireshark />;

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { logEvent } from './analytics';
+import AppLoader from '../components/AppLoader';
 
 export const createDynamicApp = (path, name) =>
   dynamic(
@@ -11,11 +12,7 @@ export const createDynamicApp = (path, name) =>
       }),
     {
       ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${name}...`}
-        </div>
-      ),
+      loading: () => <AppLoader />,
     }
   );
 


### PR DESCRIPTION
## Summary
- add reusable AppLoader component that displays a shimmer skeleton after 1s
- wire AppLoader into dynamic app factory and app pages

## Testing
- `yarn test` *(fails: memoryGame.test.tsx, autopsy.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b087bb59c08328b44e009579209501