### PR TITLE
feat: render resume from json with pdf download

### DIFF
--- a/components/apps/alex/resume.json
+++ b/components/apps/alex/resume.json
@@ -1,0 +1,45 @@
+{
+  "skills": [
+    "Networking",
+    "Security",
+    "JavaScript",
+    "React"
+  ],
+  "projects": [
+    {
+      "name": "Text-Encryption-Decryption-AES-PKCS7",
+      "link": "https://github.com/Alex-Unnippillil/Text-Encryption-Decryption-AES-PKCS7"
+    },
+    {
+      "name": "Cyber Security Dictionary",
+      "link": "https://github.com/Alex-Unnippillil/CyberSecuirtyDictionary"
+    }
+  ],
+  "experience": [
+    {
+      "date": "2012",
+      "description": "Began Nuclear Engineering at Ontario Tech.",
+      "tags": ["education"]
+    },
+    {
+      "date": "2016",
+      "description": "Graduated with B. Eng.",
+      "tags": ["education"]
+    },
+    {
+      "date": "2020",
+      "description": "Started Networking and I.T. Security program.",
+      "tags": ["education"]
+    },
+    {
+      "date": "2024",
+      "description": "Graduated with BIT in Networking and I.T. Security.",
+      "tags": ["education"]
+    },
+    {
+      "date": "2024",
+      "description": "Cybersecurity Internship at Example Corp.",
+      "tags": ["work"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- load resume.json and show skills chips, project links
- add html2pdf-powered resume download and tag-filterable experience timeline

## Testing
- `yarn test` *(fails: hashcat, mimikatz, dsniff, wordSearch, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b113fe33908328bf8df0d705431a27