### PR TITLE
Add gamepad support and persistence for Asteroids

### DIFF
--- a/public/apps/asteroids/index.html
+++ b/public/apps/asteroids/index.html
@@ -10,6 +10,16 @@
 </head>
 <body>
   <canvas id="game" width="800" height="600"></canvas>
+  <div id="hud" style="position:fixed;top:10px;left:10px;font-family:monospace;">
+    <div id="score">Score: 0</div>
+    <div id="level">Level: 1</div>
+    <div id="controls" style="margin-top:4px;">
+      Move: arrows or left stick. Shoot: space or buttons. Pause: P or Start.
+    </div>
+  </div>
+  <div id="paused" style="display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);font-family:monospace;">
+    Paused
+  </div>
   <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- poll gamepad input each frame and allow start button pause
- overlay HUD showing controls, score, and level with pause screen
- save and restore last level and score in localStorage

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, frogger.config, snake.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880d2ea48328a3b2ff3333d9fe04