### PR TITLE
feat: add doc-pip pinning for hashcat gauges

### DIFF
--- a/docs/pip-portal.md
+++ b/docs/pip-portal.md
@@ -12,7 +12,7 @@ hook to open or close the PiP window.
 import PipPortalProvider, { usePipPortal } from '../components/common/PipPortal';
 
 function HudButton() {
-  const { open, close } = usePipPortal();
+  const { open, close, isOpen, isSupported } = usePipPortal();
 
   return (
     <div>
@@ -23,7 +23,9 @@ function HudButton() {
       >
         Show Timer
       </button>
-      <button onClick={close}>Close</button>
+      {isSupported && (
+        <button onClick={close}>{isOpen ? 'Unpin' : 'Close'}</button>
+      )}
     </div>
   );
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -9,6 +9,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import PipPortalProvider from '../components/common/PipPortal';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -109,10 +110,12 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <div aria-live="polite" id="live-region" />
-      <Component {...pageProps} />
-      <ShortcutOverlay />
-      <Analytics />
+      <PipPortalProvider>
+        <div aria-live="polite" id="live-region" />
+        <Component {...pageProps} />
+        <ShortcutOverlay />
+        <Analytics />
+      </PipPortalProvider>
     </SettingsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- expose `isOpen` and `isSupported` from PipPortal and auto-close on page hide or visibility change
- wrap app with PipPortalProvider
- add Pin button for Hashcat gauges that opens live Doc-PiP window

## Testing
- `yarn test` *(fails: youtube search app loads video when thumbnail clicked; mimikatz api retrieves module list; mimikatz api executes script template; word search generator is deterministic with the same seed; NiktoApp updates command with tuning flags and shows risk info)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d827cf88328b36ec5cd4754ddf0