### PR TITLE
Add Space Invaders game logic module

### DIFF
--- a/__tests__/spaceInvadersGame.test.ts
+++ b/__tests__/spaceInvadersGame.test.ts
@@ -1,0 +1,25 @@
+import { createGame, spawnUFO, advanceWave } from '../apps/games/space-invaders';
+
+describe('space-invaders logic', () => {
+  test('initializes with shields and inactive ufo', () => {
+    const game = createGame();
+    expect(game.shields).toHaveLength(3);
+    game.shields.forEach((s) => expect(s.hp).toBe(6));
+    expect(game.ufo.active).toBe(false);
+  });
+
+  test('spawnUFO activates bonus target', () => {
+    const game = createGame();
+    spawnUFO(game);
+    expect(game.ufo.active).toBe(true);
+  });
+
+  test('advanceWave increments stage and invader count', () => {
+    const game = createGame();
+    game.invaders.forEach((i) => (i.alive = false));
+    const initialCount = game.invaders.length;
+    advanceWave(game);
+    expect(game.stage).toBe(2);
+    expect(game.invaders.length).toBeGreaterThan(initialCount);
+  });
+});

--- a/apps/games/space-invaders.ts
+++ b/apps/games/space-invaders.ts
@@ -1,0 +1,65 @@
+export interface Invader {
+  x: number;
+  y: number;
+  alive: boolean;
+}
+
+export interface Shield {
+  x: number;
+  y: number;
+  hp: number;
+}
+
+export interface UFO {
+  active: boolean;
+  x: number;
+  y: number;
+  dir: number;
+}
+
+export interface GameState {
+  stage: number;
+  invaders: Invader[];
+  shields: Shield[];
+  ufo: UFO;
+}
+
+const COLS = 8;
+const SPACING = 30;
+
+export const createShields = (): Shield[] => [
+  { x: SPACING * 2, y: 0, hp: 6 },
+  { x: SPACING * 4, y: 0, hp: 6 },
+  { x: SPACING * 6, y: 0, hp: 6 },
+];
+
+export const createWave = (stage: number): Invader[] => {
+  const rows = 4 + (stage - 1);
+  const inv: Invader[] = [];
+  for (let r = 0; r < rows; r += 1) {
+    for (let c = 0; c < COLS; c += 1) {
+      inv.push({ x: c * SPACING, y: r * SPACING, alive: true });
+    }
+  }
+  return inv;
+};
+
+export const createGame = (): GameState => ({
+  stage: 1,
+  invaders: createWave(1),
+  shields: createShields(),
+  ufo: { active: false, x: 0, y: 15, dir: 1 },
+});
+
+export const advanceWave = (state: GameState) => {
+  if (state.invaders.every((i) => !i.alive)) {
+    state.stage += 1;
+    state.invaders = createWave(state.stage);
+    state.shields = createShields();
+    state.ufo.active = false;
+  }
+};
+
+export const spawnUFO = (state: GameState) => {
+  state.ufo = { active: true, x: 0, y: 15, dir: 1 };
+};


### PR DESCRIPTION
## Summary
- implement Space Invaders logic with shields, UFO bonus target and progressive waves
- test game logic and existing Space Invaders component

## Testing
- `yarn test __tests__/spaceInvadersGame.test.ts __tests__/spaceInvaders.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa4bb2708328bb33cae5a0a6a7c8