### PR TITLE
feat: add Workbox caching with offline fallback

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Offline</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: sans-serif;
+        text-align: center;
+        padding: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline</h1>
+    <p>The application shell is unavailable. Please check your connection.</p>
+    <img src="/images/logos/logo.png" alt="Logo" width="128" />
+  </body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,34 +1,36 @@
-const CACHE_NAME = 'weather-cache-v1';
+importScripts(
+  "https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js",
+);
 
-self.addEventListener('install', () => {
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
-self.addEventListener('activate', (event) => {
+self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('fetch', (event) => {
-  const { request } = event;
-  if (request.url.startsWith('https://api.open-meteo.com')) {
-    event.respondWith(
-      caches.open(CACHE_NAME).then(async (cache) => {
-        try {
-          const response = await fetch(request);
-          cache.put(request, response.clone());
-          return response;
-        } catch (err) {
-          const cached = await cache.match(request);
-          if (cached) return cached;
-          throw err;
-        }
-      })
-    );
-  }
+const { recipes, navigationPreload, routing, strategies } = workbox;
+
+navigationPreload.enable();
+
+recipes.pageCache();
+recipes.staticResourceCache();
+recipes.imageCache();
+recipes.offlineFallback({
+  pageFallback: "/offline.html",
+  imageFallback: "/images/logos/logo.png",
 });
 
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'seed') {
+routing.registerRoute(
+  ({ url }) => url.origin === "https://api.open-meteo.com",
+  new strategies.NetworkFirst({
+    cacheName: "weather-cache-v1",
+  }),
+);
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "seed") {
     const seed = Math.random().toString(36).slice(2, 10);
     if (event.ports && event.ports[0]) {
       event.ports[0].postMessage({ seed });


### PR DESCRIPTION
## Summary
- add Workbox recipes to cache pages, static assets, and images
- provide offline page and fallback image for offline navigation
- keep weather API caching via NetworkFirst strategy

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: multiple failing test suites including memoryGame, BeEF app, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880571a0832888a4fabe0d17c64a