### PR TITLE
Add reduced motion and data preferences

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, reducedData, setReducedData } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
 
@@ -91,6 +91,17 @@ export function Settings() {
                 </label>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={reducedData}
+                        onChange={(e) => setReducedData(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Reduced Data
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
                     style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
@@ -134,7 +145,7 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4">
                 <button
-                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); }}
+                    onClick={async () => { await resetSettings(); setAccent(defaults.accent); setWallpaper(defaults.wallpaper); setDensity(defaults.density); setReducedMotion(defaults.reducedMotion); setReducedData(defaults.reducedData); }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,8 +1,20 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
+    const { wallpaper, reducedData } = useSettings();
+    const [prefersReducedData, setPrefersReducedData] = useState(false);
+
+    useEffect(() => {
+        const mq = window.matchMedia('(prefers-reduced-data: reduce)');
+        const handler = (e) => setPrefersReducedData(e.matches);
+        setPrefersReducedData(mq.matches);
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, []);
+
+    if (reducedData || prefersReducedData) return null;
+
     return (
         <div style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPositionX: "center" }} className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
         </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -8,6 +8,8 @@ import {
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
+  getReducedData as loadReducedData,
+  setReducedData as saveReducedData,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -17,10 +19,12 @@ interface SettingsContextValue {
   wallpaper: string;
   density: Density;
   reducedMotion: boolean;
+  reducedData: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
+  setReducedData: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -28,10 +32,12 @@ export const SettingsContext = createContext<SettingsContextValue>({
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
+  reducedData: defaults.reducedData,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
+  setReducedData: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -39,6 +45,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
+  const [reducedData, setReducedData] = useState<boolean>(defaults.reducedData);
 
   useEffect(() => {
     (async () => {
@@ -46,6 +53,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
+      setReducedData(await loadReducedData());
     })();
   }, []);
 
@@ -89,8 +97,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('reduced-data', reducedData);
+    saveReducedData(reducedData);
+  }, [reducedData]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, setAccent, setWallpaper, setDensity, setReducedMotion }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, reducedData, setAccent, setWallpaper, setDensity, setReducedMotion, setReducedData }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,3 +17,25 @@
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (prefers-reduced-data: reduce) {
+  .bg-ubuntu-img {
+    background-image: none !important;
+  }
+}
+
+.reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+.reduced-data .bg-ubuntu-img {
+  background-image: none !important;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -5,6 +5,7 @@ const DEFAULT_SETTINGS = {
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,
+  reducedData: false,
 };
 
 export async function getAccent() {
@@ -47,6 +48,16 @@ export async function setReducedMotion(value) {
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
+export async function getReducedData() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedData;
+  return window.localStorage.getItem('reduced-data') === 'true';
+}
+
+export async function setReducedData(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('reduced-data', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -55,6 +66,7 @@ export async function resetSettings() {
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
+  window.localStorage.removeItem('reduced-data');
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add global CSS to honor `prefers-reduced-motion` and `prefers-reduced-data`
- expose reduced motion and data saver toggles in settings
- avoid loading wallpapers when reduced data is enabled

## Testing
- `npm test` *(fails: memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, frogger.config.test.ts, snake.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b098dc58cc8328b72d190ed15e9e2b