### PR TITLE
feat: add tree view for msf post modules

### DIFF
--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -3,25 +3,31 @@ import React, { useEffect, useState } from 'react';
 // Sample module catalog for demo purposes only
 const MODULE_CATALOG = [
   {
-    name: 'post/multi/recon/local_exploit_suggester',
-    platform: 'multi',
-    session: 'meterpreter',
+    path: 'post/multi/recon/local_exploit_suggester',
+    description:
+      'Examines the target system to suggest potential local privilege escalation exploits.',
+    options: [{ name: 'SESSION', label: 'Session ID', value: '1' }],
+    sampleOutput:
+      '# Running local_exploit_suggester\n[*] Checking target...\n[+] Found 0-day privilege escalation path',
   },
   {
-    name: 'post/windows/manage/enable_rdp',
-    platform: 'windows',
-    session: 'meterpreter',
+    path: 'post/windows/manage/enable_rdp',
+    description: 'Enables Remote Desktop Protocol on the target Windows system.',
+    options: [{ name: 'SESSION', label: 'Session ID', value: '1' }],
+    sampleOutput:
+      '# Running enable_rdp\n[*] RDP is already enabled\n[+] Operation completed successfully',
   },
   {
-    name: 'post/linux/gather/enum_network',
-    platform: 'linux',
-    session: 'shell',
+    path: 'post/linux/gather/enum_network',
+    description:
+      'Collects network interface and routing information from a Linux host.',
+    options: [{ name: 'SESSION', label: 'Session ID', value: '1' }],
+    sampleOutput:
+      '# Running enum_network\n[*] Gathering network info\n[+] Interface eth0 192.168.0.5',
   },
 ];
 
-const PLATFORMS = ['multi', 'windows', 'linux'];
-const SESSION_TYPES = ['meterpreter', 'shell'];
-
+// Escape text for clipboard copy
 const escapeText = (text) =>
   text
     .replace(/&/g, '&amp;')
