### PR TITLE
feat: add HTML rewriter utility

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -103,6 +103,7 @@ const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
+const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
 
@@ -186,6 +187,7 @@ const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
+const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
@@ -878,6 +880,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHTTP,
+  },
+  {
+    id: 'html-rewriter',
+    title: 'HTML Rewriter',
+    icon: './themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayHtmlRewrite,
   },
   {
     id: 'contact',

--- a/apps/html-rewriter/index.tsx
+++ b/apps/html-rewriter/index.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { diffLines } from 'diff';
+
+interface Rule {
+  selector: string;
+  action: 'remove' | 'replace';
+  value?: string;
+}
+
+const DEFAULT_RULES: Rule[] = [
+  { selector: 'script', action: 'remove' },
+  { selector: 'h1', action: 'replace', value: 'Rewritten Title' },
+];
+
+const DEFAULT_HTML = `<h1>Hello</h1>\n<p>Sample <strong>content</strong>.</p>\n<script>alert("xss")</script>`;
+
+const serialize = (rules: Rule[]) => JSON.stringify(rules, null, 2);
+
+const applyRules = (html: string, rules: Rule[]): string => {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  for (const r of rules) {
+    const els = Array.from(doc.querySelectorAll(r.selector));
+    if (r.action === 'remove') {
+      els.forEach((el) => el.remove());
+    } else if (r.action === 'replace') {
+      els.forEach((el) => {
+        el.textContent = r.value || '';
+      });
+    }
+  }
+  return doc.body.innerHTML;
+};
+
+const HtmlRewriterApp: React.FC = () => {
+  const [ruleText, setRuleText] = useState(serialize(DEFAULT_RULES));
+  const [html, setHtml] = useState(DEFAULT_HTML);
+  const [error, setError] = useState<string | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+
+  const { rewritten, diff } = useMemo(() => {
+    try {
+      const rules = JSON.parse(ruleText) as Rule[];
+      setError(null);
+      const rewritten = applyRules(html, rules);
+      const diff = diffLines(html, rewritten);
+      return { rewritten, diff };
+    } catch (e: any) {
+      setError(e.message);
+      return { rewritten: html, diff: diffLines(html, html) };
+    }
+  }, [ruleText, html]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-gray-900 p-4 text-white space-y-4">
+      <h1 className="text-2xl">HTML Rewriter</h1>
+      <div className="flex gap-4 flex-col md:flex-row">
+        <div className="flex-1 flex flex-col">
+          <label className="mb-1">Rewrite Rules (JSON)</label>
+          <textarea
+            className="flex-1 p-2 rounded bg-gray-800 font-mono text-sm"
+            value={ruleText}
+            onChange={(e) => setRuleText(e.target.value)}
+          />
+          {error && <p className="text-red-400 mt-1">{error}</p>}
+        </div>
+        <div className="flex-1 flex flex-col">
+          <label className="mb-1">Sample HTML</label>
+          <textarea
+            className="flex-1 p-2 rounded bg-gray-800 font-mono text-sm"
+            value={html}
+            onChange={(e) => setHtml(e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Diff</h2>
+        <pre className="whitespace-pre-wrap bg-gray-800 p-2 rounded overflow-auto">
+          {diff.map((part, i) => (
+            <span
+              key={i}
+              className={part.added ? 'bg-green-800' : part.removed ? 'bg-red-800 line-through' : ''}
+            >
+              {part.value}
+            </span>
+          ))}
+        </pre>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Rewritten HTML</h2>
+        <pre className="whitespace-pre-wrap bg-gray-800 p-2 rounded overflow-auto">{rewritten}</pre>
+      </div>
+      <button
+        className="mt-4 px-4 py-2 bg-blue-600 rounded"
+        onClick={() => setShowHelp(true)}
+      >
+        Help
+      </button>
+      {showHelp && (
+        <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center p-4">
+          <div className="bg-gray-900 p-4 rounded max-w-lg w-full text-left space-y-4">
+            <h2 className="text-xl">Rewrite Rule Examples</h2>
+            <p>Rules are objects with a CSS selector and an action.</p>
+            <pre className="bg-gray-800 p-2 rounded">
+{`[
+  { "selector": "script", "action": "remove" },
+  { "selector": "img", "action": "replace", "value": "[image]" }
+]`}
+            </pre>
+            <button
+              className="mt-2 px-4 py-2 bg-blue-600 rounded"
+              onClick={() => setShowHelp(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HtmlRewriterApp;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chrono-node": "^2.8.4",
     "cytoscape": "^3.33.1",
     "cytoscape-cose-bilkent": "^4.1.0",
+    "diff": "^5.1.0",
     "dompurify": "^3.2.6",
     "figlet": "^1.8.2",
     "howler": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5079,6 +5079,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "diff@npm:5.2.0"
+  checksum: 10c0/aed0941f206fe261ecb258dc8d0ceea8abbde3ace5827518ff8d302f0fc9cc81ce116c4d8f379151171336caf0516b79e01abdc1ed1201b6440d895a66689eb4
+  languageName: node
+  linkType: hard
+
 "dijkstrajs@npm:^1.0.1":
   version: 1.0.3
   resolution: "dijkstrajs@npm:1.0.3"
@@ -11278,6 +11285,7 @@ __metadata:
     chrono-node: "npm:^2.8.4"
     cytoscape: "npm:^3.33.1"
     cytoscape-cose-bilkent: "npm:^4.1.0"
+    diff: "npm:^5.1.0"
     dompurify: "npm:^3.2.6"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:^15.0.0"


### PR DESCRIPTION
## Summary
- add HTML Rewriter app with JSON rule editor and diff view
- allow inline validation and provide sample filters in help
- register app and add diff dependency

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test --passWithNoTests apps/html-rewriter`


------
https://chatgpt.com/codex/tasks/task_e_68b12d8486bc8328983d80cd707bac11