### PR TITLE
feat(autopsy): add keyword search panel

### DIFF
--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -1,0 +1,79 @@
+import React from 'react';
+
+const escapeHtml = (str = '') =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // eslint-disable-next-line no-useless-escape
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
+  const highlight = (text = '') => {
+    const safe = escapeHtml(text);
+    if (!keyword) return safe;
+    const re = new RegExp(
+      `(${keyword.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`,
+      'gi'
+    );
+    return safe.replace(re, '<mark>$1</mark>');
+  };
+
+  const exportHits = () => {
+    const data = JSON.stringify(artifacts, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'autopsy-hits.json';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <>
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="Keyword search"
+          className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
+        />
+        <button
+          onClick={exportHits}
+          className="bg-ub-orange px-2 py-1 rounded text-sm text-black"
+        >
+          Export Hits
+        </button>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2">
+        {artifacts.map((a, idx) => (
+          <button
+            type="button"
+            key={`${a.name}-${idx}`}
+            onClick={() => onSelect(a)}
+            className="p-2 bg-ub-grey rounded text-sm text-left"
+          >
+            <div
+              className="font-bold"
+              dangerouslySetInnerHTML={{ __html: highlight(a.name) }}
+            />
+            <div className="text-gray-400">{a.type}</div>
+            <div className="text-xs">
+              {new Date(a.timestamp).toLocaleString()}
+            </div>
+            <div
+              className="text-xs"
+              dangerouslySetInnerHTML={{ __html: highlight(a.description) }}
+            />
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default KeywordSearchPanel;
+

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import KeywordSearchPanel from './KeywordSearchPanel';
 
 const escapeFilename = (str = '') =>
   str
@@ -384,27 +385,6 @@ function Autopsy({ initialArtifacts = null }) {
     );
   };
 
-  const highlight = (text = '') => {
-    const safe = escapeFilename(text);
-    if (!keyword) return safe;
-    const re = new RegExp(
-      `(${keyword.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`,
-      'gi'
-    );
-    return safe.replace(re, '<mark>$1</mark>');
-  };
-
-  const exportHits = () => {
-    const data = JSON.stringify(visibleArtifacts, null, 2);
-    const blob = new Blob([data], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'autopsy-hits.json';
-    link.click();
-    URL.revokeObjectURL(url);
-  };
-
   const downloadReport = () => {
     const lines = artifacts.map(
       (a) => `${a.timestamp} - ${a.name} (${a.size} bytes) [Plugin: ${a.plugin}]`
@@ -496,44 +476,12 @@ function Autopsy({ initialArtifacts = null }) {
               </option>
             ))}
           </select>
-          <div className="flex space-x-2">
-            <input
-              type="text"
-              value={keyword}
-              onChange={(e) => setKeyword(e.target.value)}
-              placeholder="Keyword search"
-              className="flex-grow bg-ub-grey text-white px-2 py-1 rounded"
-            />
-            <button
-              onClick={exportHits}
-              className="bg-ub-orange px-2 py-1 rounded text-sm text-black"
-            >
-              Export Hits
-            </button>
-          </div>
-          <div className="grid gap-2 md:grid-cols-2">
-            {visibleArtifacts.map((a, idx) => (
-              <button
-                type="button"
-                key={`${a.name}-${idx}`}
-                onClick={() => setSelectedArtifact(a)}
-                className="p-2 bg-ub-grey rounded text-sm text-left"
-              >
-                <div
-                  className="font-bold"
-                  dangerouslySetInnerHTML={{ __html: highlight(a.name) }}
-                />
-                <div className="text-gray-400">{a.type}</div>
-                <div className="text-xs">
-                  {new Date(a.timestamp).toLocaleString()}
-                </div>
-                <div
-                  className="text-xs"
-                  dangerouslySetInnerHTML={{ __html: highlight(a.description) }}
-                />
-              </button>
-            ))}
-          </div>
+          <KeywordSearchPanel
+            keyword={keyword}
+            setKeyword={setKeyword}
+            artifacts={visibleArtifacts}
+            onSelect={setSelectedArtifact}
+          />
           {visibleArtifacts.length > 0 && (
             <>
               <div className="text-sm font-bold">Timeline</div>


### PR DESCRIPTION
## Summary
- add reusable keyword search panel to Autopsy simulator
- allow exporting current hits

## Testing
- `yarn test components/apps/autopsy --passWithNoTests`
- `ESLINT_USE_FLAT_CONFIG=false yarn lint components/apps/autopsy/index.js components/apps/autopsy/KeywordSearchPanel.js` *(fails: ESLint errors elsewhere)*

------
https://chatgpt.com/codex/tasks/task_e_68b113ea53a88328a3d51ca1bc9b50e1