### PR TITLE
Add dynamic attempt timeline to Hydra demo

### DIFF
--- a/components/apps/hydra/Timeline.js
+++ b/components/apps/hydra/Timeline.js
@@ -1,28 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-const AttemptTimeline = () => {
-  const [attempts, setAttempts] = useState([]);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await fetch('/fixtures/hydra-timeline.json');
-        const json = await res.json();
-        setAttempts(json);
-      } catch {
-        // ignore fetch errors in environments without network
-      }
-    };
-    load();
-  }, []);
-
+const AttemptTimeline = ({ attempts = [] }) => {
   if (attempts.length === 0) {
     return null;
   }
 
   return (
     <div className="mt-4">
-      <h3 className="mb-2 text-lg">Sample Attempt Timeline</h3>
+      <h3 className="mb-2 text-lg">Attempt Timeline</h3>
       <ol className="space-y-1 text-sm">
         {attempts.map((a, i) => (
           <li key={i} className="font-mono">


### PR DESCRIPTION
## Summary
- track each hydra attempt with time, user/password combo and result
- show dynamic attempt timeline for throttling and lockout simulation
- reset timeline when runs start or cancel

## Testing
- `npm test hydra`


------
https://chatgpt.com/codex/tasks/task_e_68b113f02ac48328bab24f3cf2bdc16e