### PR TITLE
feat: stabilize Spotify playlist callbacks

### DIFF
--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState.js';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
@@ -20,21 +20,21 @@ export default function SpotifyApp() {
         }
       })
       .catch(() => {});
-  }, []);
+  }, [mood, setMood]);
 
   useRovingTabIndex(gridRef, true, 'horizontal');
 
-  const post = (cmd) => {
+  const post = useCallback((cmd) => {
     iframeRef.current?.contentWindow?.postMessage({ command: cmd }, '*');
-  };
+  }, []);
 
-  const togglePlay = () => {
+  const togglePlay = useCallback(() => {
     post(isPlaying ? 'pause' : 'play');
     setIsPlaying(!isPlaying);
-  };
+  }, [post, isPlaying]);
 
-  const next = () => post('next');
-  const previous = () => post('previous');
+  const next = useCallback(() => post('next'), [post]);
+  const previous = useCallback(() => post('previous'), [post]);
 
   useEffect(() => {
     const handleMessage = (e) => {
@@ -61,7 +61,7 @@ export default function SpotifyApp() {
     };
     window.addEventListener('keydown', handleKeys);
     return () => window.removeEventListener('keydown', handleKeys);
-  }, [togglePlay]);
+  }, [togglePlay, next, previous]);
 
   return (
     <div className="h-full w-full bg-ub-cool-grey flex flex-col">


### PR DESCRIPTION
## Summary
- include mood state in playlist-fetch effect dependencies
- wrap next/previous controls in `useCallback` and add to key handler deps

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/spotify.js -f json`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb37bda483288ed49f48a66106ac