### PR TITLE
feat: add battleship game modes

### DIFF
--- a/__tests__/battleship-ai.test.js
+++ b/__tests__/battleship-ai.test.js
@@ -1,4 +1,4 @@
-import { MonteCarloAI, randomizePlacement, BOARD_SIZE } from '../components/apps/battleship/ai';
+import { MonteCarloAI, randomizePlacement, BOARD_SIZE } from '../apps/games/battleship/ai';
 
 test('AI computes move under 500ms', () => {
   const ai = new MonteCarloAI();

--- a/components/apps/battleship/GameLayout.js
+++ b/components/apps/battleship/GameLayout.js
@@ -1,6 +1,18 @@
 import React from 'react';
 
-const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats, showHeatmap, onToggleHeatmap }) => {
+const GameLayout = ({
+  children,
+  difficulty,
+  onDifficultyChange,
+  onRestart,
+  stats,
+  showHeatmap,
+  onToggleHeatmap,
+  salvo,
+  onSalvoChange,
+  fog,
+  onFogChange,
+}) => {
   return (
     <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
       <div className="flex items-center space-x-2 mb-2">
@@ -22,6 +34,24 @@ const GameLayout = ({ children, difficulty, onDifficultyChange, onRestart, stats
         <button className="px-2 py-1 bg-gray-700" onClick={onToggleHeatmap}>
           {showHeatmap ? 'Hide' : 'Show'} Heatmap
         </button>
+        <label className="text-sm">
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={salvo}
+            onChange={(e) => onSalvoChange(e.target.checked)}
+          />
+          Salvo
+        </label>
+        <label className="text-sm">
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={fog}
+            onChange={(e) => onFogChange(e.target.checked)}
+          />
+          Fog of War
+        </label>
         {stats && (
           <div className="ml-4 text-sm">
             W: {stats.wins} L: {stats.losses}


### PR DESCRIPTION
## Summary
- move battleship AI logic into games module
- add selectable Salvo and Fog of War modes
- wire difficulty selection and update tests

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` (fails: Parsing error: Identifier 'togglePause' has already been declared)
- `yarn test` (fails: hashcat, mimikatz, snake.config, frogger.config)
- `yarn test __tests__/battleship-ai.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0bfa71338832880b4607f5c380d96