### PR TITLE
feat(reader): add markdown view toggle

### DIFF
--- a/__tests__/reader.test.tsx
+++ b/__tests__/reader.test.tsx
@@ -11,6 +11,7 @@ describe('Reader', () => {
   beforeEach(() => {
     (global as any).fetch = jest.fn(async () => ({ text: async () => sampleHtml }));
     writeTextMock.mockClear();
+    localStorage.clear();
   });
 
   it('parses same-origin pages', async () => {
@@ -35,5 +36,16 @@ describe('Reader', () => {
     await screen.findByText('Sample');
     await user.click(screen.getByText('Copy as Markdown'));
     expect(writeTextMock).toHaveBeenCalled();
+  });
+
+  it('toggles markdown view and saves preference', async () => {
+    const user = userEvent.setup();
+    render(<Reader url="/test" />);
+    await screen.findByText('Sample');
+    await user.click(screen.getByText('Markdown'));
+    expect(
+      screen.getByText((content) => content.includes('# t'))
+    ).toBeInTheDocument();
+    expect(localStorage.getItem('readerView')).toBe('markdown');
   });
 });


### PR DESCRIPTION
## Summary
- allow Chrome Reader to toggle between rendered, markdown, or split view
- persist Reader view preference via localStorage
- add test for markdown view toggle

## Testing
- `npx jest __tests__/reader.test.tsx`
- `yarn test` *(fails: memoryGame and other suites)*
- `yarn lint` *(fails: components/apps/Chrome/index.tsx parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880e605c83289c008fde5f7971d8