### PR TITLE
feat(quote-generator): add quote packs and shuffle persistence

### DIFF
--- a/components/apps/quotes_tech.json
+++ b/components/apps/quotes_tech.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 1,
+    "quote": "Technology is best when it brings people together.",
+    "author": "Matt Mullenweg"
+  },
+  {
+    "id": 2,
+    "quote": "It has become appallingly obvious that our technology has exceeded our humanity.",
+    "author": "Albert Einstein"
+  },
+  {
+    "id": 3,
+    "quote": "Any sufficiently advanced technology is indistinguishable from magic.",
+    "author": "Arthur C. Clarke"
+  }
+]


### PR DESCRIPTION
## Summary
- support multiple quote packs, including a technology pack
- add pack selection with shuffle order stored in localStorage
- allow navigating forward/backward through quotes without repeats

## Testing
- `npm test` *(fails: youtube, mimikatz, wordSearch, niktoApp)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d97347c8328894861c2ba25b6ab