### PR TITLE
chore: use eslint for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ See [`LICENSE`](./LICENSE).
 - `export` → `next export`
 - `test` → `jest`
 - `test:watch` → `jest --watch`
-- `lint` → `next lint`
+- `lint` → `eslint --max-warnings=0 .`
 - `smoke` → `node scripts/smoke-all-apps.mjs`
 
 ### Smoke Tests

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "export": "next export",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "next lint",
+    "lint": "eslint --max-warnings=0 .",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "build:sw": "node scripts/generate-sw.mjs"


### PR DESCRIPTION
## Summary
- replace Next.js lint command with direct ESLint check with zero warnings allowed
- document updated lint command

## Testing
- `yarn lint` (fails: ESLint couldn't find configuration file)
- `yarn test` (fails: multiple test suites failing)


------
https://chatgpt.com/codex/tasks/task_e_68b0a31c35a48328af5cee79041d5f8c