### PR TITLE
feat: add settings export and import

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings } from '../../hooks/useSettings';
-import { resetSettings, defaults } from '../../utils/settingsStore';
+import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
+    const fileInput = useRef(null);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -132,7 +133,28 @@ export function Settings() {
                     ))
                 }
             </div>
-            <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
+            <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
+                <button
+                    onClick={async () => {
+                        const data = await exportSettingsData();
+                        const blob = new Blob([data], { type: 'application/json' });
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = 'settings.json';
+                        a.click();
+                        URL.revokeObjectURL(url);
+                    }}
+                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                >
+                    Export Settings
+                </button>
+                <button
+                    onClick={() => fileInput.current && fileInput.current.click()}
+                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                >
+                    Import Settings
+                </button>
                 <button
                     onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -140,6 +162,28 @@ export function Settings() {
                     Reset Desktop
                 </button>
             </div>
+            <input
+                type="file"
+                accept="application/json"
+                ref={fileInput}
+                onChange={async (e) => {
+                    const file = e.target.files && e.target.files[0];
+                    if (!file) return;
+                    const text = await file.text();
+                    await importSettingsData(text);
+                    try {
+                        const parsed = JSON.parse(text);
+                        if (parsed.accent !== undefined) setAccent(parsed.accent);
+                        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+                        if (parsed.density !== undefined) setDensity(parsed.density);
+                        if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                    } catch (err) {
+                        console.error('Invalid settings', err);
+                    }
+                    e.target.value = '';
+                }}
+                className="hidden"
+            />
         </div>
     )
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -57,4 +57,30 @@ export async function resetSettings() {
   window.localStorage.removeItem('reduced-motion');
 }
 
+export async function exportSettings() {
+  const [accent, wallpaper, density, reducedMotion] = await Promise.all([
+    getAccent(),
+    getWallpaper(),
+    getDensity(),
+    getReducedMotion(),
+  ]);
+  return JSON.stringify({ accent, wallpaper, density, reducedMotion });
+}
+
+export async function importSettings(json) {
+  if (typeof window === 'undefined') return;
+  let settings;
+  try {
+    settings = typeof json === 'string' ? JSON.parse(json) : json;
+  } catch (e) {
+    console.error('Invalid settings', e);
+    return;
+  }
+  const { accent, wallpaper, density, reducedMotion } = settings;
+  if (accent !== undefined) await setAccent(accent);
+  if (wallpaper !== undefined) await setWallpaper(wallpaper);
+  if (density !== undefined) await setDensity(density);
+  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
+}
+
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- allow exporting accent, wallpaper, density and motion prefs to JSON
- add import to apply settings from JSON
- expose import/export controls in Settings app

## Testing
- `npm test` *(fails: memoryGame.test.tsx, autopsy.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b08802a9688328809e7825bbcd7726