### PR TITLE
feat(nikto): add tuning flags and report demo

### DIFF
--- a/__tests__/niktoApp.test.tsx
+++ b/__tests__/niktoApp.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NiktoApp from "../components/apps/nikto";
+
+describe("NiktoApp", () => {
+  it("updates command with tuning flags and shows risk info", async () => {
+    const user = userEvent.setup();
+    render(<NiktoApp />);
+    expect(
+      screen.getByText(/Nikto scans for known web vulnerabilities/i),
+    ).toBeInTheDocument();
+    const tuning = screen.getByLabelText(/Tuning Flags/i);
+    await user.type(tuning, "5");
+    expect(
+      screen.getByText(/nikto -h example.com -Tuning 5/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,13 +1,23 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from "react";
+
+const highlightLine = (line) => {
+  if (/vulnerability/i.test(line)) return "bg-red-700 text-white";
+  if (/not defined/i.test(line)) return "bg-yellow-700 text-white";
+  return "";
+};
 
 const NiktoApp = () => {
-  const [target, setTarget] = useState('example.com');
-  const [status, setStatus] = useState('');
+  const [target, setTarget] = useState("example.com");
+  const [status, setStatus] = useState("");
   const [results, setResults] = useState({});
+  const [tuning, setTuning] = useState("");
+  const [report, setReport] = useState("");
   const workerRef = useRef(null);
 
   useEffect(() => {
-    workerRef.current = new Worker(new URL('./nikto.worker.js', import.meta.url));
+    workerRef.current = new Worker(
+      new URL("./nikto.worker.js", import.meta.url),
+    );
     workerRef.current.onmessage = (e) => {
       const { clusters, error } = e.data || {};
       if (error) {
@@ -15,34 +25,42 @@ const NiktoApp = () => {
         setResults({});
       } else if (clusters) {
         setResults(clusters);
-        setStatus('Scan complete');
+        setStatus("Scan complete");
       }
     };
     workerRef.current.onerror = () => {
-      setStatus('Worker error');
+      setStatus("Worker error");
     };
     return () => workerRef.current?.terminate();
   }, []);
 
   const runDemo = async () => {
-    setStatus('Running scan...');
+    setStatus("Running scan...");
     setResults({});
+    setReport("");
     try {
-      const res = await fetch('/demo/nikto-output.txt');
+      const res = await fetch("/demo/nikto-output.txt");
       const text = await res.text();
-      setStatus('Parsing results...');
+      setStatus("Parsing results...");
+      setReport(text);
       workerRef.current?.postMessage({ text });
     } catch (e) {
       setStatus(`Error: ${e.message}`);
     }
   };
 
-  const command = `nikto -h ${target}`;
+  const command = `nikto -h ${target}${tuning ? ` -Tuning ${tuning}` : ""}`;
 
   return (
     <div className="h-full w-full flex flex-col md:flex-row text-white">
       <div className="md:w-1/2 p-4 bg-ub-dark overflow-y-auto">
         <h1 className="text-lg mb-4">Nikto Demo</h1>
+        <div className="bg-yellow-900 text-yellow-100 p-2 rounded mb-4 text-sm">
+          Nikto scans for known web vulnerabilities. Running it against systems
+          without permission may be illegal and can disrupt services. Tuning
+          flags limit tests but misconfiguration might still trigger security
+          defenses.
+        </div>
         <label htmlFor="target" className="block text-sm mb-1">
           Target
         </label>
@@ -51,6 +69,16 @@ const NiktoApp = () => {
           value={target}
           onChange={(e) => setTarget(e.target.value)}
           className="w-full p-2 mb-4 text-black"
+        />
+        <label htmlFor="tuning" className="block text-sm mb-1">
+          Tuning Flags
+        </label>
+        <input
+          id="tuning"
+          value={tuning}
+          onChange={(e) => setTuning(e.target.value)}
+          className="w-full p-2 mb-4 text-black"
+          placeholder="e.g. 1,2,3"
         />
         <pre className="bg-black text-green-400 p-2 rounded mb-4 overflow-auto">
           {command}
@@ -95,6 +123,18 @@ const NiktoApp = () => {
                 </ul>
               </div>
             ))}
+          </div>
+        )}
+        {report && (
+          <div className="mt-4">
+            <h3 className="text-lg mb-2">Example Report</h3>
+            <pre className="bg-black text-green-400 p-2 rounded overflow-auto">
+              {report.split("\n").map((line, i) => (
+                <span key={i} className={`block ${highlightLine(line)}`}>
+                  {line}
+                </span>
+              ))}
+            </pre>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- allow entering tuning flags for Nikto scans
- warn about scanning risks and show highlighted example report
- add test covering tuning flag command behavior

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: existing suites such as terminal, memoryGame, beef, autopsy, converter; parse error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aec1b53c8328af799af7ecb5b7b7