### PR TITLE
feat: add sandboxed beef demo

### DIFF
--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,322 +1,83 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import Image from 'next/image';
-import dynamic from 'next/dynamic';
-import GuideOverlay from './GuideOverlay';
-import PayloadBuilder from './PayloadBuilder';
-
-const HookGraph = dynamic(() => import('./HookGraph'), { ssr: false });
+import React, { useState } from 'react';
 
 export default function Beef() {
-  const [authorized, setAuthorized] = useState(false);
-  const [hooks, setHooks] = useState([]);
-  const [selected, setSelected] = useState(null);
-  const [moduleId, setModuleId] = useState('');
-  const [modules, setModules] = useState([]);
-  const [output, setOutput] = useState('');
-  const [showHelp, setShowHelp] = useState(false);
-  const [steps, setSteps] = useState([]);
-  const [liveMessage, setLiveMessage] = useState('');
-  const prevHooks = useRef(0);
-  const prevSteps = useRef(0);
-  const [activeTab, setActiveTab] = useState('modules');
+  const targetPage = `\n<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8"/>\n  <title>Sandboxed Target</title>\n</head>\n<body>\n  <h1>Sandboxed Target Page</h1>\n  <p>This page is isolated and cannot make network requests.</p>\n  <script>document.body.append(' - loaded');<\/script>\n</body>\n</html>`;
 
-  const hooksUrl = '/demo-data/beef/hooks.json';
-  const modulesUrl = '/demo-data/beef/modules.json';
+  const steps = [
+    {
+      title: 'Disclaimer',
+      body:
+        'Use these security tools only in environments where you have explicit authorization. Unauthorized testing is illegal.',
+      action: 'Begin',
+    },
+    {
+      title: 'Sandboxed Target',
+      body: 'The iframe below hosts an isolated page for demonstration. It runs entirely locally.',
+      render: (
+        <iframe
+          title="sandbox"
+          className="w-full h-48 border"
+          sandbox=""
+          srcDoc={targetPage}
+        />
+      ),
+      action: 'Next',
+    },
+    {
+      title: 'Simulated Hook',
+      body: 'The target has been locally “hooked”. No packets left this machine.',
+      action: 'Next',
+    },
+    {
+      title: 'Run Demo Module',
+      body: 'A deterministic module runs and prints output below.',
+      render: (
+        <pre className="bg-black text-white p-2 text-xs rounded">{`Demo module executed\nResult: success`}</pre>
+      ),
+      action: 'Next',
+    },
+    {
+      title: 'Complete',
+      body: 'The lab sequence is finished. Reset to clear all data.',
+      action: 'Reset Lab',
+      final: true,
+    },
+  ];
 
-  const getStatus = (hook) => {
-    if (hook.status) return hook.status;
-    if (typeof hook.online === 'boolean') return hook.online ? 'online' : 'offline';
-    return 'idle';
+  const [step, setStep] = useState(0);
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    }
   };
 
