### PR TITLE
feat: filter Volatility plugins and show sample output

### DIFF
--- a/__tests__/volatilityPluginBrowser.test.tsx
+++ b/__tests__/volatilityPluginBrowser.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PluginBrowser from '../components/apps/volatility/PluginBrowser';
+
+describe('Volatility PluginBrowser', () => {
+  test('filters plugins and shows output', () => {
+    render(<PluginBrowser />);
+    // disclaimer is visible
+    expect(
+      screen.getByText(/educational use only/i)
+    ).toBeInTheDocument();
+
+    // initially all plugins are listed
+    expect(screen.getByText('pslist')).toBeInTheDocument();
+    expect(screen.getByText('netscan')).toBeInTheDocument();
+    expect(screen.getByText('malfind')).toBeInTheDocument();
+
+    // filter by category
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'Network' },
+    });
+    expect(screen.getByText('netscan')).toBeInTheDocument();
+    expect(screen.queryByText('pslist')).toBeNull();
+
+    // display plugin output
+    fireEvent.click(screen.getByText('netscan'));
+    expect(screen.getByText(/Proto LocalAddr/)).toBeInTheDocument();
+  });
+});

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -1,23 +1,61 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import plugins from '../../../public/demo-data/volatility/plugins.json';
 
-const PluginBrowser = () => (
-  <div className="space-y-3">
-    {plugins.map((p) => (
-      <div key={p.name} className="bg-gray-800 p-3 rounded">
-        <h3 className="font-semibold text-sm">{p.name}</h3>
-        <p className="text-xs mb-1">{p.description}</p>
-        <a
-          href={p.doc}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-blue-400 underline"
+const PluginBrowser = () => {
+  const [category, setCategory] = useState('All');
+  const [selected, setSelected] = useState(null);
+
+  const categories = useMemo(
+    () => ['All', ...Array.from(new Set(plugins.map((p) => p.category)))],
+    []
+  );
+
+  const filtered = plugins.filter(
+    (p) => category === 'All' || p.category === category
+  );
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-yellow-400">
+        Plugin data is provided for educational use only.
+      </p>
+      <select
+        className="bg-gray-800 text-xs p-1 rounded"
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+      >
+        {categories.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      {filtered.map((p) => (
+        <div
+          key={p.name}
+          className="bg-gray-800 p-3 rounded cursor-pointer"
+          onClick={() => setSelected(p)}
         >
-          Volatility 3 docs
-        </a>
-      </div>
-    ))}
-  </div>
-);
+          <h3 className="font-semibold text-sm">{p.name}</h3>
+          <p className="text-[10px] text-gray-400">{p.category}</p>
+          <p className="text-xs mb-1">{p.description}</p>
+          <a
+            href={p.doc}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-400 underline"
+          >
+            Volatility 3 docs
+          </a>
+        </div>
+      ))}
+      {selected && (
+        <pre className="text-xs bg-black p-3 rounded overflow-auto">
+          {selected.output}
+        </pre>
+      )}
+    </div>
+  );
+};
 
 export default PluginBrowser;

--- a/public/demo-data/volatility/plugins.json
+++ b/public/demo-data/volatility/plugins.json
@@ -1,17 +1,23 @@
 [
   {
     "name": "pslist",
+    "category": "Processes",
     "description": "List running processes.",
-    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html"
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html",
+    "output": "PID   PPID   Name\n4     0      System\n248   4      smss.exe\n612   248    csrss.exe"
   },
   {
     "name": "netscan",
+    "category": "Network",
     "description": "Scan for network connections.",
-    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/netscan.html"
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/netscan.html",
+    "output": "Proto LocalAddr           ForeignAddr         State\nTCP   0.0.0.0:80          0.0.0.0:0           LISTENING\nUDP   127.0.0.1:53        0.0.0.0:0           NONE"
   },
   {
     "name": "malfind",
+    "category": "Malware",
     "description": "Find hidden or injected code sections.",
-    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/malfind.html"
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/malfind.html",
+    "output": "PID   Address     Protection Description\n612   0x7f12a000  RWX        Injected Code\n700   0x401000    RWX        Suspicious Section"
   }
 ]


### PR DESCRIPTION
## Summary
- categorize Volatility plugins and add demo output data
- allow filtering and selection with static output and educational disclaimer
- test plugin browser filtering and output rendering

## Testing
- `yarn test __tests__/volatilityPluginBrowser.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0aebba24c8328963daea1afc95bf2