### PR TITLE
feat: simulate bluetooth scanning with filters and pairing dialogs

### DIFF
--- a/public/demo-data/bluetooth/scan.json
+++ b/public/demo-data/bluetooth/scan.json
@@ -1,0 +1,32 @@
+[
+  {
+    "address": "AA:BB:CC:DD:EE:01",
+    "name": "Keyboard",
+    "rssi": -40,
+    "class": "Peripheral"
+  },
+  {
+    "address": "AA:BB:CC:DD:EE:02",
+    "name": "Headphones",
+    "rssi": -65,
+    "class": "Audio"
+  },
+  {
+    "address": "AA:BB:CC:DD:EE:03",
+    "name": "Smartphone",
+    "rssi": -55,
+    "class": "Phone"
+  },
+  {
+    "address": "AA:BB:CC:DD:EE:04",
+    "name": "Fitness Tracker",
+    "rssi": -70,
+    "class": "Wearable"
+  },
+  {
+    "address": "AA:BB:CC:DD:EE:05",
+    "name": "Laptop",
+    "rssi": -45,
+    "class": "Computer"
+  }
+]


### PR DESCRIPTION
## Summary
- load bundled Bluetooth scan data and support filtering by RSSI, class, and name
- add permission and pairing modals to mimic device access flow

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: unable to find elements in BeEF, Autopsy, MemoryGame, and Terminal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af5d3ef88328aea14de77ff2bd34