### PR TITLE
feat: add command palette

### DIFF
--- a/components/command-palette/index.jsx
+++ b/components/command-palette/index.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  KBarPortal,
+  KBarPositioner,
+  KBarAnimator,
+  KBarSearch,
+  KBarResults,
+  useMatches,
+  useRegisterActions,
+} from 'kbar';
+import apps from '../../apps.config';
+import { useSettings } from '../../hooks/useSettings';
+
+function Results() {
+  const { results } = useMatches();
+  return (
+    <KBarResults
+      items={results}
+      onRender={({ item, active }) =>
+        typeof item === 'string' ? (
+          <div className="px-2 py-1 text-xs uppercase opacity-50">{item}</div>
+        ) : (
+          <div className={`px-4 py-2 ${active ? 'bg-blue-100' : ''}`}>{item.name}</div>
+        )
+      }
+    />
+  );
+}
+
+export default function CommandPalette() {
+  const { wallpaper, setWallpaper } = useSettings();
+  const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+
+  useRegisterActions(
+    [
+      {
+        id: 'open-settings',
+        name: 'Open Settings',
+        keywords: 'settings',
+        perform: () => window.desktopApi?.openApp?.('settings'),
+      },
+      {
+        id: 'change-wallpaper',
+        name: 'Change Wallpaper',
+        keywords: 'background wallpaper',
+        perform: () => {
+          const index = wallpapers.indexOf(wallpaper);
+          const next = wallpapers[(index + 1) % wallpapers.length];
+          setWallpaper(next);
+        },
+      },
+      ...apps.map((app) => ({
+        id: `launch-${app.id}`,
+        name: `Launch ${app.title}`,
+        section: 'Apps',
+        perform: () => window.desktopApi?.openApp?.(app.id),
+      })),
+      ...apps.map((app) => ({
+        id: `focus-${app.id}`,
+        name: `Focus ${app.title}`,
+        section: 'Windows',
+        perform: () => window.desktopApi?.focusApp?.(app.id),
+      })),
+    ],
+    [wallpaper]
+  );
+
+  return (
+    <KBarPortal>
+      <KBarPositioner className="z-50 bg-black/80 backdrop-blur-sm">
+        <KBarAnimator className="w-full max-w-md bg-white text-black rounded overflow-hidden shadow-lg">
+          <KBarSearch className="p-4 w-full outline-none" />
+          <Results />
+        </KBarAnimator>
+      </KBarPositioner>
+    </KBarPortal>
+  );
+}
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -49,10 +49,18 @@ export class Desktop extends Component {
         this.setEventListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
+        window.desktopApi = {
+            openApp: this.openApp,
+            focusApp: this.focus,
+            getOpenWindows: () => Object.keys(this.state.closed_windows).filter(id => !this.state.closed_windows[id])
+        };
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
+        if (window.desktopApi) {
+            delete window.desktopApi;
+        }
     }
 
     checkForNewFolders = () => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "html-to-image": "^1.11.13",
     "idb": "7.1.1",
     "idb-keyval": "^6.2.1",
+    "kbar": "^0.1.0-beta.48",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
     "next": "^15.0.0",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,23 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { KBarProvider, useKBar } from 'kbar';
