### PR TITLE
feat(game): add flexible controls and settings

### DIFF
--- a/components/game/GameSettingsPanel.jsx
+++ b/components/game/GameSettingsPanel.jsx
@@ -1,0 +1,199 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from 'react';
+import usePersistentState from "../usePersistentState";
+
+/**
+ * Generic game settings panel providing common functionality for browser games.
+ * Handles key remapping, speed control, audio mute, snapshot persistence,
+ * high score tracking, achievements, color palettes, screen shake and an input
+ * latency tester. All state is persisted to localStorage so settings survive
+ * page reloads.
+ */
+export default function GameSettingsPanel({
+  onApplyKeymap,
+  getSnapshot,
+  loadSnapshot,
+  currentScore,
+}) {
+  // --- Controls -----------------------------------------------------------
+  const [keymap, setKeymap] = usePersistentState("game-keymap", {
+    up: "ArrowUp",
+    down: "ArrowDown",
+    left: "ArrowLeft",
+    right: "ArrowRight",
+    action: "Space",
+    pause: "Escape",
+  });
+  const [waitingFor, setWaitingFor] = useState(null);
+
+  const assignKey = useCallback(
+    (e) => {
+      if (!waitingFor) return;
+      e.preventDefault();
+      setKeymap({ ...keymap, [waitingFor]: e.key });
+      setWaitingFor(null);
+    },
+    [waitingFor, keymap, setKeymap]
+  );
+
+  useEffect(() => {
+    if (waitingFor) {
+      window.addEventListener("keydown", assignKey, { once: true });
+      return () => window.removeEventListener("keydown", assignKey);
+    }
+  }, [waitingFor, assignKey]);
+
+  useEffect(() => {
+    onApplyKeymap && onApplyKeymap(keymap);
+  }, [keymap, onApplyKeymap]);
+
+  const [gamepadConnected, setGamepadConnected] = useState(false);
+  useEffect(() => {
+    const connect = () => setGamepadConnected(true);
+    const disconnect = () => setGamepadConnected(false);
+    window.addEventListener("gamepadconnected", connect);
+    window.addEventListener("gamepaddisconnected", disconnect);
+    return () => {
+      window.removeEventListener("gamepadconnected", connect);
+      window.removeEventListener("gamepaddisconnected", disconnect);
+    };
+  }, []);
+
+  // --- Gameplay ----------------------------------------------------------
+  const [speed, setSpeed] = usePersistentState("game-speed", 1);
+  const [muted, setMuted] = usePersistentState("game-muted", false);
+  const toggleMute = () => setMuted((m) => !m);
+
+  // --- Persistence -------------------------------------------------------
+  const saveSnapshot = () => {
+    if (getSnapshot) {
+      const snap = getSnapshot();
+      try {
+        window.localStorage.setItem("game-snapshot", JSON.stringify(snap));
+      } catch {}
+    }
+  };
+
+  const loadSnapshotClick = () => {
+    if (loadSnapshot) {
+      const data = window.localStorage.getItem("game-snapshot");
+      if (data) loadSnapshot(JSON.parse(data));
+    }
+  };
+
+  const [highScore, setHighScore] = usePersistentState("game-highscore", 0);
+  useEffect(() => {
+    if (typeof currentScore === "number" && currentScore > highScore) {
+      setHighScore(currentScore);
+    }
+  }, [currentScore, highScore, setHighScore]);
+
+  const [achievements, setAchievements] = usePersistentState(
+    "game-achievements",
+    []
+  );
+  const unlockAchievement = (name) => {
+    setAchievements((a) => (a.includes(name) ? a : [...a, name]));
+  };
+
+  // --- Display -----------------------------------------------------------
+  const [palette, setPalette] = usePersistentState("game-palette", "default");
+  const [screenShake, setScreenShake] = usePersistentState(
+    "game-screen-shake",
+    true
+  );
+
+  // --- Input Latency Tester ---------------------------------------------
+  const [latency, setLatency] = useState(null);
+  const startLatencyTest = () => {
+    const start = performance.now();
+    const handler = () => {
+      setLatency(performance.now() - start);
+      window.removeEventListener("keydown", handler);
+    };
+    window.addEventListener("keydown", handler);
+  };
+
+  return (
+    <div className="game-settings-panel">
+      <section>
+        <h3>Controls</h3>
+        {Object.entries(keymap).map(([action, key]) => (
+          <div key={action} className="flex gap-2 items-center">
+            <span className="w-20 capitalize">{action}</span>
+            <button onClick={() => setWaitingFor(action)}>
+              {waitingFor === action ? "Press key" : key}
+            </button>
+          </div>
+        ))}
+        <p className="text-sm mt-2">
+          {gamepadConnected ? "Gamepad connected" : "No gamepad"}
+        </p>
+      </section>
+
+      <section>
+        <h3>Gameplay</h3>
+        <label className="block">
+          Speed:
+          <input
+            type="range"
+            min="0.5"
+            max="2"
+            step="0.5"
+            value={speed}
+            onChange={(e) => setSpeed(parseFloat(e.target.value))}
+          />
+          <span className="ml-2">{speed.toFixed(1)}x</span>
+        </label>
+        <button onClick={toggleMute} className="mt-2">
+          {muted ? "Unmute" : "Mute"}
+        </button>
+      </section>
+
+      <section>
+        <h3>Progress</h3>
+        <div className="flex gap-2">
+          <button onClick={saveSnapshot}>Save Snapshot</button>
+          <button onClick={loadSnapshotClick}>Load Snapshot</button>
+        </div>
+        <div className="mt-2">High Score: {highScore}</div>
+        <div className="mt-1 text-sm">
+          Achievements: {achievements.join(", ") || "None"}
+        </div>
+      </section>
+
+      <section>
+        <h3>Display</h3>
+        <label className="block mb-2">
+          Palette:
+          <select
+            value={palette}
+            onChange={(e) => setPalette(e.target.value)}
+            className="ml-2"
+          >
+            <option value="default">Default</option>
+            <option value="protanopia">Protanopia</option>
+            <option value="deuteranopia">Deuteranopia</option>
+            <option value="tritanopia">Tritanopia</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={screenShake}
+            onChange={(e) => setScreenShake(e.target.checked)}
+          />
+          Screen Shake
+        </label>
+      </section>
+
+      <section>
+        <h3>Input Latency</h3>
+        <button onClick={startLatencyTest}>Start Test</button>
+        {latency !== null && <div>{latency.toFixed(0)} ms</div>}
+      </section>
+    </div>
+  );
+}
+

