### PR TITLE
feat: add accent color picker

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import { useSettings } from '../hooks/useSettings';
 
 interface Props {
   highScore?: number;
@@ -9,6 +10,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const [theme, setThemeState] = useState(getTheme());
   const unlocked = getUnlockedThemes(highScore);
+  const { accent, setAccent } = useSettings();
 
   const changeTheme = (t: string) => {
     setThemeState(t);
@@ -35,6 +37,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 </option>
               ))}
             </select>
+          </label>
+          <label>
+            Accent
+            <input
+              aria-label="accent-color-picker"
+              type="color"
+              value={accent}
+              onChange={(e) => setAccent(e.target.value)}
+            />
           </label>
         </div>
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -12,6 +12,22 @@ import {
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
 
+// Utility to lighten or darken a hex color by a percentage
+const shadeColor = (color: string, percent: number): string => {
+  const f = parseInt(color.slice(1), 16);
+  const t = percent < 0 ? 0 : 255;
+  const p = Math.abs(percent);
+  const R = f >> 16;
+  const G = (f >> 8) & 0x00ff;
+  const B = f & 0x0000ff;
+  const newR = Math.round((t - R) * p) + R;
+  const newG = Math.round((t - G) * p) + G;
+  const newB = Math.round((t - B) * p) + B;
+  return `#${(0x1000000 + newR * 0x10000 + newG * 0x100 + newB)
+    .toString(16)
+    .slice(1)}`;
+};
+
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
@@ -50,7 +66,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--color-ub-orange', accent);
+    const border = shadeColor(accent, -0.2);
+    const vars: Record<string, string> = {
+      '--color-ub-orange': accent,
+      '--color-ub-border-orange': border,
+      '--color-primary': accent,
+      '--color-accent': accent,
+    };
+    Object.entries(vars).forEach(([key, value]) => {
+      document.documentElement.style.setProperty(key, value);
+    });
     saveAccent(accent);
   }, [accent]);
 


### PR DESCRIPTION
## Summary
- add accent color picker in settings drawer
- recompute theme variables when accent changes

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880087d0832899d920eb5d459db0