### PR TITLE
feat: overlay daily quote

### DIFF
--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import useDailyQuote from '../../hooks/useDailyQuote';
 
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
+    const dailyQuote = useDailyQuote();
 
     useEffect(() => {
         const img = new Image();
@@ -46,6 +48,11 @@ export default function BackgroundImage() {
         >
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+            )}
+            {dailyQuote && (
+                <div className="pointer-events-none absolute inset-0 flex items-end justify-center p-4 text-center">
+                    <p className="max-w-2xl text-white text-sm md:text-lg bg-black/40 rounded p-2">&quot;{dailyQuote.content}&quot; - {dailyQuote.author}</p>
+                </div>
             )}
         </div>
     )

--- a/hooks/useDailyQuote.ts
+++ b/hooks/useDailyQuote.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import Filter from 'bad-words';
+import offlineQuotesData from '../components/apps/quotes.json';
+
+const SAFE_CATEGORIES = [
+  'inspirational',
+  'life',
+  'love',
+  'wisdom',
+  'technology',
+  'humor',
+  'general',
+];
+
+const CATEGORY_KEYWORDS: Record<string, string[]> = {
+  inspirational: [
+    'inspire',
+    'dream',
+    'goal',
+    'courage',
+    'success',
+    'motivation',
+    'believe',
+    'achieve',
+  ],
+  life: ['life', 'living', 'journey', 'experience'],
+  love: ['love', 'heart', 'passion'],
+  wisdom: ['wisdom', 'knowledge', 'learn', 'education'],
+  technology: ['technology', 'science', 'computer'],
+  humor: ['laugh', 'funny', 'humor'],
+};
+
+const filter = new Filter();
+
+const processQuotes = (data: any[]) =>
+  data
+    .map((q) => {
+      const content = q.content || q.quote || '';
+      const author = q.author || 'Unknown';
+      let tags = Array.isArray(q.tags) ? q.tags.map((t) => t.toLowerCase()) : [];
+      if (!tags.length) {
+        const lower = content.toLowerCase();
+        Object.entries(CATEGORY_KEYWORDS).forEach(([cat, keywords]) => {
+          if (keywords.some((k) => lower.includes(k))) tags.push(cat);
+        });
+      }
+      if (!tags.length) tags.push('general');
+      return { content, author, tags };
+    })
+    .filter(
+      (q) =>
+        !filter.isProfane(q.content) &&
+        q.tags.some((t) => SAFE_CATEGORIES.includes(t))
+    );
+
+const offlineQuotes = processQuotes(offlineQuotesData as any[]);
+
+interface Quote {
+  content: string;
+  author: string;
+  date: string;
+  tags?: string[];
+}
+
+export default function useDailyQuote(tag?: string) {
+  const [quote, setQuote] = useState<Quote | null>(null);
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      const stored = localStorage.getItem('dailyQuote');
+      if (stored) {
+        const parsed: Quote = JSON.parse(stored);
+        if (parsed.date === today && (!tag || parsed.tags?.includes(tag))) {
+          setQuote(parsed);
+          return;
+        }
+      }
+    } catch {
+      // ignore storage errors
+    }
+
+    const fetchQuote = async () => {
+      let fetched: { content: string; author: string; tags?: string[] } | null = null;
+      try {
+        const url = tag
+          ? `https://api.quotable.io/random?tags=${encodeURIComponent(tag)}`
+          : 'https://api.quotable.io/random';
+        const res = await fetch(url);
+        if (res.ok) {
+          const data = await res.json();
+          fetched = { content: data.content, author: data.author, tags: data.tags };
+        }
+      } catch {
+        // ignore network errors
+      }
+      if (!fetched) {
+        const pool = tag
+          ? offlineQuotes.filter((q) => q.tags.includes(tag))
+          : offlineQuotes;
+        fetched = pool[Math.floor(Math.random() * pool.length)];
+      }
+      const toStore: Quote = { ...fetched, date: today } as Quote;
+      try {
+        localStorage.setItem('dailyQuote', JSON.stringify(toStore));
+      } catch {
+        // ignore storage errors
+      }
+      setQuote(toStore);
+    };
+    fetchQuote();
+  }, [tag]);
+
+  return quote;
+}
+


### PR DESCRIPTION
## Summary
- overlay cached daily quote on wallpaper background
- add hook to fetch quotes from API or fallback dataset with tag filter and offline cache

## Testing
- `yarn test` *(fails: terminal, memoryGame, beef, autopsy, converter, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a39e7df48328b1101fba4904bd30