### PR TITLE
Add byte and time conversion utilities with tests

### DIFF
--- a/__tests__/converter/conversionUtils.test.ts
+++ b/__tests__/converter/conversionUtils.test.ts
@@ -1,0 +1,29 @@
+import { formatBytes, formatDuration } from '../../components/apps/converter/format';
+
+describe('formatBytes', () => {
+  it('handles bytes to KB', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+  });
+
+  it('handles large numbers', () => {
+    expect(formatBytes(123456789)).toBe('117.74 MB');
+  });
+
+  it('handles negatives', () => {
+    expect(formatBytes(-1024)).toBe('-1 KB');
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats seconds', () => {
+    expect(formatDuration(65)).toBe('1m 5s');
+  });
+
+  it('formats hours', () => {
+    expect(formatDuration(3661)).toBe('1h 1m 1s');
+  });
+
+  it('handles negatives', () => {
+    expect(formatDuration(-3661)).toBe('-1h 1m 1s');
+  });
+});

--- a/components/apps/converter/Base64Converter.js
+++ b/components/apps/converter/Base64Converter.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { formatBytes, formatDuration } from './format';
 
 const Base64Converter = () => {
   const [text, setText] = useState('');
@@ -55,6 +56,13 @@ const Base64Converter = () => {
           rows={3}
         />
       </label>
+      <details>
+        <summary>Examples</summary>
+        <ul className="list-disc ml-4">
+          <li>{formatBytes(1536)} = 1536 bytes</li>
+          <li>{formatDuration(3661)} = 3661 seconds</li>
+        </ul>
+      </details>
     </div>
   );
 };

--- a/components/apps/converter/format.js
+++ b/components/apps/converter/format.js
@@ -1,0 +1,32 @@
+export const formatBytes = (bytes, decimals = 2) => {
+  if (!Number.isFinite(bytes)) return '0 B';
+  const sign = bytes < 0 ? '-' : '';
+  const abs = Math.abs(bytes);
+  if (abs === 0) return '0 B';
+  const k = 1024;
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(abs) / Math.log(k));
+  const value = abs / Math.pow(k, i);
+  const num = parseFloat(value.toFixed(decimals));
+  return `${sign}${num} ${units[i]}`;
+};
+
+export const formatDuration = (seconds) => {
+  if (!Number.isFinite(seconds)) return '0s';
+  const sign = seconds < 0 ? '-' : '';
+  let remaining = Math.abs(seconds);
+  const units = [
+    { label: 'h', value: 3600 },
+    { label: 'm', value: 60 },
+    { label: 's', value: 1 },
+  ];
+  const parts = [];
+  for (const { label, value } of units) {
+    if (remaining >= value || (label === 's' && parts.length === 0)) {
+      const amount = Math.floor(remaining / value);
+      remaining %= value;
+      parts.push(`${amount}${label}`);
+    }
+  }
+  return sign + parts.join(' ');
+};


### PR DESCRIPTION
## Summary
- add `formatBytes` and `formatDuration` utilities for human-readable conversions
- expose example usage in Base64 converter help
- test conversion utilities

## Testing
- `yarn test __tests__/converter.test.tsx`
- `yarn test __tests__/converter/conversionUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b12d8f211c83289b89a55d1ef2ce05