### PR TITLE
Persist 2048 score and improve key handling

### DIFF
--- a/__tests__/game2048.test.tsx
+++ b/__tests__/game2048.test.tsx
@@ -33,6 +33,36 @@ test('merge triggers animation', () => {
   expect(firstCell?.querySelector('.merge-ripple')).toBeTruthy();
 });
 
+test('score persists in localStorage', async () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 2, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  const { unmount } = render(<Game2048 />);
+  fireEvent.keyDown(window, { key: 'ArrowLeft' });
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  expect(window.localStorage.getItem('2048-score')).toBe('4');
+  unmount();
+  const { getByText } = render(<Game2048 />);
+  expect(getByText(/Score:/).textContent).toContain('4');
+});
+
+test('ignores browser key repeat events', () => {
+  window.localStorage.setItem('2048-board', JSON.stringify([
+    [2, 2, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ]));
+  const { getByText } = render(<Game2048 />);
+  fireEvent.keyDown(window, { key: 'ArrowLeft', repeat: true });
+  expect(getByText(/Moves: 0/)).toBeTruthy();
+});
+
 test('tracks moves and allows multiple undos', async () => {
   window.localStorage.setItem('2048-board', JSON.stringify([
     [2, 2, 0, 0],

--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -185,7 +185,11 @@ const Game2048 = () => {
   const [colorBlind, setColorBlind] = usePersistentState('2048-cb', false, (v) => typeof v === 'boolean');
   const [animCells, setAnimCells] = useState(new Set());
   const [mergeCells, setMergeCells] = useState(new Set());
-  const [score, setScore] = useState(0);
+  const [score, setScore] = usePersistentState(
+    '2048-score',
+    0,
+    (v) => typeof v === 'number',
+  );
   const [scorePop, setScorePop] = useState(false);
   const [combo, setCombo] = useState(0);
   const [hint, setHint] = useState(null);

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -42,6 +42,7 @@ const useGameControls = (arg, gameId = 'default') => {
     };
     let timeout;
     const debounced = (e) => {
+      if (e.repeat) return;
       if (timeout) return;
       timeout = setTimeout(() => {
         timeout = null;


### PR DESCRIPTION
## Summary
- persist 2048 game score to localStorage
- guard against browser key repeat events in game control hook
- add tests for score persistence and key repeat handling

## Testing
- `npm test __tests__/game2048.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0aec64a948328b00e26524f48fe22