### PR TITLE
feat: add scan profiles and HTML report to OpenVAS demo

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -37,7 +37,27 @@ describe('OpenVASApp', () => {
     fireEvent.click(screen.getByText('Scan'));
     await waitFor(() => expect(fetch).toHaveBeenCalled());
     expect(fetch).toHaveBeenCalledWith(
-      '/api/openvas?target=1.2.3.4&group=servers'
+      '/api/openvas?target=1.2.3.4&group=servers&profile=quick'
+    );
+  });
+
+  it('passes selected profile in scan request', async () => {
+    render(<OpenVASApp />);
+    fireEvent.change(
+      screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
+      { target: { value: '1.2.3.4' } }
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText('Group (e.g. Servers)'),
+      { target: { value: 'servers' } }
+    );
+    fireEvent.change(screen.getByDisplayValue('Quick'), {
+      target: { value: 'full' },
+    });
+    fireEvent.click(screen.getByText('Scan'));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/openvas?target=1.2.3.4&group=servers&profile=full'
     );
   });
 


### PR DESCRIPTION
## Summary
- add quick/full profile selection for OpenVAS scans
- visualize canned severity data with a donut chart
- export scan output as downloadable HTML report

## Testing
- `npm test` *(fails: terminal, memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm test -- __tests__/openvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0aebf57e4832899fee3a492f42c82