### PR TITLE
feat: enhance Breakout with power-ups and customization

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -12,6 +12,7 @@ interface GameLayoutProps {
   lives?: number;
   score?: number;
   highScore?: number;
+  editor?: React.ReactNode;
 }
 
 const GameLayout: React.FC<GameLayoutProps> = ({
@@ -21,6 +22,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   lives,
   score,
   highScore,
+  editor,
 }) => {
   const [showHelp, setShowHelp] = useState(false);
   const [paused, setPaused] = useState(false);
@@ -177,6 +179,9 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         {highScore !== undefined && <div>High: {highScore}</div>}
       </div>
       {!prefersReducedMotion && <PerfOverlay />}
+      {editor && (
+        <div className="absolute bottom-2 left-2 z-30">{editor}</div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add optional editor slot to GameLayout and expose Breakout level editor
- support paddle speed slider with persistent setting in Breakout
- document power-up drops and multi-ball/expand paddle effects

## Testing
- `npm test` *(fails: terminal.test.tsx, memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, snake.config.test.ts, frogger.config.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0aec99f2c832886b45733cc99db95