### PR TITLE
Add advanced calculator with big-number evaluator

### DIFF
--- a/__tests__/calcShunting.test.ts
+++ b/__tests__/calcShunting.test.ts
@@ -1,0 +1,12 @@
+import { evaluate } from '../apps/calc/evaluate';
+
+describe('shunting-yard evaluator', () => {
+  it('handles basic arithmetic', () => {
+    expect(evaluate('2+3*4')).toBe('14');
+    expect(evaluate('(2+3)*4')).toBe('20');
+  });
+
+  it('supports big integers', () => {
+    expect(evaluate('9007199254740991+1', true)).toBe('9007199254740992');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -20,6 +20,7 @@ const TerminalApp = createDynamicApp('terminal', 'Terminal');
 const VsCodeApp = createDynamicApp('vscode', 'VsCode');
 const YouTubeApp = createDynamicApp('youtube', 'YouTube');
 const CalculatorApp = createDynamicApp('calculator', 'Calculator');
+const CalcApp = createDynamicApp('calc', 'Calc');
 const TicTacToeApp = createDynamicApp('tictactoe', 'Tic Tac Toe');
 const ChessApp = createDynamicApp('chess', 'Chess');
 const ConnectFourApp = createDynamicApp('connect-four', 'Connect Four');
@@ -106,6 +107,7 @@ const displayTerminal = createDisplay(TerminalApp);
 const displayVsCode = createDisplay(VsCodeApp);
 const displayYouTube = createDisplay(YouTubeApp);
 const displayCalculator = createDisplay(CalculatorApp);
+const displayCalc = createDisplay(CalcApp);
 const displayTicTacToe = createDisplay(TicTacToeApp);
 const displayChess = createDisplay(ChessApp);
 const displayConnectFour = createDisplay(ConnectFourApp);
@@ -592,6 +594,19 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayCalculator,
+    resizable: false,
+    allowMaximize: false,
+    defaultWidth: 28,
+    defaultHeight: 50,
+  },
+  {
+    id: 'calc',
+    title: 'Calc',
+    icon: './themes/Yaru/apps/calc.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayCalc,
     resizable: false,
     allowMaximize: false,
     defaultWidth: 28,

--- a/apps/calc/evaluate.ts
+++ b/apps/calc/evaluate.ts
@@ -1,0 +1,190 @@
+export type Token =
+  | { type: 'number'; value: string }
+  | { type: 'operator'; value: string }
+  | { type: 'paren'; value: string }
+  | { type: 'func'; value: string };
+
+function tokenize(expr: string): Token[] {
+  const tokens: Token[] = [];
+  for (let i = 0; i < expr.length; i += 1) {
+    let c = expr[i];
+    if (/\s/.test(c)) continue;
+    if (
+      c === '-' &&
+      (i === 0 || '+-*/^('.includes(expr[i - 1])) &&
+      /[0-9.]/.test(expr[i + 1])
+    ) {
+      let num = c;
+      i += 1;
+      while (i < expr.length && /[0-9.]/.test(expr[i])) {
+        num += expr[i];
+        i += 1;
+      }
+      i -= 1;
+      tokens.push({ type: 'number', value: num });
+    } else if (/[0-9]/.test(c) || c === '.') {
+      let num = c;
+      while (i + 1 < expr.length && /[0-9.]/.test(expr[i + 1])) {
+        i += 1;
+        num += expr[i];
+      }
+      tokens.push({ type: 'number', value: num });
+    } else if ('+-*/^'.includes(c)) {
+      tokens.push({ type: 'operator', value: c });
+    } else if (c === '(' || c === ')') {
+      tokens.push({ type: 'paren', value: c });
+    } else if (/[a-z]/i.test(c)) {
+      let name = c;
+      while (i + 1 < expr.length && /[a-z]/i.test(expr[i + 1])) {
+        i += 1;
+        name += expr[i];
+      }
+      tokens.push({ type: 'func', value: name });
+    } else {
+      throw new Error(`Invalid character: ${c}`);
+    }
+  }
+  return tokens;
+}
+
+const precedence: Record<string, number> = { '+': 1, '-': 1, '*': 2, '/': 2, '^': 3 };
+const rightAssoc: Record<string, boolean> = { '^': true };
+
+function toRPN(tokens: Token[]): Token[] {
+  const out: Token[] = [];
+  const stack: Token[] = [];
+  tokens.forEach((t) => {
+    if (t.type === 'number') {
+      out.push(t);
+    } else if (t.type === 'func') {
+      stack.push(t);
+    } else if (t.type === 'operator') {
+      while (stack.length) {
+        const top = stack[stack.length - 1];
+        if (
+          (top.type === 'operator' &&
+            ((rightAssoc[t.value]
+              ? precedence[t.value] < precedence[(top as any).value]
+              : precedence[t.value] <= precedence[(top as any).value]))) ||
+          top.type === 'func'
+        ) {
+          out.push(stack.pop()!);
+        } else {
+          break;
+        }
+      }
+      stack.push(t);
+    } else if (t.value === '(') {
+      stack.push(t);
+    } else if (t.value === ')') {
+      while (stack.length && stack[stack.length - 1].value !== '(') {
+        out.push(stack.pop()!);
+      }
+      stack.pop();
+      if (stack.length && stack[stack.length - 1].type === 'func') {
+        out.push(stack.pop()!);
+      }
+    }
+  });
+  while (stack.length) out.push(stack.pop()!);
+  return out;
+}
+
+export function evaluate(expr: string, big = false): string {
+  const tokens = toRPN(tokenize(expr));
+  const stack: (number | bigint)[] = [];
+  tokens.forEach((t) => {
+    if (t.type === 'number') {
+      if (big) {
+        if (t.value.includes('.')) throw new Error('No decimals in big mode');
+        stack.push(BigInt(t.value));
+      } else {
+        stack.push(parseFloat(t.value));
+      }
+    } else if (t.type === 'operator') {
+      const b = stack.pop();
+      const a = stack.pop();
+      if (a === undefined || b === undefined) throw new Error('Invalid expression');
+      if (big) {
+        const ai = BigInt(a as any);
+        const bi = BigInt(b as any);
+        let r: bigint;
+        switch (t.value) {
+          case '+':
+            r = ai + bi;
+            break;
+          case '-':
+            r = ai - bi;
+            break;
+          case '*':
+            r = ai * bi;
+            break;
+          case '/':
+            r = ai / bi;
+            break;
+          case '^': {
+            let res = 1n;
+            for (let i = 0n; i < bi; i += 1n) res *= ai;
+            r = res;
+            break;
+          }
+          default:
+            throw new Error('Unknown operator');
+        }
+        stack.push(r);
+      } else {
+        const an = Number(a);
+        const bn = Number(b);
+        let r: number;
+        switch (t.value) {
+          case '+':
+            r = an + bn;
+            break;
+          case '-':
+            r = an - bn;
+            break;
+          case '*':
+            r = an * bn;
+            break;
+          case '/':
+            r = an / bn;
+            break;
+          case '^':
+            r = an ** bn;
+            break;
+          default:
+            throw new Error('Unknown operator');
+        }
+        stack.push(r);
+      }
+    } else if (t.type === 'func') {
+      const a = stack.pop();
+      if (a === undefined) throw new Error('Invalid expression');
+      if (big) throw new Error('Functions unsupported in big mode');
+      const an = Number(a);
+      let r: number;
+      switch (t.value) {
+        case 'sin':
+          r = Math.sin(an);
+          break;
+        case 'cos':
+          r = Math.cos(an);
+          break;
+        case 'tan':
+          r = Math.tan(an);
+          break;
+        case 'sqrt':
+          r = Math.sqrt(an);
+          break;
+        default:
+          throw new Error('Unknown function');
+      }
+      stack.push(r);
+    }
+  });
+  if (stack.length !== 1) throw new Error('Invalid expression');
+  const res = stack[0];
+  return big ? (res as bigint).toString() : (res as number).toString();
+}
+
+export default evaluate;

--- a/apps/calc/index.tsx
+++ b/apps/calc/index.tsx
@@ -1,0 +1,153 @@
+'use client';
+import React, { useState, useEffect, useCallback } from 'react';
+import evaluate from './evaluate';
+
+interface TapeItem {
+  expr: string;
+  res: string;
+}
+
+const Calc: React.FC = () => {
+  const [expr, setExpr] = useState('');
+  const [big, setBig] = useState(false);
+  const [tape, setTape] = useState<TapeItem[]>([]);
+  const [memory, setMemory] = useState<bigint | number>(0);
+  const [showSci, setShowSci] = useState(false);
+
+  useEffect(() => {
+    setShowSci(localStorage.getItem('calc-sci') === '1');
+  }, []);
+  useEffect(() => {
+    localStorage.setItem('calc-sci', showSci ? '1' : '0');
+  }, [showSci]);
+
+  const calculate = () => {
+    try {
+      const res = evaluate(expr, big);
+      setTape((prev) => [...prev, { expr, res }]);
+      setExpr(res);
+    } catch {
+      setExpr('Error');
+    }
+  };
+
+  const copyTape = useCallback(async () => {
+    const text = tape.map((t) => `${t.expr} = ${t.res}`).join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      /* ignore */
+    }
+  }, [tape]);
+  const clearTape = useCallback(() => setTape([]), []);
+  const undoTape = useCallback(() => setTape((prev) => prev.slice(0, -1)), []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === 'z') {
+        undoTape();
+        e.preventDefault();
+      }
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'c') {
+        copyTape();
+        e.preventDefault();
+      }
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'x') {
+        clearTape();
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [tape, copyTape, clearTape, undoTape]);
+
+  const append = (v: string) => setExpr((prev) => prev + v);
+  const mPlus = () => {
+    try {
+      const val = evaluate(expr, big);
+      setMemory((m) => (big ? (BigInt(m as any) + BigInt(val)) : (Number(m) + Number(val))));
+    } catch {
+      /* ignore */
+    }
+  };
+  const mMinus = () => {
+    try {
+      const val = evaluate(expr, big);
+      setMemory((m) => (big ? (BigInt(m as any) - BigInt(val)) : (Number(m) - Number(val))));
+    } catch {
+      /* ignore */
+    }
+  };
+  const mRecall = () => setExpr(String(memory));
+
+  return (
+    <div className="w-full h-full bg-gray-900 text-white p-4 space-y-2">
+      <input
+        className="w-full text-black px-2 py-1"
+        value={expr}
+        onChange={(e) => setExpr(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') calculate();
+        }}
+      />
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={() => setBig((b) => !b)}
+          className="px-2 py-1 bg-blue-600 rounded"
+        >
+          Big: {big ? 'On' : 'Off'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowSci((s) => !s)}
+          aria-pressed={showSci}
+          className="px-2 py-1 bg-blue-600 rounded"
+        >
+          Scientific
+        </button>
+      </div>
+      <div className="flex space-x-2">
+        <button onClick={mPlus} className="px-2 py-1 bg-gray-700 rounded">M+</button>
+        <button onClick={mMinus} className="px-2 py-1 bg-gray-700 rounded">M−</button>
+        <button onClick={mRecall} className="px-2 py-1 bg-gray-700 rounded">MR</button>
+      </div>
+      <div className="grid grid-cols-4 gap-2">
+        {['7','8','9','/','4','5','6','*','1','2','3','-','0','.','=','+'].map((ch) => (
+          ch === '=' ? (
+            <button key={ch} onClick={calculate} className="px-2 py-1 bg-green-600 rounded">=</button>
+          ) : (
+            <button key={ch} onClick={() => append(ch)} className="px-2 py-1 bg-gray-700 rounded">{ch}</button>
+          )
+        ))}
+        <button onClick={() => setExpr('')} className="col-span-2 px-2 py-1 bg-red-600 rounded">C</button>
+        <button onClick={() => setExpr((v) => v.slice(0, -1))} className="col-span-2 px-2 py-1 bg-red-600 rounded">⌫</button>
+      </div>
+      {showSci && (
+        <div className="grid grid-cols-4 gap-2">
+          {['sin(','cos(','tan(','sqrt('].map((fn) => (
+            <button key={fn} onClick={() => append(fn)} className="px-2 py-1 bg-gray-700 rounded">
+              {fn.replace('(','')}
+            </button>
+          ))}
+          <button onClick={() => append('(')} className="px-2 py-1 bg-gray-700 rounded">(</button>
+          <button onClick={() => append(')')} className="px-2 py-1 bg-gray-700 rounded">)</button>
+        </div>
+      )}
+      <div className="mt-4">
+        <div className="flex space-x-2 mb-2">
+          <button onClick={copyTape} className="px-2 py-1 bg-gray-700 rounded">Copy</button>
+          <button onClick={undoTape} className="px-2 py-1 bg-gray-700 rounded">Undo</button>
+          <button onClick={clearTape} className="px-2 py-1 bg-gray-700 rounded">Clear</button>
+        </div>
+        <ul className="text-sm max-h-40 overflow-auto">
+          {tape.map((t, i) => (
+            <li key={i}>{t.expr} = {t.res}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default Calc;


### PR DESCRIPTION
## Summary
- implement shunting-yard based evaluator with optional BigInt mode
- add new Calc app with tape history, memory registers, and persistent scientific panel
- register Calc app in configuration and add tests

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/calc __tests__/calcShunting.test.ts`
- `yarn test` *(fails: HashcatApp labels hashcat modes, BeEF app updates hook list, mimikatz api retrieves module list, frogger.config, snake.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf9662b483288ef383f6a6be8c03