### PR TITLE
feat: add hash worker and drag-and-drop hash converter

### DIFF
--- a/components/apps/converter/HashConverter.js
+++ b/components/apps/converter/HashConverter.js
@@ -1,62 +1,106 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
-const algorithms = ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'];
+const algorithms = [
+  'SHA-1',
+  'SHA-256',
+  'SHA-384',
+  'SHA-512',
+  'SHA3-256',
+  'SHA3-512',
+  'BLAKE3',
+  'CRC32',
+];
 
 const HashConverter = () => {
-  const [text, setText] = useState('');
-  const [algorithm, setAlgorithm] = useState('SHA-256');
-  const [hash, setHash] = useState('');
+  const workerRef = useRef(null);
+  const [progress, setProgress] = useState(0);
+  const [results, setResults] = useState({});
+  const [fileName, setFileName] = useState('');
 
   useEffect(() => {
-    const generate = async () => {
-      if (!text || typeof window === 'undefined' || !window.crypto?.subtle) {
-        setHash('');
-        return;
-      }
-      const enc = new TextEncoder();
-      const data = enc.encode(text);
-      try {
-        const digest = await window.crypto.subtle.digest(algorithm, data);
-        const result = Array.from(new Uint8Array(digest))
-          .map((b) => b.toString(16).padStart(2, '0'))
-          .join('');
-        setHash(result);
-      } catch {
-        setHash('');
+    workerRef.current = new Worker(
+      new URL('../../../workers/hash-worker.ts', import.meta.url),
+    );
+
+    workerRef.current.onmessage = (e) => {
+      const { type, loaded, total, results: res } = e.data;
+      if (type === 'progress') {
+        setProgress(total ? loaded / total : 0);
+      } else if (type === 'result') {
+        setResults(res);
+        setProgress(1);
       }
     };
-    generate();
-  }, [text, algorithm]);
+
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  const handleFiles = (files) => {
+    const file = files?.[0];
+    if (!file || !workerRef.current) return;
+    setFileName(file.name);
+    setResults({});
+    setProgress(0);
+    workerRef.current.postMessage({ file, algorithms });
+  };
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onChange = (e) => {
+    handleFiles(e.target.files);
+  };
+
+  const preventDefault = (e) => e.preventDefault();
+
+  const copy = (val) => navigator.clipboard?.writeText(val);
 
   return (
     <div className="bg-gray-700 text-white p-4 rounded flex flex-col gap-2">
       <h2 className="text-xl mb-2">Hash Converter</h2>
-      <textarea
-        className="text-black p-1 rounded"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        rows={3}
-      />
-      <label className="flex flex-col">
-        Algorithm
-        <select
-          className="text-black p-1 rounded"
-          value={algorithm}
-          onChange={(e) => setAlgorithm(e.target.value)}
-        >
-          {algorithms.map((alg) => (
-            <option key={alg} value={alg}>
-              {alg}
-            </option>
-          ))}
-        </select>
-      </label>
-      <input
-        className="text-black p-1 rounded"
-        value={hash}
-        readOnly
-        aria-label="hash result"
-      />
+      <div
+        onDragOver={preventDefault}
+        onDrop={onDrop}
+        className="border-2 border-dashed border-gray-500 p-4 text-center rounded cursor-pointer"
+      >
+        <input
+          id="hash-file-input"
+          type="file"
+          className="hidden"
+          onChange={onChange}
+        />
+        <label htmlFor="hash-file-input" className="cursor-pointer block">
+          {fileName ? `File: ${fileName}` : 'Drag & drop a file or click to select'}
+        </label>
+      </div>
+      {progress > 0 && progress < 1 && (
+        <progress className="w-full" value={progress} max="1" />
+      )}
+      {Object.keys(results).length > 0 && (
+        <div className="flex flex-col gap-2">
+          {algorithms.map(
+            (alg) =>
+              results[alg] && (
+                <div key={alg} className="flex items-center gap-2">
+                  <span className="w-24 shrink-0">{alg}</span>
+                  <input
+                    className="text-black flex-1 p-1 rounded"
+                    value={results[alg]}
+                    readOnly
+                  />
+                  <button
+                    className="bg-gray-600 px-2 py-1 rounded"
+                    onClick={() => copy(results[alg])}
+                  >
+                    Copy
+                  </button>
+                </div>
+              ),
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cytoscape-cose-bilkent": "^4.1.0",
     "dompurify": "^3.2.6",
     "figlet": "^1.8.2",
+    "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
     "idb": "7.1.1",

--- a/workers/hash-worker.ts
+++ b/workers/hash-worker.ts
@@ -1,0 +1,176 @@
+import {
+  createSHA1,
+  createSHA256,
+  createSHA384,
+  createSHA512,
+  createSHA3,
+  createBLAKE3,
+  createCRC32,
+} from 'hash-wasm';
+
+export type Algorithm =
+  | 'SHA-1'
+  | 'SHA-256'
+  | 'SHA-384'
+  | 'SHA-512'
+  | 'SHA3-256'
+  | 'SHA3-512'
+  | 'BLAKE3'
+  | 'CRC32'
+  | 'BASE64'
+  | 'BASE64URL'
+  | 'URL';
+
+export interface HashWorkerRequest {
+  file?: File;
+  text?: string;
+  algorithms: Algorithm[];
+}
+
+export interface ProgressMessage {
+  type: 'progress';
+  loaded: number;
+  total: number;
+}
+
+export interface ResultMessage {
+  type: 'result';
+  results: Record<string, string>;
+}
+
+self.onmessage = async ({ data }: MessageEvent<HashWorkerRequest>) => {
+  const { file, text, algorithms } = data;
+  const results: Record<string, string> = {};
+
+  if (file) {
+    const hashers: Record<string, any> = {};
+
+    for (const alg of algorithms) {
+      switch (alg) {
+        case 'SHA-1':
+          hashers[alg] = await createSHA1();
+          break;
+        case 'SHA-256':
+          hashers[alg] = await createSHA256();
+          break;
+        case 'SHA-384':
+          hashers[alg] = await createSHA384();
+          break;
+        case 'SHA-512':
+          hashers[alg] = await createSHA512();
+          break;
+        case 'SHA3-256':
+          hashers[alg] = await createSHA3(256);
+          break;
+        case 'SHA3-512':
+          hashers[alg] = await createSHA3(512);
+          break;
+        case 'BLAKE3':
+          hashers[alg] = await createBLAKE3();
+          break;
+        case 'CRC32':
+          hashers[alg] = await createCRC32();
+          break;
+        default:
+          break;
+      }
+    }
+
+    const reader = file.stream().getReader();
+    let loaded = 0;
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      loaded += value.length;
+      for (const hasher of Object.values(hashers)) {
+        hasher.update(value);
+      }
+      (self as any).postMessage({
+        type: 'progress',
+        loaded,
+        total: file.size,
+      } as ProgressMessage);
+    }
+
+    for (const [alg, hasher] of Object.entries(hashers)) {
+      if (alg === 'CRC32') {
+        const num = hasher.digest();
+        results[alg] = num.toString(16).padStart(8, '0');
+      } else {
+        results[alg] = hasher.digest('hex');
+      }
+    }
+  } else if (typeof text === 'string') {
+    const data = new TextEncoder().encode(text);
+
+    // Hashing for text
+    const hashAlgs = algorithms.filter(
+      (a) => !['BASE64', 'BASE64URL', 'URL'].includes(a),
+    );
+    const hashers: Record<string, any> = {};
+    for (const alg of hashAlgs) {
+      switch (alg) {
+        case 'SHA-1':
+          hashers[alg] = await createSHA1();
+          break;
+        case 'SHA-256':
+          hashers[alg] = await createSHA256();
+          break;
+        case 'SHA-384':
+          hashers[alg] = await createSHA384();
+          break;
+        case 'SHA-512':
+          hashers[alg] = await createSHA512();
+          break;
+        case 'SHA3-256':
+          hashers[alg] = await createSHA3(256);
+          break;
+        case 'SHA3-512':
+          hashers[alg] = await createSHA3(512);
+          break;
+        case 'BLAKE3':
+          hashers[alg] = await createBLAKE3();
+          break;
+        case 'CRC32':
+          hashers[alg] = await createCRC32();
+          break;
+        default:
+          break;
+      }
+    }
+
+    for (const hasher of Object.values(hashers)) {
+      hasher.update(data);
+    }
+
+    for (const [alg, hasher] of Object.entries(hashers)) {
+      if (alg === 'CRC32') {
+        const num = hasher.digest();
+        results[alg] = num.toString(16).padStart(8, '0');
+      } else {
+        results[alg] = hasher.digest('hex');
+      }
+    }
+
+    if (algorithms.includes('BASE64')) {
+      results.BASE64 = btoa(text);
+    }
+    if (algorithms.includes('BASE64URL')) {
+      results.BASE64URL = btoa(text).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+    if (algorithms.includes('URL')) {
+      results.URL = encodeURIComponent(text);
+    }
+
+    (self as any).postMessage({
+      type: 'progress',
+      loaded: data.length,
+      total: data.length,
+    } as ProgressMessage);
+  }
+
+  (self as any).postMessage({ type: 'result', results } as ResultMessage);
+};
+
+export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6511,6 +6511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash-wasm@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "hash-wasm@npm:4.12.0"
+  checksum: 10c0/6cb95055319810b6f673de755289960683a9831807690795f0e8918b2fd7e6ae5b82a9dc47cbace171cf2814b412ef68c315a0ead0b4d96bd3e56a05e4bde136
+  languageName: node
+  linkType: hard
+
 "hasown@npm:^2.0.0, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
@@ -11284,6 +11291,7 @@ __metadata:
     eslint-plugin-no-top-level-window: "file:eslint-plugin-no-top-level-window"
     fake-indexeddb: "npm:^6.1.0"
     figlet: "npm:^1.8.2"
+    hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
     idb: "npm:7.1.1"


### PR DESCRIPTION
## Summary
- add web worker using `hash-wasm` to stream hashes and CRC with progress updates
- build hash converter UI with drag-and-drop, progress, and copy buttons
- include `hash-wasm` dependency

## Testing
- `npx eslint -c .eslintrc.cjs components/apps/converter/HashConverter.js workers/hash-worker.ts` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `yarn test workers/hash-worker.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b12d8eafc883289da7f52ffc97050a