### PR TITLE
feat: enhance nmap nse demo

### DIFF
--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -1,108 +1,11 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
+import NmapNSEApp from '../../components/apps/nmap-nse';
 
-interface Script {
-  name: string;
-  description: string;
-  example: string;
-}
-
-type ScriptData = Record<string, Script[]>;
-
-const NmapNSE: React.FC = () => {
-  const [data, setData] = useState<ScriptData>({});
-  const [query, setQuery] = useState('');
-  const copyExample = useCallback((text: string) => {
-    if (typeof window !== 'undefined') {
-      try {
-        navigator.clipboard?.writeText(text);
-      } catch (e) {
-        // ignore copy errors
-      }
-    }
-  }, []);
-  const openScriptDoc = useCallback((name: string) => {
-    if (typeof window !== 'undefined') {
-      window.open(
-        `https://nmap.org/nsedoc/scripts/${name}.html`,
-        '_blank',
-        'noopener,noreferrer'
-      );
-    }
-  }, []);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await fetch('/demo-data/nmap/scripts.json');
-        const json = await res.json();
-        setData(json);
-      } catch (e) {
-        // ignore
-      }
-    };
-    load();
-  }, []);
-
-  const queryLower = query.toLowerCase();
-  const filtered = Object.entries(data).flatMap(([category, scripts]) => {
-    const categoryMatch = category.toLowerCase().includes(queryLower);
-    const matchedScripts = scripts.filter((s) =>
-      s.name.toLowerCase().includes(queryLower)
-    );
-    if (categoryMatch) {
-      return [[category, scripts]];
-    }
-    if (matchedScripts.length > 0) {
-      return [[category, matchedScripts]];
-    }
-    return [] as [string, Script[]][];
-  });
-
-  return (
-    <div className="p-4 bg-gray-900 text-white min-h-screen">
-      <h1 className="text-2xl mb-4">Nmap NSE Script Library</h1>
-      <input
-        type="text"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Filter scripts"
-        className="mb-4 p-2 w-full rounded text-black"
-      />
-      <p className="text-sm text-yellow-300 mb-4">
-        Script details use static demo data for learning purposes only. Links open
-        in isolated tabs.
-      </p>
-      {filtered.map(([category, scripts]) => (
-        <div key={category} className="mb-6">
-          <h2 className="text-xl mb-2 capitalize">{category}</h2>
-          {scripts.map((script) => (
-            <div key={script.name} className="mb-4">
-              <button
-                type="button"
-                onClick={() => openScriptDoc(script.name)}
-                className="font-mono text-blue-400 underline"
-              >
-                {script.name}
-              </button>
-              <p className="mb-2">{script.description}</p>
-              <pre className="bg-black text-green-400 p-2 rounded overflow-auto font-mono leading-[1.2]">
-                {script.example}
-              </pre>
-              <button
-                type="button"
-                onClick={() => copyExample(script.example)}
-                className="mt-2 px-2 py-1 bg-blue-700 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-              >
-                Copy
-              </button>
-            </div>
-          ))}
-        </div>
-      ))}
-    </div>
-  );
+const NmapNsePage: React.FC = () => {
+  return <NmapNSEApp />;
 };
 
-export default NmapNSE;
+export default NmapNsePage;
+

--- a/components/apps/nmap-nse/discovery.worker.js
+++ b/components/apps/nmap-nse/discovery.worker.js
@@ -2,20 +2,25 @@ const WIDTH = 300;
 const HEIGHT = 200;
 let ctx;
 let hosts = [];
+let names = [];
 let step = 0;
 let reduceMotion = false;
 
 self.onmessage = (e) => {
   const { type } = e.data || {};
   if (type === 'init') {
-    const { canvas } = e.data;
+    const { canvas, addresses = [] } = e.data;
     ctx = canvas.getContext('2d');
     reduceMotion = !!e.data.reduceMotion;
     const width = canvas.width || WIDTH;
     const height = canvas.height || HEIGHT;
-    hosts = Array.from({ length: 5 }, (_, i) => ({
-      x: width / 2 + 100 * Math.cos((i / 5) * 2 * Math.PI),
-      y: height / 2 + 100 * Math.sin((i / 5) * 2 * Math.PI),
+    names =
+      addresses.length > 0
+        ? addresses
+        : Array.from({ length: 5 }, (_, i) => `host${i + 1}`);
+    hosts = names.map((_, i) => ({
+      x: width / 2 + 100 * Math.cos((i / names.length) * 2 * Math.PI),
+      y: height / 2 + 100 * Math.sin((i / names.length) * 2 * Math.PI),
       discovered: false,
       scripted: false,
     }));
@@ -65,14 +70,16 @@ function draw(width, height) {
 function tick(width, height) {
   if (step < hosts.length) {
     hosts[step].discovered = true;
-    self.postMessage({ message: `Host ${step + 1} discovered` });
+    self.postMessage({ message: `Host ${names[step]} discovered` });
     step += 1;
     draw(width, height);
     self.requestAnimationFrame(() => tick(width, height));
   } else if (step < hosts.length * 2) {
     const idx = step - hosts.length;
     hosts[idx].scripted = true;
-    self.postMessage({ message: `Script stage completed for host ${idx + 1}` });
+    self.postMessage({
+      message: `Script stage completed for host ${names[idx]}`,
+    });
     step += 1;
     draw(width, height);
     self.requestAnimationFrame(() => tick(width, height));


### PR DESCRIPTION
## Summary
- add script gallery with tagging and script-arg form
- show parsed host/port tree with CVSS badges
- seed topology mini-map from fixture addresses

## Testing
- `npm test` (failed: HashcatApp, BeEF app)
- `npm run lint` (failed: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68b0bf8ba4e08328bc3bafdb32dff14d