### PR TITLE
feat: enhance nmap demo with multi-script and port presets

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -14,7 +14,7 @@ describe('NmapNSEApp', () => {
     render(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
-    await userEvent.selectOptions(screen.getByLabelText('Script'), 'ftp-anon');
+    await userEvent.click(screen.getByLabelText(/ftp-anon/i));
     expect(await screen.findByText('FTP output')).toBeInTheDocument();
 
     mockFetch.mockRestore();
@@ -58,7 +58,9 @@ describe('NmapNSEApp', () => {
     await userEvent.click(
       screen.getByRole('button', { name: /copy output/i })
     );
-    expect(writeText).toHaveBeenCalledWith('Sample output');
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Sample output')
+    );
     expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();


### PR DESCRIPTION
## Summary
- allow choosing multiple NSE scripts with search
- add port preset buttons and highlight sample output findings
- include stronger educational disclaimer and updated tests

## Testing
- `yarn test` *(fails: Terminal component, memoryGame, BeEF, Autopsy, Converter, snake.config, frogger.config)*
- `yarn test __tests__/nmapNse.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3a90470832887260f8fa84a9de5