### PR TITLE
feat: enhance project gallery filtering and modal

### DIFF
--- a/__tests__/projectGallery.test.tsx
+++ b/__tests__/projectGallery.test.tsx
@@ -40,12 +40,35 @@ describe('ProjectGallery', () => {
   it('filters projects and updates live region', async () => {
     render(<ProjectGallery />);
     await waitFor(() => screen.getByText('Repo1'));
-    fireEvent.click(screen.getByRole('button', { name: 'TS' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'TS' })[0]);
     await waitFor(() =>
       expect(screen.queryByText('Repo1')).not.toBeInTheDocument()
     );
     expect(screen.getByText(/Showing/)).toHaveTextContent(
       'Showing 1 project filtered by TS'
     );
+  });
+
+  it('filters when clicking tag chip inside a project', async () => {
+    render(<ProjectGallery />);
+    await waitFor(() => screen.getByText('Repo1'));
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'JS' })[1] // chip inside Repo1
+    );
+    await waitFor(() =>
+      expect(screen.queryByText('Repo2')).not.toBeInTheDocument()
+    );
+    expect(screen.getByText(/Showing/)).toHaveTextContent(
+      'Showing 1 project filtered by JS'
+    );
+  });
+
+  it('updates hash when opening project details', async () => {
+    render(<ProjectGallery />);
+    await screen.findByText('Repo1');
+    fireEvent.click(screen.getAllByText('Details')[0]);
+    await screen.findByRole('dialog');
+    expect(window.location.hash).toBe('#1');
+    window.location.hash = '';
   });
 });


### PR DESCRIPTION
## Summary
- add clickable tag chips and URL hash linking in project gallery
- show project images in modal slideshow
- test project gallery interactions

## Testing
- `npm test` *(fails: terminal.test.tsx, memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm test __tests__/projectGallery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0a39939948328809dc87c4b5bd37e