-  const fetchHooks = useCallback(async () => {
+  const resetLab = () => {
     try {
-      const res = await fetch(hooksUrl);
-      const data = await res.json();
-      setHooks(data.hooked_browsers || []);
-    } catch (err) {
-      console.error(err);
-    }
-  }, [hooksUrl]);
-
-  const fetchModules = useCallback(async () => {
-    try {
-      const res = await fetch(modulesUrl);
-      const data = await res.json();
-      setModules(data.modules || []);
-    } catch (err) {
-      console.error(err);
-    }
-  }, [modulesUrl]);
-
-  useEffect(() => {
-    try {
-      const ok = localStorage.getItem('beef-lab-ok');
-      setAuthorized(ok === 'true');
-    } catch {
-      setAuthorized(false);
-    }
-  }, []);
-
-  const acceptLab = () => {
-    try {
-      localStorage.setItem('beef-lab-ok', 'true');
+      localStorage.removeItem('beef-lab-ok');
     } catch {
       // ignore
     }
-    setAuthorized(true);
+    setStep(0);
   };
 
-  useEffect(() => {
-    fetchHooks();
-  }, [fetchHooks]);
-
-  useEffect(() => {
-    fetchModules();
-  }, [fetchModules]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const dismissed = localStorage.getItem('beefHelpDismissed');
-      if (!dismissed) setShowHelp(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (hooks.length > prevHooks.current) {
-      const h = hooks[hooks.length - 1];
-      const id = h.session || h.id;
-      setLiveMessage(`Hook ${h.name || id} added`);
-    }
-    prevHooks.current = hooks.length;
-  }, [hooks, prevHooks]);
-
-  useEffect(() => {
-    if (steps.length > prevSteps.current) {
-      const s = steps[steps.length - 1];
-      setLiveMessage(`Module ${s.module} run on ${s.hook}`);
-    }
-    prevSteps.current = steps.length;
-  }, [steps, prevSteps]);
-
-  const findModule = (list, id) => {
-    for (const m of list) {
-      if (m.id === id) return m;
-      if (m.children) {
-        const found = findModule(m.children, id);
-        if (found) return found;
-      }
-    }
-    return null;
-  };
-
-  const runModule = () => {
-    if (!selected || !moduleId) return;
-    setOutput('');
-    const mod = findModule(modules, moduleId);
-    if (mod) setOutput(mod.output || '');
-    setSteps((prev) => [
-      ...prev,
-      { id: prev.length + 1, hook: selected, module: moduleId },
-    ]);
-  };
-
-  const renderTree = (nodes) => (
-    <ul className="ml-4">
-      {nodes.map((node) => {
-        const label = node.name || node.id;
-        if (node.children && node.children.length) {
-          return (
-            <li key={label} className="mb-1">
-              <details>
-                <summary className="cursor-pointer">{label}</summary>
-                {renderTree(node.children)}
-              </details>
-            </li>
-          );
-        }
-        return (
-          <li key={node.id} className="mb-1">
-            <button
-              type="button"
-              onClick={() => setModuleId(node.id)}
-              className={`w-full text-left px-1 py-0.5 rounded ${
-                moduleId === node.id ? 'bg-ub-primary text-white' : 'bg-transparent'
-              }`}
-            >
-              {label}
-            </button>
-          </li>
-        );
-      })}
-    </ul>
-  );
-
-  if (!authorized) {
-    return (
-      <div
-        className="w-full h-full bg-ub-dark text-white p-4 flex flex-col items-center justify-center text-center"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="beef-lab-modal-title"
-      >
-        <p id="beef-lab-modal-title" className="mb-4 text-sm">
-          Security tools are for lab use only. Review{' '}
-          <a
-            href="https://csrc.nist.gov/publications/detail/sp/800-115/final"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            NIST SP 800-115
-          </a>{' '}
-          and{' '}
-          <a
-            href="https://owasp.org/www-project-web-security-testing-guide/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            OWASP Testing Guide
-          </a>{' '}
-          before proceeding.
-        </p>
-        <button
-          onClick={acceptLab}
-          className="px-2 py-1 bg-ub-green text-black text-xs rounded"
-        >
-          Enter Lab
-        </button>
-      </div>
-    );
-  }
+  const current = steps[step];
 
   return (
-    <div className="relative flex h-full w-full bg-ub-cool-grey text-white pt-6">
-      <div className="absolute inset-x-0 top-0 bg-yellow-400 text-black text-center text-sm py-1 z-10">
-        Demo data, no live scanning
-      </div>
-      {showHelp && <GuideOverlay onClose={() => setShowHelp(false)} />}
-      <div className="w-1/3 border-r border-gray-700 overflow-y-auto">
-        <div className="flex items-center justify-between p-2">
-          <h2 className="font-bold">Hooked Browsers</h2>
-          <button
-            type="button"
-            className="px-2 py-1 bg-ub-gray-50 text-black rounded"
-            onClick={fetchHooks}
-          >
-            Refresh
-          </button>
-        </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 p-2">
-          {hooks.length === 0 && (
-            <p className="col-span-full text-center text-sm">No hooks yet.</p>
-          )}
-          {hooks.map((hook) => {
-            const id = hook.session || hook.id;
-            const status = getStatus(hook);
-            return (
-              <div
-                key={id}
-                onClick={() => setSelected(id)}
-                className={`flex flex-col items-center p-2 cursor-pointer rounded hover:bg-ub-gray-50 ${
-                  selected === id ? 'bg-ub-gray-50 text-black' : ''
-                }`}
-              >
-                <Image
-                  src={`/themes/Yaru/apps/beef-${status}.svg`}
-                  alt={status}
-                  className="w-12 h-12 mb-1"
-                  width={48}
-                  height={48}
-                  sizes="48px"
-                />
-                <span className="text-xs text-center truncate w-full">
-                  {hook.name || id}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-      <div className="flex-1 p-4 overflow-y-auto flex flex-col">
-        <div className="h-64 mb-4">
-          <HookGraph hooks={hooks} steps={steps} />
-        </div>
-        {selected ? (
-          <>
-            <div role="tablist" aria-label="BeEF tools" className="flex space-x-2 mb-2">
-              <button
-                id="tab-modules"
-                role="tab"
-                aria-selected={activeTab === 'modules'}
-                aria-controls="panel-modules"
-                className={`px-3 py-1 rounded ${
-                  activeTab === 'modules'
-                    ? 'bg-ub-primary text-white'
-                    : 'bg-ub-gray-50 text-black'
-                }`}
-                onClick={() => setActiveTab('modules')}
-              >
-                Modules
-              </button>
-              <button
-                id="tab-payload"
-                role="tab"
-                aria-selected={activeTab === 'payload'}
-                aria-controls="panel-payload"
-                className={`px-3 py-1 rounded ${
-                  activeTab === 'payload'
-                    ? 'bg-ub-primary text-white'
-                    : 'bg-ub-gray-50 text-black'
-                }`}
-                onClick={() => setActiveTab('payload')}
-              >
-                Payload Builder
-              </button>
-            </div>
-            <div
-              id="panel-modules"
-              role="tabpanel"
-              aria-labelledby="tab-modules"
-              hidden={activeTab !== 'modules'}
-            >
-              <div className="mb-2 flex">
-                <div className="flex-1 overflow-auto max-h-40 border border-gray-700 p-1 mr-2">
-                  {modules.length > 0 ? (
-                    renderTree(modules)
-                  ) : (
-                    <p className="text-sm">No modules</p>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={runModule}
-                  className="px-3 py-1 bg-ub-primary text-white rounded h-max"
-                >
-                  Run Module
-                </button>
-              </div>
-              {output && (
-                <pre className="whitespace-pre-wrap text-xs bg-black p-2 rounded mb-4">
-                  {output}
-                </pre>
-              )}
-            </div>
-            <div
-              id="panel-payload"
-              role="tabpanel"
-              aria-labelledby="tab-payload"
-              hidden={activeTab !== 'payload'}
-            >
-              <PayloadBuilder />
-            </div>
-          </>
-        ) : (
-          <p>Select a hooked browser to run modules.</p>
-        )}
-      </div>
-      <div aria-live="polite" className="sr-only">{liveMessage}</div>
+    <div className="p-4 text-white bg-ub-cool-grey h-full w-full flex flex-col">
+      <h2 className="text-xl mb-4">{current.title}</h2>
+      <p className="mb-4 text-sm">{current.body}</p>
+      {current.render && <div className="mb-4">{current.render}</div>}
+      <button
+        type="button"
+        onClick={current.final ? resetLab : next}
+        className="self-start px-3 py-1 bg-ub-primary text-white rounded"
+      >
+        {current.action}
+      </button>
+      <p className="mt-4 text-xs">
+        For educational use only. No network calls occur during this demo.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace BeEF app with step-based demo
- include sandboxed target iframe and deterministic flow
- reset lab state on exit to keep demo self-contained

## Testing
- `npx eslint -c .eslintrc.cjs components/apps/beef/index.js` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `yarn test components/apps/beef/index.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b12d7dd03c832883e91244f6d89034