### PR TITLE
feat: add 2048 game config

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -114,7 +114,7 @@ const displayConnectFour = createDisplay(ConnectFourApp);
 const displayHangman = createDisplay(HangmanApp);
 const displayFrogger = createDisplay(FroggerApp);
 const displayFlappyBird = createDisplay(FlappyBirdApp);
-const display2048 = createDisplay(Game2048App);
+const displayGame2048 = createDisplay(Game2048App);
 const displaySnake = createDisplay(SnakeApp);
 const displayMemory = createDisplay(MemoryApp);
 const displayMinesweeper = createDisplay(MinesweeperApp);
@@ -271,7 +271,7 @@ const gameList = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
-    screen: display2048,
+    screen: displayGame2048,
     defaultWidth: 35,
     defaultHeight: 45,
   },

--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -5,6 +5,8 @@ import useGameControls from './useGameControls';
 import { findHint } from '../../apps/games/_2048/ai';
 import { vibrate } from './Games/common/haptics';
 
+// Basic 2048 game logic with tile merging mechanics.
+
 const SIZE = 4;
 
 // seeded RNG so tests can be deterministic
@@ -439,5 +441,6 @@ const Game2048 = () => {
   );
 };
 
+export { slide };
 export default Game2048;
 


### PR DESCRIPTION
## Summary
- expose 2048 slide logic and note tile merging
- wire 2048 game into dynamic app configuration

## Testing
- npx eslint -c .eslintrc.cjs apps.config.js components/apps/2048.js (fails: extends key not supported)
- npx jest __tests__/game2048.test.tsx __tests__/game2048.test.ts
- npm test (fails: hashcat.test.tsx, mimikatz.test.ts, wordSearch.test.ts, kismet.test.tsx)

------
https://chatgpt.com/codex/tasks/task_e_68b0fe1fc9ec8328b6c232e44c143cd8