### PR TITLE
feat(spotify): add mood playlist grid with mini controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Project Gallery | /apps/project-gallery | Utility / Media |
 | Quote_Generator | /apps/quote_generator | Utility / Media |
 
+The Spotify app loads its mood-to-playlist mapping from `public/spotify-playlists.json`,
+remembers the last mood you played, and exposes play/pause and track controls with
+keyboard hotkeys.
+
 ### Terminal Commands
 - `clear` – clears the terminal display.
 - `help` – lists available commands.

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,19 +1,119 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState.js';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 export default function SpotifyApp() {
+  const [playlists, setPlaylists] = useState({});
+  const [mood, setMood] = usePersistentState('spotify-mood', '');
+  const [isPlaying, setIsPlaying] = useState(false);
+  const gridRef = useRef(null);
+  const iframeRef = useRef(null);
+
+  useEffect(() => {
+    fetch('/spotify-playlists.json')
+      .then((res) => res.json())
+      .then((data) => {
+        setPlaylists(data);
+        if (!data[mood]) {
+          const first = Object.keys(data)[0];
+          if (first) setMood(first);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useRovingTabIndex(gridRef, true, 'horizontal');
+
+  const post = (cmd) => {
+    iframeRef.current?.contentWindow?.postMessage({ command: cmd }, '*');
+  };
+
+  const togglePlay = () => {
+    post(isPlaying ? 'pause' : 'play');
+    setIsPlaying(!isPlaying);
+  };
+
+  const next = () => post('next');
+  const previous = () => post('previous');
+
+  useEffect(() => {
+    const handleMessage = (e) => {
+      if (!e.origin.includes('spotify')) return;
+      const data = e.data;
+      if (Array.isArray(data) && data[0] === 'playback_update') {
+        setIsPlaying(!data[1]?.is_paused);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  useEffect(() => {
+    const handleKeys = (e) => {
+      if (e.key === ' ') {
+        e.preventDefault();
+        togglePlay();
+      } else if (e.key.toLowerCase() === 'n') {
+        next();
+      } else if (e.key.toLowerCase() === 'p') {
+        previous();
+      }
+    };
+    window.addEventListener('keydown', handleKeys);
+    return () => window.removeEventListener('keydown', handleKeys);
+  }, [togglePlay]);
+
   return (
-    <div className="h-full w-full bg-ub-cool-grey">
-      <iframe
-        src="https://open.spotify.com/embed/playlist/37i9dQZF1E37fa3zdWtvQY?utm_source=generator&theme=0"
-        title="Daily Mix 2"
-        width="100%"
-        height="100%"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      />
+    <div className="h-full w-full bg-ub-cool-grey flex flex-col">
+      <div
+        ref={gridRef}
+        role="listbox"
+        className="grid grid-cols-2 gap-2 p-2 overflow-auto"
+      >
+        {Object.entries(playlists).map(([m, id]) => (
+          <button
+            key={m}
+            role="option"
+            aria-label={m}
+            aria-selected={mood === m}
+            onClick={() => {
+              setMood(m);
+              setIsPlaying(false);
+            }}
+            className={`focus:outline-none rounded overflow-hidden ${
+              mood === m ? 'ring-2 ring-white' : ''
+            }`}
+          >
+            <iframe
+              ref={m === mood ? iframeRef : null}
+              src={`https://open.spotify.com/embed/playlist/${id}?utm_source=generator&theme=0`}
+              title={m}
+              width="100%"
+              height="152"
+              frameBorder="0"
+              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+              loading="lazy"
+            />
+            <span className="block text-center text-xs capitalize">{m}</span>
+          </button>
+        ))}
+      </div>
+      {mood && (
+        <div className="flex justify-center space-x-4 p-2 bg-black bg-opacity-30 text-white">
+          <button onClick={previous} title="Prev (P)" className="flex items-center gap-1">
+            ⏮<span className="text-xs">(P)</span>
+          </button>
+          <button onClick={togglePlay} title="Play/Pause (Space)" className="flex items-center gap-1">
+            {isPlaying ? '⏸' : '▶'}<span className="text-xs">(Space)</span>
+          </button>
+          <button onClick={next} title="Next (N)" className="flex items-center gap-1">
+            ⏭<span className="text-xs">(N)</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }
 
 export const displaySpotify = () => <SpotifyApp />;
+

--- a/public/spotify-playlists.json
+++ b/public/spotify-playlists.json
@@ -1,0 +1,5 @@
+{
+  "chill": "37i9dQZF1DX4WYpdgoIcn6",
+  "focus": "37i9dQZF1DX8Uebhn9wzrS",
+  "energize": "37i9dQZF1DX1g0iEXLFycr"
+}


### PR DESCRIPTION
## Summary
- add public mood-to-playlist mapping and persist last selection
- build keyboard navigable playlist card grid using Spotify embeds
- introduce mini controller with hotkey tooltips synced to iframe state

## Testing
- `yarn test components/apps/spotify --passWithNoTests`
- `yarn lint` *(fails: Parsing error in unrelated Chrome component)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af56cbac8328a56a4e1d3617f92a