### PR TITLE
feat: prefetch dynamic apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ export const displaySudoku = () => <SudokuApp />;
 ```
 Heavy apps are wrapped with **dynamic import** and most games share a `GameLayout` with a help overlay.
 
+### Prefetching dynamic apps
+Dynamic app modules include a `webpackPrefetch` hint and expose a `prefetch()` helper. Desktop tiles call this helper on hover or
+keyboard focus so bundles are warmed before launch. When adding a new app, export a default component and register it with
+`createDynamicApp` to opt into this behaviour.
+
 ---
 
 ## Environment Variables

--- a/apps.config.js
+++ b/apps.config.js
@@ -2,13 +2,11 @@ import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
 
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
-import { displayVsCode } from './components/apps/vscode';
 import { displaySettings } from './components/apps/settings';
 import { displayChrome } from './components/apps/Chrome';
 import { displayTrash } from './components/apps/trash';
 import { displayGedit } from './components/apps/gedit';
 import { displayTodoist } from './components/apps/todoist';
-import { displayYouTube } from './components/apps/youtube';
 import { displayWeather } from './components/apps/weather';
 import { displayConverter } from './components/apps/converter';
 import { displayClipboardManager } from './components/apps/ClipboardManager';
@@ -19,6 +17,8 @@ import { displayNikto } from './components/apps/nikto';
 
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
+const VsCodeApp = createDynamicApp('vscode', 'VsCode');
+const YouTubeApp = createDynamicApp('youtube', 'YouTube');
 const CalculatorApp = createDynamicApp('calculator', 'Calculator');
 const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
 const ChessApp = createDynamicApp('chess', 'Chess');
@@ -101,6 +101,8 @@ const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 
 
 const displayTerminal = createDisplay(TerminalApp);
+const displayVsCode = createDisplay(VsCodeApp);
+const displayYouTube = createDisplay(YouTubeApp);
 const displayCalculator = createDisplay(CalculatorApp);
 const displayTicTacToe = createDisplay(TicTacToeApp);
 const displayChess = createDisplay(ChessApp);

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -4,7 +4,7 @@ import Image from 'next/image'
 export class UbuntuApp extends Component {
     constructor() {
         super();
-        this.state = { launching: false, dragging: false };
+        this.state = { launching: false, dragging: false, prefetched: false };
     }
 
     handleDragStart = () => {
@@ -23,6 +23,13 @@ export class UbuntuApp extends Component {
         this.props.openApp(this.props.id);
     }
 
+    handlePrefetch = () => {
+        if (!this.state.prefetched && typeof this.props.prefetch === 'function') {
+            this.props.prefetch();
+            this.setState({ prefetched: true });
+        }
+    }
+
     render() {
         return (
             <div
@@ -39,6 +46,8 @@ export class UbuntuApp extends Component {
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
+                onMouseEnter={this.handlePrefetch}
+                onFocus={this.handlePrefetch}
             >
                 <Image
                     width={40}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -48,6 +48,7 @@ class AllApplications extends React.Component {
                 icon={app.icon}
                 openApp={() => this.openApp(app.id)}
                 disabled={app.disabled}
+                prefetch={app.screen?.prefetch}
             />
         ));
     };

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -329,7 +329,8 @@ export class Desktop extends Component {
                     id: app.id,
                     icon: app.icon,
                     openApp: this.openApp,
-                    disabled: this.state.disabled_apps[app.id]
+                    disabled: this.state.disabled_apps[app.id],
+                    prefetch: app.screen?.prefetch,
                 }
 
                 appsJsx.push(

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -48,6 +48,7 @@ class ShortcutSelector extends React.Component {
                 icon={app.icon}
                 openApp={() => this.selectApp(app.id)}
                 disabled={app.disabled}
+                prefetch={app.screen?.prefetch}
             />
         ));
     };

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -5,10 +5,12 @@ import { logEvent } from './analytics';
 export const createDynamicApp = (path, name) =>
   dynamic(
     () =>
-      import(`../components/apps/${path}`).then((mod) => {
-        logEvent({ category: 'Application', action: `Loaded ${name}` });
-        return mod.default;
-      }),
+      import(/* webpackPrefetch: true */ `../components/apps/${path}`).then(
+        (mod) => {
+          logEvent({ category: 'Application', action: `Loaded ${name}` });
+          return mod.default;
+        }
+      ),
     {
       ssr: false,
       loading: () => (
@@ -19,7 +21,17 @@ export const createDynamicApp = (path, name) =>
     }
   );
 
-export const createDisplay = (Component) => (addFolder, openApp) => (
-  <Component addFolder={addFolder} openApp={openApp} />
-);
+export const createDisplay = (Component) => {
+  const Display = (addFolder, openApp) => (
+    <Component addFolder={addFolder} openApp={openApp} />
+  );
+
+  Display.prefetch = () => {
+    if (typeof Component.preload === 'function') {
+      Component.preload();
+    }
+  };
+
+  return Display;
+};
 


### PR DESCRIPTION
## Summary
- prefetch dynamically imported apps on hover and focus
- load heavy apps (VS Code, YouTube) with next/dynamic and prefetch hints
- document hover prefetch strategy for future apps

## Testing
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*
- `yarn test` *(fails: Terminal component, memory game, BeEF, Autopsy, converter tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af5175e083289687e9e5d7545106