### PR TITLE
Add Metasploit app with module docs and loot viewer

### DIFF
--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import MetasploitApp from '../../components/apps/metasploit';
+
+const MetasploitPage: React.FC = () => {
+  return <MetasploitApp />;
+};
+
+export default MetasploitPage;

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -28,6 +28,11 @@ const MetasploitApp = ({
   const [animationStyle, setAnimationStyle] = useState({ opacity: 1 });
   const [reduceMotion, setReduceMotion] = useState(false);
 
+  const [selectedModule, setSelectedModule] = useState(null);
+  const [loot, setLoot] = useState([]);
+  const [notes, setNotes] = useState([]);
+  const [showLoot, setShowLoot] = useState(false);
+
   const [timeline, setTimeline] = useState([]);
   const [replaying, setReplaying] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -49,6 +54,23 @@ const MetasploitApp = ({
     handler();
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch('/fixtures/metasploit_loot.json');
+        const data = await res.json();
+        if (active) {
+          setLoot(data.loot || []);
+          setNotes(data.notes || []);
+        }
+      } catch (e) {}
+    })();
+    return () => {
+      active = false;
+    };
   }, []);
 
   const filtered = useMemo(() => {
@@ -112,15 +134,28 @@ const MetasploitApp = ({
     }
   };
 
-  const runDemo = () => {
-    const first = modules[0];
+  const runDemo = async () => {
+    const exploit = modules[0];
+    const post = modules.find((m) => m.type === 'post');
+    if (!exploit || !post) return;
     setOutput(
       (prev) =>
-        `${prev}\nmsf6 > use ${first.name}\n${first.transcript || ''}`
+        `${prev}\nmsf6 > use ${exploit.name}\n${exploit.transcript || ''}`
+    );
+    await new Promise((r) => setTimeout(r, 500));
+    setOutput(
+      (prev) =>
+        `${prev}\nmsf6 exploit(${exploit.name}) > sessions -i 1\n[*] Session 1 opened`
+    );
+    await new Promise((r) => setTimeout(r, 500));
+    setOutput(
+      (prev) =>
+        `${prev}\nmsf6 exploit(${exploit.name}) > run ${post.name}\n${post.transcript || ''}`
     );
   };
 
   const showModule = (mod) => {
+    setSelectedModule(mod);
     setOutput((prev) => `${prev}\nmsf6 > use ${mod.name}\n${mod.transcript || ''}`);
   };
 
@@ -185,124 +220,159 @@ const MetasploitApp = ({
           Run Demo
         </button>
       </div>
-      <div className="p-2">
-        <div className="flex mb-2">
-          <input
-            className="flex-grow bg-ub-grey text-white p-1 rounded"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search modules"
-            spellCheck={false}
-          />
-          <select
-            className="ml-2 bg-ub-grey text-white p-1 rounded"
-            value={searchField}
-            onChange={(e) => setSearchField(e.target.value)}
-          >
-            <option value="name">Name</option>
-            <option value="type">Type</option>
-            <option value="platform">Platform</option>
-            <option value="cve">CVE</option>
-          </select>
-        </div>
-        {query && (
-          <ul className="mt-2 max-h-40 overflow-auto text-xs">
-            {filtered.map((m) => (
-              <li key={m.name} className="mb-1">
-                <span className="font-mono">{m.name}</span> - {m.description}
-                {m.platform && (
-                  <span className="ml-1">[{m.platform}]</span>
-                )}
-                {(m.cve || []).map((c) => (
-                  <span key={c} className="ml-1">{c}</span>
-                ))}
-              </li>
-            ))}
-          </ul>
-        )}
-        <div className="mt-4">
-          <div className="flex flex-wrap mb-2">
-            {severities.map((s) => (
-              <button
-                key={s}
-                onClick={() => setSelectedSeverity(s)}
-                aria-pressed={selectedSeverity === s}
-                className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus:outline-none ${severityStyles[s]} ${
-                  selectedSeverity === s
-                    ? 'ring-2 ring-white motion-safe:transition-transform motion-safe:duration-300 motion-safe:scale-110 motion-reduce:transition-none motion-reduce:scale-100'
-                    : ''
-                }`}
-              >
-                {s}
-              </button>
+      <div className="flex p-2">
+        <div className="w-2/3 pr-2">
+          <div className="flex mb-2">
+            <input
+              className="flex-grow bg-ub-grey text-white p-1 rounded"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search modules"
+              spellCheck={false}
+            />
+            <select
+              className="ml-2 bg-ub-grey text-white p-1 rounded"
+              value={searchField}
+              onChange={(e) => setSearchField(e.target.value)}
+            >
+              <option value="name">Name</option>
+              <option value="type">Type</option>
+              <option value="platform">Platform</option>
+              <option value="cve">CVE</option>
+            </select>
+          </div>
+          {query && (
+            <ul className="mt-2 max-h-40 overflow-auto text-xs">
+              {filtered.map((m) => (
+                <li key={m.name} className="mb-1">
+                  <span className="font-mono">{m.name}</span> - {m.description}
+                  {m.platform && <span className="ml-1">[{m.platform}]</span>}
+                  {(m.cve || []).map((c) => (
+                    <span key={c} className="ml-1">{c}</span>
+                  ))}
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-4">
+            <div className="flex flex-wrap mb-2">
+              {severities.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setSelectedSeverity(s)}
+                  aria-pressed={selectedSeverity === s}
+                  className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus:outline-none ${severityStyles[s]} ${
+                    selectedSeverity === s
+                      ? 'ring-2 ring-white motion-safe:transition-transform motion-safe:duration-300 motion-safe:scale-110 motion-reduce:transition-none motion-reduce:scale-100'
+                      : ''
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            {moduleTypes.map((type) => (
+              <div key={type} className="mb-2">
+                <h3 className="text-sm font-bold capitalize">{type}</h3>
+                <ul style={animationStyle} className="max-h-32 overflow-auto text-xs">
+                  {(modulesByType[type] || []).map((m) => (
+                    <li key={m.name} className="mb-1">
+                      <button
+                        type="button"
+                        onClick={() => showModule(m)}
+                        className="text-left w-full"
+                      >
+                        <span className={`px-1 rounded mr-1 ${severityStyles[m.severity]}`}>
+                          {m.severity}
+                        </span>
+                        <span className="font-mono">{m.name}</span> - {m.description}
+                        {m.tags.map((t) => (
+                          <span key={t} className="ml-1 px-1 bg-ub-grey rounded">
+                            {t}
+                          </span>
+                        ))}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
           </div>
-          {moduleTypes.map((type) => (
-            <div key={type} className="mb-2">
-              <h3 className="text-sm font-bold capitalize">{type}</h3>
-              <ul style={animationStyle} className="max-h-32 overflow-auto text-xs">
-                {(modulesByType[type] || []).map((m) => (
-                  <li key={m.name} className="mb-1">
-                    <button
-                      type="button"
-                      onClick={() => showModule(m)}
-                      className="text-left w-full"
-                    >
-                      <span
-                        className={`px-1 rounded mr-1 ${severityStyles[m.severity]}`}
-                      >
-                        {m.severity}
-                      </span>
-                      <span className="font-mono">{m.name}</span> - {m.description}
-                      {m.tags.map((t) => (
-                        <span
-                          key={t}
-                          className="ml-1 px-1 bg-ub-grey rounded"
-                        >
-                          {t}
-                        </span>
-                      ))}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-        <div className="mt-4">
-          <button
-            onClick={startReplay}
-            className="px-2 py-1 bg-ub-orange rounded text-black"
-          >
-            Replay Mock Exploit
-          </button>
-          {timeline.length > 0 && (
-            <>
-              <ul
-                className="mt-2 text-xs max-h-32 overflow-auto"
-                role="log"
-                aria-live="polite"
-                aria-relevant="additions"
-              >
-                {timeline.map((t, i) => (
-                  <li key={i}>{t}</li>
-                ))}
-              </ul>
-              <div
-                className="w-full bg-ub-grey h-2 mt-2"
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={Math.round(progress)}
-              >
+          <div className="mt-4">
+            <button
+              onClick={startReplay}
+              className="px-2 py-1 bg-ub-orange rounded text-black"
+            >
+              Replay Mock Exploit
+            </button>
+            {timeline.length > 0 && (
+              <>
+                <ul
+                  className="mt-2 text-xs max-h-32 overflow-auto"
+                  role="log"
+                  aria-live="polite"
+                  aria-relevant="additions"
+                >
+                  {timeline.map((t, i) => (
+                    <li key={i}>{t}</li>
+                  ))}
+                </ul>
                 <div
-                  className="h-full bg-ub-orange"
-                  style={{ width: `${progress}%` }}
-                />
+                  className="w-full bg-ub-grey h-2 mt-2"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(progress)}
+                >
+                  <div className="h-full bg-ub-orange" style={{ width: `${progress}%` }} />
+                </div>
+              </>
+            )}
+          </div>
+          <div className="mt-4">
+            <button
+              onClick={() => setShowLoot((s) => !s)}
+              className="px-2 py-1 bg-blue-600 rounded text-white"
+            >
+              Toggle Loot/Notes
+            </button>
+            {showLoot && (
+              <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                <div>
+                  <h4 className="font-bold mb-1">Loot</h4>
+                  <ul className="max-h-24 overflow-auto">
+                    {loot.map((l, i) => (
+                      <li key={i}>
+                        {l.host}: {l.data || l.path || l.type}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="font-bold mb-1">Notes</h4>
+                  <ul className="max-h-24 overflow-auto">
+                    {notes.map((n, i) => (
+                      <li key={i}>
+                        {n.host}: {n.note}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
-            </>
-          )}
+            )}
+          </div>
         </div>
+        <aside className="w-1/3 bg-ub-grey p-2 overflow-auto text-xs">
+          {selectedModule ? (
+            <>
+              <h3 className="font-bold mb-1">{selectedModule.name}</h3>
+              <p className="mb-2">{selectedModule.description}</p>
+              <p>{selectedModule.doc || 'No documentation available.'}</p>
+            </>
+          ) : (
+            <p>Select a module to view docs.</p>
+          )}
+        </aside>
       </div>
       <pre className="flex-grow bg-black text-green-400 p-2 overflow-auto whitespace-pre-wrap">
         {loading ? 'Running...' : output}

--- a/components/apps/metasploit/modules.json
+++ b/components/apps/metasploit/modules.json
@@ -7,7 +7,8 @@
     "platform": "windows",
     "cve": ["CVE-2017-0144"],
     "tags": ["smb", "rce"],
-    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] 192.168.1.100 - Connecting to target...\n[+] 192.168.1.100 - Connection established\n[*] 192.168.1.100 - Sending exploit...\n[+] 192.168.1.100 - Exploit completed, but no session was created."
+    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] 192.168.1.100 - Connecting to target...\n[+] 192.168.1.100 - Connection established\n[*] 192.168.1.100 - Sending exploit...\n[+] 192.168.1.100 - Exploit completed, but no session was created.",
+    "doc": "Mock documentation for EternalBlue exploit."
   },
   {
     "name": "exploit/multi/http/struts2_content_type_ognl",
@@ -17,7 +18,8 @@
     "platform": "multi",
     "cve": ["CVE-2017-5638"],
     "tags": ["http", "rce"],
-    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] http://example.com - Sending exploit payload...\n[+] http://example.com - Exploit completed"
+    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] http://example.com - Sending exploit payload...\n[+] http://example.com - Exploit completed",
+    "doc": "Mock docs for Struts2 OGNL RCE."
   },
   {
     "name": "exploit/unix/ftp/vsftpd_234_backdoor",
@@ -27,7 +29,8 @@
     "platform": "unix",
     "cve": ["CVE-2011-2523"],
     "tags": ["ftp", "backdoor"],
-    "transcript": "[*] 10.0.0.2:21 - Connecting to server...\n[+] 10.0.0.2:21 - Backdoor service discovered\n[*] Command shell session 1 opened"
+    "transcript": "[*] 10.0.0.2:21 - Connecting to server...\n[+] 10.0.0.2:21 - Backdoor service discovered\n[*] Command shell session 1 opened",
+    "doc": "Mock docs for VSFTPD backdoor."
   },
   {
     "name": "auxiliary/scanner/portscan/tcp",
@@ -37,7 +40,8 @@
     "platform": "multi",
     "cve": [],
     "tags": ["scanner", "network"],
-    "transcript": "[*] Scanning 192.168.1.0/24 ports 1-1000\n[*] 192.168.1.1:80 - open\n[*] 192.168.1.10:22 - open\n[*] Scanning completed"
+    "transcript": "[*] Scanning 192.168.1.0/24 ports 1-1000\n[*] 192.168.1.1:80 - open\n[*] 192.168.1.10:22 - open\n[*] Scanning completed",
+    "doc": "Documentation for TCP port scanner."
   },
   {
     "name": "post/multi/gather/ssh_creds",
@@ -47,6 +51,7 @@
     "platform": "multi",
     "cve": [],
     "tags": ["ssh", "credentials"],
-    "transcript": "[*] Gathering SSH credentials...\n[+] user:password found in /home/user/.ssh/config\n[*] Post module execution completed"
+    "transcript": "[*] Gathering SSH credentials...\n[+] user:password found in /home/user/.ssh/config\n[*] Post module execution completed",
+    "doc": "Collect SSH credentials from config files."
   }
 ]

--- a/pages/apps/metasploit.tsx
+++ b/pages/apps/metasploit.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Metasploit = dynamic(() => import('../../apps/metasploit'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function MetasploitPage() {
+  return <Metasploit />;
+}

--- a/public/fixtures/metasploit_loot.json
+++ b/public/fixtures/metasploit_loot.json
@@ -1,0 +1,10 @@
+{
+  "loot": [
+    { "host": "10.0.0.2", "type": "ssh_private_key", "path": "/home/user/.ssh/id_rsa" },
+    { "host": "10.0.0.3", "type": "password", "data": "admin:admin123" }
+  ],
+  "notes": [
+    { "host": "10.0.0.2", "note": "Potential privileged account" },
+    { "host": "10.0.0.3", "note": "Web server credentials found" }
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Metasploit app entry and route
- add documentation-aware module browser with sequential demo
- surface loot and notes from local fixture

## Testing
- `yarn test __tests__/metasploit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf816ef4832891ed36a78019856a