--- a/components/games/GameShell.jsx
+++ b/components/games/GameShell.jsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useCallback } from 'react';
 import useOrientationGuard from '../../hooks/useOrientationGuard';
+import useGameInput from '../../hooks/useGameInput';
+import usePersistentState from '../usePersistentState';
 
 /**
  * Generic shell for browser games. Exposes slots for the game content,
@@ -19,6 +21,8 @@ export default function GameShell({
 
   const [paused, setPaused] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [speed, setSpeed] = usePersistentState('game-speed', 1);
+  const [muted, setMuted] = usePersistentState('game-muted', false);
 
   const pause = useCallback(() => {
     setPaused(true);
@@ -31,9 +35,19 @@ export default function GameShell({
   }, [onResume]);
 
   const toggleSettings = () => setShowSettings((s) => !s);
+  const toggleMute = () => setMuted((m) => !m);
+
+  const handleInput = ({ action, type }) => {
+    if (action === 'pause' && type === 'keydown') {
+      paused ? resume() : pause();
+    }
+  };
+
+  useGameInput({ onInput: handleInput });
 
   return (
-    <div className={`game-shell${paused ? ' paused' : ''}`}>
+    <div className={`game-shell${paused ? ' paused' : ''}${muted ? ' muted' : ''}`}
+         data-speed={speed}>
       <div className="game-content">{children}</div>
       {controls && <div className="game-controls">{controls}</div>}
       {showSettings && settings && (
@@ -42,6 +56,21 @@ export default function GameShell({
       <button onClick={paused ? resume : pause} aria-label={paused ? 'Resume' : 'Pause'}>
         {paused ? 'Resume' : 'Pause'}
       </button>
+      <button onClick={toggleMute} aria-label={muted ? 'Unmute' : 'Mute'}>
+        {muted ? 'Unmute' : 'Mute'}
+      </button>
+      <label>
+        Speed
+        <select
+          value={speed}
+          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+        >
+          <option value={0.5}>0.5x</option>
+          <option value={1}>1x</option>
+          <option value={1.5}>1.5x</option>
+          <option value={2}>2x</option>
+        </select>
+      </label>
       {settings && (
         <button onClick={toggleSettings} aria-label="Settings">
           Settings

--- a/hooks/useGameInput.js
+++ b/hooks/useGameInput.js
@@ -1,12 +1,43 @@
 "use client";
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-// Basic keyboard input handler. Works even when no touch or gamepad is present.
+// Default keyboard mapping. Users can override via settings stored in
+// localStorage under the `game-keymap` key.
+const DEFAULT_MAP = {
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  action: 'Space',
+  pause: 'Escape',
+};
+
+// Keyboard input handler that respects user remapping. It emits high level
+// actions like `up`/`down`/`pause` instead of raw keyboard events.
 export default function useGameInput({ onInput } = {}) {
+  const mapRef = useRef(DEFAULT_MAP);
+
+  // Load mapping once on mount
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem('game-keymap');
+      if (stored) {
+        mapRef.current = { ...DEFAULT_MAP, ...JSON.parse(stored) };
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
   useEffect(() => {
     const handle = (e) => {
-      onInput && onInput(e);
+      const map = mapRef.current;
+      const action = Object.keys(map).find((k) => map[k] === e.key);
+      if (action && onInput) {
+        onInput({ action, type: e.type });
+        e.preventDefault();
+      }
     };
     window.addEventListener('keydown', handle);
     window.addEventListener('keyup', handle);


### PR DESCRIPTION
## Summary
- add `GameSettingsPanel` with remappable keys, gamepad detection, snapshot save/load, high score + achievements, color palettes, screen shake toggle and latency tester
- extend `GameShell` with pause hotkey, speed control and mute
- allow `useGameInput` to read custom key mappings from localStorage

## Testing
- `yarn test` *(fails: hashcat.test.tsx, beef.test.tsx, mimikatz.test.ts, snake.config.test.ts, frogger.config.test.ts)*
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bfa2ff0083288dd0033dc18a132f