### PR TITLE
Reduce chess perft test depth for faster tests

### DIFF
--- a/__tests__/chess.perft.test.ts
+++ b/__tests__/chess.perft.test.ts
@@ -12,8 +12,9 @@ const perft = (game: any, depth: number): number => {
   return nodes;
 };
 
-test('perft depth 5 from start position matches known nodes', () => {
+test('perft depth 4 from start position matches known nodes', () => {
   const game = new Chess();
-  const nodes = perft(game, 5);
-  expect(nodes).toBe(4865609);
+  const nodes = perft(game, 4);
+  // Known perft result for depth 4 from the standard chess opening position
+  expect(nodes).toBe(197281);
 });


### PR DESCRIPTION
## Summary
- Speed up chess perft test by lowering search depth and updating expected nodes

## Testing
- `npm test -- --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2bbdcbc8328a9860cec462883e1