### PR TITLE
feat: persist Spotify playlists in OPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,10 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
 
-The Spotify app loads its mood-to-playlist mapping from `public/spotify-playlists.json`,
-remembers the last mood you played, and exposes play/pause and track controls with
-keyboard hotkeys.
+The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app form to
+add, reorder, or delete moods; selections persist in the browser's Origin Private File
+System so your choices restore on load. The last mood played is remembered, and
+play/pause and track controls include keyboard hotkeys.
 
 ### Terminal Commands
 - `clear` – clears the terminal display.

--- a/components/apps/spotify.js
+++ b/components/apps/spotify.js
@@ -1,26 +1,33 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState.js';
+import useOPFS from '../../hooks/useOPFS.js';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 export default function SpotifyApp() {
-  const [playlists, setPlaylists] = useState({});
+  const [playlists, setPlaylists, ready] = useOPFS('spotify-playlists.json', {});
   const [mood, setMood] = usePersistentState('spotify-mood', '');
   const [isPlaying, setIsPlaying] = useState(false);
+  const [newMood, setNewMood] = useState('');
+  const [newId, setNewId] = useState('');
   const gridRef = useRef(null);
   const iframeRef = useRef(null);
 
   useEffect(() => {
-    fetch('/spotify-playlists.json')
-      .then((res) => res.json())
-      .then((data) => {
-        setPlaylists(data);
-        if (!data[mood]) {
+    if (!ready) return;
+    if (Object.keys(playlists).length === 0) {
+      fetch('/spotify-playlists.json')
+        .then((res) => res.json())
+        .then((data) => {
+          setPlaylists(data);
           const first = Object.keys(data)[0];
           if (first) setMood(first);
-        }
-      })
-      .catch(() => {});
-  }, [mood, setMood]);
+        })
+        .catch(() => {});
+    } else if (!playlists[mood]) {
+      const first = Object.keys(playlists)[0];
+      if (first) setMood(first);
+    }
+  }, [ready, playlists, mood, setMood, setPlaylists]);
 
   useRovingTabIndex(gridRef, true, 'horizontal');
 
