### PR TITLE
feat: add contact app with helpers

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -99,6 +99,7 @@ const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+const ContactApp = createDynamicApp('contact', 'Contact');
 
 
 
@@ -178,6 +179,7 @@ const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
+const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -867,6 +869,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
+  },
+  {
+    id: 'contact',
+    title: 'Contact',
+    icon: './themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayContact,
   },
   {
     id: 'hydra',

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import FormError from '../../components/ui/FormError';
+import Toast from '../../components/ui/Toast';
+import { processContactForm } from '../../components/apps/contact';
+import { copyToClipboard } from '../../utils/clipboard';
+import { openMailto } from '../../utils/mailto';
+
+const DRAFT_KEY = 'contact-draft';
+const EMAIL = 'alex.unnippillil@hotmail.com';
+
+const getRecaptchaToken = (siteKey: string): Promise<string> =>
+  new Promise((resolve) => {
+    const g: any = (window as any).grecaptcha;
+    if (!g || !siteKey) return resolve('');
+    g.ready(() => {
+      g
+        .execute(siteKey, { action: 'submit' })
+        .then((token: string) => resolve(token))
+        .catch(() => resolve(''));
+    });
+  });
+
+const ContactApp: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [honeypot, setHoneypot] = useState('');
+  const [error, setError] = useState('');
+  const [toast, setToast] = useState('');
+  const [csrfToken, setCsrfToken] = useState('');
+
+  useEffect(() => {
+    const saved = localStorage.getItem(DRAFT_KEY);
+    if (saved) {
+      try {
+        const draft = JSON.parse(saved);
+        setName(draft.name || '');
+        setEmail(draft.email || '');
+        setMessage(draft.message || '');
+      } catch {
+        /* ignore */
+      }
+    }
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    setCsrfToken(meta?.getAttribute('content') || '');
+  }, []);
+
+  useEffect(() => {
+    const draft = { name, email, message };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  }, [name, email, message]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
+    const recaptchaToken = await getRecaptchaToken(siteKey);
+    const result = await processContactForm({
+      name,
+      email,
+      message,
+      honeypot,
+      csrfToken,
+      recaptchaToken,
+    });
+    if (result.success) {
+      setToast('Message sent');
+      setName('');
+      setEmail('');
+      setMessage('');
+      setHoneypot('');
+      localStorage.removeItem(DRAFT_KEY);
+    } else {
+      setError(result.error || 'Submission failed');
+      setToast('Failed to send');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white p-4">
+      <h1 className="mb-4 text-2xl">Contact</h1>
+      <p className="mb-4 text-sm">
+        Prefer email?{' '}
+        <button
+          type="button"
+          onClick={() => copyToClipboard(EMAIL)}
+          className="underline mr-2"
+        >
+          Copy address
+        </button>
+        <button
+          type="button"
+          onClick={() => openMailto(EMAIL)}
+          className="underline"
+        >
+          Open email app
+        </button>
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label htmlFor="contact-name" className="mb-1 block text-sm">Name</label>
+          <input
+            id="contact-name"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="contact-email" className="mb-1 block text-sm">Email</label>
+          <input
+            id="contact-email"
+            type="email"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="contact-message" className="mb-1 block text-sm">Message</label>
+          <textarea
+            id="contact-message"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            rows={4}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            required
+          />
+        </div>
+        <input
+          type="text"
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
+          className="hidden"
+          tabIndex={-1}
+          autoComplete="off"
+        />
+        {error && <FormError>{error}</FormError>}
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2"
+        >
+          Send
+        </button>
+      </form>
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+    </div>
+  );
+};
+
+export default ContactApp;

--- a/pages/apps/contact.tsx
+++ b/pages/apps/contact.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const ContactApp = dynamic(() => import('../../apps/contact'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function ContactPage() {
+  return <ContactApp />;
+}

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,0 +1,22 @@
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export default copyToClipboard;

--- a/utils/mailto.ts
+++ b/utils/mailto.ts
@@ -1,0 +1,14 @@
+export const openMailto = (
+  email: string,
+  subject = '',
+  body = '',
+): void => {
+  const params = new URLSearchParams();
+  if (subject) params.set('subject', subject);
+  if (body) params.set('body', body);
+  const query = params.toString();
+  const href = `mailto:${email}${query ? `?${query}` : ''}`;
+  window.location.href = href;
+};
+
+export default openMailto;


### PR DESCRIPTION
## Summary
- add standalone contact app with form validation, local drafts, and toast feedback
- provide clipboard and mailto utilities for reuse across apps
- register contact app in global config

## Testing
- `yarn test contact`
- `yarn lint apps/contact pages/apps/contact.tsx utils/clipboard.ts utils/mailto.ts` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf9ef7d08328a5e3f714de58ad4f