### PR TITLE
feat: add responsive typography scale

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -5,6 +5,39 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    font-size: var(--font-size-base);
+}
+
+h1 {
+    font-size: var(--font-size-4xl);
+}
+
+h2 {
+    font-size: var(--font-size-3xl);
+}
+
+h3 {
+    font-size: var(--font-size-2xl);
+}
+
+h4 {
+    font-size: var(--font-size-xl);
+}
+
+h5 {
+    font-size: var(--font-size-lg);
+}
+
+h6 {
+    font-size: var(--font-size-base);
+}
+
+p {
+    font-size: var(--font-size-base);
+}
+
+small {
+    font-size: var(--font-size-sm);
 }
 
 a:focus-visible,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -47,6 +47,16 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+
+  /* Responsive typography scale */
+  --font-size-xs: clamp(0.75rem, 0.7rem + 0.5vw, 0.875rem);
+  --font-size-sm: clamp(0.875rem, 0.83rem + 0.5vw, 1rem);
+  --font-size-base: clamp(1rem, 0.95rem + 0.5vw, 1.125rem);
+  --font-size-lg: clamp(1.125rem, 1.05rem + 0.6vw, 1.25rem);
+  --font-size-xl: clamp(1.25rem, 1.15rem + 0.6vw, 1.5rem);
+  --font-size-2xl: clamp(1.5rem, 1.35rem + 0.8vw, 1.875rem);
+  --font-size-3xl: clamp(1.875rem, 1.6rem + 1vw, 2.25rem);
+  --font-size-4xl: clamp(2.25rem, 2rem + 1.2vw, 3rem);
 }
 
 /* High contrast theme */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,16 @@ module.exports = {
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },
+      fontSize: {
+        xs: 'var(--font-size-xs)',
+        sm: 'var(--font-size-sm)',
+        base: 'var(--font-size-base)',
+        lg: 'var(--font-size-lg)',
+        xl: 'var(--font-size-xl)',
+        '2xl': 'var(--font-size-2xl)',
+        '3xl': 'var(--font-size-3xl)',
+        '4xl': 'var(--font-size-4xl)',
+      },
       minWidth: {
         '0': '0',
         '1/4': '25%',


### PR DESCRIPTION
## Summary
- define responsive font-size tokens using `clamp`
- apply new scale to global typography and Tailwind theme

## Testing
- `npm test` *(fails: combo meter increments and resets, card flip applies transform style, filters artifacts by type, updates hook list when new hooks arrive, streams module output to UI, keeps sliders synchronized, Snake config, Frogger config)*
- `npm run lint` *(fails: Parsing error in components/apps/Chrome/index.tsx:391:4)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880364388328a141887b7da9c47c