### PR TITLE
feat: lane runner speed and lives updates

### DIFF
--- a/__tests__/laneRunner.test.ts
+++ b/__tests__/laneRunner.test.ts
@@ -5,6 +5,8 @@ describe('lane runner', () => {
     const playerLane = 1;
     const obstacles = [{ lane: 1, y: 460 }];
     expect(detectCollision(playerLane, obstacles, 460, 20)).toBe(true);
+    const nearMiss = [{ lane: 1, y: 477 }];
+    expect(detectCollision(playerLane, nearMiss, 460, 20)).toBe(false);
   });
 
   test('score increments with distance', () => {


### PR DESCRIPTION
## Summary
- assign unique base speeds to each lane and move obstacles with lane-specific velocities
- shrink collision hitboxes for more forgiving gameplay and test near-miss
- display remaining lives with heart icons

## Testing
- `yarn test` *(fails: terminal, memory game, beef, autopsy suites)*
- `yarn lint` *(fails: Parsing error in components/apps/Chrome/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aeceb3548328967eba2564ef0e7f