### PR TITLE
feat(beef): add tabbed modules and payload builder

### DIFF
--- a/components/apps/beef/PayloadBuilder.js
+++ b/components/apps/beef/PayloadBuilder.js
@@ -5,7 +5,9 @@ export default function PayloadBuilder() {
   const [message, setMessage] = useState('');
 
   const buildPayload = () => {
-    setMessage('Execution blocked by same-origin policy or Content Security Policy.');
+    setMessage(
+      'Execution blocked. The browser\'s Same-Origin Policy and Content Security Policy prevent running arbitrary scripts in this demo.'
+    );
   };
 
   return (

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -18,6 +18,7 @@ export default function Beef() {
   const [liveMessage, setLiveMessage] = useState('');
   const prevHooks = useRef(0);
   const prevSteps = useRef(0);
+  const [activeTab, setActiveTab] = useState('modules');
 
   const hooksUrl = '/demo-data/beef/hooks.json';
   const modulesUrl = '/demo-data/beef/modules.json';
@@ -153,8 +154,13 @@ export default function Beef() {
 
   if (!authorized) {
     return (
-      <div className="w-full h-full bg-ub-dark text-white p-4 flex flex-col items-center justify-center text-center">
-        <p className="mb-4 text-sm">
+      <div
+        className="w-full h-full bg-ub-dark text-white p-4 flex flex-col items-center justify-center text-center"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="beef-lab-modal-title"
+      >
+        <p id="beef-lab-modal-title" className="mb-4 text-sm">
           Security tools are for lab use only. Review{' '}
           <a
             href="https://csrc.nist.gov/publications/detail/sp/800-115/final"
@@ -239,22 +245,72 @@ export default function Beef() {
         </div>
         {selected ? (
           <>
-            <div className="mb-2 flex">
-              <div className="flex-1 overflow-auto max-h-40 border border-gray-700 p-1 mr-2">
-                {modules.length > 0 ? renderTree(modules) : <p className="text-sm">No modules</p>}
-              </div>
+            <div role="tablist" aria-label="BeEF tools" className="flex space-x-2 mb-2">
               <button
-                type="button"
-                onClick={runModule}
-                className="px-3 py-1 bg-ub-primary text-white rounded h-max"
+                id="tab-modules"
+                role="tab"
+                aria-selected={activeTab === 'modules'}
+                aria-controls="panel-modules"
+                className={`px-3 py-1 rounded ${
+                  activeTab === 'modules'
+                    ? 'bg-ub-primary text-white'
+                    : 'bg-ub-gray-50 text-black'
+                }`}
+                onClick={() => setActiveTab('modules')}
               >
-                Run Module
+                Modules
+              </button>
+              <button
+                id="tab-payload"
+                role="tab"
+                aria-selected={activeTab === 'payload'}
+                aria-controls="panel-payload"
+                className={`px-3 py-1 rounded ${
+                  activeTab === 'payload'
+                    ? 'bg-ub-primary text-white'
+                    : 'bg-ub-gray-50 text-black'
+                }`}
+                onClick={() => setActiveTab('payload')}
+              >
+                Payload Builder
               </button>
             </div>
-            {output && (
-              <pre className="whitespace-pre-wrap text-xs bg-black p-2 rounded mb-4">{output}</pre>
-            )}
-            <PayloadBuilder />
+            <div
+              id="panel-modules"
+              role="tabpanel"
+              aria-labelledby="tab-modules"
+              hidden={activeTab !== 'modules'}
+            >
+              <div className="mb-2 flex">
+                <div className="flex-1 overflow-auto max-h-40 border border-gray-700 p-1 mr-2">
+                  {modules.length > 0 ? (
+                    renderTree(modules)
+                  ) : (
+                    <p className="text-sm">No modules</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={runModule}
+                  className="px-3 py-1 bg-ub-primary text-white rounded h-max"
+                >
+                  Run Module
+                </button>
+              </div>
+              {output && (
+                <pre className="whitespace-pre-wrap text-xs bg-black p-2 rounded mb-4">
+                  {output}
+                </pre>
+              )}
+            </div>
+            <div
+              id="panel-payload"
+              role="tabpanel"
+              aria-labelledby="tab-payload"
+              hidden={activeTab !== 'payload'}
+            >
+              <PayloadBuilder />
+            </div>
           </>
         ) : (
           <p>Select a hooked browser to run modules.</p>

--- a/public/demo-data/beef/modules.json
+++ b/public/demo-data/beef/modules.json
@@ -1,14 +1,26 @@
 {
   "modules": [
     {
-      "id": "alert",
-      "name": "Alert Dialog",
-      "output": "Alert executed on target."
+      "id": "commands",
+      "name": "Commands",
+      "children": [
+        {
+          "id": "alert",
+          "name": "Alert Dialog",
+          "output": "Alert executed on target."
+        }
+      ]
     },
     {
-      "id": "get-cookie",
-      "name": "Get Cookies",
-      "output": "sessionid=demo123; csrftoken=demo456"
+      "id": "network",
+      "name": "Network",
+      "children": [
+        {
+          "id": "get-cookie",
+          "name": "Get Cookies",
+          "output": "sessionid=demo123; csrftoken=demo456"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Render module tree and payload builder in a controlled tab interface for BeEF demo
- Explain Same-Origin and CSP blocking in payload builder message
- Provide modules tree fixture and gate Lab Mode with ethics/legal modal

## Testing
- `yarn test __tests__/beef.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b113e60e30832896c3626a36de397d