### PR TITLE
chore: remove unused turbo setting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -78,9 +78,6 @@ module.exports = {
       'i.scdn.co',
     ],
   },
-  experimental: {
-    turbo: false,
-  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- remove unused `experimental.turbo` setting from `next.config.js`

## Testing
- `yarn build` *(fails: Global CSS cannot be imported from within node_modules)*
- `yarn test __tests__/hashcat.test.tsx __tests__/beef.test.tsx __tests__/mimikatz.test.ts` *(fails: 3 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb31760c8328a794e45da792c498