### PR TITLE
Add vendor-aware Kismet heatmap and seeded map

### DIFF
--- a/components/apps/kismet/sampleCapture.json
+++ b/components/apps/kismet/sampleCapture.json
@@ -1,8 +1,38 @@
 [
-  {"ssid":"CoffeeShopWiFi","channel":1,"signal":-45},
-  {"ssid":"FreeAirport","channel":6,"signal":-70},
-  {"ssid":"HomeWiFi","channel":11,"signal":-30},
-  {"ssid":"CoffeeShopWiFi","channel":1,"signal":-47},
-  {"ssid":"FreeAirport","channel":6,"signal":-72},
-  {"ssid":"NewCafe","channel":3,"signal":-80}
+  {
+    "ssid": "CoffeeShopWiFi",
+    "bssid": "66:77:88:00:00:01",
+    "channel": 1,
+    "signal": -45
+  },
+  {
+    "ssid": "FreeAirport",
+    "bssid": "AA:BB:CC:00:00:01",
+    "channel": 6,
+    "signal": -70
+  },
+  {
+    "ssid": "HomeWiFi",
+    "bssid": "00:11:22:00:00:01",
+    "channel": 11,
+    "signal": -30
+  },
+  {
+    "ssid": "CoffeeShopWiFi",
+    "bssid": "66:77:88:00:00:01",
+    "channel": 1,
+    "signal": -47
+  },
+  {
+    "ssid": "FreeAirport",
+    "bssid": "AA:BB:CC:00:00:01",
+    "channel": 6,
+    "signal": -72
+  },
+  {
+    "ssid": "NewCafe",
+    "bssid": "DD:EE:FF:00:00:01",
+    "channel": 3,
+    "signal": -80
+  }
 ]


### PR DESCRIPTION
## Summary
- track Wi-Fi networks by BSSID with vendor lookup via OUI JSON
- render SSID/channel heatmap including vendor details
- use seeded random generator for wardriving map points

## Testing
- `npm test` *(fails: hashcat, mimikatz, wordSearch, dsniff, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b113e9541483289952861324da03b3