### PR TITLE
feat(nmap-nse): add script gallery and topology view

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -7,8 +7,15 @@ describe('NmapNSEApp', () => {
   it('shows example output for selected script', async () => {
     const mockFetch = jest
       .spyOn(global, 'fetch')
-      .mockImplementation(() =>
-        Promise.resolve({ json: () => Promise.resolve({ 'ftp-anon': 'FTP output' }) })
+      .mockImplementation((url: RequestInfo | URL) =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve(
+              typeof url === 'string' && url.includes('nmap-results')
+                ? { hosts: [] }
+                : { 'ftp-anon': 'FTP output' }
+            ),
+        })
       );
 
     render(<NmapNSEApp />);
@@ -23,7 +30,16 @@ describe('NmapNSEApp', () => {
   it('copies command to clipboard', async () => {
     const mockFetch = jest
       .spyOn(global, 'fetch')
-      .mockImplementation(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+      .mockImplementation((url: RequestInfo | URL) =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve(
+              typeof url === 'string' && url.includes('nmap-results')
+                ? { hosts: [] }
+                : {}
+            ),
+        })
+      );
     const writeText = jest.fn();
     // @ts-ignore
     navigator.clipboard = { writeText };
@@ -43,9 +59,14 @@ describe('NmapNSEApp', () => {
   it('copies example output to clipboard', async () => {
     const mockFetch = jest
       .spyOn(global, 'fetch')
-      .mockImplementation(() =>
+      .mockImplementation((url: RequestInfo | URL) =>
         Promise.resolve({
-          json: () => Promise.resolve({ 'http-title': 'Sample output' }),
+          json: () =>
+            Promise.resolve(
+              typeof url === 'string' && url.includes('nmap-results')
+                ? { hosts: [] }
+                : { 'http-title': 'Sample output' }
+            ),
         })
       );
     const writeText = jest.fn();

--- a/public/demo/nmap-results.json
+++ b/public/demo/nmap-results.json
@@ -1,0 +1,23 @@
+{
+  "hosts": [
+    {
+      "ip": "192.0.2.10",
+      "ports": [
+        { "port": 80, "service": "http", "cvss": 5.0 },
+        { "port": 443, "service": "https", "cvss": 3.1 }
+      ]
+    },
+    {
+      "ip": "192.0.2.20",
+      "ports": [
+        { "port": 21, "service": "ftp", "cvss": 7.5 }
+      ]
+    },
+    {
+      "ip": "192.0.2.30",
+      "ports": [
+        { "port": 445, "service": "microsoft-ds", "cvss": 4.0 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add tag-filtered script gallery with optional arguments
- visualize parsed Nmap results with CVSS badges and topology mini-map

## Testing
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn lint components/apps/nmap-nse/index.js components/apps/nmap-nse/DiscoveryMap.js __tests__/nmapNse.test.tsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b113f11ed48328a6f0ce728b2d6047