### PR TITLE
Add share target to PWA

### DIFF
--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -31,9 +31,29 @@ const InputHub = () => {
   const [emailjsReady, setEmailjsReady] = useState(false);
 
   useEffect(() => {
-    const { preset } = router.query;
+    const { preset, title, text, url, files } = router.query;
     if (preset === 'contact') {
       setSubject('General Inquiry');
+    }
+    const parts: string[] = [];
+    if (title) parts.push(String(title));
+    if (text) parts.push(String(text));
+    if (url) parts.push(String(url));
+    if (files) {
+      try {
+        const list = JSON.parse(
+          decodeURIComponent(String(files))
+        ) as { name: string; type: string }[];
+        parts.push(
+          ...list.map((f) => `File: ${f.name} (${f.type})`)
+        );
+      } catch {
+        // ignore parse errors
+      }
+    }
+    if (parts.length) {
+      const incoming = parts.join('\n');
+      setMessage((m) => (m ? `${m}\n${incoming}` : incoming));
     }
   }, [router.query]);
 

--- a/pages/share-target.tsx
+++ b/pages/share-target.tsx
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function ShareTarget() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const params = new URLSearchParams();
+    const { title, text, url } = router.query;
+    if (title) params.set('title', String(title));
+    if (text) params.set('text', String(text));
+    if (url) params.set('url', String(url));
+
+    if ('launchQueue' in window) {
+      (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+        if (launchParams.files && launchParams.files.length) {
+          const fileInfos = await Promise.all(
+            launchParams.files.map(async (f: any) => {
+              const file = await f.getFile();
+              return { name: file.name, type: file.type };
+            })
+          );
+          params.set('files', encodeURIComponent(JSON.stringify(fileInfos)));
+        }
+        router.replace(`/input-hub?${params.toString()}`);
+      });
+    } else {
+      router.replace(`/input-hub?${params.toString()}`);
+    }
+  }, [router]);
+
+  return <p>Loading...</p>;
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -19,13 +19,19 @@
     }
   ],
   "share_target": {
-    "action": "/api/share",
+    "action": "/share-target",
     "method": "POST",
-    "enctype": "application/x-www-form-urlencoded",
+    "enctype": "multipart/form-data",
     "params": {
       "title": "title",
       "text": "text",
-      "url": "url"
+      "url": "url",
+      "files": [
+        {
+          "name": "files",
+          "accept": ["*/*"]
+        }
+      ]
     }
   },
   "shortcuts": [


### PR DESCRIPTION
## Summary
- add share target in manifest to receive shared text and files
- handle share-target route and forward data to compose UI
- prefill compose form with incoming shared content

## Testing
- `yarn lint` (fails: ESLint couldn't find an eslint.config.js)
- `yarn test` (fails: 5 failed, 2 skipped, 88 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b12d8dd5b083289fa92c81d487073a