### PR TITLE
docs: clarify service worker behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ To send text or links directly into the Sticky Notes app:
 3. After installation, use the system **Share** action and select "Kali Linux Portfolio".
 4. The shared content will appear as a new note.
 
+### Service Worker (SW)
+
+- Only assets under `public/` are precached.
+- Dynamic routes or API responses are not cached.
+- Future work may use `injectManifest` for finer control.
+
 ---
 
 ## Tech Stack


### PR DESCRIPTION
## Summary
- document service worker precaching limitations
- note that dynamic routes and API responses are not cached
- mention potential future use of `injectManifest`

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: multiple failing test suites such as terminal, memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3257e408328a80e569e77d875d8