### PR TITLE
chore: add type check and serial Jest to deploy workflow

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -20,10 +20,13 @@ jobs:
         run: yarn install
 
       - name: Test
-        run: yarn test
+        run: yarn jest -w=1
 
       - name: Lint
         run: yarn lint
+
+      - name: Type Check
+        run: yarn tsc --noEmit
 
       - name: Building
         run: yarn build


### PR DESCRIPTION
## Summary
- run Jest serially in deploy workflow
- type check with `tsc --noEmit` before building

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint --fix` *(fails: Identifier 'togglePause' has already been declared)*
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: Identifier 'togglePause' has already been declared)*
- `yarn tsc --noEmit` *(fails: Argument of type 'RefObject<HTMLDivElement | null>' is not assignable to parameter of type 'RefObject<HTMLElement>'*)
- `yarn jest -w=1` *(fails: HashcatApp labels hashcat modes with example hashes)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd79705c8328ba145f4c616fa30c