### PR TITLE
feat(sokoban): add move counter with multi-level undo

### DIFF
--- a/apps/sokoban/engine.ts
+++ b/apps/sokoban/engine.ts
@@ -15,6 +15,7 @@ interface HistoryEntry {
   player: Position;
   boxes: string[];
   pushes: number;
+  moves: number;
 }
 const key = (p: Position) => `${p.x},${p.y}`;
 
@@ -75,6 +76,7 @@ function cloneState(state: State): HistoryEntry {
     player: { ...state.player },
     boxes: Array.from(state.boxes),
     pushes: state.pushes,
+    moves: state.moves,
   };
 }
 
@@ -149,7 +151,7 @@ export function undo(state: State): State {
     player: { ...prev.player },
     boxes,
     pushes: prev.pushes,
-    moves: state.moves + 1,
+    moves: prev.moves,
     history: state.history.slice(0, -1),
   };
   restored.deadlocks = computeDeadlocks(restored);

--- a/apps/sokoban/index.tsx
+++ b/apps/sokoban/index.tsx
@@ -339,7 +339,8 @@ const Sokoban: React.FC<SokobanProps> = ({ getDailySeed }) => {
         <button type="button" onClick={handleHint} className="px-2 py-1 bg-gray-300 rounded">
           Hint
         </button>
-        <div className="ml-4">Pushes: {state.pushes}</div>
+        <div className="ml-4">Moves: {state.moves}</div>
+        <div>Pushes: {state.pushes}</div>
         <div>Best: {best ?? '-'}</div>
         {hint && <div className="ml-4">Hint: {hint}</div>}
         {status && <div className="ml-4 text-red-500">{status}</div>}


### PR DESCRIPTION
## Summary
- track move count and include in undo history
- show move counter alongside pushes

## Testing
- `npm test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0aed98d088328b7c91a27f881ee66