### PR TITLE
feat: add input hub page with emailjs support

### DIFF
--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import FormError from '../../ui/FormError';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { contactSchema } from '../../../utils/contactSchema';
 
 const sanitize = (str: string) =>
@@ -59,103 +59,11 @@ export const processContactForm = async (
 };
 
 const ContactApp = () => {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [message, setMessage] = useState('');
-  const [honeypot, setHoneypot] = useState('');
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState(false);
-  const [csrfToken, setCsrfToken] = useState('');
-
+  const router = useRouter();
   useEffect(() => {
-    fetch('/api/contact')
-      .then((res) => res.json())
-      .then((d) => setCsrfToken(d.csrfToken || ''))
-      .catch(() => {});
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
-    if (siteKey) {
-      const script = document.createElement('script');
-      script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
-      script.async = true;
-      document.head.appendChild(script);
-    }
-  }, []);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
-    const recaptchaToken = await new Promise<string>((resolve) => {
-      const g: any = (window as any).grecaptcha;
-      if (!g || !siteKey) return resolve('');
-      g.ready(() => {
-        g.execute(siteKey, { action: 'submit' })
-          .then((token: string) => resolve(token))
-          .catch(() => resolve(''));
-      });
-    });
-    const result = await processContactForm({
-      name,
-      email,
-      message,
-      honeypot,
-      csrfToken,
-      recaptchaToken,
-    });
-    if (!result.success) {
-      setError(result.error ? sanitize(result.error) : 'Submission failed');
-      setSuccess(false);
-    } else {
-      setError('');
-      setSuccess(true);
-      setName('');
-      setEmail('');
-      setMessage('');
-    }
-  };
-
-  return (
-    <div className="p-4 text-black">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-        <input
-          className="p-1 border"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-        />
-        <input
-          className="p-1 border"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-        <textarea
-          className="p-1 border"
-          placeholder="Message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          required
-        />
-        <input
-          className="hidden"
-          tabIndex={-1}
-          autoComplete="off"
-          value={honeypot}
-          onChange={(e) => setHoneypot(e.target.value)}
-        />
-        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
-          Send
-        </button>
-      </form>
-      {error && <FormError>{error}</FormError>}
-      {success && !error && (
-        <div role="status" className="text-green-600 mt-2">
-          Message sent!
-        </div>
-      )}
-    </div>
-  );
+    router.replace('/input-hub?preset=contact');
+  }, [router]);
+  return null;
 };
 
 export default ContactApp;

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import emailjs from '@emailjs/browser';
+import { useRouter } from 'next/router';
+
+const subjectTemplates = [
+  'General Inquiry',
+  'Bug Report',
+  'Feedback',
+];
+
+const getRecaptchaToken = (siteKey: string): Promise<string> =>
+  new Promise((resolve) => {
+    const g: any = (window as any).grecaptcha;
+    if (!g || !siteKey) return resolve('');
+    g.ready(() => {
+      g
+        .execute(siteKey, { action: 'submit' })
+        .then((token: string) => resolve(token))
+        .catch(() => resolve(''));
+    });
+  });
+
+const InputHub = () => {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [subject, setSubject] = useState(subjectTemplates[0]);
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('');
+  const [useCaptcha, setUseCaptcha] = useState(false);
+  const [emailjsReady, setEmailjsReady] = useState(false);
+
+  useEffect(() => {
+    const { preset } = router.query;
+    if (preset === 'contact') {
+      setSubject('General Inquiry');
+    }
+  }, [router.query]);
+
+  useEffect(() => {
+    const userId = process.env.NEXT_PUBLIC_USER_ID;
+    const serviceId = process.env.NEXT_PUBLIC_SERVICE_ID;
+    const templateId = process.env.NEXT_PUBLIC_TEMPLATE_ID;
+    if (userId && serviceId && templateId) {
+      try {
+        emailjs.init(userId);
+        setEmailjsReady(true);
+      } catch {
+        setEmailjsReady(false);
+      }
+    }
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+    if (siteKey) {
+      const script = document.createElement('script');
+      script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      script.async = true;
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!emailjsReady) {
+      setStatus('Email service unavailable');
+      return;
+    }
+    const serviceId = process.env.NEXT_PUBLIC_SERVICE_ID as string;
+    const templateId = process.env.NEXT_PUBLIC_TEMPLATE_ID as string;
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
+    const token = useCaptcha ? await getRecaptchaToken(siteKey) : '';
+    setStatus('Sending...');
+    try {
+      await emailjs.send(serviceId, templateId, {
+        name,
+        email,
+        subject,
+        message,
+        'g-recaptcha-response': token,
+      });
+      setStatus('Message sent!');
+      setName('');
+      setEmail('');
+      setMessage('');
+    } catch {
+      setStatus('Failed to send message');
+    }
+  };
+
+  return (
+    <div className="p-4 text-black max-w-md mx-auto">
+      <div className="mb-4">
+        <span
+          className={`px-2 py-1 text-sm rounded ${
+            emailjsReady ? 'bg-green-600 text-white' : 'bg-red-600 text-white'
+          }`}
+        >
+          {emailjsReady ? 'EmailJS: Online' : 'EmailJS: Offline'}
+        </span>
+      </div>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="p-1 border"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          className="p-1 border"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <select
+          className="p-1 border"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        >
+          {subjectTemplates.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <textarea
+          className="p-1 border"
+          placeholder="Message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+        />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={useCaptcha}
+            onChange={(e) => setUseCaptcha(e.target.checked)}
+            disabled={!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+          />
+          <span>Use reCAPTCHA</span>
+        </label>
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Send
+        </button>
+      </form>
+      {status && (
+        <div role="status" className="mt-2 text-sm">
+          {status}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InputHub;


### PR DESCRIPTION
## Summary
- redirect legacy contact app to new input hub page
- implement input hub form with subject templates, optional reCAPTCHA and EmailJS status badge

## Testing
- `npm test` *(fails: terminal component, memory game, beef, converter, snake.config, frogger.config, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a39bb2a08328b3f51aacd0ccf3b0