### PR TITLE
feat: add font size and theme preferences

### DIFF
--- a/__tests__/fontSizePersistence.test.ts
+++ b/__tests__/fontSizePersistence.test.ts
@@ -1,0 +1,13 @@
+import { getFontSize, setFontSize } from '../utils/fontSize';
+
+describe('font size persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('font size persists across sessions', () => {
+    setFontSize(20);
+    expect(getFontSize()).toBe(20);
+    expect(window.localStorage.getItem('app:font-size')).toBe('20');
+  });
+});

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import { getFontSize, setFontSize } from '../utils/fontSize';
 
 interface Props {
   highScore?: number;
@@ -8,11 +9,31 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const [theme, setThemeState] = useState(getTheme());
+  const [fontSize, setFontSizeState] = useState(getFontSize());
   const unlocked = getUnlockedThemes(highScore);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle(
+      'high-contrast',
+      theme === 'high-contrast'
+    );
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--font-size-base',
+      `${fontSize}px`
+    );
+  }, [fontSize]);
 
   const changeTheme = (t: string) => {
     setThemeState(t);
     setTheme(t);
+  };
+
+  const changeFont = (size: number) => {
+    setFontSizeState(size);
+    setFontSize(size);
   };
 
   return (
@@ -35,6 +56,17 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 </option>
               ))}
             </select>
+          </label>
+          <label>
+            Font Size
+            <input
+              type="range"
+              min={12}
+              max={24}
+              value={fontSize}
+              onChange={(e) => changeFont(parseInt(e.target.value))}
+              aria-label="font-size-slider"
+            />
           </label>
         </div>
       )}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,9 @@
 @import './globals.css';
 
+html{
+    font-size: var(--font-size-base);
+}
+
 body{
     font-family: var(--font-family-base);
     font-display: swap;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -47,6 +47,7 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+  --font-size-base: 16px;
 }
 
 /* High contrast theme */

--- a/utils/fontSize.ts
+++ b/utils/fontSize.ts
@@ -1,0 +1,20 @@
+export const FONT_SIZE_KEY = 'app:font-size';
+
+export const getFontSize = (): number => {
+  if (typeof window === 'undefined') return 16;
+  try {
+    const stored = window.localStorage.getItem(FONT_SIZE_KEY);
+    return stored ? parseInt(stored, 10) : 16;
+  } catch {
+    return 16;
+  }
+};
+
+export const setFontSize = (size: number): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(FONT_SIZE_KEY, String(size));
+  } catch {
+    /* ignore storage errors */
+  }
+};

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  'high-contrast': 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add high contrast option to theme selector and persist selection
- include font size slider with preference stored in local storage
- ensure root CSS uses base font size variable and test persistence

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b08810e38083288c577caea8521873