### PR TITLE
Add offline EAPOL handshake stepper

### DIFF
--- a/components/apps/reaver/data/handshakes.json
+++ b/components/apps/reaver/data/handshakes.json
@@ -1,0 +1,42 @@
+{
+  "handshakes": [
+    {
+      "id": "sample",
+      "label": "WPA2 4-Way Handshake",
+      "messages": [
+        {
+          "step": "M1",
+          "from": "Access Point",
+          "to": "Client",
+          "description": "Authenticator sends ANonce and security parameters to start the handshake."
+        },
+        {
+          "step": "M2",
+          "from": "Client",
+          "to": "Access Point",
+          "description": "Supplicant responds with SNonce and a MIC computed with the PTK."
+        },
+        {
+          "step": "M3",
+          "from": "Access Point",
+          "to": "Client",
+          "description": "Authenticator sends the GTK and a MIC, instructing the client to install the PTK."
+        },
+        {
+          "step": "M4",
+          "from": "Client",
+          "to": "Access Point",
+          "description": "Supplicant acknowledges installation of the PTK completing the handshake."
+        }
+      ]
+    }
+  ],
+  "risks": [
+    "Captured handshakes can be brute‑forced offline to recover weak passphrases.",
+    "Attackers can lure clients to rogue access points to obtain handshakes."
+  ],
+  "defenses": [
+    "Use strong, unique passphrases and prefer WPA3 when possible.",
+    "Monitor for rogue APs and disable WPS to reduce attack surface."
+  ]
+}

--- a/components/apps/reaver/index.js
+++ b/components/apps/reaver/index.js
@@ -1,8 +1,87 @@
-import dynamic from 'next/dynamic';
+import React, { useState } from 'react';
+import data from './data/handshakes.json';
 
-const Reaver = dynamic(() => import('../../apps/reaver'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const ReaverStepper = () => {
+  const { handshakes, risks, defenses } = data;
+  const messages = handshakes[0]?.messages || [];
+  const [current, setCurrent] = useState(0);
+  const isSummary = current >= messages.length;
 
-export default Reaver;
+  const next = () => setCurrent((c) => Math.min(messages.length, c + 1));
+  const prev = () => setCurrent((c) => Math.max(0, c - 1));
+  const restart = () => setCurrent(0);
+
+  return (
+    <div
+      id="reaver-stepper"
+      className="p-4 bg-ub-cool-grey text-white h-full overflow-y-auto"
+    >
+      <h1 className="text-2xl mb-4">EAPOL Handshake Explorer</h1>
+
+      {isSummary ? (
+        <div id="summary">
+          <h2 className="text-xl mb-2">Risks &amp; Defenses</h2>
+          <div className="mb-4">
+            <h3 className="font-semibold">Risks</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              {risks.map((r) => (
+                <li key={r}>{r}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold">Defenses</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              {defenses.map((d) => (
+                <li key={d}>{d}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <h2 className="text-xl mb-2">
+            {messages[current].step}: {messages[current].from} ➜ {messages[current].to}
+          </h2>
+          <p className="text-sm">{messages[current].description}</p>
+        </div>
+      )}
+
+      <div className="mt-4 flex justify-between print:hidden">
+        <button
+          onClick={prev}
+          disabled={current === 0}
+          className="px-4 py-2 bg-gray-700 rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        {isSummary ? (
+          <button
+            onClick={restart}
+            className="px-4 py-2 bg-ub-green text-black rounded"
+          >
+            Restart
+          </button>
+        ) : (
+          <button
+            onClick={next}
+            className="px-4 py-2 bg-ub-green text-black rounded"
+          >
+            Next
+          </button>
+        )}
+      </div>
+
+      <style jsx>{`
+        @media print {
+          #reaver-stepper {
+            background: white;
+            color: black;
+          }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default ReaverStepper;


### PR DESCRIPTION
## Summary
- load sample EAPOL handshakes from local JSON data
- add stepper UI with final Risks & Defenses print-friendly page

## Testing
- `yarn test` *(fails: youtube.test.tsx, mimikatz.test.ts, wordSearch.test.ts, niktoApp.test.tsx)*
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d9376408328a3c1bc7166040203