### PR TITLE
feat: improve nonogram with hints and auto-fill

### DIFF
--- a/__tests__/nonogram.test.ts
+++ b/__tests__/nonogram.test.ts
@@ -1,4 +1,11 @@
-import { validateSolution, findHint, getPuzzleBySeed, generateLinePatterns, lineToClues } from '../components/apps/nonogramUtils';
+import {
+  validateSolution,
+  findHint,
+  getPuzzleBySeed,
+  generateLinePatterns,
+  lineToClues,
+  autoFillLines,
+} from '../components/apps/nonogramUtils';
 
 describe('nonogram utilities', () => {
   test('validateSolution confirms grid matches clues', () => {
@@ -45,6 +52,22 @@ describe('nonogram utilities', () => {
     backtrack(0);
     expect(solutions.length).toBeGreaterThan(0);
     solutions.forEach((sol) => expect(sol[i][j]).toBe(1));
+  });
+
+  test('autoFillLines solves uniquely determined lines', () => {
+    const rows = [[1]];
+    const cols = [[1]];
+    const grid = [[0]];
+    const result = autoFillLines(grid, rows, cols);
+    expect(result[0][0]).toBe(1);
+  });
+
+  test('autoFillLines marks blanks for empty clues', () => {
+    const rows: number[][] = [[]];
+    const cols: number[][] = [[]];
+    const grid = [[0]];
+    const result = autoFillLines(grid, rows, cols);
+    expect(result[0][0]).toBe(-1);
   });
 
   test('daily seed deterministic', () => {

--- a/components/apps/nonogramUtils.js
+++ b/components/apps/nonogramUtils.js
@@ -87,26 +87,29 @@ export const autoFillLines = (grid, rows, cols) => {
   while (changed) {
     changed = false;
     rows.forEach((clue, i) => {
-      const { solved } = evaluateLine(g[i], clue);
-      if (solved) {
-        for (let j = 0; j < g[i].length; j++) {
-          if (g[i][j] === 0) {
-            g[i][j] = -1;
+      const line = g[i];
+      const solutions = getPossibleLineSolutions(clue, line);
+      if (solutions.length === 1) {
+        solutions[0].forEach((val, j) => {
+          const newVal = val ? 1 : -1;
+          if (g[i][j] !== newVal) {
+            g[i][j] = newVal;
             changed = true;
           }
-        }
+        });
       }
     });
     cols.forEach((clue, j) => {
       const col = g.map((row) => row[j]);
-      const { solved } = evaluateLine(col, clue);
-      if (solved) {
-        for (let i = 0; i < col.length; i++) {
-          if (g[i][j] === 0) {
-            g[i][j] = -1;
+      const solutions = getPossibleLineSolutions(clue, col);
+      if (solutions.length === 1) {
+        solutions[0].forEach((val, i) => {
+          const newVal = val ? 1 : -1;
+          if (g[i][j] !== newVal) {
+            g[i][j] = newVal;
             changed = true;
           }
-        }
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- allow cross marks via right click
- auto-fill lines with a single remaining configuration
- track mistakes and add logic-based hint button

## Testing
- `yarn test __tests__/nonogram.test.ts`
- `yarn test __tests__/terminal.test.tsx` *(fails: Cannot read properties of null (reading 'runCommand'))*


------
https://chatgpt.com/codex/tasks/task_e_68b0aedf038c8328a35ac968179646c0