### PR TITLE
feat: add large hit areas and keyboard reference

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, fontScale, setFontScale, highContrast, setHighContrast } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast } = useSettings();
     const [theme, setThemeState] = useState(getTheme());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -122,6 +122,17 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        checked={largeHitAreas}
+                        onChange={(e) => setLargeHitAreas(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Large Hit Areas
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
                         className="mr-2"
@@ -200,6 +211,7 @@ export function Settings() {
                         setWallpaper(defaults.wallpaper);
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
+                        setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
                         setThemeState('default');
@@ -225,6 +237,7 @@ export function Settings() {
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setThemeState(parsed.theme); setTheme(parsed.theme); }
                     } catch (err) {

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -12,6 +12,8 @@ import {
   setFontScale as saveFontScale,
   getHighContrast as loadHighContrast,
   setHighContrast as saveHighContrast,
+  getLargeHitAreas as loadLargeHitAreas,
+  setLargeHitAreas as saveLargeHitAreas,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -39,12 +41,14 @@ interface SettingsContextValue {
   reducedMotion: boolean;
   fontScale: number;
   highContrast: boolean;
+  largeHitAreas: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
+  setLargeHitAreas: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -54,12 +58,14 @@ export const SettingsContext = createContext<SettingsContextValue>({
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
+  largeHitAreas: defaults.largeHitAreas,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
   setHighContrast: () => {},
+  setLargeHitAreas: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -69,6 +75,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
+  const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
 
   useEffect(() => {
     (async () => {
@@ -78,6 +85,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
+      setLargeHitAreas(await loadLargeHitAreas());
     })();
   }, []);
 
@@ -140,8 +148,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHighContrast(highContrast);
   }, [highContrast]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('large-hit-area', largeHitAreas);
+    saveLargeHitAreas(largeHitAreas);
+  }, [largeHitAreas]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const KeyboardReference = () => (
+  <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
+    <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
+    <p className="mb-4">Common shortcuts for navigating and interacting with the desktop.</p>
+    <table className="w-full border-collapse">
+      <thead>
+        <tr>
+          <th className="p-2 text-left border border-ubt-grey">Key</th>
+          <th className="p-2 text-left border border-ubt-grey">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Ctrl + C</td>
+          <td className="p-2 border border-ubt-grey">Copy selected text</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Ctrl + V</td>
+          <td className="p-2 border border-ubt-grey">Paste from clipboard</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Ctrl + X</td>
+          <td className="p-2 border border-ubt-grey">Cut selected text</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Alt + Tab</td>
+          <td className="p-2 border border-ubt-grey">Switch between apps</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Alt + F4</td>
+          <td className="p-2 border border-ubt-grey">Close current window</td>
+        </tr>
+      </tbody>
+    </table>
+  </main>
+);
+
+export default KeyboardReference;

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,11 @@ body{
     color: var(--color-text);
 }
 
+button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
+    min-width: var(--hit-area);
+    min-height: var(--hit-area);
+}
+
 a:focus-visible,
 button:focus-visible {
     outline: 2px solid var(--color-ubt-blue) !important;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -48,6 +48,8 @@
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
+  /* Minimum interactive target size */
+  --hit-area: 32px;
 }
 
 /* High contrast theme */
@@ -66,6 +68,11 @@
 /* Dyslexia-friendly fonts */
 .dyslexia {
   --font-family-base: 'OpenDyslexic', 'Comic Sans MS', Arial, sans-serif;
+}
+
+/* Larger hit areas */
+.large-hit-area {
+  --hit-area: 48px;
 }
 
 /* Reduced motion */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -8,6 +8,7 @@ const DEFAULT_SETTINGS = {
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,
+  largeHitAreas: false,
 };
 
 export async function getAccent() {
@@ -71,6 +72,16 @@ export async function setHighContrast(value) {
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
+export async function getLargeHitAreas() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
+  return window.localStorage.getItem('large-hit-areas') === 'true';
+}
+
+export async function setLargeHitAreas(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -81,19 +92,21 @@ export async function resetSettings() {
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
+  window.localStorage.removeItem('large-hit-areas');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast] = await Promise.all([
+  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
     getReducedMotion(),
     getFontScale(),
     getHighContrast(),
+    getLargeHitAreas(),
   ]);
   const theme = getTheme();
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, theme });
+  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, theme });
 }
 
 export async function importSettings(json) {
@@ -105,13 +118,14 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, theme } = settings;
+  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, theme } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
+  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add hit-area design tokens and large-hit-area theme toggle
- wire up reduced motion and large hit area controls in settings
- document keyboard shortcuts in new reference page

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` (fails: React lint warnings/errors)
- `yarn test` (fails: YouTube, mimikatz, wordSearch, niktoApp, kismet)
- `yarn a11y` (fails: missing libatk-1.0.so.0)


------
https://chatgpt.com/codex/tasks/task_e_68b12d80958c8328b7675a7f783c6a65