### PR TITLE
feat: expand mimikatz demo with parsing and redaction

### DIFF
--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+import MimikatzApp from '../../components/apps/mimikatz';
+
+const MimikatzPage: React.FC = () => {
+  return <MimikatzApp />;
+};
+
+export default MimikatzPage;
+

--- a/components/apps/mimikatz/index.js
+++ b/components/apps/mimikatz/index.js
@@ -1,17 +1,60 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import CredentialArtifactLocator from './CredentialLocator';
 import modulesData from './modules.json';
 
-// Mimikatz simulator: displays sample data only. Uploads and real credential handling are disabled.
+// Sample outputs for demonstration only. No real credentials are processed.
 const sampleOutputs = {
-  sekurlsa: 'Sample output: dumped credentials (not real).',
-  lsadump: 'Sample output: LSASS secrets (not real).',
+  sekurlsa: `Authentication Id : 0 ; 999 (00000000:000003E7)
+User Name         : alice
+Domain            : CONTOSO
+Password          : P@ssw0rd!
+NTLM              : 8846f7eaee8fb117ad06bdd830b7586c`,
+  lsadump: `LSA Secret       : DefaultPassword
+Key              : _SC_MachineAccount
+Credential       : SuperSecretValue`,
   misc: 'Sample output: miscellaneous helper command.',
+};
+
+const mitigations = [
+  {
+    item: 'Enable LSA Protection',
+    risk: 'Prevents credential dumping by blocking code injection into LSASS.',
+  },
+  {
+    item: 'Disable WDigest',
+    risk: 'Stops storage of clear-text passwords in memory.',
+  },
+  {
+    item: 'Use strong passwords and MFA',
+    risk: 'Reduces the impact of credential theft.',
+  },
+];
+
+const severityClass = {
+  high: 'text-red-400',
+  medium: 'text-yellow-400',
+  info: '',
+};
+
+const parseOutput = (text, redact) => {
+  return text.split(/\r?\n/).map((line) => {
+    let severity = 'info';
+    if (/password|ntlm|credential/i.test(line)) {
+      severity = 'high';
+    } else if (/lsa|secret/i.test(line)) {
+      severity = 'medium';
+    }
+    const redactedLine = redact
+      ? line.replace(/(:\s*)(.+)/, '$1[REDACTED]')
+      : line;
+    return { line: redactedLine, severity };
+  });
 };
 
 const MimikatzApp = () => {
   const [modules] = useState(modulesData);
   const [output, setOutput] = useState('');
+  const [parsed, setParsed] = useState([]);
   const [history, setHistory] = useState([]);
   const [templates, setTemplates] = useState(() => {
     if (typeof window === 'undefined') return [];
@@ -23,6 +66,11 @@ const MimikatzApp = () => {
   });
   const [templateName, setTemplateName] = useState('');
   const [templateScript, setTemplateScript] = useState('');
+  const [redact, setRedact] = useState(true);
+
+  useEffect(() => {
+    setParsed(parseOutput(output, redact));
+  }, [output, redact]);
 
   const addHistory = (command, text) => {
     setHistory((h) => [
@@ -54,6 +102,20 @@ const MimikatzApp = () => {
     addHistory(script, msg);
   };
 
+  const copyOutput = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      const text = parsed.map((p) => p.line).join('\n');
+      try {
+        navigator.clipboard?.writeText(text);
+      } catch {
+        // ignore copy errors
+      }
+    }
+  }, [parsed]);
+
+  const mask = (text) =>
+    redact ? text.replace(/(:\s*)(.+)/g, '$1[REDACTED]') : text;
+
   return (
     <div className="h-full w-full flex text-white">
       <div className="w-1/4 bg-ub-dark p-2 overflow-y-auto">
@@ -70,7 +132,9 @@ const MimikatzApp = () => {
             </li>
           ))}
         </ul>
-        <p className="text-xs italic mt-2">Sample modules only. No real credentials are processed.</p>
+        <p className="text-xs italic mt-2">
+          Sample modules only. No real credentials are processed.
+        </p>
         <h2 className="text-lg mt-4">Templates</h2>
         <ul>
           {templates.map((t, idx) => (
@@ -107,16 +171,47 @@ const MimikatzApp = () => {
       </div>
       <div className="flex-1 p-4 bg-ub-cool-grey overflow-auto">
         <h1 className="text-lg mb-4">Mimikatz (Sample Simulator)</h1>
-        <p className="text-sm mb-4 italic">All outputs are sample data. Uploads are disabled.</p>
-        <pre className="whitespace-pre-wrap mb-4">{output}</pre>
+        <p className="text-sm mb-4 italic">
+          All outputs are sample data. Uploads are disabled.
+        </p>
+        <label className="flex items-center space-x-2 mb-2">
+          <input
+            type="checkbox"
+            checked={redact}
+            onChange={() => setRedact((r) => !r)}
+          />
+          <span>Redact secrets</span>
+        </label>
+        <button
+          type="button"
+          className="mb-4 px-2 py-1 bg-blue-700 rounded"
+          onClick={copyOutput}
+        >
+          Copy Output
+        </button>
+        <pre className="whitespace-pre-wrap mb-4">
+          {parsed.map((p, idx) => (
+            <div key={idx} className={severityClass[p.severity]}>
+              {p.line}
+            </div>
+          ))}
+        </pre>
         <CredentialArtifactLocator />
+        <h2 className="text-lg mt-4 mb-2">Mitigations</h2>
+        <ul className="list-disc pl-4 mb-4">
+          {mitigations.map((m, idx) => (
+            <li key={idx}>
+              <span className="font-semibold">{m.item}:</span> {m.risk}
+            </li>
+          ))}
+        </ul>
         <h2 className="text-lg mb-2">History</h2>
         <ul className="space-y-1">
           {history.map((h, idx) => (
             <li key={idx}>
               <span className="text-xs text-gray-300">{h.timestamp}</span> -{' '}
               <span className="font-bold">{h.command}</span>
-              <pre className="whitespace-pre-wrap">{h.output}</pre>
+              <pre className="whitespace-pre-wrap">{mask(h.output)}</pre>
             </li>
           ))}
         </ul>
@@ -130,3 +225,4 @@ export default MimikatzApp;
 export const displayMimikatz = (addFolder, openApp) => {
   return <MimikatzApp addFolder={addFolder} openApp={openApp} />;
 };
+


### PR DESCRIPTION
## Summary
- add Next.js page for Mimikatz demo
- parse sample output highlighting credentials/LSA severity with optional redaction and copy
- show mitigation checklist with risk explanations

## Testing
- `yarn test` *(fails: HashcatApp labels hashcat modes with example hashes; BeEF app updates hook list; mimikatz api retrieves module list; snake.config.test.ts SyntaxError; frogger.config.test.ts SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf89d9d08328a71e60ad1f682035