### PR TITLE
feat(nonogram): add logic with contradiction checks and pack loader

### DIFF
--- a/__tests__/nonogramGame.test.ts
+++ b/__tests__/nonogramGame.test.ts
@@ -1,0 +1,29 @@
+import { checkContradictions } from '../apps/games/nonogram/logic';
+import { parsePack } from '../apps/games/nonogram/packs';
+
+describe('games/nonogram logic', () => {
+  test('detects contradictions from cross marks', () => {
+    const rows = [[1]];
+    const cols = [[1]];
+    const grid = [[-1]] as (-1 | 0 | 1)[][];
+    const result = checkContradictions(grid, rows, cols);
+    expect(result.rows[0]).toBe(true);
+    expect(result.cols[0]).toBe(true);
+  });
+
+  test('loads puzzles from packs', () => {
+    const raw = `
+#..
+##.
+...
+
+.#.
+###
+.#.
+`;
+    const puzzles = parsePack(raw);
+    expect(puzzles).toHaveLength(2);
+    expect(puzzles[0].rows).toEqual([[1], [2], []]);
+    expect(puzzles[0].cols).toEqual([[2], [1], []]);
+  });
+});

--- a/apps/games/nonogram/logic.ts
+++ b/apps/games/nonogram/logic.ts
@@ -1,0 +1,84 @@
+export type Cell = -1 | 0 | 1;
+export type Grid = Cell[][];
+export type Clue = number[];
+
+// Convert a line of cells into Nonogram clues
+export const lineToClues = (line: Cell[]): number[] => {
+  const clues: number[] = [];
+  let count = 0;
+  line.forEach((cell) => {
+    if (cell === 1) count += 1;
+    else if (count) {
+      clues.push(count);
+      count = 0;
+    }
+  });
+  if (count) clues.push(count);
+  return clues.length ? clues : [];
+};
+
+// Generate all patterns for a clue in a line of given length
+export const generateLinePatterns = (clue: Clue, length: number): Cell[][] => {
+  if (clue.length === 0) return [Array(length).fill(0)];
+  const [first, ...rest] = clue;
+  const patterns: Cell[][] = [];
+  for (let offset = 0; offset <= length - first; offset++) {
+    const head: Cell[] = Array(offset).fill(0).concat(Array(first).fill(1));
+    if (rest.length) {
+      const tails = generateLinePatterns(rest, length - offset - first - 1);
+      tails.forEach((t) => patterns.push(head.concat([0], t)));
+    } else if (head.length < length) {
+      patterns.push(head.concat(Array(length - head.length).fill(0)));
+    } else patterns.push(head);
+  }
+  return patterns;
+};
+
+// Filter patterns based on current line state
+export const getPossibleLineSolutions = (clue: Clue, line: Cell[]): Cell[][] => {
+  const patterns = generateLinePatterns(clue, line.length);
+  return patterns.filter((p) =>
+    line.every((cell, i) =>
+      cell === 1 ? p[i] === 1 : cell === -1 ? p[i] === 0 : true
+    )
+  );
+};
+
+// Evaluate whether a line is solved or contradictory
+export const evaluateLine = (line: Cell[], clue: Clue) => {
+  const solved = JSON.stringify(lineToClues(line)) === JSON.stringify(clue);
+  const contradiction = getPossibleLineSolutions(clue, line).length === 0;
+  return { solved, contradiction };
+};
+
+// Check contradictions across all rows and columns
+export const checkContradictions = (
+  grid: Grid,
+  rows: Clue[],
+  cols: Clue[]
+): { rows: boolean[]; cols: boolean[] } => {
+  const rowContradictions = rows.map((clue, i) =>
+    evaluateLine(grid[i], clue).contradiction
+  );
+  const colContradictions = cols.map((clue, j) => {
+    const column = grid.map((row) => row[j]);
+    return evaluateLine(column, clue).contradiction;
+  });
+  return { rows: rowContradictions, cols: colContradictions };
+};
+
+// Toggle a cross mark on the grid
+export const toggleCross = (grid: Grid, r: number, c: number): Grid => {
+  const g = grid.map((row) => row.slice());
+  g[r][c] = g[r][c] === -1 ? 0 : -1;
+  return g;
+};
+
+export default {
+  lineToClues,
+  generateLinePatterns,
+  getPossibleLineSolutions,
+  evaluateLine,
+  checkContradictions,
+  toggleCross,
+};

--- a/apps/games/nonogram/packs.ts
+++ b/apps/games/nonogram/packs.ts
@@ -1,0 +1,40 @@
+import { lineToClues, Grid, Clue } from './logic';
+
+export interface Puzzle {
+  name: string;
+  rows: Clue[];
+  cols: Clue[];
+  grid: Grid;
+}
+
+export interface PuzzlePack {
+  name: string;
+  puzzles: Puzzle[];
+}
+
+// Parse a puzzle pack string into puzzle objects. Puzzles are separated
+// by blank lines and use '#' for filled cells and '.' for blanks.
+export const parsePack = (raw: string): Puzzle[] => {
+  const blocks = raw.trim().split(/\n\s*\n/).filter(Boolean);
+  return blocks.map((block, idx) => {
+    const lines = block.trim().split(/\n/);
+    const grid: Grid = lines.map((line) =>
+      Array.from(line).map((ch) => (ch === '#' ? 1 : 0))
+    );
+    const rows = grid.map(lineToClues);
+    const width = grid[0]?.length || 0;
+    const cols: Clue[] = [];
+    for (let c = 0; c < width; c++) {
+      const col = grid.map((row) => row[c]);
+      cols.push(lineToClues(col));
+    }
+    return { name: `Puzzle ${idx + 1}`, rows, cols, grid };
+  });
+};
+
+export const loadPack = (name: string, raw: string): PuzzlePack => ({
+  name,
+  puzzles: parsePack(raw),
+});
+
+export default { parsePack, loadPack };


### PR DESCRIPTION
## Summary
- implement nonogram logic module with cross-mark toggling and contradiction detection
- add puzzle pack parser for loading multiple grids
- cover nonogram logic and pack parsing with tests

## Testing
- `npm test __tests__/nonogramGame.test.ts`
- `npm test __tests__/nonogram.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa4aab908328acf38e64aaf6d6fb