### PR TITLE
feat: add module workspace with command composer

### DIFF
--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import usePersistentState from '../hooks/usePersistentState';
+
+interface ModuleOption {
+  name: string;
+  required: boolean;
+}
+
+interface Module {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  options: ModuleOption[];
+  sample: string;
+}
+
+const modules: Module[] = [
+  {
+    id: 'port-scan',
+    name: 'Port Scanner',
+    description: 'Scans for open network ports',
+    tags: ['network', 'scanner'],
+    options: [{ name: 'TARGET', required: true }],
+    sample: '[+] 192.168.0.1: Ports 22,80 open',
+  },
+  {
+    id: 'bruteforce',
+    name: 'Brute Force',
+    description: 'Attempts common passwords',
+    tags: ['attack', 'password'],
+    options: [
+      { name: 'TARGET', required: true },
+      { name: 'WORDLIST', required: true },
+    ],
+    sample: '[-] No valid password found',
+  },
+  {
+    id: 'vuln-check',
+    name: 'Vuln Check',
+    description: 'Checks for known CVEs',
+    tags: ['vulnerability', 'scanner'],
+    options: [{ name: 'HOST', required: true }],
+    sample: '[+] CVE-2024-1234 present on host',
+  },
+];
+
+const ModuleWorkspace: React.FC = () => {
+  const [workspaces, setWorkspaces] = usePersistentState<string[]>(
+    'workspaces',
+    [],
+  );
+  const [newWorkspace, setNewWorkspace] = useState('');
+  const [currentWorkspace, setCurrentWorkspace] = useState('');
+
+  const [filter, setFilter] = useState('');
+  const [selected, setSelected] = useState<Module | null>(null);
+  const [optionValues, setOptionValues] = useState<Record<string, string>>({});
+  const [result, setResult] = useState('');
+
+  const tags = Array.from(new Set(modules.flatMap((m) => m.tags)));
+  const filteredModules = filter
+    ? modules.filter((m) => m.tags.includes(filter))
+    : modules;
+
+  const addWorkspace = () => {
+    const name = newWorkspace.trim();
+    if (!name) return;
+    if (!workspaces.includes(name)) {
+      setWorkspaces([...workspaces, name]);
+    }
+    setCurrentWorkspace(name);
+    setNewWorkspace('');
+  };
+
+  const selectModule = (mod: Module) => {
+    setSelected(mod);
+    const initial: Record<string, string> = {};
+    mod.options.forEach((o) => {
+      initial[o.name] = '';
+    });
+    setOptionValues(initial);
+    setResult('');
+  };
+
+  const runCommand = () => {
+    if (!selected) return;
+    const opts = selected.options
+      .map((o) => `${o.name}=${optionValues[o.name] || ''}`)
+      .join(' ');
+    const cmd = `${selected.id} ${opts}`.trim();
+    setResult(`$ ${cmd}\n${selected.sample}`);
+  };
+
+  return (
+    <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
+      <section className="space-y-2">
+        <h1 className="text-xl font-semibold">Workspaces</h1>
+        <div className="flex gap-2">
+          <input
+            value={newWorkspace}
+            onChange={(e) => setNewWorkspace(e.target.value)}
+            placeholder="New workspace"
+            className="p-1 rounded text-black"
+          />
+          <button
+            onClick={addWorkspace}
+            className="px-2 py-1 bg-ub-orange rounded text-black"
+          >
+            Create
+          </button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {workspaces.map((ws) => (
+            <button
+              key={ws}
+              onClick={() => setCurrentWorkspace(ws)}
+              className={`px-2 py-1 rounded ${
+                currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
+              }`}
+            >
+              {ws}
+            </button>
+          ))}
+        </div>
+      </section>
+      {currentWorkspace && (
+        <>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => setFilter('')}
+              className={`px-2 py-1 text-sm rounded ${
+                filter === '' ? 'bg-blue-600' : 'bg-gray-700'
+              }`}
+            >
+              All
+            </button>
+            {tags.map((t) => (
+              <button
+                key={t}
+                onClick={() => setFilter(t)}
+                className={`px-2 py-1 text-sm rounded ${
+                  filter === t ? 'bg-blue-600' : 'bg-gray-700'
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredModules.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => selectModule(m)}
+                className="p-3 text-left bg-ub-grey rounded border border-gray-700"
+              >
+                <h3 className="font-semibold">{m.name}</h3>
+                <p className="text-sm text-gray-300">{m.description}</p>
+              </button>
+            ))}
+          </div>
+          {selected && (
+            <div className="space-y-2">
+              <h2 className="font-semibold">Command Composer</h2>
+              {selected.options.map((opt) => (
+                <div key={opt.name}>
+                  <label className="block text-sm">
+                    {opt.name} {opt.required ? '*' : ''}
+                    <input
+                      value={optionValues[opt.name]}
+                      onChange={(e) =>
+                        setOptionValues({
+                          ...optionValues,
+                          [opt.name]: e.target.value,
+                        })
+                      }
+                      className="mt-1 w-full p-1 rounded text-black"
+                    />
+                  </label>
+                </div>
+              ))}
+              <button
+                onClick={runCommand}
+                className="px-2 py-1 bg-green-600 rounded text-black"
+              >
+                Run
+              </button>
+              {result && (
+                <pre
+                  className="bg-black text-green-400 p-2 overflow-auto"
+                  role="log"
+                >
+                  {result}
+                </pre>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ModuleWorkspace;
+


### PR DESCRIPTION
## Summary
- allow users to create named workspaces stored in localStorage
- filter security modules by tag and compose commands with module options
- show static sample output for composed commands

## Testing
- `yarn test` (fails: terminal, memoryGame, beef, autopsy)
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0aec06a2883288d67a8b2244245a2