### PR TITLE
Add sample wireless capture playback to Kismet

### DIFF
--- a/__tests__/kismet.test.tsx
+++ b/__tests__/kismet.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import KismetApp from '../components/apps/kismet';
+
+describe('KismetApp', () => {
+  it('steps through sample capture frames', async () => {
+    const user = userEvent.setup();
+    render(<KismetApp />);
+    await user.click(screen.getByRole('button', { name: /load sample/i }));
+    await user.click(screen.getByRole('button', { name: /step/i }));
+    expect(screen.getByText('CoffeeShopWiFi')).toBeInTheDocument();
+  });
+});

--- a/components/apps/kismet/sampleCapture.json
+++ b/components/apps/kismet/sampleCapture.json
@@ -1,0 +1,8 @@
+[
+  {"ssid":"CoffeeShopWiFi","channel":1,"signal":-45},
+  {"ssid":"FreeAirport","channel":6,"signal":-70},
+  {"ssid":"HomeWiFi","channel":11,"signal":-30},
+  {"ssid":"CoffeeShopWiFi","channel":1,"signal":-47},
+  {"ssid":"FreeAirport","channel":6,"signal":-72},
+  {"ssid":"NewCafe","channel":3,"signal":-80}
+]


### PR DESCRIPTION
## Summary
- add bundled sample wireless capture data
- animate SSID list and channel heatmap with play/pause/step controls
- test stepping through capture frames

## Testing
- `yarn test` *(fails: Terminal component, memoryGame, beef, autopsy, converter, snake.config, frogger.config)*
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0aec1102883289591a5939b3bb405