### PR TITLE
Add keyboard shortcuts help modal

### DIFF
--- a/components/help/ShortcutsModal.tsx
+++ b/components/help/ShortcutsModal.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+import useFocusTrap from '../../hooks/useFocusTrap';
+
+interface Shortcut {
+  keys: string;
+  description: string;
+}
+
+interface Group {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+const GROUPS: Group[] = [
+  {
+    title: 'General',
+    shortcuts: [
+      { keys: 'Ctrl+/', description: 'Show keyboard shortcuts' },
+      { keys: 'Esc', description: 'Close active modal' }
+    ]
+  },
+  {
+    title: 'Navigation',
+    shortcuts: [
+      { keys: 'Tab', description: 'Move focus forward' },
+      { keys: 'Shift+Tab', description: 'Move focus backward' }
+    ]
+  }
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ShortcutsModal = ({ open, onClose }: Props) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap(modalRef, open);
+
+  useEffect(() => {
+    if (!open) return;
+
+    closeRef.current?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        ref={modalRef}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white text-black p-4 rounded max-w-md w-full focus:outline-none"
+      >
+        <h2 className="text-lg font-bold mb-4">Keyboard Shortcuts</h2>
+        {GROUPS.map((group) => (
+          <div key={group.title} className="mb-4">
+            <h3 className="font-semibold mb-2">{group.title}</h3>
+            <ul>
+              {group.shortcuts.map((s) => (
+                <li key={s.keys} className="flex justify-between mb-1">
+                  <span>{s.description}</span>
+                  <kbd className="px-1 py-0.5 border rounded bg-gray-100">
+                    {s.keys}
+                  </kbd>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+        <Link href="/settings" className="text-blue-600 underline">
+          Customize shortcuts in settings
+        </Link>
+        <div className="mt-4 text-right">
+          <button
+            ref={closeRef}
+            className="px-2 py-1 bg-blue-600 text-white rounded"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShortcutsModal;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import 'tailwindcss/tailwind.css';
@@ -7,43 +7,62 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import ShortcutsModal from '../components/help/ShortcutsModal';
 
 /**
  * @param {import('next/app').AppProps} props
  */
-function MyApp({ Component, pageProps }) {
-  useEffect(() => {
-    const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
-    if (trackingId) {
-      ReactGA.initialize(trackingId);
-    }
-    if (
-      process.env.NODE_ENV === 'production' &&
-      'serviceWorker' in navigator
-    ) {
-      fetch('/service-worker.js', { method: 'HEAD' })
-        .then((res) => {
-          if (res.ok) {
-            navigator.serviceWorker
-              .register('/service-worker.js')
-              .catch((err) => {
-                console.error('Service worker registration failed', err);
-              });
-          } else {
-            console.warn('Service worker file not found');
-          }
-        })
-        .catch((err) => {
-          console.error('Service worker check failed', err);
-        });
-    }
-  }, []);
-  return (
-    <SettingsProvider>
-      <Component {...pageProps} />
-      <Analytics />
-    </SettingsProvider>
-  );
-}
+  function MyApp({ Component, pageProps }) {
+    const [showShortcuts, setShowShortcuts] = useState(false);
+
+    useEffect(() => {
+      const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
+      if (trackingId) {
+        ReactGA.initialize(trackingId);
+      }
+      if (
+        process.env.NODE_ENV === 'production' &&
+        'serviceWorker' in navigator
+      ) {
+        fetch('/service-worker.js', { method: 'HEAD' })
+          .then((res) => {
+            if (res.ok) {
+              navigator.serviceWorker
+                .register('/service-worker.js')
+                .catch((err) => {
+                  console.error('Service worker registration failed', err);
+                });
+            } else {
+              console.warn('Service worker file not found');
+            }
+          })
+          .catch((err) => {
+            console.error('Service worker check failed', err);
+          });
+      }
+    }, []);
+
+    useEffect(() => {
+      const handle = (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === '/') {
+          e.preventDefault();
+          setShowShortcuts(true);
+        }
+      };
+      document.addEventListener('keydown', handle);
+      return () => document.removeEventListener('keydown', handle);
+    }, []);
+
+    return (
+      <SettingsProvider>
+        <Component {...pageProps} />
+        <ShortcutsModal
+          open={showShortcuts}
+          onClose={() => setShowShortcuts(false)}
+        />
+        <Analytics />
+      </SettingsProvider>
+    );
+  }
 
 export default MyApp;


### PR DESCRIPTION
## Summary
- add ShortcutsModal component with grouped keyboard shortcuts and settings link
- trigger ShortcutsModal on Ctrl+/ with focus trapping for accessibility

## Testing
- `npm test` *(fails: combo meter increments, BeEF app hooks, Autopsy filters, UnitConverter sliders, snake.config, frogger.config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx:391)*

------
https://chatgpt.com/codex/tasks/task_e_68b098d6f4c883288e14887337ac6e63