### PR TITLE
feat(x): add offline feed with hashtag filters

### DIFF
--- a/public/x-feed.json
+++ b/public/x-feed.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "user": { "name": "Alice", "handle": "alice" },
+    "text": "Learning #kali #security is fun!",
+    "hashtags": ["kali", "security"]
+  },
+  {
+    "id": 2,
+    "user": { "name": "Bob", "handle": "bob" },
+    "text": "Check out #kali Linux tips.",
+    "hashtags": ["kali"]
+  },
+  {
+    "id": 3,
+    "user": { "name": "Charlie", "handle": "charlie" },
+    "text": "Exploring #hacking and #security!",
+    "hashtags": ["hacking", "security"]
+  }
+]


### PR DESCRIPTION
## Summary
- add saved hashtag and profile cards with keyboard focus
- filter local feed by hashtag with search chips and skeleton loaders
- allow toggling to offline JSON feed when network unavailable

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: multiple failing suites e.g., terminal.test.tsx, memoryGame.test.tsx, beef.test.tsx, autopsy.test.tsx, converter.test.tsx, frogger.config.test.ts, snake.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af55f36083288a94facb08afb48f