### PR TITLE
feat(hangman): add categories and hint tokens

### DIFF
--- a/__tests__/hangman.test.ts
+++ b/__tests__/hangman.test.ts
@@ -5,11 +5,13 @@ import {
   isWinner,
   isLoser,
   isGameOver,
+  importWordList,
+  FAMILY_WORDS,
 } from '../apps/hangman/engine';
 
 describe('hangman engine', () => {
   test('repeated guess is ignored', () => {
-    const game = createGame('letter');
+    const game = createGame({ word: 'letter' });
     expect(guess(game, 'e')).toBe(true);
     guess(game, 'e');
     expect(game.guessed).toEqual(['e']);
@@ -20,8 +22,8 @@ describe('hangman engine', () => {
     expect(game.wrong).toBe(1);
   });
 
-  test('hint reveals one new letter', () => {
-    const game = createGame('dog');
+  test('hint tokens limit usage', () => {
+    const game = createGame({ word: 'dog', hints: 2 });
     guess(game, 'd');
     const first = useHint(game);
     expect(first && ['o', 'g'].includes(first)).toBe(true);
@@ -29,20 +31,30 @@ describe('hangman engine', () => {
     const second = useHint(game);
     expect(second && first !== second).toBe(true);
     expect(game.guessed.includes(second as string)).toBe(true);
+    expect(useHint(game)).toBeNull();
   });
 
   test('win and loss detection', () => {
-    const winGame = createGame('hi');
+    const winGame = createGame({ word: 'hi' });
     guess(winGame, 'h');
     guess(winGame, 'i');
     expect(isWinner(winGame)).toBe(true);
     expect(isLoser(winGame)).toBe(false);
     expect(isGameOver(winGame)).toBe(true);
 
-    const loseGame = createGame('hi');
+    const loseGame = createGame({ word: 'hi' });
     ['a', 'b', 'c', 'd', 'e', 'f'].forEach((l) => guess(loseGame, l));
     expect(isLoser(loseGame)).toBe(true);
     expect(isWinner(loseGame)).toBe(false);
     expect(isGameOver(loseGame)).toBe(true);
+  });
+
+  test('category selection and custom word list import', () => {
+    const catGame = createGame({ category: 'family' });
+    expect(FAMILY_WORDS.includes(catGame.word)).toBe(true);
+
+    importWordList('colors', ['red', 'blue']);
+    const customGame = createGame({ category: 'colors' });
+    expect(['red', 'blue']).toContain(customGame.word);
   });
 });


### PR DESCRIPTION
## Summary
- extend hangman game engine with category selection and configurable hint tokens
- allow importing custom word lists for new categories
- update tests for hint tokens, category selection, and custom word list import

## Testing
- `yarn test __tests__/hangman.test.ts`
- `ESLINT_USE_FLAT_CONFIG=0 npx eslint -c .eslintrc.cjs apps/hangman/engine.ts __tests__/hangman.test.ts` *(failed: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fa3d8f6c8328a38fcb7fe3b285fe