### PR TITLE
chore: expand a11y tests and img alt text

### DIFF
--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -161,7 +161,7 @@ export default function YouTubePlayer({ videoId }) {
             >
               <img
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
-                alt=""
+                alt="YouTube video thumbnail"
                 loading="lazy"
                 className="absolute inset-0 w-full h-full object-cover"
               />

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -134,7 +134,11 @@ export class SideBarApp extends Component {
                             " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
                         }
                     >
-                        <img src={this.state.thumbnail} alt="" className="w-32 h-auto" />
+                        <img
+                            src={this.state.thumbnail}
+                            alt={`Preview of ${this.props.title}`}
+                            className="w-32 h-auto"
+                        />
                     </div>
                 )}
                 <div

--- a/playwright/a11y.spec.ts
+++ b/playwright/a11y.spec.ts
@@ -1,7 +1,21 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const urls = ['/', '/apps'];
+const urls = [
+  '/',
+  '/apps',
+  '/apps/chess',
+  '/apps/sudoku',
+  '/apps/youtube',
+  // Additional resource-heavy apps
+  '/apps/vscode',
+  '/apps/spotify',
+  '/apps/x',
+  '/apps/chrome',
+  '/apps/trash',
+  '/apps/gedit',
+  '/apps/todoist',
+];
 
 for (const path of urls) {
   test(`no critical accessibility violations on ${path}`, async ({ page }) => {


### PR DESCRIPTION
## Summary
- broaden Playwright a11y coverage to heavy application routes
- add descriptive alt text for preview thumbnails and video posters

## Testing
- `npm test` *(fails: terminal, autopsy, converter, snake.config, frogger.config)*
- `npx playwright test playwright/a11y.spec.ts` *(missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a32081f88328905f4a3ede1d3b9c