### PR TITLE
feat: reorderable dock with persistent pins

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -37,6 +37,10 @@ export class SideBarApp extends Component {
                 aria-label={this.props.title}
                 data-context="app"
                 data-app-id={this.props.id}
+                draggable={this.props.draggable}
+                onDragStart={this.props.onDragStart}
+                onDragOver={this.props.onDragOver}
+                onDrop={this.props.onDrop}
                 onClick={this.openApp}
                 onMouseEnter={() => {
                     this.setState({ showTitle: true });

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -2,17 +2,6 @@ import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
 
-let renderApps = (props) => {
-    let sideBarAppsJsx = [];
-    props.apps.forEach((app, index) => {
-        if (props.favourite_apps[app.id] === false) return;
-        sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
-        );
-    });
-    return sideBarAppsJsx;
-}
-
 export default function SideBar(props) {
 
     function showSideBar() {
@@ -25,16 +14,57 @@ export default function SideBar(props) {
         }, 2000);
     }
 
+    const handleDragStart = (id) => (e) => {
+        e.dataTransfer.setData('text/plain', id);
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+    };
+
+    const handleDrop = (id) => (e) => {
+        e.preventDefault();
+        const draggedId = e.dataTransfer.getData('text/plain');
+        if (!draggedId || draggedId === id) return;
+        const order = [...props.pinnedOrder];
+        const from = order.indexOf(draggedId);
+        const to = order.indexOf(id);
+        if (from === -1 || to === -1) return;
+        order.splice(from, 1);
+        order.splice(to, 0, draggedId);
+        props.setPinnedOrder(order);
+    };
+
+    const openUnpinned = props.apps
+        .filter(app => props.favourite_apps[app.id] && !props.pinnedOrder.includes(app.id))
+        .map(app => app.id);
+
+    const appsInOrder = [...props.pinnedOrder, ...openUnpinned];
+
     return (
         <>
             <div className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-7 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}>
-                {
-                    (
-                        Object.keys(props.closed_windows).length !== 0
-                            ? renderApps(props)
-                            : null
-                    )
-                }
+                {appsInOrder.map(id => {
+                    const app = props.apps.find(a => a.id === id);
+                    if (!app) return null;
+                    const draggable = props.pinnedOrder.includes(id);
+                    return (
+                        <SideBarApp
+                            key={id}
+                            id={id}
+                            title={app.title}
+                            icon={app.icon}
+                            isClose={props.closed_windows}
+                            isFocus={props.focused_windows}
+                            openApp={props.openAppByAppId}
+                            isMinimized={props.isMinimized}
+                            draggable={draggable}
+                            onDragStart={draggable ? handleDragStart(id) : undefined}
+                            onDragOver={draggable ? handleDragOver : undefined}
+                            onDrop={draggable ? handleDrop(id) : undefined}
+                        />
+                    );
+                })}
                 <AllApps showApps={props.showAllApps} />
             </div>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>


### PR DESCRIPTION
## Summary
- enable dragging dock icons to reorder and persist order
- toggle app pins via right-click with persistent storage using usePersistentState

## Testing
- `yarn lint` *(fails: Parsing error in Chrome/index.tsx)*
- `yarn test` *(fails: memoryGame.test.tsx, autopsy.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880199a083288a6ec37aa9a9f124