### PR TITLE
feat(wordle): add stats and keyboard hints

### DIFF
--- a/__tests__/wordle.test.tsx
+++ b/__tests__/wordle.test.tsx
@@ -19,6 +19,7 @@ describe('Wordle', () => {
     Object.assign(navigator, {
       clipboard: { writeText: jest.fn() },
     });
+    localStorage.clear();
     Wordle = require('../components/apps/wordle').default;
   });
   afterEach(() => {
@@ -46,7 +47,7 @@ describe('Wordle', () => {
     fireEvent.change(input, { target: { value: 'ABDOM' } });
     fireEvent.submit(input.closest('form')!);
 
-    fireEvent.change(input, { target: { value: 'ABASE' } });
+    fireEvent.change(input, { target: { value: 'ACORN' } });
     fireEvent.submit(input.closest('form')!);
 
     expect(await screen.findByText(/Hard mode:/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- track overall Wordle stats and win streaks
- display on-screen keyboard with letter hints
- reset localStorage in tests to avoid state bleed

## Testing
- `npm test __tests__/wordle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0aeddeb648328a33bff4815332e08