### PR TITLE
Add hook flow diagram page with official docs link

### DIFF
--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+const HookFlow: React.FC = () => {
+  const [consented, setConsented] = useState(false);
+
+  if (!consented) {
+    return (
+      <main className="p-4 text-center">
+        <p className="mb-4 font-bold">
+          This page contains diagrams and links to external documentation.
+        </p>
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={() => setConsented(true)}
+        >
+          Continue
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <img
+        src="/hook-flow.svg"
+        alt="React hook flow diagram"
+        className="mx-auto"
+      />
+      <iframe
+        title="React Hooks Documentation"
+        src="https://react.dev/learn/hooks"
+        sandbox="allow-scripts allow-same-origin"
+        className="w-full h-96 border"
+      />
+    </main>
+  );
+};
+
+export default HookFlow;

--- a/public/hook-flow.svg
+++ b/public/hook-flow.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="120" viewBox="0 0 420 120">
+  <style>
+    text { font-family: sans-serif; font-size: 14px; }
+  </style>
+  <rect x="10" y="40" width="100" height="40" fill="#4ade80" />
+  <text x="60" y="65" text-anchor="middle">useState</text>
+  <line x1="110" y1="60" x2="190" y2="60" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="190" y="40" width="100" height="40" fill="#60a5fa" />
+  <text x="240" y="65" text-anchor="middle">useEffect</text>
+  <line x1="290" y1="60" x2="370" y2="60" stroke="#000" marker-end="url(#arrow)" />
+  <rect x="370" y="40" width="40" height="40" fill="#f87171" />
+  <text x="390" y="65" text-anchor="middle">cleanup</text>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#000" />
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add `/hook-flow` page gating access with an opt-in disclaimer
- include static SVG diagram describing React hook flow
- embed sandboxed iframe pointing to official React hooks docs

## Testing
- `yarn test` *(fails: Terminal component, beef, autopsy, converter, frogger config, snake config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a39349d88328a7da140b94555458