### PR TITLE
feat: add monaco-based tabbed code viewer

### DIFF
--- a/apps/code-viewer/index.tsx
+++ b/apps/code-viewer/index.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import tree from './sample-project.json';
+
+// Dynamically import Monaco and TypeScript language support
+const Editor = dynamic(async () => {
+  await import('monaco-editor/esm/vs/language/typescript/monaco.contribution');
+  const mod = await import('@monaco-editor/react');
+  return mod.default;
+}, { ssr: false });
+
+type FileNode = {
+  name: string;
+  type: 'file' | 'folder';
+  content?: string;
+  children?: FileNode[];
+};
+
+type FileEntry = { path: string; content: string };
+
+function flatten(node: FileNode, prefix = ''): FileEntry[] {
+  if (node.type === 'file') {
+    return [{ path: `${prefix}${node.name}`, content: node.content || '' }];
+  }
+  return (
+    node.children?.flatMap((child) => flatten(child, `${prefix}${node.name}/`)) || []
+  );
+}
+
+const allFiles: FileEntry[] = (tree as FileNode[]).flatMap((n) => flatten(n));
+
+export default function CodeViewer() {
+  const [openFiles, setOpenFiles] = useState<FileEntry[]>([]);
+  const [active, setActive] = useState(0);
+
+  function open(file: FileEntry) {
+    const existing = openFiles.findIndex((f) => f.path === file.path);
+    if (existing !== -1) {
+      setActive(existing);
+    } else {
+      setOpenFiles([...openFiles, file]);
+      setActive(openFiles.length);
+    }
+  }
+
+  const activeFile = openFiles[active];
+
+  return (
+    <div className="flex h-screen bg-gray-900 text-gray-100">
+      <aside className="w-64 overflow-auto border-r border-gray-700">
+        <ul>
+          {allFiles.map((file) => (
+            <li key={file.path}>
+              <button
+                className="w-full px-3 py-1 text-left hover:bg-gray-800"
+                onClick={() => open(file)}
+              >
+                {file.path}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <div className="flex border-b border-gray-700">
+          {openFiles.map((file, i) => (
+            <button
+              key={file.path}
+              onClick={() => setActive(i)}
+              className={`px-3 py-1 text-sm border-r border-gray-700 ${
+                i === active ? 'bg-gray-900' : 'bg-gray-800'
+              }`}
+            >
+              {file.path.split('/').pop()}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1">
+          {activeFile ? (
+            <Editor
+              height="100%"
+              defaultLanguage={languageFromPath(activeFile.path)}
+              value={activeFile.content}
+              options={{ readOnly: true, minimap: { enabled: false } }}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              Select a file
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function languageFromPath(path: string): string {
+  if (path.endsWith('.ts') || path.endsWith('.tsx')) return 'typescript';
+  if (path.endsWith('.js') || path.endsWith('.jsx')) return 'javascript';
+  if (path.endsWith('.json')) return 'json';
+  if (path.endsWith('.md')) return 'markdown';
+  return 'plaintext';
+}

--- a/apps/code-viewer/sample-project.json
+++ b/apps/code-viewer/sample-project.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "src",
+    "type": "folder",
+    "children": [
+      {
+        "name": "index.ts",
+        "type": "file",
+        "content": "export const hello = () => console.log('Hello, Monaco!');\n"
+      },
+      {
+        "name": "App.tsx",
+        "type": "file",
+        "content": "import React from 'react';\nexport default function App() {\n  return <h1>Sample Project</h1>;\n}\n"
+      }
+    ]
+  },
+  {
+    "name": "package.json",
+    "type": "file",
+    "content": "{\n  \"name\": \"sample-project\",\n  \"version\": \"1.0.0\"\n}\n"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
+    "@monaco-editor/react": "^4.7.0",
     "@mozilla/readability": "^0.6.0",
     "@vercel/analytics": "^1.5.0",
     "@xterm/addon-fit": "^0.10.0",
@@ -43,6 +44,7 @@
     "idb-keyval": "^6.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
+    "monaco-editor": "^0.52.2",
     "next": "^15.0.0",
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",

--- a/pages/apps/code-viewer.tsx
+++ b/pages/apps/code-viewer.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const CodeViewer = dynamic(() => import('../../apps/code-viewer'), { ssr: false });
+
+export default function CodeViewerPage() {
+  return <CodeViewer />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,6 +2202,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@monaco-editor/loader@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@monaco-editor/loader@npm:1.5.0"
+  dependencies:
+    state-local: "npm:^1.0.6"
+  checksum: 10c0/d8e1fd75fea113b4d91405784ed4db757df450c6e57a85e87728281e819a73a3ef9fe0cbb1dc1509456f1e895ad9c11e4748f80b68900cb6cf600170e14ce6ed
+  languageName: node
+  linkType: hard
+
+"@monaco-editor/react@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@monaco-editor/react@npm:4.7.0"
+  dependencies:
+    "@monaco-editor/loader": "npm:^1.5.0"
+  peerDependencies:
+    monaco-editor: ">= 0.25.0 < 1"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/a4e91c6eda1a71f5fd23871bd801de435490ccbc43934d23cba65cefe2be7e9d02c9a57c4ef80fc9fe99e4d4deea51e5db19cb4e0ecf3f51818dda0eb9cdbf12
+  languageName: node
+  linkType: hard
+
 "@mozilla/readability@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mozilla/readability@npm:0.6.0"
@@ -8345,6 +8367,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:^0.52.2":
+  version: 0.52.2
+  resolution: "monaco-editor@npm:0.52.2"
+  checksum: 10c0/5a92da64f1e2ab375c0ce99364137f794d057c97bed10ecc65a08d6e6846804b8ecbd377eacf01e498f7dfbe1b21e8be64f728256681448f0484df90e767b435
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -10294,6 +10323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"state-local@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "state-local@npm:1.0.7"
+  checksum: 10c0/8dc7daeac71844452fafb514a6d6b6f40d7e2b33df398309ea1c7b3948d6110c57f112b7196500a10c54fdde40291488c52c875575670fb5c819602deca48bd9
+  languageName: node
+  linkType: hard
+
 "static-eval@npm:2.0.2":
   version: 2.0.2
   resolution: "static-eval@npm:2.0.2"
@@ -11211,6 +11247,7 @@ __metadata:
   dependencies:
     "@axe-core/playwright": "npm:^4.10.2"
     "@emailjs/browser": "npm:^3.10.0"
+    "@monaco-editor/react": "npm:^4.7.0"
     "@mozilla/readability": "npm:^0.6.0"
     "@playwright/test": "npm:^1.55.0"
     "@testing-library/dom": "npm:^10.4.1"
@@ -11251,6 +11288,7 @@ __metadata:
     jest-environment-jsdom: "npm:30.0.5"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
+    monaco-editor: "npm:^0.52.2"
     next: "npm:^15.0.0"
     pa11y: "npm:^9.0.0"
     pdfjs-dist: "npm:^5.4.54"


### PR DESCRIPTION
## Summary
- dynamically load Monaco editor with TypeScript support
- render sample project from JSON file tree
- provide tabbed, read-only code viewer

## Testing
- `yarn test` *(fails: Terminal component, memoryGame, autopsy, beef, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a38e15e883288f4499a58c24096f