### PR TITLE
feat: exportable batch QR scanning

### DIFF
--- a/__tests__/qrStorage.test.ts
+++ b/__tests__/qrStorage.test.ts
@@ -1,0 +1,20 @@
+import { clearScans, loadScans, saveScans } from '../utils/qrStorage';
+
+describe('qrStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves and loads scans', async () => {
+    await saveScans(['a', 'b']);
+    const loaded = await loadScans();
+    expect(loaded).toEqual(['a', 'b']);
+  });
+
+  it('clears scans', async () => {
+    await saveScans(['c']);
+    await clearScans();
+    const loaded = await loadScans();
+    expect(loaded).toEqual([]);
+  });
+});

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -1,0 +1,53 @@
+const STORAGE_KEY = 'qrScans';
+const FILE_NAME = 'qr-scans.json';
+
+const hasOpfs =
+  typeof window !== 'undefined' &&
+  'storage' in navigator &&
+  Boolean((navigator.storage as any).getDirectory);
+
+export const loadScans = async (): Promise<string[]> => {
+  if (typeof window === 'undefined') return [];
+  if (hasOpfs) {
+    try {
+      const root = await (navigator.storage as any).getDirectory();
+      const handle = await root.getFileHandle(FILE_NAME);
+      const file = await handle.getFile();
+      return JSON.parse(await file.text());
+    } catch {
+      return [];
+    }
+  }
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const saveScans = async (scans: string[]): Promise<void> => {
+  if (typeof window === 'undefined') return;
+  if (hasOpfs) {
+    const root = await (navigator.storage as any).getDirectory();
+    const handle = await root.getFileHandle(FILE_NAME, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(JSON.stringify(scans));
+    await writable.close();
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(scans));
+};
+
+export const clearScans = async (): Promise<void> => {
+  if (typeof window === 'undefined') return;
+  if (hasOpfs) {
+    try {
+      const root = await (navigator.storage as any).getDirectory();
+      await root.removeEntry(FILE_NAME);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+  localStorage.removeItem(STORAGE_KEY);
+};


### PR DESCRIPTION
## Summary
- accumulate QR scan results and persist them for later export
- add Blob-based CSV export and batch clearing controls
- cover storage helpers with tests

## Testing
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test` *(fails: youtube, mimikatz, wordSearch, niktoApp, kismet suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d9212448328b57b7f63dd1fe935