### PR TITLE
feat: add per-game input mapping profiles

### DIFF
--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -13,7 +13,7 @@ import {
 import useGameControls from './useGameControls';
 import GameLayout from './GameLayout';
 import { vibrate } from './Games/common/haptics';
-import { getMapping } from './Games/common/input-remap/useInputMapping';
+import { getMapping, loadProfile } from './Games/common/input-remap/useInputMapping';
 
 // Arcade-style tuning constants
 const THRUST = 0.1;
@@ -121,6 +121,7 @@ const Asteroids = () => {
   const lastScoreRef = useRef(0);
 
   useEffect(() => {
+    loadProfile('asteroids', DEFAULT_MAP);
     const hs = Number(localStorage.getItem(HIGH_KEY) || 0);
     const ls = Number(localStorage.getItem(LAST_KEY) || 0);
     setHighScore(hs);

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { getMapping } from './Games/common/input-remap/useInputMapping';
+import { getMapping, loadProfile } from './Games/common/input-remap/useInputMapping';
 import useGamepad from '../../hooks/useGamepad';
 import usePersistedState from '../../hooks/usePersistedState';
 
@@ -30,6 +30,10 @@ const useGameControls = (arg, gameId = 'default') => {
   });
   const gamepad = useGamepad();
   const padTime = useRef(0);
+
+  useEffect(() => {
+    loadProfile(gameId, defaultMap);
+  }, [gameId]);
 
   // keyboard controls for directional games
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add game control mapping section to settings with import/export
- store input mappings per game in OPFS and load for games
- apply loaded mappings when games start

## Testing
- `npm test` (fails: youtube, mimikatz, niktoApp, wordSearch)
- `npm run lint` (fails: eslint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68b12d8121d48328bb96a245604ae453