### PR TITLE
feat: add progress bar for long tasks

### DIFF
--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
+import ProgressBar from '../ui/ProgressBar';
 
 export class Gedit extends Component {
 
@@ -9,6 +10,8 @@ export class Gedit extends Component {
         super();
         this.state = {
             sending: false,
+            showProgress: false,
+            progress: 0,
             name: '',
             subject: '',
             message: '',
@@ -20,6 +23,8 @@ export class Gedit extends Component {
             timezone: '',
             localTime: '',
         }
+        this.progressTimer = null;
+        this.progressInterval = null;
     }
 
     componentDidMount() {
@@ -29,6 +34,8 @@ export class Gedit extends Component {
 
     componentWillUnmount() {
         if (this.timeFrame) cancelAnimationFrame(this.timeFrame);
+        if (this.progressTimer) clearTimeout(this.progressTimer);
+        if (this.progressInterval) clearInterval(this.progressInterval);
     }
 
     fetchLocation = () => {
@@ -93,7 +100,14 @@ export class Gedit extends Component {
         }
         if (error) return;
 
-        this.setState({ sending: true });
+        this.setState({ sending: true, showProgress: false, progress: 0 });
+
+        this.progressTimer = setTimeout(() => {
+            this.setState({ showProgress: true });
+            this.progressInterval = setInterval(() => {
+                this.setState((prev) => ({ progress: Math.min(prev.progress + 5, 95) }));
+            }, 500);
+        }, 10000);
 
         const serviceID = process.env.NEXT_PUBLIC_SERVICE_ID;
         const templateID = process.env.NEXT_PUBLIC_TEMPLATE_ID;
@@ -103,20 +117,22 @@ export class Gedit extends Component {
             'message': message,
         }
 
-        emailjs.send(serviceID, templateID, templateParams)
-            .then(() => {
-                this.setState({ sending: false, name: '', subject: '', message: '' });
-                document.getElementById('close-gedit')?.click();
-
-                ReactGA.event({
-                    category: "contact",
-                    action: "submit_success",
-                });
-            })
-            .catch(() => {
-                this.setState({ sending: false });
-                document.getElementById('close-gedit')?.click();
+        try {
+            await emailjs.send(serviceID, templateID, templateParams);
+            this.setState({ name: '', subject: '', message: '' });
+            ReactGA.event({
+                category: "contact",
+                action: "submit_success",
             });
+        } catch {
+            // ignore errors
+        } finally {
+            if (this.progressTimer) clearTimeout(this.progressTimer);
+            if (this.progressInterval) clearInterval(this.progressInterval);
+            this.setState({ progress: 100 });
+            document.getElementById('close-gedit')?.click();
+            setTimeout(() => this.setState({ sending: false, showProgress: false, progress: 0 }), 300);
+        }
 
     }
 
@@ -166,20 +182,22 @@ export class Gedit extends Component {
                     </div>
                 }
                 {
-                    (this.state.sending
-                        ?
-                        <div className="flex justify-center items-center motion-safe:animate-pulse h-full w-full bg-gray-400 bg-opacity-30 absolute top-0 left-0">
-                            <Image
-                                className=" w-8 absolute motion-safe:animate-spin"
-                                src="/themes/Yaru/status/process-working-symbolic.svg"
-                                alt="Ubuntu Process Symbol"
-                                width={32}
-                                height={32}
-                                sizes="32px"
-                                priority
-                            />
+                    this.state.sending && (
+                        <div className="flex justify-center items-center h-full w-full bg-gray-400 bg-opacity-30 absolute top-0 left-0">
+                            {this.state.showProgress ? (
+                                <ProgressBar progress={this.state.progress} />
+                            ) : (
+                                <Image
+                                    className="w-8 motion-safe:animate-spin"
+                                    src="/themes/Yaru/status/process-working-symbolic.svg"
+                                    alt="Ubuntu Process Symbol"
+                                    width={32}
+                                    height={32}
+                                    sizes="32px"
+                                    priority
+                                />
+                            )}
                         </div>
-                        : null
                     )
                 }
             </div>

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface ProgressBarProps {
+  progress: number;
+  className?: string;
+}
+
+export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
+  const clamped = Math.max(0, Math.min(progress, 100));
+  return (
+    <div
+      className={`w-32 h-2 bg-gray-300 rounded ${className}`}
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className="h-full bg-blue-500 transition-all duration-200"
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable ProgressBar component
- switch gedit mail sending to progress bar after 10s

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b087bcbd6c832894745c739b026812