### PR TITLE
chore: set up node in deploy workflow

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -9,18 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
+          node-version: '20.x'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
       - name: Installing Packages
         run: yarn install
 


### PR DESCRIPTION
## Summary
- configure Node.js 20 setup with yarn cache for gh-deploy workflow

## Testing
- `yarn install --frozen-lockfile`
- `yarn build` *(fails: Parsing error in components/apps/Chrome/index.tsx:391)*
- `yarn test --ci` *(fails: multiple failing tests and syntax error in components/apps/Chrome/index.tsx)*
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx:391)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a31501548328ac7254e19ed4ce5a