### PR TITLE
feat: add dsniff domain summary and export

### DIFF
--- a/apps/dsniff/index.tsx
+++ b/apps/dsniff/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import DsniffApp from '../../components/apps/dsniff';
+
+const DsniffPage: React.FC = () => {
+  return <DsniffApp />;
+};
+
+export default DsniffPage;


### PR DESCRIPTION
## Summary
- add standalone dsniff page
- group captured URLs and credentials by domain with risk levels
- provide redacted export and animated timeline

## Testing
- `npm test` *(fails: hashcat.test.tsx, beef.test.tsx, mimikatz.test.ts, snake.config.test.ts, frogger.config.test.ts, dsniff.test.tsx)*
- `npm test __tests__/dsniff.test.tsx` *(fails: Dsniff component shows fixture logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf91114483289e1912632f203b5d