### PR TITLE
feat: persist ble profiles with opfs

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -1,18 +1,18 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import FormError from '../ui/FormError';
+import {
+  loadProfiles,
+  loadProfile,
+  saveProfile,
+  renameProfile,
+  deleteProfile,
+  SavedProfile,
+  ServiceData,
+  CharacteristicData,
+} from '../../utils/bleProfiles';
 
 type BluetoothDevice = any;
 type BluetoothRemoteGATTServer = any;
-
-interface CharacteristicData {
-  uuid: string;
-  value: string;
-}
-
-interface ServiceData {
-  uuid: string;
-  characteristics: CharacteristicData[];
-}
 
 const MAX_RETRIES = 3;
 
@@ -24,6 +24,20 @@ const BleSensor: React.FC = () => {
   const [services, setServices] = useState<ServiceData[]>([]);
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
+  const [profiles, setProfiles] = useState<SavedProfile[]>([]);
+  const bcRef = useRef<BroadcastChannel>();
+
+  const refreshProfiles = async () => setProfiles(await loadProfiles());
+
+  useEffect(() => {
+    refreshProfiles();
+    if (typeof window !== 'undefined' && 'BroadcastChannel' in window) {
+      const bc = new BroadcastChannel('ble-profiles');
+      bc.onmessage = () => refreshProfiles();
+      bcRef.current = bc;
+      return () => bc.close();
+    }
+  }, []);
 
   const connectWithRetry = async (
     device: BluetoothDevice,
@@ -62,6 +76,13 @@ const BleSensor: React.FC = () => {
         optionalServices: ['battery_service', 'device_information'],
       });
 
+      const saved = await loadProfile(device.id);
+      if (saved) {
+        setDeviceName(saved.name);
+        setServices(saved.services);
+        return;
+      }
+
       setDeviceName(device.name || 'Unknown device');
 
       const server = await connectWithRetry(device);
@@ -75,7 +96,7 @@ const BleSensor: React.FC = () => {
 
       for (const service of primServices) {
         const chars = await service.getCharacteristics();
-        const charData = await Promise.all(
+        const charData: CharacteristicData[] = await Promise.all(
           chars.map(async (char: any) => {
             try {
               const val = await char.readValue();
@@ -89,6 +110,12 @@ const BleSensor: React.FC = () => {
         serviceData.push({ uuid: service.uuid, characteristics: charData });
       }
       setServices(serviceData);
+      await saveProfile(device.id, {
+        name: device.name || 'Unknown device',
+        services: serviceData,
+      });
+      bcRef.current?.postMessage('update');
+      await refreshProfiles();
     } catch (err) {
       const e = err as DOMException;
       if (e.name === 'NotAllowedError') {
@@ -120,6 +147,37 @@ const BleSensor: React.FC = () => {
       </button>
 
       {error && <FormError className="mt-0 mb-4">{error}</FormError>}
+
+      {profiles.length > 0 && (
+        <div className="mb-4">
+          <p className="mb-2 font-bold">Saved Profiles</p>
+          <ul className="space-y-1">
+            {profiles.map((p) => (
+              <li key={p.deviceId} className="flex items-center space-x-2">
+                <input
+                  defaultValue={p.name}
+                  onBlur={async (e) => {
+                    await renameProfile(p.deviceId, e.target.value);
+                    bcRef.current?.postMessage('update');
+                    await refreshProfiles();
+                  }}
+                  className="w-40 bg-gray-800 px-1"
+                />
+                <button
+                  onClick={async () => {
+                    await deleteProfile(p.deviceId);
+                    bcRef.current?.postMessage('update');
+                    await refreshProfiles();
+                  }}
+                  className="text-red-400"
+                >
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {deviceName && <p className="mb-2">Connected to: {deviceName}</p>}
 

--- a/utils/bleProfiles.ts
+++ b/utils/bleProfiles.ts
@@ -1,0 +1,85 @@
+export interface CharacteristicData {
+  uuid: string;
+  value: string;
+}
+
+export interface ServiceData {
+  uuid: string;
+  characteristics: CharacteristicData[];
+}
+
+export interface SavedProfile {
+  deviceId: string;
+  name: string;
+  services: ServiceData[];
+}
+
+const getDir = async (): Promise<any> => {
+  if (
+    typeof navigator === 'undefined' ||
+    !(navigator as any).storage?.getDirectory
+  ) {
+    throw new Error('OPFS not supported');
+  }
+  return await (navigator as any).storage.getDirectory();
+};
+
+export const saveProfile = async (
+  deviceId: string,
+  profile: Omit<SavedProfile, 'deviceId'>
+): Promise<void> => {
+  const dir = await getDir();
+  const handle = await dir.getFileHandle(`${deviceId}.json`, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(JSON.stringify(profile));
+  await writable.close();
+};
+
+export const loadProfile = async (
+  deviceId: string
+): Promise<SavedProfile | null> => {
+  try {
+    const dir = await getDir();
+    const handle = await dir.getFileHandle(`${deviceId}.json`);
+    const file = await handle.getFile();
+    const data = JSON.parse(await file.text());
+    return { deviceId, ...data } as SavedProfile;
+  } catch {
+    return null;
+  }
+};
+
+export const loadProfiles = async (): Promise<SavedProfile[]> => {
+  try {
+    const dir = await getDir();
+    const profiles: SavedProfile[] = [];
+    for await (const [name, handle] of (dir as any).entries()) {
+      if (!name.endsWith('.json')) continue;
+      const file = await handle.getFile();
+      const data = JSON.parse(await file.text());
+      profiles.push({ deviceId: name.replace(/\.json$/, ''), ...data });
+    }
+    return profiles;
+  } catch {
+    return [];
+  }
+};
+
+export const renameProfile = async (
+  deviceId: string,
+  newName: string
+): Promise<void> => {
+  const existing = await loadProfile(deviceId);
+  if (existing) {
+    await saveProfile(deviceId, {
+      name: newName,
+      services: existing.services,
+    });
+  }
+};
+
+export const deleteProfile = async (deviceId: string): Promise<void> => {
+  const dir = await getDir();
+  await dir.removeEntry(`${deviceId}.json`);
+};
+


### PR DESCRIPTION
## Summary
- store BLE service and characteristic IDs in OPFS by device ID
- skip rediscovery by loading saved profiles
- add UI to rename or delete profiles and sync across sessions

## Testing
- `npm test` (fails: unable to find element in youtube app, mimikatz API 501, word search generator, Nikto app, Kismet app)
- `npm run lint` (fails: ESLint couldn't find a config file)


------
https://chatgpt.com/codex/tasks/task_e_68b12d86387483289c24ff5f59f32679