### PR TITLE
feat: enhance app context menus

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -13,6 +13,11 @@ function AppMenu(props) {
         }
     }
 
+    const handleOpen = () => {
+        props.openApp && props.openApp()
+        props.onClose && props.onClose()
+    }
+
     const handlePin = () => {
         if (props.pinned) {
             props.unpinApp && props.unpinApp()
@@ -21,10 +26,16 @@ function AppMenu(props) {
         }
     }
 
+    const handleAbout = () => {
+        props.aboutApp && props.aboutApp()
+        props.onClose && props.onClose()
+    }
+
     return (
         <div
             id="app-menu"
             role="menu"
+            aria-label="Application context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
@@ -32,15 +43,43 @@ function AppMenu(props) {
         >
             <button
                 type="button"
-                onClick={handlePin}
+                onClick={handleOpen}
                 role="menuitem"
-                aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                aria-label="Open"
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <span className="ml-5">Open</span>
+            </button>
+            <button
+                type="button"
+                onClick={handlePin}
+                role="menuitem"
+                aria-label={props.pinned ? 'Unpin from Dock' : 'Pin to Dock'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.pinned ? 'Unpin from Dock' : 'Pin to Dock'}</span>
+            </button>
+            <Devider />
+            <button
+                type="button"
+                onClick={handleAbout}
+                role="menuitem"
+                aria-label="About"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">About</span>
             </button>
         </div>
     )
 }
 
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    );
+}
+
 export default AppMenu
+

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,14 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import logger from '../../utils/logger'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -43,11 +48,20 @@ function DesktopMenu(props) {
         }
     }
 
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
+
     return (
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -612,13 +612,21 @@ export class Desktop extends Component {
                 {this.renderDesktopApps()}
 
                 {/* Context Menus */}
-                <DesktopMenu active={this.state.context_menus.desktop} openApp={this.openApp} addNewFolder={this.addNewFolder} openShortcutSelector={this.openShortcutSelector} />
+                <DesktopMenu
+                    active={this.state.context_menus.desktop}
+                    openApp={this.openApp}
+                    addNewFolder={this.addNewFolder}
+                    openShortcutSelector={this.openShortcutSelector}
+                    onClose={this.hideAllContextMenu}
+                />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu
                     active={this.state.context_menus.app}
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
+                    openApp={() => this.openApp(this.state.context_app)}
+                    aboutApp={() => this.openApp('about')}
                     onClose={this.hideAllContextMenu}
                 />
 


### PR DESCRIPTION
## Summary
- add Open, Pin to Dock, and About entries to application context menu
- enable ARIA roles and keyboard navigation for desktop context menu
- wire context menu actions into desktop state handlers

## Testing
- `yarn test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b098d8798883289f24280a284308b8