### PR TITLE
feat: add roving tabindex to dock and app grid

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -44,7 +44,10 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") + " w-auto p-2 outline-none relative transition hover:bg-white hover:bg-opacity-10 rounded m-1"}
+                tabIndex={this.props.tabIndex ?? -1}
+                onKeyDown={this.props.onKeyDown}
+                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                    " w-auto p-2 outline-none relative transition hover:bg-white hover:bg-opacity-10 focus:bg-white focus:bg-opacity-10 focus:outline focus:outline-2 focus:outline-white rounded m-1"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -21,11 +21,18 @@ export class UbuntuApp extends Component {
                 aria-label={this.props.name}
                 data-context="app"
                 data-app-id={this.props.id}
-                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
+                className={(this.state.launching ? " app-icon-launch " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 focus:outline focus:outline-2 focus:outline-yellow-400 border border-transparent rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={0}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.openApp();
+                    } else if (this.props.onKeyDown) {
+                        this.props.onKeyDown(e);
+                    }
+                }}
+                tabIndex={this.props.tabIndex ?? -1}
             >
                 <Image
                     width={40}


### PR DESCRIPTION
## Summary
- add roving tabindex and arrow key navigation to dock
- enable arrow-key navigation through app grid
- improve focus visibility on dock and app grid icons

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b098d7ed748328a83e677a1176b3d3