### PR TITLE
feat: add disassembly viewer with function tree

### DIFF
--- a/components/apps/ghidra/FunctionTree.js
+++ b/components/apps/ghidra/FunctionTree.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+function FunctionNode({ func, funcMap, onSelect, selected }) {
+  return (
+    <li>
+      <button
+        onClick={() => onSelect(func.name)}
+        className={`text-left w-full ${selected === func.name ? 'font-bold' : ''}`}
+      >
+        {func.name}
+      </button>
+      {func.calls && func.calls.length > 0 && (
+        <ul className="ml-4">
+          {func.calls.map((c) =>
+            funcMap[c] ? (
+              <FunctionNode
+                key={c}
+                func={funcMap[c]}
+                funcMap={funcMap}
+                onSelect={onSelect}
+                selected={selected}
+              />
+            ) : (
+              <li key={c}>{c}</li>
+            )
+          )}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function FunctionTree({ functions, onSelect, selected }) {
+  const funcMap = React.useMemo(() => {
+    const map = {};
+    functions.forEach((f) => {
+      map[f.name] = f;
+    });
+    return map;
+  }, [functions]);
+
+  const called = React.useMemo(() => {
+    const set = new Set();
+    functions.forEach((f) => f.calls && f.calls.forEach((c) => set.add(c)));
+    return set;
+  }, [functions]);
+
+  const roots = functions.filter((f) => !called.has(f.name));
+
+  return (
+    <ul className="p-2 text-sm space-y-1">
+      {roots.map((f) => (
+        <FunctionNode
+          key={f.name}
+          func={f}
+          funcMap={funcMap}
+          onSelect={onSelect}
+          selected={selected}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/public/demo-data/ghidra/disassembly.json
+++ b/public/demo-data/ghidra/disassembly.json
@@ -1,0 +1,29 @@
+{
+  "functions": [
+    {
+      "name": "start",
+      "code": ["start:", "  mov eax, 1", "  call check", "  ret"],
+      "calls": ["check"],
+      "blocks": [
+        {"id": "start", "label": "Start", "code": ["mov eax, 1", "call check", "ret"], "edges": [], "x": 40, "y": 60}
+      ]
+    },
+    {
+      "name": "check",
+      "code": ["check:", "  cmp eax, 2", "  jne end", "  call helper", "  ret"],
+      "calls": ["helper"],
+      "blocks": [
+        {"id": "check", "label": "Check", "code": ["cmp eax, 2", "jne end", "call helper", "ret"], "edges": ["end"], "x": 40, "y": 60},
+        {"id": "end", "label": "End", "code": ["ret"], "edges": [], "x": 160, "y": 60}
+      ]
+    },
+    {
+      "name": "helper",
+      "code": ["helper:", "  ret"],
+      "calls": [],
+      "blocks": [
+        {"id": "helper", "label": "Helper", "code": ["ret"], "edges": [], "x": 40, "y": 60}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- load pre-generated disassembly JSON
- render function tree and code map
- support cross-reference jumps between functions

## Testing
- `npm test` *(fails: terminal.test.tsx, memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3ad26d48328a0a1f4af7613e887