### PR TITLE
Load Volatility demo data from memory fixture

### DIFF
--- a/__tests__/volatilityApp.test.tsx
+++ b/__tests__/volatilityApp.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VolatilityApp from '../components/apps/volatility';
+
+describe('VolatilityApp demo', () => {
+  test('renders process tree and modules from fixture', () => {
+    render(<VolatilityApp />);
+    expect(screen.getByText(/System \(4\)/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/smss\.exe \(248\)/i));
+    expect(screen.getByText('0x2000')).toBeInTheDocument();
+  });
+
+  test('shows yara heuristics badges', () => {
+    render(<VolatilityApp />);
+    fireEvent.click(screen.getByText('yarascan'));
+
+    const heuristic = screen.getByText('suspicious');
+    expect(heuristic).toHaveClass('bg-yellow-600');
+  });
+});

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -3,51 +3,14 @@ import MemoryHeatmap from './MemoryHeatmap';
 import PluginBrowser from './PluginBrowser';
 import memoryDemo from '../../../public/demo-data/volatility/memory.json';
 
-const demoPstree = [
-  {
-    pid: 4,
-    name: 'System',
-    children: [
-      {
-        pid: 248,
-        name: 'smss.exe',
-        children: [
-          { pid: 612, name: 'csrss.exe', children: [] },
-        ],
-      },
-    ],
-  },
-];
-
-const demoDlllist = {
-  4: [{ base: '0x1000', name: 'ntoskrnl.exe' }],
-  248: [{ base: '0x2000', name: 'smss.exe' }],
-  612: [
-    { base: '0x3000', name: 'csrss.exe' },
-    { base: '0x4000', name: 'kernel32.dll' },
-  ],
-};
-
-const demoNetscan = [
-  { proto: 'TCP', local: '0.0.0.0:80', foreign: '0.0.0.0:0', state: 'LISTENING' },
-  { proto: 'UDP', local: '127.0.0.1:53', foreign: '0.0.0.0:0', state: 'NONE' },
-  {
-    proto: 'TCP',
-    local: '192.168.1.5:445',
-    foreign: '192.168.1.10:51234',
-    state: 'ESTABLISHED',
-  },
-];
-
-const demoMalfind = [
-  { pid: 612, address: '0x7f12a000', protection: 'RWX', description: 'Injected Code' },
-  { pid: 700, address: '0x401000', protection: 'RWX', description: 'Suspicious Section' },
-];
-
-const demoYara = [
-  { pid: 612, rule: 'SuspiciousAPIs', address: '0x401000', heuristic: 'suspicious' },
-  { pid: 248, rule: 'EncodedPayload', address: '0x500000', heuristic: 'malicious' },
-];
+// pull demo data for various volatility plugins from the memory fixture
+const {
+  pstree = [],
+  dlllist = {},
+  netscan = [],
+  malfind = [],
+  yarascan = [],
+} = memoryDemo;
 
 const heuristicColors = {
   informational: 'bg-blue-600',
@@ -220,7 +183,7 @@ const VolatilityApp = () => {
             {activeTab === 'pstree' && (
               <div className="flex space-x-4">
                 <ul className="w-1/2 text-xs">
-                  {demoPstree.map((node) => (
+                  {pstree.map((node) => (
                     <TreeNode key={node.pid} node={node} />
                   ))}
                 </ul>
@@ -233,7 +196,7 @@ const VolatilityApp = () => {
                           { key: 'base', label: 'Base' },
                           { key: 'name', label: 'Name' },
                         ]}
-                        data={demoDlllist[selectedPid] || []}
+                        data={dlllist[selectedPid] || []}
                         onRowClick={() => setFinding(glossary.dlllist)}
                       />
                     </>
@@ -251,7 +214,7 @@ const VolatilityApp = () => {
                   { key: 'foreign', label: 'ForeignAddr' },
                   { key: 'state', label: 'State' },
                 ]}
-                data={demoNetscan}
+                data={netscan}
                 onRowClick={() => setFinding(glossary.netscan)}
               />
             )}
@@ -263,7 +226,7 @@ const VolatilityApp = () => {
                   { key: 'protection', label: 'Protection' },
                   { key: 'description', label: 'Description' },
                 ]}
-                data={demoMalfind}
+                data={malfind}
                 onRowClick={() => setFinding(glossary.malfind)}
               />
             )}
@@ -287,7 +250,7 @@ const VolatilityApp = () => {
                     ),
                   },
                 ]}
-                data={demoYara}
+                data={yarascan}
                 onRowClick={() => setFinding(glossary.yara)}
               />
             )}

--- a/public/demo-data/volatility/memory.json
+++ b/public/demo-data/volatility/memory.json
@@ -3,5 +3,46 @@
     { "size": 2000, "type": "process" },
     { "size": 2000, "type": "dll" },
     { "size": 2000, "type": "socket" }
+  ],
+  "pstree": [
+    {
+      "pid": 4,
+      "name": "System",
+      "children": [
+        {
+          "pid": 248,
+          "name": "smss.exe",
+          "children": [
+            { "pid": 612, "name": "csrss.exe", "children": [] }
+          ]
+        }
+      ]
+    }
+  ],
+  "dlllist": {
+    "4": [{ "base": "0x1000", "name": "ntoskrnl.exe" }],
+    "248": [{ "base": "0x2000", "name": "smss.exe" }],
+    "612": [
+      { "base": "0x3000", "name": "csrss.exe" },
+      { "base": "0x4000", "name": "kernel32.dll" }
+    ]
+  },
+  "netscan": [
+    { "proto": "TCP", "local": "0.0.0.0:80", "foreign": "0.0.0.0:0", "state": "LISTENING" },
+    { "proto": "UDP", "local": "127.0.0.1:53", "foreign": "0.0.0.0:0", "state": "NONE" },
+    {
+      "proto": "TCP",
+      "local": "192.168.1.5:445",
+      "foreign": "192.168.1.10:51234",
+      "state": "ESTABLISHED"
+    }
+  ],
+  "malfind": [
+    { "pid": 612, "address": "0x7f12a000", "protection": "RWX", "description": "Injected Code" },
+    { "pid": 700, "address": "0x401000", "protection": "RWX", "description": "Suspicious Section" }
+  ],
+  "yarascan": [
+    { "pid": 612, "rule": "SuspiciousAPIs", "address": "0x401000", "heuristic": "suspicious" },
+    { "pid": 248, "rule": "EncodedPayload", "address": "0x500000", "heuristic": "malicious" }
   ]
 }


### PR DESCRIPTION
## Summary
- Load pstree, module, network, malfind and Yara demo data from memory fixture
- Show process modules, network connections, malfind and Yara results with glossary explanations
- Add unit tests for process tree and Yara heuristic badges

## Testing
- `npm test volatility`

------
https://chatgpt.com/codex/tasks/task_e_68b113f276948328b57a9134d0923a39