### PR TITLE
feat: add module search and command preview

### DIFF
--- a/__tests__/popularModules.test.tsx
+++ b/__tests__/popularModules.test.tsx
@@ -20,5 +20,19 @@ describe('PopularModules', () => {
       expect.stringContaining('tryhackme.com/room/rpnmap')
     );
   });
+
+  it('searches modules and builds command preview', () => {
+    render(<PopularModules />);
+    const search = screen.getByPlaceholderText(/search modules/i);
+    fireEvent.change(search, { target: { value: 'port' } });
+    fireEvent.click(screen.getByRole('button', { name: /Port Scanner/i }));
+    fireEvent.change(screen.getByLabelText('Target'), {
+      target: { value: '192.168.0.1' },
+    });
+    expect(screen.getByTestId('command-preview')).toHaveTextContent(
+      'port-scan --target 192.168.0.1'
+    );
+    expect(screen.getByRole('log')).toHaveTextContent('Starting port scan');
+  });
 });
 


### PR DESCRIPTION
## Summary
- add searchable filter and option form for modules
- show command preview and static logs with non-op disclaimer
- test module search and command preview

## Testing
- `npm test` *(fails: Terminal component, memoryGame, beef, autopsy, converter, snake.config, frogger.config, etc.)*
- `npm test __tests__/popularModules.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3a767288328be989d31f385a22d