### PR TITLE
Add network speed monitoring worker to resource monitor

### DIFF
--- a/components/apps/speedtest.worker.js
+++ b/components/apps/speedtest.worker.js
@@ -1,0 +1,31 @@
+let running = false;
+let timer = null;
+
+self.onmessage = (e) => {
+  const { type } = e.data || {};
+  if (type === 'start' && !running) {
+    running = true;
+    runTest();
+  } else if (type === 'stop' && running) {
+    running = false;
+    if (timer) clearTimeout(timer);
+  }
+};
+
+async function runTest() {
+  if (!running) return;
+  const size = 100000; // bytes
+  const url = `https://speed.cloudflare.com/__down?bytes=${size}&cacheBust=${Math.random()}`;
+  let speed = 0;
+  try {
+    const start = performance.now();
+    const res = await fetch(url, { cache: 'no-store', mode: 'cors' });
+    await res.blob();
+    const duration = performance.now() - start;
+    speed = (size * 8) / duration / 1000; // Mbps
+  } catch (err) {
+    // ignore errors, report 0 speed
+  }
+  self.postMessage({ speed });
+  timer = setTimeout(runTest, 1000);
+}


### PR DESCRIPTION
## Summary
- track CPU, memory, FPS and network speed in ResourceMonitor with 60s history
- spawn web worker to run periodic download speed tests and feed sparkline
- add pause/resume control wiring to start/stop worker

## Testing
- `npm test` *(fails: youtube.test.tsx, mimikatz.test.ts, wordSearch.test.ts, niktoApp.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d82061c8328ad687886a16fdb5f