### PR TITLE
feat: add accessible modal component

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Modal from '../components/base/Modal';
+
+test('modal traps focus and restores focus on close', async () => {
+  const Wrapper: React.FC = () => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <>
+        <button onClick={() => setOpen(true)}>open</button>
+        <Modal isOpen={open} onClose={() => setOpen(false)}>
+          <button>first</button>
+          <button>second</button>
+        </Modal>
+      </>
+    );
+  };
+
+  const { getByText } = render(<Wrapper />);
+  const openButton = getByText('open');
+  openButton.focus();
+  fireEvent.click(openButton);
+
+  const first = getByText('first');
+  const second = getByText('second');
+  expect(first).toHaveFocus();
+
+  second.focus();
+  fireEvent.keyDown(second, { key: 'Tab' });
+  expect(first).toHaveFocus();
+
+  fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+  expect(second).toHaveFocus();
+
+  fireEvent.keyDown(first, { key: 'Escape' });
+  await waitFor(() => expect(openButton).toHaveFocus());
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+
+interface ModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    children: React.ReactNode;
+}
+
+const FOCUSABLE_SELECTORS = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '[tabindex]:not([tabindex="-1"])',
+    '[contenteditable]'
+].join(',');
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLElement | null>(null);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            onClose();
+            return;
+        }
+        if (e.key !== 'Tab') return;
+        const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+        if (!elements || elements.length === 0) return;
+        const first = elements[0];
+        const last = elements[elements.length - 1];
+        const current = document.activeElement as HTMLElement;
+        if (!e.shiftKey && current === last) {
+            e.preventDefault();
+            first.focus();
+        } else if (e.shiftKey && current === first) {
+            e.preventDefault();
+            last.focus();
+        }
+    }, [onClose]);
+
+    useEffect(() => {
+        if (isOpen) {
+            triggerRef.current = document.activeElement as HTMLElement;
+            const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+            if (elements && elements.length > 0) {
+                elements[0].focus();
+            } else {
+                modalRef.current?.focus();
+            }
+        } else {
+            triggerRef.current?.focus();
+            triggerRef.current = null;
+        }
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            ref={modalRef}
+            onKeyDown={handleKeyDown}
+            tabIndex={-1}
+        >
+            {children}
+        </div>
+    );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- add base Modal component with focus management and keyboard handling
- ensure Tab loops within modal and Escape closes
- restore focus to trigger after close

## Testing
- `npm test __tests__/Modal.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b098dd9adc8328b2fc07348624138a