### PR TITLE
feat(youtube): add keyboard shortcuts and queue sidebar

### DIFF
--- a/components/apps/youtube.js
+++ b/components/apps/youtube.js
@@ -1,1 +1,9 @@
-export { default } from '../../apps/youtube';
+import React from 'react';
+import dynamic from 'next/dynamic';
+
+const YouTubeApp = dynamic(() => import('../../apps/youtube'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default YouTubeApp;


### PR DESCRIPTION
## Summary
- implement YouTube search app with queue and watch-later support
- add keyboard shortcuts for search, queue, watch-later, and next video
- lazy load YouTube app component

## Testing
- `npm test` *(fails: hashcat modes, youtube, mimikatz, word search, dsniff)*

------
https://chatgpt.com/codex/tasks/task_e_68b113fdb4408328a0b0967cd7d696ac