### PR TITLE
Add PiP slide deck for About app

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -7,6 +7,7 @@ import Certs from '../certs';
 import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
+import AboutSlides from './slides';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
@@ -153,7 +154,12 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
 }
 
 export default function AboutApp() {
-  return <AboutAlex />;
+  return (
+    <>
+      <AboutAlex />
+      <AboutSlides />
+    </>
+  );
 }
 
 export { default as SafetyNote } from './SafetyNote';

--- a/components/apps/About/slides/data.ts
+++ b/components/apps/About/slides/data.ts
@@ -1,0 +1,25 @@
+export interface Slide {
+  title: string;
+  body: string;
+  notes: string;
+}
+
+export const slides: Slide[] = [
+  {
+    title: 'Welcome',
+    body: 'Welcome to the About section! This brief talk will highlight key features.',
+    notes: 'Greet the audience and introduce the focus of the presentation.',
+  },
+  {
+    title: 'Portfolio',
+    body: 'This app showcases various cybersecurity tools and projects.',
+    notes: 'Describe the different applications and their purposes.',
+  },
+  {
+    title: 'Thanks',
+    body: 'Thanks for taking the tour!',
+    notes: 'Wrap up the talk and encourage further exploration.',
+  },
+];
+
+export default slides;

--- a/components/apps/About/slides/index.tsx
+++ b/components/apps/About/slides/index.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+import { usePipPortal } from '../../../common/PipPortal';
+import slides from './data';
+
+export default function AboutSlides() {
+  const { open, close } = usePipPortal();
+  const [index, setIndex] = useState(0);
+
+  const show = useCallback(
+    (i: number) => {
+      const slide = slides[i];
+      if (!slide) {
+        close();
+        return;
+      }
+      open(
+        <div className="p-4 bg-black text-white text-sm">
+          <h1 className="text-lg font-bold mb-2">{slide.title}</h1>
+          <p>{slide.body}</p>
+        </div>
+      );
+    },
+    [open, close]
+  );
+
+  useEffect(() => {
+    show(index);
+  }, [index, show]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight' || e.key === ' ') {
+        e.preventDefault();
+        setIndex((i) => i + 1);
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setIndex((i) => Math.max(0, i - 1));
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  return null;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -9,6 +9,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import PipPortalProvider from '../components/common/PipPortal';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -109,10 +110,12 @@ function MyApp({ Component, pageProps }) {
   }, []);
   return (
     <SettingsProvider>
-      <div aria-live="polite" id="live-region" />
-      <Component {...pageProps} />
-      <ShortcutOverlay />
-      <Analytics />
+      <PipPortalProvider>
+        <div aria-live="polite" id="live-region" />
+        <Component {...pageProps} />
+        <ShortcutOverlay />
+        <Analytics />
+      </PipPortalProvider>
     </SettingsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Add slide data and speaker notes for About section
- Display slides in Document PiP window with keyboard navigation
- Wrap app with PipPortalProvider to enable PiP content

## Testing
- `npm test` *(fails: YouTube, mimikatz, wordSearch, nikto tests)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d7fb72c8328929f59ce458e77a1