### PR TITLE
feat(platformer): add level editor and physics settings

### DIFF
--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -5,7 +5,7 @@ import {
   updatePhysics,
   collectCoin,
   movePlayer,
-  GRAVITY,
+  physics,
 } from '../../public/apps/platformer/engine.js';
 
 const TILE_SIZE = 16;
@@ -165,7 +165,7 @@ const Platformer = () => {
             life: p.life - dt,
             x: p.x + p.vx * dt,
             y: p.y + p.vy * dt,
-            vy: p.vy + GRAVITY * dt * 0.5,
+            vy: p.vy + physics.GRAVITY * dt * 0.5,
           }))
           .filter((p) => p.life > 0);
         bgOffsets.forEach((o, i) => {

--- a/public/apps/platformer/editor.html
+++ b/public/apps/platformer/editor.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Platformer Editor</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body { font-family: sans-serif; padding: 4px; }
+    #palette button { width: 24px; height: 24px; margin: 2px; }
+    #output { width: 100%; margin-top: 4px; }
+    canvas { border: 1px solid #555; image-rendering: pixelated; }
+  </style>
+</head>
+<body>
+  <div id="palette"></div>
+  <button id="exportBtn">Export</button>
+  <textarea id="output" rows="5"></textarea>
+  <p>Left click to paint tiles. Right click to set spawn.</p>
+  <canvas id="editor" width="320" height="160"></canvas>
+  <script type="module" src="editor.js"></script>
+</body>
+</html>
+

--- a/public/apps/platformer/editor.js
+++ b/public/apps/platformer/editor.js
@@ -1,0 +1,92 @@
+const tileSize = 16;
+const width = 20;
+const height = 10;
+
+const canvas = document.getElementById('editor');
+const ctx = canvas.getContext('2d');
+
+const tiles = Array.from({ length: height }, () => Array(width).fill(0));
+let spawn = { x: 0, y: 0 };
+let current = 1;
+
+const palette = document.getElementById('palette');
+const types = [
+  { id: 0, color: '#222', label: '0' },
+  { id: 1, color: '#777', label: '1' },
+  { id: 2, color: 'red', label: '2' },
+  { id: 5, color: 'gold', label: '5' },
+  { id: 6, color: 'blue', label: '6' },
+];
+
+types.forEach((t) => {
+  const b = document.createElement('button');
+  b.textContent = t.label;
+  b.style.background = t.color;
+  b.addEventListener('click', () => (current = t.id));
+  palette.appendChild(b);
+});
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const t = tiles[y][x];
+      if (t === 1) {
+        ctx.fillStyle = '#666';
+        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      } else if (t === 2) {
+        ctx.fillStyle = 'red';
+        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      } else if (t === 5) {
+        ctx.fillStyle = 'gold';
+        ctx.fillRect(
+          x * tileSize + 4,
+          y * tileSize + 4,
+          tileSize - 8,
+          tileSize - 8
+        );
+      } else if (t === 6) {
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      }
+    }
+  }
+  // spawn marker
+  ctx.strokeStyle = 'lime';
+  ctx.strokeRect(spawn.x, spawn.y, tileSize, tileSize);
+  // grid
+  ctx.strokeStyle = 'rgba(255,255,255,0.1)';
+  for (let x = 0; x <= width; x++) {
+    ctx.beginPath();
+    ctx.moveTo(x * tileSize, 0);
+    ctx.lineTo(x * tileSize, height * tileSize);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= height; y++) {
+    ctx.beginPath();
+    ctx.moveTo(0, y * tileSize);
+    ctx.lineTo(width * tileSize, y * tileSize);
+    ctx.stroke();
+  }
+}
+
+canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+canvas.addEventListener('mousedown', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.floor((e.clientX - rect.left) / tileSize);
+  const y = Math.floor((e.clientY - rect.top) / tileSize);
+  if (e.button === 2) {
+    spawn = { x: x * tileSize, y: y * tileSize };
+  } else {
+    tiles[y][x] = current;
+  }
+  draw();
+});
+
+draw();
+
+document.getElementById('exportBtn').addEventListener('click', () => {
+  const data = { width, height, tiles, spawn };
+  document.getElementById('output').value = JSON.stringify(data);
+});
+

