### PR TITLE
feat: validate hydra service

### DIFF
--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
+const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
 export default async function handler(req, res) {
   // Hydra is an optional external dependency. Environments without the
@@ -16,6 +17,10 @@ export default async function handler(req, res) {
   const { target, service, userList, passList } = req.body || {};
   if (!target || !service || !userList || !passList) {
     res.status(400).json({ error: 'Missing parameters' });
+    return;
+  }
+  if (!allowed.has(service)) {
+    res.status(400).json({ error: 'Unsupported service' });
     return;
   }
 


### PR DESCRIPTION
## Summary
- restrict hydra API to known services
- reject unsupported hydra service requests with 400

## Testing
- `yarn test hydra`
- `yarn lint` *(fails: Parsing error: ')' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a31b4e7c8328a7dcbd3c4638f8d0