### PR TITLE
Add Wordle page with keyboard hints and sharing

### DIFF
--- a/pages/apps/wordle.tsx
+++ b/pages/apps/wordle.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const Wordle = dynamic(() => import('../../components/apps/wordle'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function WordlePage() {
+  return <Wordle />;
+}
+


### PR DESCRIPTION
## Summary
- expose Wordle game at `/apps/wordle`
- add on-screen keyboard with status hints and shareable result card
- cover Wordle gameplay with tests for keyboard hints and hard mode

## Testing
- `yarn test wordle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa49d84c8328b974c971b6baa576