### PR TITLE
feat: persist desktop session

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -8,8 +8,8 @@ export class Window extends Component {
     constructor(props) {
         super(props);
         this.id = null;
-        this.startX = 60;
-        this.startY = 10;
+        this.startX = props.initialX ?? 60;
+        this.startY = props.initialY ?? 10;
         this.state = {
             cursorType: "cursor-default",
             width: props.defaultWidth || 60,
@@ -157,9 +157,15 @@ export class Window extends Component {
 
     setWinowsPosition = () => {
         var r = document.querySelector("#" + this.id);
+        if (!r) return;
         var rect = r.getBoundingClientRect();
-        r.style.setProperty('--window-transform-x', rect.x.toFixed(1).toString() + "px");
-        r.style.setProperty('--window-transform-y', (rect.y.toFixed(1) - 32).toString() + "px");
+        const x = rect.x;
+        const y = rect.y - 32;
+        r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
+        r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
+        if (this.props.onPositionChange) {
+            this.props.onPositionChange(x, y);
+        }
     }
 
     unsnapWindow = () => {

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -118,6 +118,16 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
+            <Devider />
+            <button
+                onClick={props.clearSession}
+                type="button"
+                role="menuitem"
+                aria-label="Clear Session"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Clear Session</span>
+            </button>
         </div>
     )
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -26,6 +26,7 @@ export class Desktop extends Component {
             favourite_apps: {},
             hideSideBar: false,
             minimized_windows: {},
+            window_positions: {},
             desktop_apps: [],
             context_menus: {
                 desktop: false,
@@ -43,7 +44,26 @@ export class Desktop extends Component {
         ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
         this.fetchAppsData(() => {
-            this.openApp('about-alex');
+            const session = this.props.session || {};
+            const positions = {};
+            if (session.dock && session.dock.length) {
+                let favourite_apps = { ...this.state.favourite_apps };
+                session.dock.forEach(id => {
+                    favourite_apps[id] = true;
+                });
+                this.setState({ favourite_apps });
+            }
+
+            if (session.windows && session.windows.length) {
+                session.windows.forEach(({ id, x, y }) => {
+                    positions[id] = { x, y };
+                });
+                this.setState({ window_positions: positions }, () => {
+                    session.windows.forEach(({ id }) => this.openApp(id));
+                });
+            } else {
+                this.openApp('about-alex');
+            }
         });
         this.setContextListeners();
         this.setEventListeners();
@@ -288,6 +308,7 @@ export class Desktop extends Component {
         apps.forEach((app, index) => {
             if (this.state.closed_windows[app.id] === false) {
 
+                const pos = this.state.window_positions[app.id];
                 const props = {
                     title: app.title,
                     id: app.id,
@@ -304,6 +325,9 @@ export class Desktop extends Component {
                     allowMaximize: app.allowMaximize,
                     defaultWidth: app.defaultWidth,
                     defaultHeight: app.defaultHeight,
+                    initialX: pos ? pos.x : undefined,
+                    initialY: pos ? pos.y : undefined,
+                    onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                 }
 
                 windowsJsx.push(
@@ -312,6 +336,24 @@ export class Desktop extends Component {
             }
         });
         return windowsJsx;
+    }
+
+    updateWindowPosition = (id, x, y) => {
+        this.setState(prev => ({
+            window_positions: { ...prev.window_positions, [id]: { x, y } }
+        }), this.saveSession);
+    }
+
+    saveSession = () => {
+        if (!this.props.setSession) return;
+        const openWindows = Object.keys(this.state.closed_windows).filter(id => this.state.closed_windows[id] === false);
+        const windows = openWindows.map(id => ({
+            id,
+            x: this.state.window_positions[id] ? this.state.window_positions[id].x : 60,
+            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10
+        }));
+        const dock = Object.keys(this.state.favourite_apps).filter(id => this.state.favourite_apps[id]);
+        this.props.setSession({ ...this.props.session, windows, dock });
     }
 
     hideSideBar = (objId, hide) => {
@@ -401,12 +443,15 @@ export class Desktop extends Component {
             // tell childs that his app has been not minimised
             let minimized_windows = this.state.minimized_windows;
             minimized_windows[objId] = false;
-            this.setState({ minimized_windows: minimized_windows });
+            this.setState({ minimized_windows: minimized_windows }, this.saveSession);
             return;
         }
 
         //if app is already opened
-        if (this.app_stack.includes(objId)) this.focus(objId);
+        if (this.app_stack.includes(objId)) {
+            this.focus(objId);
+            this.saveSession();
+        }
         else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
@@ -437,7 +482,10 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, this.focus(objId));
+                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
+                    this.focus(objId);
+                    this.saveSession();
+                });
                 this.app_stack.push(objId);
             }, 200);
         }
@@ -459,7 +507,7 @@ export class Desktop extends Component {
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
 
-        this.setState({ closed_windows, favourite_apps });
+        this.setState({ closed_windows, favourite_apps }, this.saveSession);
     }
 
     pinApp = (id) => {
@@ -471,7 +519,7 @@ export class Desktop extends Component {
         let pinnedApps = JSON.parse(localStorage.getItem('pinnedApps')) || []
         if (!pinnedApps.includes(id)) pinnedApps.push(id)
         localStorage.setItem('pinnedApps', JSON.stringify(pinnedApps))
-        this.setState({ favourite_apps })
+        this.setState({ favourite_apps }, () => { this.saveSession(); })
         this.hideAllContextMenu()
     }
 
@@ -484,7 +532,7 @@ export class Desktop extends Component {
         let pinnedApps = JSON.parse(localStorage.getItem('pinnedApps')) || []
         pinnedApps = pinnedApps.filter(appId => appId !== id)
         localStorage.setItem('pinnedApps', JSON.stringify(pinnedApps))
-        this.setState({ favourite_apps })
+        this.setState({ favourite_apps }, () => { this.saveSession(); })
         this.hideAllContextMenu()
     }
 
@@ -612,7 +660,13 @@ export class Desktop extends Component {
                 {this.renderDesktopApps()}
 
                 {/* Context Menus */}
-                <DesktopMenu active={this.state.context_menus.desktop} openApp={this.openApp} addNewFolder={this.addNewFolder} openShortcutSelector={this.openShortcutSelector} />
+                <DesktopMenu
+                    active={this.state.context_menus.desktop}
+                    openApp={this.openApp}
+                    addNewFolder={this.addNewFolder}
+                    openShortcutSelector={this.openShortcutSelector}
+                    clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu
                     active={this.state.context_menus.app}

--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -1,11 +1,17 @@
-import React, { Component } from 'react';
+import React, { Component, useEffect } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
+import useSession from '../hooks/useSession';
+import { useSettings } from '../hooks/useSettings';
 
-interface UbuntuProps {}
+interface UbuntuProps {
+  session: ReturnType<typeof useSession>['session'];
+  setSession: ReturnType<typeof useSession>['setSession'];
+  clearSession: ReturnType<typeof useSession>['resetSession'];
+}
 
 interface UbuntuState {
   screen_locked: boolean;
@@ -15,7 +21,7 @@ interface UbuntuState {
 
 interface UbuntuContext {}
 
-export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuContext> {
+export class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuContext> {
   context!: UbuntuContext;
 
   constructor(props: UbuntuProps) {
@@ -138,8 +144,33 @@ export default class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuCo
           turnOn={this.turnOn}
         />
         <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-        <Desktop />
+        <Desktop
+          session={this.props.session}
+          setSession={this.props.setSession}
+          clearSession={this.props.clearSession}
+        />
       </div>
     );
   }
+}
+
+export default function UbuntuWithSession() {
+  const { session, setSession, resetSession } = useSession();
+  const { wallpaper, setWallpaper } = useSettings();
+
+  useEffect(() => {
+    setWallpaper(session.wallpaper);
+  }, [session.wallpaper, setWallpaper]);
+
+  useEffect(() => {
+    setSession({ ...session, wallpaper });
+  }, [wallpaper]);
+
+  return (
+    <Ubuntu
+      session={session}
+      setSession={setSession}
+      clearSession={resetSession}
+    />
+  );
 }

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -40,6 +40,14 @@ export default function usePersistentState<T>(
   }, [key, state]);
 
   const reset = () => setState(getInitial());
+  const clear = () => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // ignore remove errors
+    }
+    reset();
+  };
 
-  return [state, setState, reset] as const;
+  return [state, setState, reset, clear] as const;
 }

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,0 +1,44 @@
+import usePersistentState from './usePersistentState';
+import { defaults } from '../utils/settingsStore';
+
+export interface SessionWindow {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface DesktopSession {
+  windows: SessionWindow[];
+  wallpaper: string;
+  dock: string[];
+}
+
+const initialSession: DesktopSession = {
+  windows: [],
+  wallpaper: defaults.wallpaper,
+  dock: [],
+};
+
+function isSession(value: unknown): value is DesktopSession {
+  if (!value || typeof value !== 'object') return false;
+  const s = value as DesktopSession;
+  return (
+    Array.isArray(s.windows) &&
+    typeof s.wallpaper === 'string' &&
+    Array.isArray(s.dock)
+  );
+}
+
+export default function useSession() {
+  const [session, setSession, _reset, clear] = usePersistentState<DesktopSession>(
+    'desktop-session',
+    initialSession,
+    isSession,
+  );
+
+  const resetSession = () => {
+    clear();
+  };
+
+  return { session, setSession, resetSession };
+}


### PR DESCRIPTION
## Summary
- persist open windows, dock, and wallpaper to localStorage
- restore saved session on launch
- add clear session action to desktop menu

## Testing
- `npm test` *(fails: memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b098dab12483289b972e6d772f9da7