### PR TITLE
feat: enhance figlet with custom fonts and styling

### DIFF
--- a/components/apps/figlet/worker.js
+++ b/components/apps/figlet/worker.js
@@ -48,6 +48,19 @@ function init() {
 init();
 
 self.onmessage = (e) => {
+  if (e.data?.type === 'load') {
+    const { name, data } = e.data;
+    try {
+      figlet.parseFont(name, data);
+      const preview = figlet.textSync('Figlet', { font: name });
+      const mono = isMonospace(name);
+      self.postMessage({ type: 'font', font: name, preview, mono });
+    } catch {
+      /* ignore bad font */
+    }
+    return;
+  }
+
   const { text = '', font, width = 80, layout = 'default' } = e.data;
   if (!font) return;
   const normalized = String(text)


### PR DESCRIPTION
## Summary
- allow importing `.flf` fonts and remember last selection in OPFS
- add gradient hue and kerning sliders for richer previews
- encode figlet settings in URL for easy sharing

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: 5 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d9633e08328af0f33f6596c3d81