### PR TITLE
Add drag-and-drop Nikto report parsing with filtering and CSV export

### DIFF
--- a/__tests__/niktoApp.test.tsx
+++ b/__tests__/niktoApp.test.tsx
@@ -1,19 +1,17 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import NiktoApp from "../components/apps/nikto";
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NiktoApp from '../components/apps/nikto';
 
-describe("NiktoApp", () => {
-  it("updates command with tuning flags and shows risk info", async () => {
-    const user = userEvent.setup();
+describe('NiktoApp', () => {
+  it('parses dropped text report and displays data', async () => {
     render(<NiktoApp />);
-    expect(
-      screen.getByText(/Nikto scans for known web vulnerabilities/i),
-    ).toBeInTheDocument();
-    const tuning = screen.getByLabelText(/Tuning Flags/i);
-    await user.type(tuning, "5");
-    expect(
-      screen.getByText(/nikto -h example.com -Tuning 5/i),
-    ).toBeInTheDocument();
+    const zone = screen.getByTestId('drop-zone');
+    const file = {
+      name: 'report.txt',
+      text: () => Promise.resolve('Host: example.com\n/admin High'),
+    } as any;
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+    expect(await screen.findByText('example.com')).toBeInTheDocument();
+    expect(screen.getByText('/admin')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- parse dropped Nikto text or XML reports
- show hosts, paths and severities with host/path filters
- export filtered results to CSV and warn on invalid files

## Testing
- `yarn test __tests__/niktoApp.test.tsx __tests__/niktoPage.test.tsx __tests__/niktoReport.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b12d907f088328b258b34f3e17b253