### PR TITLE
feat(autopsy): add timeline filters

### DIFF
--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -64,6 +64,12 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
             <div className="text-xs">
               {new Date(a.timestamp).toLocaleString()}
             </div>
+            {a.user && (
+              <div
+                className="text-xs"
+                dangerouslySetInnerHTML={{ __html: `User: ${highlight(a.user)}` }}
+              />
+            )}
             <div
               className="text-xs"
               dangerouslySetInnerHTML={{ __html: highlight(a.description) }}

--- a/components/apps/autopsy/data/sample-artifacts.json
+++ b/components/apps/autopsy/data/sample-artifacts.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "resume.docx",
+    "type": "Document",
+    "description": "Resume found on user's desktop",
+    "size": 12345,
+    "plugin": "metadata",
+    "timestamp": "2023-08-01T10:00:00Z",
+    "user": "alice"
+  },
+  {
+    "name": "photo.jpg",
+    "type": "Image",
+    "description": "Photo from mobile device",
+    "size": 23456,
+    "plugin": "hash",
+    "timestamp": "2023-08-01T12:30:00Z",
+    "user": "bob"
+  },
+  {
+    "name": "system.log",
+    "type": "Log",
+    "description": "System log entry",
+    "size": 34567,
+    "plugin": "metadata",
+    "timestamp": "2023-08-01T14:45:00Z",
+    "user": "alice"
+  },
+  {
+    "name": "run.exe",
+    "type": "File",
+    "description": "Executable recovered from temp folder",
+    "size": 45678,
+    "plugin": "hash",
+    "timestamp": "2023-08-01T16:15:00Z",
+    "user": "bob"
+  },
+  {
+    "name": "HKCU\\\\Software\\\\Example",
+    "type": "Registry",
+    "description": "Registry key with suspicious value",
+    "size": 0,
+    "plugin": "regParser",
+    "timestamp": "2023-08-01T18:20:00Z",
+    "user": "system"
+  }
+]


### PR DESCRIPTION
## Summary
- add sample autopsy artifacts JSON
- filter timeline by user and timestamp and show user details

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d92ed248328a52b0273290612d9