### PR TITLE
feat(qr): use BarcodeDetector with ZXing fallback

### DIFF
--- a/apps/qr/index.tsx
+++ b/apps/qr/index.tsx
@@ -1,4 +1,4 @@
 'use client';
-import QRTool from '../../components/apps/qr_tool';
+import QRScanner from '../../components/apps/qr';
 
-export default QRTool;
+export default QRScanner;

--- a/components/apps/qr.tsx
+++ b/components/apps/qr.tsx
@@ -1,9 +1,0 @@
-import dynamic from 'next/dynamic';
-
-const QRApp = dynamic(() => import('../../apps/qr'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
-
-export default QRApp;
-

--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const QRScanner: React.FC = () => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const controlsRef = useRef<{ stop: () => void } | null>(null);
+  const [result, setResult] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    const start = async () => {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError('Camera API not supported');
+        return;
+      }
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+        if (!active) return;
+        const videoEl = videoRef.current;
+        if (videoEl) {
+          videoEl.srcObject = stream;
+          await videoEl.play();
+        }
+        if ('BarcodeDetector' in window) {
+          const detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] });
+          const scan = async () => {
+            if (!active) return;
+            try {
+              const codes = await detector.detect(videoRef.current!);
+              if (codes[0]) setResult(codes[0].rawValue);
+            } catch {
+              /* ignore */
+            }
+            requestAnimationFrame(scan);
+          };
+          scan();
+        } else {
+          const [{ BrowserQRCodeReader }, { NotFoundException }] = await Promise.all([
+            import('@zxing/browser'),
+            import('@zxing/library'),
+          ]);
+          const codeReader = new BrowserQRCodeReader();
+          controlsRef.current = await codeReader.decodeFromVideoDevice(
+            null,
+            videoRef.current!,
+            (res, err) => {
+              if (res) setResult(res.getText());
+              if (err && !(err instanceof NotFoundException)) {
+                setError('Failed to read QR code');
+              }
+            },
+          );
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'NotAllowedError') {
+          setError('Camera access was denied');
+        } else {
+          setError('Could not start camera');
+        }
+      }
+    };
+    start();
+    return () => {
+      active = false;
+      controlsRef.current?.stop?.();
+      const stream = videoRef.current?.srcObject as MediaStream | null;
+      stream?.getTracks().forEach((t) => t.stop());
+      if (videoRef.current) videoRef.current.srcObject = null;
+    };
+  }, []);
+
+  const copyResult = () => {
+    if (result) navigator.clipboard?.writeText(result).catch(() => {});
+  };
+
+  const shareResult = () => {
+    if (result && (navigator as any).share) {
+      (navigator as any).share({ text: result }).catch(() => {});
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full flex flex-col items-center">
+      <video ref={videoRef} className="w-full max-w-sm rounded bg-black" />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      {result && (
+        <div className="space-y-2 w-full max-w-sm">
+          <p className="break-all text-sm">{result}</p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={copyResult}
+              className="px-2 py-1 bg-blue-600 rounded"
+            >
+              Copy
+            </button>
+            {'share' in navigator && (
+              <button
+                type="button"
+                onClick={shareResult}
+                className="px-2 py-1 bg-blue-600 rounded"
+              >
+                Share
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QRScanner;
+

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
     "@xterm/xterm": "^5.5.0",
+    "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "aframe": "^1.5.0",
     "autoprefixer": "^10.4.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,6 +3421,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zxing/browser@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@zxing/browser@npm:0.1.5"
+  dependencies:
+    "@zxing/text-encoding": "npm:^0.9.0"
+  peerDependencies:
+    "@zxing/library": ^0.21.0
+  dependenciesMeta:
+    "@zxing/text-encoding":
+      optional: true
+  checksum: 10c0/458042ed56402d20a673b7f58cdd346cf15b0b2b84860c2529f7b86e774bd74a02b007bd2e6e5b6231b624a3f28d8e296ce943f7c6c78999d19300cae87d35e3
+  languageName: node
+  linkType: hard
+
 "@zxing/library@npm:^0.21.3":
   version: 0.21.3
   resolution: "@zxing/library@npm:0.21.3"
@@ -3434,7 +3448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zxing/text-encoding@npm:~0.9.0":
+"@zxing/text-encoding@npm:^0.9.0, @zxing/text-encoding@npm:~0.9.0":
   version: 0.9.0
   resolution: "@zxing/text-encoding@npm:0.9.0"
   checksum: 10c0/d15bff181d46c2ab709e7242801a8d40408aa8c19b44462e5f60e766bf59105b44957914ab6baab60d10d466a5e965f21fe890c67dfdb7d5c7f940df457b4d0d
@@ -11269,6 +11283,7 @@ __metadata:
     "@xterm/addon-fit": "npm:^0.10.0"
     "@xterm/addon-search": "npm:^0.15.0"
     "@xterm/xterm": "npm:^5.5.0"
+    "@zxing/browser": "npm:^0.1.5"
     "@zxing/library": "npm:^0.21.3"
     aframe: "npm:^1.5.0"
     autoprefixer: "npm:^10.4.13"


### PR DESCRIPTION
## Summary
- add QR scanner component that uses `BarcodeDetector` when available
- fallback to ZXing WASM decoder and expose copy/share actions
- wire QR app to new scanner and add `@zxing/browser` dependency

## Testing
- `yarn test` *(fails: youtube, mimikatz, wordSearch, niktoApp)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d916fb083289a0023785774eb85