### PR TITLE
docs: note StackBlitz VS Code embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | --- | --- | --- |
 | Alex | /apps/alex | Utility / Media |
 | Chrome | /apps/chrome | Utility / Media |
-| Vscode | /apps/vscode | Utility / Media |
+| VS Code | /apps/vscode | StackBlitz IDE embed |
 | Spotify | /apps/spotify | Utility / Media |
 | Youtube | /apps/youtube | Utility / Media |
 | Weather | /apps/weather | Utility / Media |
@@ -320,6 +320,8 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 | Trash | /apps/trash | Utility / Media |
 | Project Gallery | /apps/project-gallery | Utility / Media |
 | Quote | /apps/quote | Utility / Media |
+
+> The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
 
 The Spotify app loads its mood-to-playlist mapping from `public/spotify-playlists.json`,
 remembers the last mood you played, and exposes play/pause and track controls with

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -29,8 +29,7 @@ This document tracks planned improvements and new features for the desktop portf
 - Keep client-only dynamic import.
 
 ### Visual Studio Code
-- Convert to JS and export `displayVsCode`.
-- Add "Open folder" using JSON "virtual FS" backed by `localStorage` with editor tabs and search.
+- App now embeds a StackBlitz IDE via iframe instead of a local Monaco editor.
 
 ### X
 - Implement read-only timeline embed with SSR disabled and light/dark toggle.


### PR DESCRIPTION
## Summary
- highlight that VS Code app is now a StackBlitz embed
- update tasks to reflect VS Code iframe approach

## Testing
- `yarn test` *(fails: HashcatApp, mimikatz api, word search generator, Dsniff component, KismetApp)*

------
https://chatgpt.com/codex/tasks/task_e_68b113333bb083289616d65880c6bd60