+import CommandPalette from '../components/command-palette';
+
+function KBarShortcut() {
+  const { query } = useKBar();
+  useEffect(() => {
+    const handleKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        query.toggle();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [query]);
+  return null;
+}
 
 /**
  * @param {import('next/app').AppProps} props
@@ -40,8 +57,12 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <Component {...pageProps} />
-      <Analytics />
+      <KBarProvider actions={[]}>
+        <KBarShortcut />
+        <Component {...pageProps} />
+        <CommandPalette />
+        <Analytics />
+      </KBarProvider>
     </SettingsProvider>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,93 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d36a9c589eb75d634b9b139c80f916aadaf8a68a7c1c4b8c6c6b88755af1a92f2e343457042089f04cc3f23073619d08bb65419ced1402e9d4e299576d970771
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:^1.0.1":
+  version: 1.1.9
+  resolution: "@radix-ui/react-portal@npm:1.1.9"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/45b432497c722720c72c493a29ef6085bc84b50eafe79d48b45c553121b63e94f9cdb77a3a74b9c49126f8feb3feee009fe400d48b7759d3552396356b192cd7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
+  languageName: node
+  linkType: hard
+
+"@reach/observe-rect@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "@reach/observe-rect@npm:1.2.0"
+  checksum: 10c0/e2d2b399381e466705bcf7535ba1ed29866792d7aff386a2a41ca1f5ae9d8920f21c769d67b82b38045cd14e1c2aa29dbf6f37a77f323d16d01378eb02ad2925
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
@@ -4667,6 +4754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-equals@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "fast-equals@npm:2.0.4"
+  checksum: 10c0/2867aa148c995e4ea921242ab605b157e5cbdc44793ebddf83684a5e6673be5016eb790ec4d8329317b92887e1108fb67ed3d4334529f2a7650c1338e6aa2c5f
+  languageName: node
+  linkType: hard
+
 "fast-fifo@npm:^1.2.0, fast-fifo@npm:^1.3.2":
   version: 1.3.2
   resolution: "fast-fifo@npm:1.3.2"
@@ -4986,6 +5080,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 10c0/33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 10c0/c2fe4f234f516e9ea83b06f06f8f3c8b7117f51aa75bbccd052eed0c0423364bf1e360ffbf29cadae8ef6aa39476b7961eaf9d07bed779cea5c83d62b34e2df9
   languageName: node
   linkType: hard
 
@@ -6510,6 +6611,22 @@ __metadata:
   dependencies:
     lodash-es: "npm:4"
   checksum: 10c0/023322fdfa41e98a2b83ee02cd00509f3b5041c542dd4405dc3fee2e8cb0928e24a5e681ea1c3df86c82f5fbfcbe61161bfc9ea16dd9f353d7332b314ce34cf6
+  languageName: node
+  linkType: hard
+
+"kbar@npm:^0.1.0-beta.48":
+  version: 0.1.0-beta.48
+  resolution: "kbar@npm:0.1.0-beta.48"
+  dependencies:
+    "@radix-ui/react-portal": "npm:^1.0.1"
+    fast-equals: "npm:^2.0.3"
+    fuse.js: "npm:^6.6.2"
+    react-virtual: "npm:^2.8.2"
+    tiny-invariant: "npm:^1.2.0"
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/9c897d933c24ac1db6806021f07b87ba55164db8cce6ff2fbb8b072d2b97b2ccd3e35ce20596b55242cc41ec4abd716657e83151b5eb901e88505b2f6544187f
   languageName: node
   linkType: hard
 
@@ -8206,6 +8323,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-virtual@npm:^2.8.2":
+  version: 2.10.4
+  resolution: "react-virtual@npm:2.10.4"
+  dependencies:
+    "@reach/observe-rect": "npm:^1.1.0"
+  peerDependencies:
+    react: ^16.6.3 || ^17.0.0
+  checksum: 10c0/96813e174f21e044152c09da4782b97dd55a6e32ddad743b39a79afc69e525d591b3263f7001f0e7f453ca5316743a2192bcb6a3686ce1b0ec14d1be8a2ea8e0
+  languageName: node
+  linkType: hard
+
 "react@npm:^18.2.0":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -9315,6 +9443,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-invariant@npm:^1.2.0":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:1, tinycolor2@npm:^1.6.0":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
@@ -9656,6 +9791,7 @@ __metadata:
     idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
+    kbar: "npm:^0.1.0-beta.48"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     next: "npm:^15.0.0"


### PR DESCRIPTION
## Summary
- add kbar command palette with actions to launch apps, change wallpaper, and focus windows
- expose desktop API and register global keyboard shortcut
- include kbar dependency

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b098d5c6e48328849a6704424a00ad