### PR TITLE
Add evidence vault app and enhance msf-post

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -89,6 +89,7 @@ const KismetApp = createDynamicApp('kismet', 'Kismet');
 
 const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
+const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
 const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
 const ReaverApp = createDynamicApp('reaver', 'Reaver');
@@ -171,6 +172,7 @@ const displayPinball = createDisplay(PinballApp);
 const displayVolatility = createDisplay(VolatilityApp);
 
 const displayMsfPost = createDisplay(MsfPostApp);
+const displayEvidenceVault = createDisplay(EvidenceVaultApp);
 const displayMimikatz = createDisplay(MimikatzApp);
 const displayEttercap = createDisplay(EttercapApp);
 const displayReaver = createDisplay(ReaverApp);
@@ -964,6 +966,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMsfPost,
+  },
+  {
+    id: 'evidence-vault',
+    title: 'Evidence Vault',
+    icon: './themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayEvidenceVault,
   },
   {
     id: 'dsniff',

--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -1,0 +1,168 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+// Build hierarchical tree from slash-delimited tags
+const buildTagTree = (items) => {
+  const root = {};
+  items.forEach((item) => {
+    item.tags.forEach((tag) => {
+      const parts = tag.split('/').filter(Boolean);
+      let node = root;
+      parts.forEach((part, idx) => {
+        node[part] = node[part] || { children: {}, items: [] };
+        if (idx === parts.length - 1) {
+          node[part].items.push(item);
+        }
+        node = node[part].children;
+      });
+    });
+  });
+  return root;
+};
+
+const TagTree = ({ data, onSelect }) => (
+  <ul className="pl-4">
+    {Object.entries(data).map(([name, node]) => (
+      <TagTreeNode key={name} name={name} node={node} onSelect={onSelect} />
+    ))}
+  </ul>
+);
+
+const TagTreeNode = ({ name, node, onSelect }) => {
+  const hasChildren = Object.keys(node.children).length > 0;
+  return (
+    <li className="mb-1">
+      {hasChildren ? (
+        <details>
+          <summary className="cursor-pointer">{name}</summary>
+          {node.items.length > 0 && (
+            <button
+              onClick={() => onSelect(node)}
+              className="ml-2 text-xs text-blue-400 hover:underline"
+            >
+              View items
+            </button>
+          )}
+          <TagTree data={node.children} onSelect={onSelect} />
+        </details>
+      ) : (
+        <button
+          onClick={() => onSelect(node)}
+          className="text-left hover:underline focus:outline-none"
+        >
+          {name}
+        </button>
+      )}
+    </li>
+  );
+};
+
+const EvidenceVaultApp = () => {
+  const [items, setItems] = useState([]);
+  const [selectedNode, setSelectedNode] = useState(null);
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    // reset selection when items change
+    setSelectedNode(null);
+  }, [items]);
+
+  const addNote = () => {
+    const title = prompt('Note title');
+    if (!title) return;
+    const content = prompt('Note content') || '';
+    const tagInput = prompt('Tags (comma separated, use / for hierarchy)') || '';
+    const tags = tagInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    setItems((prev) => [
+      ...prev,
+      { id: Date.now(), type: 'note', title, content, tags },
+    ]);
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const tagInput = prompt('Tags (comma separated, use / for hierarchy)') || '';
+    const tags = tagInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const url = URL.createObjectURL(file);
+    setItems((prev) => [
+      ...prev,
+      { id: Date.now(), type: 'file', name: file.name, url, tags },
+    ]);
+    e.target.value = '';
+  };
+
+  const treeData = buildTagTree(items);
+  const displayItems = selectedNode ? selectedNode.items : items;
+
+  return (
+    <div className="h-full w-full bg-gray-900 text-white p-4 flex">
+      <div className="w-1/3 border-r border-gray-700 pr-2 overflow-auto">
+        <button
+          onClick={() => setSelectedNode(null)}
+          className="text-sm text-blue-400 hover:underline mb-2"
+        >
+          All Items
+        </button>
+        <TagTree data={treeData} onSelect={setSelectedNode} />
+      </div>
+      <div className="flex-1 pl-4 flex flex-col">
+        <div className="mb-2 space-x-2">
+          <button
+            onClick={addNote}
+            className="px-2 py-1 bg-blue-600 rounded"
+          >
+            Add Note
+          </button>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="px-2 py-1 bg-blue-600 rounded"
+          >
+            Add File
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+        </div>
+        <ul className="flex-1 overflow-auto space-y-2">
+          {displayItems.map((item) => (
+            <li key={item.id} className="p-2 bg-gray-800 rounded">
+              {item.type === 'note' ? (
+                <div>
+                  <h4 className="font-semibold">{item.title}</h4>
+                  <p className="text-sm whitespace-pre-wrap">{item.content}</p>
+                </div>
+              ) : (
+                <div>
+                  <h4 className="font-semibold">{item.name}</h4>
+                  <a
+                    href={item.url}
+                    download
+                    className="text-blue-400 underline text-sm"
+                  >
+                    Download
+                  </a>
+                </div>
+              )}
+              {item.tags.length > 0 && (
+                <p className="text-xs mt-1 text-gray-400">
+                  Tags: {item.tags.join(', ')}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default EvidenceVaultApp;

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -145,7 +145,17 @@ const MsfPostApp = () => {
 
   const runModule = () => {
     if (!selectedModule) return;
-    setOutput(selectedModule.sampleOutput);
+    const lines = selectedModule.sampleOutput.split('\n');
+    setOutput('');
+    let idx = 0;
+    const append = () => {
+      setOutput((prev) => prev + (idx > 0 ? '\n' : '') + lines[idx]);
+      idx += 1;
+      if (idx < lines.length) {
+        setTimeout(append, 500);
+      }
+    };
+    append();
     animateSteps();
   };
 
@@ -212,55 +222,25 @@ const MsfPostApp = () => {
       <div className="sr-only" aria-live="polite" role="status">
         {liveMessage}
       </div>
-      <svg
+      <ul
+        className="mt-4 space-y-2"
         role="list"
         aria-label="Post-exploitation checklist"
-        className="mt-4 mx-auto"
-        width="220"
-        height={steps.length * 80}
       >
-        {steps.map((step, i) => (
-          <g
-            key={step.label}
-            role="listitem"
-            aria-label={`${step.label} ${step.done ? 'completed' : 'pending'}`}
-            transform={`translate(20, ${i * 70 + 20})`}
-          >
-            <circle
-              cx="0"
-              cy="0"
-              r="20"
-              fill={step.done ? '#22c55e' : '#6b7280'}
+        {steps.map((step) => (
+          <li key={step.label} className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={step.done}
+              readOnly
+              className="form-checkbox h-4 w-4 text-green-500 rounded"
             />
-            {step.done && (
-              <path
-                d="M-8 0 l4 4 l8 -8"
-                stroke="#fff"
-                strokeWidth="2"
-                fill="none"
-              />
-            )}
-            <text
-              x="40"
-              y="5"
-              fill={step.done ? '#22c55e' : '#d1d5db'}
-              fontSize="14"
-            >
+            <span className={step.done ? 'text-green-400' : 'text-gray-400'}>
               {step.label}
-            </text>
-            {i < steps.length - 1 && (
-              <line
-                x1="0"
-                y1="20"
-                x2="0"
-                y2="70"
-                stroke="#6b7280"
-                strokeWidth="2"
-              />
-            )}
-          </g>
+            </span>
+          </li>
         ))}
-      </svg>
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add Evidence Vault app for storing tagged notes and files with a tag tree view
- stage Metasploit Post module output and switch to checklist-style UI
- register Evidence Vault in app configuration

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/msf-post/index.js components/apps/evidence-vault/index.js apps.config.js`
- `yarn test components/apps/msf-post/index.js components/apps/evidence-vault/index.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b113f4c6c08328a2f66a125fdf429c