### PR TITLE
feat(memory): add deck, timer, and size options

### DIFF
--- a/__tests__/memoryGame.test.tsx
+++ b/__tests__/memoryGame.test.tsx
@@ -74,8 +74,8 @@ afterEach(() => {
 });
 
 test('combo meter increments and resets', () => {
-  const { getAllByRole, getByTestId } = render(<Memory />);
-  const cards = getAllByRole('button');
+  const { getAllByTestId, getByTestId } = render(<Memory />);
+  const cards = getAllByTestId('card-inner').map((el) => el.parentElement as HTMLElement);
   const combo = getByTestId('combo-meter');
 
   expect(combo.textContent).toContain('0');
@@ -103,9 +103,9 @@ test('combo meter increments and resets', () => {
 });
 
 test('card flip applies transform style', () => {
-  const { getAllByRole } = render(<Memory />);
-  const card = getAllByRole('button')[0];
-  const inner = card.querySelector('[data-testid="card-inner"]') as HTMLElement;
+  const { getAllByTestId } = render(<Memory />);
+  const inner = getAllByTestId('card-inner')[0] as HTMLElement;
+  const card = inner.parentElement as HTMLElement;
   expect(inner.style.transform).toBe('rotateY(0deg)');
   fireEvent.click(card);
   expect(inner.style.transform).toBe('rotateY(180deg)');

--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -16,20 +16,36 @@ export const EMOJIS = [
   '\u{1F965}', // coconut
   '\u{1FAD0}', // blueberry
   '\u{1F96D}', // mango
-  '\u{1F345}'  // tomato
+  '\u{1F345}', // tomato
 ];
 
-// Accessible pattern deck using distinct shapes and colors
-export const PATTERNS = [
-  { value: '\u25B2', color: 'text-red-600' }, // triangle
-  { value: '\u25A0', color: 'text-blue-600' }, // square
-  { value: '\u25CF', color: 'text-green-600' }, // circle
-  { value: '\u25C6', color: 'text-yellow-600' }, // diamond
-  { value: '\u2605', color: 'text-purple-600' }, // star
-  { value: '\u271A', color: 'text-pink-600' }, // plus
-  { value: '\u25B3', color: 'text-orange-600' }, // outlined triangle
-  { value: '\u25A1', color: 'text-teal-600' }, // outlined square
+// Build a large enough pattern deck using distinct shapes and colors
+const SHAPES = ['\u25B2', '\u25A0', '\u25CF', '\u25C6', '\u2605', '\u271A', '\u25B3', '\u25A1'];
+const COLORS = [
+  'text-red-600',
+  'text-blue-600',
+  'text-green-600',
+  'text-yellow-600',
+  'text-purple-600',
+  'text-pink-600',
+  'text-orange-600',
+  'text-teal-600',
+  'text-lime-600',
+  'text-indigo-600',
+  'text-amber-600',
+  'text-rose-600',
+  'text-sky-600',
+  'text-fuchsia-600',
+  'text-violet-600',
+  'text-cyan-600',
+  'text-emerald-600',
+  'text-gray-600',
 ];
+
+export const PATTERNS = COLORS.map((color, i) => ({ value: SHAPES[i % SHAPES.length], color }));
+
+// Simple letter deck
+export const LETTERS = Array.from({ length: 26 }, (_, i) => ({ value: String.fromCharCode(65 + i) }));
 
 export function fisherYatesShuffle(array) {
   const arr = array.slice();
@@ -45,6 +61,8 @@ export function createDeck(size, type = 'emoji') {
   let selected;
   if (type === 'pattern') {
     selected = PATTERNS.slice(0, pairs);
+  } else if (type === 'letters') {
+    selected = LETTERS.slice(0, pairs);
   } else {
     selected = EMOJIS.slice(0, pairs).map((value) => ({ value }));
   }


### PR DESCRIPTION
## Summary
- add letter-based deck and expand pattern deck for memory game
- support countdown timer and configurable board sizes
- store best scores per size and timer mode

## Testing
- `yarn test __tests__/memoryGame.test.tsx`
- `npx eslint components/apps/memory.js components/apps/memory_utils.js __tests__/memoryGame.test.tsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aed1a9788328a4e1fdd4088b6548