### PR TITLE
Add OpenVAS policy view and issue detail panel

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -71,4 +71,19 @@ describe('OpenVASApp', () => {
       })
     );
   });
+
+  it('displays sample policy settings', () => {
+    render(<OpenVASApp />);
+    expect(screen.getByText('Policy Settings')).toBeInTheDocument();
+    expect(screen.getByText('Full and Fast')).toBeInTheDocument();
+  });
+
+  it('opens issue detail panel with remediation info', () => {
+    render(<OpenVASApp />);
+    fireEvent.click(screen.getByText('Outdated banner exposes software version'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/Remediation/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Close'));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });

--- a/components/apps/openvas/policy-settings.js
+++ b/components/apps/openvas/policy-settings.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const PolicySettings = () => {
+  const policy = {
+    name: 'Full and Fast',
+    portList: 'OpenVAS Default',
+    maxHosts: '10 concurrent hosts',
+    qod: '70% minimum',
+  };
+  return (
+    <div className="p-4 bg-gray-800 rounded mb-4">
+      <h3 className="text-md font-bold mb-2">Policy Settings</h3>
+      <ul className="text-sm space-y-1">
+        <li><span className="font-semibold">Name:</span> {policy.name}</li>
+        <li><span className="font-semibold">Port List:</span> {policy.portList}</li>
+        <li><span className="font-semibold">Max Hosts:</span> {policy.maxHosts}</li>
+        <li><span className="font-semibold">QoD:</span> {policy.qod}</li>
+      </ul>
+      <p className="text-xs text-gray-400 mt-2">
+        Sample configuration shown for demo purposes.
+      </p>
+    </div>
+  );
+};
+
+export default PolicySettings;
+


### PR DESCRIPTION
## Summary
- Display read-only OpenVAS policy settings
- Enable severity-filtered findings with issue detail drawer and remediation text
- Cover new UI with tests

## Testing
- `npm test` *(fails: terminal, memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0aec25a908328b275ff46a64aed43