### PR TITLE
fix: include setScore dependency in 2048

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -283,7 +283,7 @@ const Game2048 = () => {
         }, 200);
       }
     },
-    [board, won, lost, hardMode, score, moves, setBoard, setLost, setWon],
+    [board, won, lost, hardMode, score, moves, setBoard, setLost, setWon, setScore],
   );
 
   useGameControls(handleDirection, '2048');


### PR DESCRIPTION
## Summary
- include setScore in the dependency array for handleDirection

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/2048.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0fb334330832893c3f4b2e957e85c