### PR TITLE
Guard Web Worker creation against non-browser environments

### DIFF
--- a/apps/checkers/index.tsx
+++ b/apps/checkers/index.tsx
@@ -103,12 +103,15 @@ export default function CheckersPage() {
   );
 
   useEffect(() => {
-    workerRef.current = new Worker('/checkers-worker.js');
-    workerRef.current.onmessage = (e: MessageEvent<Move>) => {
-      const move = e.data;
-      if (move) makeMove(move);
-    };
-    return () => workerRef.current?.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker('/checkers-worker.js');
+      workerRef.current.onmessage = (e: MessageEvent<Move>) => {
+        const move = e.data;
+        if (move) makeMove(move);
+      };
+      return () => workerRef.current?.terminate();
+    }
+    return undefined;
   }, [makeMove]);
 
   useEffect(() => {

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -42,7 +42,7 @@ function updateTimerDisplay() {
 }
 
 function startTimer() {
-  if (timerWorker) return;
+  if (timerWorker || typeof Worker !== 'function') return;
   const mins = parseInt(minutesInput.value, 10) || 0;
   const secs = parseInt(secondsInput.value, 10) || 0;
   timerRemaining = mins * 60 + secs;
@@ -81,7 +81,7 @@ function updateStopwatchDisplay() {
 }
 
 function startWatch() {
-  if (stopwatchWorker) return;
+  if (stopwatchWorker || typeof Worker !== 'function') return;
   stopwatchStartTime = Date.now() - stopwatchElapsed * 1000;
   stopwatchWorker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
   stopwatchWorker.onmessage = () => {

--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -43,7 +43,7 @@ const PerfOverlay: React.FC = () => {
     // Prefer OffscreenCanvas with a worker when supported
     if (
       typeof window !== 'undefined' &&
-      'Worker' in window &&
+      typeof Worker === 'function' &&
       'OffscreenCanvas' in window
     ) {
       const worker = new Worker(new URL('./perf.worker.js', import.meta.url));

--- a/components/apps/archive/Terminal/index.tsx
+++ b/components/apps/archive/Terminal/index.tsx
@@ -471,7 +471,7 @@ const TerminalPane = forwardRef<
         renderHint();
       });
 
-      if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+      if (typeof window !== 'undefined' && typeof Worker === 'function') {
         workerRef.current = new Worker(
           new URL('./terminal.worker.js', import.meta.url),
         );

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -63,11 +63,14 @@ function Timeline({ events, onSelect }) {
   const [zoomAnnouncement, setZoomAnnouncement] = useState('');
 
   useEffect(() => {
-    workerRef.current = new Worker(
-      new URL('./timelineWorker.js', import.meta.url)
-    );
-    workerRef.current.onmessage = (e) => setSorted(e.data);
-    return () => workerRef.current.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker(
+        new URL('./timelineWorker.js', import.meta.url)
+      );
+      workerRef.current.onmessage = (e) => setSorted(e.data);
+      return () => workerRef.current?.terminate();
+    }
+    return undefined;
   }, []);
 
   useEffect(() => {
@@ -232,7 +235,7 @@ function Autopsy() {
   }, []);
 
   useEffect(() => {
-    if (typeof Worker !== 'undefined') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       try {
         parseWorkerRef.current = new Worker(
           new URL('./jsonWorker.js', import.meta.url)
@@ -243,7 +246,7 @@ function Autopsy() {
         parseWorkerRef.current = null;
       }
     }
-    return () => parseWorkerRef.current && parseWorkerRef.current.terminate();
+    return () => parseWorkerRef.current?.terminate();
   }, []);
 
   useEffect(() => {

--- a/components/apps/beef/HookGraph.js
+++ b/components/apps/beef/HookGraph.js
@@ -19,29 +19,32 @@ export default function HookGraph({ hooks, steps }) {
   }, []);
 
   useEffect(() => {
-    workerRef.current = new Worker(
-      URL.createObjectURL(
-        new Blob(
-          [
-            `self.onmessage = (e) => {\n` +
-              `  const { hooks, steps } = e.data;\n` +
-              `  const elements = [];\n` +
-              `  hooks.forEach((h) => {\n` +
-              `    elements.push({ data: { id: h.id, label: h.label, type: 'hook' } });\n` +
-              `  });\n` +
-              `  steps.forEach((s) => {\n` +
-              `    const moduleNode = 'module-' + s.id;\n` +
-              `    elements.push({ data: { id: moduleNode, label: s.module, type: 'module' } });\n` +
-              `    elements.push({ data: { id: 'edge-' + s.id, source: s.hook, target: moduleNode } });\n` +
-              `  });\n` +
-              `  self.postMessage(elements);\n` +
-              `};`
-          ],
-          { type: 'application/javascript' }
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker(
+        URL.createObjectURL(
+          new Blob(
+            [
+              `self.onmessage = (e) => {\n` +
+                `  const { hooks, steps } = e.data;\n` +
+                `  const elements = [];\n` +
+                `  hooks.forEach((h) => {\n` +
+                `    elements.push({ data: { id: h.id, label: h.label, type: 'hook' } });\n` +
+                `  });\n` +
+                `  steps.forEach((s) => {\n` +
+                `    const moduleNode = 'module-' + s.id;\n` +
+                `    elements.push({ data: { id: moduleNode, label: s.module, type: 'module' } });\n` +
+                `    elements.push({ data: { id: 'edge-' + s.id, source: s.hook, target: moduleNode } });\n` +
+                `  });\n` +
+                `  self.postMessage(elements);\n` +
+                `};`
+            ],
+            { type: 'application/javascript' }
+          )
         )
-      )
-    );
-    return () => workerRef.current && workerRef.current.terminate();
+      );
+      return () => workerRef.current && workerRef.current.terminate();
+    }
+    return undefined;
   }, []);
 
   useEffect(() => {

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -99,7 +99,8 @@ const CarRacer = () => {
     const canvas = canvasRef.current;
     if (!canvas || typeof window === 'undefined') return;
 
-    const supportsWorker = window.Worker && 'OffscreenCanvas' in window;
+    const supportsWorker =
+      typeof Worker === 'function' && 'OffscreenCanvas' in window;
     let worker;
     let ctx;
     if (supportsWorker) {

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -85,18 +85,21 @@ const Checkers = () => {
   };
 
   useEffect(() => {
-    workerRef.current = new Worker('/checkers-worker.js');
-    workerRef.current.onmessage = (e: MessageEvent<Move>) => {
-      const move = e.data;
-      if (hintRequest.current) {
-        setHint(move);
-        hintRequest.current = false;
-        setTimeout(() => setHint(null), 1000);
-      } else if (move) {
-        makeMoveRef.current?.(move);
-      }
-    };
-    return () => workerRef.current?.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker('/checkers-worker.js');
+      workerRef.current.onmessage = (e: MessageEvent<Move>) => {
+        const move = e.data;
+        if (hintRequest.current) {
+          setHint(move);
+          hintRequest.current = false;
+          setTimeout(() => setHint(null), 1000);
+        } else if (move) {
+          makeMoveRef.current?.(move);
+        }
+      };
+      return () => workerRef.current?.terminate();
+    }
+    return undefined;
   }, []);
 
   useEffect(() => {

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -117,11 +117,14 @@ export default function GhidraApp() {
 
   // S3: Offload hex generation to worker only when needed
   useEffect(() => {
-    hexWorkerRef.current = new Worker(new URL('./hexWorker.js', import.meta.url));
-    hexWorkerRef.current.onmessage = (e) => {
-      setHexMap((m) => ({ ...m, [e.data.id]: e.data.hex }));
-    };
-    return () => hexWorkerRef.current.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      hexWorkerRef.current = new Worker(new URL('./hexWorker.js', import.meta.url));
+      hexWorkerRef.current.onmessage = (e) => {
+        setHexMap((m) => ({ ...m, [e.data.id]: e.data.hex }));
+      };
+      return () => hexWorkerRef.current?.terminate();
+    }
+    return undefined;
   }, []);
 
   useEffect(() => {

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -178,7 +178,7 @@ function HashcatApp() {
     setProgress(0);
     setResult('');
     if (typeof window === 'undefined') return;
-    if (window.Worker) {
+    if (typeof Worker === 'function') {
       workerRef.current = new Worker(
         new URL('./progress.worker.js', import.meta.url)
       );

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -48,13 +48,15 @@ const JohnApp = () => {
 
   const startProgress = (total) => {
     if (workerRef.current) workerRef.current.terminate();
-    workerRef.current = new Worker(new URL('./progress.worker.js', import.meta.url));
-    workerRef.current.onmessage = (e) => {
-      const { percent, phase: p } = e.data;
-      setProgress(percent);
-      setPhase(p);
-    };
-    workerRef.current.postMessage({ type: 'init', total });
+    if (typeof Worker === 'function') {
+      workerRef.current = new Worker(new URL('./progress.worker.js', import.meta.url));
+      workerRef.current.onmessage = (e) => {
+        const { percent, phase: p } = e.data;
+        setProgress(percent);
+        setPhase(p);
+      };
+      workerRef.current.postMessage({ type: 'init', total });
+    }
   };
 
   const incrementProgress = (p) => {

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -129,17 +129,19 @@ const MetasploitApp = ({
     setTimeline([]);
     setProgress(0);
     setReplaying(true);
-    const worker = new Worker(new URL('./exploit.worker.js', import.meta.url));
-    worker.onmessage = (e) => {
-      if (e.data.step) {
-        setTimeline((t) => [...t, e.data.step]);
-      } else if (e.data.done) {
-        setReplaying(false);
-        worker.terminate();
-      }
-    };
-    worker.postMessage('start');
-    workerRef.current = worker;
+    if (typeof Worker === 'function') {
+      const worker = new Worker(new URL('./exploit.worker.js', import.meta.url));
+      worker.onmessage = (e) => {
+        if (e.data.step) {
+          setTimeline((t) => [...t, e.data.step]);
+        } else if (e.data.done) {
+          setReplaying(false);
+          worker.terminate();
+        }
+      };
+      worker.postMessage('start');
+      workerRef.current = worker;
+    }
   };
 
   useEffect(() => {

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -199,7 +199,7 @@ const Minesweeper = () => {
   const audioRef = useRef(null);
   const workerRef = useRef(null);
   const initWorker = () => {
-    if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(
         new URL('./minesweeper.worker.js', import.meta.url),
       );

--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -29,20 +29,23 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
   );
 
   useEffect(() => {
-    workerRef.current = new Worker(
-      new URL('./filter.worker.js', import.meta.url)
-    );
-    const worker = workerRef.current;
-    worker.onmessage = (e) => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      const data = e.data || [];
-      rafRef.current = requestAnimationFrame(() => setDisplayData(data));
-    };
-    worker.postMessage({ hosts, filter });
-    return () => {
-      worker.terminate();
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker(
+        new URL('./filter.worker.js', import.meta.url)
+      );
+      const worker = workerRef.current;
+      worker.onmessage = (e) => {
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        const data = e.data || [];
+        rafRef.current = requestAnimationFrame(() => setDisplayData(data));
+      };
+      worker.postMessage({ hosts, filter });
+      return () => {
+        worker.terminate();
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      };
+    }
+    return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -15,23 +15,26 @@ const NiktoApp = () => {
   const workerRef = useRef(null);
 
   useEffect(() => {
-    workerRef.current = new Worker(
-      new URL("./nikto.worker.js", import.meta.url),
-    );
-    workerRef.current.onmessage = (e) => {
-      const { clusters, error } = e.data || {};
-      if (error) {
-        setStatus(error);
-        setResults({});
-      } else if (clusters) {
-        setResults(clusters);
-        setStatus("Scan complete");
-      }
-    };
-    workerRef.current.onerror = () => {
-      setStatus("Worker error");
-    };
-    return () => workerRef.current?.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      workerRef.current = new Worker(
+        new URL("./nikto.worker.js", import.meta.url),
+      );
+      workerRef.current.onmessage = (e) => {
+        const { clusters, error } = e.data || {};
+        if (error) {
+          setStatus(error);
+          setResults({});
+        } else if (clusters) {
+          setResults(clusters);
+          setStatus("Scan complete");
+        }
+      };
+      workerRef.current.onerror = () => {
+        setStatus("Worker error");
+      };
+      return () => workerRef.current?.terminate();
+    }
+    return undefined;
   }, []);
 
   const runDemo = async () => {

--- a/components/apps/nmap-nse/DiscoveryMap.js
+++ b/components/apps/nmap-nse/DiscoveryMap.js
@@ -10,7 +10,7 @@ const DiscoveryMap = ({ trigger }) => {
 
     const supportsWorker =
       typeof window !== 'undefined' &&
-      window.Worker &&
+      typeof Worker === 'function' &&
       'OffscreenCanvas' in window;
     let worker;
     let animationFrame;

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -113,7 +113,7 @@ const OpenVASApp = () => {
     if (typeof window !== 'undefined') {
       const media = window.matchMedia('(prefers-reduced-motion: reduce)');
       reduceMotion.current = media.matches;
-      if (typeof window.Worker === 'function') {
+      if (typeof Worker === 'function') {
         workerRef.current = new Worker(new URL('./openvas.worker.js', import.meta.url));
         workerRef.current.onmessage = (e) => {
           const { type, data } = e.data || {};

--- a/components/apps/qr_tool/index.js
+++ b/components/apps/qr_tool/index.js
@@ -77,7 +77,7 @@ const QRTool = () => {
   };
 
   const initWorker = () => {
-    if (!workerRef.current) {
+    if (!workerRef.current && typeof Worker === 'function') {
       workerRef.current = new Worker(new URL('./scan.worker.js', import.meta.url));
       workerRef.current.onmessage = (e) => {
         setDecodedText(e.data || 'No QR code found');

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -21,12 +21,12 @@ const HexEditor = ({ hex }) => {
   }, []);
 
   useEffect(() => {
-    if (typeof Worker !== 'undefined') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(
         new URL('./hexWorker.js', import.meta.url)
       );
       workerRef.current.onmessage = (e) => setBytes(e.data);
-      return () => workerRef.current.terminate();
+      return () => workerRef.current?.terminate();
     }
     return undefined;
   }, []);

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -32,7 +32,7 @@ const Radare2 = () => {
   // Kick off the worker with the pre-baked analysis so no real
   // analysis runs in the browser.
   useEffect(() => {
-    if (typeof Worker !== 'undefined') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(
         new URL('./analysisWorker.js', import.meta.url)
       );
@@ -42,7 +42,7 @@ const Radare2 = () => {
         }
       };
       workerRef.current.postMessage({ type: 'graph', analysis: demoAnalysis });
-      return () => workerRef.current.terminate();
+      return () => workerRef.current?.terminate();
     }
     return undefined;
   }, []);

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -43,7 +43,7 @@ const Reversi = () => {
       reduceMotionRef.current = window.matchMedia(
         '(prefers-reduced-motion: reduce)'
       ).matches;
-      if (typeof window.Worker === 'function') {
+      if (typeof Worker === 'function') {
         workerRef.current = new Worker(
           new URL('./reversi.worker.js', import.meta.url)
         );

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -45,7 +45,7 @@ export default function Todoist() {
   }, []);
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(new URL('./todoist.worker.js', import.meta.url));
       workerRef.current.onmessage = (e) => {
         const { groups: newGroups, taskTitle, to } = e.data || {};

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -83,7 +83,7 @@ const VolatilityApp = () => {
   const workerRef = useRef(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && typeof window.Worker === 'function') {
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(new URL('./heatmap.worker.js', import.meta.url));
       workerRef.current.onmessage = (e) => setHeatmapData(e.data);
       workerRef.current.postMessage({ segments: memoryDemo.segments });

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -279,11 +279,14 @@ const Weather = () => {
 
   // S3: Offload polyline generation to worker only when needed
   useEffect(() => {
-    pointsWorkerRef.current = new Worker(
-      new URL('./weather.worker.js', import.meta.url)
-    );
-    pointsWorkerRef.current.onmessage = (e) => setPoints(e.data);
-    return () => pointsWorkerRef.current.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      pointsWorkerRef.current = new Worker(
+        new URL('./weather.worker.js', import.meta.url)
+      );
+      pointsWorkerRef.current.onmessage = (e) => setPoints(e.data);
+      return () => pointsWorkerRef.current?.terminate();
+    }
+    return undefined;
   }, []);
 
   useEffect(() => {

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -45,20 +45,22 @@ const WiresharkApp = ({ initialPackets = [] }) => {
 
   // instantiate worker for burst grouping
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof Worker === 'undefined') return;
-    const worker = new Worker(new URL('./burstWorker.js', import.meta.url));
-    worker.onmessage = (e) => {
-      if (e.data.type === 'burst') {
-        setAnnouncement(`Burst starting at ${e.data.start}`);
-      }
-      if (e.data.type === 'timeline') {
-        setTimeline(e.data.timeline);
-      }
-    };
-    // seed worker with any bundled packets
-    initialPackets.forEach((pkt) => worker.postMessage(pkt));
-    workerRef.current = worker;
-    return () => worker.terminate();
+    if (typeof window !== 'undefined' && typeof Worker === 'function') {
+      const worker = new Worker(new URL('./burstWorker.js', import.meta.url));
+      worker.onmessage = (e) => {
+        if (e.data.type === 'burst') {
+          setAnnouncement(`Burst starting at ${e.data.start}`);
+        }
+        if (e.data.type === 'timeline') {
+          setTimeline(e.data.timeline);
+        }
+      };
+      // seed worker with any bundled packets
+      initialPackets.forEach((pkt) => worker.postMessage(pkt));
+      workerRef.current = worker;
+      return () => worker.terminate();
+    }
+    return undefined;
   }, [initialPackets]);
 
   useEffect(() => {

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -12,7 +12,7 @@ export default class Clock extends Component {
     }
 
     componentDidMount() {
-        if (typeof window !== 'undefined' && window.Worker) {
+        if (typeof window !== 'undefined' && typeof Worker === 'function') {
             this.worker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
             this.worker.onmessage = () => {
                 this.setState({ current_time: new Date() });

--- a/next.config.js
+++ b/next.config.js
@@ -65,6 +65,9 @@ module.exports = {
       'i.scdn.co',
     ],
   },
+  experimental: {
+    turbo: false,
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- Guard Web Worker instantiation with `typeof window !== 'undefined' && typeof Worker === 'function'`
- Terminate workers in cleanup and disable turbopack via `experimental.turbo`

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: HashcatApp labels, BeEF hooks, mimikatz api, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd77386c8328bd7ef2490bda7971