### PR TITLE
test: cover radare2 notes and bookmarks utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ keyboard hotkeys.
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
+- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 
 ---

--- a/__tests__/radare2.test.js
+++ b/__tests__/radare2.test.js
@@ -1,4 +1,12 @@
-import { saveSnippet, loadSnippets, convertAnalysisToGhidra } from '../components/apps/radare2/utils';
+import {
+  saveSnippet,
+  loadSnippets,
+  convertAnalysisToGhidra,
+  saveNotes,
+  loadNotes,
+  saveBookmarks,
+  loadBookmarks,
+} from '../components/apps/radare2/utils';
 
 describe('Radare2 utilities', () => {
   beforeEach(() => {
@@ -23,5 +31,23 @@ describe('Radare2 utilities', () => {
         { name: 'helper', calls: [] },
       ],
     });
+  });
+
+  test('stores notes per file', () => {
+    const notesA = [{ addr: '0x1', text: 'foo' }];
+    const notesB = [{ addr: '0x2', text: 'bar' }];
+    saveNotes('a.bin', notesA);
+    saveNotes('b.bin', notesB);
+    expect(loadNotes('a.bin')).toEqual(notesA);
+    expect(loadNotes('b.bin')).toEqual(notesB);
+  });
+
+  test('stores bookmarks per file', () => {
+    const bmA = ['0x1'];
+    const bmB = ['0x2'];
+    saveBookmarks('a.bin', bmA);
+    saveBookmarks('b.bin', bmB);
+    expect(loadBookmarks('a.bin')).toEqual(bmA);
+    expect(loadBookmarks('b.bin')).toEqual(bmB);
   });
 });


### PR DESCRIPTION
## Summary
- test radare2 utilities for per-file notes and bookmarks
- document radare2 component capabilities in README

## Testing
- `yarn test __tests__/radare2.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b113f1971883289346ddecb17fd91b