### PR TITLE
docs: document core yarn commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ To send text or links directly into the Sticky Notes app:
 
 ---
 
+## Core Commands
+
+- `yarn install` – install project dependencies.
+- `yarn dev` – start the development server with hot reloading.
+- `yarn test` – run the test suite.
+- `yarn lint` – check code for linting issues.
+- `yarn export` – generate a static export in the `out/` directory.
+
+---
+
 ## Tech Stack
 
 - **Next.js 15** (app uses `/pages` routing) + **TypeScript** in parts


### PR DESCRIPTION
## Summary
- document core yarn commands for install, development, testing, linting and static export

## Testing
- `yarn lint` *(fails: components/apps/Chrome/index.tsx parsing error)*
- `yarn test` *(fails: multiple test suites such as terminal and memoryGame)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3237d8c83288f3c4fcae7c6fb80