### PR TITLE
feat: enable calculator history reuse and clipboard copy

### DIFF
--- a/apps/calculator/main.js
+++ b/apps/calculator/main.js
@@ -177,9 +177,22 @@ function renderHistory() {
   history.forEach(({ expr, result }) => {
     const entry = document.createElement('div');
     entry.className = 'history-entry';
+    entry.addEventListener('click', () => {
+      display.value = expr;
+      updateParenBalance();
+      validateBaseInput();
+      display.focus();
+    });
     const text = document.createElement('span');
     text.textContent = `${expr} = ${result}`;
     entry.appendChild(text);
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = 'Copy';
+    copyBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      navigator.clipboard?.writeText(`${expr} = ${result}`);
+    });
+    entry.appendChild(copyBtn);
     historyEl.appendChild(entry);
   });
 }


### PR DESCRIPTION
## Summary
- make calculator history entries clickable to reuse expressions
- add copy buttons that use Clipboard API

## Testing
- `yarn test __tests__/calc.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0880fcfb48328857a916923ef2979