### PR TITLE
Include spritesReady in chess rendering effect

### DIFF
--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -413,6 +413,7 @@ const ChessGame = () => {
   }, [showHints]);
 
   useEffect(() => {
+    if (!spritesReady) return;
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     const render = () => {
@@ -516,7 +517,7 @@ const ChessGame = () => {
     };
     animRef.current = requestAnimationFrame(render);
     return () => cancelAnimationFrame(animRef.current);
-  }, [selected, moves, mateSquares, cursor]);
+  }, [selected, moves, mateSquares, cursor, spritesReady]);
 
   const endGame = (result) => {
     // result: 1 win, 0 draw, -1 loss


### PR DESCRIPTION
## Summary
- render chess board only after sprites load
- add `spritesReady` to rendering hook dependencies

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/chess.js && echo 'eslint: ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb3408f8832887b62b9ddcdb7c08