### PR TITLE
feat: add share buttons with fallback

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -29,6 +29,38 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
 
+  const fallbackCopy = useCallback((text: string) => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).catch(() => {
+        /* ignore clipboard errors */
+      });
+    }
+  }, []);
+
+  const shareApp = useCallback(() => {
+    const url = window.location.href;
+    if (navigator.share) {
+      navigator.share({ url }).catch(() => {
+        fallbackCopy(url);
+      });
+    } else {
+      fallbackCopy(url);
+    }
+  }, [fallbackCopy]);
+
+  const shareScore = useCallback(() => {
+    if (highScore === undefined) return;
+    const url = window.location.href;
+    const text = `I scored ${highScore} in ${gameId}!`;
+    if (navigator.share) {
+      navigator
+        .share({ text, url })
+        .catch(() => fallbackCopy(`${text} ${url}`));
+    } else {
+      fallbackCopy(`${text} ${url}`);
+    }
+  }, [fallbackCopy, highScore, gameId]);
+
   // Keyboard shortcut to toggle help overlay
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -110,15 +142,33 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           </button>
         </div>
       )}
-      <button
-        type="button"
-        aria-label="Help"
-        aria-expanded={showHelp}
-        onClick={toggle}
-        className="absolute top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
-      >
-        ?
-      </button>
+      <div className="absolute top-2 right-2 z-40 flex space-x-2">
+        <button
+          type="button"
+          onClick={shareApp}
+          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+        >
+          Share
+        </button>
+        {highScore !== undefined && (
+          <button
+            type="button"
+            onClick={shareScore}
+            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          >
+            Share Score
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label="Help"
+          aria-expanded={showHelp}
+          onClick={toggle}
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        >
+          ?
+        </button>
+      </div>
       {children}
       <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
         {stage !== undefined && <div>Stage: {stage}</div>}


### PR DESCRIPTION
## Summary
- add share app and score buttons with navigator.share
- fall back to copying links when sharing unsupported

## Testing
- `npm test __tests__/memoryGame.test.tsx` (fails: combo meter increments and resets; card flip transform)
- `npm test __tests__/beef.test.tsx` (fails: updates hook list when new hooks arrive; streams module output to UI)
- `npm test __tests__/autopsy.test.tsx` (fails: filters artifacts by type)
- `npm test __tests__/converter.test.tsx` (fails: keeps sliders synchronized; shows rounding preview bubble)
- `npm run lint` (fails: Parsing error in components/apps/Chrome/index.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b0880677a0832892853a7c4e83167c