### PR TITLE
feat: add offline metasploit index and filtering

### DIFF
--- a/components/apps/metasploit/modules.json
+++ b/components/apps/metasploit/modules.json
@@ -1,57 +1,10690 @@
 [
   {
-    "name": "exploit/windows/smb/ms17_010_eternalblue",
-    "description": "MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption",
-    "severity": "critical",
-    "type": "exploit",
-    "platform": "windows",
-    "cve": ["CVE-2017-0144"],
-    "tags": ["smb", "rce"],
-    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] 192.168.1.100 - Connecting to target...\n[+] 192.168.1.100 - Connection established\n[*] 192.168.1.100 - Sending exploit...\n[+] 192.168.1.100 - Exploit completed, but no session was created.",
-    "doc": "Mock documentation for EternalBlue exploit."
-  },
-  {
-    "name": "exploit/multi/http/struts2_content_type_ognl",
-    "description": "Apache Struts 2 Content-Type OGNL RCE",
-    "severity": "high",
-    "type": "exploit",
+    "name": "auxiliary/admin/2wire/xslt_password_reset",
+    "description": "This module will reset the admin password on a 2Wire wireless router.  This is\n          done by using the /xslt page where authentication is not required, thus allowing\n          configuration changes (such as resetting the password) as administrators.",
+    "severity": "low",
+    "type": "auxiliary",
     "platform": "multi",
-    "cve": ["CVE-2017-5638"],
-    "tags": ["http", "rce"],
-    "transcript": "[*] Started reverse TCP handler on 0.0.0.0:4444\n[*] http://example.com - Sending exploit payload...\n[+] http://example.com - Exploit completed",
-    "doc": "Mock docs for Struts2 OGNL RCE."
+    "cve": [
+      "CVE-2007-4387"
+    ],
+    "tags": [
+      "admin",
+      "2wire",
+      "xslt-password-reset"
+    ],
+    "transcript": "",
+    "doc": "2Wire Cross-Site Request Forgery Password Reset Vulnerability",
+    "disclosure_date": "2007-08-15",
+    "teaches": "Teaches about admin"
   },
   {
-    "name": "exploit/unix/ftp/vsftpd_234_backdoor",
-    "description": "VSFTPD v2.3.4 Backdoor Command Execution",
-    "severity": "medium",
-    "type": "exploit",
-    "platform": "unix",
-    "cve": ["CVE-2011-2523"],
-    "tags": ["ftp", "backdoor"],
-    "transcript": "[*] 10.0.0.2:21 - Connecting to server...\n[+] 10.0.0.2:21 - Backdoor service discovered\n[*] Command shell session 1 opened",
-    "doc": "Mock docs for VSFTPD backdoor."
+    "name": "auxiliary/admin/android/google_play_store_uxss_xframe_rce",
+    "description": "This module combines two vulnerabilities to achieve remote code\n          execution on affected Android devices. First, the module exploits\n          CVE-2014-6041, a Universal Cross-Site Scripting (UXSS) vulnerability present in\n          versions of Android's open source stock browser (the AOSP Browser) prior to\n          4.4. Second, the Google Play store's web interface fails to enforce a\n          X-Frame-Options: DENY header (XFO) on some error pages, and therefore, can be\n          targeted for script injection. As a result, this leads to remote code execution\n          through Google Play's remote installation feature, as any application available\n          on the Google Play store can be installed and launched on the user's device.\n\n          This module requires that the user is logged into Google with a vulnerable browser.\n\n          To list the activities in an APK, you can use `aapt dump badging /path/to/app.apk`.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-6041"
+    ],
+    "tags": [
+      "admin",
+      "android",
+      "google-play-store-uxss-xframe-rce"
+    ],
+    "transcript": "",
+    "doc": "Android Browser RCE Through Google Play Store XFO",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
   },
   {
-    "name": "auxiliary/scanner/portscan/tcp",
-    "description": "TCP Port Scanner",
+    "name": "auxiliary/admin/appletv/appletv_display_image",
+    "description": "This module will show an image on an AppleTV device for a period of time.\n          Some AppleTV devices are actually password-protected, in that case please\n          set the PASSWORD datastore option. For password brute forcing, please see\n          the module auxiliary/scanner/http/appletv_login.",
     "severity": "low",
     "type": "auxiliary",
     "platform": "multi",
     "cve": [],
-    "tags": ["scanner", "network"],
-    "transcript": "[*] Scanning 192.168.1.0/24 ports 1-1000\n[*] 192.168.1.1:80 - open\n[*] 192.168.1.10:22 - open\n[*] Scanning completed",
-    "doc": "Documentation for TCP port scanner."
+    "tags": [
+      "admin",
+      "appletv",
+      "appletv-display-image"
+    ],
+    "transcript": "",
+    "doc": "Apple TV Image Remote Control",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
   },
   {
-    "name": "post/multi/gather/ssh_creds",
-    "description": "SSH Credentials Gather",
-    "severity": "medium",
-    "type": "post",
+    "name": "auxiliary/admin/appletv/appletv_display_video",
+    "description": "This module plays a video on an AppleTV device. Note that\n          AppleTV can be somewhat picky about the server that hosts the video.\n          Tested servers include default IIS, default Apache, and Ruby's WEBrick.\n          For WEBrick, the default MIME list may need to be updated, depending on\n          what media file is to be played. Python SimpleHTTPServer is not\n          recommended. Also, if you're playing a video, the URL must be an IP\n          address. Some AppleTV devices are actually password-protected; in that\n          case please set the PASSWORD datastore option. For password\n          brute forcing, please see the module auxiliary/scanner/http/appletv_login.",
+    "severity": "low",
+    "type": "auxiliary",
     "platform": "multi",
     "cve": [],
-    "tags": ["ssh", "credentials"],
-    "transcript": "[*] Gathering SSH credentials...\n[+] user:password found in /home/user/.ssh/config\n[*] Post module execution completed",
-    "doc": "Collect SSH credentials from config files."
+    "tags": [
+      "admin",
+      "appletv",
+      "appletv-display-video"
+    ],
+    "transcript": "",
+    "doc": "Apple TV Video Remote Control",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/atg/atg_client",
+    "description": "This module acts as a simplistic administrative client for interfacing\n        with Veeder-Root Automatic Tank Gauges (ATGs) or other devices speaking\n        the TLS-250 and TLS-350 protocols.  This has been tested against\n        GasPot and Conpot, both honeypots meant to simulate ATGs; it has not\n        been tested against anything else, so use at your own risk.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "atg",
+      "atg-client"
+    ],
+    "transcript": "",
+    "doc": "Veeder-Root Automatic Tank Gauge (ATG) Administrative Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/aws/aws_launch_instances",
+    "description": "This module will attempt to launch an AWS instances (hosts) in EC2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "aws",
+      "aws-launch-instances"
+    ],
+    "transcript": "",
+    "doc": "Launches Hosts in AWS",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/backupexec/dump",
+    "description": "This module abuses a logic flaw in the Backup Exec Windows Agent to download\n          arbitrary files from the system. This flaw was found by someone who wishes to\n          remain anonymous and affects all known versions of the Backup Exec Windows Agent. The\n          output file is in 'MTF' format, which can be extracted by the 'NTKBUp' program\n          listed in the references section. To transfer an entire directory, specify a\n          path that includes a trailing backslash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2005-2611"
+    ],
+    "tags": [
+      "admin",
+      "backupexec",
+      "dump"
+    ],
+    "transcript": "",
+    "doc": "Veritas Backup Exec Windows Remote File Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/backupexec/registry",
+    "description": "This modules exploits a remote registry access flaw in the BackupExec Windows\n          Server RPC service. This vulnerability was discovered by Pedram Amini and is based\n          on the NDR stub information posted to openrce.org.\n          Please see the action list for the different attack modes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2005-0771"
+    ],
+    "tags": [
+      "admin",
+      "backupexec",
+      "registry"
+    ],
+    "transcript": "",
+    "doc": "Veritas Backup Exec Server Registry Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/chromecast/chromecast_reset",
+    "description": "This module performs a factory reset on a Chromecast, causing a denial of service (DoS).\n          No user authentication is required.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "chromecast",
+      "chromecast-reset"
+    ],
+    "transcript": "",
+    "doc": "Chromecast Factory Reset DoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/chromecast/chromecast_youtube",
+    "description": "This module acts as a simple remote control for Chromecast YouTube.\n\n          Only the deprecated DIAL protocol is supported by this module.\n          Casting via the newer CASTV2 protocol is unsupported at this time.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "chromecast",
+      "chromecast-youtube"
+    ],
+    "transcript": "",
+    "doc": "Chromecast YouTube Remote Control",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/citrix/citrix_netscaler_config_decrypt",
+    "description": "This module takes a Citrix NetScaler ns.conf configuration file as\n          input and extracts secrets that have been stored with reversible\n          encryption. The module supports legacy NetScaler encryption (RC4)\n          as well as the newer AES-256-ECB and AES-256-CBC encryption types.\n          It is also possible to decrypt secrets protected by the Key\n          Encryption Key (KEK) method, provided the key fragment files F1.key\n          and F2.key are provided.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "BSD",
+    "cve": [],
+    "tags": [
+      "admin",
+      "citrix",
+      "citrix-netscaler-config-decrypt"
+    ],
+    "transcript": "",
+    "doc": "Decrypt Citrix NetScaler Config Secrets",
+    "disclosure_date": "2022-05-19",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/db2/db2rcmd",
+    "description": "This module exploits a vulnerability in the Remote Command Server\n          component in IBM's DB2 Universal Database 8.1. An authenticated\n          attacker can send arbitrary commands to the DB2REMOTECMD named pipe\n          which could lead to administrator privileges.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2004-0795"
+    ],
+    "tags": [
+      "admin",
+      "db2",
+      "db2rcmd"
+    ],
+    "transcript": "",
+    "doc": "IBM DB2 db2rcmd.exe Command Execution Vulnerability",
+    "disclosure_date": "2004-03-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dcerpc/cve_2020_1472_zerologon",
+    "description": "A vulnerability exists within the Netlogon authentication process where the security properties granted by AES\n          are lost due to an implementation flaw related to the use of a static initialization vector (IV). An attacker\n          can leverage this flaw to target an Active Directory Domain Controller and make repeated authentication attempts\n          using NULL data fields which will succeed every 1 in 256 tries (~0.4%). This module leverages the vulnerability\n          to reset the machine account password to an empty string, which will then allow the attacker to authenticate as\n          the machine account. After exploitation, it's important to restore this password to it's original value. Failure\n          to do so can result in service instability.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-1472"
+    ],
+    "tags": [
+      "admin",
+      "dcerpc",
+      "cve-2020-1472-zerologon"
+    ],
+    "transcript": "",
+    "doc": "Netlogon Weak Cryptographic Authentication",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dcerpc/cve_2022_26923_certifried",
+    "description": "This module exploits a privilege escalation vulnerability in Active\n          Directory Certificate Services (ADCS) to generate a valid certificate\n          impersonating the Domain Controller (DC) computer account. This\n          certificate is then used to authenticate to the target as the DC\n          account using PKINIT preauthentication mechanism. The module will get\n          and cache the Ticket-Granting-Ticket (TGT) for this account along\n          with its NTLM hash. Finally, it requests a TGS impersonating a\n          privileged user (Administrator by default). This TGS can then be used\n          by other modules or external tools.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-26923"
+    ],
+    "tags": [
+      "admin",
+      "dcerpc",
+      "cve-2022-26923-certifried"
+    ],
+    "transcript": "",
+    "doc": "Active Directory Certificate Services (ADCS) privilege escalation (Certifried)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dcerpc/esc_update_ldap_object",
+    "description": "This module exploits Active Directory Certificate Services (AD CS) template misconfigurations, specifically\n          ESC9, ESC10, and ESC16, by updating an LDAP object and requesting a certificate on behalf of a target user.\n          The module leverages the auxiliary/admin/ldap/ldap_object_attribute module to update the LDAP object and the\n          admin/ldap/shadow_credentials module to add shadow credentials for the target user. It then uses the\n          admin/kerberos/get_ticket module to retrieve the NTLM hash of the target user and requests a certificate via\n          MS-ICPR. The resulting certificate can be used for various operations, such as authentication.\n\n          The module ensures that any changes made by the ldap_object_attribute or shadow_credentials module are\n          reverted after execution to maintain system integrity.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "dcerpc",
+      "esc-update-ldap-object"
+    ],
+    "transcript": "",
+    "doc": "Exploits AD CS Template misconfigurations which involve updating an LDAP object: ESC9, ESC10, and ESC16",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dcerpc/icpr_cert",
+    "description": "Request certificates via MS-ICPR (Active Directory Certificate Services). Depending on the certificate\n          template's configuration the resulting certificate can be used for various operations such as authentication.\n          PFX certificate files that are saved are encrypted with a blank password.\n\n          This module is capable of exploiting ESC1, ESC2, ESC3, ESC13 and ESC15.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "dcerpc",
+      "icpr-cert"
+    ],
+    "transcript": "",
+    "doc": "ICPR Certificate Management",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dcerpc/samr_account",
+    "description": "Add, lookup and delete user / machine accounts via MS-SAMR. By default\n          standard active directory users can add up to 10 new computers to the\n          domain (MachineAccountQuota). Administrative privileges however are required\n          to delete the created accounts, or to create/delete user accounts.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "dcerpc",
+      "samr-account"
+    ],
+    "transcript": "",
+    "doc": "SAMR Account Management",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/dns/dyn_dns_update",
+    "description": "This module allows adding and/or deleting a record to\n        any remote DNS server that allows unrestricted dynamic updates.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "dns",
+      "dyn-dns-update"
+    ],
+    "transcript": "",
+    "doc": "DNS Server Dynamic Update Record Injection",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/edirectory/edirectory_dhost_cookie",
+    "description": "This module is able to predict the next session cookie value issued\n          by the DHOST web service of Novell eDirectory 8.8.5. An attacker can run\n          this module, wait until the real administrator logs in, then specify the\n          predicted cookie value to hijack their session.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-4655"
+    ],
+    "tags": [
+      "admin",
+      "edirectory",
+      "edirectory-dhost-cookie"
+    ],
+    "transcript": "",
+    "doc": "Novell eDirectory DHOST Predictable Session Cookie",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/edirectory/edirectory_edirutil",
+    "description": "This module will access Novell eDirectory's eMBox service and can run the\n          following actions via the SOAP interface: GET_DN, READ_LOGS, LIST_SERVICES,\n          STOP_SERVICE, START_SERVICE, SET_LOGFILE.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-0926"
+    ],
+    "tags": [
+      "admin",
+      "edirectory",
+      "edirectory-edirutil"
+    ],
+    "transcript": "",
+    "doc": "Novell eDirectory eMBox Unauthenticated File Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/emc/alphastor_devicemanager_exec",
+    "description": "EMC AlphaStor Device Manager is prone to a remote command-injection vulnerability\n          because the application fails to properly sanitize user-supplied input.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2157"
+    ],
+    "tags": [
+      "admin",
+      "emc",
+      "alphastor-devicemanager-exec"
+    ],
+    "transcript": "",
+    "doc": "EMC AlphaStor Device Manager Arbitrary Command Execution",
+    "disclosure_date": "2008-05-27",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/emc/alphastor_librarymanager_exec",
+    "description": "EMC AlphaStor Library Manager is prone to a remote command-injection vulnerability\n          because the application fails to properly sanitize user-supplied input.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2157"
+    ],
+    "tags": [
+      "admin",
+      "emc",
+      "alphastor-librarymanager-exec"
+    ],
+    "transcript": "",
+    "doc": "EMC AlphaStor Library Manager Arbitrary Command Execution",
+    "disclosure_date": "2008-05-27",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/firetv/firetv_youtube",
+    "description": "This module acts as a simple remote control for the Amazon Fire TV's\n          YouTube app.\n\n          Tested on the Amazon Fire TV Stick.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "firetv",
+      "firetv-youtube"
+    ],
+    "transcript": "",
+    "doc": "Amazon Fire TV YouTube Remote Control",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/hp/hp_data_protector_cmd",
+    "description": "This module exploits HP Data Protector's omniinet process, specifically\n          against a Windows setup.\n\n          When an EXEC_CMD packet is sent, omniinet.exe will attempt to look\n          for that user-supplied filename with kernel32!FindFirstFileW().  If the file\n          is found, the process will then go ahead execute it with CreateProcess()\n          under a new thread.  If the filename isn't found, FindFirstFileW() will throw\n          an error (0x03), and then bails early without triggering CreateProcess().\n\n          Because of these behaviors, if you try to supply an argument, FindFirstFileW()\n          will look at that as part of the filename, and then bail.\n\n          Please note that when you specify the 'CMD' option, the base path begins\n          under C:\\.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0923"
+    ],
+    "tags": [
+      "admin",
+      "hp",
+      "hp-data-protector-cmd"
+    ],
+    "transcript": "",
+    "doc": "HP Data Protector 6.1 EXEC_CMD Command Execution",
+    "disclosure_date": "2011-02-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/hp/hp_ilo_create_admin_account",
+    "description": "This module exploits an authentication bypass in HP iLO 4 1.00 to 2.50, triggered by a buffer\n          overflow in the Connection HTTP header handling by the web server.\n          Exploiting this vulnerability gives full access to the REST API, allowing arbitrary\n          accounts creation.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-12542"
+    ],
+    "tags": [
+      "admin",
+      "hp",
+      "hp-ilo-create-admin-account"
+    ],
+    "transcript": "",
+    "doc": "HP iLO 4 1.00-2.50 Authentication Bypass Administrator Account Creation",
+    "disclosure_date": "2017-08-24",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/hp/hp_imc_som_create_account",
+    "description": "This module exploits a lack of authentication and access control in HP Intelligent\n          Management, specifically in the AccountService RpcServiceServlet from the SOM component,\n          in order to create a SOM account with Account Management permissions. This module has\n          been tested successfully on HP Intelligent Management Center 5.2 E0401 and 5.1 E202 with\n          SOM 5.2 E0401 and SOM 5.1 E0201 over Windows 2003 SP2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4824"
+    ],
+    "tags": [
+      "admin",
+      "hp",
+      "hp-imc-som-create-account"
+    ],
+    "transcript": "",
+    "doc": "HP Intelligent Management SOM Account Creation",
+    "disclosure_date": "2013-10-08",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/allegro_rompager_auth_bypass",
+    "description": "This module exploits HTTP servers that appear to be vulnerable to the\n          'Misfortune Cookie' vulnerability which affects Allegro Software\n          Rompager versions before 4.34 and can allow attackers to authenticate\n          to the HTTP service as an administrator without providing valid\n          credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-9222"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "allegro-rompager-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Allegro Software RomPager 'Misfortune Cookie' (CVE-2014-9222) Authentication Bypass",
+    "disclosure_date": "2014-12-17",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss",
+    "description": "The web interface for the Arris / Motorola Surfboard SBG6580 has\n          several vulnerabilities that, when combined, allow an arbitrary website to take\n          control of the modem, even if the user is not currently logged in. The attacker\n          must successfully know, or guess, the target's internal gateway IP address.\n          This is usually a default value of 192.168.0.1.\n\n          First, a hardcoded backdoor account was discovered in the source code\n          of one device with the credentials \"technician/yZgO8Bvj\". Due to lack of CSRF\n          in the device's login form, these credentials - along with the default\n          \"admin/motorola\" - can be sent to the device by an arbitrary website, thus\n          inadvertently logging the user into the router.\n\n          Once successfully logged in, a persistent XSS vulnerability is\n          exploited in the firewall configuration page. This allows injection of\n          Javascript that can perform any available action in the router interface.\n\n          The following firmware versions have been tested as vulnerable:\n\n          SBG6580-6.5.2.0-GA-06-077-NOSH, and\n          SBG6580-8.6.1.0-GA-04-098-NOSH",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-0964",
+      "CVE-2015-0965",
+      "CVE-2015-0966"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "arris-motorola-surfboard-backdoor-xss"
+    ],
+    "transcript": "",
+    "doc": "Arris / Motorola Surfboard SBG6580 Web Interface Takeover",
+    "disclosure_date": "2015-04-08",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/atlassian_confluence_auth_bypass",
+    "description": "This module exploits a broken access control vulnerability in Atlassian Confluence servers leading to an authentication bypass.\n          A specially crafted request can be create new admin account without authentication on the target Atlassian server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-22515"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "atlassian-confluence-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Atlassian Confluence Data Center and Server Authentication Bypass via Broken Access Control",
+    "disclosure_date": "2023-10-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/axigen_file_access",
+    "description": "This module exploits a directory traversal vulnerability in the WebAdmin\n          interface of Axigen, which allows an authenticated user to read and delete\n          arbitrary files with SYSTEM privileges. The vulnerability is known to work on\n          Windows platforms. This module has been tested successfully on Axigen 8.10 over\n          Windows 2003 SP2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-4940"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "axigen-file-access"
+    ],
+    "transcript": "",
+    "doc": "Axigen Arbitrary File Read and Delete",
+    "disclosure_date": "2012-10-31",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cfme_manageiq_evm_pass_reset",
+    "description": "This module exploits a SQL injection vulnerability in the \"explorer\"\n        action of \"miq_policy\" controller of the Red Hat CloudForms Management\n        Engine 5.1 (ManageIQ Enterprise Virtualization Manager 5.0 and earlier) by\n        changing the password of the target account to the specified password.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-2050"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cfme-manageiq-evm-pass-reset"
+    ],
+    "transcript": "",
+    "doc": "Red Hat CloudForms Management Engine 5.1 miq_policy/explorer SQL Injection",
+    "disclosure_date": "2013-11-12",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cisco_7937g_ssh_privesc",
+    "description": "This module exploits a feature that should not be available \n\tvia the web interface. An unauthenticated user may change \n\tthe credentials for SSH access to any username and password \n\tcombination desired, giving access to administrative \n\tfunctions through an SSH connection.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-16137"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cisco-7937g-ssh-privesc"
+    ],
+    "transcript": "",
+    "doc": "Cisco 7937G SSH Privilege Escalation",
+    "disclosure_date": "2020-06-02",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198",
+    "description": "This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the\n          Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.\n\n          You must specify the IOS command mode to execute a CLI command in. Valid modes are `user`, `privileged`, and\n          `global`. To run a command in \"Privileged\" mode, set the `CMD` option to the command you want to run,\n          e.g. `show version` and set the `MODE` to `privileged`.  To run a command in \"Global Configuration\" mode, set\n          the `CMD` option to the command you want to run,  e.g. `username hax0r privilege 15 password hax0r` and set\n          the `MODE` to `global`.\n\n          The vulnerable IOS XE versions are:\n          16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,\n          16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,\n          16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,\n          16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,\n          16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,\n          16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,\n          16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,\n          16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,\n          16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,\n          16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,\n          16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,\n          16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,\n          16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,\n          17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,\n          17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,\n          17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,\n          17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,\n          17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,\n          17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,\n          17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,\n          17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,\n          17.11.99SW",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-20198"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cisco-ios-xe-cli-exec-cve-2023-20198"
+    ],
+    "transcript": "",
+    "doc": "Cisco IOX XE unauthenticated Command Line Interface (CLI) execution",
+    "disclosure_date": "2023-10-16",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273",
+    "description": "This module leverages both CVE-2023-20198 and CVE-2023-20273 against vulnerable instances of Cisco IOS XE\n          devices which have the Web UI exposed. An attacker can execute arbitrary OS commands with root privileges.\n\n          This module leverages CVE-2023-20198 to create a new admin user, then authenticating as this user,\n          CVE-2023-20273 is leveraged for OS command injection. The output of the command is written to a file and read\n          back via the webserver. Finally the output file is deleted and the admin user is removed.\n\n          The vulnerable IOS XE versions are:\n          16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,\n          16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,\n          16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,\n          16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,\n          16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,\n          16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,\n          16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,\n          16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,\n          16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,\n          16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,\n          16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,\n          16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,\n          16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,\n          17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,\n          17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,\n          17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,\n          17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,\n          17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,\n          17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,\n          17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,\n          17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,\n          17.11.99SW\n\n          NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even\n          though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-20198",
+      "CVE-2023-20273"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cisco-ios-xe-os-exec-cve-2023-20273"
+    ],
+    "transcript": "",
+    "doc": "Cisco IOX XE unauthenticated OS command execution",
+    "disclosure_date": "2023-10-16",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cisco_ssm_onprem_account",
+    "description": "This module exploits an improper access control vulnerability in Cisco Smart Software Manager (SSM) On-Prem <= 8-202206. An unauthenticated remote attacker\n          can change the password of any existing user, including administrative users.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-20419"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cisco-ssm-onprem-account"
+    ],
+    "transcript": "",
+    "doc": "Cisco Smart Software Manager (SSM) On-Prem Account Takeover (CVE-2024-20419)",
+    "disclosure_date": "2024-07-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cnpilot_r_cmd_exec",
+    "description": "Cambium cnPilot r200/r201 device software versions 4.2.3-R4 to\n          4.3.3-R4, contain an undocumented, backdoor 'root' shell. This shell is\n          accessible via a specific url, to any authenticated user. The module uses this\n          shell to execute arbitrary system commands as 'root'.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-5259"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cnpilot-r-cmd-exec"
+    ],
+    "transcript": "",
+    "doc": "Cambium cnPilot r200/r201 Command Execution as 'root'",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/cnpilot_r_fpt",
+    "description": "This module exploits a File Path Traversal vulnerability in Cambium\n          cnPilot r200/r201 to read arbitrary files off the file system. Affected\n          versions - 4.3.3-R4 and prior.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-5261"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "cnpilot-r-fpt"
+    ],
+    "transcript": "",
+    "doc": "Cambium cnPilot r200/r201 File Path Traversal",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/contentkeeper_fileaccess",
+    "description": "This module abuses the 'mimencode' binary present within\n        ContentKeeper Web filtering appliances to retrieve arbitrary\n        files outside of the webroot.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "contentkeeper-fileaccess"
+    ],
+    "transcript": "",
+    "doc": "ContentKeeper Web Appliance mimencode File Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/dlink_dir_300_600_exec_noauth",
+    "description": "This module exploits an OS Command Injection vulnerability in some D-Link\n          Routers like the DIR-600 rev B and the DIR-300 rev B. The vulnerability exists in\n          command.php, which is accessible without authentication. This module has been\n          tested with the versions DIR-600 2.14b01 and below, DIR-300 rev B 2.13 and below.\n          In order to get a remote shell the telnetd could be started without any\n          authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "dlink-dir-300-600-exec-noauth"
+    ],
+    "transcript": "",
+    "doc": "D-Link DIR-600 / DIR-300 Unauthenticated Remote Command Execution",
+    "disclosure_date": "2013-02-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/dlink_dir_645_password_extractor",
+    "description": "This module exploits an authentication bypass vulnerability in DIR 645 < v1.03.\n        With this vulnerability you are able to extract the password for the remote\n        management.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "dlink-dir-645-password-extractor"
+    ],
+    "transcript": "",
+    "doc": "D-Link DIR 645 Password Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/dlink_dsl320b_password_extractor",
+    "description": "This module exploits an authentication bypass vulnerability in D-Link DSL 320B\n        <=v1.23. This vulnerability allows to extract the credentials for the remote\n        management interface.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "dlink-dsl320b-password-extractor"
+    ],
+    "transcript": "",
+    "doc": "D-Link DSL 320B Password Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/foreman_openstack_satellite_priv_esc",
+    "description": "This module exploits a mass assignment vulnerability in the 'create'\n        action of 'users' controller of Foreman and Red Hat OpenStack/Satellite\n        (Foreman 1.2.0-RC1 and earlier) by creating an arbitrary administrator\n        account. For this exploit to work, your account must have 'create_users'\n        permission (e.g., Manager role).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-2113"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "foreman-openstack-satellite-priv-esc"
+    ],
+    "transcript": "",
+    "doc": "Foreman (Red Hat OpenStack/Satellite) users/create Mass Assignment",
+    "disclosure_date": "2013-06-06",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/fortra_filecatalyst_workflow_sqli",
+    "description": "This module exploits a SQL injection vulnerability in Fortra FileCatalyst Workflow <= v5.1.6 Build 135, by adding a new\n          administrative user to the web interface of the application.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-5276"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "fortra-filecatalyst-workflow-sqli"
+    ],
+    "transcript": "",
+    "doc": "Fortra FileCatalyst Workflow SQL Injection (CVE-2024-5276)",
+    "disclosure_date": "2024-06-25",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/gitlab_password_reset_account_takeover",
+    "description": "This module exploits an account-take-over vulnerability that allows users\n        to take control of a gitlab account without user interaction.\n\n        The vulnerability lies in the password reset functionality. Its possible to provide 2 emails\n        and the reset code will be sent to both. It is therefore possible to provide the e-mail\n        address of the target account as well as that of one we control, and to reset the password.\n\n        2-factor authentication prevents this vulnerability from being exploitable. There is no\n        discernable difference between a vulnerable and non-vulnerable server response.\n\n        Vulnerable versions include:\n        16.1 < 16.1.6,\n        16.2 < 16.2.9,\n        16.3 < 16.3.7,\n        16.4 < 16.4.5,\n        16.5 < 16.5.6,\n        16.6 < 16.6.4,\n        and 16.7 < 16.7.2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-7028"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "gitlab-password-reset-account-takeover"
+    ],
+    "transcript": "",
+    "doc": "GitLab Password Reset Account Takeover",
+    "disclosure_date": "2024-01-11",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/gitstack_rest",
+    "description": "This modules exploits unauthenticated REST API requests in GitStack through v2.3.10.\n          The module supports requests for listing users of the application and listing\n          available repositories. Additionally, the module can create a user and add the user\n          to the application's repositories. This module has been tested against GitStack v2.3.10.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-5955"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "gitstack-rest"
+    ],
+    "transcript": "",
+    "doc": "GitStack Unauthenticated REST API Requests",
+    "disclosure_date": "2018-01-15",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/grafana_auth_bypass",
+    "description": "This module generates a remember me cookie for a valid username. Through unpropper seeding \n        while userdate are requested from LDAP or OAuth it's possible to craft a valid remember me cookie. \n        This cookie can be used for bypass authentication for everyone knowing a valid username.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-15727"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "grafana-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Grafana 2.0 through 5.2.2 authentication bypass for LDAP and OAuth",
+    "disclosure_date": "2019-08-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921",
+    "description": "Many Hikvision IP cameras contain improper authentication logic which allows unauthenticated impersonation of any configured user account.\n          The vulnerability has been present in Hikvision products since 2014. In addition to Hikvision-branded devices, it\n          affects many white-labeled camera products sold under a variety of brand names.\n\n          Hundreds of thousands of vulnerable devices are still exposed to the Internet at the time\n          of publishing (shodan search: '\"App-webs\" \"200 OK\"'). Some of these devices can never be patched due to to the\n          vendor preventing users from upgrading the installed firmware on the affected device.\n\n          This module utilizes the bug in the authentication logic to perform an unauthenticated password change of any user account on\n          a vulnerable Hikvision IP Camera. This can then be utilized to gain full administrative access to the affected device.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-7921"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "hikvision-unauth-pwd-reset-cve-2017-7921"
+    ],
+    "transcript": "",
+    "doc": "Hikvision IP Camera Unauthenticated Password Change Via Improper Authentication Logic",
+    "disclosure_date": "2017-09-23",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/hp_web_jetadmin_exec",
+    "description": "This module abuses a command execution vulnerability within the\n          web based management console of the Hewlett-Packard Web JetAdmin\n          network printer tool v6.2 - v6.5. It is possible to execute commands\n          as SYSTEM without authentication. The vulnerability also affects POSIX\n          systems, however at this stage the module only works against Windows.\n          This module does not apply to HP printers.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "hp-web-jetadmin-exec"
+    ],
+    "transcript": "",
+    "doc": "HP Web JetAdmin 6.5 Server Arbitrary Command Execution",
+    "disclosure_date": "2004-04-27",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/ibm_drm_download",
+    "description": "IBM Data Risk Manager (IDRM) contains two vulnerabilities that can be chained by\n          an unauthenticated attacker to download arbitrary files off the system.\n          The first is an unauthenticated bypass, followed by a path traversal.\n          This module exploits both vulnerabilities, giving an attacker the ability to download (non-root) files.\n          A downloaded file is zipped, and this module also unzips it before storing it in the database.\n          By default this module downloads Tomcat's application.properties files, which contains the\n          database password, amongst other sensitive data.\n          At the time of disclosure, this is was a 0 day, but IBM later patched it and released their advisory.\n          Versions 2.0.2 to 2.0.4 are vulnerable, version 2.0.1 is not.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-4427",
+      "CVE-2020-4429"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "ibm-drm-download"
+    ],
+    "transcript": "",
+    "doc": "IBM Data Risk Manager Arbitrary File Download",
+    "disclosure_date": "2020-04-21",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/idsecure_auth_bypass",
+    "description": "This module exploits an improper access control vulnerability (CVE-2023-6329) in Control iD iDSecure <= v4.7.43.0. It allows an\n          unauthenticated remote attacker to compute valid credentials and to add a new administrative user to the web interface of the product.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-6329"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "idsecure-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Control iD iDSecure Authentication Bypass (CVE-2023-6329)",
+    "disclosure_date": "2023-11-27",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/iis_auth_bypass",
+    "description": "This module bypasses basic authentication for Internet Information Services (IIS).\n          By appending the NTFS stream name to the directory name in a request, it is\n          possible to bypass authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-2731"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "iis-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "MS10-065 Microsoft IIS 5 NTFS Stream Authentication Bypass",
+    "disclosure_date": "2010-07-02",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/intersil_pass_reset",
+    "description": "The Intersil extension in the Boa HTTP Server 0.93.x - 0.94.11\n          allows basic authentication bypass when the user string is greater\n          than 127 bytes long.  The long string causes the password to be\n          overwritten in memory, which enables the attacker to reset the\n          password.  In addition, the malicious attempt also may cause a\n          denial-of-service condition.\n\n          Please note that you must set the request URI to the directory that\n          requires basic authentication in order to work properly.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-4915"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "intersil-pass-reset"
+    ],
+    "transcript": "",
+    "doc": "Intersil (Boa) HTTPd Basic Authentication Password Reset",
+    "disclosure_date": "2007-09-10",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/iomega_storcenterpro_sessionid",
+    "description": "The Iomega StorCenter Pro Network Attached Storage device web interface increments sessions IDs,\n        allowing for simple brute force attacks to bypass authentication and gain administrative\n        access.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-2367"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "iomega-storcenterpro-sessionid"
+    ],
+    "transcript": "",
+    "doc": "Iomega StorCenter Pro NAS Web Authentication Bypass",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/ivanti_vtm_admin",
+    "description": "This module exploits an access control issue in Ivanti Virtual Traffic Manager (vTM), by adding a new\n          administrative user to the web interface of the application.\n\n          Affected versions include 22.7R1, 22.6R1, 22.5R1, 22.3R2, 22.3, 22.2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-7593"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "ivanti-vtm-admin"
+    ],
+    "transcript": "",
+    "doc": "Ivanti Virtual Traffic Manager Authentication Bypass (CVE-2024-7593)",
+    "disclosure_date": "2024-08-05",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/jboss_bshdeployer",
+    "description": "This module can be used to install a WAR file payload on JBoss servers that have\n        an exposed \"jmx-console\" application. The payload is put on the server by\n        using the jboss.system:BSHDeployer's createScriptDeployment() method.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0738"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "jboss-bshdeployer"
+    ],
+    "transcript": "",
+    "doc": "JBoss JMX Console Beanshell Deployer WAR Upload and Deployment",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/jboss_deploymentfilerepository",
+    "description": "This module uses the DeploymentFileRepository class in the JBoss Application Server\n        to deploy a JSP file which then deploys an arbitrary WAR file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0738"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "jboss-deploymentfilerepository"
+    ],
+    "transcript": "",
+    "doc": "JBoss JMX Console DeploymentFileRepository WAR Upload and Deployment",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/jboss_seam_exec",
+    "description": "JBoss Seam 2 (jboss-seam2), as used in JBoss Enterprise Application Platform\n          4.3.0 for Red Hat Linux, does not properly sanitize inputs for JBoss Expression\n          Language (EL) expressions, which allows remote attackers to execute arbitrary code\n          via a crafted URL. This modules also has been tested successfully against IBM\n          WebSphere 6.1 running on iSeries.\n\n          NOTE: this is only a vulnerability when the Java Security Manager is not properly\n          configured.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-1871"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "jboss-seam-exec"
+    ],
+    "transcript": "",
+    "doc": "JBoss Seam 2 Remote Command Execution",
+    "disclosure_date": "2010-07-19",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/joomla_registration_privesc",
+    "description": "This module creates an arbitrary account with administrative privileges in Joomla versions 3.4.4\n          through 3.6.3. If an email server is configured in Joomla, an email will be sent to activate the account (the account is disabled by default).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-8869",
+      "CVE-2016-8870"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "joomla-registration-privesc"
+    ],
+    "transcript": "",
+    "doc": "Joomla Account Creation and Privilege Escalation",
+    "disclosure_date": "2016-10-25",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/kaseya_master_admin",
+    "description": "This module abuses the setAccount page on Kaseya VSA between 7 and 9.1 to create a new\n          Master Administrator account. Normally this page is only accessible via the localhost\n          interface, but the application does nothing to prevent this apart from attempting to\n          force a redirect. This module has been tested with Kaseya VSA v7.0.0.17, v8.0.0.10 and\n          v9.0.0.3.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-6922"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "kaseya-master-admin"
+    ],
+    "transcript": "",
+    "doc": "Kaseya VSA Master Administrator Account Creation",
+    "disclosure_date": "2015-09-23",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/katello_satellite_priv_esc",
+    "description": "This module exploits a missing authorization vulnerability in the\n        \"update_roles\" action of \"users\" controller of Katello and Red Hat Satellite\n        (Katello 1.5.0-14 and earlier) by changing the specified account to an\n        administrator account.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-2143"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "katello-satellite-priv-esc"
+    ],
+    "transcript": "",
+    "doc": "Katello (Red Hat Satellite) users/update_roles Missing Authorization",
+    "disclosure_date": "2014-03-24",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/limesurvey_file_download",
+    "description": "This module exploits an unauthenticated file download vulnerability\n          in limesurvey between 2.0+ and 2.06+ Build 151014. The file is downloaded\n          as a ZIP and unzipped automatically, thus binary files can be downloaded.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "limesurvey-file-download"
+    ],
+    "transcript": "",
+    "doc": "Limesurvey Unauthenticated File Download",
+    "disclosure_date": "2015-10-12",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/linksys_e1500_e2500_exec",
+    "description": "Some Linksys Routers are vulnerable to an authenticated OS command injection.\n          Default credentials for the web interface are admin/admin or admin/password. Since\n          it is a blind os command injection vulnerability, there is no output for the\n          executed command. A ping command against a controlled system for can be used for\n          testing purposes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "linksys-e1500-e2500-exec"
+    ],
+    "transcript": "",
+    "doc": "Linksys E1500/E2500 Remote Command Execution",
+    "disclosure_date": "2013-02-05",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/linksys_tmunblock_admin_reset_bof",
+    "description": "This module exploits a stack-based buffer overflow vulnerability in the WRT120N Linksys router\n          to reset the password of the management interface temporarily to an empty value.\n          This module has been tested successfully on a WRT120N device with firmware version\n          1.0.07.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "linksys-tmunblock-admin-reset-bof"
+    ],
+    "transcript": "",
+    "doc": "Linksys WRT120N tmUnblock Stack Buffer Overflow",
+    "disclosure_date": "2014-02-19",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/linksys_wrt54gl_exec",
+    "description": "Some Linksys Routers are vulnerable to OS Command injection.\n          You will need credentials to the web interface to access the vulnerable part\n          of the application.\n          Default credentials are always a good starting point. admin/admin or admin\n          and blank password could be a first try.\n          Note: This is a blind OS command injection vulnerability. This means that\n          you will not see any output of your command. Try a ping command to your\n          local system and observe the packets with tcpdump (or equivalent) for a first test.\n\n          Hint: To get a remote shell you could upload a netcat binary and exec it.\n          WARNING: this module will overwrite network and DHCP configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "linksys-wrt54gl-exec"
+    ],
+    "transcript": "",
+    "doc": "Linksys WRT54GL Remote Command Execution",
+    "disclosure_date": "2013-01-18",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/manage_engine_dc_create_admin",
+    "description": "This module exploits an administrator account creation vulnerability in Desktop Central\n          from v7 onwards by sending a crafted request to DCPluginServelet. It has been tested in\n          several versions of Desktop Central (including MSP) from v7 onwards.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-7862"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "manage-engine-dc-create-admin"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine Desktop Central Administrator Account Creation",
+    "disclosure_date": "2014-12-31",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/manageengine_dir_listing",
+    "description": "This module exploits a directory listing information disclosure vulnerability in the\n          FailOverHelperServlet on ManageEngine OpManager, Applications Manager and IT360. It\n          makes a recursive listing, so it will list the whole drive if you ask it to list / in\n          Linux or C:\\ in Windows. This vulnerability is unauthenticated on OpManager and\n          Applications Manager, but authenticated in IT360. This module will attempt to login\n          using the default credentials for the administrator and guest accounts; alternatively\n          you can provide a pre-authenticated cookie or a username / password combo. For IT360\n          targets enter the RPORT of the OpManager instance (usually 8300). This module has been\n          tested on both Windows and Linux with several different versions. Windows paths have to\n          be escaped with 4 backslashes on the command line. There is a companion module that\n          allows for arbitrary file download. This vulnerability has been fixed in Applications\n          Manager v11.9 b11912 and OpManager 11.6.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-7863"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "manageengine-dir-listing"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine Multiple Products Arbitrary Directory Listing",
+    "disclosure_date": "2015-01-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/manageengine_file_download",
+    "description": "This module exploits an arbitrary file download vulnerability in the FailOverHelperServlet\n          on ManageEngine OpManager, Applications Manager and IT360. This vulnerability is\n          unauthenticated on OpManager and Applications Manager, but authenticated in IT360. This\n          module will attempt to login using the default credentials for the administrator and\n          guest accounts; alternatively you can provide a pre-authenticated cookie or a username\n          and password combo. For IT360 targets enter the RPORT of the OpManager instance (usually\n          8300). This module has been tested on both Windows and Linux with several different\n          versions. Windows paths have to be escaped with 4 backslashes on the command line. There is\n          a companion module that allows the recursive listing of any directory. This\n          vulnerability has been fixed in Applications Manager v11.9 b11912 and OpManager 11.6.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-7863"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "manageengine-file-download"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine Multiple Products Arbitrary File Download",
+    "disclosure_date": "2015-01-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/manageengine_pmp_privesc",
+    "description": "ManageEngine Password Manager Pro (PMP) has an authenticated blind SQL injection\n          vulnerability in SQLAdvancedALSearchResult.cc that can be abused to escalate\n          privileges and obtain Super Administrator access. A Super Administrator can then\n          use his privileges to dump the whole password database in CSV format. PMP can use\n          both MySQL and PostgreSQL databases but this module only exploits the latter as\n          MySQL does not support stacked queries with Java. PostgreSQL is the default database\n          in v6.8 and above, but older PMP versions can be upgraded and continue using MySQL,\n          so a higher version does not guarantee exploitability. This module has been tested\n          on v6.8 to v7.1 build 7104 on both Windows and Linux. The vulnerability is fixed in\n          v7.1 build 7105 and above.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-8499"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "manageengine-pmp-privesc"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine Password Manager SQLAdvancedALSearchResult.cc Pro SQL Injection",
+    "disclosure_date": "2014-11-08",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/mantisbt_password_reset",
+    "description": "MantisBT before 1.3.10, 2.2.4, and 2.3.1 are vulnerable to unauthenticated password reset.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux,Windows",
+    "cve": [
+      "CVE-2017-7615"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "mantisbt-password-reset"
+    ],
+    "transcript": "",
+    "doc": "MantisBT password reset",
+    "disclosure_date": "2017-04-16",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/mutiny_frontend_read_delete",
+    "description": "This module exploits the EditDocument servlet from the frontend on the Mutiny 5\n          appliance. The EditDocument servlet provides file operations, such as copy and\n          delete, which are affected by a directory traversal vulnerability. Because of this,\n          any authenticated frontend user can read and delete arbitrary files from the system\n          with root privileges. In order to exploit the vulnerability a valid user (any role)\n          in the web frontend is required. The module has been tested successfully on the\n          Mutiny 5.0-1.07 appliance.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-0136"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "mutiny-frontend-read-delete"
+    ],
+    "transcript": "",
+    "doc": "Mutiny 5 Arbitrary File Read and Delete",
+    "disclosure_date": "2013-05-15",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netflow_file_download",
+    "description": "This module exploits an arbitrary file download vulnerability in CSVServlet\n          on ManageEngine NetFlow Analyzer. This module has been tested on both Windows\n          and Linux with versions 8.6 to 10.2. Note that when typing Windows paths, you\n          must escape the backslash with a backslash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-5445"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "netflow-file-download"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine NetFlow Analyzer Arbitrary File Download",
+    "disclosure_date": "2014-11-30",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_auth_download",
+    "description": "Netgear's ProSafe NMS300 is a network management utility that runs on Windows systems.\n          The application has a file download vulnerability that can be exploited by an\n          authenticated remote attacker to download any file in the system.\n          This module has been tested with versions 1.5.0.2, 1.4.0.17 and 1.1.0.13.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-1524"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-auth-download"
+    ],
+    "transcript": "",
+    "doc": "NETGEAR ProSafe Network Management System 300 Authenticated File Download",
+    "disclosure_date": "2016-02-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass",
+    "description": "This module targets an authentication bypass vulnerability in the mini_http binary of several Netgear Routers\n          running firmware versions prior to 1.2.0.88, 1.0.1.80, 1.1.0.110, and 1.1.0.84. The vulnerability allows\n          unauthenticated attackers to reveal the password for the admin user that is used to log into the\n          router's administrative portal, in plaintext.\n\n          Once the password has been been obtained, the exploit enables telnet on the target router and then utiltizes\n          the auxiliary/scanner/telnet/telnet_login module to log into the router using the stolen credentials of the\n          admin user. This will result in the attacker obtaining a new telnet session as the \"root\" user.\n\n          This vulnerability was discovered and exploited by an independent security researcher who reported it to SSD.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-pnpx-getsharefolderlist-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Netgear PNPX_GetShareFolderList Authentication Bypass",
+    "disclosure_date": "2021-09-06",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_r6700_pass_reset",
+    "description": "This module targets ZDI-20-704 (aka CVE-2020-10924), a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd),\n          on Netgear R6700v3 routers running firmware versions from V1.0.2.62 up to but not including V1.0.4.94, to reset\n          the password for the 'admin' user back to its factory default of 'password'. Authentication is bypassed by\n          using ZDI-20-703 (aka CVE-2020-10923), an authentication bypass that occurs when network adjacent\n          computers send SOAPAction UPnP messages to a vulnerable Netgear R6700v3 router. Currently this module only\n          supports exploiting Netgear R6700v3 routers running either the V1.0.0.4.82_10.0.57 or V1.0.0.4.84_10.0.58\n          firmware, however support for other firmware versions may be added in the future.\n\n          Once the password has been reset, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a\n          special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can\n          then log into this telnet server using the new password, and obtain a shell as the \"root\" user.\n\n          These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.\n          It should be noted that successful exploitation will result in the upnpd binary crashing on the target router.\n          As the upnpd binary will not restart until the router is rebooted, this means that attackers can only exploit\n          this vulnerability once per reboot of the router.\n\n          This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +\n          Radek Domanski).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-10923",
+      "CVE-2020-10924"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-r6700-pass-reset"
+    ],
+    "transcript": "",
+    "doc": "Netgear R6700v3 Unauthenticated LAN Admin Password Reset",
+    "disclosure_date": "2020-06-15",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_r7000_backup_cgi_heap_overflow_rce",
+    "description": "This module exploits a heap buffer overflow in the genie.cgi?backup.cgi\n          page of Netgear R7000 routers running firmware version 1.0.11.116.\n          Successful exploitation results in unauthenticated attackers gaining\n          code execution as the root user.\n\n          The exploit utilizes these privileges to enable the telnet server\n          which allows attackers to connect to the target and execute commands\n          as the admin user from within a BusyBox shell. Users can connect to\n          this telnet server by running the command \"telnet *target IP*\".",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [
+      "CVE-2021-31802"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-r7000-backup-cgi-heap-overflow-rce"
+    ],
+    "transcript": "",
+    "doc": "Netgear R7000 backup.cgi Heap Overflow RCE",
+    "disclosure_date": "2021-04-21",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_soap_password_extractor",
+    "description": "This module exploits an authentication bypass vulnerability in different Netgear devices.\n        It allows to extract the password for the remote management interface. This module has been\n        tested on a Netgear WNDR3700v4 - V1.0.1.42, but other devices are reported as vulnerable:\n        NetGear WNDR3700v4 - V1.0.0.4SH, NetGear WNDR3700v4 - V1.0.1.52, NetGear WNR2200 - V1.0.1.88,\n        NetGear WNR2500 - V1.0.0.24, NetGear WNDR3700v2 - V1.0.1.14 (Tested by Paula Thomas),\n        NetGear WNDR3700v1 - V1.0.16.98 (Tested by Michal Bartoszkiewicz),\n        NetGear WNDR3700v1 - V1.0.7.98 (Tested by Michal Bartoszkiewicz),\n        NetGear WNDR4300 - V1.0.1.60 (Tested by Ronny Lindner),\n        NetGear R6300v2 - V1.0.3.8 (Tested by Robert Mueller),\n        NetGear WNDR3300 - V1.0.45 (Tested by Robert Mueller),\n        NetGear WNDR3800 - V1.0.0.48 (Tested by an Anonymous contributor),\n        NetGear WNR1000v2 - V1.0.1.1 (Tested by Jimi Sebree),\n        NetGear WNR1000v2 - V1.1.2.58 (Tested by Chris Boulton),\n        NetGear WNR2000v3 - v1.1.2.10 (Tested by h00die)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-soap-password-extractor"
+    ],
+    "transcript": "",
+    "doc": "Netgear Unauthenticated SOAP Password Extractor",
+    "disclosure_date": "2015-02-11",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/netgear_wnr2000_pass_recovery",
+    "description": "The NETGEAR WNR2000 router has a vulnerability in the way it handles password recovery.\n          This vulnerability can be exploited by an unauthenticated attacker who is able to guess\n          the value of a certain timestamp which is in the configuration of the router.\n          Brute forcing the timestamp token might take a few minutes, a few hours, or days, but\n          it is guaranteed that it can be bruteforced.\n          This module works very reliably and it has been tested with the WNR2000v5, firmware versions\n          1.0.0.34 and 1.0.0.18. It should also work with the hardware revisions v4 and v3, but this\n          has not been tested.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-10175",
+      "CVE-2016-10176"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "netgear-wnr2000-pass-recovery"
+    ],
+    "transcript": "",
+    "doc": "NETGEAR WNR2000v5 Administrator Password Recovery",
+    "disclosure_date": "2016-12-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/nexpose_xxe_file_read",
+    "description": "Nexpose v5.7.2 and prior is vulnerable to a XML External Entity attack via a number\n          of vectors. This vulnerability can allow an attacker to a craft special XML that\n          could read arbitrary files from the filesystem. This module exploits the\n          vulnerability via the XML API.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "nexpose-xxe-file-read"
+    ],
+    "transcript": "",
+    "doc": "Nexpose XXE Arbitrary File Read",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/novell_file_reporter_filedelete",
+    "description": "NFRAgent.exe in Novell File Reporter allows remote attackers to delete\n          arbitrary files via a full pathname in an SRS request with OPERATION set to 4 and\n          CMD set to 5 against /FSF/CMD. This module has been tested successfully on NFR\n          Agent 1.0.4.3 (File Reporter 1.0.2) and NFR Agent 1.0.3.22 (File Reporter 1.0.1) on\n          Windows platforms.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-2750"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "novell-file-reporter-filedelete"
+    ],
+    "transcript": "",
+    "doc": "Novell File Reporter Agent Arbitrary File Delete",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/nuuo_nvrmini_reset",
+    "description": "The NVRmini 2 Network Video Recorded and the ReadyNAS Surveillance application are vulnerable\n          to an administrator password reset on the exposed web management interface.\n          Note that this only works for unauthenticated attackers in earlier versions of the Nuuo firmware\n          (before v1.7.6), otherwise you need an administrative user password.\n          This exploit has been tested on several versions of the NVRmini 2 and the ReadyNAS Surveillance.\n          It probably also works on the NVRsolo and other Nuuo devices, but it has not been tested\n          in those devices.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-5676"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "nuuo-nvrmini-reset"
+    ],
+    "transcript": "",
+    "doc": "NUUO NVRmini 2 / NETGEAR ReadyNAS Surveillance Default Configuration Load and Administrator Password Reset",
+    "disclosure_date": "2016-08-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/openbravo_xxe",
+    "description": "The Openbravo ERP XML API expands external entities which can be defined as\n          local files. This allows the user to read any files from the FS as the\n          user Openbravo is running as (generally not root).\n\n          This module was tested against Openbravo ERP version 3.0MP25 and 2.50MP6.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3617"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "openbravo-xxe"
+    ],
+    "transcript": "",
+    "doc": "Openbravo ERP XXE Arbitrary File Read",
+    "disclosure_date": "2013-10-30",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/pfadmin_set_protected_alias",
+    "description": "Postfixadmin installations between 2.91 and 3.0.1 do not check if an\n          admin is allowed to delete protected aliases. This vulnerability can be\n          used to redirect protected aliases to an other mail address. Eg. rewrite\n          the postmaster@domain alias.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "PHP",
+    "cve": [
+      "CVE-2017-5930"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "pfadmin-set-protected-alias"
+    ],
+    "transcript": "",
+    "doc": "Postfixadmin Protected Alias Deletion Vulnerability",
+    "disclosure_date": "2017-02-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/pihole_domains_api_exec",
+    "description": "This exploits a command execution in Pi-Hole Web Interface <= 5.5.\n          The Settings > API/Web inetrace page contains the field\n          Top Domains/Top Advertisers which is validated by a regex which does not properly\n          filter system commands, which can then be executed by calling the gravity\n          functionality.  However, the regex only allows a-z, 0-9, _.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "PHP",
+    "cve": [
+      "CVE-2021-32706"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "pihole-domains-api-exec"
+    ],
+    "transcript": "",
+    "doc": "Pi-Hole Top Domains API Authenticated Exec",
+    "disclosure_date": "2021-08-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/rails_devise_pass_reset",
+    "description": "The Devise authentication gem for Ruby on Rails is vulnerable\n          to a password reset exploit leveraging type confusion.  By submitting XML\n          to rails, we can influence the type used for the reset_password_token\n          parameter.  This allows for resetting passwords of arbitrary accounts,\n          knowing only the associated email address.\n\n          This module defaults to the most common devise URIs and response values,\n          but these may require adjustment for implementations which customize them.\n\n          Affects Devise < v2.2.3, 2.1.3, 2.0.5 and 1.5.4 when backed by any database\n          except PostgreSQL or SQLite3. Tested with v2.2.2, 2.1.2, and 2.0.4 on Rails\n          3.2.11. Patch applied to Rails 3.2.12 and 3.1.11 should prevent exploitation\n          of this vulnerability, by quoting numeric values when comparing them with\n          non numeric values.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-0233"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "rails-devise-pass-reset"
+    ],
+    "transcript": "",
+    "doc": "Ruby on Rails Devise Authentication Password Reset",
+    "disclosure_date": "2013-01-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/scadabr_credential_dump",
+    "description": "This module retrieves credentials from ScadaBR, including\n          service credentials and unsalted SHA1 password hashes for\n          all users, by invoking the `EmportDwr.createExportData` DWR\n          method of Mango M2M which is exposed to all authenticated\n          users regardless of privilege level.\n\n          This module has been tested successfully with ScadaBR\n          versions 1.0 CE and 0.9 on Windows and Ubuntu systems.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "scadabr-credential-dump"
+    ],
+    "transcript": "",
+    "doc": "ScadaBR Credentials Dumper",
+    "disclosure_date": "2017-05-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/scrutinizer_add_user",
+    "description": "This will add an administrative account to Scrutinizer NetFlow and sFlow Analyzer\n          without any authentication.  Versions such as 9.0.1 or older are affected.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-2626"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "scrutinizer-add-user"
+    ],
+    "transcript": "",
+    "doc": "Plixer Scrutinizer NetFlow and sFlow Analyzer HTTP Authentication Bypass",
+    "disclosure_date": "2012-07-27",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/sophos_wpa_traversal",
+    "description": "This module abuses a directory traversal in Sophos Web Protection Appliance, specifically\n          on the /cgi-bin/patience.cgi component. This module has been tested successfully on the\n          Sophos Web Virtual Appliance v3.7.0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-2641"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "sophos-wpa-traversal"
+    ],
+    "transcript": "",
+    "doc": "Sophos Web Protection Appliance patience.cgi Directory Traversal",
+    "disclosure_date": "2013-04-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/supra_smart_cloud_tv_rfi",
+    "description": "This module exploits an unauthenticated remote file inclusion which\n          exists in Supra Smart Cloud TV. The media control for the device doesn't\n          have any session management or authentication. Leveraging this, an\n          attacker on the local network can send a crafted request to broadcast a\n          fake video.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-12477"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "supra-smart-cloud-tv-rfi"
+    ],
+    "transcript": "",
+    "doc": "Supra Smart Cloud TV Remote File Inclusion",
+    "disclosure_date": "2019-06-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/sysaid_admin_acct",
+    "description": "This module exploits a vulnerability in SysAid Help Desk that allows an unauthenticated\n          user to create an administrator account. Note that this exploit will only work once. Any\n          subsequent attempts will fail. On the other hand, the credentials must be verified\n          manually. This module has been tested on SysAid 14.4 in Windows and Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-2993"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "sysaid-admin-acct"
+    ],
+    "transcript": "",
+    "doc": "SysAid Help Desk Administrator Account Creation",
+    "disclosure_date": "2015-06-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/sysaid_file_download",
+    "description": "This module exploits two vulnerabilities in SysAid Help Desk that allows\n          an unauthenticated user to download arbitrary files from the system. First, an\n          information disclosure vulnerability (CVE-2015-2997) is used to obtain the file\n          system path, and then we abuse a directory traversal (CVE-2015-2996) to download\n          the file. Note that there are some limitations on Windows, in that the information\n          disclosure vulnerability doesn't work on a Windows platform, and we can only\n          traverse the current drive (if you enter C:\\afile.txt and the server is running\n          on D:\\ the file will not be downloaded).\n\n          This module has been tested with SysAid 14.4 on Windows and Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-2996",
+      "CVE-2015-2997"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "sysaid-file-download"
+    ],
+    "transcript": "",
+    "doc": "SysAid Help Desk Arbitrary File Download",
+    "disclosure_date": "2015-06-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/sysaid_sql_creds",
+    "description": "This module exploits a vulnerability in SysAid Help Desk that allows an unauthenticated\n          user to download arbitrary files from the system. This is used to download the server\n          configuration file that contains the database username and password, which is encrypted\n          with a fixed, known key. This module has been tested with SysAid 14.4 on Windows and Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-2996",
+      "CVE-2015-2998"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "sysaid-sql-creds"
+    ],
+    "transcript": "",
+    "doc": "SysAid Help Desk Database Credentials Disclosure",
+    "disclosure_date": "2015-06-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/telpho10_credential_dump",
+    "description": "This module exploits a vulnerability present in all versions of Telpho10 telephone system\n          appliance. This module generates a configuration backup of Telpho10,\n          downloads the file and dumps the credentials for admin login,\n          phpmyadmin, phpldapadmin, etc.\n          This module has been successfully tested on the appliance versions 2.6.31 and 2.6.39.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "telpho10-credential-dump"
+    ],
+    "transcript": "",
+    "doc": "Telpho10 Backup Credentials Dumper",
+    "disclosure_date": "2016-09-02",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/tomcat_administration",
+    "description": "Detect the Tomcat administration interface.  The administration interface is included in versions 5.5 and lower.\n                        Port 8180 is the default for FreeBSD, 8080 for all others.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "tomcat-administration"
+    ],
+    "transcript": "",
+    "doc": "Tomcat Administration Tool Default Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/tomcat_ghostcat",
+    "description": "When using the Apache JServ Protocol (AJP), care must be taken when trusting incoming connections to Apache\n          Tomcat. Tomcat treats AJP connections as having higher trust than, for example, a similar HTTP connection.\n          If such connections are available to an attacker, they can be exploited in ways that may be surprising.\n\n          In Apache Tomcat 9.0.0.M1 to 9.0.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99, Tomcat shipped with an AJP\n          Connector enabled by default that listened on all configured IP addresses. It was expected (and recommended\n          in the security guide) that this Connector would be disabled if not required. This vulnerability report\n          identified a mechanism that allowed: - returning arbitrary files from anywhere in the web application -\n          processing any file in the web application as a JSP. Further, if the web application allowed file upload\n          and stored those files within the web application (or the attacker was able to control the content of the\n          web application by some other means) then this, along with the ability to process a file as a JSP, made\n          remote code execution possible.\n\n          It is important to note that mitigation is only required if an AJP port is accessible to untrusted users.\n          Users wishing to take a defence-in-depth approach and block the vector that permits returning arbitrary files\n          and execution as JSP may upgrade to Apache Tomcat 9.0.31, 8.5.51 or 7.0.100 or later. A number of changes were\n          made to the default AJP Connector configuration in 9.0.31 to harden the default configuration.\n          It is likely that users upgrading to 9.0.31, 8.5.51 or 7.0.100 or later will need to make small changes\n          to their configurations.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-1938"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "tomcat-ghostcat"
+    ],
+    "transcript": "",
+    "doc": "Apache Tomcat AJP File Read",
+    "disclosure_date": "2020-02-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/tomcat_utf8_traversal",
+    "description": "This module tests whether a directory traversal vulnerability is present\n        in versions of Apache Tomcat 4.1.0 - 4.1.37, 5.5.0 - 5.5.26 and 6.0.0\n        - 6.0.16 under specific and non-default installations. The connector must have\n        allowLinking set to true and URIEncoding set to UTF-8. Furthermore, the\n        vulnerability actually occurs within Java and not Tomcat; the server must\n        use Java versions prior to Sun 1.4.2_19, 1.5.0_17, 6u11 - or prior IBM Java\n        5.0 SR9, 1.4.2 SR13, SE 6 SR4 releases. This module has only been tested against\n        RedHat 9 running Tomcat 6.0.16 and Sun JRE 1.5.0-05. You may wish to change\n        FILE (hosts,sensitive files), MAXDIRS and RPORT depending on your environment.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2938"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "tomcat-utf8-traversal"
+    ],
+    "transcript": "",
+    "doc": "Tomcat UTF-8 Directory Traversal Vulnerability",
+    "disclosure_date": "2009-01-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/trendmicro_dlp_traversal",
+    "description": "This module tests whether a directory traversal vulnerability is present\n        in Trend Micro DLP (Data Loss Prevention) Appliance v5.5 build <= 1294.\n        The vulnerability appears to be actually caused by the Tomcat UTF-8\n        bug which is implemented in module tomcat_utf8_traversal CVE 2008-2938.\n        This module simply tests for the same bug with Trend Micro specific settings.\n        Note that in the Trend Micro appliance, /etc/shadow is not used and therefore\n        password hashes are stored and anonymously accessible in the passwd file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2938"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "trendmicro-dlp-traversal"
+    ],
+    "transcript": "",
+    "doc": "TrendMicro Data Loss Prevention 5.5 Directory Traversal",
+    "disclosure_date": "2009-01-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/typo3_news_module_sqli",
+    "description": "This module exploits a SQL Injection vulnerability In TYPO3 NewsController.php\n          in the news module 5.3.2 and earlier. It allows an unauthenticated user to execute arbitrary\n          SQL commands via vectors involving overwriteDemand and OrderByAllowed. The SQL injection\n          can be used to obtain password hashes for application user accounts. This module has been\n          tested on TYPO3 3.16.0 running news extension 5.0.0.\n\n          This module tries to extract username and password hash of the administrator user.\n          It tries to inject sql and check every letter of a pattern, to see\n          if it belongs to the username or password it tries to alter the ordering of results. If\n          the letter doesn't belong to the word being extracted then all results are inverted\n          (News #2 appears before News #1, so Pattern2 before Pattern1), instead if the letter belongs\n          to the word being extracted then the results are in proper order (News #1 appears before News #2,\n          so Pattern1 before Pattern2)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "PHP",
+    "cve": [
+      "CVE-2017-7581"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "typo3-news-module-sqli"
+    ],
+    "transcript": "",
+    "doc": "TYPO3 News Module SQL Injection",
+    "disclosure_date": "2017-04-06",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/typo3_sa_2009_001",
+    "description": "This module exploits a flaw in TYPO3 encryption ey creation process to allow for\n        file disclosure in the jumpUrl mechanism. This flaw can be used to read any file\n        that the web server user account has access to view.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-0255"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "typo3-sa-2009-001"
+    ],
+    "transcript": "",
+    "doc": "TYPO3 sa-2009-001 Weak Encryption Key File Disclosure",
+    "disclosure_date": "2009-01-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/typo3_sa_2009_002",
+    "description": "This module exploits a file disclosure vulnerability in the jumpUrl mechanism of\n          Typo3. This flaw can be used to read any file that the web server user account has\n          access to.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-0815"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "typo3-sa-2009-002"
+    ],
+    "transcript": "",
+    "doc": "Typo3 sa-2009-002 File Disclosure",
+    "disclosure_date": "2009-02-10",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/typo3_sa_2010_020",
+    "description": "This module exploits a flaw in the way the TYPO3 jumpurl feature matches hashes.\n        Due to this flaw a Remote File Disclosure is possible by matching the juhash of 0.\n        This flaw can be used to read any file that the web server user account has access to view.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-3714"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "typo3-sa-2010-020"
+    ],
+    "transcript": "",
+    "doc": "TYPO3 sa-2010-020 Remote File Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/typo3_winstaller_default_enc_keys",
+    "description": "This module exploits known default encryption keys found in the TYPO3 Winstaller.\n        This flaw allows for file disclosure in the jumpUrl mechanism. This issue can be\n        used to read any file that the web server user account has access to view.\n\n        The method used to create the juhash (short MD5 hash) was altered in later versions\n        of Typo3. Use the show actions command to display and select the version of TYPO3 in\n        use (defaults to the older method of juhash creation).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "typo3-winstaller-default-enc-keys"
+    ],
+    "transcript": "",
+    "doc": "TYPO3 Winstaller Default Encryption Keys",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/ulterius_file_download",
+    "description": "This module exploits a directory traversal vulnerability in Ulterius Server < v1.9.5.0\n          to download files from the affected host. A valid file path is needed to download a file.\n          Fortunately, Ulterius indexes every file on the system, which can be stored in the\n          following location:\n\n          http://ulteriusURL:port/.../fileIndex.db.\n\n          This module can download and parse the fileIndex.db file. There is also an option to\n          download a file using a provided path.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-16806"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "ulterius-file-download"
+    ],
+    "transcript": "",
+    "doc": "Ulterius Server File Download Vulnerability",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/vbulletin_upgrade_admin",
+    "description": "This module abuses the \"install/upgrade.php\" component on vBulletin 4.1+ and 4.5+ to\n          create a new administrator account, as exploited in the wild on October 2013. This module\n          has been tested successfully on vBulletin 4.1.5 and 4.1.0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-6129"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "vbulletin-upgrade-admin"
+    ],
+    "transcript": "",
+    "doc": "vBulletin Administrator Account Creation",
+    "disclosure_date": "2013-10-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/webnms_cred_disclosure",
+    "description": "This module abuses two vulnerabilities in WebNMS Framework Server 5.2 to extract\n          all user credentials. The first vulnerability is an unauthenticated file download\n          in the FetchFile servlet, which is used to download the file containing the user\n          credentials. The second vulnerability is that the passwords in the file are\n          obfuscated with a very weak algorithm which can be easily reversed.\n          This module has been tested with WebNMS Framework Server 5.2 and 5.2 SP1 on\n          Windows and Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-6601",
+      "CVE-2016-6602"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "webnms-cred-disclosure"
+    ],
+    "transcript": "",
+    "doc": "WebNMS Framework Server Credential Disclosure",
+    "disclosure_date": "2016-07-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/webnms_file_download",
+    "description": "This module abuses a vulnerability in WebNMS Framework Server 5.2 that allows an\n          unauthenticated user to download files off the file system by using a directory\n          traversal attack on the FetchFile servlet.\n          Note that only text files can be downloaded properly, as any binary file will get\n          mangled by the servlet. Also note that for Windows targets you can only download\n          files that are in the same drive as the WebNMS installation.\n          This module has been tested with WebNMS Framework Server 5.2 and 5.2 SP1 on\n          Windows and Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-6601"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "webnms-file-download"
+    ],
+    "transcript": "",
+    "doc": "WebNMS Framework Server Arbitrary Text File Download",
+    "disclosure_date": "2016-07-04",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/whatsup_gold_sqli",
+    "description": "This module exploits a SQL injection vulnerability in WhatsUp Gold, by changing the password of an existing user (such as of the default admin account)\n          to an attacker-controlled one.\n\n          WhatsUp Gold versions < v24.0.0 are affected.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-6670"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "whatsup-gold-sqli"
+    ],
+    "transcript": "",
+    "doc": "WhatsUp Gold SQL Injection (CVE-2024-6670)",
+    "disclosure_date": "2024-08-29",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_automatic_plugin_privesc",
+    "description": "This module exploits an unauthenticated arbitrary wordpress options change vulnerability\n          in the Automatic (wp-automatic) plugin <= 3.53.2. If WPEMAIL is provided, the administrator's email\n          address will be changed. User registration is\n          enabled, and default user role is set to administrator. A user is then created with\n          the USER name set. A valid EMAIL is required to get the registration email (not handled in MSF).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "PHP",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "wp-automatic-plugin-privesc"
+    ],
+    "transcript": "",
+    "doc": "WordPress Plugin Automatic Config Change to RCE",
+    "disclosure_date": "2021-09-06",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_custom_contact_forms",
+    "description": "The WordPress custom-contact-forms plugin <= 5.1.0.3 allows unauthenticated users to download\n          a SQL dump of the plugins database tables. It's also possible to upload files containing\n          SQL statements which will be executed. The module first tries to extract the WordPress\n          table prefix from the dump and then attempts to create a new admin user.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "wp-custom-contact-forms"
+    ],
+    "transcript": "",
+    "doc": "WordPress custom-contact-forms Plugin SQL Upload",
+    "disclosure_date": "2014-08-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_easycart_privilege_escalation",
+    "description": "The WordPress WP EasyCart plugin from version 1.1.30 to 3.0.20 allows authenticated\n          users of any user level to set any system option via a lack of validation in the\n          ec_ajax_update_option and ec_ajax_clear_all_taxrates functions located in\n          /inc/admin/admin_ajax_functions.php. The module first changes the admin e-mail address\n          to prevent any notifications being sent to the actual administrator during the attack,\n          re-enables user registration in case it has been disabled and sets the default role to\n          be administrator. This will allow for the user to create a new account with admin\n          privileges via the default registration page found at /wp-login.php?action=register.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-2673"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-easycart-privilege-escalation"
+    ],
+    "transcript": "",
+    "doc": "WordPress WP EasyCart Plugin Privilege Escalation",
+    "disclosure_date": "2015-02-25",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_gdpr_compliance_privesc",
+    "description": "The Wordpress GDPR Compliance plugin <= v1.4.2 allows unauthenticated users to set\n          wordpress administration options by overwriting values within the database.\n\n          The vulnerability is present in WordPress's admin-ajax.php, which allows unauthorized\n          users to trigger handlers and make configuration changes because of a failure to do\n          capability checks when executing the 'save_setting' internal action.\n\n          WARNING: The module sets Wordpress configuration options without reading their current\n          values and restoring them later.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-19207"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-gdpr-compliance-privesc"
+    ],
+    "transcript": "",
+    "doc": "WordPress WP GDPR Compliance Plugin Privilege Escalation",
+    "disclosure_date": "2018-11-08",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_google_maps_sqli",
+    "description": "This module exploits a SQL injection vulnerability in a REST endpoint\n        registered by the WordPress plugin wp-google-maps between 7.11.00 and\n        7.11.17 (included).\n\n        As the table prefix can be changed by administrators, set DB_PREFIX\n        accordingly.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-10692"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-google-maps-sqli"
+    ],
+    "transcript": "",
+    "doc": "WordPress Google Maps Plugin SQL Injection",
+    "disclosure_date": "2019-04-02",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_masterstudy_privesc",
+    "description": "MasterStudy LMS, a WordPress plugin,\n          prior to 2.7.6 is affected by a privilege escalation where an unauthenticated\n          user is able to create an administrator account for wordpress itself.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-0441"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-masterstudy-privesc"
+    ],
+    "transcript": "",
+    "doc": "Wordpress MasterStudy Admin Account Creation",
+    "disclosure_date": "2022-02-18",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_post_smtp_acct_takeover",
+    "description": "The POST SMTP WordPress plugin prior to 2.8.7 is affected by a privilege\n          escalation where an unauthenticated user is able to reset the password\n          of an arbitrary user. This is done by requesting a password reset, then\n          viewing the latest email logs to find the associated password reset email.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-6875"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-post-smtp-acct-takeover"
+    ],
+    "transcript": "",
+    "doc": "Wordpress POST SMTP Account Takeover",
+    "disclosure_date": "2024-01-10",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_symposium_sql_injection",
+    "description": "This module exploits a SQL injection vulnerability in the WP Symposium plugin\n          before 15.8 for WordPress, which allows remote attackers to extract credentials\n          via the size parameter to get_album_item.php.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-6522"
+    ],
+    "tags": [
+      "admin",
+      "http",
+      "wp-symposium-sql-injection"
+    ],
+    "transcript": "",
+    "doc": "WordPress Symposium Plugin SQL Injection",
+    "disclosure_date": "2015-08-18",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/wp_wplms_privilege_escalation",
+    "description": "The WordPress WPLMS theme from version 1.5.2 to 1.8.4.1 allows an\n          authenticated user of any user level to set any system option due to a lack of\n          validation in the import_data function of /includes/func.php.\n\n          The module first changes the admin e-mail address to prevent any\n          notifications being sent to the actual administrator during the attack,\n          re-enables user registration in case it has been disabled and sets the default\n          role to be administrator.  This will allow for the user to create a new account\n          with admin privileges via the default registration page found at\n          /wp-login.php?action=register.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "wp-wplms-privilege-escalation"
+    ],
+    "transcript": "",
+    "doc": "WordPress WPLMS Theme Privilege Escalation",
+    "disclosure_date": "2015-02-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/http/zyxel_admin_password_extractor",
+    "description": "This module exploits a vulnerability in ZyXEL GS1510-16 routers\n          to extract the admin password. Due to a lack of authentication on the\n          webctrl.cgi script, unauthenticated attackers can recover the\n          administrator password for these devices. The vulnerable device\n          has reached end of life for support from the manufacturer, so it is\n          unlikely this problem will be addressed.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "http",
+      "zyxel-admin-password-extractor"
+    ],
+    "transcript": "",
+    "doc": "ZyXEL GS1510-16 Password Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/forge_ticket",
+    "description": "This module forges a Kerberos ticket. Four different techniques can be used:\n          - Silver ticket: Using a service account hash, craft a ticket impersonating any user and privileges to that account.\n          - Golden ticket: Using the krbtgt hash, craft a ticket impersonating any user and privileges.\n          - Diamond ticket: Authenticate to the domain controller, and using the krbtgt hash, copy the PAC from the authenticated user to a forged ticket.\n          - Sapphire ticket: Use the S4U2Self+U2U trick to retrieve the PAC of another user, then use the krbtgt hash to craft a forged ticket.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "kerberos",
+      "forge-ticket"
+    ],
+    "transcript": "",
+    "doc": "Kerberos Silver/Golden/Diamond/Sapphire Ticket Forging",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/get_ticket",
+    "description": "This module requests TGT/TGS Kerberos tickets from the KDC",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "kerberos",
+      "get-ticket"
+    ],
+    "transcript": "",
+    "doc": "Kerberos TGT/TGS Ticket Requester",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/inspect_ticket",
+    "description": "This module outputs the contents of a ccache/kirbi file and optionally (when provided with the appropriate key)\n          decrypts and displays the encrypted content too.\n          Can be used for inspecting tickets that aren't working as intended in an effort to debug them.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "kerberos",
+      "inspect-ticket"
+    ],
+    "transcript": "",
+    "doc": "Kerberos Ticket Inspecting",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/keytab",
+    "description": "Utilities for interacting with keytab files, which can store the hashed passwords of one or\n          more principals.\n\n          Discovered keytab files can be used to generate Kerberos Ticket Granting Tickets, or bruteforced\n          offline.\n\n          Keytab files can be also useful for decrypting Kerberos traffic using Wireshark dissectors,\n          including the krbtgt encrypted blobs if the AES password hash is used.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "kerberos",
+      "keytab"
+    ],
+    "transcript": "",
+    "doc": "Kerberos keytab utilities",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/ms14_068_kerberos_checksum",
+    "description": "This module exploits a vulnerability in the Microsoft Kerberos implementation. The problem\n          exists in the verification of the Privilege Attribute Certificate (PAC) from a Kerberos TGS\n          request, where a domain user may forge a PAC with arbitrary privileges, including\n          Domain Administrator. This module requests a TGT ticket with a forged PAC and exports it to\n          a MIT Kerberos Credential Cache file. It can be loaded on Windows systems with the Mimikatz\n          help. It has been tested successfully on Windows 2008.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-6324"
+    ],
+    "tags": [
+      "admin",
+      "kerberos",
+      "ms14-068-kerberos-checksum"
+    ],
+    "transcript": "",
+    "doc": "MS14-068 Microsoft Kerberos Checksum Validation Vulnerability",
+    "disclosure_date": "2014-11-18",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/kerberos/ticket_converter",
+    "description": "This module converts tickets to the ccache format from the kirbi format and vice versa.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "kerberos",
+      "ticket-converter"
+    ],
+    "transcript": "",
+    "doc": "Kerberos ticket converter",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/ad_cs_cert_template",
+    "description": "This module can create, read, update, and delete AD CS certificate templates from a Active Directory Domain\n          Controller.\n\n          The READ, UPDATE, and DELETE actions will write a copy of the certificate template to disk that can be\n          restored using the CREATE or UPDATE actions. The CREATE and UPDATE actions require a certificate template data\n          file to be specified to define the attributes. Template data files are provided to create a template that is\n          vulnerable to ESC1, ESC2, ESC3 and ESC15.\n\n          This module is capable of exploiting ESC4.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "ldap",
+      "ad-cs-cert-template"
+    ],
+    "transcript": "",
+    "doc": "AD CS Certificate Template Management",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/change_password",
+    "description": "This module allows Active Directory users to change their own passwords, or reset passwords for\n          accounts they have privileges over.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "ldap",
+      "change-password"
+    ],
+    "transcript": "",
+    "doc": "Change Password",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/ldap_object_attribute",
+    "description": "This module allows creating, reading, updating and deleting attributes of LDAP objects.\n          Users can specify the object and must specify a corresponding attribute.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "ldap",
+      "ldap-object-attribute"
+    ],
+    "transcript": "",
+    "doc": "LDAP Update Object",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/rbcd",
+    "description": "This module can read and write the necessary LDAP attributes to configure a particular object for Role Based\n          Constrained Delegation (RBCD). When writing, the module will add an access control entry to allow the account\n          specified in DELEGATE_FROM to the object specified in DELEGATE_TO. In order for this to succeed, the\n          authenticated user must have write access to the target object (the object specified in DELEGATE_TO).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "ldap",
+      "rbcd"
+    ],
+    "transcript": "",
+    "doc": "Role Base Constrained Delegation",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/shadow_credentials",
+    "description": "This module can read and write the necessary LDAP attributes to configure a particular account with a\n          Key Credential Link. This allows weaponising write access to a user account by adding a certificate\n          that can subsequently be used to authenticate. In order for this to succeed, the authenticated user\n          must have write access to the target object (the object specified in TARGET_USER).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "ldap",
+      "shadow-credentials"
+    ],
+    "transcript": "",
+    "doc": "Shadow Credentials",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass",
+    "description": "This module bypasses LDAP authentication in VMware vCenter Server's\n          vmdir service to add an arbitrary administrator user. Version 6.7\n          prior to the 6.7U3f update is vulnerable, only if upgraded from a\n          previous release line, such as 6.0 or 6.5.\n          Note that it is also possible to provide a bind username and password\n          to authenticate if the target is not vulnerable. It will add an\n          arbitrary administrator user the same way.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-3952"
+    ],
+    "tags": [
+      "admin",
+      "ldap",
+      "vmware-vcenter-vmdir-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "VMware vCenter Server vmdir Authentication Bypass",
+    "disclosure_date": "2020-04-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/maxdb/maxdb_cons_exec",
+    "description": "SAP MaxDB is prone to a remote command-injection vulnerability\n          because the application fails to properly sanitize user-supplied input.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-0244"
+    ],
+    "tags": [
+      "admin",
+      "maxdb",
+      "maxdb-cons-exec"
+    ],
+    "transcript": "",
+    "doc": "SAP MaxDB cons.exe Remote Command Injection",
+    "disclosure_date": "2008-01-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/misc/brother_default_admin_auth_bypass_cve_2024_51978",
+    "description": "By leaking a target devices serial number, a remote attacker can generate the target devices default\n          administrator password. The target device may leak its serial number via unauthenticated HTTP, HTTPS, IPP,\n          SNMP, or PJL requests.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-51977",
+      "CVE-2024-51978"
+    ],
+    "tags": [
+      "admin",
+      "misc",
+      "brother-default-admin-auth-bypass-cve-2024-51978"
+    ],
+    "transcript": "",
+    "doc": "Multiple Brother devices authentication bypass via default administrator password generation",
+    "disclosure_date": "2025-06-25",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/misc/sercomm_dump_config",
+    "description": "This module will dump the configuration of several SerComm devices. These devices\n          typically include routers from NetGear and Linksys. This module was tested\n          successfully against the NetGear DG834 series ADSL modem router.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "misc",
+      "sercomm-dump-config"
+    ],
+    "transcript": "",
+    "doc": "SerComm Device Configuration Dump",
+    "disclosure_date": "2013-12-31",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/misc/wol",
+    "description": "This module will turn on a remote machine with a network card that\n          supports wake-on-lan (or MagicPacket).  In order to use this, you must\n          know the machine's MAC address in advance.  The current default MAC\n          address is just an example of how your input should look like.\n\n          The password field is optional.  If present, it should be in this hex\n          format: 001122334455, which is translated to \"0x001122334455\" in binary.\n          Note that this should be either 4 or 6 bytes long.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "misc",
+      "wol"
+    ],
+    "transcript": "",
+    "doc": "UDP Wake-On-Lan (WOL)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/motorola/wr850g_cred",
+    "description": "Login credentials to the Motorola WR850G router with\n          firmware v4.03 can be obtained via a simple GET request\n          if issued while the administrator is logged in.  A lot\n          more information is available through this request, but\n          you can get it all and more after logging in.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2004-1550"
+    ],
+    "tags": [
+      "admin",
+      "motorola",
+      "wr850g-cred"
+    ],
+    "transcript": "",
+    "doc": "Motorola WR850G v4.03 Credentials",
+    "disclosure_date": "2004-09-24",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/ms/ms08_059_his2006",
+    "description": "This module exploits a command-injection vulnerability in Microsoft Host Integration Server 2006.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-3466"
+    ],
+    "tags": [
+      "admin",
+      "ms",
+      "ms08-059-his2006"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Host Integration Server 2006 Command Execution Vulnerability",
+    "disclosure_date": "2008-10-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_enum",
+    "description": "This module will perform a series of configuration audits and\n          security checks against a Microsoft SQL Server database. For this\n          module to work, valid administrative user credentials must be\n          supplied.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-enum"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Configuration Enumerator",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_enum_domain_accounts",
+    "description": "This module can be used to bruteforce RIDs associated with the domain of the SQL Server\n          using the SUSER_SNAME function. This is similar to the smb_lookupsid module, but executed\n          through SQL Server queries as any user with the PUBLIC role (everyone). Information that\n          can be enumerated includes Windows domain users, groups, and computer accounts. Enumerated\n          accounts can then be used in online dictionary attacks.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-enum-domain-accounts"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SUSER_SNAME Windows Domain Account Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_enum_domain_accounts_sqli",
+    "description": "This module can be used to bruteforce RIDs associated with the domain of the SQL Server\n          using the SUSER_SNAME function via Error Based SQL injection. This is similar to the\n          smb_lookupsid module, but executed through SQL Server queries as any user with the PUBLIC\n          role (everyone). Information that can be enumerated includes Windows domain users, groups,\n          and computer accounts.  Enumerated accounts can then be used in online dictionary attacks.\n          The syntax for injection URLs is: /testing.asp?id=1+and+1=[SQLi];--",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-enum-domain-accounts-sqli"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SQLi SUSER_SNAME Windows Domain Account Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_enum_sql_logins",
+    "description": "This module can be used to obtain a list of all logins from a SQL Server with any login.\n          Selecting all of the logins from the master..syslogins table is restricted to sysadmins.\n          However, logins with the PUBLIC role (everyone) can quickly enumerate all SQL Server\n          logins using the SUSER_SNAME function by fuzzing the principal_id parameter. This is\n          pretty simple, because the principal IDs assigned to logins are incremental.  Once logins\n          have been enumerated they can be verified via sp_defaultdb error analysis. This is\n          important, because not all of the principal IDs resolve to SQL logins (some resolve to\n          roles instead). Once logins have been enumerated, they can be used in dictionary attacks.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-enum-sql-logins"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SUSER_SNAME SQL Logins Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_escalate_dbowner",
+    "description": "This module can be used to escalate privileges to sysadmin if the user has\n          the db_owner role in a trustworthy database owned by a sysadmin user.  Once\n          the user has the sysadmin role the msssql_payload module can be used to obtain\n          a shell on the system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-escalate-dbowner"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Escalate Db_Owner",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_escalate_dbowner_sqli",
+    "description": "This module can be used to escalate SQL Server user privileges to sysadmin through a web\n          SQL Injection. In order to escalate, the database user must to have the db_owner role in\n          a trustworthy database owned by a sysadmin user. Once the database user has the sysadmin\n          role, the mssql_payload_sqli module can be used to obtain a shell on the system.\n\n          The syntax for injection URLs is: /testing.asp?id=1+and+1=[SQLi];--",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-escalate-dbowner-sqli"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SQLi Escalate Db_Owner",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_escalate_execute_as",
+    "description": "This module can be used escalate privileges if the IMPERSONATION privilege has been\n          assigned to the user. In most cases, this results in additional data access, but in\n          some cases it can be used to gain sysadmin privileges.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-escalate-execute-as"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Escalate EXECUTE AS",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_escalate_execute_as_sqli",
+    "description": "This module can be used escalate privileges if the IMPERSONATION privilege has been\n          assigned to the user via error based SQL injection.  In most cases, this results in\n          additional data access, but in some cases it can be used to gain sysadmin privileges.\n          The syntax for injection URLs is: /testing.asp?id=1+and+1=[SQLi];--",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-escalate-execute-as-sqli"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SQLi Escalate Execute AS",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_exec",
+    "description": "This module will execute a Windows command on a MSSQL/MSDE instance via the xp_cmdshell (default) or the\n          sp_oacreate procedure (more opsec safe, no output, no temporary data table). A valid username and password is\n          required to use this module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-exec"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Command Execution",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_findandsampledata",
+    "description": "This script will search through all of the non-default databases\n          on the SQL Server for columns that match the keywords defined in the TSQL KEYWORDS\n          option. If column names are found that match the defined keywords and data is present\n          in the associated tables, the script will select a sample of the records from each of\n          the affected tables.  The sample size is determined by the SAMPLE_SIZE option, and results\n          output in a CSV format.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-findandsampledata"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Find and Sample Data",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_idf",
+    "description": "This module will search the specified MSSQL server for\n          'interesting' columns and data.\n\n          This module has been tested against the latest SQL Server 2019 docker container image (22/04/2021).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-idf"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Interesting Data Finder",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_ntlm_stealer",
+    "description": "This module can be used to help capture or relay the LM/NTLM credentials of the\n          account running the remote SQL Server service. The module will use the supplied\n          credentials to connect to the target SQL Server instance and execute the native\n          \"xp_dirtree\" or \"xp_fileexist\" stored procedure.   The stored procedures will then\n          force the service account to authenticate to the system defined in the SMBProxy\n          option. In order for the attack to be successful, the SMB capture or relay module\n          must be running on the system defined as the SMBProxy.  The database account used\n          to connect to the database should only require the \"PUBLIC\" role to execute.\n          Successful execution of this attack usually results in local administrative access\n          to the Windows system.  Specifically, this works great for relaying credentials\n          between two SQL Servers using a shared service account to get shells.  However, if\n          the relay fails, then the LM hash can be reversed using the Halflm rainbow tables\n          and john the ripper. Thanks to \"Sh2kerr\" who wrote the ora_ntlm_stealer for the\n          inspiration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-ntlm-stealer"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server NTLM Stealer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_ntlm_stealer_sqli",
+    "description": "This module can be used to help capture or relay the LM/NTLM credentials of the\n          account running the remote SQL Server service. The module will use the SQL\n          injection from GET_PATH to connect to the target SQL Server instance and execute\n          the native \"xp_dirtree\" or stored procedure.   The stored procedures will then\n          force the service account to authenticate to the system defined in the SMBProxy\n          option. In order for the attack to be successful, the SMB capture or relay module\n          must be running on the system defined as the SMBProxy. The database account used to\n          connect to the database should only require the \"PUBLIC\" role to execute.\n          Successful execution of this attack usually results in local administrative access\n          to the Windows system.  Specifically, this works great for relaying credentials\n          between two SQL Servers using a shared service account to get shells.  However, if\n          the relay fails, then the LM hash can be reversed using the Halflm rainbow tables\n          and john the ripper.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-ntlm-stealer-sqli"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server SQLi NTLM Stealer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_sql",
+    "description": "This module will allow for simple SQL statements to be executed against a\n          MSSQL/MSDE instance given the appropriate credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-sql"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Generic Query",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mssql/mssql_sql_file",
+    "description": "This module will allow for multiple SQL queries contained within a specified\n          file to be executed against a Microsoft SQL (MSSQL) Server instance, given\n          the appropriate credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mssql",
+      "mssql-sql-file"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SQL Server Generic Query from File",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mysql/mysql_enum",
+    "description": "This module allows for simple enumeration of MySQL Database Server\n          provided proper credentials to connect remotely.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mysql",
+      "mysql-enum"
+    ],
+    "transcript": "",
+    "doc": "MySQL Enumeration Module",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/mysql/mysql_sql",
+    "description": "This module allows for simple SQL statements to be executed\n          against a MySQL instance given the appropriate credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "mysql",
+      "mysql-sql"
+    ],
+    "transcript": "",
+    "doc": "MySQL SQL Generic Query",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/natpmp/natpmp_map",
+    "description": "Map (forward) TCP and UDP ports on NAT devices using NAT-PMP",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "natpmp",
+      "natpmp-map"
+    ],
+    "transcript": "",
+    "doc": "NAT-PMP Port Mapper",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/netbios/netbios_spoof",
+    "description": "This module continuously spams NetBIOS responses to a target for given hostname,\n        causing the target to cache a malicious address for this name. On high-speed local\n        networks, the PPSRATE value should be increased to speed up this attack. As an\n        example, a value of around 30,000 is almost 100% successful when spoofing a\n        response for a 'WPAD' lookup. Distant targets may require more time and lower\n        rates for a successful attack.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "netbios",
+      "netbios-spoof"
+    ],
+    "transcript": "",
+    "doc": "NetBIOS Response Brute Force Spoof (Direct)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/arista_config",
+    "description": "This module imports an Arista device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "arista-config"
+    ],
+    "transcript": "",
+    "doc": "Arista Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/brocade_config",
+    "description": "This module imports a Brocade device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "brocade-config"
+    ],
+    "transcript": "",
+    "doc": "Brocade Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_asa_extrabacon",
+    "description": "This module patches the authentication functions of a Cisco ASA\n          to allow uncredentialed logins. Uses improved shellcode for payload.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-6366"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-asa-extrabacon"
+    ],
+    "transcript": "",
+    "doc": "Cisco ASA Authentication Bypass (EXTRABACON)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_config",
+    "description": "This module imports a Cisco IOS or NXOS device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-config"
+    ],
+    "transcript": "",
+    "doc": "Cisco Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_dcnm_auth_bypass",
+    "description": "This exploit is able to add an admin account to a Cisco DCNM with credentials you can choose.\n          After that, you can login to the web interface with those credentials.\n          The only necessary condition is the more or less recent connection of an admin as this exploit\n          uses a kind of session stealing.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-15975"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-dcnm-auth-bypass"
+    ],
+    "transcript": "",
+    "doc": "Cisco DCNM auth bypass",
+    "disclosure_date": "2020-06-01",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_dcnm_download",
+    "description": "DCNM exposes a servlet to download files on /fm/downloadServlet.\n          An authenticated user can abuse this servlet to download arbitrary files as root by specifying\n          the full path of the file.\n          This module was tested on the DCNM Linux virtual appliance 10.4(2), 11.0(1) and 11.1(1), and should\n          work on a few versions below 10.4(2). Only version 11.0(1) requires authentication to exploit\n          (see References to understand why).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-1619",
+      "CVE-2019-1621"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-dcnm-download"
+    ],
+    "transcript": "",
+    "doc": "Cisco Data Center Network Manager Unauthenticated File Download",
+    "disclosure_date": "2019-06-26",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_secure_acs_bypass",
+    "description": "This module exploits an authentication bypass issue which allows arbitrary\n          password change requests to be issued for any user in the local store.\n          Instances of Secure ACS running version 5.1 with patches 3, 4, or 5 as well\n          as version 5.2 with either no patches or patches 1 and 2 are vulnerable.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0951"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-secure-acs-bypass"
+    ],
+    "transcript": "",
+    "doc": "Cisco Secure ACS Unauthorized Password Change",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/cisco_vpn_3000_ftp_bypass",
+    "description": "This module tests for a logic vulnerability in the Cisco VPN Concentrator\n          3000 series. It is possible to execute some FTP statements without authentication\n          (CWD, RNFR, MKD, RMD, SIZE, CDUP). It also appears to have some memory leak bugs\n          when working with CWD commands. This module simply creates an arbitrary directory,\n          verifies that the directory has been created, then deletes it and verifies deletion\n          to confirm the bug.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-4313"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "cisco-vpn-3000-ftp-bypass"
+    ],
+    "transcript": "",
+    "doc": "Cisco VPN Concentrator 3000 FTP Unauthorized Administrative Access",
+    "disclosure_date": "2006-08-23",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/f5_config",
+    "description": "This module imports an F5 device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "f5-config"
+    ],
+    "transcript": "",
+    "doc": "F5 Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/juniper_config",
+    "description": "This module imports a Juniper ScreenOS or JunOS device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "juniper-config"
+    ],
+    "transcript": "",
+    "doc": "Juniper Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/mikrotik_config",
+    "description": "This module imports a Mikrotik device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "mikrotik-config"
+    ],
+    "transcript": "",
+    "doc": "Mikrotik Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/thinmanager_traversal_delete",
+    "description": "This module exploits a path traversal vulnerability (CVE-2023-2915) in\n          ThinManager <= v13.1.0 to delete arbitrary files from the system.\n          The affected service listens by default on TCP port 2031 and runs in the\n          context of NT AUTHORITY\\SYSTEM.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-2915"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "thinmanager-traversal-delete"
+    ],
+    "transcript": "",
+    "doc": "ThinManager Path Traversal (CVE-2023-2915) Arbitrary File Delete",
+    "disclosure_date": "2023-08-17",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/thinmanager_traversal_upload",
+    "description": "This module exploits a path traversal vulnerability (CVE-2023-27855) in\n          ThinManager <= v13.0.1 to upload arbitrary files to the target system.\n          The affected service listens by default on TCP port 2031 and runs in the\n          context of NT AUTHORITY\\SYSTEM.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-27855"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "thinmanager-traversal-upload"
+    ],
+    "transcript": "",
+    "doc": "ThinManager Path Traversal (CVE-2023-27855) Arbitrary File Upload",
+    "disclosure_date": "2023-04-05",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/thinmanager_traversal_upload2",
+    "description": "This module exploits a path traversal vulnerability (CVE-2023-2917) in\n          ThinManager <= v13.1.0 to upload arbitrary files to the target system.\n          The affected service listens by default on TCP port 2031 and runs in the\n          context of NT AUTHORITY\\SYSTEM.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-2917"
+    ],
+    "tags": [
+      "admin",
+      "networking",
+      "thinmanager-traversal-upload2"
+    ],
+    "transcript": "",
+    "doc": "ThinManager Path Traversal (CVE-2023-2917) Arbitrary File Upload",
+    "disclosure_date": "2023-08-17",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/ubiquiti_config",
+    "description": "This module imports an Ubiquiti device configuration.\n          The db file within the .unf backup is the data file for\n          Unifi. This module can take either the db file or .unf.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "ubiquiti-config"
+    ],
+    "transcript": "",
+    "doc": "Ubiquiti Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/networking/vyos_config",
+    "description": "This module imports a VyOS device configuration.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "networking",
+      "vyos-config"
+    ],
+    "transcript": "",
+    "doc": "VyOS Configuration Importer",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/officescan/tmlisten_traversal",
+    "description": "This module tests for directory traversal vulnerability in the UpdateAgent\n        function in the OfficeScanNT Listener (TmListen.exe) service in Trend Micro\n        OfficeScan. This allows remote attackers to read arbitrary files as SYSTEM\n        via dot dot sequences in an HTTP request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2439"
+    ],
+    "tags": [
+      "admin",
+      "officescan",
+      "tmlisten-traversal"
+    ],
+    "transcript": "",
+    "doc": "TrendMicro OfficeScanNT Listener Traversal Arbitrary File Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/ora_ntlm_stealer",
+    "description": "This module will help you to get Administrator access to OS using an unprivileged\n          Oracle database user (you need only CONNECT and RESOURCE privileges).\n          To do this you must firstly run smb_sniffer or smb_relay module on your server.\n          Then you must connect to Oracle database and run this module Ora_NTLM_stealer.rb\n          which will connect to your SMB server with credentials of Oracle RDBMS.\n          So if smb_relay is working, you will get Administrator access to server which\n          runs Oracle. If not than you can decrypt HALFLM hash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "ora-ntlm-stealer"
+    ],
+    "transcript": "",
+    "doc": "Oracle SMB Relay Code Execution",
+    "disclosure_date": "2009-04-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/oracle_index_privesc",
+    "description": "This module will escalate an Oracle DB user to DBA by creating a\n          function-based index on a table owned by a more-privileged user.\n          Credits to David Litchfield for publishing the technique.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "oracle-index-privesc"
+    ],
+    "transcript": "",
+    "doc": "Oracle DB Privilege Escalation via Function-Based Index",
+    "disclosure_date": "2015-01-21",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/oracle_login",
+    "description": "This module uses a list of well known default authentication credentials\n          to discover easily guessed accounts.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "oracle-login"
+    ],
+    "transcript": "",
+    "doc": "Oracle Account Discovery",
+    "disclosure_date": "2008-11-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/oracle_sql",
+    "description": "This module allows for simple SQL statements to be executed\n          against an Oracle instance given the appropriate credentials\n          and sid.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "oracle-sql"
+    ],
+    "transcript": "",
+    "doc": "Oracle SQL Generic Query",
+    "disclosure_date": "2007-12-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/oraenum",
+    "description": "This module provides a simple way to scan an Oracle database server\n          for configuration parameters that may be useful during a penetration\n          test. Valid database credentials must be provided for this module to\n          run.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "oraenum"
+    ],
+    "transcript": "",
+    "doc": "Oracle Database Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/osb_execqr",
+    "description": "This module exploits a command injection vulnerability in Oracle Secure Backup version 10.1.0.3 to 10.2.0.2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-5448"
+    ],
+    "tags": [
+      "admin",
+      "oracle",
+      "osb-execqr"
+    ],
+    "transcript": "",
+    "doc": "Oracle Secure Backup exec_qr() Command Injection Vulnerability",
+    "disclosure_date": "2009-01-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/osb_execqr2",
+    "description": "This module exploits an authentication bypass vulnerability\n          in login.php in order to execute arbitrary code via a command injection\n          vulnerability in property_box.php. This module was tested\n          against Oracle Secure Backup version 10.3.0.1.0 (Win32).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-1977",
+      "CVE-2009-1978"
+    ],
+    "tags": [
+      "admin",
+      "oracle",
+      "osb-execqr2"
+    ],
+    "transcript": "",
+    "doc": "Oracle Secure Backup Authentication Bypass/Command Injection Vulnerability",
+    "disclosure_date": "2009-08-18",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/osb_execqr3",
+    "description": "This module exploits an authentication bypass vulnerability\n          in login.php in order to execute arbitrary code via a command injection\n          vulnerability in property_box.php. This module was tested\n          against Oracle Secure Backup version 10.3.0.1.0 (Win32).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0904"
+    ],
+    "tags": [
+      "admin",
+      "oracle",
+      "osb-execqr3"
+    ],
+    "transcript": "",
+    "doc": "Oracle Secure Backup Authentication Bypass/Command Injection Vulnerability",
+    "disclosure_date": "2010-07-13",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/post_exploitation/win32exec",
+    "description": "This module will create a java class which enables the execution of OS commands.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "post-exploitation"
+    ],
+    "transcript": "",
+    "doc": "Oracle Java execCommand (Win32)",
+    "disclosure_date": "2007-12-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/post_exploitation/win32upload",
+    "description": "This module will create a Java class which enables the download\n          of a binary from a webserver to the Oracle filesystem.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "post-exploitation"
+    ],
+    "transcript": "",
+    "doc": "Oracle URL Download",
+    "disclosure_date": "2005-02-10",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/sid_brute",
+    "description": "This module simply attempts to discover the protected SID.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "sid-brute"
+    ],
+    "transcript": "",
+    "doc": "Oracle TNS Listener SID Brute Forcer",
+    "disclosure_date": "2009-01-07",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/oracle/tnscmd",
+    "description": "This module allows for the sending of arbitrary TNS commands in order\n          to gather information.\n          Inspired from tnscmd.pl from www.jammed.com/~jwa/hacks/security/tnscmd/tnscmd",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "oracle",
+      "tnscmd"
+    ],
+    "transcript": "",
+    "doc": "Oracle TNS Listener Command Issuer",
+    "disclosure_date": "2009-02-01",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/pop2/uw_fileretrieval",
+    "description": "This module exploits a vulnerability in the FOLD command of the\n          University of Washington ipop2d service. By specifying an arbitrary\n          folder name it is possible to retrieve any file which is world or group\n          readable by the user ID of the POP account. This vulnerability can only\n          be exploited with a valid username and password. The From address is\n          the file owner.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "pop2",
+      "uw-fileretrieval"
+    ],
+    "transcript": "",
+    "doc": "UoW pop2d Remote File Retrieval Vulnerability",
+    "disclosure_date": "2000-07-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/postgres/postgres_readfile",
+    "description": "This module imports a file local on the PostgreSQL Server into a\n          temporary table, reads it, and then drops the temporary table.\n          It requires PostgreSQL credentials with table CREATE privileges\n          as well as read privileges to the target file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "postgres",
+      "postgres-readfile"
+    ],
+    "transcript": "",
+    "doc": "PostgreSQL Server Generic Query",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/postgres/postgres_sql",
+    "description": "This module will allow for simple SQL statements to be executed against a\n          PostgreSQL instance given the appropriate credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "postgres",
+      "postgres-sql"
+    ],
+    "transcript": "",
+    "doc": "PostgreSQL Server Generic Query",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/registry_security_descriptor",
+    "description": "Read or write a Windows registry security descriptor remotely.\n\n          In READ mode, the `FILE` option can be set to specify where the\n          security descriptor should be written to.\n\n          The following format is used:\n          ```\n          key: <registry key>\n          security_info: <security information>\n          sd: <security descriptor as a hex string>\n          ```\n\n          In WRITE mode, the `FILE` option can be used to specify the information\n          needed to write the security descriptor to the remote registry. The file must\n          follow the same format as described above.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "registry-security-descriptor"
+    ],
+    "transcript": "",
+    "doc": "Windows Registry Security Descriptor Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sap/cve_2020_6207_solman_rce",
+    "description": "This module exploits the CVE-2020-6207 vulnerability within the SAP EEM servlet (tc~smd~agent~application~eem) of\n          SAP Solution Manager (SolMan) running version 7.2. The vulnerability occurs due to missing authentication\n          checks when submitting SOAP requests to the /EemAdminService/EemAdmin page to get information about connected SMDAgents,\n          send HTTP request (SSRF), and execute OS commands on connected SMDAgent. Works stable in connected SMDAgent with Java version 1.8.\n\n          Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected\n          to SolMan as a user from which the SMDAgent service starts, usually the daaadm.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-6207"
+    ],
+    "tags": [
+      "admin",
+      "sap",
+      "cve-2020-6207-solman-rce"
+    ],
+    "transcript": "",
+    "doc": "SAP Solution Manager remote unauthorized OS commands execution",
+    "disclosure_date": "2020-10-03",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sap/cve_2020_6287_ws_add_user",
+    "description": "This module leverages an unauthenticated web service to submit a job which will create a user with a specified\n          role. The job involves running a wizard. After the necessary action is taken, the job is canceled to avoid\n          unnecessary system changes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-6287"
+    ],
+    "tags": [
+      "admin",
+      "sap",
+      "cve-2020-6287-ws-add-user"
+    ],
+    "transcript": "",
+    "doc": "SAP Unauthenticated WebService User Creation",
+    "disclosure_date": "2020-07-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sap/sap_configservlet_exec_noauth",
+    "description": "This module allows execution of operating system commands through the SAP\n          ConfigServlet without any authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "sap",
+      "sap-configservlet-exec-noauth"
+    ],
+    "transcript": "",
+    "doc": "SAP ConfigServlet OS Command Execution",
+    "disclosure_date": "2012-11-01",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sap/sap_igs_xmlchart_xxe",
+    "description": "This module exploits CVE-2018-2392 and CVE-2018-2393, two XXE vulnerabilities within the XMLCHART page\n          of SAP Internet Graphics Servers (IGS) running versions 7.20, 7.20EXT, 7.45, 7.49, or 7.53. These\n          vulnerabilities occur due to a lack of appropriate validation on the Extension HTML tag when\n          submitting a POST request to the XMLCHART page to generate a new chart.\n\n          Successful exploitation will allow unauthenticated remote attackers to read files from the server as the user\n          from which the IGS service is started, which will typically be the SAP admin user. Alternatively attackers\n          can also abuse the XXE vulnerability to conduct a denial of service attack against the vulnerable\n          SAP IGS server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-2392",
+      "CVE-2018-2393"
+    ],
+    "tags": [
+      "admin",
+      "sap",
+      "sap-igs-xmlchart-xxe"
+    ],
+    "transcript": "",
+    "doc": "SAP Internet Graphics Server (IGS) XMLCHART XXE",
+    "disclosure_date": "2018-03-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sap/sap_mgmt_con_osexec",
+    "description": "This module allows execution of operating system commands through the SAP\n        Management Console SOAP Interface. A valid username and password must be\n        provided.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "sap",
+      "sap-mgmt-con-osexec"
+    ],
+    "transcript": "",
+    "doc": "SAP Management Console OSExecute",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/advantech_webaccess_dbvisitor_sqli",
+    "description": "This module exploits a SQL injection vulnerability found in Advantech WebAccess 7.1. The\n          vulnerability exists in the DBVisitor.dll component, and can be abused through malicious\n          requests to the ChartThemeConfig web service. This module can be used to extract the site\n          and project usernames and hashes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-0763"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "advantech-webaccess-dbvisitor-sqli"
+    ],
+    "transcript": "",
+    "doc": "Advantech WebAccess DBVisitor.dll ChartThemeConfig SQL Injection",
+    "disclosure_date": "2014-04-08",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/ge_proficy_substitute_traversal",
+    "description": "This module abuses a directory traversal in GE Proficy Cimplicity, specifically on the\n          gefebt.exe component used by the WebView, in order to retrieve arbitrary files with SYSTEM\n          privileges. This module has been tested successfully on GE Proficy Cimplicity 7.5.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-0653"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "ge-proficy-substitute-traversal"
+    ],
+    "transcript": "",
+    "doc": "GE Proficy Cimplicity WebView substitute.bcl Directory Traversal",
+    "disclosure_date": "2013-01-22",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/modicon_command",
+    "description": "The Schneider Modicon with Unity series of PLCs use Modbus function\n          code 90 (0x5a) to perform administrative commands without authentication.\n          This module allows a remote user to change the state of the PLC between\n          STOP and RUN, allowing an attacker to end process control by the PLC.\n\n          This module is based on the original 'modiconstop.rb' Basecamp module from\n          DigitalBond.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "scada",
+      "modicon-command"
+    ],
+    "transcript": "",
+    "doc": "Schneider Modicon Remote START/STOP Command",
+    "disclosure_date": "2012-04-05",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/modicon_password_recovery",
+    "description": "The Schneider Modicon Quantum series of Ethernet cards store usernames and\n          passwords for the system in files that may be retrieved via backdoor access.\n\n          This module is based on the original 'modiconpass.rb' Basecamp module from\n          DigitalBond.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "scada",
+      "modicon-password-recovery"
+    ],
+    "transcript": "",
+    "doc": "Schneider Modicon Quantum Password Recovery",
+    "disclosure_date": "2012-01-19",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/modicon_stux_transfer",
+    "description": "The Schneider Modicon with Unity series of PLCs use Modbus function\n          code 90 (0x5a) to send and receive ladder logic.  The protocol is\n          unauthenticated, and allows a rogue host to retrieve the existing\n          logic and to upload new logic.\n\n          Two modes are supported: \"SEND\" and \"RECV,\" which behave as one might\n          expect -- use 'set mode ACTIONAME' to use either mode of operation.\n\n          In either mode, FILENAME must be set to a valid path to an existing\n          file (for SENDing) or a new file (for RECVing), and the directory must\n          already exist.  The default, 'modicon_ladder.apx' is a blank\n          ladder logic file which can be used for testing.\n\n          This module is based on the original 'modiconstux.rb' Basecamp module from\n          DigitalBond.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "scada",
+      "modicon-stux-transfer"
+    ],
+    "transcript": "",
+    "doc": "Schneider Modicon Ladder Logic Upload/Download",
+    "disclosure_date": "2012-04-05",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/moxa_credentials_recovery",
+    "description": "The Moxa protocol listens on 4800/UDP and will respond to broadcast\n          or direct traffic.  The service is known to be used on Moxa devices\n          in the NPort, OnCell, and MGate product lines.  Many devices with\n          firmware versions older than 2017 or late 2016 allow admin credentials\n          and SNMP read and read/write community strings to be retrieved without\n          authentication.\n\n          This module is the work of Patrick DeSantis of Cisco Talos and K. Reid\n          Wightman.\n\n          Tested on: Moxa NPort 6250 firmware v1.13, MGate MB3170 firmware 2.5,\n          and NPort 5110 firmware 2.6.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-9361"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "moxa-credentials-recovery"
+    ],
+    "transcript": "",
+    "doc": "Moxa Device Credential Retrieval",
+    "disclosure_date": "2015-07-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/multi_cip_command",
+    "description": "The EtherNet/IP CIP protocol allows a number of unauthenticated commands to a PLC which\n          implements the protocol.  This module implements the CPU STOP command, as well as\n          the ability to crash the Ethernet card in an affected device.\n\n          This module is based on the original 'ethernetip-multi.rb' Basecamp module\n          from DigitalBond.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "scada",
+      "multi-cip-command"
+    ],
+    "transcript": "",
+    "doc": "Allen-Bradley/Rockwell Automation EtherNet/IP CIP Commands",
+    "disclosure_date": "2012-01-19",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/mypro_mgr_creds",
+    "description": "Credential Harvester in MyPRO Manager <= v1.3 from mySCADA.\n          The product suffers from a broken authentication vulnerability (CVE-2025-24865) for certain functions. One of them is the configuration page for notifications, which returns the cleartext credentials (CVE-2025-22896) before correctly veryfing that the associated request is coming from an authenticated and authorized entity.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2025-24865",
+      "CVE-2025-22896"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "mypro-mgr-creds"
+    ],
+    "transcript": "",
+    "doc": "mySCADA myPRO Manager Credential Harvester (CVE-2025-24865 and CVE-2025-22896)",
+    "disclosure_date": "2025-02-13",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/pcom_command",
+    "description": "Unitronics Vision PLCs allow remote administrative functions to control\n          the PLC using authenticated PCOM commands.\n\n          This module supports START, STOP and RESET operations.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "scada",
+      "pcom-command"
+    ],
+    "transcript": "",
+    "doc": "Unitronics PCOM remote START/STOP/RESET command",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/phoenix_command",
+    "description": "PhoenixContact Programmable Logic Controllers are built upon a variant of\n          ProConOS. Communicating using a proprietary protocol over ports TCP/1962\n          and TCP/41100 or TCP/20547.\n          It allows a remote user to read out the PLC Type, Firmware and\n          Build number on port TCP/1962.\n          And also to read out the CPU State (Running or Stopped) AND start\n          or stop the CPU on port TCP/41100 (confirmed ILC 15x and 17x series)\n          or on port TCP/20547 (confirmed ILC 39x series)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-9195"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "phoenix-command"
+    ],
+    "transcript": "",
+    "doc": "PhoenixContact PLC Remote START/STOP Command",
+    "disclosure_date": "2015-05-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/scada/yokogawa_bkbcopyd_client",
+    "description": "This module allows an unauthenticated user to interact with the Yokogawa\n          CENTUM CS3000 BKBCopyD.exe service through the PMODE, RETR and STOR\n          operations.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-5208"
+    ],
+    "tags": [
+      "admin",
+      "scada",
+      "yokogawa-bkbcopyd-client"
+    ],
+    "transcript": "",
+    "doc": "Yokogawa BKBCopyD.exe Client",
+    "disclosure_date": "2014-08-09",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sccm/get_naa_credentials",
+    "description": "This module attempts to retrieve the Network Access Account(s), if configured, from the SCCM server.\n          This requires a computer account, which can be added using the samr_account module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "sccm",
+      "get-naa-credentials"
+    ],
+    "transcript": "",
+    "doc": "Get NAA Credentials",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/serverprotect/file",
+    "description": "This modules exploits a remote file access flaw in the ServerProtect Windows\n          Server RPC service. Please see the action list (or the help output) for more\n          information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-6507"
+    ],
+    "tags": [
+      "admin",
+      "serverprotect",
+      "file"
+    ],
+    "transcript": "",
+    "doc": "TrendMicro ServerProtect File Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/change_password",
+    "description": "Change the password of an account using SMB. This provides several different\n          APIs, each of which have their respective benefits and drawbacks.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "change-password"
+    ],
+    "transcript": "",
+    "doc": "SMB Password Change",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/check_dir_file",
+    "description": "This module is useful when checking an entire network\n        of SMB hosts for the presence of a known file or directory.\n        An example would be to scan all systems for the presence of\n        antivirus or known malware outbreak. Typically you must set\n        RPATH, SMBUser, SMBDomain and SMBPass to operate correctly.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "check-dir-file"
+    ],
+    "transcript": "",
+    "doc": "SMB Scanner Check File/Directory Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/delete_file",
+    "description": "This module deletes a file from a target share and path. The usual reason\n      to use this module is to work around limitations in an existing SMB client that may not\n      be able to take advantage of pass-the-hash style authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "delete-file"
+    ],
+    "transcript": "",
+    "doc": "SMB File Delete Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/download_file",
+    "description": "This module downloads a file from a target share and path. The usual reason\n      to use this module is to work around limitations in an existing SMB client that may not\n      be able to take advantage of pass-the-hash style authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "download-file"
+    ],
+    "transcript": "",
+    "doc": "SMB File Download Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/list_directory",
+    "description": "This module lists the directory of a target share and path. The only reason\n      to use this module is if your existing SMB client is not able to support the features\n      of the Metasploit Framework that you need, like pass-the-hash authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "list-directory"
+    ],
+    "transcript": "",
+    "doc": "SMB Directory Listing Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/ms17_010_command",
+    "description": "This module will exploit SMB with vulnerabilities in MS17-010 to achieve a write-what-where\n          primitive. This will then be used to overwrite the connection session information with as an\n          Administrator session. From there, the normal psexec command execution is done.\n\n          Exploits a type confusion between Transaction and WriteAndX requests and a race condition in\n          Transaction requests, as seen in the EternalRomance, EternalChampion, and EternalSynergy\n          exploits. This exploit chain is more reliable than the EternalBlue exploit, but requires a\n          named pipe.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-0143",
+      "CVE-2017-0146",
+      "CVE-2017-0147"
+    ],
+    "tags": [
+      "admin",
+      "smb",
+      "ms17-010-command"
+    ],
+    "transcript": "",
+    "doc": "MS17-010 EternalRomance/EternalSynergy/EternalChampion SMB Remote Windows Command Execution",
+    "disclosure_date": "2017-03-14",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/psexec_ntdsgrab",
+    "description": "This module authenticates to an Active Directory Domain Controller and creates\n          a volume shadow copy of the %SYSTEMDRIVE%. It then pulls down copies of the\n          ntds.dit file as well as the SYSTEM hive and stores them. The ntds.dit and SYSTEM\n          hive copy can be used in combination with other tools for offline extraction of AD\n          password hashes. All of this is done without uploading a single binary to the\n          target host.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "psexec-ntdsgrab"
+    ],
+    "transcript": "",
+    "doc": "PsExec NTDS.dit And SYSTEM Hive Download Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/samba_symlink_traversal",
+    "description": "This module exploits a directory traversal flaw in the Samba\n      CIFS server. To exploit this flaw, a writeable share must be specified.\n      The newly created directory will link to the root filesystem.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0926"
+    ],
+    "tags": [
+      "admin",
+      "smb",
+      "samba-symlink-traversal"
+    ],
+    "transcript": "",
+    "doc": "Samba Symlink Directory Traversal",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/upload_file",
+    "description": "This module uploads a file to a target share and path. The only reason\n      to use this module is if your existing SMB client is not able to support the features\n      of the Metasploit Framework that you need, like pass-the-hash authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "smb",
+      "upload-file"
+    ],
+    "transcript": "",
+    "doc": "SMB File Upload Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/smb/webexec_command",
+    "description": "This module enables the execution of a single command as System by exploiting a remote\n          code execution vulnerability in Cisco's WebEx client software.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-15442"
+    ],
+    "tags": [
+      "admin",
+      "smb",
+      "webexec-command"
+    ],
+    "transcript": "",
+    "doc": "WebEx Remote Command Execution Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/sunrpc/solaris_kcms_readfile",
+    "description": "This module targets a directory traversal vulnerability in the\n        kcms_server component from the Kodak Color Management System. By\n        utilizing the ToolTalk Database Server\\'s TT_ISBUILD procedure, an\n        attacker can bypass existing directory traversal validation and\n        read arbitrary files.\n\n        Vulnerable systems include Solaris 2.5 - 9 SPARC and x86. Both\n        kcms_server and rpc.ttdbserverd must be running on the target\n        host.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2003-0027"
+    ],
+    "tags": [
+      "admin",
+      "sunrpc",
+      "solaris-kcms-readfile"
+    ],
+    "transcript": "",
+    "doc": "Solaris KCMS + TTDB Arbitrary File Read",
+    "disclosure_date": "2003-01-22",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/teradata/teradata_odbc_sql",
+    "description": "SQL query module for ODBC connections to local Teradata databases.\n\n        Port specification (TCP 1025 by default) is not necessary for ODBC connections.\n\n        Requires ODBC driver and Python Teradata module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "teradata",
+      "teradata-odbc-sql"
+    ],
+    "transcript": "",
+    "doc": "Teradata ODBC SQL Query Module",
+    "disclosure_date": "2018-03-29",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/tftp/tftp_transfer_util",
+    "description": "This module will transfer a file to or from a remote TFTP server.\n          Note that the target must be able to connect back to the Metasploit system,\n          and NAT traversal for TFTP is often unsupported.\n\n          Two actions are supported: \"Upload\" and \"Download,\" which behave as one might\n          expect -- use 'set action Actionname' to use either mode of operation.\n\n          If \"Download\" is selected, at least one of FILENAME or REMOTE_FILENAME\n          must be set. If \"Upload\" is selected, either FILENAME must be set to a valid path to\n          a source file, or FILEDATA must be populated. FILENAME may be a fully qualified path,\n          or the name of a file in the Msf::Config.local_directory or Msf::Config.data_directory.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "tftp",
+      "tftp-transfer-util"
+    ],
+    "transcript": "",
+    "doc": "TFTP File Transfer Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/tikiwiki/tikidblib",
+    "description": "A vulnerability has been reported in Tikiwiki, which can be exploited by\n          an anonymous user to dump the MySQL user & passwd just by creating a mysql\n          error with the \"sort_mode\" var.\n\n          The vulnerability was reported in Tikiwiki version 1.9.5.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-5702"
+    ],
+    "tags": [
+      "admin",
+      "tikiwiki",
+      "tikidblib"
+    ],
+    "transcript": "",
+    "doc": "TikiWiki Information Disclosure",
+    "disclosure_date": "2006-11-01",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/upnp/soap_portmapping",
+    "description": "Manage port mappings on UPnP IGD-capable device using the AddPortMapping and\n        DeletePortMapping SOAP requests",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "upnp",
+      "soap-portmapping"
+    ],
+    "transcript": "",
+    "doc": "UPnP IGD SOAP Port Mapping Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/poweroff_vm",
+    "description": "This module will log into the Web API of VMWare and try to power off\n        a specified Virtual Machine.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "poweroff-vm"
+    ],
+    "transcript": "",
+    "doc": "VMWare Power Off Virtual Machine",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/poweron_vm",
+    "description": "This module will log into the Web API of VMWare and try to power on\n        a specified Virtual Machine.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "poweron-vm"
+    ],
+    "transcript": "",
+    "doc": "VMWare Power On Virtual Machine",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/tag_vm",
+    "description": "This module will log into the Web API of VMWare and\n        'tag' a specified Virtual Machine. It does this by\n        logging a user event with user supplied text",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "tag-vm"
+    ],
+    "transcript": "",
+    "doc": "VMWare Tag Virtual Machine",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/terminate_esx_sessions",
+    "description": "This module will log into the Web API of VMWare and try to terminate\n        user login sessions as specified by the session keys.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "terminate-esx-sessions"
+    ],
+    "transcript": "",
+    "doc": "VMWare Terminate ESX Login Sessions",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/vcenter_forge_saml_token",
+    "description": "This module forges valid SAML credentials for vCenter server\n          using the vCenter SSO IdP certificate, IdP private key, and\n          VMCA certificates as input objects; you must also  provide\n          the vCenter SSO domain name and vCenter FQDN. The module will\n          return a session cookie for the /ui path that grants access to\n          the SSO domain as a vSphere administrator. The IdP trusted\n          certificate chain can be retrieved using Metasploit post\n          exploitation modules or extracted manually from\n          /storage/db/vmware-vmdir/data.mdb using binwalk.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "vcenter-forge-saml-token"
+    ],
+    "transcript": "",
+    "doc": "VMware vCenter Forge SAML Authentication Credentials",
+    "disclosure_date": "2022-04-20",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vmware/vcenter_offline_mdb_extract",
+    "description": "Grab certificates from the vCenter server vmdird and vmafd\n          database files and adds them to loot. The vmdird MDB database file\n          can be found on the live appliance under the path\n          /storage/db/vmware-vmdir/data.mdb, and the DB vmafd is under path\n          /storage/db/vmware-vmafd/afd.db. The vmdir database contains the\n          IdP signing credential, and vmafd contains the vCenter certificate\n          store. This module will accept either file from a live vCenter\n          appliance, or from a vCenter appliance backup archive; either or\n          both files can be supplied.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vmware",
+      "vcenter-offline-mdb-extract"
+    ],
+    "transcript": "",
+    "doc": "VMware vCenter Extract Secrets from vmdir / vmafd DB File",
+    "disclosure_date": "2022-05-10",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vnc/realvnc_41_bypass",
+    "description": "This module exploits an Authentication bypass vulnerability\n          in RealVNC Server version 4.1.0 and 4.1.1. It sets up a proxy\n          listener on LPORT and proxies to the target server.\n\n          The AUTOVNC option requires that vncviewer be installed on\n          the attacking machine.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-2369"
+    ],
+    "tags": [
+      "admin",
+      "vnc",
+      "realvnc-41-bypass"
+    ],
+    "transcript": "",
+    "doc": "RealVNC NULL Authentication Mode Bypass",
+    "disclosure_date": "2006-05-15",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vxworks/apple_airport_extreme_password",
+    "description": "This module can be used to read the stored password of a vulnerable\n          Apple Airport Extreme access point. Only a small number of firmware versions\n          have the WDBRPC service running, however the factory configuration was\n          vulnerable. It appears that firmware versions 5.0.x as well as 5.1.x are\n          susceptible to this issue. Once the password is obtained, the access point\n          can be managed using the Apple AirPort utility.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vxworks",
+      "apple-airport-extreme-password"
+    ],
+    "transcript": "",
+    "doc": "Apple Airport Extreme Password Extraction (WDBRPC)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vxworks/dlink_i2eye_autoanswer",
+    "description": "This module can be used to enable auto-answer mode for the D-Link\n          i2eye video conferencing system. Once this setting has been flipped,\n          the device will accept incoming video calls without acknowledgement.\n          The NetMeeting software included in Windows XP can be used to connect\n          to this device. The i2eye product is no longer supported by the vendor\n          and all models have reached their end of life (EOL).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vxworks",
+      "dlink-i2eye-autoanswer"
+    ],
+    "transcript": "",
+    "doc": "D-Link i2eye Video Conference AutoAnswer (WDBRPC)",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vxworks/wdbrpc_memory_dump",
+    "description": "This module provides the ability to dump the system memory of a VxWorks target through WDBRPC",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vxworks",
+      "wdbrpc-memory-dump"
+    ],
+    "transcript": "",
+    "doc": "VxWorks WDB Agent Remote Memory Dump",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/vxworks/wdbrpc_reboot",
+    "description": "This module provides the ability to reboot a VxWorks target through WDBRPC.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "vxworks",
+      "wdbrpc-reboot"
+    ],
+    "transcript": "",
+    "doc": "VxWorks WDB Agent Remote Reboot",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/webmin/edit_html_fileaccess",
+    "description": "This module exploits a directory traversal in Webmin 1.580. The vulnerability\n          exists in the edit_html.cgi component and allows an authenticated user with access\n          to the File Manager Module to access arbitrary files with root privileges. The\n          module has been tested successfully with Webmin 1.580 over Ubuntu 10.04.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-2983"
+    ],
+    "tags": [
+      "admin",
+      "webmin",
+      "edit-html-fileaccess"
+    ],
+    "transcript": "",
+    "doc": "Webmin edit_html.cgi file Parameter Traversal Arbitrary File Access",
+    "disclosure_date": "2012-09-06",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/webmin/file_disclosure",
+    "description": "A vulnerability has been reported in Webmin and Usermin, which can be\n          exploited by malicious people to disclose potentially sensitive information.\n          The vulnerability is caused due to an unspecified error within the handling\n          of an URL. This can be exploited to read the contents of any files on the\n          server via a specially crafted URL, without requiring a valid login.\n          The vulnerability has been reported in Webmin (versions prior to 1.290) and\n          Usermin (versions prior to 1.220).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-3392"
+    ],
+    "tags": [
+      "admin",
+      "webmin",
+      "file-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Webmin File Disclosure",
+    "disclosure_date": "2006-06-30",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/wemo/crockpot",
+    "description": "This module acts as a simple remote control for Belkin Wemo-enabled\n          Crock-Pots by implementing a subset of the functionality provided by the\n          Wemo App.\n\n          No vulnerabilities are exploited by this Metasploit module in any way.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "wemo",
+      "crockpot"
+    ],
+    "transcript": "",
+    "doc": "Belkin Wemo-Enabled Crock-Pot Remote Control",
+    "disclosure_date": "",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/admin/zend/java_bridge",
+    "description": "This module abuses a flaw in the Zend Java Bridge Component of\n          the Zend Server Framework. By sending a specially crafted packet, an\n          attacker may be able to execute arbitrary code.\n\n          NOTE: This module has only been tested with the Win32 build of the software.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "admin",
+      "zend",
+      "java-bridge"
+    ],
+    "transcript": "",
+    "doc": "Zend Server Java Bridge Design Flaw Remote Code Execution",
+    "disclosure_date": "2011-03-28",
+    "teaches": "Teaches about admin"
+  },
+  {
+    "name": "auxiliary/analyze/apply_pot",
+    "description": "This module uses a John the Ripper or Hashcat .pot file to crack any password\n        hashes in the creds database instantly.  JtR's --show functionality is used to\n        help combine all the passwords into an easy to use format.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "apply-pot"
+    ],
+    "transcript": "",
+    "doc": "Apply Pot File To Hashes",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_aix",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from passwd files on AIX systems.  These utilize DES hashing.\n        DES is format 1500 in Hashcat.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-aix"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: AIX",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_databases",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from the mssql_hashdump, mysql_hashdump, postgres_hashdump, or oracle_hashdump modules.\n        Passwords that have been successfully cracked are then saved as proper credentials.\n        Due to the complexity of some of the hash types, they can be very slow.  Setting the\n        ITERATION_TIMEOUT is highly recommended.\n        MSSQL is 131, 132, and 1731 in hashcat.\n        MYSQL is 200, and 300 in hashcat.\n        ORACLE is 112, and 12300 in hashcat.\n        POSTGRES is 12 in hashcat.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-databases"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: Databases",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_linux",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from unshadowed passwd files from Unix/Linux systems. The module will only crack\n        MD5, BSDi and DES implementations by default. However, it can also crack\n        Blowfish and SHA(256/512), but it is much slower.\n        MD5 is format 500 in hashcat.\n        DES is format 1500 in hashcat.\n        BSDI is format 12400 in hashcat.\n        BLOWFISH is format 3200 in hashcat.\n        SHA256 is format 7400 in hashcat.\n        SHA512 is format 1800 in hashcat.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-linux"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: Linux",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_mobile",
+    "description": "This module uses Hashcat to identify weak passwords that have been\n        acquired from Android systems.  These utilize MD5 or SHA1 hashing.\n        Android (Samsung) SHA1 is format 5800 in Hashcat.  Android\n        (non-Samsung) SHA1 is format 110 in Hashcat.  Android MD5 is format 10.\n        JTR does not support Android hashes at the time of writing.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-mobile"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: Mobile",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_osx",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from OSX systems. The module will only crack xsha from OSX 10.4-10.6, xsha512\n        from 10.7, and PBKDF2 from OSX 10.8+.\n        XSHA is 122 in hashcat.\n        XSHA512 is 1722 in hashcat.\n        PBKDF2 (PBKDF2-HMAC-SHA512) is 7100 in hashcat.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-osx"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: OSX",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_webapps",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from various web applications.\n        Atlassian uses PBKDF2-HMAC-SHA1 which is 12001 in hashcat.\n        PHPass uses phpass which is 400 in hashcat.\n        Mediawiki is MD5 based and is 3711 in hashcat.\n        Apache Superset, some Flask and Werkzeug apps is pbkdf2-sha256 and is 10900 in hashcat",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-webapps"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: Webapps",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/crack_windows",
+    "description": "This module uses John the Ripper or Hashcat to identify weak passwords that have been\n        acquired from Windows systems.\n        LANMAN is format 3000 in hashcat.\n        NTLM is format 1000 in hashcat.\n        MSCASH is format 1100 in hashcat.\n        MSCASH2 is format 2100 in hashcat.\n        NetNTLM is format 5500 in hashcat.\n        NetNTLMv2 is format 5600 in hashcat.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "crack-windows"
+    ],
+    "transcript": "",
+    "doc": "Password Cracker: Windows",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/analyze/modbus_zip",
+    "description": "This module is able to extract a zip file sent through Modbus from a pcap.\n        Tested with Schneider TM221CE16R.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "analyze",
+      "modbus-zip"
+    ],
+    "transcript": "",
+    "doc": "Extract zip from Modbus communication",
+    "disclosure_date": "",
+    "teaches": "Teaches about analyze"
+  },
+  {
+    "name": "auxiliary/bnat/bnat_router",
+    "description": "This module will properly route BNAT traffic and allow for connections to be\n        established to machines on ports which might not otherwise be accessible.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "bnat",
+      "bnat-router"
+    ],
+    "transcript": "",
+    "doc": "BNAT Router",
+    "disclosure_date": "",
+    "teaches": "Teaches about bnat"
+  },
+  {
+    "name": "auxiliary/bnat/bnat_scan",
+    "description": "This module is a scanner which can detect Broken NAT (network address translation)\n        implementations, which could result in an inability to reach ports on remote\n        machines. Typically, these ports will appear in nmap scans as 'filtered'/'closed'.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "bnat",
+      "bnat-scan"
+    ],
+    "transcript": "",
+    "doc": "BNAT Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about bnat"
+  },
+  {
+    "name": "auxiliary/client/hwbridge/connect",
+    "description": "The Hardware Bridge (HWBridge) is a standardized method for\n          Metasploit to interact with Hardware Devices.  This extends\n          the normal exploit capabilities to the non-ethernet realm and\n          enables direct hardware and alternative bus manipulations.  You\n          must have compatible bridging hardware attached to this machine or\n          reachable on your network to use any HWBridge exploits.\n\n          Use this exploit module to connect the physical HWBridge which\n          will start an interactive hwbridge session.  You can launch a hwbridge\n          server locally by using compliant hardware and executing the local_hwbridge\n          module.  After that module has started, pass the HWBRIDGE_BASE_URL\n          options to this connector module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "hwbridge",
+      "connect"
+    ],
+    "transcript": "",
+    "doc": "Hardware Bridge Session Connector",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/client/iec104/iec104",
+    "description": "This module allows sending 104 commands.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "iec104",
+      "iec104"
+    ],
+    "transcript": "",
+    "doc": "IEC104 Client Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/client/mms/send_mms",
+    "description": "This module sends an MMS message to multiple phones of the same carrier.\n          You can use it to send a malicious attachment to phones.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "mms",
+      "send-mms"
+    ],
+    "transcript": "",
+    "doc": "MMS Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/client/sms/send_text",
+    "description": "This module sends a text message to multiple phones of the same carrier.\n          You can use it to send a malicious link to phones.\n\n          Please note that you do not use this module to send a media file (attachment).\n          In order to send a media file, please use auxiliary/client/mms/send_mms instead.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "sms",
+      "send-text"
+    ],
+    "transcript": "",
+    "doc": "SMS Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/client/smtp/emailer",
+    "description": "This module can be used to automate email delivery.\n          This code is based on Joshua Abraham's email script for social\n          engineering.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "smtp",
+      "emailer"
+    ],
+    "transcript": "",
+    "doc": "Generic Emailer (SMTP)",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/client/telegram/send_message",
+    "description": "This module can be used to send a document and/or message to\n        multiple chats on telegram. Please refer to the module\n        documentation for info on how to retrieve the bot token and corresponding chat\n        ID values.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "client",
+      "telegram",
+      "send-message"
+    ],
+    "transcript": "",
+    "doc": "Telegram Message Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about client"
+  },
+  {
+    "name": "auxiliary/cloud/aws/enum_ec2",
+    "description": "Provided AWS credentials, this module will call the authenticated\n          API of Amazon Web Services to list all EC2 instances associated\n          with the account",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "cloud",
+      "aws",
+      "enum-ec2"
+    ],
+    "transcript": "",
+    "doc": "Amazon Web Services EC2 instance enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about cloud"
+  },
+  {
+    "name": "auxiliary/cloud/aws/enum_iam",
+    "description": "Provided AWS credentials, this module will call the authenticated\n          API of Amazon Web Services to list all IAM credentials associated\n          with the account",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "cloud",
+      "aws",
+      "enum-iam"
+    ],
+    "transcript": "",
+    "doc": "Amazon Web Services IAM credential enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about cloud"
+  },
+  {
+    "name": "auxiliary/cloud/aws/enum_s3",
+    "description": "Provided AWS credentials, this module will call the authenticated\n          API of Amazon Web Services to list all S3 buckets associated\n          with the account",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "cloud",
+      "aws",
+      "enum-s3"
+    ],
+    "transcript": "",
+    "doc": "Amazon Web Services S3 instance enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about cloud"
+  },
+  {
+    "name": "auxiliary/cloud/aws/enum_ssm",
+    "description": "Provided AWS credentials, this module will call the authenticated\n          API of Amazon Web Services to list all SSM-enabled EC2 instances\n          accessible to the account. Once enumerated as SSM-enabled, the\n          instances can be controlled using out-of-band WebSocket sessions\n          provided by the AWS API (nominally, privileged out of the box).\n          This module provides not only the API enumeration identifying EC2\n          instances accessible via SSM with given credentials, but enables\n          session initiation for all identified targets (without requiring\n          target-level credentials) using the CreateSession datastore option.\n          The module also provides an EC2 ID filter and a limiting throttle\n          to prevent session stampedes or expensive messes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "cloud",
+      "aws",
+      "enum-ssm"
+    ],
+    "transcript": "",
+    "doc": "Amazon Web Services EC2 SSM enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about cloud"
+  },
+  {
+    "name": "auxiliary/cloud/kubernetes/enum_kubernetes",
+    "description": "Enumerate a Kubernetes API to report useful resources such as available namespaces,\n          pods, secrets, etc.\n\n          Useful resources will be highlighted using the HIGHLIGHT_NAME_PATTERN option.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux,Unix",
+    "cve": [],
+    "tags": [
+      "cloud",
+      "kubernetes",
+      "enum-kubernetes"
+    ],
+    "transcript": "",
+    "doc": "Kubernetes Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about cloud"
+  },
+  {
+    "name": "auxiliary/crawler/msfcrawler",
+    "description": "This auxiliary module is a modular web crawler, to be used in conjunction with wmap (someday) or standalone.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "crawler",
+      "msfcrawler"
+    ],
+    "transcript": "",
+    "doc": "Metasploit Web Crawler",
+    "disclosure_date": "",
+    "teaches": "Teaches about crawler"
+  },
+  {
+    "name": "auxiliary/dos/android/android_stock_browser_iframe",
+    "description": "This module exploits a vulnerability in the native browser that comes with Android 4.0.3.\n          If successful, the browser will crash after viewing the webpage.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-6301"
+    ],
+    "tags": [
+      "dos",
+      "android",
+      "android-stock-browser-iframe"
+    ],
+    "transcript": "",
+    "doc": "Android Stock Browser Iframe DOS",
+    "disclosure_date": "2012-12-01",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/apple_ios/webkit_backdrop_filter_blur",
+    "description": "This module exploits a vulnerability in WebKit on Apple iOS.\n          If successful, the device will restart after viewing the webpage.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "apple-ios",
+      "webkit-backdrop-filter-blur"
+    ],
+    "transcript": "",
+    "doc": "iOS Safari Denial of Service with CSS",
+    "disclosure_date": "2018-09-15",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/cisco/cisco_7937g_dos",
+    "description": "This module exploits a bug in how the conference station \n\thandles incoming SSH connections that provide an incompatible \n\tkey exchange. By connecting with an incompatible key exchange, \n\tthe device becomes nonresponsive until it is manually power\n\tcycled.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-16138"
+    ],
+    "tags": [
+      "dos",
+      "cisco",
+      "cisco-7937g-dos"
+    ],
+    "transcript": "",
+    "doc": "Cisco 7937G Denial-of-Service Attack",
+    "disclosure_date": "2020-06-02",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/cisco/cisco_7937g_dos_reboot",
+    "description": "This module exploits a bug in how the conference station handles \n\texecuting a ping via its web interface. By repeatedly executing \n\tthe ping function without clearing out the resulting output, \n\ta DoS is caused that will reset the device after a few minutes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-16139"
+    ],
+    "tags": [
+      "dos",
+      "cisco",
+      "cisco-7937g-dos-reboot"
+    ],
+    "transcript": "",
+    "doc": "Cisco 7937G Denial-of-Service Reboot Attack",
+    "disclosure_date": "2020-06-02",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/cisco/ios_http_percentpercent",
+    "description": "This module triggers a Denial of Service condition in the Cisco IOS\n          HTTP server. By sending a GET request for \"/%%\", the device becomes\n          unresponsive. IOS 11.1 -> 12.1 are reportedly vulnerable. This module\n          tested successfully against a Cisco 1600 Router IOS v11.2(18)P.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2000-0380"
+    ],
+    "tags": [
+      "dos",
+      "cisco",
+      "ios-http-percentpercent"
+    ],
+    "transcript": "",
+    "doc": "Cisco IOS HTTP GET /%% Request Denial of Service",
+    "disclosure_date": "2000-04-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/cisco/ios_telnet_rocem",
+    "description": "This module triggers a Denial of Service condition in the Cisco IOS\n          telnet service affecting multiple Cisco switches. Tested against Cisco\n          Catalyst 2960 and 3750.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-3881"
+    ],
+    "tags": [
+      "dos",
+      "cisco",
+      "ios-telnet-rocem"
+    ],
+    "transcript": "",
+    "doc": "Cisco IOS Telnet Denial of Service",
+    "disclosure_date": "2017-03-17",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/dhcp/isc_dhcpd_clientid",
+    "description": "This module performs a Denial of Service Attack against the ISC DHCP server,\n        versions 4.1 before 4.1.1-P1 and 4.0 before 4.0.2-P1. It sends out a DHCP Request\n        message with a 0-length client_id option for an IP address on the appropriate range\n        for the dhcp server. When ISC DHCP Server tries to hash this value it exits\n        abnormally.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-2156"
+    ],
+    "tags": [
+      "dos",
+      "dhcp",
+      "isc-dhcpd-clientid"
+    ],
+    "transcript": "",
+    "doc": "ISC DHCP Zero Length ClientID Denial of Service Module",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/dns/bind_tkey",
+    "description": "This module sends a malformed TKEY query, which exploits an\n          error in handling TKEY queries on affected BIND9 'named' DNS servers.\n          As a result, a vulnerable named server will exit with a REQUIRE\n          assertion failure. This condition can be exploited in versions of BIND\n          between BIND 9.1.0 through 9.8.x, 9.9.0 through 9.9.7-P1 and 9.10.0\n          through 9.10.2-P2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-5477"
+    ],
+    "tags": [
+      "dos",
+      "dns",
+      "bind-tkey"
+    ],
+    "transcript": "",
+    "doc": "BIND TKEY Query Denial of Service",
+    "disclosure_date": "2015-07-28",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/dns/bind_tsig",
+    "description": "A defect in the rendering of messages into packets can cause named to\n          exit with an assertion failure in buffer.c while constructing a response\n          to a query that meets certain criteria.\n\n          This assertion can be triggered even if the apparent source address\n          isn't allowed to make queries.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-2776"
+    ],
+    "tags": [
+      "dos",
+      "dns",
+      "bind-tsig"
+    ],
+    "transcript": "",
+    "doc": "BIND TSIG Query Denial of Service",
+    "disclosure_date": "2016-09-27",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/dns/bind_tsig_badtime",
+    "description": "A logic error in code which checks TSIG validity can be used to\n          trigger an assertion failure in tsig.c.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-8617"
+    ],
+    "tags": [
+      "dos",
+      "dns",
+      "bind-tsig-badtime"
+    ],
+    "transcript": "",
+    "doc": "BIND TSIG Badtime Query Denial of Service",
+    "disclosure_date": "2020-05-19",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/freebsd/nfsd/nfsd_mount",
+    "description": "This module sends a specially-crafted NFS Mount request causing a\n          kernel panic on host running FreeBSD 6.0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-0900"
+    ],
+    "tags": [
+      "dos",
+      "freebsd",
+      "nfsd"
+    ],
+    "transcript": "",
+    "doc": "FreeBSD Remote NFS RPC Request Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/ftp/vsftpd_232",
+    "description": "This module triggers a Denial of Service condition in the VSFTPD server in\n          versions before 2.3.3. So far, it has been tested on 2.3.0, 2.3.1, and 2.3.2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0762"
+    ],
+    "tags": [
+      "dos",
+      "ftp",
+      "vsftpd-232"
+    ],
+    "transcript": "",
+    "doc": "VSFTPD 2.3.2 Denial of Service",
+    "disclosure_date": "2011-02-03",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/hp/data_protector_rds",
+    "description": "This module causes a remote DOS on HP Data Protector's RDS service.  By sending\n          a malformed packet to port 1530, _rm32.dll causes RDS to crash due to an enormous\n          size for malloc().",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0514"
+    ],
+    "tags": [
+      "dos",
+      "hp",
+      "data-protector-rds"
+    ],
+    "transcript": "",
+    "doc": "HP Data Protector Manager RDS DOS",
+    "disclosure_date": "2011-01-08",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/3com_superstack_switch",
+    "description": "This module causes a temporary denial of service condition\n          against 3Com SuperStack switches. By sending excessive data\n          to the HTTP Management interface, the switch stops responding\n          temporarily. The device does not reset. Tested successfully\n          against a 3300SM firmware v2.66. Reported to affect versions\n          prior to v2.72.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2004-2691"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "3com-superstack-switch"
+    ],
+    "transcript": "",
+    "doc": "3Com SuperStack Switch Denial of Service",
+    "disclosure_date": "2004-06-24",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/apache_commons_fileupload_dos",
+    "description": "This module triggers an infinite loop in Apache Commons FileUpload 1.0\n          through 1.3 via a specially crafted Content-Type header.\n          Apache Tomcat 7 and Apache Tomcat 8 use a copy of FileUpload to handle\n          mime-multipart requests, therefore, Apache Tomcat 7.0.0 through 7.0.50\n          and 8.0.0-RC1 through 8.0.1 are affected by this issue. Tomcat 6 also\n          uses Commons FileUpload as part of the Manager application.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-0050"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "apache-commons-fileupload-dos"
+    ],
+    "transcript": "",
+    "doc": "Apache Commons FileUpload and Apache Tomcat DoS",
+    "disclosure_date": "2014-02-06",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/apache_mod_isapi",
+    "description": "This module triggers a use-after-free vulnerability in the Apache\n          Software Foundation mod_isapi extension for versions 2.2.14 and earlier.\n          In order to reach the vulnerable code, the target server must have an\n          ISAPI module installed and configured.\n\n          By making a request that terminates abnormally (either an aborted TCP\n          connection or an unsatisfied chunked request), mod_isapi will unload the\n          ISAPI extension. Later, if another request comes for that ISAPI module,\n          previously obtained pointers will be used resulting in an access\n          violation or potentially arbitrary code execution.\n\n          Although arbitrary code execution is theoretically possible, a\n          real-world method of invoking this consequence has not been proven. In\n          order to do so, one would need to find a situation where a particular\n          ISAPI module loads at an image base address that can be re-allocated by\n          a remote attacker.\n\n          Limited success was encountered using two separate ISAPI modules. In\n          this scenario, a second ISAPI module was loaded into the same memory\n          area as the previously unloaded module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0425"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "apache-mod-isapi"
+    ],
+    "transcript": "",
+    "doc": "Apache mod_isapi Dangling Pointer",
+    "disclosure_date": "2010-03-05",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/apache_range_dos",
+    "description": "The byterange filter in the Apache HTTP Server 2.0.x through 2.0.64, and 2.2.x\n          through 2.2.19 allows remote attackers to cause a denial of service (memory and\n          CPU consumption) via a Range header that expresses multiple overlapping ranges,\n          exploit called \"Apache Killer\".",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-3192"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "apache-range-dos"
+    ],
+    "transcript": "",
+    "doc": "Apache Range Header DoS (Apache Killer)",
+    "disclosure_date": "2011-08-19",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/apache_tomcat_transfer_encoding",
+    "description": "Apache Tomcat 5.5.0 through 5.5.29, 6.0.0 through 6.0.27, and 7.0.0 beta does not\n          properly handle an invalid Transfer-Encoding header, which allows remote attackers\n          to cause a denial of service (application outage) or obtain sensitive information\n          via a crafted header that interferes with \"recycling of a buffer.\"",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-2227"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "apache-tomcat-transfer-encoding"
+    ],
+    "transcript": "",
+    "doc": "Apache Tomcat Transfer-Encoding Information Disclosure and DoS",
+    "disclosure_date": "2010-07-09",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/brother_debut_dos",
+    "description": "The Debut embedded HTTP server <= 1.20 on Brother printers allows for a Denial\n          of Service (DoS) condition via a crafted HTTP request.  The printer will be\n          unresponsive from HTTP and printing requests for ~300 seconds.  After which, the\n          printer will start responding again.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-16249"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "brother-debut-dos"
+    ],
+    "transcript": "",
+    "doc": "Brother Debut http Denial Of Service",
+    "disclosure_date": "2017-11-02",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/cable_haunt_websocket_dos",
+    "description": "There exists a buffer overflow vulnerability in certain\n          Cable Modem Spectrum Analyzer interfaces.  This overflow\n          is exploitable, but since an exploit would differ between\n          every make, model, and firmware version (which also\n          differs from ISP to ISP), this module simply causes a\n          Denial of Service to test if the vulnerability is present.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-19494"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "cable-haunt-websocket-dos"
+    ],
+    "transcript": "",
+    "doc": "\"Cablehaunt\" Cable Modem WebSocket DoS",
+    "disclosure_date": "2020-01-07",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/canon_wireless_printer",
+    "description": "The HTTP management interface on several models of Canon Wireless printers\n          allows for a Denial of Service (DoS) condition via a crafted HTTP request. Note:\n          if this module is successful, the device can only be recovered with a physical\n          power cycle.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4615"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "canon-wireless-printer"
+    ],
+    "transcript": "",
+    "doc": "Canon Wireless Printer Denial Of Service",
+    "disclosure_date": "2013-06-18",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/dell_openmanage_post",
+    "description": "This module exploits a heap overflow in the Dell OpenManage\n          Web Server (omws32.exe), versions 3.2-3.7.1. The vulnerability\n          exists due to a boundary error within the handling of POST requests,\n          where the application input is set to an overly long file name.\n          This module will crash the web server, however it is likely exploitable\n          under certain conditions.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2004-0331"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "dell-openmanage-post"
+    ],
+    "transcript": "",
+    "doc": "Dell OpenManage POST Request Heap Overflow (win32)",
+    "disclosure_date": "2004-02-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/f5_bigip_apm_max_sessions",
+    "description": "This module exploits a resource exhaustion denial of service in F5 BigIP devices. An\n          unauthenticated attacker can establish multiple connections with BigIP Access Policy\n          Manager (APM) and exhaust all available sessions defined in customer license. In the\n          first step of the BigIP APM negotiation the client sends a HTTP request. The BigIP\n          system creates a session, marks it as pending and then redirects the client to an access\n          policy URI. Since BigIP allocates a new session after the first unauthenticated request,\n          and deletes the session only if an access policy timeout expires, the attacker can exhaust\n          all available sessions by repeatedly sending the initial HTTP request and leaving the\n          sessions as pending.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "http",
+      "f5-bigip-apm-max-sessions"
+    ],
+    "transcript": "",
+    "doc": "F5 BigIP Access Policy Manager Session Exhaustion Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/flexense_http_server_dos",
+    "description": "This module triggers a Denial of Service vulnerability in the Flexense HTTP server.\n          Vulnerability caused by a user mode write access memory violation and can be triggered with\n          rapidly sending variety of HTTP requests with long HTTP header values.\n\n          Multiple Flexense applications that are using Flexense HTTP server 10.6.24 and below versions reportedly vulnerable.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-8065"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "flexense-http-server-dos"
+    ],
+    "transcript": "",
+    "doc": "Flexense HTTP Server Denial Of Service",
+    "disclosure_date": "2018-03-09",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/gzip_bomb_dos",
+    "description": "This module generates and hosts a 10MB single-round gzip file that decompresses to 10GB.\n          Many applications will not implement a length limit check and will eat up all memory and\n          eventually die. This can also be used to kill systems that download/parse content from\n          a user-provided URL (image-processing servers, AV, websites that accept zipped POST data, etc).\n\n          A FILEPATH datastore option can also be provided to save the .gz bomb locally.\n\n          Some clients (Firefox) will allow for multiple rounds of gzip. Most gzip utils will correctly\n          deflate multiple rounds of gzip on a file. Setting ROUNDS=3 and SIZE=10240 (default value)\n          will generate a 300 byte gzipped file that expands to 10GB.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "http",
+      "gzip-bomb-dos"
+    ],
+    "transcript": "",
+    "doc": "Gzip Memory Bomb Denial Of Service",
+    "disclosure_date": "2004-01-01",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/hashcollision_dos",
+    "description": "This module uses a denial-of-service (DoS) condition appearing in a variety of\n          programming languages. This vulnerability occurs when storing multiple values\n          in a hash table and all values have the same hash value. This can cause a web server\n          parsing the POST parameters issued with a request into a hash table to consume\n          hours of CPU with a single HTTP request.\n\n          Currently, only the hash functions for PHP and Java are implemented.\n          This module was tested with PHP + httpd, Tomcat, Glassfish and Geronimo.\n          It also generates a random payload to bypass some IDS signatures.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-5034",
+      "CVE-2011-5035",
+      "CVE-2011-4885",
+      "CVE-2011-4858"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "hashcollision-dos"
+    ],
+    "transcript": "",
+    "doc": "Hashtable Collisions",
+    "disclosure_date": "2011-12-28",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/ibm_lotus_notes",
+    "description": "This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.\n          If successful, it could cause the Notes client to hang and have to be restarted.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-1129"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "ibm-lotus-notes"
+    ],
+    "transcript": "",
+    "doc": "IBM Notes encodeURI DOS",
+    "disclosure_date": "2017-08-31",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/ibm_lotus_notes2",
+    "description": "This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.\n          If successful, the browser will crash after viewing the webpage.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-1130"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "ibm-lotus-notes2"
+    ],
+    "transcript": "",
+    "doc": "IBM Notes Denial Of Service",
+    "disclosure_date": "2017-08-31",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/marked_redos",
+    "description": "This module exploits a Regular Expression Denial of Service vulnerability\n          in the npm module \"marked\". The vulnerable portion of code that this module\n          targets is in the \"heading\" regular expression. Web applications that use\n          \"marked\" for generating html from markdown are vulnerable. Versions up to\n          0.4.0 are vulnerable.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "http",
+      "marked-redos"
+    ],
+    "transcript": "",
+    "doc": "marked npm module \"heading\" ReDoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/metasploit_httphandler_dos",
+    "description": "This module exploits the Metasploit HTTP(S) handler by sending\n          a specially crafted HTTP request that gets added as a resource handler.\n          Resources (which come from the external connections) are evaluated as RegEx\n          in the handler server. Specially crafted input can trigger Gentle, Soft and Hard DoS.\n\n          Tested against Metasploit 5.0.20.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-5645"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "metasploit-httphandler-dos"
+    ],
+    "transcript": "",
+    "doc": "Metasploit HTTP(S) handler DoS",
+    "disclosure_date": "2019-09-04",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/monkey_headers",
+    "description": "This module causes improper header parsing that leads to a segmentation fault\n          due to a specially crafted HTTP request. Affects version <= 1.2.0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3843"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "monkey-headers"
+    ],
+    "transcript": "",
+    "doc": "Monkey HTTPD Header Parsing Denial of Service (DoS)",
+    "disclosure_date": "2013-05-30",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/ms15_034_ulonglongadd",
+    "description": "This module will check if scanned hosts are vulnerable to CVE-2015-1635 (MS15-034), a\n          vulnerability in the HTTP protocol stack (HTTP.sys) that could result in arbitrary code\n          execution. This module will try to cause a denial-of-service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-1635"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "ms15-034-ulonglongadd"
+    ],
+    "transcript": "",
+    "doc": "MS15-034 HTTP Protocol Stack Request Handling Denial-of-Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/nodejs_pipelining",
+    "description": "This module exploits a Denial of Service (DoS) condition in the HTTP parser of Node.js versions\n          released before 0.10.21 and 0.8.26. The attack sends many pipelined\n          HTTP requests on a single connection, which causes unbounded memory\n          allocation when the client does not read the responses.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4450"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "nodejs-pipelining"
+    ],
+    "transcript": "",
+    "doc": "Node.js HTTP Pipelining Denial of Service",
+    "disclosure_date": "2013-10-18",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/novell_file_reporter_heap_bof",
+    "description": "This module exploits a heap overflow in NFRAgent.exe, a component of Novell\n          File Reporter (NFR). The vulnerability occurs when handling requests of name \"SRS\",\n          where NFRAgent.exe fails to generate a response in a secure way, copying user\n          controlled data into a fixed-length buffer in the heap without bounds checking.\n          This module has been tested against NFR Agent 1.0.4.3 (File Reporter 1.0.2).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-4956"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "novell-file-reporter-heap-bof"
+    ],
+    "transcript": "",
+    "doc": "NFR Agent Heap Overflow Vulnerability",
+    "disclosure_date": "2012-11-16",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/rails_action_view",
+    "description": "This module exploits a Denial of Service (DoS) condition in Action View that requires\n          a controller action. By sending a specially crafted content-type header to a Rails\n          application, it is possible for it to store the invalid MIME type, and may eventually\n          consume all memory if enough invalid MIMEs are given.\n\n          Versions 3.0.0 and other later versions are affected, fixed in 4.0.2 and 3.2.16.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-6414"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "rails-action-view"
+    ],
+    "transcript": "",
+    "doc": "Ruby on Rails Action View MIME Memory Exhaustion",
+    "disclosure_date": "2013-12-04",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/rails_json_float_dos",
+    "description": "When Ruby attempts to convert a string representation of a large floating point\n          decimal number to its floating point equivalent, a heap-based buffer overflow\n          can be triggered. This module has been tested successfully on a Ruby on Rails application\n          using Ruby version 1.9.3-p448 with WebRick and Thin web servers, where the Rails application\n          crashes with a segfault error. Other versions of Ruby are reported to be affected.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4164"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "rails-json-float-dos"
+    ],
+    "transcript": "",
+    "doc": "Ruby on Rails JSON Processor Floating Point Heap Overflow DoS",
+    "disclosure_date": "2013-11-22",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/slowloris",
+    "description": "Slowloris tries to keep many connections to the target web server open and hold them open as long as possible.\n        It accomplishes this by opening connections to the target web server and sending a partial request.\n        Periodically, it will send subsequent HTTP headers, adding to-but never completing-the request.\n        Affected servers will keep these connections open, filling their maximum concurrent connection pool,\n        eventually denying additional connection attempts from clients.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-6750",
+      "CVE-2010-2227"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "slowloris"
+    ],
+    "transcript": "",
+    "doc": "Slowloris Denial of Service Attack",
+    "disclosure_date": "2009-06-17",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/sonicwall_ssl_format",
+    "description": "There is a format string vulnerability within the SonicWALL\n          SSL-VPN Appliance - 200, 2000 and 4000 series. Arbitrary memory\n          can be read or written to, depending on the format string used.\n          There appears to be a length limit of 127 characters of format\n          string data. With physical access to the device and debugging,\n          this module may be able to be used to execute arbitrary code remotely.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "http",
+      "sonicwall-ssl-format"
+    ],
+    "transcript": "",
+    "doc": "SonicWALL SSL-VPN Format String Vulnerability",
+    "disclosure_date": "2009-05-29",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/squid_range_dos",
+    "description": "The range handler in The Squid Caching Proxy Server 3.0-4.1.4 and\n          5.0.1-5.0.5 suffers from multiple vulnerabilities triggered\n          by specific HTTP requests and responses.\n\n          These vulnerabilities allow remote attackers to cause a\n          denial of service through specifically crafted requests.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-31806",
+      "CVE-2021-31807"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "squid-range-dos"
+    ],
+    "transcript": "",
+    "doc": "Squid Proxy Range Header DoS",
+    "disclosure_date": "2021-05-27",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/tautulli_shutdown_exec",
+    "description": "Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-19833"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "tautulli-shutdown-exec"
+    ],
+    "transcript": "",
+    "doc": "Tautulli v2.1.9 - Shutdown Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/ua_parser_js_redos",
+    "description": "This module exploits a Regular Expression Denial of Service vulnerability\n        in the npm module \"ua-parser-js\". Server-side applications that use\n        \"ua-parser-js\" for parsing the browser user-agent string will be vulnerable\n        if they call the \"getOS\" or \"getResult\" functions. This vulnerability was\n        fixed as of version 0.7.16.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-16086"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "ua-parser-js-redos"
+    ],
+    "transcript": "",
+    "doc": "ua-parser-js npm module ReDoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/webkitplus",
+    "description": "This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset.\n          If successful, it could lead to application crash, resulting in denial of service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-11646"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "webkitplus"
+    ],
+    "transcript": "",
+    "doc": "WebKitGTK+ WebKitFaviconDatabase DoS",
+    "disclosure_date": "2018-06-03",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/webrick_regex",
+    "description": "The WEBrick::HTTP::DefaultFileHandler in WEBrick in\n          Ruby 1.8.5 and earlier, 1.8.6 to 1.8.6-p286, 1.8.7\n          to 1.8.7-p71, and 1.9 to r18423 allows for a DoS\n          (CPU consumption) via a crafted HTTP request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-3656"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "webrick-regex"
+    ],
+    "transcript": "",
+    "doc": "Ruby WEBrick::HTTP::DefaultFileHandler DoS",
+    "disclosure_date": "2008-08-08",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/wordpress_directory_traversal_dos",
+    "description": "Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin\n          function in wp-admin/includes/ajax-actions.php in WordPress before 4.6\n          allows remote attackers to hijack the authentication of subscribers\n          for /dev/random read operations by leveraging a late call to\n          the check_ajax_referer function, a related issue to CVE-2016-6896.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-6897"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "wordpress-directory-traversal-dos"
+    ],
+    "transcript": "",
+    "doc": "WordPress Traversal Directory DoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/wordpress_long_password_dos",
+    "description": "WordPress before 3.7.5, 3.8.x before 3.8.5, 3.9.x before 3.9.3, and 4.x\n          before 4.0.1 allows remote attackers to cause a denial of service\n          (CPU consumption) via a long password that is improperly handled\n          during hashing.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-9016"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "wordpress-long-password-dos"
+    ],
+    "transcript": "",
+    "doc": "WordPress Long Password DoS",
+    "disclosure_date": "2014-11-20",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/wordpress_xmlrpc_dos",
+    "description": "Wordpress XMLRPC parsing is vulnerable to a XML based denial of service.\n          This vulnerability affects Wordpress 3.5 - 3.9.2 (3.8.4 and 3.7.4 are\n          also patched).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-5266"
+    ],
+    "tags": [
+      "dos",
+      "http",
+      "wordpress-xmlrpc-dos"
+    ],
+    "transcript": "",
+    "doc": "Wordpress XMLRPC DoS",
+    "disclosure_date": "2014-08-06",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/http/ws_dos",
+    "description": "This module exploits a Denial of Service vulnerability in npm module \"ws\".\n        By sending a specially crafted value of the Sec-WebSocket-Extensions header on the initial WebSocket upgrade request, the ws component will crash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "http",
+      "ws-dos"
+    ],
+    "transcript": "",
+    "doc": "ws - Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/mdns/avahi_portzero",
+    "description": "Avahi-daemon versions prior to 0.6.24 can be DoS'd\n        with an mDNS packet with a source port of 0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-5081"
+    ],
+    "tags": [
+      "dos",
+      "mdns",
+      "avahi-portzero"
+    ],
+    "transcript": "",
+    "doc": "Avahi Source Port 0 DoS",
+    "disclosure_date": "2008-11-14",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/mirageos/qubes_mirage_firewall_dos",
+    "description": "This module allows remote attackers to cause a denial of service (DoS)\n          in Mirage firewall for QubesOS 0.8.0-0.8.3 via a specifically crafted UDP request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-46770"
+    ],
+    "tags": [
+      "dos",
+      "mirageos",
+      "qubes-mirage-firewall-dos"
+    ],
+    "transcript": "",
+    "doc": "Mirage firewall for QubesOS 0.8.0-0.8.3 Denial of Service (DoS) Exploit",
+    "disclosure_date": "2022-12-04",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/misc/dopewars",
+    "description": "The jet command in Dopewars 1.5.12 is vulnerable to a segmentation fault due to\n          a lack of input validation.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-3591"
+    ],
+    "tags": [
+      "dos",
+      "misc",
+      "dopewars"
+    ],
+    "transcript": "",
+    "doc": "Dopewars Denial of Service",
+    "disclosure_date": "2009-10-05",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/misc/ibm_sametime_webplayer_dos",
+    "description": "This module exploits a known flaw in the IBM Lotus Sametime WebPlayer\n          version 8.5.2.1392 (and prior) to cause a denial of service condition\n          against specific users. For this module to function the target user\n          must be actively logged into the IBM Lotus Sametime server and have\n          the Sametime Audio Visual browser plug-in (WebPlayer) loaded as a\n          browser extension. The user should have the WebPlayer plug-in active\n          (i.e. be in a Sametime Audio/Video meeting for this DoS to work correctly.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3986"
+    ],
+    "tags": [
+      "dos",
+      "misc",
+      "ibm-sametime-webplayer-dos"
+    ],
+    "transcript": "",
+    "doc": "IBM Lotus Sametime WebPlayer DoS",
+    "disclosure_date": "2013-11-07",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/misc/ibm_tsm_dos",
+    "description": "This module exploits a denial of service condition present in IBM Tivoli Storage Manager\n          FastBack Server when dealing with packets triggering the opcode 0x534 handler.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "misc",
+      "ibm-tsm-dos"
+    ],
+    "transcript": "",
+    "doc": "IBM Tivoli Storage Manager FastBack Server Opcode 0x534 Denial of Service",
+    "disclosure_date": "2015-12-15",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/misc/memcached",
+    "description": "This module sends a specially-crafted packet to cause a\n          segmentation fault in memcached v1.4.15 or earlier versions.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-4971"
+    ],
+    "tags": [
+      "dos",
+      "misc",
+      "memcached"
+    ],
+    "transcript": "",
+    "doc": "Memcached Remote Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/ntp/ntpd_reserved_dos",
+    "description": "This module exploits a denial of service vulnerability\n          within the NTP (network time protocol) demon. By sending\n          a single packet to a vulnerable ntpd server (Victim A),\n          spoofed from the IP address of another vulnerable ntpd server\n          (Victim B), both victims will enter an infinite response loop.\n          Note, unless you control the spoofed source host or the real\n          remote host(s), you will not be able to halt the DoS condition\n          once begun!",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-3563"
+    ],
+    "tags": [
+      "dos",
+      "ntp",
+      "ntpd-reserved-dos"
+    ],
+    "transcript": "",
+    "doc": "NTP.org ntpd Reserved Mode Denial of Service",
+    "disclosure_date": "2009-10-04",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/pptp/ms02_063_pptp_dos",
+    "description": "This module exploits a kernel based overflow when sending abnormal PPTP Control Data\n          packets\tto Microsoft Windows 2000 SP0-3 and XP SP0-1 based PPTP RAS servers\n          (Remote Access Services). Kernel memory is overwritten resulting in a BSOD.\n          Code execution may be possible however this module is only a DoS.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2002-1214"
+    ],
+    "tags": [
+      "dos",
+      "pptp",
+      "ms02-063-pptp-dos"
+    ],
+    "transcript": "",
+    "doc": "MS02-063 PPTP Malformed Control Data Kernel Denial of Service",
+    "disclosure_date": "2002-09-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/rpc/rpcbomb",
+    "description": "This module exploits a vulnerability in certain versions of\n          rpcbind, LIBTIRPC, and NTIRPC, allowing an attacker to trigger\n          large (and never freed) memory allocations for XDR strings on\n          the target.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-8779"
+    ],
+    "tags": [
+      "dos",
+      "rpc",
+      "rpcbomb"
+    ],
+    "transcript": "",
+    "doc": "RPC DoS targeting *nix rpcbind/libtirpc",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/samba/lsa_addprivs_heap",
+    "description": "This module triggers a heap overflow in the LSA RPC service\n          of the Samba daemon.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-2446"
+    ],
+    "tags": [
+      "dos",
+      "samba",
+      "lsa-addprivs-heap"
+    ],
+    "transcript": "",
+    "doc": "Samba lsa_io_privilege_set Heap Overflow",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/samba/lsa_transnames_heap",
+    "description": "This module triggers a heap overflow in the LSA RPC service\n          of the Samba daemon.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-2446"
+    ],
+    "tags": [
+      "dos",
+      "samba",
+      "lsa-transnames-heap"
+    ],
+    "transcript": "",
+    "doc": "Samba lsa_io_trans_names Heap Overflow",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/samba/read_nttrans_ea_list",
+    "description": "Integer overflow in the read_nttrans_ea_list function in nttrans.c in\n          smbd in Samba 3.x before 3.5.22, 3.6.x before 3.6.17, and 4.x before\n          4.0.8 allows remote attackers to cause a denial of service (memory\n          consumption) via a malformed packet. Important Note: in order to work,\n          the \"ea support\" option on the target share must be enabled.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4124"
+    ],
+    "tags": [
+      "dos",
+      "samba",
+      "read-nttrans-ea-list"
+    ],
+    "transcript": "",
+    "doc": "Samba read_nttrans_ea_list Integer Overflow",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/sap/sap_soap_rfc_eps_delete_file",
+    "description": "This module abuses the SAP NetWeaver EPS_DELETE_FILE function, on the SAP SOAP\n        RFC Service, to delete arbitrary files on the remote file system. The module can\n        also be used to capture SMB hashes by using a fake SMB share as DIRNAME.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "sap",
+      "sap-soap-rfc-eps-delete-file"
+    ],
+    "transcript": "",
+    "doc": "SAP SOAP EPS_DELETE_FILE File Deletion",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/allen_bradley_pccc",
+    "description": "A remote, unauthenticated attacker could send a single, specially crafted\n        Programmable Controller Communication Commands (PCCC) packet to the controller\n        that could potentially cause the controller to enter a DoS condition.\n        MicroLogix 1100 controllers are affected: 1763-L16BWA, 1763-L16AWA, 1763-L16BBB, and\n        1763-L16DWD.\n        CVE-2017-7924 has been assigned to this vulnerability.\n        A CVSS v3 base score of 7.5 has been assigned.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-7924"
+    ],
+    "tags": [
+      "dos",
+      "scada",
+      "allen-bradley-pccc"
+    ],
+    "transcript": "",
+    "doc": "DoS Exploitation of Allen-Bradley's Legacy Protocol (PCCC)",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/beckhoff_twincat",
+    "description": "The Beckhoff TwinCAT version <= 2.11.0.2004 can be brought down by sending\n          a crafted UDP packet to port 48899 (TCATSysSrv.exe).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-3486"
+    ],
+    "tags": [
+      "dos",
+      "scada",
+      "beckhoff-twincat"
+    ],
+    "transcript": "",
+    "doc": "Beckhoff TwinCAT SCADA PLC 2.11.0.2004 DoS",
+    "disclosure_date": "2011-09-13",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/d20_tftp_overflow",
+    "description": "By sending a malformed TFTP request to the GE D20ME, it is possible to crash the\n          device.\n\n          This module is based on the original 'd20ftpbo.rb' Basecamp module from\n          DigitalBond.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "scada",
+      "d20-tftp-overflow"
+    ],
+    "transcript": "",
+    "doc": "General Electric D20ME TFTP Server Buffer Overflow DoS",
+    "disclosure_date": "2012-01-19",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/igss9_dataserver",
+    "description": "The 7-Technologies SCADA IGSS Data Server (IGSSdataServer.exe) <= 9.0.0.10306 can be\n          brought down by sending a crafted TCP packet to port 12401.  This should also work\n          for version <= 9.0.0.1120, but that version hasn't been tested.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-4050"
+    ],
+    "tags": [
+      "dos",
+      "scada",
+      "igss9-dataserver"
+    ],
+    "transcript": "",
+    "doc": "7-Technologies IGSS 9 IGSSdataServer.exe DoS",
+    "disclosure_date": "2011-12-20",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/siemens_siprotec4",
+    "description": "This module sends a specially crafted packet to port 50000/UDP\n         causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices.\n         A manual reboot is required to return the device to service.\n         CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-5374"
+    ],
+    "tags": [
+      "dos",
+      "scada",
+      "siemens-siprotec4"
+    ],
+    "transcript": "",
+    "doc": "Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/scada/yokogawa_logsvr",
+    "description": "This module abuses a buffer overflow vulnerability to trigger a Denial of Service\n          of the BKCLogSvr component in the Yokogaca CENTUM CS 3000 product. The vulnerability\n          exists in the handling of malformed log packets, with an unexpected long level field.\n          The root cause of the vulnerability is a combination of usage of uninitialized memory\n          from the stack and a dangerous string copy. This module has been tested successfully\n          on Yokogawa CENTUM CS 3000 R3.08.50.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-0781"
+    ],
+    "tags": [
+      "dos",
+      "scada",
+      "yokogawa-logsvr"
+    ],
+    "transcript": "",
+    "doc": "Yokogawa CENTUM CS 3000 BKCLogSvr.exe Heap Buffer Overflow",
+    "disclosure_date": "2014-03-10",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/smb/smb_loris",
+    "description": "The SMBLoris attack consumes large chunks of memory in the target by sending\n    SMB requests with the NetBios Session Service(NBSS) Length Header value set\n    to the maximum possible value. By keeping these connections open and initiating\n    large numbers of these sessions, the memory does not get freed, and the server\n    grinds to a halt. This vulnerability was originally disclosed by Sean Dillon\n    and Zach Harding.\n\n    DISCLAIMER: This module opens a lot of simultaneous connections. Please check\n    your system's ULIMIT to make sure it can handle it. This module will also run\n    continuously until stopped.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "smb",
+      "smb-loris"
+    ],
+    "transcript": "",
+    "doc": "SMBLoris NBSS Denial of Service",
+    "disclosure_date": "2017-06-29",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/smtp/sendmail_prescan",
+    "description": "This is a proof of concept denial of service module for Sendmail versions\n          8.12.8 and earlier. The vulnerability is within the prescan() method when\n          parsing SMTP headers. Due to the prescan function, only 0x5c and 0x00\n          bytes can be used, limiting the likelihood for arbitrary code execution.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2003-0694"
+    ],
+    "tags": [
+      "dos",
+      "smtp",
+      "sendmail-prescan"
+    ],
+    "transcript": "",
+    "doc": "Sendmail SMTP Address prescan Memory Corruption",
+    "disclosure_date": "2003-09-17",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/solaris/lpd/cascade_delete",
+    "description": "This module uses a vulnerability in the Solaris line printer\n          daemon to delete arbitrary files on an affected system. This\n          can be used to exploit the rpc.walld format string flaw, the\n          missing krb5.conf authentication bypass, or simply delete\n          system files. Tested on Solaris 2.6, 7, 8, 9, and 10.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2005-4797"
+    ],
+    "tags": [
+      "dos",
+      "solaris",
+      "lpd"
+    ],
+    "transcript": "",
+    "doc": "Solaris LPD Arbitrary File Delete",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/ssl/dtls_changecipherspec",
+    "description": "This module performs a Denial of Service Attack against Datagram TLS in OpenSSL\n          version 0.9.8i and earlier. OpenSSL crashes under these versions when it receives a\n          ChangeCipherspec Datagram before a ClientHello.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-1386"
+    ],
+    "tags": [
+      "dos",
+      "ssl",
+      "dtls-changecipherspec"
+    ],
+    "transcript": "",
+    "doc": "OpenSSL DTLS ChangeCipherSpec Remote DoS",
+    "disclosure_date": "2000-04-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/ssl/dtls_fragment_overflow",
+    "description": "This module performs a Denial of Service Attack against Datagram TLS in\n          OpenSSL before 0.9.8za, 1.0.0 before 1.0.0m, and 1.0.1 before 1.0.1h.\n          This occurs when a DTLS ClientHello message has multiple fragments and the\n          fragment lengths of later fragments are larger than that of the first, a\n          buffer overflow occurs, causing a DoS.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-0195"
+    ],
+    "tags": [
+      "dos",
+      "ssl",
+      "dtls-fragment-overflow"
+    ],
+    "transcript": "",
+    "doc": "OpenSSL DTLS Fragment Buffer Overflow DoS",
+    "disclosure_date": "2014-06-05",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/ssl/openssl_aesni",
+    "description": "The AES-NI implementation of OpenSSL 1.0.1c does not properly compute the\n          length of an encrypted message when used with a TLS version 1.1 or above. This\n          leads to an integer underflow which can cause a DoS. The vulnerable function\n          aesni_cbc_hmac_sha1_cipher is only included in the 64-bit versions of OpenSSL.\n          This module has been tested successfully on Ubuntu 12.04 (64-bit) with the default\n          OpenSSL 1.0.1c package.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-2686"
+    ],
+    "tags": [
+      "dos",
+      "ssl",
+      "openssl-aesni"
+    ],
+    "transcript": "",
+    "doc": "OpenSSL TLS 1.1 and 1.2 AES-NI DoS",
+    "disclosure_date": "2013-02-05",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/syslog/rsyslog_long_tag",
+    "description": "This module triggers an off-by-two overflow in the\n        rsyslog daemon. This flaw is unlikely to yield code execution\n        but is effective at shutting down a remote log daemon. This bug\n        was introduced in version 4.6.0 and corrected in 4.6.8/5.8.5.\n        Compiler differences may prevent this bug from causing any\n        noticeable result on many systems (RHEL6 is affected).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-3200"
+    ],
+    "tags": [
+      "dos",
+      "syslog",
+      "rsyslog-long-tag"
+    ],
+    "transcript": "",
+    "doc": "rsyslog Long Tag Off-By-Two DoS",
+    "disclosure_date": "2011-09-01",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/tcp/claymore_dos",
+    "description": "Claymore’s Dual GPU Miner 10.5 and below is vulnerable to a format strings vulnerability. This allows an\n    unauthenticated attacker to read memory addresses, or immediately terminate the mining process causing\n    a denial of service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-6317"
+    ],
+    "tags": [
+      "dos",
+      "tcp",
+      "claymore-dos"
+    ],
+    "transcript": "",
+    "doc": "Claymore Dual GPU Miner  Format String dos attack",
+    "disclosure_date": "2018-02-06",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/tcp/junos_tcp_opt",
+    "description": "This module exploits a denial of service vulnerability\n        in Juniper Network's JunOS router operating system. By sending a TCP\n        packet with TCP option 101 set, an attacker can cause an affected\n        router to reboot.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "tcp",
+      "junos-tcp-opt"
+    ],
+    "transcript": "",
+    "doc": "Juniper JunOS Malformed TCP Option",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/tcp/synflood",
+    "description": "A simple TCP SYN flooder",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "tcp",
+      "synflood"
+    ],
+    "transcript": "",
+    "doc": "TCP SYN Flooder",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/upnp/miniupnpd_dos",
+    "description": "This module allows remote attackers to cause a denial of service (DoS)\n          in MiniUPnP 1.0 server via a specifically crafted UDP request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-0229"
+    ],
+    "tags": [
+      "dos",
+      "upnp",
+      "miniupnpd-dos"
+    ],
+    "transcript": "",
+    "doc": "MiniUPnPd 1.4 Denial of Service (DoS) Exploit",
+    "disclosure_date": "2013-03-27",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/appian/appian_bpm",
+    "description": "This module exploits a denial of service flaw in the Appian\n          Enterprise Business Suite service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-6509"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "appian"
+    ],
+    "transcript": "",
+    "doc": "Appian Enterprise Business Suite 5.6 SP1 DoS",
+    "disclosure_date": "2007-12-17",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/browser/ms09_065_eot_integer",
+    "description": "This module exploits an integer overflow flaw in the Microsoft Windows Embedded\n          OpenType font parsing code located in win32k.sys. Since the kernel itself parses\n          embedded web fonts, it is possible to trigger a BSoD from a normal web page when\n          viewed with Internet Explorer.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-2514"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "browser"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows EOT Font Table Directory Integer Overflow",
+    "disclosure_date": "2009-11-10",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/filezilla_admin_user",
+    "description": "This module triggers a Denial of Service condition in the FileZilla FTP\n          Server Administration Interface in versions 0.9.4d and earlier.\n          By sending a procession of excessively long USER commands to the FTP\n          Server, the Administration Interface (FileZilla Server Interface.exe)\n          when running, will overwrite the stack with our string and generate an\n          exception. The FileZilla FTP Server itself will continue functioning.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2005-3589"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "FileZilla FTP Server Admin Interface Denial of Service",
+    "disclosure_date": "2005-11-07",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/filezilla_server_port",
+    "description": "This module triggers a Denial of Service condition in the FileZilla FTP\n          Server versions 0.9.21 and earlier. By sending a malformed PORT command\n          then LIST command, the server attempts to write to a NULL pointer.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-6565"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "FileZilla FTP Server Malformed PORT Denial of Service",
+    "disclosure_date": "2006-12-11",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/guildftp_cwdlist",
+    "description": "Guild FTPd 0.999.8.11 and 0.999.14 are vulnerable\n          to heap corruption.  You need to have a valid login\n          so you can run CWD and LIST.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-4572"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Guild FTPd 0.999.8.11/0.999.14 Heap Corruption",
+    "disclosure_date": "2008-10-12",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof",
+    "description": "This module triggers a heap overflow when processing a specially crafted\n          FTP request containing Telnet IAC (0xff) bytes. When constructing the response,\n          the Microsoft IIS FTP Service overflows the heap buffer with 0xff bytes.\n\n          This issue can be triggered pre-auth and may in fact be exploitable for\n          remote code execution.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-3972"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Microsoft IIS FTP Server Encoded Response Overflow Trigger",
+    "disclosure_date": "2010-12-21",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/iis_list_exhaustion",
+    "description": "This module triggers Denial of Service condition in the Microsoft Internet\n          Information Services (IIS) FTP Server 5.0 through 7.0 via a list (ls) -R command\n          containing a wildcard. For this exploit to work in most cases, you need 1) a valid\n          ftp account: either read-only or write-access account 2) the \"FTP Publishing\" must\n          be configured as \"manual\" mode in startup type 3) there must be at least one\n          directory under FTP root directory. If your provided an FTP account has write-access\n          privilege and there is no single directory, a new directory with random name will be\n          created prior to sending exploit payload.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-2521"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Microsoft IIS FTP Server LIST Stack Exhaustion",
+    "disclosure_date": "2009-09-03",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/solarftp_user",
+    "description": "This module will send a format string as USER to Solar FTP, causing a\n          READ violation in function \"__output_1()\" found in \"sfsservice.exe\"\n          while trying to calculate the length of the string. This vulnerability\n          affects versions 2.1.1 and earlier.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Solar FTP Server Malformed USER Denial of Service",
+    "disclosure_date": "2011-02-22",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/titan626_site",
+    "description": "The Titan FTP server v6.26 build 630 can be DoS'd by\n          issuing \"SITE WHO\".  You need a valid login so you\n          can send this command.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-6082"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Titan FTP Server 6.26.630 SITE WHO DoS",
+    "disclosure_date": "2008-10-14",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/vicftps50_list",
+    "description": "The Victory FTP Server v5.0 can be brought down by sending\n          a very simple LIST command",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-2031",
+      "CVE-2008-6829"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "Victory FTP Server 5.0 LIST DoS",
+    "disclosure_date": "2008-10-24",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/winftp230_nlst",
+    "description": "This module is a very rough port of Julien Bedard's\n          PoC.  You need a valid login, but even anonymous can\n          do it if it has permission to call NLST.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-5666"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "WinFTP 2.3.0 NLST Denial of Service",
+    "disclosure_date": "2008-09-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/xmeasy560_nlst",
+    "description": "This module is a port of shinnai's script.  You need\n          a valid login, but even anonymous can do it as long\n          as it has permission to call NLST.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-5626"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "XM Easy Personal FTP Server 5.6.0 NLST DoS",
+    "disclosure_date": "2008-10-13",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ftp/xmeasy570_nlst",
+    "description": "You need a valid login to DoS this FTP server, but\n          even anonymous can do it as long as it has permission\n          to call NLST.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-5626"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "ftp"
+    ],
+    "transcript": "",
+    "doc": "XM Easy Personal FTP Server 5.7.0 NLST DoS",
+    "disclosure_date": "2009-03-27",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/games/kaillera",
+    "description": "The Kaillera 0.86 server can be shut down by sending any malformed packet\n          after the initial \"hello\" packet.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "windows",
+      "games"
+    ],
+    "transcript": "",
+    "doc": "Kaillera 0.86 Server Denial of Service",
+    "disclosure_date": "2011-07-02",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/http/http_sys_accept_encoding_dos_cve_2021_31166",
+    "description": "This module exploits CVE-2021-31166, a UAF bug in http.sys\n          when parsing specially crafted Accept-Encoding headers\n          that was patched by Microsoft in May 2021, on vulnerable\n          IIS servers. Successful exploitation will result in\n          the target computer BSOD'ing before subsequently rebooting.\n          Note that the target IIS server may or may not come back up,\n          this depends on the target's settings as to whether IIS\n          is configured to start on reboot.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2021-31166"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "http"
+    ],
+    "transcript": "",
+    "doc": "Windows IIS HTTP Protocol Stack DOS",
+    "disclosure_date": "2021-05-11",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/http/ms10_065_ii6_asp_dos",
+    "description": "The vulnerability allows remote unauthenticated attackers to force the IIS server\n          to become unresponsive until the IIS service is restarted manually by the administrator.\n          Required is that Active Server Pages are hosted by the IIS and that an ASP script reads\n          out a Post Form value.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-1899"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "http"
+    ],
+    "transcript": "",
+    "doc": "Microsoft IIS 6.0 ASP Stack Exhaustion Denial of Service",
+    "disclosure_date": "2010-09-14",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/http/pi3web_isapi",
+    "description": "The Pi3Web HTTP server crashes when a request is made for an invalid DLL\n          file in /isapi for versions 2.0.13 and earlier. By default, the non-DLLs\n          in this directory after installation are users.txt, install.daf and\n          readme.daf.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-6938"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "http"
+    ],
+    "transcript": "",
+    "doc": "Pi3Web ISAPI DoS",
+    "disclosure_date": "2008-11-13",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/llmnr/ms11_030_dnsapi",
+    "description": "This module exploits a buffer underrun vulnerability in Microsoft's DNSAPI.dll\n        as distributed with Windows Vista and later without KB2509553. By sending a\n        specially crafted LLMNR query, containing a leading '.' character, an attacker\n        can trigger stack exhaustion or potentially cause stack memory corruption.\n\n        Although this vulnerability may lead to code execution, it has not been proven\n        to be possible at the time of this writing.\n\n        NOTE: In some circumstances, a '.' may be found before the top of the stack is\n        reached. In these cases, this module may not be able to cause a crash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0657"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "llmnr"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows DNSAPI.dll LLMNR Buffer Underrun DoS",
+    "disclosure_date": "2011-04-12",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/nat/nat_helper",
+    "description": "This module exploits a denial of service vulnerability\n          within the Internet Connection Sharing service in\n          Windows XP.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-5614"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "nat"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows NAT Helper Denial of Service",
+    "disclosure_date": "2006-10-26",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/rdp/ms12_020_maxchannelids",
+    "description": "This module exploits the MS12-020 RDP vulnerability originally discovered and\n          reported by Luigi Auriemma.  The flaw can be found in the way the T.125\n          ConnectMCSPDU packet is handled in the maxChannelIDs field, which will result\n          an invalid pointer being used, therefore causing a denial-of-service condition.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-0002"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "rdp"
+    ],
+    "transcript": "",
+    "doc": "MS12-020 Microsoft Remote Desktop Use-After-Free DoS",
+    "disclosure_date": "2012-03-16",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms05_047_pnp",
+    "description": "This module triggers a stack buffer overflow in the Windows Plug\n          and Play service. This vulnerability can be exploited on\n          Windows 2000 without a valid user account. Since the PnP\n          service runs inside the service.exe process, this module\n          will result in a forced reboot on Windows 2000. Obtaining\n          code execution is possible if user-controlled memory can\n          be placed at 0x00000030, 0x0030005C, or 0x005C005C.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2005-2120"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Plug and Play Service Registry Overflow",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms06_035_mailslot",
+    "description": "This module triggers a kernel pool corruption bug in SRV.SYS. Each\n          call to the mailslot write function results in a two byte return value\n          being written into the response packet. The code which creates this packet\n          fails to consider these two bytes in the allocation routine, resulting in\n          a slow corruption of the kernel memory pool. These two bytes are almost\n          always set to \"\\xff\\xff\" (a short integer with value of -1).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-3942"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SRV.SYS Mailslot Write Corruption",
+    "disclosure_date": "2006-07-11",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms06_063_trans",
+    "description": "This module exploits a NULL pointer dereference flaw in the\n          SRV.SYS driver of the Windows operating system. This bug was\n          independently discovered by CORE Security and ISS.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-3942"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SRV.SYS Pipe Transaction No Null",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms09_001_write",
+    "description": "This module exploits a denial of service vulnerability in the\n          SRV.SYS driver of the Windows operating system.\n\n          This module has been tested successfully against Windows Vista.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-4114"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SRV.SYS WriteAndX Invalid DataOffset",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh",
+    "description": "This module exploits an out of bounds function table dereference in the SMB\n          request validation code of the SRV2.SYS driver included with Windows Vista, Windows 7\n          release candidates (not RTM), and Windows 2008 Server prior to R2.  Windows\tVista\n          without SP1 does not seem affected by this flaw.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-3103"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SRV2.SYS SMB Negotiate ProcessID Function Table Dereference",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff",
+    "description": "This module triggers a NULL pointer dereference in the SRV2.SYS kernel driver when processing\n          an SMB2 logoff request before a session has been correctly negotiated, resulting in a BSOD.\n          Affecting Vista SP1/SP2 (and possibly Server 2008 SP1/SP2), the flaw was resolved with MS09-050.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-3103"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft SRV2.SYS SMB2 Logoff Remote Kernel NULL Pointer Dereference",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop",
+    "description": "This module exploits a denial of service flaw in the Microsoft\n          Windows SMB client on Windows 7 and Windows Server 2008 R2. To trigger\n          this bug, run this module as a service and forces a vulnerable client\n          to access the IP of this system as an SMB server. This can be accomplished\n          by embedding a UNC path (\\HOST\\share\\something) into a web page if the\n          target is using Internet Explorer, or a Word document otherwise.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0017"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows 7 / Server 2008 R2 SMB Client Infinite Loop",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow",
+    "description": "This module exploits a denial of service flaw in the Microsoft\n          Windows SMB service on versions of Windows prior to the August 2010 Patch\n          Tuesday. To trigger this bug, you must be able to access a share with\n          at least read privileges. That generally means you will need authentication.\n          However, if a system has a guest accessible share, you can trigger it\n          without any authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-2550"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows SRV.SYS SrvSmbQueryFsInformation Pool Overflow DoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/ms11_019_electbowser",
+    "description": "This module exploits a denial of service flaw in the Microsoft\n          Windows SMB service on versions of Windows Server 2003 that have been\n          configured as a domain controller. By sending a specially crafted election\n          request, an attacker can cause a pool overflow.\n\n          The vulnerability appears to be due to an error handling a length value\n          while calculating the amount of memory to copy to a buffer. When there are\n          zero bytes left in the buffer, the length value is improperly decremented\n          and an integer underflow occurs. The resulting value is used in several\n          calculations and is then passed as the length value to an inline memcpy\n          operation.\n\n          Unfortunately, the length value appears to be fixed at -2 (0xfffffffe) and\n          causes considerable damage to kernel heap memory. While theoretically possible,\n          it does not appear to be trivial to turn this vulnerability into remote (or\n          even local) code execution.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-0654"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows Browser Pool DoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/rras_vls_null_deref",
+    "description": "This module triggers a NULL dereference in svchost.exe on\n          all current versions of Windows that run the RRAS service. This\n          service is only accessible without authentication on Windows XP\n          SP1 (using the SRVSVC pipe).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft RRAS InterfaceAdjustVLSPointers NULL Dereference",
+    "disclosure_date": "2006-06-14",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smb/vista_negotiate_stop",
+    "description": "This module exploits a flaw in Windows Vista that allows a remote\n          unauthenticated attacker to disable the SMB service. This vulnerability\n          was silently fixed in Microsoft Vista Service Pack 1.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "windows",
+      "smb"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Vista SP0 SMB Negotiate Protocol DoS",
+    "disclosure_date": "",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/smtp/ms06_019_exchange",
+    "description": "This module triggers a heap overflow vulnerability in MS\n          Exchange that occurs when multiple malformed MODPROP values\n          occur in a VCAL request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-0027"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "smtp"
+    ],
+    "transcript": "",
+    "doc": "MS06-019 Exchange MODPROP Heap Overflow",
+    "disclosure_date": "2004-11-12",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/ssh/sysax_sshd_kexchange",
+    "description": "This module sends a specially-crafted SSH Key Exchange causing the service to\n          crash.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "dos",
+      "windows",
+      "ssh"
+    ],
+    "transcript": "",
+    "doc": "Sysax Multi-Server 6.10 SSHD Key Exchange Denial of Service",
+    "disclosure_date": "2013-03-17",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/tftp/pt360_write",
+    "description": "The PacketTrap TFTP server version 2.2.5459.0 can be\n          brought down by sending a special write request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-1311"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "tftp"
+    ],
+    "transcript": "",
+    "doc": "PacketTrap TFTP Server 2.2.5459.0 DoS",
+    "disclosure_date": "2008-10-29",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/windows/tftp/solarwinds",
+    "description": "The SolarWinds TFTP server can be shut down by sending a 'netascii' read\n          request with a specially crafted file name.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-2115"
+    ],
+    "tags": [
+      "dos",
+      "windows",
+      "tftp"
+    ],
+    "transcript": "",
+    "doc": "SolarWinds TFTP Server 10.4.0.10 Denial of Service",
+    "disclosure_date": "2010-05-21",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/wireshark/capwap",
+    "description": "This module injects a malformed UDP packet to crash Wireshark and TShark 1.8.0 to 1.8.7, as well\n          as 1.6.0 to 1.6.15. The vulnerability exists in the CAPWAP dissector which fails to handle a\n          packet correctly when an incorrect length is given.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-4074"
+    ],
+    "tags": [
+      "dos",
+      "wireshark",
+      "capwap"
+    ],
+    "transcript": "",
+    "doc": "Wireshark CAPWAP Dissector DoS",
+    "disclosure_date": "2014-04-28",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/wireshark/chunked",
+    "description": "Wireshark crash when dissecting an HTTP chunked response.\n          Versions affected: 0.99.5 (Bug 1394)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2007-3389"
+    ],
+    "tags": [
+      "dos",
+      "wireshark",
+      "chunked"
+    ],
+    "transcript": "",
+    "doc": "Wireshark chunked_encoding_dissector Function DOS",
+    "disclosure_date": "2007-02-22",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/wireshark/cldap",
+    "description": "This module causes infinite recursion to occur within the\n          CLDAP dissector by sending a specially crafted UDP packet.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2011-1140"
+    ],
+    "tags": [
+      "dos",
+      "wireshark",
+      "cldap"
+    ],
+    "transcript": "",
+    "doc": "Wireshark CLDAP Dissector DOS",
+    "disclosure_date": "2011-03-01",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/dos/wireshark/ldap",
+    "description": "The LDAP dissector in Wireshark 0.99.2 through 0.99.8 allows remote attackers\n        to cause a denial of service (application crash) via a malformed packet.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2008-1562"
+    ],
+    "tags": [
+      "dos",
+      "wireshark",
+      "ldap"
+    ],
+    "transcript": "",
+    "doc": "Wireshark LDAP Dissector DOS",
+    "disclosure_date": "2008-03-28",
+    "teaches": "Teaches about dos"
+  },
+  {
+    "name": "auxiliary/fileformat/badpdf",
+    "description": "This module can either creates a blank PDF file which contains a UNC link which can be used\n          to capture NetNTLM credentials, or if the PDFINJECT option is used it will inject the necessary\n          code into an existing PDF document if possible.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2018-4993"
+    ],
+    "tags": [
+      "fileformat",
+      "badpdf"
+    ],
+    "transcript": "",
+    "doc": "BADPDF Malicious PDF Creator",
+    "disclosure_date": "",
+    "teaches": "Teaches about fileformat"
+  },
+  {
+    "name": "auxiliary/fileformat/maldoc_in_pdf_polyglot",
+    "description": "A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file\n          structure of PDF.\n\n          If the file has configured macro, by opening it in Microsoft Word, VBS runs and performs malicious behaviors.\n\n          The attack does not bypass configured macro locks. And the malicious macros are also not executed when the\n          file is opened in PDF readers or similar software.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [],
+    "tags": [
+      "fileformat",
+      "maldoc-in-pdf-polyglot"
+    ],
+    "transcript": "",
+    "doc": "Maldoc in PDF Polyglot converter",
+    "disclosure_date": "",
+    "teaches": "Teaches about fileformat"
+  },
+  {
+    "name": "auxiliary/fileformat/multidrop",
+    "description": "This module dependent on the given filename extension creates either\n          a .lnk, .scf, .url, .xml, .library-ms, or desktop.ini file which includes\n          a reference to the specified remote host, causing SMB connections to be\n          initiated from any user that views the file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [],
+    "tags": [
+      "fileformat",
+      "multidrop"
+    ],
+    "transcript": "",
+    "doc": "Windows SMB Multi Dropper",
+    "disclosure_date": "",
+    "teaches": "Teaches about fileformat"
+  },
+  {
+    "name": "auxiliary/fileformat/odt_badodt",
+    "description": "Generates a Malicious ODT File which can be used with auxiliary/server/capture/smb or similar to capture hashes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-10583"
+    ],
+    "tags": [
+      "fileformat",
+      "odt-badodt"
+    ],
+    "transcript": "",
+    "doc": "LibreOffice 6.03 /Apache OpenOffice 4.1.5 Malicious ODT File Generator",
+    "disclosure_date": "2018-05-01",
+    "teaches": "Teaches about fileformat"
+  },
+  {
+    "name": "auxiliary/fileformat/word_unc_injector",
+    "description": "This module modifies a .docx file that will, upon opening, submit stored\n          netNTLM credentials to a remote host. It can also create an empty docx file. If\n          emailed the receiver needs to put the document in editing mode before the remote\n          server will be contacted. Preview and read-only mode do not work. Verified to work\n          with Microsoft Word 2003, 2007, 2010, and 2013. In order to get the hashes the\n          auxiliary/server/capture/smb module can be used.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fileformat",
+      "word-unc-injector"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Word UNC Path Injector",
+    "disclosure_date": "",
+    "teaches": "Teaches about fileformat"
+  },
+  {
+    "name": "auxiliary/fuzzers/dns/dns_fuzzer",
+    "description": "This module will connect to a DNS server and perform DNS and\n        DNSSEC protocol-level fuzzing. Note that this module may inadvertently\n        crash the target server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "dns",
+      "dns-fuzzer"
+    ],
+    "transcript": "",
+    "doc": "DNS and DNSSEC Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ftp/client_ftp",
+    "description": "This module will serve an FTP server and perform FTP client interaction fuzzing",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ftp",
+      "client-ftp"
+    ],
+    "transcript": "",
+    "doc": "Simple FTP Client Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ftp/ftp_pre_post",
+    "description": "This module will connect to a FTP server and perform pre- and post-authentication fuzzing",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ftp",
+      "ftp-pre-post"
+    ],
+    "transcript": "",
+    "doc": "Simple FTP Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/http/http_form_field",
+    "description": "This module will grab all fields from a form,\n          and launch a series of POST actions, fuzzing the contents\n          of the form fields. You can optionally fuzz headers too\n          (option is enabled by default)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "http",
+      "http-form-field"
+    ],
+    "transcript": "",
+    "doc": "HTTP Form Field Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/http/http_get_uri_long",
+    "description": "This module sends a series of HTTP GET request with incrementing URL lengths.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "http",
+      "http-get-uri-long"
+    ],
+    "transcript": "",
+    "doc": "HTTP GET Request URI Fuzzer (Incrementing Lengths)",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/http/http_get_uri_strings",
+    "description": "This module sends a series of HTTP GET request with malicious URIs.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "http",
+      "http-get-uri-strings"
+    ],
+    "transcript": "",
+    "doc": "HTTP GET Request URI Fuzzer (Fuzzer Strings)",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ntp/ntp_protocol_fuzzer",
+    "description": "A simplistic fuzzer for the Network Time Protocol that sends the\n        following probes to understand NTP and look for anomalous NTP behavior:\n\n        * All possible combinations of NTP versions and modes, even if not\n          allowed or specified in the RFCs\n        * Short versions of the above\n        * Short, invalid datagrams\n        * Full-size, random datagrams\n        * All possible NTP control messages\n        * All possible NTP private messages\n\n        This findings of this fuzzer are not necessarily indicative of bugs,\n        let alone vulnerabilities, rather they point out interesting things\n        that might deserve more attention.  Furthermore, this module is not\n        particularly intelligent and there are many more areas of NTP that\n        could be explored, including:\n\n        * Warn if the response is 100% identical to the request\n        * Warn if the \"mode\" (if applicable) doesn't align with what we expect,\n        * Filter out the 12-byte mode 6 unsupported opcode errors.\n        * Fuzz the control message payload offset/size/etc.  There be bugs",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ntp",
+      "ntp-protocol-fuzzer"
+    ],
+    "transcript": "",
+    "doc": "NTP Protocol Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb2_negotiate_corrupt",
+    "description": "This module sends a series of SMB negotiate requests that advertise a\n          SMB2 dialect with corrupted bytes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb2-negotiate-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SMB Negotiate SMB2 Dialect Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_create_pipe",
+    "description": "This module sends a series of SMB create pipe\n          requests using malicious strings.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-create-pipe"
+    ],
+    "transcript": "",
+    "doc": "SMB Create Pipe Request Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_create_pipe_corrupt",
+    "description": "This module sends a series of SMB create pipe requests with corrupted bytes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-create-pipe-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SMB Create Pipe Request Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_negotiate_corrupt",
+    "description": "This module sends a series of SMB negotiate requests with corrupted bytes",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-negotiate-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SMB Negotiate Dialect Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt",
+    "description": "This module sends a series of SMB login requests using\n          the NTLMv1 protocol with corrupted bytes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-ntlm1-login-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SMB NTLMv1 Login Request Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_tree_connect",
+    "description": "This module sends a series of SMB tree connect\n          requests using malicious strings.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-tree-connect"
+    ],
+    "transcript": "",
+    "doc": "SMB Tree Connect Request Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smb/smb_tree_connect_corrupt",
+    "description": "This module sends a series of SMB tree connect requests with corrupted bytes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smb",
+      "smb-tree-connect-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SMB Tree Connect Request Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/smtp/smtp_fuzzer",
+    "description": "SMTP Simple Fuzzer",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "smtp",
+      "smtp-fuzzer"
+    ],
+    "transcript": "",
+    "doc": "SMTP Simple Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ssh/ssh_kexinit_corrupt",
+    "description": "This module sends a series of SSH requests with a corrupted initial key exchange payload.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ssh",
+      "ssh-kexinit-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SSH Key Exchange Init Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ssh/ssh_version_15",
+    "description": "This module sends a series of SSH requests with malicious version strings.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ssh",
+      "ssh-version-15"
+    ],
+    "transcript": "",
+    "doc": "SSH 1.5 Version Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ssh/ssh_version_2",
+    "description": "This module sends a series of SSH requests with malicious version strings.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ssh",
+      "ssh-version-2"
+    ],
+    "transcript": "",
+    "doc": "SSH 2.0 Version Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/ssh/ssh_version_corrupt",
+    "description": "This module sends a series of SSH requests with a corrupted version string",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "ssh",
+      "ssh-version-corrupt"
+    ],
+    "transcript": "",
+    "doc": "SSH Version Corruption",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/tds/tds_login_corrupt",
+    "description": "This module sends a series of malformed TDS login requests.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "tds",
+      "tds-login-corrupt"
+    ],
+    "transcript": "",
+    "doc": "TDS Protocol Login Request Corruption Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/fuzzers/tds/tds_login_username",
+    "description": "This module sends a series of malformed TDS login requests.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "fuzzers",
+      "tds",
+      "tds-login-username"
+    ],
+    "transcript": "",
+    "doc": "TDS Protocol Login Request Username Fuzzer",
+    "disclosure_date": "",
+    "teaches": "Teaches about fuzzers"
+  },
+  {
+    "name": "auxiliary/gather/acronis_cyber_protect_machine_info_disclosure",
+    "description": "Acronis Cyber Protect or Backup is an enterprise backup/recovery solution for all,\n          compute, storage and application resources. Businesses and Service Providers are using it\n          to protect and backup all IT assets in their IT environment.\n          This module exploits an authentication bypass vulnerability at the Acronis Cyber Protect\n          appliance which, in its default configuration, allows the anonymous registration of new\n          backup/protection agents on new endpoints. This API endpoint also generates bearer tokens\n          which the agent then uses to authenticate to the appliance.\n          As the management web console is running on the same port as the API for the agents, this\n          bearer token is also valid for any actions on the web console. This allows an attacker\n          with network access to the appliance to start the registration of a new agent, retrieve\n          a bearer token that provides admin access to the available functions in the web console.\n\n          This module will gather all machine info (endpoints) configured and managed by the appliance.\n          This information can be used in a subsequent attack that exploits this vulnerability to\n          execute arbitrary commands on both the managed endpoint and the appliance.\n          This exploit is covered in another module `exploit/multi/acronis_cyber_protect_unauth_rce_cve_2022_3405`.\n\n          Acronis Cyber Protect 15 (Windows, Linux) before build 29486 and\n          Acronis Cyber Backup 12.5 (Windows, Linux) before build 16545 are vulnerable.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-30995",
+      "CVE-2022-3405"
+    ],
+    "tags": [
+      "gather",
+      "acronis-cyber-protect-machine-info-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Acronis Cyber Protect/Backup machine info disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/adobe_coldfusion_fileread_cve_2023_26360",
+    "description": "This module exploits a remote unauthenticated deserialization of untrusted data vulnerability in Adobe\n          ColdFusion 2021 Update 5 and earlier as well as ColdFusion 2018 Update 15 and earlier, in order to read\n          an arbitrary file from the server.\n\n          To run this module you must provide a valid ColdFusion Component (CFC) endpoint via the CFC_ENDPOINT option,\n          and a valid remote method name from that endpoint via the CFC_METHOD option. By default an endpoint in the\n          ColdFusion Administrator (CFIDE) is provided. If the CFIDE is not accessible you will need to choose a\n          different CFC endpoint, method and parameters.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-26360"
+    ],
+    "tags": [
+      "gather",
+      "adobe-coldfusion-fileread-cve-2023-26360"
+    ],
+    "transcript": "",
+    "doc": "Adobe ColdFusion Unauthenticated Arbitrary File Read",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/advantech_webaccess_creds",
+    "description": "This module allows you to log into Advantech WebAccess 8.1, and collect all of the credentials.\n          Although authentication is required, any level of user permission can exploit this vulnerability.\n\n          Note that 8.2 is not suitable for this.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-5810"
+    ],
+    "tags": [
+      "gather",
+      "advantech-webaccess-creds"
+    ],
+    "transcript": "",
+    "doc": "Advantech WebAccess 8.1 Post Authentication Credential Collector",
+    "disclosure_date": "2017-01-21",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/alienvault_iso27001_sqli",
+    "description": "AlienVault 4.5.0 is susceptible to an authenticated SQL injection attack via a PNG\n          generation PHP file. This module exploits this to read an arbitrary file from\n          the file system. Any authenticated user is able to exploit it, as administrator\n          privileges aren't required.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [],
+    "tags": [
+      "gather",
+      "alienvault-iso27001-sqli"
+    ],
+    "transcript": "",
+    "doc": "AlienVault Authenticated SQL Injection Arbitrary File Read",
+    "disclosure_date": "2014-03-30",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/alienvault_newpolicyform_sqli",
+    "description": "AlienVault 4.6.1 and below is susceptible to an authenticated SQL injection attack against\n          newpolicyform.php, using the 'insertinto' parameter. This module exploits the vulnerability\n          to read an arbitrary file from the file system. Any authenticated user is able to exploit\n          this, as administrator privileges are not required.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-5383"
+    ],
+    "tags": [
+      "gather",
+      "alienvault-newpolicyform-sqli"
+    ],
+    "transcript": "",
+    "doc": "AlienVault Authenticated SQL Injection Arbitrary File Read",
+    "disclosure_date": "2014-05-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/android_browser_file_theft",
+    "description": "This module steals the cookie, password, and autofill databases from the\n          Browser application on AOSP 4.3 and below.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "android-browser-file-theft"
+    ],
+    "transcript": "",
+    "doc": "Android Browser File Theft",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/android_browser_new_tab_cookie_theft",
+    "description": "In Android's stock AOSP Browser application and WebView component, the\n          \"open in new tab\" functionality allows a file URL to be opened. On\n          versions of Android before 4.4, the path to the sqlite cookie\n          database could be specified. By saving a cookie containing a <script>\n          tag and then loading the sqlite database into the browser as an HTML file,\n          XSS can be achieved inside the cookie file, disclosing *all* cookies\n          (HttpOnly or not) to an attacker.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "android-browser-new-tab-cookie-theft"
+    ],
+    "transcript": "",
+    "doc": "Android Browser \"Open in New Tab\" Cookie Theft",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/android_htmlfileprovider",
+    "description": "This module exploits a cross-domain issue within the Android web browser to\n          exfiltrate files from a vulnerable device.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-4804"
+    ],
+    "tags": [
+      "gather",
+      "android-htmlfileprovider"
+    ],
+    "transcript": "",
+    "doc": "Android Content Provider File Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/android_object_tag_webview_uxss",
+    "description": "This module exploits a Universal Cross-Site Scripting (UXSS) vulnerability present in\n          all versions of Android's open source stock browser before 4.4, and Android apps running\n          on < 4.4 that embed the WebView component. If successful, an attacker can leverage this bug\n          to scrape both cookie data and page contents from a vulnerable browser window.\n\n          Target URLs that use X-Frame-Options can not be exploited with this vulnerability.\n\n          Some sample UXSS scripts are provided in data/exploits/uxss.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "android-object-tag-webview-uxss"
+    ],
+    "transcript": "",
+    "doc": "Android Open Source Platform (AOSP) Browser UXSS",
+    "disclosure_date": "2014-10-04",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/android_stock_browser_uxss",
+    "description": "This module exploits a Universal Cross-Site Scripting (UXSS) vulnerability present in\n          all versions of Android's open source stock browser before 4.4, and Android apps running\n          on < 4.4 that embed the WebView component. If successful, an attacker can leverage this bug\n          to scrape both cookie data and page contents from a vulnerable browser window.\n\n          If your target URLs use X-Frame-Options, you can enable the \"BYPASS_XFO\" option,\n          which will cause a popup window to be used. This requires a click from the user\n          and is much less stealthy, but is generally harmless-looking.\n\n          By supplying a CUSTOM_JS parameter and ensuring CLOSE_POPUP is set to false, this\n          module also allows running arbitrary javascript in the context of the targeted URL.\n          Some sample UXSS scripts are provided in data/exploits/uxss.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-6041"
+    ],
+    "tags": [
+      "gather",
+      "android-stock-browser-uxss"
+    ],
+    "transcript": "",
+    "doc": "Android Open Source Platform (AOSP) Browser UXSS",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/apache_rave_creds",
+    "description": "This module exploits an information disclosure in Apache Rave 0.20 and prior. The\n          vulnerability exists in the RPC API, which allows any authenticated user to\n          disclose information about all the users, including their password hashes. In order\n          to authenticate, the user can provide his own credentials. Also the default users\n          installed with Apache Rave 0.20 will be tried automatically. This module has been\n          successfully tested on Apache Rave 0.20.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-1814"
+    ],
+    "tags": [
+      "gather",
+      "apache-rave-creds"
+    ],
+    "transcript": "",
+    "doc": "Apache Rave User Information Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/apache_superset_cookie_sig_priv_esc",
+    "description": "Apache Superset versions <= 2.0.0 utilize Flask with a known default secret key which is used to sign HTTP cookies.\n          These cookies can therefore be forged. If a user is able to login to the site, they can decode the cookie, set their user_id to that\n          of an administrator, and re-sign the cookie. This valid cookie can then be used to login as the targeted user and retrieve database\n          credentials saved in Apache Superset.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-27524"
+    ],
+    "tags": [
+      "gather",
+      "apache-superset-cookie-sig-priv-esc"
+    ],
+    "transcript": "",
+    "doc": "Apache Superset Signed Cookie Priv Esc",
+    "disclosure_date": "2023-04-25",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/apple_safari_ftp_url_cookie_theft",
+    "description": "A vulnerability exists in versions of OSX, iOS, and Windows Safari released\n          before April 8, 2015 that allows the non-HTTPOnly cookies of any\n          domain to be stolen.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-1126"
+    ],
+    "tags": [
+      "gather",
+      "apple-safari-ftp-url-cookie-theft"
+    ],
+    "transcript": "",
+    "doc": "Apple OSX/iOS/Windows Safari Non-HTTPOnly Cookie Theft",
+    "disclosure_date": "2015-04-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/apple_safari_webarchive_uxss",
+    "description": "Generates a .webarchive file for Mac OS X Safari that will attempt to\n          inject cross-domain Javascript (UXSS), silently install a browser\n          extension, collect user information, steal the cookie database,\n          and steal arbitrary local files.\n\n          When opened on the target machine the webarchive file must not have the\n          quarantine attribute set, as this forces the webarchive to execute in a\n          sandbox.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "apple-safari-webarchive-uxss"
+    ],
+    "transcript": "",
+    "doc": "Mac OS X Safari .webarchive File Format UXSS",
+    "disclosure_date": "2013-02-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745",
+    "description": "This module leverages an unauthenticated arbitrary file read for\n          the Argus Surveillance 4.0.0.0 system which never saw an update since.\n          As this is a Windows related application we recommend looking for common\n          Windows file locations, especially C:\\ProgramData\\PY_Software\\Argus Surveillance DVR\\DVRParams.ini\n          which houses another vulnerability in the Argus Surveillance system. This directory traversal vuln\n          is being tracked as CVE-2018-15745",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-15745"
+    ],
+    "tags": [
+      "gather",
+      "argus-dvr-4-lfi-cve-2018-15745"
+    ],
+    "transcript": "",
+    "doc": "Argus Surveillance DVR 4.0.0.0 - Directory Traversal",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/asrep",
+    "description": "This module searches for AD users without pre-auth required. Two different approaches\n          are provided:\n          - Brute force of usernames (does not require a user account; should not lock out accounts)\n          - LDAP lookup (requires an AD user account)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "asrep"
+    ],
+    "transcript": "",
+    "doc": "Find Users Without Pre-Auth Required (ASREP-roast)",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/asterisk_creds",
+    "description": "This module retrieves SIP and IAX2 user extensions and credentials from\n          Asterisk Call Manager service. Valid manager credentials are required.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "asterisk-creds"
+    ],
+    "transcript": "",
+    "doc": "Asterisk Gather Credentials",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/avtech744_dvr_accounts",
+    "description": "This module will extract the account information from the AVTECH 744 DVR devices,\n          including usernames, cleartext passwords, and the device PIN, along with\n          a few other miscellaneous details. In order to extract the information, hardcoded\n          credentials admin/admin are used. These credentials can't be changed from the device\n          console UI nor from the web UI.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "avtech744-dvr-accounts"
+    ],
+    "transcript": "",
+    "doc": "AVTECH 744 DVR Account Information Retrieval",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/billquick_txtid_sqli",
+    "description": "This module exploits a SQL injection vulnerability in BillQUick Web Suite prior to version 22.0.9.1.\n          The application is .net based, and the database is required to be MSSQL.  Luckily the website gives\n          error based SQLi messages, so it is trivial to pull data from the database.  However the webapp\n          uses an unknown password security algorithm.  This vulnerability does not seem to support stacked\n          queries.\n          This module pulls the database name, banner, user, hostname, and the SecurityTable (user table).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-42258"
+    ],
+    "tags": [
+      "gather",
+      "billquick-txtid-sqli"
+    ],
+    "transcript": "",
+    "doc": "BillQuick Web Suite txtID SQLi",
+    "disclosure_date": "2021-10-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/browser_info",
+    "description": "This module gathers information about a browser that exploits might be interested in, such\n          as OS name, browser version, plugins, etc. By default, the module will return a fake 404,\n          but you can customize this output by changing the Custom404 datastore option, and\n          redirect to an external web page.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "browser-info"
+    ],
+    "transcript": "",
+    "doc": "HTTP Client Information Gather",
+    "disclosure_date": "2016-03-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/browser_lanipleak",
+    "description": "This module retrieves a browser's network interface IP addresses\n          using WebRTC.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-6849"
+    ],
+    "tags": [
+      "gather",
+      "browser-lanipleak"
+    ],
+    "transcript": "",
+    "doc": "HTTP Client LAN IP Address Gather",
+    "disclosure_date": "2013-09-05",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/c2s_dvr_password_disclosure",
+    "description": "C2S DVR allows an unauthenticated user to disclose the username\n        & password by requesting the javascript page 'read.cgi?page=2'.\n        This may also work on some cameras including IRDOME-II-C2S, IRBOX-II-C2S.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "c2s-dvr-password-disclosure"
+    ],
+    "transcript": "",
+    "doc": "C2S DVR Management Password Disclosure",
+    "disclosure_date": "2016-08-19",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/censys_search",
+    "description": "The module uses the Censys REST API to access the same data accessible\n          through the web interface. The search endpoint allows queries using\n          the Censys Search Language against the Hosts dataset. Setting the\n          CERTIFICATES option will also retrieve the certificate details for each\n          relevant service by querying the Certificates dataset.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "censys-search"
+    ],
+    "transcript": "",
+    "doc": "Censys Search",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/cerberus_helpdesk_hash_disclosure",
+    "description": "This module extracts usernames and password hashes from the Cerberus Helpdesk\n        through an unauthenticated access to a workers file.\n        Verified on Version 4.2.3 Stable (Build 925) and 5.4.4",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "cerberus-helpdesk-hash-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Cerberus Helpdesk User Hash Disclosure",
+    "disclosure_date": "2016-03-07",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919",
+    "description": "This module leverages an unauthenticated arbitrary root file read vulnerability for\n          Check Point Security Gateway appliances. When the IPSec VPN or Mobile Access blades\n          are enabled on affected devices, traversal payloads can be used to read any files on\n          the local file system. Password hashes read from disk may be cracked, potentially\n          resulting in administrator-level access to the target device. This vulnerability is\n          tracked as CVE-2024-24919.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "checkpoint-gateway-fileread-cve-2024-24919"
+    ],
+    "transcript": "",
+    "doc": "Check Point Security Gateway Arbitrary File Read",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/checkpoint_hostname",
+    "description": "This module sends a query to the port 264/TCP on CheckPoint Firewall-1\n          firewalls to obtain the firewall name and management station\n          (such as SmartCenter) name via a pre-authentication request. The string\n          returned is the CheckPoint Internal CA CN for SmartCenter and the firewall\n          host. Whilst considered \"public\" information, the majority of installations\n          use detailed hostnames which may aid an attacker in focusing on compromising\n          the SmartCenter host, or useful for government, intelligence and military\n          networks where the hostname reveals the physical location and rack number\n          of the device, which may be unintentionally published to the world.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "checkpoint-hostname"
+    ],
+    "transcript": "",
+    "doc": "CheckPoint Firewall-1 SecuRemote Topology Service Hostname Disclosure",
+    "disclosure_date": "2011-12-14",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/chrome_debugger",
+    "description": "This module uses the Chrome Debugger's API to read\n          files off the remote file system, or to make web requests\n          from a remote machine.  Useful for cloud metadata endpoints!",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "chrome-debugger"
+    ],
+    "transcript": "",
+    "doc": "Chrome Debugger Arbitrary File Read / Arbitrary Web Request",
+    "disclosure_date": "2019-09-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/cisco_pvc2300_download_config",
+    "description": "This module exploits an information disclosure vulnerability in Cisco PVC2300 cameras in order\n            to download the configuration file containing the admin credentials for the web interface.\n\n            The module first performs a basic check to see if the target is likely Cisco PVC2300. If so, the\n            module attempts to obtain a sessionID via an HTTP GET request to the vulnerable /oamp/System.xml\n            endpoint using hardcoded credentials.\n\n            If a session ID is obtained, the module uses it in another HTTP GET request to /oamp/System.xml\n            with the aim of downloading the configuration file. The configuration file, if obtained, is then\n            decoded and saved to the loot directory. Finally, the module attempts to extract the admin\n            credentials to the web interface from the decoded configuration file.\n\n            No known solution was made available for this vulnerability and no CVE has been published. It is\n            therefore likely that most (if not all) Cisco PVC2300 cameras are affected.\n\n            This module was successfully tested against several Cisco PVC2300 cameras.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "cisco-pvc2300-download-config"
+    ],
+    "transcript": "",
+    "doc": "Cisco PVC2300 POE Video Camera configuration download",
+    "disclosure_date": "2013-07-12",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/cisco_rv320_config",
+    "description": "A vulnerability in the web-based management interface of Cisco Small Business\n          RV320 and RV325 Dual Gigabit WAN VPN routers could allow an unauthenticated,\n          remote attacker to retrieve sensitive information. The vulnerability is due\n          to improper access controls for URLs. An attacker could exploit this\n          vulnerability by connecting to an affected device via HTTP or HTTPS and\n          requesting specific URLs. A successful exploit could allow the attacker to\n          download the router configuration or detailed diagnostic information. Cisco\n          has released firmware updates that address this vulnerability.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-1653"
+    ],
+    "tags": [
+      "gather",
+      "cisco-rv320-config"
+    ],
+    "transcript": "",
+    "doc": "Cisco RV320/RV326 Configuration Disclosure",
+    "disclosure_date": "2019-01-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/citrix_published_applications",
+    "description": "This module attempts to query Citrix Metaframe ICA server to obtain\n          a published list of applications.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "citrix-published-applications"
+    ],
+    "transcript": "",
+    "doc": "Citrix MetaFrame ICA Published Applications Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/citrix_published_bruteforce",
+    "description": "This module attempts to brute force program names within the Citrix\n          Metaframe ICA server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "citrix-published-bruteforce"
+    ],
+    "transcript": "",
+    "doc": "Citrix MetaFrame ICA Published Applications Bruteforcer",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/cloud_lookup",
+    "description": "This module can be useful if you need to test the security of your server and your\n          website behind a solution Cloud based. By discovering the origin IP address of the\n          targeted host.\n\n          More precisely, this module uses multiple data sources (in order ViewDNS.info, DNS enumeration\n          and Censys) to collect assigned (or have been assigned) IP addresses from the targeted site or domain\n          that uses the following:\n          * Cloudflare, Amazon CloudFront, ArvanCloud, Envoy Proxy, Fastly, Stackpath Fireblade,\n          Stackpath MaxCDN, Imperva Incapsula, InGen Security (BinarySec EasyWAF), KeyCDN, Microsoft AzureCDN,\n          Netlify and Sucuri.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "cloud-lookup"
+    ],
+    "transcript": "",
+    "doc": "Cloud Lookup (and Bypass)",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/coldfusion_pms_servlet_file_read",
+    "description": "This module exploits an Improper Access Vulnerability in Adobe Coldfusion versions prior to version\n          '2023 Update 6' and '2021 Update 12'. The vulnerability allows unauthenticated attackers to request authentication\n          token in the form of a UUID from the /CFIDE/adminapi/_servermanager/servermanager.cfc endpoint. Using that\n          UUID attackers can hit the /pms endpoint in order to exploit the Arbitrary File Read Vulnerability.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-20767"
+    ],
+    "tags": [
+      "gather",
+      "coldfusion-pms-servlet-file-read"
+    ],
+    "transcript": "",
+    "doc": "CVE-2024-20767 - Adobe Coldfusion Arbitrary File Read",
+    "disclosure_date": "2024-03-12",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/coldfusion_pwd_props",
+    "description": "This module uses a directory traversal vulnerability to extract information\n          such as password, rdspassword, and \"encrypted\" properties. This module has been\n          tested successfully on ColdFusion 9 and ColdFusion 10 (auto-detect).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3336"
+    ],
+    "tags": [
+      "gather",
+      "coldfusion-pwd-props"
+    ],
+    "transcript": "",
+    "doc": "ColdFusion 'password.properties' Hash Extraction",
+    "disclosure_date": "2013-05-07",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/corpwatch_lookup_id",
+    "description": "This module interfaces with the CorpWatch API to get publicly available\n          info for a given CorpWatch ID of the company.  If you don't know the\n          CorpWatch ID, please use the corpwatch_lookup_name module first.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "corpwatch-lookup-id"
+    ],
+    "transcript": "",
+    "doc": "CorpWatch Company ID Information Search",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/corpwatch_lookup_name",
+    "description": "This module interfaces with the CorpWatch API to get publicly available\n          info for a given company name.  Please note that by using CorpWatch API, you\n          acknowledge the limitations of the data CorpWatch provides, and should always\n          verify the information with the official SEC filings before taking any action.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "corpwatch-lookup-name"
+    ],
+    "transcript": "",
+    "doc": "CorpWatch Company Name Information Search",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/crushftp_authbypass_cve_2025_2825",
+    "description": "This module leverages an authentication bypass in CrushFTP 11 < 11.3.1 and 10 < 10.8.4. Attackers\n          with knowledge of a valid username can provide a crafted S3 authentication header to the CrushFTP web API\n          to authenticate as that user without valid credentials. When successfully executed, the exploit will\n          output working session cookies for the target user account.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2025-2825"
+    ],
+    "tags": [
+      "gather",
+      "crushftp-authbypass-cve-2025-2825"
+    ],
+    "transcript": "",
+    "doc": "CrushFTP AWS4-HMAC Authentication Bypass",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/crushftp_fileread_cve_2024_4040",
+    "description": "This module leverages an unauthenticated server-side template injection vulnerability in CrushFTP < 10.7.1 and\n          < 11.1.0 (as well as legacy 9.x versions). Attackers can submit template injection payloads to the web API without\n          authentication. When attacker payloads are reflected in the server's responses, the payloads are evaluated. The\n          primary impact of the injection is arbitrary file read as root, which can result in authentication bypass, remote\n          code execution, and NetNTLMv2 theft (when the host OS is Windows and SMB egress traffic is permitted).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-4040"
+    ],
+    "tags": [
+      "gather",
+      "crushftp-fileread-cve-2024-4040"
+    ],
+    "transcript": "",
+    "doc": "CrushFTP Unauthenticated Arbitrary File Read",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key",
+    "description": "This exploit finds the HMAC secret key used in Java serialization by Apache Tapestry. This key\n          is located in the file AppModule.class by default and looks like the standard representation of UUID in hex digits (hd) :\n          6hd-4hd-4hd-4hd-12hd\n          If the HMAC key has been changed to look differently, this module won't find the key because it tries to download the file\n          and then uses a specific regex to find the key.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-27850"
+    ],
+    "tags": [
+      "gather",
+      "cve-2021-27850-apache-tapestry-hmac-key"
+    ],
+    "transcript": "",
+    "doc": "Apache Tapestry HMAC secret key leak",
+    "disclosure_date": "2021-04-15",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/d20pass",
+    "description": "The General Electric D20ME and possibly other units (D200?) feature\n          TFTP readable configurations with plaintext passwords.  This module\n          retrieves the username, password, and authentication level list.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-6663"
+    ],
+    "tags": [
+      "gather",
+      "d20pass"
+    ],
+    "transcript": "",
+    "doc": "General Electric D20 Password Recovery",
+    "disclosure_date": "2012-01-19",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/darkcomet_filedownloader",
+    "description": "This module exploits an arbitrary file download vulnerability in the DarkComet C&C server versions 3.2 and up.\n          The exploit does not need to know the password chosen for the bot/server communication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [],
+    "tags": [
+      "gather",
+      "darkcomet-filedownloader"
+    ],
+    "transcript": "",
+    "doc": "DarkComet Server Remote File Download Exploit",
+    "disclosure_date": "2012-10-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/dolibarr_creds_sqli",
+    "description": "This module enables an authenticated user to collect the usernames and\n          encrypted passwords of other users in the Dolibarr ERP/CRM via SQL\n          injection.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-10094"
+    ],
+    "tags": [
+      "gather",
+      "dolibarr-creds-sqli"
+    ],
+    "transcript": "",
+    "doc": "Dolibarr Gather Credentials via SQL Injection",
+    "disclosure_date": "2018-05-30",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/doliwamp_traversal_creds",
+    "description": "This module will extract user credentials from DoliWamp - a WAMP\n          packaged installer distribution for Dolibarr ERP on Windows - versions\n          3.3.0 to 3.4.2 by hijacking a user's session. DoliWamp stores session\n          tokens in filenames in the 'tmp' directory. A directory traversal\n          vulnerability in 'jqueryFileTree.php' allows unauthenticated users\n          to retrieve session tokens by listing the contents of this directory.\n          Note: All tokens expire after 30 minutes of inactivity by default.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "doliwamp-traversal-creds"
+    ],
+    "transcript": "",
+    "doc": "DoliWamp 'jqueryFileTree.php' Traversal Gather Credentials",
+    "disclosure_date": "2014-01-12",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/drupal_openid_xxe",
+    "description": "This module abuses an XML External Entity Injection\n          vulnerability on the OpenID module from Drupal. The vulnerability exists\n          in the parsing of a malformed XRDS file coming from a malicious OpenID\n          endpoint. This module has been tested successfully on Drupal 7.15 and\n          7.2 with the OpenID module enabled.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2012-4554"
+    ],
+    "tags": [
+      "gather",
+      "drupal-openid-xxe"
+    ],
+    "transcript": "",
+    "doc": "Drupal OpenID External Entity Injection",
+    "disclosure_date": "2012-10-17",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/eaton_nsm_creds",
+    "description": "This module will extract user credentials from Network Shutdown Module\n          versions 3.21 and earlier by exploiting a vulnerability found in\n          lib/dbtools.inc, which uses unsanitized user input inside a eval() call.\n          Please note that in order to extract credentials, the vulnerable service\n          must have at least one USV module (an entry in the \"nodes\" table in\n          mgedb.db).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "eaton-nsm-creds"
+    ],
+    "transcript": "",
+    "doc": "Network Shutdown Module sort_values Credential Dumper",
+    "disclosure_date": "2012-06-26",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/elasticsearch_enum",
+    "description": "This module enumerates Elasticsearch instances. It uses the REST API\n          in order to gather information about the server, the cluster, nodes,\n          in the cluster, indices, and pull data from those indices.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "elasticsearch-enum"
+    ],
+    "transcript": "",
+    "doc": "Elasticsearch Enumeration Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/emc_cta_xxe",
+    "description": "EMC CTA v10.0 is susceptible to an unauthenticated XXE attack\n          that allows an attacker to read arbitrary files from the file system\n          with the permissions of the root user.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-0644"
+    ],
+    "tags": [
+      "gather",
+      "emc-cta-xxe"
+    ],
+    "transcript": "",
+    "doc": "EMC CTA v10.0 Unauthenticated XXE Arbitrary File Read",
+    "disclosure_date": "2014-03-31",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/enum_dns",
+    "description": "This module can be used to gather information about a domain from a\n          given DNS server by performing various DNS queries such as zone\n          transfers, reverse lookups, SRV record brute forcing, and other techniques.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-1999-0532"
+    ],
+    "tags": [
+      "gather",
+      "enum-dns"
+    ],
+    "transcript": "",
+    "doc": "DNS Record Scanner and Enumerator",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/eventlog_cred_disclosure",
+    "description": "ManageEngine Eventlog Analyzer from v7 to v9.9 b9002 has two security vulnerabilities that\n          allow an unauthenticated user to obtain the superuser password of any managed Windows and\n          AS/400 hosts. This module abuses both vulnerabilities to collect all the available\n          usernames and passwords. First the agentHandler servlet is abused to get the hostid and\n          slid of each device (CVE-2014-6038); then these numeric IDs are used to extract usernames\n          and passwords by abusing the hostdetails servlet (CVE-2014-6039). Note that on version 7,\n          the TARGETURI has to be prepended with /event.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-6038",
+      "CVE-2014-6039"
+    ],
+    "tags": [
+      "gather",
+      "eventlog-cred-disclosure"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine Eventlog Analyzer Managed Hosts Administrator Credential Disclosure",
+    "disclosure_date": "2014-11-05",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/exchange_proxylogon_collector",
+    "description": "This module exploit a vulnerability on Microsoft Exchange Server that\n          allows an attacker bypassing the authentication and impersonating as the\n          admin (CVE-2021-26855).\n\n          By taking advantage of this vulnerability, it is possible to dump all\n          mailboxes (emails, attachments, contacts, ...).\n\n          This vulnerability affects (Exchange 2013 Versions < 15.00.1497.012,\n          Exchange 2016 CU18 < 15.01.2106.013, Exchange 2016 CU19 < 15.01.2176.009,\n          Exchange 2019 CU7 < 15.02.0721.013, Exchange 2019 CU8 < 15.02.0792.010).\n\n          All components are vulnerable by default.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-26855"
+    ],
+    "tags": [
+      "gather",
+      "exchange-proxylogon-collector"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Exchange ProxyLogon Collector",
+    "disclosure_date": "2021-03-02",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/external_ip",
+    "description": "This module checks for the public source IP address of the current\n        route to the RHOST by querying the public web application at ifconfig.me.\n        It should be noted this module will register activity on ifconfig.me,\n        which is not affiliated with Metasploit.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "external-ip"
+    ],
+    "transcript": "",
+    "doc": "Discover External IP via Ifconfig.me",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/f5_bigip_cookie_disclosure",
+    "description": "This module identifies F5 BIG-IP load balancers and leaks backend information\n          (pool name, routed domain, and backend servers' IP addresses and ports) through\n          cookies inserted by the BIG-IP systems.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "f5-bigip-cookie-disclosure"
+    ],
+    "transcript": "",
+    "doc": "F5 BIG-IP Backend Cookie Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/firefox_pdfjs_file_theft",
+    "description": "This module abuses an XSS vulnerability in versions prior to Firefox 39.0.3, Firefox ESR\n          38.1.1, and Firefox OS 2.2 that allows arbitrary files to be stolen. The vulnerability\n          occurs in the PDF.js component, which uses Javascript to render a PDF inside a frame with\n          privileges to read local files. The in-the-wild malicious payloads searched for sensitive\n          files on Windows, Linux, and OSX. Android versions are reported to be unaffected, as they\n          do not use the Mozilla PDF viewer.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-4495"
+    ],
+    "tags": [
+      "gather",
+      "firefox-pdfjs-file-theft"
+    ],
+    "transcript": "",
+    "doc": "Firefox PDF.js Browser File Theft",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/flash_rosetta_jsonp_url_disclosure",
+    "description": "A website that serves a JSONP endpoint that accepts a custom alphanumeric\n          callback of 1200 chars can be abused to serve an encoded swf payload that\n          steals the contents of a same-domain URL. Flash < 14.0.0.145 is required.\n\n          This module spins up a web server that, upon navigation from a user, attempts\n          to abuse the specified JSONP endpoint URLs by stealing the response from\n          GET requests to STEAL_URLS.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-4671"
+    ],
+    "tags": [
+      "gather",
+      "flash-rosetta-jsonp-url-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Flash \"Rosetta\" JSONP GET/POST Response Disclosure",
+    "disclosure_date": "2014-07-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/fortios_vpnssl_traversal_creds_leak",
+    "description": "Fortinet FortiOS versions 5.4.6 to 5.4.12, 5.6.3 to 5.6.7 and 6.0.0 to\n          6.0.4 are vulnerable to a path traversal vulnerability within the SSL VPN\n          web portal which allows unauthenticated attackers to download FortiOS system\n          files through specially crafted HTTP requests.\n\n          This module exploits this vulnerability to read the usernames and passwords\n          of users currently logged into the FortiOS SSL VPN, which are stored in\n          plaintext in the \"/dev/cmdb/sslvpn_websession\" file on the VPN server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-13379"
+    ],
+    "tags": [
+      "gather",
+      "fortios-vpnssl-traversal-creds-leak"
+    ],
+    "transcript": "",
+    "doc": "FortiOS Path Traversal Credential Gatherer",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/gitlab_authenticated_subgroups_file_read",
+    "description": "GitLab version 16.0 contains a directory traversal for arbitrary file read\n          as the `gitlab-www` user. This module requires authentication for exploitation.\n          In order to use this module, a user must be able to create a project and groups.\n          When exploiting this vulnerability, there is a direct correlation between the traversal\n          depth, and the depth of groups the vulnerable project is in. The minimum for this seems\n          to be 5, but up to 11 have also been observed. An example of this, is if the directory\n          traversal needs a depth of 11, a group\n          and 10 nested child groups, each a sub of the previous, will be created (adding up to 11).\n          Visually this looks like:\n          Group1->sub1->sub2->sub3->sub4->sub5->sub6->sub7->sub8->sub9->sub10.\n          If the depth was 5, a group and 4 nested child groups would be created.\n          With all these requirements satisfied a dummy file is uploaded, and the full\n          traversal is then executed. Cleanup is performed by deleting the first group which\n          cascades to deleting all other objects created.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-2825"
+    ],
+    "tags": [
+      "gather",
+      "gitlab-authenticated-subgroups-file-read"
+    ],
+    "transcript": "",
+    "doc": "GitLab Authenticated File Read",
+    "disclosure_date": "2023-05-23",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/gitlab_tags_rss_feed_email_disclosure",
+    "description": "An issue has been discovered in GitLab affecting all versions\n          before 16.6.6, 16.7 prior to 16.7.4, and 16.8 prior to 16.8.1.\n          It is possible to read the user email address via tags feed\n          although the visibility in the user profile has been disabled.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-5612"
+    ],
+    "tags": [
+      "gather",
+      "gitlab-tags-rss-feed-email-disclosure"
+    ],
+    "transcript": "",
+    "doc": "GitLab Tags RSS feed email disclosure",
+    "disclosure_date": "2024-01-25",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/glpi_inventory_plugin_unauth_sqli",
+    "description": "GLPI <= 1.0.18 fails to properly sanitize user supplied data when sent inside a `SimpleXMLElement`\n          (available to unauthenticated users), prior to using it in a dynamically constructed SQL query.\n          As a result, unauthenticated attackers can conduct an SQL injection attack to dump sensitive\n          data from the backend database such as usernames and password hashes.\n\n          In order for GLPI to be exploitable the GLPI Inventory plugin must be installed and enabled, and the\n          \"Enable Inventory\" radio button inside the administration configuration also must be checked.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2025-24799"
+    ],
+    "tags": [
+      "gather",
+      "glpi-inventory-plugin-unauth-sqli"
+    ],
+    "transcript": "",
+    "doc": "GLPI Inventory Plugin Unauthenticated Blind Boolean SQLi",
+    "disclosure_date": "2025-03-12",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/grandstream_ucm62xx_sql_account_guess",
+    "description": "This module uses a blind SQL injection (CVE-2020-5724) affecting the Grandstream UCM62xx\n          IP PBX to dump the users table. The injection occurs over a websocket at the websockify\n          endpoint, and specifically occurs when the user requests the challenge (as part of a\n          challenge and response authentication scheme). The injection is blind, but the server\n          response contains a different status code if the query was successful. As such, the\n          attacker can guess the contents of the user database. Most helpfully, the passwords are\n          stored in cleartext within the user table (CVE-2020-5723).\n\n          This issue was patched in Grandstream UCM62xx IP PBX firmware version 1.20.22.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-5724",
+      "CVE-2020-5723"
+    ],
+    "tags": [
+      "gather",
+      "grandstream-ucm62xx-sql-account-guess"
+    ],
+    "transcript": "",
+    "doc": "Grandstream UCM62xx IP PBX WebSocket Blind SQL Injection Credential Dump",
+    "disclosure_date": "2020-03-30",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/hikvision_info_disclosure_cve_2017_7921",
+    "description": "Many Hikvision IP cameras have improper authorization logic that allows unauthenticated information disclosure of camera information,\n          such as detailed hardware and software configuration, user credentials, and camera snapshots.\n          The vulnerability has been present in Hikvision products since 2014.\n          In addition to Hikvision-branded devices, it affects many white-labeled camera products sold under a variety of brand names.\n          Hundreds of thousands of vulnerable devices are still exposed to the Internet at the time of publishing (shodan search: \"App-webs\" \"200 OK\").\n          This module allows the attacker to retrieve this information without any authentication. The information is stored in loot for future use.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-7921"
+    ],
+    "tags": [
+      "gather",
+      "hikvision-info-disclosure-cve-2017-7921"
+    ],
+    "transcript": "",
+    "doc": "Unauthenticated information disclosure such as configuration, credentials and camera snapshots of a vulnerable Hikvision IP Camera",
+    "disclosure_date": "2017-09-23",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/hp_enum_perfd",
+    "description": "This module will enumerate the process list of a remote machine by abusing\n        HP Operation Manager's unauthenticated 'perfd' daemon.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "hp-enum-perfd"
+    ],
+    "transcript": "",
+    "doc": "HP Operations Manager Perfd Environment Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/hp_snac_domain_creds",
+    "description": "This module will extract Domain Controller credentials from vulnerable installations of HP\n          SNAC as distributed with HP ProCurve 4.00 and 3.20. The authentication bypass vulnerability\n          has been used to exploit remote file uploads. This vulnerability can be used to gather important\n          information handled by the vulnerable application, like plain text domain controller\n          credentials. This module has been tested successfully with HP SNAC included with ProCurve\n          Manager 4.0.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "hp-snac-domain-creds"
+    ],
+    "transcript": "",
+    "doc": "HP ProCurve SNAC Domain Controller Credential Dumper",
+    "disclosure_date": "2013-09-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/http_pdf_authors",
+    "description": "This module downloads PDF documents and extracts the author's\n          name from the document metadata.\n\n          This module expects a URL to be provided using the URL option.\n          Alternatively, multiple URLs can be provided by supplying the\n          path to a file containing a list of URLs in the URL_LIST option.\n\n          The URL_TYPE option is used to specify the type of URLs supplied.\n\n          By specifying 'pdf' for the URL_TYPE, the module will treat\n          the specified URL(s) as PDF documents. The module will\n          download the documents and extract the authors' names from the\n          document metadata.\n\n          By specifying 'html' for the URL_TYPE, the module will treat\n          the specified URL(s) as HTML pages. The module will scrape the\n          pages for links to PDF documents, download the PDF documents,\n          and extract the author's name from the document metadata.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "http-pdf-authors"
+    ],
+    "transcript": "",
+    "doc": "Gather PDF Authors",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/huawei_wifi_info",
+    "description": "This module exploits an unauthenticated information disclosure vulnerability in Huawei\n          SOHO routers. The module will gather information by accessing the /api pages where\n          authentication is not required, allowing configuration changes as well as information\n          disclosure, including any stored SMS.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-6031"
+    ],
+    "tags": [
+      "gather",
+      "huawei-wifi-info"
+    ],
+    "transcript": "",
+    "doc": "Huawei Datacard Information Disclosure Vulnerability",
+    "disclosure_date": "2013-11-11",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ibm_bigfix_sites_packages_enum",
+    "description": "This module retrieves masthead, site, and available package information\n          from IBM BigFix Relay Servers.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-4061"
+    ],
+    "tags": [
+      "gather",
+      "ibm-bigfix-sites-packages-enum"
+    ],
+    "transcript": "",
+    "doc": "IBM BigFix Relay Server Sites and Package Enum",
+    "disclosure_date": "2019-03-18",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ibm_sametime_enumerate_users",
+    "description": "This module extracts usernames using the IBM Lotus Notes Sametime web\n          interface using either a dictionary attack (which is preferred), or a\n          bruteforce attack trying all usernames of MAXDEPTH length or less.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3975"
+    ],
+    "tags": [
+      "gather",
+      "ibm-sametime-enumerate-users"
+    ],
+    "transcript": "",
+    "doc": "IBM Lotus Notes Sametime User Enumeration",
+    "disclosure_date": "2013-12-27",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ibm_sametime_room_brute",
+    "description": "This module bruteforces Sametime meeting room names via the IBM\n          Lotus Notes Sametime web interface.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3977"
+    ],
+    "tags": [
+      "gather",
+      "ibm-sametime-room-brute"
+    ],
+    "transcript": "",
+    "doc": "IBM Lotus Notes Sametime Room Name Bruteforce",
+    "disclosure_date": "2013-12-27",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ibm_sametime_version",
+    "description": "This module scans an IBM Lotus Sametime web interface to enumerate\n          the application's version and configuration information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3982"
+    ],
+    "tags": [
+      "gather",
+      "ibm-sametime-version"
+    ],
+    "transcript": "",
+    "doc": "IBM Lotus Sametime Version Enumeration",
+    "disclosure_date": "2013-12-27",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ie_sandbox_findfiles",
+    "description": "It was found that Internet Explorer allows the disclosure of local file names.\n          This issue exists due to the fact that Internet Explorer behaves different for\n          file:// URLs pointing to existing and non-existent files. When used in\n          combination with HTML5 sandbox iframes it is possible to use this behavior to\n          find out if a local file exists. This technique only works on Internet Explorer\n          10 & 11 since these support the HTML5 sandbox. Also it is not possible to do\n          this from a regular website as file:// URLs are blocked all together. The attack\n          must be performed locally (works with Internet zone Mark of the Web) or from a\n          share.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2016-3321"
+    ],
+    "tags": [
+      "gather",
+      "ie-sandbox-findfiles"
+    ],
+    "transcript": "",
+    "doc": "Internet Explorer Iframe Sandbox File Name Disclosure Vulnerability",
+    "disclosure_date": "2016-08-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ie_uxss_injection",
+    "description": "This module exploits a universal cross-site scripting (UXSS) vulnerability found in Internet\n          Explorer 10 and 11. By default, you will steal the cookie from TARGET_URI (which cannot\n          have X-Frame-Options or it will fail). You can also have your own custom JavaScript\n          by setting the CUSTOMJS option. Lastly, you might need to configure the URIHOST option if\n          you are behind NAT.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2015-0072"
+    ],
+    "tags": [
+      "gather",
+      "ie-uxss-injection"
+    ],
+    "transcript": "",
+    "doc": "MS15-018 Microsoft Internet Explorer 10 and 11 Cross-Domain JavaScript Injection",
+    "disclosure_date": "2015-02-01",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/impersonate_ssl",
+    "description": "This module request a copy of the remote SSL certificate and creates a local\n          (self.signed) version using the information from the remote version. The module\n          then Outputs (PEM|DER) format private key / certificate and a combined version\n          for use in Apache or other Metasploit modules requiring SSLCert Inputs for private\n          key / CA cert have been provided for those with DigiNotar certs hanging about!",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "impersonate-ssl"
+    ],
+    "transcript": "",
+    "doc": "HTTP SSL Certificate Impersonation",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ipcamera_password_disclosure",
+    "description": "SIEMENS IP-Camera (CVMS2025-IR + CCMS2025), JVC IP-Camera (VN-T216VPRU),\n        and Vanderbilt IP-Camera (CCPW3025-IR + CVMW3025-IR)\n        allow an unauthenticated user to disclose the username & password by\n        requesting the javascript page 'readfile.cgi?query=ADMINID'.\n        Siemens firmwares affected: x.2.2.1798, CxMS2025_V2458_SP1, x.2.2.1798, x.2.2.1235",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "ipcamera-password-disclosure"
+    ],
+    "transcript": "",
+    "doc": "JVC/Siemens/Vanderbilt IP-Camera Readfile Password Disclosure",
+    "disclosure_date": "2016-08-16",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/jasmin_ransomware_dir_traversal",
+    "description": "The Jasmin Ransomware web server contains an unauthenticated directory traversal vulnerability\n          within the download functionality. As of April 15, 2024 this was still unpatched, so all\n          versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-30851"
+    ],
+    "tags": [
+      "gather",
+      "jasmin-ransomware-dir-traversal"
+    ],
+    "transcript": "",
+    "doc": "Jasmin Ransomware Web Server Unauthenticated Directory Traversal",
+    "disclosure_date": "2023-04-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/jasmin_ransomware_sqli",
+    "description": "The Jasmin Ransomware web server contains an unauthenticated SQL injection vulnerability\n          within the login functionality. As of April 15, 2024 this was still unpatched, so all\n          versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.\n\n          Retrieving the victim's data may take a long amount of time. It is much quicker to\n          get the logins, then just login to the site.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "jasmin-ransomware-sqli"
+    ],
+    "transcript": "",
+    "doc": "Jasmin Ransomware Web Server Unauthenticated SQL Injection",
+    "disclosure_date": "2023-04-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/java_rmi_registry",
+    "description": "This module gathers information from an RMI endpoint running an RMI registry\n        interface. It enumerates the names bound in a registry and looks up each\n        remote reference.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "java-rmi-registry"
+    ],
+    "transcript": "",
+    "doc": "Java RMI Registry Interfaces Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read",
+    "description": "This module utilizes the Jenkins cli protocol to run the `help` command.\n          The cli is accessible with read-only permissions by default, which are\n          all thats required.\n\n          Jenkins cli utilizes `args4j's` `parseArgument`, which calls `expandAtFiles` to\n          replace any `@<filename>` with the contents of a file. We are then able to retrieve\n          the error message to read up to the first two lines of a file.\n\n          Exploitation by hand can be done with the cli, see markdown documents for additional\n          instructions.\n\n          There are a few exploitation oddities:\n          1. The injection point for the `help` command requires 2 input arguments.\n          When the `expandAtFiles` is called, each line of the `FILE_PATH` becomes an input argument.\n          If a file only contains one line, it will throw an error: `ERROR: You must authenticate to access this Jenkins.`\n          However, we can pad out the content by supplying a first argument.\n          2. There is a strange timing requirement where the `download` (or first) request must get\n          to the server first, but the `upload` (or second) request must be very close behind it.\n          From testing against the docker image, it was found values between `.01` and `1.9` were\n          viable. Due to the round trip time of the first request and response happening before\n          request 2 would be received, it is necessary to use threading to ensure the requests\n          happen within rapid succession.\n\n          Files of value:\n          * /var/jenkins_home/secret.key\n          * /var/jenkins_home/secrets/master.key\n          * /var/jenkins_home/secrets/initialAdminPassword\n          * /etc/passwd\n          * /etc/shadow\n          * Project secrets and credentials\n          * Source code, build artifacts",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-23897"
+    ],
+    "tags": [
+      "gather",
+      "jenkins-cli-ampersand-arbitrary-file-read"
+    ],
+    "transcript": "",
+    "doc": "Jenkins cli Ampersand Replacement Arbitrary File Read",
+    "disclosure_date": "2024-01-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/jenkins_cred_recovery",
+    "description": "This module will collect Jenkins domain credentials, and uses\n          the script console to decrypt each password if anonymous permission\n          is allowed.\n\n          It has been tested against Jenkins version 1.590, 1.633, and 1.638.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "jenkins-cred-recovery"
+    ],
+    "transcript": "",
+    "doc": "Jenkins Domain Credential Recovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/jetty_web_inf_disclosure",
+    "description": "Jetty suffers from a vulnerability where certain encoded URIs and ambiguous paths can access\n          protected files in the WEB-INF folder. Versions effected are:\n          9.4.37.v20210219, 9.4.38.v20210224 and 9.4.37-9.4.42, 10.0.1-10.0.5, 11.0.1-11.0.5.\n          Exploitation can obtain any file in the WEB-INF folder, but web.xml is most likely\n          to have information of value.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-34429",
+      "CVE-2021-28164"
+    ],
+    "tags": [
+      "gather",
+      "jetty-web-inf-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Jetty WEB-INF File Disclosure",
+    "disclosure_date": "2021-07-15",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/joomla_com_realestatemanager_sqli",
+    "description": "This module exploits a SQL injection vulnerability in Joomla Plugin\n          com_realestatemanager versions 3.7 in order to either enumerate\n          usernames and password hashes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "joomla-com-realestatemanager-sqli"
+    ],
+    "transcript": "",
+    "doc": "Joomla Real Estate Manager Component Error-Based SQL Injection",
+    "disclosure_date": "2015-10-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/joomla_contenthistory_sqli",
+    "description": "This module exploits a SQL injection vulnerability in Joomla versions 3.2\n          through 3.4.4 in order to either enumerate usernames and password hashes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-7297"
+    ],
+    "tags": [
+      "gather",
+      "joomla-contenthistory-sqli"
+    ],
+    "transcript": "",
+    "doc": "Joomla com_contenthistory Error-Based SQL Injection",
+    "disclosure_date": "2015-10-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/joomla_weblinks_sqli",
+    "description": "Joomla versions 3.2.2 and below are vulnerable to an unauthenticated SQL injection\n          which allows an attacker to access the database or read arbitrary files as the\n          'mysql' user. This module will only work if the mysql user Joomla is using\n          to access the database has the LOAD_FILE permission.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "joomla-weblinks-sqli"
+    ],
+    "transcript": "",
+    "doc": "Joomla weblinks-categories Unauthenticated SQL Injection Arbitrary File Read",
+    "disclosure_date": "2014-03-02",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/kerberoast",
+    "description": "This module will try to find Service Principal Names that are associated with normal user accounts.\n          Since normal accounts' passwords tend to be shorter than machine accounts, and knowing that a TGS request\n          will encrypt the ticket with the account the SPN is running under, this could be used for an offline\n          bruteforcing attack of the SPNs account NTLM hash if we can gather valid TGS for those SPNs.\n          This is part of the kerberoast attack research by Tim Medin (@timmedin).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "kerberoast"
+    ],
+    "transcript": "",
+    "doc": "Gather Ticket Granting Service (TGS) tickets for User Service Principal Names (SPN)",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/kerberos_enumusers",
+    "description": "This module will enumerate valid Domain Users via Kerberos from an unauthenticated perspective. It utilizes\n          the different responses returned by the service for valid and invalid users. This module can also detect accounts\n          that are vulnerable to ASREPRoast attacks.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "kerberos-enumusers"
+    ],
+    "transcript": "",
+    "doc": "Kerberos Domain User Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/konica_minolta_pwd_extract",
+    "description": "This module will extract FTP and SMB account usernames and passwords\n          from Konica Minolta multifunction printer (MFP) devices. Tested models include\n          C224, C280, 283, C353, C360, 363, 420, C452, C452, C452, C454e, and C554.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "konica-minolta-pwd-extract"
+    ],
+    "transcript": "",
+    "doc": "Konica Minolta Password Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/lansweeper_collector",
+    "description": "Lansweeper stores the credentials it uses to scan the computers\n          in its Microsoft SQL database.  The passwords are XTea-encrypted with a\n          68 character long key, in which the first 8 characters are stored with\n          the password in the database and the other 60 is static. Lansweeper, by\n          default, creates an MSSQL user \"lansweeperuser\" with the password is\n          \"mysecretpassword0*\", and stores its data in a database called\n          \"lansweeperdb\". This module will query the MSSQL database for the\n          credentials.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "lansweeper-collector"
+    ],
+    "transcript": "",
+    "doc": "Lansweeper Credential Collector",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ldap_esc_vulnerable_cert_finder",
+    "description": "This module allows users to query a LDAP server for vulnerable certificate\n          templates and will print these certificates out in a table along with which\n          attack they are vulnerable to and the SIDs that can be used to enroll in that\n          certificate template.\n\n          Additionally the module will also print out a list of known certificate servers\n          along with info about which vulnerable certificate templates the certificate server\n          allows enrollment in and which SIDs are authorized to use that certificate server to\n          perform this enrollment operation.\n\n          Currently the module is capable of checking for certificates that are vulnerable to ESC1, ESC2, ESC3, ESC4,\n          ESC13, and ESC15. The module is limited to checking for these techniques due to them being identifiable\n          remotely from a normal user account by analyzing the objects in LDAP.\n\n          The module can also check for ESC9, ESC10 and ESC16 but this requires an Administrative WinRM session to be\n          established to definitively check for these techniques.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "ldap-esc-vulnerable-cert-finder"
+    ],
+    "transcript": "",
+    "doc": "Misconfigured Certificate Template Finder",
+    "disclosure_date": "2021-06-17",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ldap_passwords",
+    "description": "This module will gather passwords and password hashes from a target LDAP server via multiple techniques\n          including Windows LAPS. For best results, run with SSL because some attributes are only readable over\n          encrypted connections.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "ldap-passwords"
+    ],
+    "transcript": "",
+    "doc": "LDAP Password Disclosure",
+    "disclosure_date": "2020-07-23",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ldap_query",
+    "description": "This module allows users to query an LDAP server using either a custom LDAP query, or\n          a set of LDAP queries under a specific category. Users can also specify a JSON or YAML\n          file containing custom queries to be executed using the RUN_QUERY_FILE action.\n          If this action is specified, then QUERY_FILE_PATH must be a path to the location\n          of this JSON/YAML file on disk.\n\n          Users can also run a single query by using the RUN_SINGLE_QUERY option and then setting\n          the QUERY_FILTER datastore option to the filter to send to the LDAP server and QUERY_ATTRIBUTES\n          to a comma separated string containing the list of attributes they are interested in obtaining\n          from the results.\n\n          As a third option can run one of several predefined queries by setting ACTION to the\n          appropriate value. These options will be loaded from the ldap_queries_default.yaml file\n          located in the MSF configuration directory, located by default at ~/.msf4/ldap_queries_default.yaml.\n\n          All results will be returned to the user in table, CSV or JSON format, depending on the value\n          of the OUTPUT_FORMAT datastore option. The characters || will be used as a delimiter\n          should multiple items exist within a single column.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "ldap-query"
+    ],
+    "transcript": "",
+    "doc": "LDAP Query and Enumeration Module",
+    "disclosure_date": "2022-05-19",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/magento_xxe_cve_2024_34102",
+    "description": "This module exploits a XXE vulnerability in Magento 2.4.7-p1 and below which allows an attacker to read any file on the system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-34102"
+    ],
+    "tags": [
+      "gather",
+      "magento-xxe-cve-2024-34102"
+    ],
+    "transcript": "",
+    "doc": "Magento XXE Unserialize Arbitrary File Read",
+    "disclosure_date": "2024-06-11",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/manageengine_adaudit_plus_xnode_enum",
+    "description": "This module exploits default admin credentials for the DataEngine\n        Xnode server in ADAudit Plus versions prior to 6.0.3 (6032) in\n        order to dump the contents of Xnode data repositories (tables),\n        which may contain (a limited amount of) Active Directory\n        information including domain names, host names, usernames and SIDs.\n        This module can also be used against patched ADAudit Plus versions\n        if the correct credentials are provided.\n\n        By default, this module dumps only the data repositories and fields\n        (columns) specified in the configuration file (set via the\n        CONFIG_FILE option). The configuration file is also used to\n        add labels to the values sent by Xnode in response to a query.\n\n        It is also possible to use the DUMP_ALL option to obtain all data\n        in all known data repositories without specifying data field names.\n        However, note that when using the DUMP_ALL option, the data won't be labeled.\n\n        This module has been successfully tested against ManageEngine\n        ADAudit Plus 6.0.3 (6031) running on Windows Server 2012 R2 and\n        ADAudit Plus 6.0.7 (6076) running on Windows Server 2019.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-11532"
+    ],
+    "tags": [
+      "gather",
+      "manageengine-adaudit-plus-xnode-enum"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine ADAudit Plus Xnode Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/manageengine_datasecurity_plus_xnode_enum",
+    "description": "This module exploits default admin credentials for the DataEngine\n        Xnode server in DataSecurity Plus versions prior to 6.0.1 (6011)\n        in order to dump the contents of Xnode data repositories (tables),\n        which may contain (a limited amount of) Active Directory\n        information including domain names, host names, usernames and SIDs.\n        This module can also be used against patched DataSecurity Plus\n        versions if the correct credentials are provided.\n\n        By default, this module dumps only the data repositories and fields\n        (columns) specified in the configuration file (set via the\n        CONFIG_FILE option). The configuration file is also used to\n        add labels to the values sent by Xnode in response to a query.\n\n        It is also possible to use the DUMP_ALL option to obtain all data\n        in all known data repositories without specifying data field names.\n        However, note that when using the DUMP_ALL option, the data won't be labeled.\n\n        This module has been successfully tested against ManageEngine\n        DataSecurity Plus 6.0.1 (6010) running on Windows Server 2012 R2.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-11532"
+    ],
+    "tags": [
+      "gather",
+      "manageengine-datasecurity-plus-xnode-enum"
+    ],
+    "transcript": "",
+    "doc": "ManageEngine DataSecurity Plus Xnode Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mantisbt_admin_sqli",
+    "description": "Versions 1.2.13 through 1.2.16 are vulnerable to a SQL injection attack if\n          an attacker can gain access to administrative credentials.\n\n          This vuln was fixed in 1.2.17.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux,Windows",
+    "cve": [
+      "CVE-2014-2238"
+    ],
+    "tags": [
+      "gather",
+      "mantisbt-admin-sqli"
+    ],
+    "transcript": "",
+    "doc": "MantisBT Admin SQL Injection Arbitrary File Read",
+    "disclosure_date": "2014-02-28",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mcafee_epo_xxe",
+    "description": "This module will exploit an authenticated XXE vulnerability to read the keystore.properties\n          off of the filesystem. This properties file contains an encrypted password that is set during\n          installation. What is interesting about this password is that it is set as the same password\n          as the database 'sa' user and of the admin user created during installation. This password\n          is encrypted with a static key, and is encrypted using a weak cipher (ECB). By default,\n          if installed with a local SQL Server instance, the SQL Server is listening on all interfaces.\n\n          Recovering this password allows an attacker to potentially authenticate as the 'sa' SQL Server\n          user in order to achieve remote command execution with permissions of the database process. If\n          the administrator has not changed the password for the initially created account since installation,\n          the attacker will have the password for this account. By default, 'admin' is recommended.\n\n          Any user account can be used to exploit this, all that is needed is a valid credential.\n\n          The most data that can be successfully retrieved is 255 characters due to length restrictions\n          on the field used to perform the XXE attack.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-0921",
+      "CVE-2015-0922"
+    ],
+    "tags": [
+      "gather",
+      "mcafee-epo-xxe"
+    ],
+    "transcript": "",
+    "doc": "McAfee ePolicy Orchestrator Authenticated XXE Credentials Exposure",
+    "disclosure_date": "2015-01-06",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/memcached_extractor",
+    "description": "This module extracts the slabs from a memcached instance.  It then\n          finds the keys and values stored in those slabs.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "memcached-extractor"
+    ],
+    "transcript": "",
+    "doc": "Memcached Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/microweber_lfi",
+    "description": "Microweber CMS v1.2.10 has a backup functionality. Upload and download endpoints can be combined to read any file from the filesystem.\n          Upload function may delete the local file if the web service user has access.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "microweber-lfi"
+    ],
+    "transcript": "",
+    "doc": "Microweber CMS v1.2.10 Local File Inclusion (Authenticated)",
+    "disclosure_date": "2022-01-30",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mikrotik_winbox_fileread",
+    "description": "MikroTik RouterOS (bugfix) 6.30.1-6.40.7, (current) 6.29-6.42, (RC) 6.29rc1-6.43rc3 allows unauthenticated\n        remote attackers to read arbitrary files through a directory traversal through the WinBox interface\n        (typically port 8291).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-14847"
+    ],
+    "tags": [
+      "gather",
+      "mikrotik-winbox-fileread"
+    ],
+    "transcript": "",
+    "doc": "Mikrotik Winbox Arbitrary File Read",
+    "disclosure_date": "2018-08-02",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/minio_bootstrap_verify_info_disc",
+    "description": "MinIO is a Multi-Cloud Object Storage framework. In a cluster deployment starting with\n          RELEASE.2019-12-17T23-16-33Z and prior to RELEASE.2023-03-20T20-16-18Z, MinIO returns\n          all environment variables, including `MINIO_SECRET_KEY` and `MINIO_ROOT_PASSWORD`,\n          resulting in information disclosure.\n\n          Verified against MinIO 2023-02-27T18:10:45Z",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-28432"
+    ],
+    "tags": [
+      "gather",
+      "minio-bootstrap-verify-info-disc"
+    ],
+    "transcript": "",
+    "doc": "MinIO Bootstrap Verify Information Disclosure",
+    "disclosure_date": "2023-03-20",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mongodb_js_inject_collection_enum",
+    "description": "This module can exploit NoSQL injections on MongoDB versions less than 2.4\n          and enumerate the collections available in the data via boolean injections.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux,Windows",
+    "cve": [],
+    "tags": [
+      "gather",
+      "mongodb-js-inject-collection-enum"
+    ],
+    "transcript": "",
+    "doc": "MongoDB NoSQL Collection Enumeration Via Injection",
+    "disclosure_date": "2014-06-07",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mongodb_ops_manager_diagnostic_archive_info",
+    "description": "MongoDB Ops Manager Diagnostics Archive does not redact SAML SSL Pem Key File Password\n          field (mms.saml.ssl.PEMKeyFilePassword) within app settings. Archives do not include\n          the PEM files themselves. This module extracts that unredacted password and stores\n          the diagnostic archive for additional manual review.\n\n          This issue affects MongoDB Ops Manager v5.0 prior to 5.0.21 and\n          MongoDB Ops Manager v6.0 prior to 6.0.12.\n\n          API credentials with the role of GLOBAL_MONITORING_ADMIN or GLOBAL_OWNER are required.\n\n          Successfully tested against MongoDB Ops Manager v6.0.11.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-0342"
+    ],
+    "tags": [
+      "gather",
+      "mongodb-ops-manager-diagnostic-archive-info"
+    ],
+    "transcript": "",
+    "doc": "MongoDB Ops Manager Diagnostic Archive Sensitive Information Retriever",
+    "disclosure_date": "2023-06-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ms14_052_xmldom",
+    "description": "This module will use the Microsoft XMLDOM object to enumerate a remote machine's filenames.\n          It will try to do so against Internet Explorer 8 and Internet Explorer 9. To use it, you\n          must supply your own list of file paths. Each file path should look like this:\n          c:\\windows\\system32\\calc.exe",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2013-7331"
+    ],
+    "tags": [
+      "gather",
+      "ms14-052-xmldom"
+    ],
+    "transcript": "",
+    "doc": "MS14-052 Microsoft Internet Explorer XMLDOM Filename Disclosure",
+    "disclosure_date": "2014-09-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/mybb_db_fingerprint",
+    "description": "This module checks if MyBB is running behind an URL. Also uses a malformed query to\n          force an error and fingerprint the backend database used by MyBB on version 1.6.12\n          and prior.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "mybb-db-fingerprint"
+    ],
+    "transcript": "",
+    "doc": "MyBB Database Fingerprint",
+    "disclosure_date": "2014-02-13",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/natpmp_external_address",
+    "description": "Scan NAT devices for their external address using NAT-PMP",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "natpmp-external-address"
+    ],
+    "transcript": "",
+    "doc": "NAT-PMP External Address Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/netgear_password_disclosure",
+    "description": "This module will collect the password for the `admin` user.\n          The exploit will not complete if password recovery is set on the router.\n          The password is received by passing the token generated from `unauth.cgi`\n          to `passwordrecovered.cgi`. This exploit works on many different NETGEAR\n          products. The full list of affected products is available in the 'References'\n          section.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-5521"
+    ],
+    "tags": [
+      "gather",
+      "netgear-password-disclosure"
+    ],
+    "transcript": "",
+    "doc": "NETGEAR Administrator Password Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/nis_bootparamd_domain",
+    "description": "This module discloses the NIS domain name from bootparamd.\n\n          You must know a client address from the target's bootparams file.\n\n          Hint: try hosts within the same network range as the target.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "nis-bootparamd-domain"
+    ],
+    "transcript": "",
+    "doc": "NIS bootparamd Domain Name Disclosure",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/nis_ypserv_map",
+    "description": "This module dumps the specified map from NIS ypserv.\n\n          The following examples are from ypcat -x:\n\n          Use \"ethers\"    for map \"ethers.byname\"\n          Use \"aliases\"   for map \"mail.aliases\"\n          Use \"services\"  for map \"services.byname\"\n          Use \"protocols\" for map \"protocols.bynumber\"\n          Use \"hosts\"     for map \"hosts.byname\"\n          Use \"networks\"  for map \"networks.byaddr\"\n          Use \"group\"     for map \"group.byname\"\n          Use \"passwd\"    for map \"passwd.byname\"\n\n          You may specify a map by one of the nicknames above.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "nis-ypserv-map"
+    ],
+    "transcript": "",
+    "doc": "NIS ypserv Map Dumper",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/nuuo_cms_bruteforce",
+    "description": "Nuuo Central Management Server below version 2.4 has a flaw where it sends the\n          heap address of the user object instead of a real session number when a user logs\n          in. This can be used to reduce the keyspace for the session number from 10 million\n          to 1.2 million, and with a bit of analysis it can be guessed in less than 500k tries.\n          This module does exactly that - it uses a computed occurrence table to try the most common\n          combinations up to 1.2 million to try to guess a valid user session.\n          This session number can then be used to achieve code execution or download files - see\n          the other Nuuo CMS auxiliary and exploit modules.\n          Note that for this to work a user has to be logged into the system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2018-17888"
+    ],
+    "tags": [
+      "gather",
+      "nuuo-cms-bruteforce"
+    ],
+    "transcript": "",
+    "doc": "Nuuo Central Management Server User Session Token Bruteforce",
+    "disclosure_date": "2018-10-11",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/nuuo_cms_file_download",
+    "description": "The Nuuo Central Management Server allows an authenticated user to download files from the\n          installation folder. This functionality can be abused to obtain administrative credentials,\n          the SQL Server database password and arbitrary files off the system with directory traversal.\n          The module will attempt to download CMServer.cfg (the user configuration file with all the user\n          passwords including the admin one), ServerConfig.cfg (the server configuration file with the\n          SQL Server password) and a third file if the FILE argument is provided by the user.\n          The two .cfg files are zip-encrypted files, but due to limitations of the Ruby ZIP modules\n          included in Metasploit, these files cannot be decrypted programmatically. The user will\n          have to open them with zip or a similar program and provide the default password \"NUCMS2007!\".\n          This module will either use a provided session number (which can be guessed with an auxiliary\n          module) or attempt to login using a provided username and password - it will also try the\n          default credentials if nothing is provided.\n          All versions of CMS server up to and including 3.5 are vulnerable to this attack.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [
+      "CVE-2018-17934"
+    ],
+    "tags": [
+      "gather",
+      "nuuo-cms-file-download"
+    ],
+    "transcript": "",
+    "doc": "Nuuo Central Management Server Authenticated Arbitrary File Download",
+    "disclosure_date": "2018-10-11",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/oats_downloadservlet_traversal",
+    "description": "This module exploits a vulnerability in Oracle Application Testing Suite (OATS). In the Load\n          Testing interface, a remote user can abuse the custom report template selector, and cause the\n          DownloadServlet class to read any file on the server as SYSTEM. Since the Oracle application\n          contains multiple configuration files that include encrypted credentials, and that there are\n          public resources for decryption, it is actually possible to gain remote code execution\n          by leveraging this directory traversal attack.\n\n          Please note that authentication is required. By default, OATS has two built-in accounts:\n          default and administrator. You could try to target those first.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-2557"
+    ],
+    "tags": [
+      "gather",
+      "oats-downloadservlet-traversal"
+    ],
+    "transcript": "",
+    "doc": "Oracle Application Testing Suite Post-Auth DownloadServlet Directory Traversal",
+    "disclosure_date": "2019-04-16",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/office365userenum",
+    "description": "Enumerate valid usernames (email addresses) from Office 365 using ActiveSync.\n            Differences in the HTTP Response code and HTTP Headers can be used to differentiate between:\n             - Valid Username (Response code 401)\n             - Valid Username and Password without 2FA (Response Code 200)\n             - Valid Username and Password with 2FA (Response Code 403)\n             - Invalid Username (Response code 404 with Header X-CasErrorCode: UserNotFound)\n            Note this behaviour appears to be limited to Office365, MS Exchange does not appear to be affected.\n            Microsoft Security Response Center stated on 2017-06-28 that this issue does not \"meet the bar for security\n            servicing\". As such it is not expected to be fixed any time soon.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "office365userenum"
+    ],
+    "transcript": "",
+    "doc": "Office 365 User Enumeration",
+    "disclosure_date": "2018-09-05",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/onedev_arbitrary_file_read",
+    "description": "This module exploits an unauthenticated arbitrary file read vulnerability (CVE-2024-45309), which affects OneDev versions <= 11.0.8.\n          To exploit this vulnerability, a valid OneDev project name is required. If anonymous access is enabled on the OneDev server, any visitor\n          can view existing projects without authentication.\n          However, when anonymous access is disabled, an attacker who lacks prior knowledge of existing project names can use a brute-force approach.\n          By providing a user-supplied wordlist, the module may be able to guess a valid project name and subsequently exploit the vulnerability.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-45309"
+    ],
+    "tags": [
+      "gather",
+      "onedev-arbitrary-file-read"
+    ],
+    "transcript": "",
+    "doc": "OneDev Unauthenticated Arbitrary File Read",
+    "disclosure_date": "2024-10-19",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/opennms_xxe",
+    "description": "OpenNMS is vulnerable to XML External Entity Injection in the Real-Time Console interface.\n          Although this attack requires authentication, there are several factors that increase the\n          severity of this vulnerability.\n\n          1. OpenNMS runs with root privileges, taken from the OpenNMS FAQ: \"The difficulty with the\n          core of OpenNMS is that these components need to run as root to be able to bind to low-numbered\n          ports or generate network traffic that requires root\"\n\n          2. The user that you must authenticate as is the \"rtc\" user which has the default password of\n          \"rtc\". There is no mention of this user in the installation guides found here:\n          http://www.opennms.org/wiki/Tutorial_Installation, only mention that you should change the default\n          admin password of \"admin\" for security purposes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-0975"
+    ],
+    "tags": [
+      "gather",
+      "opennms-xxe"
+    ],
+    "transcript": "",
+    "doc": "OpenNMS Authenticated XXE",
+    "disclosure_date": "2015-01-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/owncloud_phpinfo_reader",
+    "description": "Docker containers of ownCloud compiled after February 2023, which have version 0.2.0 before 0.2.1 or 0.3.0 before 0.3.1 of the app `graph` installed\n          contain a test file which prints `phpinfo()` to an unauthenticated user. A post file name must be appended to the URL to bypass the login filter.\n          Docker may export sensitive environment variables including ownCloud, DB, redis, SMTP, and S3 credentials, as well as other host information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-49103"
+    ],
+    "tags": [
+      "gather",
+      "owncloud-phpinfo-reader"
+    ],
+    "transcript": "",
+    "doc": "ownCloud Phpinfo Reader",
+    "disclosure_date": "2023-11-21",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/pacsserver_traversal",
+    "description": "This module exploits a path traversal vulnerability (CVE-2025-2264) in Sante PACS Server <= v4.1.0 to retrieve arbitrary files from the system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2025-2264"
+    ],
+    "tags": [
+      "gather",
+      "pacsserver-traversal"
+    ],
+    "transcript": "",
+    "doc": "Sante PACS Server Path Traversal (CVE-2025-2264)",
+    "disclosure_date": "2025-03-13",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/peplink_bauth_sqli",
+    "description": "Firmware versions up to 7.0.0-build1904 of Peplink Balance routers are affected by an unauthenticated\n          SQL injection vulnerability in the bauth cookie, successful exploitation of the vulnerability allows an\n          attacker to retrieve the cookies of authenticated users, bypassing the web portal authentication.\n\n          By default, a session expires 4 hours after login (the setting can be changed by the admin), for this\n          reason, the module attempts to retrieve the most recently created sessions.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Linux",
+    "cve": [
+      "CVE-2017-8835"
+    ],
+    "tags": [
+      "gather",
+      "peplink-bauth-sqli"
+    ],
+    "transcript": "",
+    "doc": "Peplink Balance routers SQLi",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/pimcore_creds_sqli",
+    "description": "This module extracts the usernames and hashed passwords of all users of\n          the Pimcore web service by exploiting a SQL injection vulnerability in\n          Pimcore's REST API.\n\n          Pimcore begins to create password hashes by concatenating a user's\n          username, the name of the application, and the user's password in the\n          format USERNAME:pimcore:PASSWORD.\n\n          The resulting string is then used to generate an MD5 hash, and then that\n          MD5 hash is used to create the final hash, which is generated using\n          PHP's built-in password_hash function.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-14058"
+    ],
+    "tags": [
+      "gather",
+      "pimcore-creds-sqli"
+    ],
+    "transcript": "",
+    "doc": "Pimcore Gather Credentials via SQL Injection",
+    "disclosure_date": "2018-08-13",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/piwigo_cve_2023_26876",
+    "description": "This module allows an authenticated user to retrieve the usernames and encrypted passwords of other users in Piwigo through SQL injection using the (filter_user_id) parameter.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-26876"
+    ],
+    "tags": [
+      "gather",
+      "piwigo-cve-2023-26876"
+    ],
+    "transcript": "",
+    "doc": "Piwigo CVE-2023-26876 Gather Credentials via SQL Injection ",
+    "disclosure_date": "2023-04-21",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/progress_moveit_sftp_fileread_cve_2024_5806",
+    "description": "This module exploits CVE-2024-5806, an authentication bypass vulnerability in the MOVEit Transfer SFTP service. The\n          following version are affected:\n\n          * MOVEit Transfer 2023.0.x (Fixed in 2023.0.11)\n          * MOVEit Transfer 2023.1.x (Fixed in 2023.1.6)\n          * MOVEit Transfer 2024.0.x (Fixed in 2024.0.2)\n\n          The module can establish an authenticated SFTP session for a MOVEit Transfer user. The module allows for both listing\n          the contents of a directory, and the reading of an arbitrary file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-5806"
+    ],
+    "tags": [
+      "gather",
+      "progress-moveit-sftp-fileread-cve-2024-5806"
+    ],
+    "transcript": "",
+    "doc": "Progress MOVEit SFTP Authentication Bypass for Arbitrary File Read",
+    "disclosure_date": "2024-06-25",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/prometheus_api_gather",
+    "description": "This module utilizes Prometheus' API calls to gather information about\n          the server's configuration, and targets. Fields which may contain\n          credentials, or credential file names are then pulled out and printed.\n\n          Targets may have a wealth of information, this module will print the following\n          values when found:\n          __meta_gce_metadata_ssh_keys, __meta_gce_metadata_startup_script,\n          __meta_gce_metadata_kube_env, kubernetes_sd_configs,\n          _meta_kubernetes_pod_annotation_kubectl_kubernetes_io_last_applied_configuration,\n          __meta_ec2_tag_CreatedBy, __meta_ec2_tag_OwnedBy\n\n          Shodan search: \"http.favicon.hash:-1399433489\"",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "prometheus-api-gather"
+    ],
+    "transcript": "",
+    "doc": "Prometheus API Information Gather",
+    "disclosure_date": "2016-07-01",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/prometheus_node_exporter_gather",
+    "description": "This modules connects to a Prometheus Node Exporter or Windows Exporter service\n          and gathers information about the host.\n\n          Tested against Docker image 1.6.1, Linux 1.6.1, and Windows 0.23.1",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "prometheus-node-exporter-gather"
+    ],
+    "transcript": "",
+    "doc": "Prometheus Node Exporter And Windows Exporter Information Gather",
+    "disclosure_date": "2013-04-18",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/pulse_secure_file_disclosure",
+    "description": "This module exploits a pre-auth directory traversal in the Pulse Secure\n          VPN server to dump an arbitrary file. Dumped files are stored in loot.\n\n          If the \"Automatic\" action is set, plaintext and hashed credentials, as\n          well as session IDs, will be dumped. Valid sessions can be hijacked by\n          setting the \"DSIG\" browser cookie to a valid session ID.\n\n          For the \"Manual\" action, please specify a file to dump via the \"FILE\"\n          option. /etc/passwd will be dumped by default. If the \"PRINT\" option is\n          set, file contents will be printed to the screen, with any unprintable\n          characters replaced by a period.\n\n          Please see related module exploit/linux/http/pulse_secure_cmd_exec for\n          a post-auth exploit that can leverage the results from this module.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-11510"
+    ],
+    "tags": [
+      "gather",
+      "pulse-secure-file-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Pulse Secure VPN Arbitrary File Disclosure",
+    "disclosure_date": "2019-04-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/python_flask_cookie_signer",
+    "description": "This is a generic module which can manipulate Python Flask-based application cookies.\n          The Retrieve action will connect to a web server, grab the cookie, and decode it.\n          The Resign action will do the same as above, but after decoding it, it will replace\n          the contents with that in NEWCOOKIECONTENT, then sign the cookie with SECRET. This\n          cookie can then be used in a browser. This is a Ruby based implementation of some\n          of the features in the Python project Flask-Unsign.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "python-flask-cookie-signer"
+    ],
+    "transcript": "",
+    "doc": "Python Flask Cookie Signer",
+    "disclosure_date": "2019-01-26",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/qnap_backtrace_admin_hash",
+    "description": "This module exploits combined heap and stack buffer overflows for QNAP\n          NAS and NVR devices to dump the admin (root) shadow hash from memory via\n          an overwrite of __libc_argv[0] in the HTTP-header-bound glibc backtrace.\n\n          A binary search is performed to find the correct offset for the BOFs.\n          Since the server forks, blind remote exploitation is possible, provided\n          the heap does not have ASLR.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "qnap-backtrace-admin-hash"
+    ],
+    "transcript": "",
+    "doc": "QNAP NAS/NVR Administrator Hash Disclosure",
+    "disclosure_date": "2017-01-31",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/qnap_lfi",
+    "description": "This module exploits a local file inclusion in QNAP QTS and Photo\n          Station that allows an unauthenticated attacker to download files from\n          the QNAP filesystem.\n\n          Because the HTTP server runs as root, it is possible to access\n          sensitive files, such as SSH private keys and password hashes.\n\n          This module has been tested on QTS 4.3.3 (unknown Photo Station\n          version) and QTS 4.3.6 with Photo Station 5.7.9.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-7192",
+      "CVE-2019-7194",
+      "CVE-2019-7195"
+    ],
+    "tags": [
+      "gather",
+      "qnap-lfi"
+    ],
+    "transcript": "",
+    "doc": "QNAP QTS and Photo Station Local File Inclusion",
+    "disclosure_date": "2019-11-25",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/rails_doubletap_file_read",
+    "description": "This module uses a path traversal vulnerability in Ruby on Rails\n          versions =< 5.2.2 to read files on a target server.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2019-5418"
+    ],
+    "tags": [
+      "gather",
+      "rails-doubletap-file-read"
+    ],
+    "transcript": "",
+    "doc": "Ruby On Rails File Content Disclosure ('doubletap')",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/rancher_authenticated_api_cred_exposure",
+    "description": "An issue was discovered in Rancher versions up to and including\n          2.5.15 and 2.6.6 where sensitive fields, like passwords, API keys\n          and Ranchers service account token (used to provision clusters),\n          were stored in plaintext directly on Kubernetes objects like Clusters,\n          for example cluster.management.cattle.io. Anyone with read access to\n          those objects in the Kubernetes API could retrieve the plaintext\n          version of those sensitive data.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-36782"
+    ],
+    "tags": [
+      "gather",
+      "rancher-authenticated-api-cred-exposure"
+    ],
+    "transcript": "",
+    "doc": "Rancher Authenticated API Credential Exposure",
+    "disclosure_date": "2022-08-18",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ray_lfi_cve_2023_6020",
+    "description": "Ray before 2.8.1 is vulnerable to a local file inclusion.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-6020"
+    ],
+    "tags": [
+      "gather",
+      "ray-lfi-cve-2023-6020"
+    ],
+    "transcript": "",
+    "doc": "Ray static arbitrary file read",
+    "disclosure_date": "2023-11-15",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/redis_extractor",
+    "description": "This module connects to a Redis instance and retrieves keys and data stored.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "redis-extractor"
+    ],
+    "transcript": "",
+    "doc": "Redis Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/roundcube_auth_file_read",
+    "description": "Roundcube Webmail allows unauthorized access to arbitrary files on the host's filesystem, including configuration files.\n          This affects all versions from 1.1.0 through version 1.3.2. The attacker must be able to authenticate at the target system\n          with a valid username/password as the attack requires an active session.\n\n          Tested against version 1.3.2",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-16651"
+    ],
+    "tags": [
+      "gather",
+      "roundcube-auth-file-read"
+    ],
+    "transcript": "",
+    "doc": "Roundcube TimeZone Authenticated File Disclosure",
+    "disclosure_date": "2017-11-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/safari_file_url_navigation",
+    "description": "Versions of Safari before 8.0.6, 7.1.6, and 6.2.6 are vulnerable to a\n          \"state management issue\" that allows a browser window to be navigated\n          to a file:// URL. By dropping and loading a malicious .webarchive file,\n          an attacker can read arbitrary files, inject cross-domain Javascript, and\n          silently install Safari extensions.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "OSX",
+    "cve": [
+      "CVE-2015-1155"
+    ],
+    "tags": [
+      "gather",
+      "safari-file-url-navigation"
+    ],
+    "transcript": "",
+    "doc": "Mac OS X Safari file:// Redirection Sandbox Escape",
+    "disclosure_date": "2014-01-16",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/saltstack_salt_root_key",
+    "description": "This module exploits unauthenticated access to the _prep_auth_info()\n          method in the SaltStack Salt master's ZeroMQ request server, for\n          versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the\n          root key used to authenticate administrative commands to the master.\n\n          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0, as\n          well as Cisco Modeling Labs Corporate Edition (CML) and Cisco Virtual\n          Internet Routing Lab Personal Edition (VIRL-PE), for versions 1.2,\n          1.3, 1.5, and 1.6 in certain configurations, are known to be affected\n          by the Salt vulnerabilities.\n\n          Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as\n          well as Vulhub's Docker image.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-11651",
+      "CVE-2020-11652"
+    ],
+    "tags": [
+      "gather",
+      "saltstack-salt-root-key"
+    ],
+    "transcript": "",
+    "doc": "SaltStack Salt Master Server Root Key Disclosure",
+    "disclosure_date": "2020-04-30",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/samsung_browser_sop_bypass",
+    "description": "This module takes advantage of a Same-Origin Policy (SOP) bypass vulnerability in the\n          Samsung Internet Browser, a popular mobile browser shipping with Samsung Android devices.\n          By default, it initiates a redirect to a child tab, and rewrites the innerHTML to gather\n          credentials via a fake pop-up.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-17692"
+    ],
+    "tags": [
+      "gather",
+      "samsung-browser-sop-bypass"
+    ],
+    "transcript": "",
+    "doc": "Samsung Internet Browser SOP Bypass",
+    "disclosure_date": "2017-11-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/search_email_collector",
+    "description": "This module uses Google, Bing and Yahoo to create a list of\n          valid email addresses for the target domain.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "search-email-collector"
+    ],
+    "transcript": "",
+    "doc": "Search Engine Domain Email Address Collector",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/searchengine_subdomains_collector",
+    "description": "This module can be used to gather subdomains about a domain\n          from Yahoo, Bing.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "searchengine-subdomains-collector"
+    ],
+    "transcript": "",
+    "doc": "Search Engine Subdomains Collector",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/selenium_file_read",
+    "description": "If there is an open selenium web driver, a remote attacker can send requests to the victims browser.\n          In certain cases this can be used to access to the remote file system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Cisco",
+    "cve": [],
+    "tags": [
+      "gather",
+      "selenium-file-read"
+    ],
+    "transcript": "",
+    "doc": "Selenium arbitrary file read",
+    "disclosure_date": "2020-10-01",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/shodan_honeyscore",
+    "description": "This module uses the shodan API to check\n          if a server is a honeypot or not. The api\n          returns a score from 0.0 to 1.0. 1.0 being a honeypot.\n          A shodan API key is needed for this module to work properly.\n\n          If you don't have an account, go here to register:\n          https://account.shodan.io/register\n          For more info on how their honeyscore system works, go here:\n          https://honeyscore.shodan.io/",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "shodan-honeyscore"
+    ],
+    "transcript": "",
+    "doc": "Shodan Honeyscore Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/shodan_host",
+    "description": "This module uses the shodan API to return all port information found on a given host IP.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "shodan-host"
+    ],
+    "transcript": "",
+    "doc": "Shodan Host Port",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/shodan_search",
+    "description": "This module uses the Shodan API to search Shodan. Accounts are free\n          and an API key is required to use this module. Output from the module\n          is displayed to the screen and can be saved to a file or the MSF database.\n          NOTE: SHODAN filters (i.e. port, hostname, os, geo, city) can be used in\n          queries, but there are limitations when used with a free API key. Please\n          see the Shodan site for more information.\n          Shodan website: https://www.shodan.io/\n          API: https://developer.shodan.io/api\n          Filters: https://www.shodan.io/search/filters\n          Facets: https://www.shodan.io/search/facet (from the scrollbox)",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "shodan-search"
+    ],
+    "transcript": "",
+    "doc": "Shodan Search",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/snare_registry",
+    "description": "This module uses the Registry Dump feature of the Snare Lite\n          for Windows service on 6161/TCP to retrieve the Windows registry.\n          The Dump Registry functionality is unavailable in Snare Enterprise.\n\n          Note: The Dump Registry functionality accepts only one connected\n          client at a time. Requesting a large key/hive will cause the service\n          to become unresponsive until the server completes the request.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "Windows",
+    "cve": [],
+    "tags": [
+      "gather",
+      "snare-registry"
+    ],
+    "transcript": "",
+    "doc": "Snare Lite for Windows Registry Access",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/solarwinds_orion_sqli",
+    "description": "This module exploits a stacked SQL injection in order to add an administrator user to the\n          SolarWinds Orion database.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-9566"
+    ],
+    "tags": [
+      "gather",
+      "solarwinds-orion-sqli"
+    ],
+    "transcript": "",
+    "doc": "Solarwinds Orion AccountManagement.asmx GetAccounts Admin Creation",
+    "disclosure_date": "2015-02-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/solarwinds_servu_fileread_cve_2024_28995",
+    "description": "This module exploits an unauthenticated file read vulnerability, due to directory traversal, affecting\n          SolarWinds Serv-U FTP Server 15.4, Serv-U Gateway 15.4, and Serv-U MFT Server 15.4. All versions prior to\n          the vendor supplied hotfix \"15.4.2 Hotfix 2\" (version 15.4.2.157) are affected.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-28995"
+    ],
+    "tags": [
+      "gather",
+      "solarwinds-servu-fileread-cve-2024-28995"
+    ],
+    "transcript": "",
+    "doc": "SolarWinds Serv-U Unauthenticated Arbitrary File Read",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/solarwinds_webhelpdesk_backdoor",
+    "description": "This module exploits a backdoor in SolarWinds Web Help Desk <= v12.8.3 to retrieve all tickets from the system.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2024-28987"
+    ],
+    "tags": [
+      "gather",
+      "solarwinds-webhelpdesk-backdoor"
+    ],
+    "transcript": "",
+    "doc": "SolarWinds Web Help Desk Backdoor (CVE-2024-28987)",
+    "disclosure_date": "2024-08-22",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/splunk_raw_server_info",
+    "description": "Splunk 6.2.3 through 7.0.1 allows information disclosure by appending\n          /__raw/services/server/info/server-info?output_mode=json to a query.\n          Versisons 6.6.0 through 7.0.1 require authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2018-11409"
+    ],
+    "tags": [
+      "gather",
+      "splunk-raw-server-info"
+    ],
+    "transcript": "",
+    "doc": "Splunk __raw Server Info Disclosure ",
+    "disclosure_date": "2018-06-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/ssllabs_scan",
+    "description": "This module is a simple client for the SSL Labs APIs, designed for\n          SSL/TLS assessment during a penetration test.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "ssllabs-scan"
+    ],
+    "transcript": "",
+    "doc": "SSL Labs API Client",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/suite_crm_export_sqli",
+    "description": "This module exploits an authenticated SQL injection in SuiteCRM in versions before 7.12.6. The vulnerability\n          allows an authenticated attacker to send specially crafted requests to the export entry point of the application in order\n          to retrieve all the usernames and their associated password from the database.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "suite-crm-export-sqli"
+    ],
+    "transcript": "",
+    "doc": "SuiteCRM authenticated SQL injection in export functionality",
+    "disclosure_date": "2022-05-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/teamtalk_creds",
+    "description": "This module retrieves user credentials from BearWare TeamTalk.\n\n          Valid administrator credentials are required.\n\n          This module has been tested successfully on TeamTalk versions\n          5.2.2.4885 and 5.2.3.4893.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "teamtalk-creds"
+    ],
+    "transcript": "",
+    "doc": "TeamTalk Gather Credentials",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/thinmanager_traversal_download",
+    "description": "This module exploits a path traversal vulnerability (CVE-2023-27856) in\n          ThinManager <= v13.0.1 to retrieve arbitrary files from the system.\n          The affected service listens by default on TCP port 2031 and runs in the\n          context of NT AUTHORITY\\SYSTEM.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2023-27856"
+    ],
+    "tags": [
+      "gather",
+      "thinmanager-traversal-download"
+    ],
+    "transcript": "",
+    "doc": "ThinManager Path Traversal (CVE-2023-27856) Arbitrary File Download",
+    "disclosure_date": "2023-04-05",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/tplink_archer_c7_traversal",
+    "description": "This module exploits a directory traversal vulnerability in the PATH_INFO found at /login/\n          on TP-Link Archer C5, C7, and C9 routers of varying versions.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2015-3035"
+    ],
+    "tags": [
+      "gather",
+      "tplink-archer-c7-traversal"
+    ],
+    "transcript": "",
+    "doc": "Archer C7 Directory Traversal Vulnerability",
+    "disclosure_date": "2015-04-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/trackit_sql_domain_creds",
+    "description": "This module exploits an unauthenticated configuration retrieval .NET remoting\n          service in Numara / BMC Track-It! v9 to v11.X, which can be abused to retrieve the Domain\n          Administrator and the SQL server user credentials.\n          This module has been tested successfully on versions 11.3.0.355, 10.0.51.135, 10.0.50.107,\n          10.0.0.143 and 9.0.30.248.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-4872"
+    ],
+    "tags": [
+      "gather",
+      "trackit-sql-domain-creds"
+    ],
+    "transcript": "",
+    "doc": "BMC / Numara Track-It! Domain Administrator and SQL Server User Password Disclosure",
+    "disclosure_date": "2014-10-07",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/upsmon_traversal",
+    "description": "This module exploits a path traversal vulnerability in UPSMON PRO <= v2.61 to retrieve arbitrary files from the system.\n          By default, the configuration file will be retrieved, which contains the credentials (CVE-2022-38121) for the web service, mail server, application, and SMS service.\n          However, any arbitrary file can be specified.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-38120",
+      "CVE-2022-38121"
+    ],
+    "tags": [
+      "gather",
+      "upsmon-traversal"
+    ],
+    "transcript": "",
+    "doc": "POWERCOM UPSMON PRO Path Traversal (CVE-2022-38120) and Credential Harvester (CVE-2022-38121)",
+    "disclosure_date": "2022-11-10",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/vbulletin_getindexablecontent_sqli",
+    "description": "This module exploits a SQL injection vulnerability found in vBulletin 5.x.x to dump the user\n          table information or to dump all of the vBulletin tables (based on the selected options). This\n          module has been tested successfully on VBulletin Version 5.6.1 on Ubuntu Linux.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-12720"
+    ],
+    "tags": [
+      "gather",
+      "vbulletin-getindexablecontent-sqli"
+    ],
+    "transcript": "",
+    "doc": "vBulletin /ajax/api/content_infraction/getIndexableContent nodeid Parameter SQL Injection",
+    "disclosure_date": "2020-03-12",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/vbulletin_vote_sqli",
+    "description": "This module exploits a SQL injection vulnerability found in vBulletin 5 that has been\n          used in the wild since March 2013. This module can be used to extract the web application's\n          usernames and hashes, which could be used to authenticate into the vBulletin admin control\n          panel.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2013-3522"
+    ],
+    "tags": [
+      "gather",
+      "vbulletin-vote-sqli"
+    ],
+    "transcript": "",
+    "doc": "vBulletin Password Collector via nodeid SQL Injection",
+    "disclosure_date": "2013-03-24",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/vmware_vcenter_vmdir_ldap",
+    "description": "This module uses an anonymous-bind LDAP connection to dump data from\n          the vmdir service in VMware vCenter Server version 6.7 prior to the\n          6.7U3f update, only if upgraded from a previous release line, such as\n          6.0 or 6.5.\n          If the bind username and password are provided (BIND_DN and LDAPPassword\n          options), these credentials will be used instead of attempting an\n          anonymous bind.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2020-3952"
+    ],
+    "tags": [
+      "gather",
+      "vmware-vcenter-vmdir-ldap"
+    ],
+    "transcript": "",
+    "doc": "VMware vCenter Server vmdir Information Disclosure",
+    "disclosure_date": "2020-04-09",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/windows_deployment_services_shares",
+    "description": "This module will search remote file shares for unattended installation files that may contain\n          domain credentials. This is often used after discovering domain credentials with the\n          auxiliary/scanner/dcerpc/windows_deployment_services module or in cases where you already\n          have domain credentials. This module will connect to the RemInst share and any Microsoft\n          Deployment Toolkit shares indicated by the share name comments.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "windows-deployment-services-shares"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows Deployment Services Unattend Gatherer",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/windows_secrets_dump",
+    "description": "Dumps SAM hashes and LSA secrets (including cached creds) from the\n          remote Windows target without executing any agent locally. This is\n          done by remotely updating the registry key security descriptor,\n          taking advantage of the WriteDACL privileges held by local\n          administrators to set temporary read permissions.\n\n          This can be disabled by setting the `INLINE` option to false and the\n          module will fallback to the original implementation, which consists\n          in saving the registry hives locally on the target\n          (%SYSTEMROOT%\\Temp\\<random>.tmp), downloading the temporary hive\n          files and reading the data from it. This temporary files are removed\n          when it's done.\n\n          On domain controllers, secrets from Active Directory is extracted\n          using [MS-DRDS] DRSGetNCChanges(), replicating the attributes we need\n          to get SIDs, NTLM hashes, groups, password history, Kerberos keys and\n          other interesting data. Note that the actual `NTDS.dit` file is not\n          downloaded. Instead, the Directory Replication Service directly asks\n          Active Directory through RPC requests.\n\n          This modules takes care of starting or enabling the Remote Registry\n          service if needed. It will restore the service to its original state\n          when it's done.\n\n          This is a port of the great Impacket `secretsdump.py` code written by\n          Alberto Solino.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "windows-secrets-dump"
+    ],
+    "transcript": "",
+    "doc": "Windows Secrets Dump",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_all_in_one_migration_export",
+    "description": "This module allows you to export Wordpress data (such as the database, plugins, themes,\n          uploaded files, etc) via the All-in-One Migration plugin without authentication.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "wp-all-in-one-migration-export"
+    ],
+    "transcript": "",
+    "doc": "WordPress All-in-One Migration Export",
+    "disclosure_date": "2015-03-19",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_bookingpress_category_services_sqli",
+    "description": "The BookingPress WordPress plugin before 1.0.11 fails to properly sanitize user supplied data\n          in the `total_service` parameter of the `bookingpress_front_get_category_services` AJAX action\n          (available to unauthenticated users), prior to using it in a dynamically constructed SQL query.\n          As a result, unauthenticated attackers can conduct an SQL injection attack to dump sensitive\n          data from the backend database such as usernames and password hashes.\n\n          This module uses this vulnerability to dump the list of WordPress users and their associated\n          email addresses and password hashes for cracking offline.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-0739"
+    ],
+    "tags": [
+      "gather",
+      "wp-bookingpress-category-services-sqli"
+    ],
+    "transcript": "",
+    "doc": "Wordpress BookingPress bookingpress_front_get_category_services SQLi",
+    "disclosure_date": "2022-02-28",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_depicter_sqli_cve_2025_2011",
+    "description": "The Slider & Popup Builder by Depicter plugin for WordPress <= 3.6.1\n          is vulnerable to unauthenticated SQL injection via the 's' parameter\n          in admin-ajax.php.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2025-2011"
+    ],
+    "tags": [
+      "gather",
+      "wp-depicter-sqli-cve-2025-2011"
+    ],
+    "transcript": "",
+    "doc": "WordPress Depicter Plugin SQL Injection (CVE-2025-2011)",
+    "disclosure_date": "2025-05-08",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_photo_gallery_sqli",
+    "description": "The Photo Gallery by 10Web WordPress plugin <= 1.6.0 is vulnerable to\n          unauthenticated SQL injection via the 'bwg_tag_id_bwg_thumbnails_0[]'\n          parameter in admin-ajax.php (action=bwg_frontend_data).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2022-0169"
+    ],
+    "tags": [
+      "gather",
+      "wp-photo-gallery-sqli"
+    ],
+    "transcript": "",
+    "doc": "WordPress Photo Gallery Plugin SQL Injection (CVE-2022-0169)",
+    "disclosure_date": "2022-03-14",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_ultimate_csv_importer_user_extract",
+    "description": "Due to lack of verification of a visitor's permissions, it is possible\n          to execute the 'export.php' script included in the default installation of the\n          Ultimate CSV Importer plugin and retrieve the full contents of the user table\n          in the WordPress installation. This results in full disclosure of usernames,\n          hashed passwords and email addresses for all users.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "wp-ultimate-csv-importer-user-extract"
+    ],
+    "transcript": "",
+    "doc": "WordPress Ultimate CSV Importer User Table Extract",
+    "disclosure_date": "2015-02-02",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/wp_w3_total_cache_hash_extract",
+    "description": "The W3-Total-Cache Wordpress Plugin <= 0.9.2.4 can cache database statements\n        and its results in files for fast access. Version 0.9.2.4 has been fixed afterwards\n        so it can be vulnerable. These cache files are in the webroot of the Wordpress\n        installation and can be downloaded if the name is guessed. This module tries to\n        locate them with brute force in order to find usernames and password hashes in these\n        files. W3 Total Cache must be configured with Database Cache enabled and Database\n        Cache Method set to Disk to be vulnerable",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "wp-w3-total-cache-hash-extract"
+    ],
+    "transcript": "",
+    "doc": "WordPress W3-Total-Cache Plugin 0.9.2.4 (or before) Username and Hash Extract",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/x11_keyboard_spy",
+    "description": "This module binds to an open X11 host to log keystrokes. This is a fairly\n          close copy of the old xspy c program which has been on Kali for a long time.\n          The module works by connecting to the X11 session, creating a background\n          window, binding a keyboard to it and creating a notification alert when a key\n          is pressed.\n\n          One of the major limitations of xspy, and thus this module, is that it polls\n          at a very fast rate, faster than a key being pressed is released (especially before\n          the repeat delay is hit). To combat printing multiple characters for a single key\n          press, repeat characters arent printed when typed in a very fast manor. This is also\n          an imperfect keylogger in that keystrokes arent stored and forwarded but status\n          displayed at poll time. Keys may be repeated or missing.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-1999-0526"
+    ],
+    "tags": [
+      "gather",
+      "x11-keyboard-spy"
+    ],
+    "transcript": "",
+    "doc": "X11 Keylogger",
+    "disclosure_date": "1997-07-01",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/xbmc_traversal",
+    "description": "This module exploits a directory traversal bug in XBMC 11, up until the\n          2012-11-04 nightly build. The module can only be used to retrieve files.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "xbmc-traversal"
+    ],
+    "transcript": "",
+    "doc": "XBMC Web Server Directory Traversal",
+    "disclosure_date": "2012-11-04",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/xerox_pwd_extract",
+    "description": "This module will extract the management console's admin password from the\n          Xerox file system using firmware bootstrap injection.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "xerox-pwd-extract"
+    ],
+    "transcript": "",
+    "doc": "Xerox Administrator Console Password Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/xerox_workcentre_5xxx_ldap",
+    "description": "This module extract the printer's LDAP username and password from Xerox Workcentre 5735.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "xerox-workcentre-5xxx-ldap"
+    ],
+    "transcript": "",
+    "doc": "Xerox Workcentre 5735 LDAP Service Redential Extractor",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/xymon_info",
+    "description": "This module retrieves information from a Xymon daemon service\n        (formerly Hobbit, based on Big Brother), including server\n        configuration information, a list of monitored hosts, and\n        associated client log for each host.\n\n        This module also retrieves usernames and password hashes from\n        the `xymonpasswd` config file from Xymon servers before 4.3.25,\n        which permit download arbitrary config files (CVE-2016-2055),\n        and servers configured with `ALLOWALLCONFIGFILES` enabled.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-2055"
+    ],
+    "tags": [
+      "gather",
+      "xymon-info"
+    ],
+    "transcript": "",
+    "doc": "Xymon Daemon Gather Information",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/zabbix_toggleids_sqli",
+    "description": "This module will exploit a SQL injection in Zabbix 3.0.3 and\n          likely prior in order to save the current usernames and\n          password hashes from the database to a JSON file.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2016-10134"
+    ],
+    "tags": [
+      "gather",
+      "zabbix-toggleids-sqli"
+    ],
+    "transcript": "",
+    "doc": "Zabbix toggle_ids SQL Injection",
+    "disclosure_date": "2016-08-11",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/zookeeper_info_disclosure",
+    "description": "Apache ZooKeeper server service runs on TCP 2181 and by default, it is accessible without any authentication. This module targets Apache ZooKeeper service instances to extract information about the system environment, and service statistics.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "zookeeper-info-disclosure"
+    ],
+    "transcript": "",
+    "doc": "Apache ZooKeeper Information Disclosure",
+    "disclosure_date": "2020-10-14",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/gather/zoomeye_search",
+    "description": "The module use the ZoomEye API to search ZoomEye. ZoomEye is a search\n          engine for cyberspace that lets the user find specific network\n          components(ip, services, etc.).\n\n          Setting facets will output a simple report on the overall search. It's values are:\n          Host search: app, device, service, os, port, country, city\n          Web search: webapp, component, framework, frontend, server, waf, os, country, city\n\n          Possible filters values are:\n          Host search: app, ver, device, os, service, ip, cidr, hostname, port, city, country, asn\n          Web search: app, header, keywords, desc, title, ip, site, city, country\n\n          When using multiple filters, you must enclose individual filter values in double quotes, separating filters with the '+' symbol as follows:\n          'country:\"FR\" + os:\"Linux\"'",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "gather",
+      "zoomeye-search"
+    ],
+    "transcript": "",
+    "doc": "ZoomEye Search",
+    "disclosure_date": "",
+    "teaches": "Teaches about gather"
+  },
+  {
+    "name": "auxiliary/parser/unattend",
+    "description": "This module parses Windows answer files (Unattend files) in the target directory.\n\n          See also: post/windows/gather/enum_unattend",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "parser",
+      "unattend"
+    ],
+    "transcript": "",
+    "doc": "Auxiliary Parser Windows Unattend Passwords",
+    "disclosure_date": "",
+    "teaches": "Teaches about parser"
+  },
+  {
+    "name": "auxiliary/pdf/foxit/authbypass",
+    "description": "This module exploits an authorization bypass vulnerability in Foxit Reader\n          build 1120. When an attacker creates a specially crafted pdf file containing\n          an Open/Execute action, arbitrary commands can be executed without confirmation\n          from the victim.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2009-0836"
+    ],
+    "tags": [
+      "pdf",
+      "foxit",
+      "authbypass"
+    ],
+    "transcript": "",
+    "doc": "Foxit Reader Authorization Bypass",
+    "disclosure_date": "2009-03-09",
+    "teaches": "Teaches about pdf"
+  },
+  {
+    "name": "auxiliary/scanner/acpp/login",
+    "description": "This module attempts to authenticate to an Apple Airport using its\n        proprietary and largely undocumented protocol known only as ACPP.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2003-0270"
+    ],
+    "tags": [
+      "scanner",
+      "acpp",
+      "login"
+    ],
+    "transcript": "",
+    "doc": "Apple Airport ACPP Authentication Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/afp/afp_login",
+    "description": "This module attempts to bruteforce authentication credentials for AFP.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "afp",
+      "afp-login"
+    ],
+    "transcript": "",
+    "doc": "Apple Filing Protocol Login Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/afp/afp_server_info",
+    "description": "This module fetches AFP server information, including server name,\n          network address, supported AFP versions, signature, machine type,\n          and server flags.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "afp",
+      "afp-server-info"
+    ],
+    "transcript": "",
+    "doc": "Apple Filing Protocol Info Enumerator",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/amqp/amqp_login",
+    "description": "This module will test AMQP logins on a range of machines and\n          report successful logins.  If you have loaded a database plugin\n          and connected to a database this module will record successful\n          logins and hosts so you can track your access.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "amqp",
+      "amqp-login"
+    ],
+    "transcript": "",
+    "doc": "AMQP 0-9-1 Login Check Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/amqp/amqp_version",
+    "description": "Detect AMQP version information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "amqp",
+      "amqp-version"
+    ],
+    "transcript": "",
+    "doc": "AMQP 0-9-1 Version Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/backdoor/energizer_duo_detect",
+    "description": "Detect instances of the Energizer DUO trojan horse software on port 7777.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2010-0103"
+    ],
+    "tags": [
+      "scanner",
+      "backdoor",
+      "energizer-duo-detect"
+    ],
+    "transcript": "",
+    "doc": "Energizer DUO Trojan Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/chargen/chargen_probe",
+    "description": "Chargen is a debugging and measurement tool and a character\n        generator service. A character generator service simply sends\n        data without regard to the input.\n        Chargen is susceptible to spoofing the source of transmissions\n        as well as use in a reflection attack vector. The misuse of the\n        testing features of the Chargen service may allow attackers to\n        craft malicious network payloads and reflect them by spoofing\n        the transmission source to effectively direct it to a target.\n        This can result in traffic loops and service degradation with\n        large amounts of network traffic.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-1999-0103"
+    ],
+    "tags": [
+      "scanner",
+      "chargen",
+      "chargen-probe"
+    ],
+    "transcript": "",
+    "doc": "Chargen Probe Utility",
+    "disclosure_date": "1996-02-08",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/couchdb/couchdb_enum",
+    "description": "This module enumerates databases on CouchDB using the REST API\n          (without authentication by default).",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2017-12635"
+    ],
+    "tags": [
+      "scanner",
+      "couchdb",
+      "couchdb-enum"
+    ],
+    "transcript": "",
+    "doc": "CouchDB Enum Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/couchdb/couchdb_login",
+    "description": "This module tests CouchDB logins on a range of\n          machines and report successful logins.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "couchdb",
+      "couchdb-login"
+    ],
+    "transcript": "",
+    "doc": "CouchDB Login Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/db2/db2_auth",
+    "description": "This module attempts to authenticate against a DB2 instance\n        using username and password combinations indicated by the\n        USER_FILE, PASS_FILE, and USERPASS_FILE options.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-1999-0502"
+    ],
+    "tags": [
+      "scanner",
+      "db2",
+      "db2-auth"
+    ],
+    "transcript": "",
+    "doc": "DB2 Authentication Brute Force Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/db2/db2_version",
+    "description": "This module queries a DB2 instance information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "db2",
+      "db2-version"
+    ],
+    "transcript": "",
+    "doc": "DB2 Probe Utility",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/db2/discovery",
+    "description": "This module simply queries the DB2 discovery service for information.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "db2",
+      "discovery"
+    ],
+    "transcript": "",
+    "doc": "DB2 Discovery Service Detection",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/dfscoerce",
+    "description": "Coerce an authentication attempt over SMB to other machines via MS-DFSNM methods.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "dfscoerce"
+    ],
+    "transcript": "",
+    "doc": "DFSCoerce",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/endpoint_mapper",
+    "description": "This module can be used to obtain information from the\n        Endpoint Mapper service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "endpoint-mapper"
+    ],
+    "transcript": "",
+    "doc": "Endpoint Mapper Service Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/hidden",
+    "description": "This module will query the endpoint mapper and make a list\n      of all ncacn_tcp RPC services. It will then connect to each of\n      these services and use the management API to list all other\n      RPC services accessible on this port. Any RPC service found attached\n      to a TCP port, but not listed in the endpoint mapper, will be displayed\n      and analyzed to see whether anonymous access is permitted.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "hidden"
+    ],
+    "transcript": "",
+    "doc": "Hidden DCERPC Service Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/management",
+    "description": "This module can be used to obtain information from the Remote\n        Management Interface DCERPC service.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "management"
+    ],
+    "transcript": "",
+    "doc": "Remote Management Interface Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/nrpc_enumusers",
+    "description": "This module will enumerate valid Domain Users via no authentication against MS-NRPC interface.\n          It calls DsrGetDcNameEx2 to check if the domain user account exists or not. It has been tested with\n          Windows servers 2012, 2016, 2019 and 2022.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "nrpc-enumusers"
+    ],
+    "transcript": "",
+    "doc": "MS-NRPC Domain Users Enumeration",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/petitpotam",
+    "description": "Coerce an authentication attempt over SMB to other machines via MS-EFSRPC methods.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2021-36942"
+    ],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "petitpotam"
+    ],
+    "transcript": "",
+    "doc": "PetitPotam",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/tcp_dcerpc_auditor",
+    "description": "Determine what DCERPC services are accessible over a TCP port.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "tcp-dcerpc-auditor"
+    ],
+    "transcript": "",
+    "doc": "DCERPC TCP Service Auditor",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dcerpc/windows_deployment_services",
+    "description": "This module retrieves the client unattend file from Windows\n          Deployment Services RPC service and parses out the stored credentials.\n          Tested against Windows 2008 R2 x64 and Windows 2003 x86.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dcerpc",
+      "windows-deployment-services"
+    ],
+    "transcript": "",
+    "doc": "Microsoft Windows Deployment Services Unattend Retrieval",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dect/call_scanner",
+    "description": "This module scans for active DECT calls.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dect",
+      "call-scanner"
+    ],
+    "transcript": "",
+    "doc": "DECT Call Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dect/station_scanner",
+    "description": "This module scans for DECT base stations.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "dect",
+      "station-scanner"
+    ],
+    "transcript": "",
+    "doc": "DECT Base Station Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/arp_sweep",
+    "description": "Enumerate alive hosts in local network using ARP requests.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "arp-sweep"
+    ],
+    "transcript": "",
+    "doc": "ARP Sweep Local Network Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/empty_udp",
+    "description": "Detect UDP services that reply to empty probes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "empty-udp"
+    ],
+    "transcript": "",
+    "doc": "UDP Empty Prober",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/ipv6_multicast_ping",
+    "description": "Send a ICMPv6 ping request to all default multicast addresses, and wait to see who responds.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "ipv6-multicast-ping"
+    ],
+    "transcript": "",
+    "doc": "IPv6 Link Local/Node Local Ping Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/ipv6_neighbor",
+    "description": "Enumerate local IPv6 hosts which respond to Neighbor Solicitations with a link-local address.\n        Note, that like ARP scanning, this usually cannot be performed beyond the local\n        broadcast network.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "ipv6-neighbor"
+    ],
+    "transcript": "",
+    "doc": "IPv6 Local Neighbor Discovery",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement",
+    "description": "Send a spoofed router advertisement with high priority to force hosts to\n        start the IPv6 address auto-config. Monitor for IPv6 host advertisements,\n        and try to guess the link-local address by concatenating the prefix, and\n        the host portion of the IPv6 address.  Use NDP host solicitation to\n        determine if the IP address is valid.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "ipv6-neighbor-router-advertisement"
+    ],
+    "transcript": "",
+    "doc": "IPv6 Local Neighbor Discovery Using Router Advertisement",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/udp_probe",
+    "description": "Detect common UDP services using sequential probes.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "udp-probe"
+    ],
+    "transcript": "",
+    "doc": "UDP Service Prober",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/discovery/udp_sweep",
+    "description": "Detect interesting UDP services.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [],
+    "tags": [
+      "scanner",
+      "discovery",
+      "udp-sweep"
+    ],
+    "transcript": "",
+    "doc": "UDP Service Sweeper",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dlsw/dlsw_leak_capture",
+    "description": "This module implements the DLSw information disclosure retrieval. There\n        is a bug in Cisco's DLSw implementation affecting 12.x and 15.x trains\n        that allows an unauthenticated remote attacker to retrieve the partial\n        contents of packets traversing a Cisco router with DLSw configured\n        and active.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2014-7992"
+    ],
+    "tags": [
+      "scanner",
+      "dlsw",
+      "dlsw-leak-capture"
+    ],
+    "transcript": "",
+    "doc": "Cisco DLSw Information Disclosure Scanner",
+    "disclosure_date": "2014-11-17",
+    "teaches": "Teaches about scanner"
+  },
+  {
+    "name": "auxiliary/scanner/dns/dns_amp",
+    "description": "This module can be used to discover DNS servers which expose recursive\n          name lookups which can be used in an amplification attack against a\n          third party.",
+    "severity": "low",
+    "type": "auxiliary",
+    "platform": "multi",
+    "cve": [
+      "CVE-2006-0987",
+      "CVE-2006-0988"
+    ],
+    "tags": [
+      "scanner",
+      "dns",
+      "dns-amp"
+    ],
+    "transcript": "",
+    "doc": "DNS Amplification Scanner",
+    "disclosure_date": "",
+    "teaches": "Teaches about scanner"
   }
 ]


### PR DESCRIPTION
## Summary
- add static index of 600 metasploit modules with disclosure dates and educational notes
- enable search and tag filtering in metasploit app
- show module disclosure date and teaching note in detail view

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: youtube, mimikatz, wordSearch, niktoApp, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d870aec8328bbf4dcbd7e5ddae6