### PR TITLE
Preload fonts and add responsive base sizing

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -47,17 +47,6 @@ export default function Meta() {
             <link rel="canonical" href="https://unnippillil.com/" />
             <link rel="icon" href="images/logos/fevicon.svg" />
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <link
-                rel="preload"
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                as="style"
-                crossOrigin="anonymous"
-            />
-            <link
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                rel="stylesheet"
-
-            />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -16,6 +16,45 @@ class MyDocument extends Document {
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            rel="preload"
+            as="style"
+            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+            rel="stylesheet"
+          />
+          <link
+            rel="preload"
+            href="https://fonts.gstatic.com/s/ubuntu/v20/4iCv6KVjbNBYlgoC1CzTtw.ttf"
+            as="font"
+            type="font/ttf"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="https://fonts.gstatic.com/s/ubuntu/v20/4iCs6KVjbNBYlgo6eA.ttf"
+            as="font"
+            type="font/ttf"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="https://fonts.gstatic.com/s/ubuntu/v20/4iCv6KVjbNBYlgoCjC3Ttw.ttf"
+            as="font"
+            type="font/ttf"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="https://fonts.gstatic.com/s/ubuntu/v20/4iCv6KVjbNBYlgoCxCvTtw.ttf"
+            as="font"
+            type="font/ttf"
+            crossOrigin="anonymous"
+          />
           <Script src="/theme.js" strategy="beforeInteractive" />
         </Head>
         <body>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2,7 +2,7 @@
 
 body{
     font-family: var(--font-family-base);
-    font-display: swap;
+    font-size: clamp(1rem, 0.875rem + 0.5vw, 1.25rem);
     background-color: var(--color-bg);
     color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- preload Ubuntu font styles and files with `font-display: swap`
- remove redundant font stylesheet references from Meta component
- use `clamp()` for responsive base text sizing

## Testing
- `npm test` *(fails: memoryGame, BeEF, converter, snake.config, frogger.config)*
- `npm run lint` *(warnings: Google font preconnect; error: parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b087e3b4b48328822d7ea5b472afdb