### PR TITLE
feat: add mimikatz storyboard with log import

### DIFF
--- a/components/apps/mimikatz/eventLogs.json
+++ b/components/apps/mimikatz/eventLogs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "step": "Invoke Mimikatz",
+    "log": "Event ID 1: mimikatz.exe executed with privilege escalation",
+    "mitigation": "Restrict execution via application whitelisting."
+  },
+  {
+    "step": "Dump LSASS",
+    "log": "Event ID 2: LSASS memory accessed to extract credentials",
+    "mitigation": "Enable LSA protection and monitor memory access."
+  }
+]

--- a/components/apps/mimikatz/index.js
+++ b/components/apps/mimikatz/index.js
@@ -1,221 +1,88 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import CredentialArtifactLocator from './CredentialLocator';
-import modulesData from './modules.json';
+import React, { useState } from 'react';
+import eventLogsData from './eventLogs.json';
+import lsassDiagrams from './lsass.json';
 
-// Sample outputs for demonstration only. No real credentials are processed.
-const sampleOutputs = {
-  sekurlsa: `Authentication Id : 0 ; 999 (00000000:000003E7)
-User Name         : alice
-Domain            : CONTOSO
-Password          : P@ssw0rd!
-NTLM              : 8846f7eaee8fb117ad06bdd830b7586c`,
-  lsadump: `LSA Secret       : DefaultPassword
-Key              : _SC_MachineAccount
-Credential       : SuperSecretValue`,
-  misc: 'Sample output: miscellaneous helper command.',
-};
-
-const mitigations = [
-  {
-    item: 'Enable LSA Protection',
-    risk: 'Prevents credential dumping by blocking code injection into LSASS.',
-  },
-  {
-    item: 'Disable WDigest',
-    risk: 'Stops storage of clear-text passwords in memory.',
-  },
-  {
-    item: 'Use strong passwords and MFA',
-    risk: 'Reduces the impact of credential theft.',
-  },
-];
-
-const severityClass = {
-  high: 'text-red-400',
-  medium: 'text-yellow-400',
-  info: '',
-};
-
-const parseOutput = (text, redact) => {
-  return text.split(/\r?\n/).map((line) => {
-    let severity = 'info';
-    if (/password|ntlm|credential/i.test(line)) {
-      severity = 'high';
-    } else if (/lsa|secret|user\s+name|domain/i.test(line)) {
-      severity = 'medium';
-    }
-    const redactedLine = redact
-      ? line.replace(/(:\s*)(.+)/, '$1[REDACTED]')
-      : line;
-    return { line: redactedLine, severity };
-  });
-};
-
+// Storyboard UI showing attack steps and mitigations.
 const MimikatzApp = () => {
-  const [modules] = useState(modulesData);
-  const [output, setOutput] = useState('');
-  const [parsed, setParsed] = useState([]);
-  const [history, setHistory] = useState([]);
-  const [templates, setTemplates] = useState(() => {
-    if (typeof window === 'undefined') return [];
-    try {
-      return JSON.parse(localStorage.getItem('mimikatz-templates') || '[]');
-    } catch {
-      return [];
-    }
-  });
-  const [templateName, setTemplateName] = useState('');
-  const [templateScript, setTemplateScript] = useState('');
-  const [redact, setRedact] = useState(true);
+  const [tab, setTab] = useState('attack');
+  const [logs, setLogs] = useState(eventLogsData);
 
-  useEffect(() => {
-    setParsed(parseOutput(output, redact));
-  }, [output, redact]);
-
-  const addHistory = (command, text) => {
-    setHistory((h) => [
-      { timestamp: new Date().toISOString(), command, output: text },
-      ...h,
-    ]);
-  };
-
-  const runCommand = (cmd) => {
-    const text = sampleOutputs[cmd] || 'Unknown command';
-    setOutput(text);
-    addHistory(cmd, text);
-  };
-
-  const saveTemplate = () => {
-    if (!templateName || !templateScript) return;
-    const next = [...templates, { name: templateName, script: templateScript }];
-    setTemplates(next);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('mimikatz-templates', JSON.stringify(next));
-    }
-    setTemplateName('');
-    setTemplateScript('');
-  };
-
-  const runTemplate = (script) => {
-    const msg = 'Template execution disabled. Uploads are not permitted.';
-    setOutput(msg);
-    addHistory(script, msg);
-  };
-
-  const copyOutput = useCallback(() => {
-    if (typeof window !== 'undefined') {
-      const text = parsed.map((p) => p.line).join('\n');
+  const handleImport = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
       try {
-        navigator.clipboard?.writeText(text);
+        const data = JSON.parse(ev.target.result);
+        if (Array.isArray(data)) setLogs(data);
       } catch {
-        // ignore copy errors
+        // ignore malformed files
       }
-    }
-  }, [parsed]);
-
-  const mask = (text) =>
-    redact ? text.replace(/(:\s*)(.+)/g, '$1[REDACTED]') : text;
+    };
+    reader.readAsText(file);
+  };
 
   return (
-    <div className="h-full w-full flex text-white">
-      <div className="w-1/4 bg-ub-dark p-2 overflow-y-auto">
-        <h2 className="text-lg mb-2">Modules</h2>
-        <ul>
-          {modules.map((m) => (
-            <li key={m.name}>
-              <button
-                className="w-full text-left py-1 hover:bg-ub-cool-grey"
-                onClick={() => runCommand(m.name)}
-              >
-                {m.name}
-              </button>
-            </li>
-          ))}
-        </ul>
-        <p className="text-xs italic mt-2">
-          Sample modules only. No real credentials are processed.
-        </p>
-        <h2 className="text-lg mt-4">Templates</h2>
-        <ul>
-          {templates.map((t, idx) => (
-            <li key={idx}>
-              <button
-                className="w-full text-left py-1 hover:bg-ub-cool-grey"
-                onClick={() => runTemplate(t.script)}
-              >
-                {t.name}
-              </button>
-            </li>
-          ))}
-        </ul>
-        <div className="mt-4 space-y-2">
-          <input
-            className="w-full p-1 text-black"
-            placeholder="Template name"
-            value={templateName}
-            onChange={(e) => setTemplateName(e.target.value)}
-          />
-          <textarea
-            className="w-full p-1 text-black"
-            placeholder="Mimikatz script"
-            value={templateScript}
-            onChange={(e) => setTemplateScript(e.target.value)}
-          />
-          <button
-            className="w-full bg-blue-600 rounded py-1"
-            onClick={saveTemplate}
-          >
-            Save Template
-          </button>
-        </div>
-      </div>
-      <div className="flex-1 p-4 bg-ub-cool-grey overflow-auto">
-        <h1 className="text-lg mb-4">Mimikatz (Sample Simulator)</h1>
-        <p className="text-sm mb-4 italic">
-          All outputs are sample data. Uploads are disabled.
-        </p>
-        <label className="flex items-center space-x-2 mb-2">
-          <input
-            type="checkbox"
-            checked={redact}
-            onChange={() => setRedact((r) => !r)}
-          />
-          <span>Redact secrets</span>
-        </label>
+    <div className="h-full w-full flex flex-col text-white">
+      <div className="flex border-b border-gray-700">
         <button
-          type="button"
-          className="mb-4 px-2 py-1 bg-blue-700 rounded"
-          onClick={copyOutput}
+          className={`px-4 py-2 ${
+            tab === 'attack' ? 'bg-red-700' : 'bg-red-600'
+          }`}
+          onClick={() => setTab('attack')}
         >
-          Copy Output
+          Red Team
         </button>
-        <pre className="whitespace-pre-wrap mb-4">
-          {parsed.map((p, idx) => (
-            <div key={idx} className={severityClass[p.severity]}>
-              {p.line}
-            </div>
-          ))}
-        </pre>
-        <CredentialArtifactLocator />
-        <h2 className="text-lg mt-4 mb-2">Mitigations</h2>
-        <ul className="list-disc pl-4 mb-4">
-          {mitigations.map((m, idx) => (
-            <li key={idx}>
-              <span className="font-semibold">{m.item}:</span> {m.risk}
-            </li>
-          ))}
-        </ul>
-        <h2 className="text-lg mb-2">History</h2>
-        <ul className="space-y-1">
-          {history.map((h, idx) => (
-            <li key={idx}>
-              <span className="text-xs text-gray-300">{h.timestamp}</span> -{' '}
-              <span className="font-bold">{h.command}</span>
-              <pre className="whitespace-pre-wrap">{mask(h.output)}</pre>
-            </li>
-          ))}
-        </ul>
+        <button
+          className={`px-4 py-2 ${
+            tab === 'defense' ? 'bg-blue-700' : 'bg-blue-600'
+          }`}
+          onClick={() => setTab('defense')}
+        >
+          Blue Team
+        </button>
       </div>
+      {tab === 'attack' ? (
+        <div className="p-4 overflow-auto flex-1 bg-ub-cool-grey">
+          <h2 className="text-lg mb-2">Attack Storyboard</h2>
+          <input
+            type="file"
+            accept="application/json"
+            onChange={handleImport}
+            className="mb-4"
+          />
+          <ul className="space-y-2">
+            {logs.map((l, idx) => (
+              <li key={idx} className="bg-ub-dark p-2 rounded">
+                <div className="font-bold">Step {idx + 1}: {l.step}</div>
+                <div className="text-sm">{l.log}</div>
+                {l.mitigation && (
+                  <div className="text-xs text-blue-300 mt-1">
+                    Mitigation: {l.mitigation}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-4">
+            <h3 className="text-lg mb-2">LSASS Diagram</h3>
+            <pre className="bg-black p-2 whitespace-pre-wrap">
+              {lsassDiagrams[0]?.diagram}
+            </pre>
+          </div>
+        </div>
+      ) : (
+        <div className="p-4 overflow-auto flex-1 bg-ub-cool-grey">
+          <h2 className="text-lg mb-2">Mitigation Tips</h2>
+          <ul className="list-disc pl-4 space-y-1">
+            {logs.map((l, idx) => (
+              <li key={idx}>
+                <span className="font-semibold">{l.step}</span>: {l.mitigation}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };
@@ -225,4 +92,3 @@ export default MimikatzApp;
 export const displayMimikatz = (addFolder, openApp) => {
   return <MimikatzApp addFolder={addFolder} openApp={openApp} />;
 };
-

--- a/components/apps/mimikatz/lsass.json
+++ b/components/apps/mimikatz/lsass.json
@@ -1,0 +1,6 @@
+[
+  {
+    "title": "LSASS Memory",
+    "diagram": "LSASS\n├── logon sessions\n│   ├── user1\n│   └── user2\n└── credentials\n    ├── NTLM hash\n    └── Kerberos tickets"
+  }
+]


### PR DESCRIPTION
## Summary
- build red/blue storyboard tabs for Mimikatz
- load sample event logs and LSASS diagram from local JSON
- allow importing log files and list mitigations

## Testing
- `yarn test components/apps/mimikatz/index.js --passWithNoTests`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/mimikatz/index.js && echo 'lint success'`


------
https://chatgpt.com/codex/tasks/task_e_68b12d98ea548328954849bd6da58f1e