### PR TITLE
feat(john): add mode selection and potfile viewer

### DIFF
--- a/components/apps/john/progress.worker.js
+++ b/components/apps/john/progress.worker.js
@@ -1,6 +1,8 @@
 let total = 0;
 let completed = 0;
 
+const curve = (x) => 1 - Math.pow(1 - x, 2);
+
 onmessage = (e) => {
   const { type, total: t, amount = 1, phase } = e.data;
   if (type === 'init') {
@@ -9,8 +11,9 @@ onmessage = (e) => {
     postMessage({ percent: 0, phase: 'wordlist' });
   } else if (type === 'increment') {
     completed += amount;
-    let percent = total ? (completed / total) * 100 : 0;
-    if (percent > 100) percent = 100;
+    let raw = total ? completed / total : 0;
+    if (raw > 1) raw = 1;
+    const percent = curve(raw) * 100;
     postMessage({ percent, phase });
   }
 };

--- a/components/apps/john/utils.js
+++ b/components/apps/john/utils.js
@@ -23,3 +23,35 @@ export const identifyHashType = (hash) => {
   if (/^[a-fA-F0-9]{64}$/.test(hash)) return 'SHA256';
   return 'Unknown';
 };
+
+export const generateIncrementalCandidates = (
+  charset = 'abcdefghijklmnopqrstuvwxyz',
+  length = 4,
+  count = 10
+) => {
+  const results = [];
+  const base = charset.length;
+  const max = Math.pow(base, length);
+  for (let i = 0; i < count && i < max; i++) {
+    let num = i;
+    let str = '';
+    for (let j = 0; j < length; j++) {
+      str = charset[num % base] + str;
+      num = Math.floor(num / base);
+    }
+    results.push(str);
+  }
+  return results;
+};
+
+export const parsePotfile = (text) =>
+  text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const idx = line.indexOf(':');
+      if (idx === -1) return null;
+      return { hash: line.slice(0, idx), password: line.slice(idx + 1) };
+    })
+    .filter(Boolean);


### PR DESCRIPTION
## Summary
- add wordlist/incremental mode selection with candidate previews
- simulate non-linear progress curve
- include potfile viewer with filtering and export

## Testing
- `npx jest components/apps/john --passWithNoTests`
- `yarn lint components/apps/john/index.js components/apps/john/utils.js components/apps/john/progress.worker.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b113f63c08832892e6f5480d178399