### PR TITLE
feat: add YouTube trending fallback and hotkeys

### DIFF
--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import YouTubeApp from '../components/apps/youtube';
+import trending from '../lib/youtubeTrending.json';
 
 const mockVideos = [
   {
     id: '1',
     title: 'React Tutorial',
     playlist: 'Dev',
+    playlistId: 'dev',
     publishedAt: '2022-01-01T00:00:00Z',
     thumbnail: 'thumb1.jpg',
     url: 'https://youtu.be/1',
@@ -16,6 +18,7 @@ const mockVideos = [
     id: '2',
     title: 'Cooking with React',
     playlist: 'Cook',
+    playlistId: 'cook',
     publishedAt: '2022-02-01T00:00:00Z',
     thumbnail: 'thumb2.jpg',
     url: 'https://youtu.be/2',
@@ -24,6 +27,7 @@ const mockVideos = [
     id: '3',
     title: 'Advanced React',
     playlist: 'Dev',
+    playlistId: 'dev',
     publishedAt: '2021-06-01T00:00:00Z',
     thumbnail: 'thumb3.jpg',
     url: 'https://youtu.be/3',
@@ -33,13 +37,14 @@ const mockVideos = [
 describe('YouTubeApp', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_YOUTUBE_API_KEY = 'test';
+    window.localStorage.clear();
   });
 
-  it('shows message when API key is missing', () => {
+  it('falls back to trending data when API key is missing', async () => {
     delete process.env.NEXT_PUBLIC_YOUTUBE_API_KEY;
     render(<YouTubeApp />);
     expect(
-      screen.getByText(/YouTube API key is not configured/i)
+      await screen.findByText(trending[0].title)
     ).toBeInTheDocument();
   });
 
@@ -148,6 +153,13 @@ describe('YouTubeApp', () => {
     screen
       .getAllByTestId('video-card')
       .forEach((card) => expect(card).toHaveClass('transition'));
+  });
+
+  it('stores last playlist ID in localStorage', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeApp initialVideos={mockVideos} />);
+    await user.click(screen.getByText('React Tutorial'));
+    expect(window.localStorage.getItem('ytLastPlaylist')).toBe('dev');
   });
 
   it('memoizes categories and sorted lists between renders', async () => {

--- a/lib/youtubeTrending.json
+++ b/lib/youtubeTrending.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "tr1",
+    "title": "Trending Video One",
+    "playlist": "Trending",
+    "playlistId": "trending",
+    "publishedAt": "2024-01-01T00:00:00Z",
+    "thumbnail": "https://i.ytimg.com/vi/tr1/mqdefault.jpg",
+    "url": "https://www.youtube.com/watch?v=tr1"
+  },
+  {
+    "id": "tr2",
+    "title": "Trending Video Two",
+    "playlist": "Trending",
+    "playlistId": "trending",
+    "publishedAt": "2024-02-01T00:00:00Z",
+    "thumbnail": "https://i.ytimg.com/vi/tr2/mqdefault.jpg",
+    "url": "https://www.youtube.com/watch?v=tr2"
+  }
+]


### PR DESCRIPTION
## Summary
- show preloaded trending videos when no YouTube API key is set
- add keyboard hotkeys and remember last playlist selection

## Testing
- `npm test` *(fails: Terminal component tests, memory game combo meter, BeEF hooks, autopsy filters, converter sliders, snake config, frogger config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3926bbc8328bd0fefcb44141e08