### PR TITLE
feat: add feature flags for tool APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Heavy apps are wrapped with **dynamic import** and most games share a `GameLayou
 | `NEXT_PUBLIC_GHIDRA_URL` | Optional URL for a remote Ghidra Web interface. |
 | `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |
 | `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
+| `FEATURE_TOOL_APIS` | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow. |
+| `FEATURE_HYDRA` | Allow the Hydra API (`/api/hydra`); requires `FEATURE_TOOL_APIS`. |
 
 > In production (Vercel/GitHub Actions), set these as **environment variables or repo secrets**. See **CI/CD** below.
 

--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -7,6 +7,9 @@ jest.mock('crypto', () => ({
   randomUUID: randomUUIDMock,
 }));
 
+process.env.FEATURE_TOOL_APIS = 'enabled';
+process.env.FEATURE_HYDRA = 'enabled';
+
 jest.mock('child_process', () => ({
   execFile: (cmd, args, options, callback) => {
     if (typeof options === 'function') {
@@ -36,4 +39,9 @@ test('removes temp files after hydra execution', async () => {
 
   await expect(fs.access(userPath)).rejects.toBeTruthy();
   await expect(fs.access(passPath)).rejects.toBeTruthy();
+});
+
+afterAll(() => {
+  delete process.env.FEATURE_TOOL_APIS;
+  delete process.env.FEATURE_HYDRA;
 });

--- a/__tests__/hydra.api.test.ts
+++ b/__tests__/hydra.api.test.ts
@@ -10,11 +10,17 @@ async function cleanup() {
 }
 
 describe('Hydra API temp file cleanup', () => {
+  beforeEach(() => {
+    process.env.FEATURE_TOOL_APIS = 'enabled';
+    process.env.FEATURE_HYDRA = 'enabled';
+  });
   afterEach(async () => {
     jest.resetModules();
     jest.dontMock('child_process');
     jest.dontMock('crypto');
     await cleanup();
+    delete process.env.FEATURE_TOOL_APIS;
+    delete process.env.FEATURE_HYDRA;
   });
 
   it('removes temp files after successful run', async () => {

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -6,6 +6,13 @@ import { promisify } from 'util';
 const execFileAsync = promisify(execFile);
 
 export default async function handler(req, res) {
+  if (
+    process.env.FEATURE_TOOL_APIS !== 'enabled' ||
+    process.env.FEATURE_HYDRA !== 'enabled'
+  ) {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
   // Hydra is an optional external dependency. Environments without the
   // actual binary may stub this handler for demonstration purposes.
   if (req.method !== 'POST') {

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -7,6 +7,10 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 
 export default async function handler(req, res) {
+  if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
   // John the Ripper is optional; environments without the binary can stub
   // this handler to return canned responses for demonstration.
   if (req.method !== 'POST') {

--- a/pages/api/metasploit.js
+++ b/pages/api/metasploit.js
@@ -1,6 +1,10 @@
 import modules from '../../components/apps/metasploit/modules.json';
 
 export default function handler(req, res) {
+  if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end('Method Not Allowed');

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,6 +1,10 @@
 import modules from '../../components/apps/mimikatz/modules.json';
 
 export default async function handler(req, res) {
+  if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
   if (req.method === 'GET') {
     const { command } = req.query || {};
     if (command) {

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -7,6 +7,10 @@ import { promisify } from 'util';
 const execFileAsync = promisify(execFile);
 
 export default async function handler(req, res) {
+  if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
+    res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
   // Radare2 utilities are optional; this endpoint may be stubbed when the
   // binaries are unavailable.
   if (req.method !== 'POST') {


### PR DESCRIPTION
## Summary
- add FEATURE_TOOL_APIS and FEATURE_HYDRA env flags
- gate hydra, john, metasploit, mimikatz, and radare2 APIs behind feature flags
- document feature flags and update hydra API tests

## Testing
- `yarn test` *(fails: terminal, memoryGame, beef, converter)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a31a547c8328b040273ec8e91bc7