### PR TITLE
feat: add word-search puzzle packs and options

### DIFF
--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -36,16 +36,28 @@ interface Direction {
   readonly dy: number;
 }
 
-const DIRECTIONS: readonly Direction[] = [
-  { dx: 1, dy: 0 },
-  { dx: -1, dy: 0 },
-  { dx: 0, dy: 1 },
-  { dx: 0, dy: -1 },
-  { dx: 1, dy: 1 },
-  { dx: -1, dy: -1 },
-  { dx: 1, dy: -1 },
-  { dx: -1, dy: 1 },
-];
+export interface GenerateOptions {
+  readonly allowBackwards?: boolean;
+  readonly allowDiagonal?: boolean;
+}
+
+function getDirections(options: GenerateOptions = {}): Direction[] {
+  const { allowBackwards = true, allowDiagonal = true } = options;
+  const dirs: Direction[] = [
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+  ];
+  if (allowBackwards) {
+    dirs.push({ dx: -1, dy: 0 }, { dx: 0, dy: -1 });
+  }
+  if (allowDiagonal) {
+    dirs.push({ dx: 1, dy: 1 });
+    if (allowBackwards) {
+      dirs.push({ dx: -1, dy: -1 }, { dx: 1, dy: -1 }, { dx: -1, dy: 1 });
+    }
+  }
+  return dirs;
+}
 
 export interface GenerateResult {
   grid: string[][];
@@ -55,15 +67,17 @@ export interface GenerateResult {
 export function generateGrid(
   words: string[],
   size = 12,
-  seed = 'seed'
+  seed = 'seed',
+  options: GenerateOptions = {}
 ): GenerateResult {
   const rng = createRNG(seed);
   const grid: string[][] = Array.from({ length: size }, () => Array(size).fill(''));
   const placements: WordPlacement[] = [];
+  const directions = getDirections(options);
   words.forEach((w) => {
     const word = w.toUpperCase();
     for (let attempt = 0; attempt < 200; attempt += 1) {
-      const dir = DIRECTIONS[Math.floor(rng() * DIRECTIONS.length)];
+      const dir = directions[Math.floor(rng() * directions.length)];
       const maxRow = dir.dy > 0 ? size - word.length : dir.dy < 0 ? word.length - 1 : size - 1;
       const maxCol = dir.dx > 0 ? size - word.length : dir.dx < 0 ? word.length - 1 : size - 1;
       const startRow = Math.floor(rng() * (maxRow + 1));

--- a/games/word-search/packs.ts
+++ b/games/word-search/packs.ts
@@ -1,0 +1,7 @@
+export const PUZZLE_PACKS: Record<string, string[]> = {
+  animals: ['DOG', 'CAT', 'EAGLE', 'TIGER', 'HORSE', 'SHARK', 'SNAKE', 'LION'],
+  fruits: ['APPLE', 'BANANA', 'ORANGE', 'GRAPE', 'MANGO', 'LEMON', 'PEACH', 'CHERRY'],
+  colors: ['RED', 'BLUE', 'GREEN', 'YELLOW', 'PURPLE', 'ORANGE', 'BLACK', 'WHITE'],
+  tech: ['REACT', 'CODE', 'TAILWIND', 'NODE', 'JAVASCRIPT', 'HTML', 'CSS', 'PYTHON'],
+};
+export type PackName = keyof typeof PUZZLE_PACKS;


### PR DESCRIPTION
## Summary
- add themed puzzle packs for word search game
- introduce backwards and diagonal placement toggles
- track playtime with on-screen timer

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint apps/word_search/index.tsx apps/word_search/generator.ts games/word-search/packs.ts` (errors)
- `yarn test --passWithNoTests apps/word_search`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa493a7c8328af2f772480bc5b60