### PR TITLE
test: verify manifest and install prompt

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InstallButton from '../components/InstallButton';
+
+describe('InstallButton', () => {
+  test('shows install prompt when beforeinstallprompt fires', async () => {
+    render(<InstallButton />);
+    expect(screen.queryByText(/install/i)).toBeNull();
+
+    let resolveChoice: (value: any) => void = () => {};
+    const userChoice = new Promise((resolve) => {
+      resolveChoice = resolve;
+    });
+
+    const prompt = jest.fn().mockResolvedValue(undefined);
+    const event: any = new Event('beforeinstallprompt');
+    event.preventDefault = jest.fn();
+    event.prompt = prompt;
+    event.userChoice = userChoice;
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    const button = await screen.findByText(/install/i);
+    await userEvent.click(button);
+    expect(prompt).toHaveBeenCalled();
+
+    await act(async () => {
+      resolveChoice({ outcome: 'accepted', platform: 'test' });
+      await userChoice;
+    });
+
+    await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
+  });
+});

--- a/__tests__/manifest.test.ts
+++ b/__tests__/manifest.test.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('web manifest', () => {
+  const manifestPath = path.join(process.cwd(), 'public', 'manifest.webmanifest');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+  test('contains icons', () => {
+    expect(Array.isArray(manifest.icons)).toBe(true);
+    expect(manifest.icons.length).toBeGreaterThan(0);
+    for (const icon of manifest.icons) {
+      expect(icon.src).toBeDefined();
+      expect(icon.sizes).toBeDefined();
+      expect(icon.type).toBeDefined();
+    }
+  });
+
+  test('has standalone display mode', () => {
+    expect(manifest.display).toBe('standalone');
+  });
+
+  test('defines start_url', () => {
+    expect(manifest.start_url).toBe('/');
+  });
+
+  test('includes shortcuts', () => {
+    expect(Array.isArray(manifest.shortcuts)).toBe(true);
+    expect(manifest.shortcuts.length).toBeGreaterThan(0);
+    for (const shortcut of manifest.shortcuts) {
+      expect(shortcut.name).toBeDefined();
+      expect(shortcut.short_name).toBeDefined();
+      expect(shortcut.url).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test to validate PWA manifest icons, display mode, start URL, and shortcuts
- add component test to display install prompt when `beforeinstallprompt` event fires

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm test __tests__/manifest.test.ts __tests__/installButton.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b08804b7588328bca45a090e7e3e5d