### PR TITLE
feat: enhance recon-ng with workspace graph builder

### DIFF
--- a/__tests__/reconng.test.tsx
+++ b/__tests__/reconng.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import ReconNG from '../components/apps/reconng';
 
 describe('ReconNG app', () => {
+  const realFetch = global.fetch;
   beforeEach(() => {
     localStorage.clear();
     global.fetch = jest.fn(() =>
@@ -11,6 +12,10 @@ describe('ReconNG app', () => {
         json: () => Promise.resolve({ modules: ['Port Scan'] }),
       })
     ) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
   });
 
   it('stores API keys in localStorage', async () => {
@@ -28,5 +33,16 @@ describe('ReconNG app', () => {
     render(<ReconNG />);
     await userEvent.click(screen.getByText('Marketplace'));
     expect(await screen.findByText('Port Scan')).toBeInTheDocument();
+  });
+
+  it('dedupes entities in table', async () => {
+    render(<ReconNG />);
+    const input = screen.getByPlaceholderText('Target');
+    await userEvent.type(input, 'example.com');
+    await userEvent.click(screen.getAllByText('Run')[1]);
+    await screen.findByText('John Doe');
+    await userEvent.click(screen.getAllByText('Run')[1]);
+    const rows = screen.getAllByText('example.com');
+    expect(rows.length).toBe(1);
   });
 });

--- a/public/reconng-chain.json
+++ b/public/reconng-chain.json
@@ -1,0 +1,27 @@
+{
+  "chain": {
+    "nodes": [
+      { "data": { "id": "dns", "label": "DNS Enumeration" } },
+      { "data": { "id": "whois", "label": "WHOIS Lookup" } },
+      { "data": { "id": "reverseip", "label": "Reverse IP Lookup" } }
+    ],
+    "edges": [
+      { "data": { "id": "c1", "source": "dns", "target": "whois" } },
+      { "data": { "id": "c2", "source": "whois", "target": "reverseip" } }
+    ]
+  },
+  "entities": {
+    "nodes": [
+      { "data": { "id": "domains", "label": "Domains" } },
+      { "data": { "id": "people", "label": "People" } },
+      { "data": { "id": "assets", "label": "Assets" } },
+      { "data": { "id": "example.com", "label": "example.com", "parent": "domains", "type": "domain" } },
+      { "data": { "id": "Jane Smith", "label": "Jane Smith", "parent": "people", "type": "person" } },
+      { "data": { "id": "Server1", "label": "Server1", "parent": "assets", "type": "asset" } }
+    ],
+    "edges": [
+      { "data": { "id": "e1", "source": "example.com", "target": "Jane Smith" } },
+      { "data": { "id": "e2", "source": "Jane Smith", "target": "Server1" } }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add workspace management, entity dedupe and CSV/JSON export to ReconNG app
- support loading sample module chains into graph builder
- extend ReconNG tests for new features

## Testing
- `npm test __tests__/reconng.test.tsx`
- `npm test` *(fails: hashcat, beef, battleship-ai, mimikatz)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf93b9108328942ea329ecd4188d