### PR TITLE
feat: add online status tray icon

### DIFF
--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,16 +1,49 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 
 export default function Status() {
+  const [online, setOnline] = useState(
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  );
+
+  useEffect(() => {
+    const pingServer = async () => {
+      if (!window?.location) return;
+      try {
+        const url = new URL('/favicon.ico', window.location.href).toString();
+        await fetch(url, { method: 'HEAD', cache: 'no-store' });
+        setOnline(true);
+      } catch (e) {
+        setOnline(false);
+      }
+    };
+
+    const updateStatus = () => {
+      const isOnline = navigator.onLine;
+      setOnline(isOnline);
+      if (isOnline) {
+        pingServer();
+      }
+    };
+
+    updateStatus();
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+    };
+  }, []);
+
   return (
     <div className="flex justify-center items-center">
-      <span className="mx-1.5">
+      <span className="mx-1.5" title={online ? 'Online' : 'Offline'}>
         <Image
           width={16}
           height={16}
-          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
-          alt="ubuntu wifi"
+          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />

--- a/public/themes/Yaru/status/network-wireless-signal-none-symbolic.svg
+++ b/public/themes/Yaru/status/network-wireless-signal-none-symbolic.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-1053 267)">
+  <path d="M1061.003-265c-2.61 0-5.22.838-7.4 2.518l-.266.205.205.263 7.457 9.672 7.668-9.931-.264-.206a12.105 12.105 0 0 0-7.4-2.521zm0 1c2.181 0 4.344.672 6.227 1.951l-6.229 8.07-6.226-8.074c1.883-1.278 4.047-1.948 6.228-1.947z" fill="gray" font-family="sans-serif" font-weight="400" overflow="visible" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:none;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-transform:none" white-space="normal"/>
+ </g>
+</svg>


### PR DESCRIPTION
## Summary
- show network status in tray icon
- verify online state by pinging favicon
- include offline network icon

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b08805fe108328bf0b47cb70cc941c