### PR TITLE
refactor: tighten csp and add nonce handling

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import Head from 'next/head';
+import { getCspNonce } from '../../utils/csp';
 
 export default function Meta() {
+    const nonce = getCspNonce();
     return (
         <Head>
             {/* Primary Meta Tags */}
@@ -60,6 +62,7 @@ export default function Meta() {
             />
             <script
                 type="application/ld+json"
+                nonce={nonce}
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify({
                         "@context": "https://schema.org",

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -6,6 +6,7 @@ import LazyGitHubButton from '../../LazyGitHubButton';
 import Certs from '../certs';
 import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
+import { getCspNonce } from '../../../utils/csp';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
@@ -104,12 +105,17 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       name: 'Alex Unnippillil',
       url: 'https://unnippillil.com',
     };
+    const nonce = getCspNonce();
 
     return (
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
         <Head>
           <title>About</title>
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }} />
+          <script
+            type="application/ld+json"
+            nonce={nonce}
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+          />
         </Head>
         <div
           className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black"

--- a/next.config.js
+++ b/next.config.js
@@ -17,12 +17,12 @@ const ContentSecurityPolicy = [
   "style-src-elem 'self' https://fonts.googleapis.com",
   // Allow loading fonts from Google
   "font-src 'self' https://fonts.gstatic.com",
-  // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com",
-  // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
-  // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com",
+  // External scripts required for embedded timelines and Google APIs
+  "script-src 'self' 'nonce-__CSP_NONCE__' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.google.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com",
+  // Allow outbound connections for embeds and APIs
+  "connect-src 'self' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.google.com https://www.gstatic.com https://www.googleapis.com https://www.googletagmanager.com https://www.google-analytics.com https://stackblitz.com",
+  // Restrict iframes to trusted providers
+  "frame-src 'self' https://stackblitz.com https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com",
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
   // Enforce HTTPS for all requests

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,30 +1,41 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import Script from 'next/script';
+import crypto from 'node:crypto';
 
 class MyDocument extends Document {
   /**
    * @param {import('next/document').DocumentContext} ctx
    */
   static async getInitialProps(ctx) {
+    const nonce = crypto.randomBytes(16).toString('base64');
     const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+    const csp = ctx.res?.getHeader('Content-Security-Policy');
+    if (csp) {
+      ctx.res.setHeader(
+        'Content-Security-Policy',
+        csp.toString().replace(/__CSP_NONCE__/g, nonce),
+      );
+    }
+    return { ...initialProps, nonce };
   }
 
   render() {
+    const { nonce } = this.props;
     return (
-      <Html lang="en">
+      <Html lang="en" data-csp-nonce={nonce}>
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
           <Script
             src="/theme.js"
             strategy="afterInteractive"
+            nonce={nonce}
             // Apply theme once the page is interactive to avoid blocking initial paint
           />
         </Head>
         <body>
           <Main />
-          <NextScript />
+          <NextScript nonce={nonce} />
         </body>
       </Html>
     );

--- a/utils/csp.ts
+++ b/utils/csp.ts
@@ -1,0 +1,6 @@
+export function getCspNonce(): string | undefined {
+  if (typeof document !== 'undefined') {
+    return document.documentElement.dataset.cspNonce;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- tighten Content Security Policy to whitelist specific script/connect/frame domains
- add dynamic nonce handling to support inline scripts
- apply nonce to structured-data scripts

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3182a4c832884da4102c82ce9e2