### PR TITLE
Add Doc-PiP controls via PipPortal

### DIFF
--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -1,6 +1,7 @@
-'use client';
+"use client";
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from "react";
+import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
 
 interface VideoPlayerProps {
   src: string;
@@ -8,24 +9,40 @@ interface VideoPlayerProps {
   className?: string;
 }
 
-const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, poster, className = '' }) => {
+const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
+  src,
+  poster,
+  className = "",
+}) => {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const { open, close } = usePipPortal();
   const [pipSupported, setPipSupported] = useState(false);
+  const [docPipSupported, setDocPipSupported] = useState(false);
   const [isPip, setIsPip] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
     setPipSupported(
-      typeof document !== 'undefined' &&
+      typeof document !== "undefined" &&
         !!document.pictureInPictureEnabled &&
         !!video &&
-        typeof video.requestPictureInPicture === 'function'
+        typeof video.requestPictureInPicture === "function"
+    );
+    setDocPipSupported(
+      typeof window !== "undefined" &&
+        !!(window as any).documentPictureInPicture
     );
 
     const handleLeave = () => setIsPip(false);
-    video?.addEventListener('leavepictureinpicture', handleLeave);
-    return () => video?.removeEventListener('leavepictureinpicture', handleLeave);
-  }, []);
+    video?.addEventListener("leavepictureinpicture", handleLeave);
+    const handleEnd = () => close();
+    video?.addEventListener("ended", handleEnd);
+
+    return () => {
+      video?.removeEventListener("leavepictureinpicture", handleLeave);
+      video?.removeEventListener("ended", handleEnd);
+    };
+  }, [close]);
 
   const togglePiP = async () => {
     const video = videoRef.current;
@@ -43,6 +60,73 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, poster, className = '' }
     }
   };
 
+  // Listen for messages from the Doc-PiP window
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (!videoRef.current || e.data?.source !== "doc-pip") return;
+      const video = videoRef.current;
+      switch (e.data.type) {
+        case "toggle":
+          if (video.paused) video.play();
+          else video.pause();
+          break;
+        case "seek":
+          video.currentTime = Math.max(
+            0,
+            Math.min(video.duration || 0, video.currentTime + Number(e.data.delta || 0))
+          );
+          break;
+        case "volume":
+          video.volume = Math.max(0, Math.min(1, Number(e.data.value)));
+          break;
+        default:
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  const openDocPip = async () => {
+    if (!docPipSupported) return;
+    const initialVolume = videoRef.current?.volume ?? 1;
+    const DocPipControls: React.FC<{ initialVolume: number }> = ({ initialVolume }) => {
+      const [vol, setVol] = useState(initialVolume);
+      const send = (msg: any) =>
+        window.opener?.postMessage({ source: "doc-pip", ...msg }, "*");
+      return (
+        <div
+          style={{
+            padding: 8,
+            background: "black",
+            color: "white",
+            fontFamily: "sans-serif",
+            display: "flex",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          <button onClick={() => send({ type: "toggle" })}>Play/Pause</button>
+          <button onClick={() => send({ type: "seek", delta: -5 })}>-5s</button>
+          <button onClick={() => send({ type: "seek", delta: 5 })}>+5s</button>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={vol}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              setVol(v);
+              send({ type: "volume", value: v });
+            }}
+          />
+        </div>
+      );
+    };
+
+    await open(<DocPipControls initialVolume={initialVolume} />);
+  };
+
   return (
     <div className={`relative ${className}`.trim()}>
       <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
@@ -52,12 +136,27 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ src, poster, className = '' }
           onClick={togglePiP}
           className="absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
         >
-          {isPip ? 'Exit PiP' : 'PiP'}
+          {isPip ? "Exit PiP" : "PiP"}
+        </button>
+      )}
+      {docPipSupported && (
+        <button
+          type="button"
+          onClick={openDocPip}
+          className="absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+        >
+          Doc-PiP
         </button>
       )}
     </div>
   );
 };
+
+const VideoPlayer: React.FC<VideoPlayerProps> = (props) => (
+  <PipPortalProvider>
+    <VideoPlayerInner {...props} />
+  </PipPortalProvider>
+);
 
 export default VideoPlayer;
 


### PR DESCRIPTION
## Summary
- add Document Picture-in-Picture controls to VideoPlayer using PipPortal
- forward Doc-PiP control actions to the main player with postMessage
- close Doc-PiP when video finishes

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: 5 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d7ccc2c8328b6490f00fad755f9