--- a/public/apps/platformer/engine.js
+++ b/public/apps/platformer/engine.js
@@ -1,10 +1,18 @@
 export const COYOTE_TIME = 0.1; // 100ms
 export const JUMP_BUFFER_TIME = 0.1; // 100ms default
-export const GRAVITY = 2000;
-export const ACCEL = 1200;
-export const FRICTION = 800;
-export const MAX_SPEED = 200;
-export const JUMP_SPEED = 600;
+
+// physics parameters are mutable so the game can expose sliders
+export const physics = {
+  GRAVITY: 2000,
+  ACCEL: 1200,
+  FRICTION: 800,
+  MAX_SPEED: 200,
+  JUMP_SPEED: 600,
+};
+
+export function setPhysics(values) {
+  Object.assign(physics, values);
+}
 
 export class Player {
   constructor() {
@@ -23,16 +31,16 @@ export class Player {
 export function updatePhysics(player, input, dt, opts = {}) {
   // horizontal acceleration and friction
   if (input.right) {
-    player.vx += ACCEL * dt;
+    player.vx += physics.ACCEL * dt;
   } else if (input.left) {
-    player.vx -= ACCEL * dt;
+    player.vx -= physics.ACCEL * dt;
   } else {
-    if (player.vx > 0) player.vx = Math.max(0, player.vx - FRICTION * dt);
-    else if (player.vx < 0) player.vx = Math.min(0, player.vx + FRICTION * dt);
+    if (player.vx > 0) player.vx = Math.max(0, player.vx - physics.FRICTION * dt);
+    else if (player.vx < 0) player.vx = Math.min(0, player.vx + physics.FRICTION * dt);
   }
   // clamp horizontal speed
-  if (player.vx > MAX_SPEED) player.vx = MAX_SPEED;
-  if (player.vx < -MAX_SPEED) player.vx = -MAX_SPEED;
+  if (player.vx > physics.MAX_SPEED) player.vx = physics.MAX_SPEED;
+  if (player.vx < -physics.MAX_SPEED) player.vx = -physics.MAX_SPEED;
 
   // timers
   if (player.onGround) player.coyoteTimer = COYOTE_TIME;
@@ -44,16 +52,16 @@ export function updatePhysics(player, input, dt, opts = {}) {
 
   // jump
   if (player.jumpBufferTimer > 0 && (player.onGround || player.coyoteTimer > 0)) {
-    player.vy = -JUMP_SPEED;
+    player.vy = -physics.JUMP_SPEED;
     player.onGround = false;
     player.jumpBufferTimer = 0;
   }
 
   // variable jump height
-  if (!input.jump && player.vy < 0) player.vy += GRAVITY * dt * 0.5;
+  if (!input.jump && player.vy < 0) player.vy += physics.GRAVITY * dt * 0.5;
 
   // gravity
-  player.vy += GRAVITY * dt;
+  player.vy += physics.GRAVITY * dt;
 
   // clamp vertical speed
   if (player.vy > 1000) player.vy = 1000;

--- a/public/apps/platformer/index.html
+++ b/public/apps/platformer/index.html
@@ -21,6 +21,31 @@
       <span id="bufferLabel"></span>ms
     </div>
     <div>
+      Gravity:
+      <input id="gravitySlider" type="range" min="500" max="4000" />
+      <span id="gravityLabel"></span>
+    </div>
+    <div>
+      Accel:
+      <input id="accelSlider" type="range" min="200" max="2000" />
+      <span id="accelLabel"></span>
+    </div>
+    <div>
+      Friction:
+      <input id="frictionSlider" type="range" min="100" max="2000" />
+      <span id="frictionLabel"></span>
+    </div>
+    <div>
+      Max Speed:
+      <input id="speedSlider" type="range" min="50" max="400" />
+      <span id="speedLabel"></span>
+    </div>
+    <div>
+      Jump Speed:
+      <input id="jumpSlider" type="range" min="100" max="1000" />
+      <span id="jumpLabel"></span>
+    </div>
+    <div>
       Pad Left: <button id="padLeft"></button>
     </div>
     <div>
@@ -30,6 +55,7 @@
       Pad Jump: <button id="padJump"></button>
     </div>
   </div>
+  <a href="editor.html" id="editorLink">Level Editor</a>
   <div id="announcer" class="sr-only" aria-live="polite"></div>
   <script type="module" src="main.js"></script>
 </body>

--- a/public/apps/platformer/main.js
+++ b/public/apps/platformer/main.js
@@ -1,4 +1,11 @@
-import { Player, updatePhysics, collectCoin, movePlayer } from './engine.js';
+import {
+  Player,
+  updatePhysics,
+  collectCoin,
+  movePlayer,
+  setPhysics,
+  physics,
+} from './engine.js';
 
 const params = new URLSearchParams(location.search);
 const levelFile = params.get('lvl') || 'levels/level1.json';
@@ -53,6 +60,54 @@ bufferSlider.addEventListener('input', () => {
   jumpBufferMs = Number(bufferSlider.value);
   bufferLabel.textContent = String(jumpBufferMs);
   localStorage.setItem('pf-buffer', String(jumpBufferMs));
+});
+
+// physics sliders
+const gravSlider = document.getElementById('gravitySlider');
+const gravLabel = document.getElementById('gravityLabel');
+const accelSlider = document.getElementById('accelSlider');
+const accelLabel = document.getElementById('accelLabel');
+const frictionSlider = document.getElementById('frictionSlider');
+const frictionLabel = document.getElementById('frictionLabel');
+const speedSlider = document.getElementById('speedSlider');
+const speedLabel = document.getElementById('speedLabel');
+const jumpSlider = document.getElementById('jumpSlider');
+const jumpLabel = document.getElementById('jumpLabel');
+
+const storedPhysics = JSON.parse(
+  localStorage.getItem('pf-physics') || '{}'
+);
+setPhysics({ ...storedPhysics });
+
+function syncPhysicsUI() {
+  gravSlider.value = String(physics.GRAVITY);
+  gravLabel.textContent = String(Math.round(physics.GRAVITY));
+  accelSlider.value = String(physics.ACCEL);
+  accelLabel.textContent = String(Math.round(physics.ACCEL));
+  frictionSlider.value = String(physics.FRICTION);
+  frictionLabel.textContent = String(Math.round(physics.FRICTION));
+  speedSlider.value = String(physics.MAX_SPEED);
+  speedLabel.textContent = String(Math.round(physics.MAX_SPEED));
+  jumpSlider.value = String(physics.JUMP_SPEED);
+  jumpLabel.textContent = String(Math.round(physics.JUMP_SPEED));
+}
+
+syncPhysicsUI();
+
+function updatePhysicsSetting() {
+  setPhysics({
+    GRAVITY: Number(gravSlider.value),
+    ACCEL: Number(accelSlider.value),
+    FRICTION: Number(frictionSlider.value),
+    MAX_SPEED: Number(speedSlider.value),
+    JUMP_SPEED: Number(jumpSlider.value),
+  });
+  syncPhysicsUI();
+  localStorage.setItem('pf-physics', JSON.stringify(physics));
+}
+
+[gravSlider, accelSlider, frictionSlider, speedSlider, jumpSlider].forEach((el) => {
+  el.addEventListener('input', updatePhysicsSetting);
 });
 
 const padButtons = {


### PR DESCRIPTION
## Summary
- add mutable physics settings and level editor for platformer game
- expose gravity, speed, and jump sliders for runtime tuning
- support checkpoint flags via editor with spawn placement

## Testing
- `npm test __tests__/platformer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa4151788328bc4c9f62eca0350c