@@ -35,6 +42,34 @@ export default function SpotifyApp() {
 
   const next = useCallback(() => post('next'), [post]);
   const previous = useCallback(() => post('previous'), [post]);
+
+  const addMood = () => {
+    if (!newMood || !newId) return;
+    if (playlists[newMood]) return;
+    setPlaylists({ ...playlists, [newMood]: newId });
+    setNewMood('');
+    setNewId('');
+  };
+
+  const removeMood = (m) => {
+    const { [m]: _, ...rest } = playlists;
+    setPlaylists(rest);
+    if (mood === m) {
+      const first = Object.keys(rest)[0] || '';
+      setMood(first);
+      setIsPlaying(false);
+    }
+  };
+
+  const moveMood = (m, dir) => {
+    const entries = Object.entries(playlists);
+    const index = entries.findIndex(([key]) => key === m);
+    const newIndex = index + dir;
+    if (newIndex < 0 || newIndex >= entries.length) return;
+    const [item] = entries.splice(index, 1);
+    entries.splice(newIndex, 0, item);
+    setPlaylists(Object.fromEntries(entries));
+  };
 
   useEffect(() => {
     const handleMessage = (e) => {
@@ -65,37 +100,93 @@ export default function SpotifyApp() {
 
   return (
     <div className="h-full w-full bg-ub-cool-grey flex flex-col">
+      <div className="p-2 flex gap-2 bg-black bg-opacity-30">
+        <input
+          value={newMood}
+          onChange={(e) => setNewMood(e.target.value)}
+          placeholder="Mood"
+          className="px-1 rounded text-black flex-1"
+        />
+        <input
+          value={newId}
+          onChange={(e) => setNewId(e.target.value)}
+          placeholder="Playlist ID"
+          className="px-1 rounded text-black flex-1"
+        />
+        <button
+          onClick={addMood}
+          className="px-2 py-1 bg-black bg-opacity-50 rounded text-white"
+        >
+          Add
+        </button>
+      </div>
       <div
         ref={gridRef}
         role="listbox"
         className="grid grid-cols-2 gap-2 p-2 overflow-auto"
       >
         {Object.entries(playlists).map(([m, id]) => (
-          <button
-            key={m}
-            role="option"
-            aria-label={m}
-            aria-selected={mood === m}
-            onClick={() => {
-              setMood(m);
-              setIsPlaying(false);
-            }}
-            className={`focus:outline-none rounded overflow-hidden ${
-              mood === m ? 'ring-2 ring-white' : ''
-            }`}
-          >
-            <iframe
-              ref={m === mood ? iframeRef : null}
-              src={`https://open.spotify.com/embed/playlist/${id}?utm_source=generator&theme=0`}
-              title={m}
-              width="100%"
-              height="152"
-              frameBorder="0"
-              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-              loading="lazy"
-            />
-            <span className="block text-center text-xs capitalize">{m}</span>
-          </button>
+          <div key={m} className="relative">
+            <button
+              role="option"
+              aria-label={m}
+              aria-selected={mood === m}
+              onClick={() => {
+                setMood(m);
+                setIsPlaying(false);
+              }}
+              className={`focus:outline-none rounded overflow-hidden ${
+                mood === m ? 'ring-2 ring-white' : ''
+              }`}
+            >
+              <iframe
+                ref={m === mood ? iframeRef : null}
+                src={`https://open.spotify.com/embed/playlist/${id}?utm_source=generator&theme=0`}
+                title={m}
+                width="100%"
+                height="152"
+                frameBorder="0"
+                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                loading="lazy"
+              />
+              <span className="block text-center text-xs capitalize">{m}</span>
+            </button>
+            <div className="absolute top-1 right-1 flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  moveMood(m, -1);
+                }}
+                className="bg-black bg-opacity-50 text-white text-xs rounded w-4 h-4 flex items-center justify-center"
+                aria-label={`Move ${m} up`}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  moveMood(m, 1);
+                }}
+                className="bg-black bg-opacity-50 text-white text-xs rounded w-4 h-4 flex items-center justify-center"
+                aria-label={`Move ${m} down`}
+              >
+                ↓
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeMood(m);
+                }}
+                className="bg-black bg-opacity-50 text-white text-xs rounded w-4 h-4 flex items-center justify-center"
+                aria-label={`Delete ${m}`}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
         ))}
       </div>
       {mood && (

--- a/hooks/useOPFS.js
+++ b/hooks/useOPFS.js
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+
+// Persist JSON data in the Origin Private File System.
+export default function useOPFS(name, initialValue) {
+  const [value, setValue] = useState(initialValue);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      if (!navigator.storage?.getDirectory) {
+        setReady(true);
+        return;
+      }
+      try {
+        const root = await navigator.storage.getDirectory();
+        try {
+          const handle = await root.getFileHandle(name);
+          const file = await handle.getFile();
+          const text = await file.text();
+          if (active) setValue(JSON.parse(text));
+        } catch {
+          const handle = await root.getFileHandle(name, { create: true });
+          const writable = await handle.createWritable();
+          await writable.write(JSON.stringify(initialValue));
+          await writable.close();
+        }
+      } catch {}
+      if (active) setReady(true);
+    };
+    load();
+    return () => {
+      active = false;
+    };
+  }, [name, initialValue]);
+
+  const save = useCallback(
+    async (v) => {
+      setValue(v);
+      if (!navigator.storage?.getDirectory) return;
+      try {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle(name, { create: true });
+        const writable = await handle.createWritable();
+        await writable.write(JSON.stringify(v));
+        await writable.close();
+      } catch {}
+    },
+    [name],
+  );
+
+  return [value, save, ready];
+}
+


### PR DESCRIPTION
## Summary
- add `useOPFS` hook to persist JSON in the browser's Origin Private File System
- allow adding, reordering, and removing Spotify moods with persisted mapping
- document customizable mood playlists

## Testing
- `npm test` (fails: youtube, mimikatz, wordSearch, niktoApp)
- `npm run lint` (fails: missing eslint config)


------
https://chatgpt.com/codex/tasks/task_e_68b12d7b3aa48328be2eb828826268e8