### PR TITLE
Add Kismet app with heatmap and client details

### DIFF
--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import KismetApp from '../../components/apps/kismet';
+
+const KismetPage: React.FC = () => {
+  return <KismetApp />;
+};
+
+export default KismetPage;

--- a/components/apps/kismet/oui.json
+++ b/components/apps/kismet/oui.json
@@ -1,0 +1,5 @@
+{
+  "00:11:22": "Acme Corp",
+  "66:77:88": "Globex",
+  "AA:BB:CC": "Initech"
+}

--- a/components/apps/kismet/sampleClients.json
+++ b/components/apps/kismet/sampleClients.json
@@ -1,0 +1,5 @@
+[
+  {"mac": "00:11:22:33:44:55", "ssid": "HomeWiFi"},
+  {"mac": "66:77:88:99:AA:BB", "ssid": "CoffeeShopWiFi"},
+  {"mac": "AA:BB:CC:DD:EE:FF", "ssid": "FreeAirport"}
+]

--- a/pages/apps/kismet.tsx
+++ b/pages/apps/kismet.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Kismet = dynamic(() => import('../../apps/kismet'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function KismetPage() {
+  return <Kismet />;
+}


### PR DESCRIPTION
## Summary
- add new Kismet app route and baseline component
- show SSID/channel heatmap, signal timeline, and client associations with vendor lookup
- render random-point wardriving map for demo purposes

## Testing
- `yarn test` *(fails: TestingLibraryElementError, SyntaxError in resource_monitor.js)*
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf830678832896f7a8d3c377051b