### PR TITLE
chore: enforce type and lint checks during build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -61,13 +61,6 @@ const securityHeaders = [
 const isExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
 module.exports = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-
   images: {
     domains: [
       'opengraph.githubassets.com',


### PR DESCRIPTION
## Summary
- remove `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` from Next.js config so build respects type and lint failures

## Testing
- `yarn tsc --noEmit` *(fails: numerous TypeScript errors)*
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn build` *(fails: missing type declarations for figlet)*

------
https://chatgpt.com/codex/tasks/task_e_68b10f5b60a08328b47c63fb9a4c9e19