### PR TITLE
refactor: cache QR video element

### DIFF
--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -23,6 +23,7 @@ const QRPage: React.FC = () => {
   };
 
   useEffect(() => {
+    const videoEl = videoRef.current;
     const startScanner = async () => {
       if (!navigator.mediaDevices) {
         setError('Camera API not supported');
@@ -32,25 +33,26 @@ const QRPage: React.FC = () => {
         const stream = await navigator.mediaDevices.getUserMedia({
           video: { facingMode: 'environment' },
         });
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play();
+        if (videoEl) {
+          videoEl.srcObject = stream;
+          await videoEl.play();
         }
-          const codeReader = new BrowserQRCodeReader();
-          codeReaderRef.current = codeReader;
+        const codeReader = new BrowserQRCodeReader();
+        codeReaderRef.current = codeReader;
+        if (videoEl) {
           codeReader.decodeFromVideoDevice(
             null,
-            videoRef.current!,
+            videoEl,
             (result, err) => {
-
-            if (result) {
-              setScanResult(result.getText());
-            }
-            if (err && !(err instanceof NotFoundException)) {
-              setError('Failed to read QR code');
-            }
-          },
-        );
+              if (result) {
+                setScanResult(result.getText());
+              }
+              if (err && !(err instanceof NotFoundException)) {
+                setError('Failed to read QR code');
+              }
+            },
+          );
+        }
       } catch (err: unknown) {
         if (err instanceof DOMException && err.name === 'NotAllowedError') {
           setError('Camera access was denied');
@@ -64,9 +66,10 @@ const QRPage: React.FC = () => {
 
     return () => {
       codeReaderRef.current?.reset();
-      if (videoRef.current && videoRef.current.srcObject) {
-        const tracks = (videoRef.current.srcObject as MediaStream).getTracks();
+      if (videoEl && videoEl.srcObject) {
+        const tracks = (videoEl.srcObject as MediaStream).getTracks();
         tracks.forEach((t) => t.stop());
+        videoEl.srcObject = null;
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- cache QR scanner video element and reuse for cleanup

## Testing
- `yarn test pages/qr.tsx --passWithNoTests`
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb3207488328a2ebfc596723aa64