### PR TITLE
feat: add hydra builder with timeline

### DIFF
--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import LegalInterstitial from '../../components/ui/LegalInterstitial';
+import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import HydraApp from '../../components/apps/hydra';
+
+const HydraPreview: React.FC = () => {
+  const [accepted, setAccepted] = useState(false);
+  const countRef = useRef(1);
+
+  if (!accepted) {
+    return <LegalInterstitial onAccept={() => setAccepted(true)} />;
+  }
+
+  const createTab = (): TabDefinition => {
+    const id = Date.now().toString();
+    return { id, title: `Run ${countRef.current++}`, content: <HydraApp /> };
+  };
+
+  return (
+    <TabbedWindow
+      className="min-h-screen bg-gray-900 text-white"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
+  );
+};
+
+export default HydraPreview;

--- a/components/apps/hydra/Timeline.js
+++ b/components/apps/hydra/Timeline.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+const AttemptTimeline = () => {
+  const [attempts, setAttempts] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/fixtures/hydra-timeline.json');
+        const json = await res.json();
+        setAttempts(json);
+      } catch {
+        // ignore fetch errors in environments without network
+      }
+    };
+    load();
+  }, []);
+
+  if (attempts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4">
+      <h3 className="mb-2 text-lg">Sample Attempt Timeline</h3>
+      <ol className="space-y-1 text-sm">
+        {attempts.map((a, i) => (
+          <li key={i} className="font-mono">
+            {a.time}s - {a.user}/{a.password} ({a.result})
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default AttemptTimeline;

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Stepper from './Stepper';
+import AttemptTimeline from './Timeline';
 
 const baseServices = ['ssh', 'ftp', 'http-get', 'http-post-form', 'smtp'];
 const pluginServices = [];
@@ -43,6 +44,7 @@ const HydraApp = () => {
   const announceRef = useRef(0);
 
   const LOCKOUT_THRESHOLD = 10;
+  const BACKOFF_THRESHOLD = 5;
 
   useEffect(() => {
     setUserLists(loadWordlists('hydraUserLists'));
@@ -313,11 +315,17 @@ const HydraApp = () => {
       <Stepper
         active={running && !paused}
         totalAttempts={totalAttempts}
-        backoffThreshold={5}
+        backoffThreshold={BACKOFF_THRESHOLD}
         lockoutThreshold={LOCKOUT_THRESHOLD}
         runId={runId}
         onAttemptChange={handleAttempt}
       />
+      <p className="mt-2 text-sm text-yellow-300">
+        This demo slows after {BACKOFF_THRESHOLD} tries to mimic password spray
+        throttling and stops at {LOCKOUT_THRESHOLD} attempts to illustrate
+        account lockout.
+      </p>
+      <AttemptTimeline />
 
       <div role="status" aria-live="polite" className="sr-only">
         {announce}

--- a/public/fixtures/hydra-timeline.json
+++ b/public/fixtures/hydra-timeline.json
@@ -1,0 +1,6 @@
+[
+  { "time": 0, "user": "alice", "password": "123456", "result": "fail" },
+  { "time": 1, "user": "bob", "password": "password", "result": "fail" },
+  { "time": 3, "user": "carol", "password": "qwerty", "result": "fail" },
+  { "time": 7, "user": "alice", "password": "letmein", "result": "lockout" }
+]


### PR DESCRIPTION
## Summary
- add hydra app wrapper for new tabbed window
- explain lockout and throttling behavior with per-attempt timeline
- ship sample timeline fixture for visualization

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `yarn test` *(fails: hashcat, beef, mimikatz and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf8c89d083289cc075e349623498