@@ -30,11 +36,60 @@ const escapeText = (text) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
+// Build a tree structure from module paths
+const buildTree = (catalog) => {
+  const root = {};
+  catalog.forEach((mod) => {
+    const parts = mod.path.split('/').slice(1); // drop "post"
+    let node = root;
+    parts.forEach((part, idx) => {
+      if (!node[part]) node[part] = {};
+      if (idx === parts.length - 1) {
+        node[part].module = mod;
+      } else {
+        node[part].children = node[part].children || {};
+        node = node[part].children;
+      }
+    });
+  });
+  return root;
+};
+
+const Tree = ({ data, onSelect }) => (
+  <ul className="pl-4">
+    {Object.entries(data).map(([name, node]) => (
+      <TreeNode key={name} name={name} node={node} onSelect={onSelect} />
+    ))}
+  </ul>
+);
+
+const TreeNode = ({ name, node, onSelect }) => {
+  if (node.module) {
+    return (
+      <li>
+        <button
+          onClick={() => onSelect(node.module)}
+          className="text-left hover:underline focus:outline-none"
+        >
+          {name}
+        </button>
+      </li>
+    );
+  }
+  return (
+    <li>
+      <details>
+        <summary className="cursor-pointer">{name}</summary>
+        <Tree data={node.children} onSelect={onSelect} />
+      </details>
+    </li>
+  );
+};
+
 const MsfPostApp = () => {
-  const [modules, setModules] = useState([]);
+  const [selectedModule, setSelectedModule] = useState(null);
+  const [params, setParams] = useState({});
   const [output, setOutput] = useState('');
-  const [platform, setPlatform] = useState('');
-  const [sessionType, setSessionType] = useState('');
   const [steps, setSteps] = useState([
     { label: 'Gather System Info', done: false },
     { label: 'Escalate Privileges', done: false },
@@ -45,10 +100,6 @@ const MsfPostApp = () => {
   const [reduceMotion, setReduceMotion] = useState(false);
 
   useEffect(() => {
-    setModules(MODULE_CATALOG);
-  }, []);
-
-  useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     const handleChange = () => setReduceMotion(mq.matches);
     handleChange();
@@ -56,11 +107,20 @@ const MsfPostApp = () => {
     return () => mq.removeEventListener('change', handleChange);
   }, []);
 
-  const filteredModules = modules.filter(
-    (m) =>
-      (!platform || m.platform === platform) &&
-      (!sessionType || m.session === sessionType)
-  );
+  const treeData = buildTree(MODULE_CATALOG);
+
+  const selectModule = (mod) => {
+    setSelectedModule(mod);
+    const initial = {};
+    mod.options?.forEach((o) => {
+      initial[o.name] = o.value || '';
+    });
+    setParams(initial);
+    setOutput('');
+  };
+
+  const handleParamChange = (name, value) =>
+    setParams((prev) => ({ ...prev, [name]: value }));
 
   const animateSteps = () => {
     setSteps((prev) => prev.map((s) => ({ ...s, done: false })));
@@ -83,9 +143,9 @@ const MsfPostApp = () => {
     update();
   };
 
-  const runModule = (mod) => {
-    if (!mod) return;
-    setOutput(`# Running ${mod}\nSample output line 1\nSample output line 2`);
+  const runModule = () => {
+    if (!selectedModule) return;
+    setOutput(selectedModule.sampleOutput);
     animateSteps();
   };
 
@@ -96,7 +156,7 @@ const MsfPostApp = () => {
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
       try {
         await navigator.clipboard.writeText(codeBlock);
-      } catch (err) {
+      } catch {
         /* ignore clipboard errors */
       }
     }
@@ -105,64 +165,50 @@ const MsfPostApp = () => {
   return (
     <div className="h-full w-full bg-gray-900 text-white p-4 flex flex-col">
       <h2 className="text-lg mb-2">Metasploit Post Modules</h2>
-      <div className="flex mb-4 space-x-2">
-        <select
-          className="bg-gray-800 p-2 rounded"
-          value={platform}
-          onChange={(e) => setPlatform(e.target.value)}
-        >
-          <option value="">All Platforms</option>
-          {PLATFORMS.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-        <select
-          className="bg-gray-800 p-2 rounded"
-          value={sessionType}
-          onChange={(e) => setSessionType(e.target.value)}
-        >
-          <option value="">All Sessions</option>
-          {SESSION_TYPES.map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
-        <button
-          onClick={copyAsCode}
-          className="px-4 py-2 bg-green-600 rounded"
-        >
-          Copy as code
-        </button>
+      <div className="flex flex-1 overflow-hidden">
+        <div className="w-1/3 overflow-auto border-r border-gray-700 pr-2">
+          <Tree data={treeData} onSelect={selectModule} />
+        </div>
+        <div className="w-2/3 pl-4 flex flex-col">
+          {selectedModule ? (
+            <div>
+              <h3 className="text-md font-semibold mb-1">
+                {selectedModule.path}
+              </h3>
+              <p className="text-sm text-gray-400 mb-2">
+                {selectedModule.description}
+              </p>
+              {selectedModule.options?.map((opt) => (
+                <label key={opt.name} className="block mb-2">
+                  {opt.label}
+                  <input
+                    className="w-full p-1 bg-gray-800 rounded mt-1"
+                    value={params[opt.name] || ''}
+                    onChange={(e) => handleParamChange(opt.name, e.target.value)}
+                  />
+                </label>
+              ))}
+              <button
+                onClick={runModule}
+                className="mt-2 px-3 py-1 bg-blue-600 rounded"
+              >
+                Run
+              </button>
+            </div>
+          ) : (
+            <p className="text-gray-400">Select a module to view details.</p>
+          )}
+          <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap mt-4">
+            {output}
+          </pre>
+          <button
+            onClick={copyAsCode}
+            className="mt-2 px-4 py-2 bg-green-600 rounded self-start"
+          >
+            Copy as code
+          </button>
+        </div>
       </div>
-      <ul className="mb-4 flex-1 overflow-auto">
-        {filteredModules.map((m) => (
-          <li key={m.name} className="mb-2 flex items-center">
-            <button
-              onClick={() => runModule(m.name)}
-              className="mr-2 px-2 py-1 bg-blue-600 rounded"
-            >
-              Run
-            </button>
-            <a
-              href={`https://www.rapid7.com/db/modules/${m.name}`}
-              target="_blank"
-              rel="noreferrer"
-              className="text-blue-400 hover:underline"
-            >
-              {m.name}
-            </a>
-            <span className="ml-2 text-xs text-gray-400">
-              [{m.platform} / {m.session}]
-            </span>
-          </li>
-        ))}
-      </ul>
-      <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap">
-        {output}
-      </pre>
       <div className="sr-only" aria-live="polite" role="status">
         {liveMessage}
       </div>
@@ -220,3 +266,4 @@ const MsfPostApp = () => {
 };
 
 export default MsfPostApp;
+


### PR DESCRIPTION
## Summary
- display metasploit post modules in a collapsible tree
- show module description and parameter fields on selection
- render canned sample output for chosen module

## Testing
- `yarn lint --file components/apps/msf-post/index.js`
- `yarn test` *(fails: Terminal component, memoryGame, BeEF, Autopsy, Converter, Snake config, Frogger config)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a3a878bc8328b83b47a9a8272d97