### PR TITLE
feat: enhance hashcat demo

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -50,5 +50,22 @@ describe('HashcatApp', () => {
         'Example hash: 5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8'
       )
     ).toBeInTheDocument();
+    expect(getByText('Description: 160-bit secure hash algorithm')).toBeInTheDocument();
+  });
+
+  it('generates demo command and shows sample output', () => {
+    const { getByLabelText, getByTestId, getByText } = render(
+      <HashcatApp />
+    );
+    fireEvent.change(getByLabelText('Hash:'), {
+      target: { value: '5f4dcc3b5aa765d61d8327deb882cf99' },
+    });
+    fireEvent.change(getByLabelText('Wordlist:'), {
+      target: { value: 'rockyou' },
+    });
+    expect(getByTestId('demo-command').textContent).toContain(
+      'hashcat -m 0 5f4dcc3b5aa765d61d8327deb882cf99 rockyou.txt'
+    );
+    expect(getByText('Sample Output:')).toBeInTheDocument();
   });
 });

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -8,6 +8,7 @@ const hashTypes = [
     regex: /^[a-f0-9]{32}$/i,
     example: '5f4dcc3b5aa765d61d8327deb882cf99',
     output: 'password',
+    description: 'Fast, legacy 32-character hash',
   },
   {
     id: '100',
@@ -15,6 +16,7 @@ const hashTypes = [
     regex: /^[a-f0-9]{40}$/i,
     example: '5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8',
     output: 'password',
+    description: '160-bit secure hash algorithm',
   },
   {
     id: '1400',
@@ -23,6 +25,7 @@ const hashTypes = [
     example:
       '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
     output: 'password',
+    description: '256-bit SHA2 hash',
   },
   {
     id: '3200',
@@ -31,6 +34,7 @@ const hashTypes = [
     example:
       '$2b$12$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     output: 'password',
+    description: 'Adaptive hash with salt and cost factor',
   },
 ];
 
@@ -293,6 +297,7 @@ function HashcatApp() {
       <div>Detected: {selectedHash}</div>
       <div>Example hash: {selected.example}</div>
       <div>Expected output: {selected.output}</div>
+      <div>Description: {selected.description}</div>
       <button onClick={runBenchmark}>Run Benchmark</button>
       {benchmark && (
         <div data-testid="benchmark-output">{benchmark}</div>
@@ -323,6 +328,10 @@ function HashcatApp() {
           </a>
           .
         </div>
+        <div className="text-xs mt-1">
+          Sample entries: <code>password123</code>, <code>qwerty</code>,{' '}
+          <code>letmein</code>
+        </div>
       </div>
       <div>
         <label className="mr-2" htmlFor="word-pattern">
@@ -347,6 +356,43 @@ function HashcatApp() {
           </a>
         )}
         <div className="text-xs mt-1">Uploading wordlists is disabled.</div>
+      </div>
+      <div className="mt-2">
+        <div className="text-sm">Demo Command:</div>
+        <div className="flex items-center">
+          <code
+            className="bg-black px-2 py-1 text-xs"
+            data-testid="demo-command"
+          >
+            {`hashcat -m ${hashType} ${hashInput || 'hash.txt'} ${
+              wordlist ? `${wordlist}.txt` : 'wordlist.txt'
+            }`}
+          </code>
+          <button
+            className="ml-2"
+            onClick={() => {
+              if (navigator?.clipboard?.writeText) {
+                navigator.clipboard.writeText(
+                  `hashcat -m ${hashType} ${hashInput || 'hash.txt'} ${
+                    wordlist ? `${wordlist}.txt` : 'wordlist.txt'
+                  }`
+                );
+              }
+            }}
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+      <div className="mt-4 w-full max-w-md">
+        <div className="text-sm">Sample Output:</div>
+        <pre className="bg-black p-2 text-xs overflow-auto">
+          hashcat (demo) starting
+
+          5f4dcc3b5aa765d61d8327deb882cf99:password
+
+          Session completed.
+        </pre>
       </div>
       <Gauge value={gpuUsage} />
       {!isCracking ? (


### PR DESCRIPTION
## Summary
- add descriptions for hash formats
- show wordlist tips, demo command, and sample crack output
- test hashcat command generation

## Testing
- `npm test __tests__/hashcat.test.tsx`
- `npm test` *(fails: terminal, autopsy, converter, snake.config)*
- `npm run lint` *(fails: components/apps/Chrome/index.tsx parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3ab3ddc8328972b4a83cd06bad2