### PR TITLE
feat: add figlet app with alignment and clipboard tools

### DIFF
--- a/apps/figlet/index.tsx
+++ b/apps/figlet/index.tsx
@@ -1,0 +1,3 @@
+import FigletApp from '../../components/apps/figlet';
+
+export default FigletApp;

--- a/components/apps/figlet/index.js
+++ b/components/apps/figlet/index.js
@@ -10,6 +10,9 @@ const FigletApp = () => {
   const [inverted, setInverted] = useState(false);
   const [fontSize, setFontSize] = useState(16);
   const [lineHeight, setLineHeight] = useState(1);
+  const [width, setWidth] = useState(80);
+  const [kerning, setKerning] = useState('default');
+  const [align, setAlign] = useState('left');
   const [announce, setAnnounce] = useState('');
   const workerRef = useRef(null);
   const frameRef = useRef(null);
@@ -41,9 +44,9 @@ const FigletApp = () => {
 
   const updateFiglet = useCallback(() => {
     if (workerRef.current && font) {
-      workerRef.current.postMessage({ type: 'render', text, font });
+      workerRef.current.postMessage({ type: 'render', text, font, width, layout: kerning });
     }
-  }, [text, font]);
+  }, [text, font, width, kerning]);
 
   useEffect(() => {
     if (frameRef.current) cancelAnimationFrame(frameRef.current);
@@ -148,12 +151,51 @@ const FigletApp = () => {
             aria-label="Line height"
           />
         </label>
+        <label className="flex items-center gap-1 text-sm">
+          Width
+          <input
+            type="number"
+            min="20"
+            max="200"
+            value={width}
+            onChange={(e) => setWidth(Number(e.target.value))}
+            className="w-16 px-1 bg-gray-700 text-white"
+            aria-label="Width"
+          />
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          Kerning
+          <select
+            value={kerning}
+            onChange={(e) => setKerning(e.target.value)}
+            className="px-1 bg-gray-700 text-white"
+            aria-label="Kerning"
+          >
+            <option value="default">Default</option>
+            <option value="full">Full</option>
+            <option value="fitted">Fitted</option>
+            <option value="smush">Smush</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          Align
+          <select
+            value={align}
+            onChange={(e) => setAlign(e.target.value)}
+            className="px-1 bg-gray-700 text-white"
+            aria-label="Alignment"
+          >
+            <option value="left">Left</option>
+            <option value="center">Center</option>
+            <option value="right">Right</option>
+          </select>
+        </label>
         <button
           onClick={copyOutput}
           className="px-2 bg-blue-700 hover:bg-blue-600 rounded text-white"
-          aria-label="Copy ASCII art"
+          aria-label="Banner to clipboard"
         >
-          Copy
+          Banner to Clipboard
         </button>
         <button
           onClick={exportPNG}
@@ -167,7 +209,7 @@ const FigletApp = () => {
           className="px-2 bg-purple-700 hover:bg-purple-600 rounded text-white"
           aria-label="Export text file"
         >
-          Text
+          TXT
         </button>
         <button
           onClick={() => setInverted((i) => !i)}
@@ -183,7 +225,7 @@ const FigletApp = () => {
           className={`min-w-full p-2 whitespace-pre font-mono transition-colors motion-reduce:transition-none ${
             inverted ? 'bg-white text-black' : 'bg-black text-white'
           }`}
-          style={{ fontSize: `${fontSize}px`, lineHeight }}
+          style={{ fontSize: `${fontSize}px`, lineHeight, textAlign: align }}
         >
           {output}
         </pre>

--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -48,12 +48,16 @@ function init() {
 init();
 
 self.onmessage = (e) => {
-  const { text = '', font } = e.data;
+  const { text = '', font, width = 80, layout = 'default' } = e.data;
   if (!font) return;
   const normalized = String(text)
     .split(/\r\n|\r|\n/)
     .map((line) => line.trim())
     .join('\n');
-  const rendered = figlet.textSync(normalized, { font });
+  const rendered = figlet.textSync(normalized, {
+    font,
+    width,
+    horizontalLayout: layout,
+  });
   self.postMessage({ type: 'render', output: rendered });
 };

--- a/pages/apps/figlet.tsx
+++ b/pages/apps/figlet.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const FigletPage = dynamic(() => import('../../apps/figlet'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default FigletPage;


### PR DESCRIPTION
## Summary
- build figlet app and page using existing component
- add width, kerning, alignment controls with live preview
- support TXT export and banner-to-clipboard button

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/figlet/index.js components/apps/figlet/worker.js apps/figlet/index.tsx pages/apps/figlet.tsx && echo 'eslint:success'`
- `yarn test --passWithNoTests components/apps/figlet/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf8781588328905459335130ee8a