### PR TITLE
feat: add offline support with toasts

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
@@ -7,11 +7,14 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import Toast from '../components/ui/Toast';
 
 /**
  * @param {import('next/app').AppProps} props
  */
 function MyApp({ Component, pageProps }) {
+  const [toastMessage, setToastMessage] = useState(null);
+
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
     if (trackingId) {
@@ -38,8 +41,23 @@ function MyApp({ Component, pageProps }) {
         });
     }
   }, []);
+
+  useEffect(() => {
+    const handleOffline = () => setToastMessage('You are offline');
+    const handleOnline = () => setToastMessage('You are back online');
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
   return (
     <SettingsProvider>
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+      )}
       <Component {...pageProps} />
       <Analytics />
     </SettingsProvider>

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline</title>
+    <style>
+      body { display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: sans-serif; background: #f0f0f0; }
+      h1 { color: #333; }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline. Please check your connection.</h1>
+  </body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,10 @@
 const CACHE_NAME = 'weather-cache-v1';
+const OFFLINE_URL = '/offline.html';
 
-self.addEventListener('install', () => {
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll([OFFLINE_URL]))
+  );
   self.skipWaiting();
 });
 
@@ -10,6 +14,14 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const { request } = event;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match(OFFLINE_URL))
+    );
+    return;
+  }
+
   if (request.url.startsWith('https://api.open-meteo.com')) {
     event.respondWith(
       caches.open(CACHE_NAME).then(async (cache) => {


### PR DESCRIPTION
## Summary
- cache offline fallback page in service worker
- show network status toasts
- add offline fallback page

## Testing
- `npm test` *(fails: combo meter increments and resets; card flip applies transform style; updates hook list when new hooks arrive; streams module output to UI; filters artifacts by type)*
- `npm run lint` *(fails: ./components/apps/Chrome/index.tsx:391:4 Parsing error: ')' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880511048328b4cff667b09fcf3b