### PR TITLE
feat: add high contrast settings with preview

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,17 +3,36 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale, highContrast, setHighContrast } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+
+    const [tempWallpaper, setTempWallpaper] = useState(wallpaper);
+    const [tempReducedMotion, setTempReducedMotion] = useState(reducedMotion);
+    const [tempFontScale, setTempFontScale] = useState(fontScale);
+    const [tempHighContrast, setTempHighContrast] = useState(highContrast);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
-        setWallpaper(name);
+        setTempWallpaper(name);
     };
+
+    useEffect(() => {
+        const root = document.documentElement;
+        root.dataset.wallpaper = tempWallpaper;
+        root.dataset.reducedMotion = tempReducedMotion ? 'true' : 'false';
+        root.dataset.fontScale = tempFontScale.toString();
+        root.dataset.highContrast = tempHighContrast ? 'true' : 'false';
+        return () => {
+            root.dataset.wallpaper = wallpaper;
+            root.dataset.reducedMotion = reducedMotion ? 'true' : 'false';
+            root.dataset.fontScale = fontScale.toString();
+            root.dataset.highContrast = highContrast ? 'true' : 'false';
+        };
+    }, [tempWallpaper, tempReducedMotion, tempFontScale, tempHighContrast, wallpaper, reducedMotion, fontScale, highContrast]);
 
     let hexToRgb = (hex) => {
         hex = hex.replace('#', '');
@@ -57,7 +76,7 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${tempWallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
@@ -87,8 +106,8 @@ export function Settings() {
                     min="0.75"
                     max="1.5"
                     step="0.05"
-                    value={fontScale}
-                    onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                    value={tempFontScale}
+                    onChange={(e) => setTempFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
                 />
             </div>
@@ -96,17 +115,28 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
-                        checked={reducedMotion}
-                        onChange={(e) => setReducedMotion(e.target.checked)}
+                        checked={tempReducedMotion}
+                        onChange={(e) => setTempReducedMotion(e.target.checked)}
                         className="mr-2"
                     />
                     Reduced Motion
                 </label>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={tempHighContrast}
+                        onChange={(e) => setTempHighContrast(e.target.checked)}
+                        className="mr-2"
+                    />
+                    High Contrast
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
                 <div
                     className="p-4 rounded transition-colors duration-300 motion-reduce:transition-none"
-                    style={{ backgroundColor: '#0f1317', color: '#ffffff' }}
+                    style={{ backgroundColor: tempHighContrast ? '#000000' : '#0f1317', color: '#ffffff' }}
                 >
                     <p className="mb-2 text-center">Preview</p>
                     <button
@@ -128,7 +158,7 @@ export function Settings() {
                             key={index}
                             role="button"
                             aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
-                            aria-pressed={name === wallpaper}
+                            aria-pressed={name === tempWallpaper}
                             tabIndex="0"
                             onClick={changeBackgroundImage}
                             onFocus={changeBackgroundImage}
@@ -139,11 +169,35 @@ export function Settings() {
                                 }
                             }}
                             data-path={name}
-                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
+                            className={((name === tempWallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
                             style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
                         ></div>
                     ))
                 }
+            </div>
+            <div className="flex justify-center my-4 space-x-4">
+                <button
+                    onClick={() => {
+                        setWallpaper(tempWallpaper);
+                        setReducedMotion(tempReducedMotion);
+                        setFontScale(tempFontScale);
+                        setHighContrast(tempHighContrast);
+                    }}
+                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                >
+                    Save
+                </button>
+                <button
+                    onClick={() => {
+                        setTempWallpaper(wallpaper);
+                        setTempReducedMotion(reducedMotion);
+                        setTempFontScale(fontScale);
+                        setTempHighContrast(highContrast);
+                    }}
+                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                >
+                    Cancel
+                </button>
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
                 <button
@@ -175,6 +229,11 @@ export function Settings() {
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
                         setFontScale(defaults.fontScale);
+                        setHighContrast(defaults.highContrast);
+                        setTempWallpaper(defaults.wallpaper);
+                        setTempReducedMotion(defaults.reducedMotion);
+                        setTempFontScale(defaults.fontScale);
+                        setTempHighContrast(defaults.highContrast);
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
@@ -193,9 +252,11 @@ export function Settings() {
                     try {
                         const parsed = JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
-                        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+                        if (parsed.wallpaper !== undefined) { setWallpaper(parsed.wallpaper); setTempWallpaper(parsed.wallpaper); }
                         if (parsed.density !== undefined) setDensity(parsed.density);
-                        if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.reducedMotion !== undefined) { setReducedMotion(parsed.reducedMotion); setTempReducedMotion(parsed.reducedMotion); }
+                        if (parsed.fontScale !== undefined) { setFontScale(parsed.fontScale); setTempFontScale(parsed.fontScale); }
+                        if (parsed.highContrast !== undefined) { setHighContrast(parsed.highContrast); setTempHighContrast(parsed.highContrast); }
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
   setFontScale as saveFontScale,
+  getHighContrast as loadHighContrast,
+  setHighContrast as saveHighContrast,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -36,11 +38,13 @@ interface SettingsContextValue {
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
+  highContrast: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
+  setHighContrast: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -49,11 +53,13 @@ export const SettingsContext = createContext<SettingsContextValue>({
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
+  highContrast: defaults.highContrast,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
+  setHighContrast: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -62,6 +68,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
+  const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
 
   useEffect(() => {
     (async () => {
@@ -70,6 +77,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
+      setHighContrast(await loadHighContrast());
     })();
   }, []);
 
@@ -89,6 +97,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     saveWallpaper(wallpaper);
+    document.documentElement.dataset.wallpaper = wallpaper;
   }, [wallpaper]);
 
   useEffect(() => {
@@ -118,17 +127,23 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [density]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('reduced-motion', reducedMotion);
+    document.documentElement.dataset.reducedMotion = reducedMotion ? 'true' : 'false';
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
 
   useEffect(() => {
+    document.documentElement.dataset.fontScale = fontScale.toString();
     document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
     saveFontScale(fontScale);
   }, [fontScale]);
 
+  useEffect(() => {
+    document.documentElement.dataset.highContrast = highContrast ? 'true' : 'false';
+    saveHighContrast(highContrast);
+  }, [highContrast]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,6 +6,7 @@ const DEFAULT_SETTINGS = {
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
+  highContrast: false,
 };
 
 export async function getAccent() {
@@ -20,12 +21,12 @@ export async function setAccent(accent) {
 
 export async function getWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  return window.localStorage.getItem('bg-image') || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  window.localStorage.setItem('bg-image', wallpaper);
 }
 
 export async function getDensity() {
@@ -59,25 +60,36 @@ export async function setFontScale(scale) {
   window.localStorage.setItem('font-scale', String(scale));
 }
 
+export async function getHighContrast() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  return window.localStorage.getItem('high-contrast') === 'true';
+}
+
+export async function setHighContrast(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
-  await Promise.all([
-    del('accent'),
-    del('bg-image'),
-  ]);
+  await del('accent');
+  window.localStorage.removeItem('bg-image');
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
+  window.localStorage.removeItem('high-contrast');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion] = await Promise.all([
+  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
     getReducedMotion(),
+    getFontScale(),
+    getHighContrast(),
   ]);
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion });
+  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast });
 }
 
 export async function importSettings(json) {
@@ -89,11 +101,13 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion } = settings;
+  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
+  if (fontScale !== undefined) await setFontScale(fontScale);
+  if (highContrast !== undefined) await setHighContrast(highContrast);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add high-contrast option and persist all settings in localStorage
- apply settings via `data-*` attributes and allow preview before saving
- expose Save/Cancel controls and include new options in export/import

## Testing
- `npm test` *(fails: terminal, memoryGame, beef, autopsy, converter)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af5ad3e88328a8a218b479ed8d00