### PR TITLE
fix: clean up type imports and annotate JS

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -25,8 +25,12 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
 
-  useFocusTrap(menuRef, open);
-  useRovingTabIndex(menuRef, open, 'vertical');
+  useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
+  useRovingTabIndex(
+    menuRef as React.RefObject<HTMLElement>,
+    open,
+    'vertical',
+  );
 
   useEffect(() => {
     const node = targetRef.current;

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -19,7 +19,11 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const [matches, setMatches] = useState<number[]>([]);
   const thumbListRef = useRef<HTMLDivElement | null>(null);
 
-  useRovingTabIndex(thumbListRef, thumbs.length > 0, 'horizontal');
+  useRovingTabIndex(
+    thumbListRef as React.RefObject<HTMLElement>,
+    thumbs.length > 0,
+    'horizontal',
+  );
 
   useEffect(() => {
     const loadPdf = async () => {
@@ -41,7 +45,9 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
       const canvas = canvasRef.current!;
       canvas.height = viewport.height;
       canvas.width = viewport.width;
-      await pg.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+      await pg
+        .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
+        .promise;
     };
     render();
   }, [pdf, page]);
@@ -56,7 +62,9 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
         const canvas = document.createElement('canvas');
         canvas.height = viewport.height;
         canvas.width = viewport.width;
-        await pg.render({ canvasContext: canvas.getContext('2d')!, viewport }).promise;
+        await pg
+          .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
+          .promise;
         arr.push(canvas);
       }
       setThumbs(arr);

--- a/hooks/useDailyQuote.ts
+++ b/hooks/useDailyQuote.ts
@@ -37,7 +37,7 @@ const processQuotes = (data: any[]) =>
     .map((q) => {
       const content = q.content || q.quote || '';
       const author = q.author || 'Unknown';
-      let tags = Array.isArray(q.tags) ? q.tags.map((t) => t.toLowerCase()) : [];
+      let tags = Array.isArray(q.tags) ? q.tags.map((t: string) => t.toLowerCase()) : [];
       if (!tags.length) {
         const lower = content.toLowerCase();
         Object.entries(CATEGORY_KEYWORDS).forEach(([cat, keywords]) => {
@@ -50,7 +50,7 @@ const processQuotes = (data: any[]) =>
     .filter(
       (q) =>
         !filter.isProfane(q.content) &&
-        q.tags.some((t) => SAFE_CATEGORIES.includes(t))
+        q.tags.some((t: string) => SAFE_CATEGORIES.includes(t))
     );
 
 const offlineQuotes = processQuotes(offlineQuotesData as any[]);

--- a/pages/apps/connect-four.tsx
+++ b/pages/apps/connect-four.tsx
@@ -219,7 +219,8 @@ const ConnectFour = () => {
     [winner, animDisc, player, board]
   );
 
-  const useControls = useGameControls as (cols: number, onDrop: (col: number) => void) => GameControls;
+  const useControls =
+    useGameControls as unknown as (cols: number, onDrop: (col: number) => void) => GameControls;
   const [selectedCol, setSelectedCol] = useControls(COLS, dropDisc);
 
   const [aiDepth, setAiDepth] = useState(4);

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -9,7 +9,7 @@ const QRPage: React.FC = () => {
   const [scanResult, setScanResult] = useState('');
   const [error, setError] = useState('');
   const videoRef = useRef<HTMLVideoElement>(null);
-  const codeReaderRef = useRef<BrowserQRCodeReader>();
+  const codeReaderRef = useRef<BrowserQRCodeReader | null>(null);
 
   const generateQr = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,12 +36,12 @@ const QRPage: React.FC = () => {
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
-        const codeReader = new BrowserQRCodeReader();
-        codeReaderRef.current = codeReader;
-        codeReader.decodeFromVideoDevice(
-          undefined,
-          videoRef.current!,
-          (result, err) => {
+          const codeReader = new BrowserQRCodeReader();
+          codeReaderRef.current = codeReader;
+          codeReader.decodeFromVideoDevice(
+            null,
+            videoRef.current!,
+            (result, err) => {
             if (result) {
               setScanResult(result.getText());
             }

--- a/types/bad-words.d.ts
+++ b/types/bad-words.d.ts
@@ -1,0 +1,1 @@
+declare module 'bad-words';


### PR DESCRIPTION
## Summary
- cast context menu and PDF viewer refs to generic HTMLElement for focus management
- annotate daily quote parsing and add type stub for `bad-words`
- fix QR scanner and Connect Four hooks after removing type imports

## Testing
- `yarn tsc --noEmit` *(fails: Bluetooth types missing, serial/usb APIs, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd78ab748328bd3ead05aea66233