### PR TITLE
feat(memory): add preview slider and pattern themes

### DIFF
--- a/__tests__/memoryGame.test.tsx
+++ b/__tests__/memoryGame.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../components/apps/memory_utils', () => ({
     { id: 14, value: 'H' },
     { id: 15, value: 'H' },
   ],
+  PATTERN_THEMES: { vibrant: [], pastel: [] },
 }));
 
 beforeEach(() => {
@@ -75,6 +76,9 @@ afterEach(() => {
 
 test('combo meter increments and resets', () => {
   const { getAllByTestId, getByTestId } = render(<Memory />);
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   const cards = getAllByTestId('card-inner').map((el) => el.parentElement as HTMLElement);
   const combo = getByTestId('combo-meter');
 
@@ -104,6 +108,9 @@ test('combo meter increments and resets', () => {
 
 test('card flip applies transform style', () => {
   const { getAllByTestId } = render(<Memory />);
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   const inner = getAllByTestId('card-inner')[0] as HTMLElement;
   const card = inner.parentElement as HTMLElement;
   expect(inner.style.transform).toBe('rotateY(0deg)');

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import GameLayout from './GameLayout';
-import { createDeck } from './memory_utils';
+import { createDeck, PATTERN_THEMES } from './memory_utils';
 
 const MAX_STORAGE = 1000; // safeguard against large writes
-const DEFAULT_TIME = { 4: 60, 6: 120 };
+const DEFAULT_TIME = { 2: 30, 4: 60, 6: 120 };
 
 const Memory = () => {
   const [size, setSize] = useState(4);
@@ -20,6 +20,9 @@ const Memory = () => {
   const [best, setBest] = useState({ moves: null, time: null });
   const [announcement, setAnnouncement] = useState('');
   const [deckType, setDeckType] = useState('emoji');
+  const [patternTheme, setPatternTheme] = useState('vibrant');
+  const [previewTime, setPreviewTime] = useState(3);
+  const [previewing, setPreviewing] = useState(false);
   const [streak, setStreak] = useState(0);
   const [particles, setParticles] = useState([]);
   const [nudge, setNudge] = useState(false);
@@ -29,6 +32,7 @@ const Memory = () => {
   const initialTimeRef = useRef(0);
   const rafRef = useRef();
   const reduceMotion = useRef(false);
+  const previewTimeout = useRef();
 
   const bestKey = useMemo(() => `game:memory:${size}:${timerMode}:best`, [size, timerMode]);
 
@@ -43,6 +47,8 @@ const Memory = () => {
       mq.removeEventListener ? mq.removeEventListener('change', update) : mq.removeListener(update);
     };
   }, []);
+
+  useEffect(() => () => clearTimeout(previewTimeout.current), []);
 
   const beep = useCallback(() => {
     if (!sound || typeof window === 'undefined') return;
@@ -63,8 +69,21 @@ const Memory = () => {
   }, [sound]);
 
   const reset = useCallback(() => {
-    setCards(createDeck(size, deckType));
-    setFlipped([]);
+    clearTimeout(previewTimeout.current);
+    const deck = createDeck(size, deckType, patternTheme);
+    setCards(deck);
+    const all = Array.from({ length: size * size }, (_, i) => i);
+    if (previewTime > 0) {
+      setFlipped(all);
+      setPreviewing(true);
+      previewTimeout.current = setTimeout(() => {
+        setFlipped([]);
+        setPreviewing(false);
+      }, previewTime * 1000);
+    } else {
+      setFlipped([]);
+      setPreviewing(false);
+    }
     setMatched([]);
     setHighlight([]);
     setMoves(0);
@@ -77,7 +96,7 @@ const Memory = () => {
     startRef.current = 0;
     setAnnouncement('');
     setStreak(0);
-  }, [size, deckType, timerMode]);
+  }, [size, deckType, timerMode, patternTheme, previewTime]);
 
   useEffect(() => {
     reset();
@@ -156,7 +175,7 @@ const Memory = () => {
   }, []);
 
   const handleCardClick = (idx) => {
-    if (paused || flipped.includes(idx) || matched.includes(idx) || (timerMode === 'countdown' && time <= 0)) return;
+    if (paused || previewing || flipped.includes(idx) || matched.includes(idx) || (timerMode === 'countdown' && time <= 0)) return;
     if (!runningRef.current) {
       runningRef.current = true;
       startRef.current = performance.now();
@@ -238,6 +257,7 @@ const Memory = () => {
                     flipped.includes(i) ||
                     matched.includes(i) ||
                     paused ||
+                    previewing ||
                     (timerMode === 'countdown' && time <= 0)
                   }
                   className={`relative w-full aspect-square [perspective:600px] rounded transform ${isHighlighted ? 'ring-4 ring-green-600' : ''} ${reduceMotion.current ? '' : 'transition-transform duration-200'} ${isHighlighted && !reduceMotion.current ? 'scale-105' : ''}`}
@@ -297,6 +317,20 @@ const Memory = () => {
             <option value="pattern">Pattern</option>
             <option value="letters">Letters</option>
           </select>
+          {deckType === 'pattern' && (
+            <select
+              aria-label="Pattern theme"
+              value={patternTheme}
+              onChange={(e) => setPatternTheme(e.target.value)}
+              className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
+            >
+              {Object.keys(PATTERN_THEMES).map((t) => (
+                <option key={t} value={t}>
+                  {t[0].toUpperCase() + t.slice(1)}
+                </option>
+              ))}
+            </select>
+          )}
           <select
             aria-label="Timer mode"
             value={timerMode}
@@ -312,9 +346,25 @@ const Memory = () => {
             onChange={(e) => setSize(Number(e.target.value))}
             className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
           >
+            <option value={2}>2x2</option>
             <option value={4}>4x4</option>
             <option value={6}>6x6</option>
           </select>
+          <div className="flex items-center space-x-1">
+            <label htmlFor="preview-time" className="text-sm">
+              Preview {previewTime}s
+            </label>
+            <input
+              id="preview-time"
+              type="range"
+              min="0"
+              max="10"
+              step="1"
+              value={previewTime}
+              onChange={(e) => setPreviewTime(Number(e.target.value))}
+              className="w-24"
+            />
+          </div>
         </div>
       </div>
     </GameLayout>

--- a/components/apps/memory_utils.js
+++ b/components/apps/memory_utils.js
@@ -19,30 +19,39 @@ export const EMOJIS = [
   '\u{1F345}', // tomato
 ];
 
-// Build a large enough pattern deck using distinct shapes and colors
+// Build pattern decks using distinct shapes and multiple color themes
 const SHAPES = ['\u25B2', '\u25A0', '\u25CF', '\u25C6', '\u2605', '\u271A', '\u25B3', '\u25A1'];
-const COLORS = [
-  'text-red-600',
-  'text-blue-600',
-  'text-green-600',
-  'text-yellow-600',
-  'text-purple-600',
-  'text-pink-600',
-  'text-orange-600',
-  'text-teal-600',
-  'text-lime-600',
-  'text-indigo-600',
-  'text-amber-600',
-  'text-rose-600',
-  'text-sky-600',
-  'text-fuchsia-600',
-  'text-violet-600',
-  'text-cyan-600',
-  'text-emerald-600',
-  'text-gray-600',
+const BASE_COLORS = [
+  'red',
+  'blue',
+  'green',
+  'yellow',
+  'purple',
+  'pink',
+  'orange',
+  'teal',
+  'lime',
+  'indigo',
+  'amber',
+  'rose',
+  'sky',
+  'fuchsia',
+  'violet',
+  'cyan',
+  'emerald',
+  'gray',
 ];
 
-export const PATTERNS = COLORS.map((color, i) => ({ value: SHAPES[i % SHAPES.length], color }));
+export const PATTERN_THEMES = {
+  vibrant: BASE_COLORS.map((c) => `text-${c}-600`),
+  pastel: BASE_COLORS.map((c) => `text-${c}-300`),
+  mono: BASE_COLORS.map((_, i) => `text-gray-${(i % 9 + 1) * 100}`),
+};
+
+function buildPatternDeck(theme = 'vibrant') {
+  const colors = PATTERN_THEMES[theme] || PATTERN_THEMES.vibrant;
+  return colors.map((color, i) => ({ value: SHAPES[i % SHAPES.length], color }));
+}
 
 // Simple letter deck
 export const LETTERS = Array.from({ length: 26 }, (_, i) => ({ value: String.fromCharCode(65 + i) }));
@@ -56,11 +65,11 @@ export function fisherYatesShuffle(array) {
   return arr;
 }
 
-export function createDeck(size, type = 'emoji') {
+export function createDeck(size, type = 'emoji', patternTheme = 'vibrant') {
   const pairs = (size * size) / 2;
   let selected;
   if (type === 'pattern') {
-    selected = PATTERNS.slice(0, pairs);
+    selected = buildPatternDeck(patternTheme).slice(0, pairs);
   } else if (type === 'letters') {
     selected = LETTERS.slice(0, pairs);
   } else {
@@ -69,3 +78,6 @@ export function createDeck(size, type = 'emoji') {
   const doubled = [...selected, ...selected].map((card, index) => ({ id: index, ...card }));
   return fisherYatesShuffle(doubled);
 }
+
+export { buildPatternDeck };
+


### PR DESCRIPTION
## Summary
- allow memory game grids in 2x2, 4x4, or 6x6 layouts
- add selectable pattern themes and pattern generation
- introduce adjustable preview-time slider for card reveal

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: hashcat.test.tsx, beef.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fa3eebb48328b09a0ce48177718c