### PR TITLE
feat(nessus): add plugin feed viewer and scan comparison

### DIFF
--- a/components/apps/nessus/PluginFeedViewer.js
+++ b/components/apps/nessus/PluginFeedViewer.js
@@ -1,0 +1,52 @@
+import React, { useMemo, useState } from 'react';
+import sampleReport from './sample-report.json';
+
+const severityLevels = ['All', 'Critical', 'High', 'Medium', 'Low'];
+
+const PluginFeedViewer = ({ plugins = sampleReport }) => {
+  const [filter, setFilter] = useState('All');
+
+  const filtered = useMemo(
+    () =>
+      filter === 'All' ? plugins : plugins.filter((p) => p.severity === filter),
+    [filter, plugins]
+  );
+
+  return (
+    <div className="mb-4">
+      <h3 className="text-lg mb-2">Plugin Feed</h3>
+      <div
+        role="radiogroup"
+        aria-label="Filter plugins by severity"
+        className="flex flex-wrap gap-2 mb-2"
+      >
+        {severityLevels.map((level) => (
+          <button
+            key={level}
+            onClick={() => setFilter(level)}
+            aria-pressed={filter === level}
+            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+              filter === level
+                ? 'bg-white text-black border-gray-300'
+                : 'bg-gray-800 text-white border-gray-600'
+            }`}
+          >
+            {level}
+          </button>
+        ))}
+      </div>
+      <ul className="space-y-1">
+        {filtered.map((plugin) => (
+          <li key={plugin.id} className="border-b border-gray-700 pb-1 text-sm">
+            <div className="font-semibold">{plugin.name}</div>
+            <div className="text-xs text-gray-400">
+              {plugin.severity} - CVSS {plugin.cvss}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PluginFeedViewer;

--- a/components/apps/nessus/ScanComparison.js
+++ b/components/apps/nessus/ScanComparison.js
@@ -1,0 +1,128 @@
+import React, { useMemo } from 'react';
+import previousScan from './fixtures/scan-1.json';
+import currentScan from './fixtures/scan-2.json';
+
+const severityOrder = ['Critical', 'High', 'Medium', 'Low'];
+const severityColors = {
+  Critical: '#991b1b',
+  High: '#b45309',
+  Medium: '#a16207',
+  Low: '#1e40af',
+};
+
+const summarize = (scan) => {
+  const summary = { Critical: 0, High: 0, Medium: 0, Low: 0 };
+  scan.forEach((vuln) => {
+    if (summary[vuln.severity] !== undefined) summary[vuln.severity] += 1;
+  });
+  return summary;
+};
+
+const ScanComparison = ({ previous = previousScan, current = currentScan }) => {
+  const { added, removed, changed } = useMemo(() => {
+    const prevMap = new Map(previous.map((v) => [v.id, v]));
+    const curMap = new Map(current.map((v) => [v.id, v]));
+    const added = current.filter((v) => !prevMap.has(v.id));
+    const removed = previous.filter((v) => !curMap.has(v.id));
+    const changed = current
+      .filter((v) => {
+        const prev = prevMap.get(v.id);
+        return prev && prev.severity !== v.severity;
+      })
+      .map((v) => ({ ...v, previousSeverity: prevMap.get(v.id).severity }));
+    return { added, removed, changed };
+  }, [previous, current]);
+
+  const summary = useMemo(() => summarize(current), [current]);
+  const maxCount = Math.max(
+    ...severityOrder.map((level) => summary[level] || 0),
+    1
+  );
+
+  return (
+    <div className="mb-4">
+      <h3 className="text-lg mb-2">Executive Summary</h3>
+      <svg
+        width="260"
+        height="120"
+        role="img"
+        aria-label="Executive summary chart"
+        className="mx-auto mb-4"
+      >
+        {severityOrder.map((level, idx) => {
+          const count = summary[level] || 0;
+          const barHeight = (count / maxCount) * 80;
+          const x = idx * 60 + 20;
+          const y = 100 - barHeight;
+          return (
+            <g key={level}>
+              <rect
+                x={x}
+                y={y}
+                width="40"
+                height={barHeight}
+                fill={severityColors[level]}
+              />
+              <text
+                x={x + 20}
+                y={y - 4}
+                textAnchor="middle"
+                className="text-xs fill-white"
+              >
+                {count}
+              </text>
+              <text
+                x={x + 20}
+                y={110}
+                textAnchor="middle"
+                className="text-xs fill-white"
+              >
+                {level}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <div className="space-y-2">
+        {added.length > 0 && (
+          <div>
+            <h4 className="font-semibold text-green-400">New Findings</h4>
+            <ul className="ml-4 list-disc">
+              {added.map((v) => (
+                <li key={v.id} className="text-sm">
+                  {v.name} ({v.severity})
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {removed.length > 0 && (
+          <div>
+            <h4 className="font-semibold text-blue-400">Resolved</h4>
+            <ul className="ml-4 list-disc">
+              {removed.map((v) => (
+                <li key={v.id} className="text-sm">
+                  {v.name} ({v.severity})
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {changed.length > 0 && (
+          <div>
+            <h4 className="font-semibold text-yellow-400">Severity Changes</h4>
+            <ul className="ml-4 list-disc">
+              {changed.map((v) => (
+                <li key={v.id} className="text-sm">
+                  {v.name}: {v.previousSeverity} → {v.severity}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScanComparison;

--- a/components/apps/nessus/fixtures/scan-1.json
+++ b/components/apps/nessus/fixtures/scan-1.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "1",
+    "name": "OpenSSL Heartbeat Information Disclosure",
+    "cvss": 5.0,
+    "severity": "Medium",
+    "host": "server1.example.com"
+  },
+  {
+    "id": "2",
+    "name": "Apache HTTP Server Privilege Escalation",
+    "cvss": 7.5,
+    "severity": "High",
+    "host": "server1.example.com"
+  },
+  {
+    "id": "3",
+    "name": "Weak SSH Cipher",
+    "cvss": 9.8,
+    "severity": "Critical",
+    "host": "server2.example.com"
+  }
+]

--- a/components/apps/nessus/fixtures/scan-2.json
+++ b/components/apps/nessus/fixtures/scan-2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "2",
+    "name": "Apache HTTP Server Privilege Escalation",
+    "cvss": 7.5,
+    "severity": "Medium",
+    "host": "server1.example.com"
+  },
+  {
+    "id": "3",
+    "name": "Weak SSH Cipher",
+    "cvss": 9.8,
+    "severity": "Critical",
+    "host": "server2.example.com"
+  },
+  {
+    "id": "4",
+    "name": "Outdated Software",
+    "cvss": 2.5,
+    "severity": "Low",
+    "host": "server3.example.com"
+  }
+]

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import HostBubbleChart from './HostBubbleChart';
+import PluginFeedViewer from './PluginFeedViewer';
+import ScanComparison from './ScanComparison';
 import FormError from '../../ui/FormError';
 
 // helpers for persistent storage of jobs and false positives
@@ -180,6 +182,8 @@ const Nessus = () => {
         </button>
       </div>
       <HostBubbleChart hosts={hostData} />
+      <PluginFeedViewer />
+      <ScanComparison />
       {error && <FormError className="mb-2">{error}</FormError>}
       <form onSubmit={addJob} className="mb-4 space-x-2">
         <input


### PR DESCRIPTION
## Summary
- add plugin feed viewer with severity filters
- compare scan fixtures and render executive summary charts

## Testing
- `yarn test __tests__/nessus.test.ts __tests__/nessus-report.test.tsx`
- `yarn lint components/apps/nessus` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b113ec465083289c5011708ad1f63d