### PR TITLE
fix: update wallpaper effect dependencies

### DIFF
--- a/components/ubuntu.tsx
+++ b/components/ubuntu.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from 'react';
+import React, { Component, useEffect, useRef } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
@@ -157,14 +157,21 @@ export class Ubuntu extends Component<UbuntuProps, UbuntuState, UbuntuContext> {
 export default function UbuntuWithSession() {
   const { session, setSession, resetSession } = useSession();
   const { wallpaper, setWallpaper } = useSettings();
+  const sessionRef = useRef(session);
 
   useEffect(() => {
     setWallpaper(session.wallpaper);
   }, [session.wallpaper, setWallpaper]);
 
   useEffect(() => {
-    setSession({ ...session, wallpaper });
-  }, [wallpaper]);
+    sessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    if (sessionRef.current.wallpaper !== wallpaper) {
+      setSession({ ...sessionRef.current, wallpaper });
+    }
+  }, [wallpaper, session, setSession]);
 
   return (
     <Ubuntu


### PR DESCRIPTION
## Summary
- add session and setSession to wallpaper effect dependencies
- track session with a ref to avoid re-running the effect unnecessarily

## Testing
- `npx -y eslint@8 -c .eslintrc.cjs components/ubuntu.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb391cbc8328bbaddd2fde7bbfbb