### PR TITLE
Add interactive artifact timeline with filtering

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -56,12 +56,10 @@ describe('Autopsy plugins and timeline', () => {
     });
     fireEvent.click(screen.getByText('Create Case'));
     await screen.findByText('Hash Analyzer');
-    const select = screen.getByRole('combobox');
-    fireEvent.change(select, { target: { value: 'hash' } });
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0], { target: { value: 'hash' } });
     await waitFor(() =>
-      expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(
-        'hash'
-      )
+      expect((selects[0] as HTMLSelectElement).value).toBe('hash')
     );
   });
 
@@ -71,8 +69,9 @@ describe('Autopsy plugins and timeline', () => {
       target: { value: 'Demo' },
     });
     fireEvent.click(screen.getByText('Create Case'));
-    await screen.findByText('resume.docx');
-    fireEvent.change(screen.getByPlaceholderText('Filter by type'), {
+    await screen.findByLabelText('Filter by type');
+    expect(screen.getByText('resume.docx')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Filter by type'), {
       target: { value: 'Log' },
     });
     expect(screen.queryByText('resume.docx')).toBeNull();

--- a/public/autopsy-demo.json
+++ b/public/autopsy-demo.json
@@ -23,6 +23,22 @@
       "size": 34567,
       "plugin": "metadata",
       "timestamp": "2023-08-01T14:45:00Z"
+    },
+    {
+      "name": "run.exe",
+      "type": "File",
+      "description": "Executable recovered from temp folder",
+      "size": 45678,
+      "plugin": "hash",
+      "timestamp": "2023-08-01T16:15:00Z"
+    },
+    {
+      "name": "HKCU\\Software\\Example",
+      "type": "Registry",
+      "description": "Registry key with suspicious value",
+      "size": 0,
+      "plugin": "regParser",
+      "timestamp": "2023-08-01T18:20:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- load demo artifact dataset with files, logs, and registry entries
- add type filter and clickable timeline to view artifact details
- extend tests for filtering and plugin selection

## Testing
- `yarn test __tests__/autopsy.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0aec582c48328adbd71d5b4f5dce3