### PR TITLE
Add BeEF simulator app with lab gate

### DIFF
--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import BeefApp from '../../components/apps/beef';
+
+const BeefPage: React.FC = () => {
+  return <BeefApp />;
+};
+
+export default BeefPage;

--- a/components/apps/beef/PayloadBuilder.js
+++ b/components/apps/beef/PayloadBuilder.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+export default function PayloadBuilder() {
+  const [payload, setPayload] = useState('');
+  const [message, setMessage] = useState('');
+
+  const buildPayload = () => {
+    setMessage('Execution blocked by same-origin policy or Content Security Policy.');
+  };
+
+  return (
+    <div className="mt-4">
+      <h3 className="font-bold mb-2">Payload Builder</h3>
+      <textarea
+        value={payload}
+        onChange={(e) => setPayload(e.target.value)}
+        rows={3}
+        className="w-full p-1 text-black mb-2"
+        placeholder="Enter JS payload..."
+      />
+      <button
+        type="button"
+        onClick={buildPayload}
+        className="px-3 py-1 bg-ub-gray-50 text-black rounded"
+      >
+        Build
+      </button>
+      {message && <p className="mt-2 text-xs">{message}</p>}
+    </div>
+  );
+}

--- a/pages/apps/beef.tsx
+++ b/pages/apps/beef.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Beef = dynamic(() => import('../../apps/beef'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function BeefPage() {
+  return <Beef />;
+}


### PR DESCRIPTION
## Summary
- scaffold BeEF simulator under apps and pages
- render hooks list and module tree from demo JSON
- add payload builder and lab ethics modal

## Testing
- `npm test` *(fails: hashcat.test.tsx, mimikatz.test.ts, frogger.config.test.ts, snake.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf7fa63c83289d1e755b741562bf