### PR TITLE
feat: add accessible settings panel controls

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale, highContrast, setHighContrast } = useSettings();
+    const [theme, setThemeState] = useState(getTheme());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -60,6 +62,19 @@ export function Settings() {
             <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Theme:</label>
+                <select
+                    value={theme}
+                    onChange={(e) => { setThemeState(e.target.value); setTheme(e.target.value); }}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="default">Default</option>
+                    <option value="dark">Dark</option>
+                    <option value="neon">Neon</option>
+                    <option value="matrix">Matrix</option>
+                </select>
+            </div>
+            <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
                 <input
                     type="color"
@@ -101,6 +116,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Reduced Motion
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={highContrast}
+                        onChange={(e) => setHighContrast(e.target.checked)}
+                        className="mr-2"
+                    />
+                    High Contrast
                 </label>
             </div>
             <div className="flex justify-center my-4">
@@ -175,6 +201,9 @@ export function Settings() {
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
                         setFontScale(defaults.fontScale);
+                        setHighContrast(defaults.highContrast);
+                        setThemeState('default');
+                        setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
@@ -196,6 +225,8 @@ export function Settings() {
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.theme !== undefined) { setThemeState(parsed.theme); setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
   setFontScale as saveFontScale,
+  getHighContrast as loadHighContrast,
+  setHighContrast as saveHighContrast,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -36,11 +38,13 @@ interface SettingsContextValue {
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
+  highContrast: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
+  setHighContrast: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -49,11 +53,13 @@ export const SettingsContext = createContext<SettingsContextValue>({
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
+  highContrast: defaults.highContrast,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
+  setHighContrast: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -62,6 +68,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
+  const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
 
   useEffect(() => {
     (async () => {
@@ -70,6 +77,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
+      setHighContrast(await loadHighContrast());
     })();
   }, []);
 
@@ -127,8 +135,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveFontScale(fontScale);
   }, [fontScale]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('high-contrast', highContrast);
+    saveHighContrast(highContrast);
+  }, [highContrast]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,4 +1,5 @@
 import { get, set, del } from 'idb-keyval';
+import { getTheme, setTheme } from './theme';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -6,6 +7,7 @@ const DEFAULT_SETTINGS = {
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
+  highContrast: false,
 };
 
 export async function getAccent() {
@@ -59,6 +61,16 @@ export async function setFontScale(scale) {
   window.localStorage.setItem('font-scale', String(scale));
 }
 
+export async function getHighContrast() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  return window.localStorage.getItem('high-contrast') === 'true';
+}
+
+export async function setHighContrast(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -68,16 +80,19 @@ export async function resetSettings() {
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
+  window.localStorage.removeItem('high-contrast');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion] = await Promise.all([
+  const [accent, wallpaper, density, reducedMotion, highContrast] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
     getReducedMotion(),
+    getHighContrast(),
   ]);
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion });
+  const theme = getTheme();
+  return JSON.stringify({ accent, wallpaper, density, reducedMotion, highContrast, theme });
 }
 
 export async function importSettings(json) {
@@ -89,11 +104,13 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion } = settings;
+  const { accent, wallpaper, density, reducedMotion, highContrast, theme } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
+  if (highContrast !== undefined) await setHighContrast(highContrast);
+  if (theme !== undefined) setTheme(theme);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- extend settings store and context with high contrast preference
- add theme selector, high contrast toggle, and other controls in settings app
- persist theme/contrast options alongside existing preferences

## Testing
- `yarn test __tests__/terminal.test.tsx __tests__/memoryGame.test.tsx` *(fails: Function components cannot be given refs, combo meter increments and resets)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a39538d08328a9e4990a45d3c284