### PR TITLE
chore: lazy load cytoscape graph

### DIFF
--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Image from 'next/image';
+import dynamic from 'next/dynamic';
 import GuideOverlay from './GuideOverlay';
-import HookGraph from './HookGraph';
+
+const HookGraph = dynamic(() => import('./HookGraph'), { ssr: false });
 
 export default function Beef() {
   const [hooks, setHooks] = useState([]);


### PR DESCRIPTION
## Summary
- audit components using heavy libs like cytoscape, three, phaser
- lazy load BeEF HookGraph component with `next/dynamic`

## Testing
- `yarn build` *(fails: Parsing error: ')' expected in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: unable to find element with text: 1 in __tests__/beef.test.tsx, plus other failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a322d94c8328bf54ac3a7c96824f