### PR TITLE
feat: add quote sharing helper

### DIFF
--- a/__tests__/share.test.ts
+++ b/__tests__/share.test.ts
@@ -1,0 +1,26 @@
+import share, { canShare } from '../utils/share';
+
+describe('share utility', () => {
+  afterEach(() => {
+    delete (navigator as any).share;
+  });
+
+  it('returns false when Web Share API unsupported', async () => {
+    expect(canShare()).toBe(false);
+    const result = await share('msg');
+    expect(result).toBe(false);
+  });
+
+  it('calls navigator.share with provided text', async () => {
+    const shareMock = jest.fn().mockResolvedValue(undefined);
+    (navigator as any).share = shareMock;
+    expect(canShare()).toBe(true);
+    const res = await share('hello', 'title', 'http://example.com');
+    expect(res).toBe(true);
+    expect(shareMock).toHaveBeenCalledWith({
+      text: 'hello',
+      title: 'title',
+      url: 'http://example.com',
+    });
+  });
+});

--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import Filter from 'bad-words';
 import { toPng } from 'html-to-image';
 import offlineQuotes from '../../components/apps/quotes.json';
+import share, { canShare } from '../../utils/share';
 
 interface Quote {
   content: string;
@@ -161,6 +162,12 @@ export default function QuoteApp() {
       .catch(() => { /* ignore */ });
   };
 
+  const shareQuote = () => {
+    if (!current) return;
+    const text = `"${current.content}" — ${current.author}`;
+    share(text);
+  };
+
   const categories = useMemo(() => {
     const base = Array.from(
       new Set(
@@ -201,6 +208,11 @@ export default function QuoteApp() {
           <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded" onClick={shareCard}>
             Share as Card
           </button>
+          {canShare() && (
+            <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded" onClick={shareQuote}>
+              Share
+            </button>
+          )}
           <label className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded cursor-pointer">
             Import
             <input type="file" accept="application/json" className="hidden" onChange={importQuotes} />

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,0 +1,20 @@
+// Simple helper around the Web Share API
+export const canShare = () =>
+  typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+// Shares the provided text along with optional title and url
+export const share = async (
+  text: string,
+  title?: string,
+  url?: string
+): Promise<boolean> => {
+  if (!canShare()) return false;
+  try {
+    await navigator.share({ text, title, url: url ?? window.location.href });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export default share;


### PR DESCRIPTION
## Summary
- add Web Share API helper
- hook up share button in quote app
- cover Web Share utility with tests

## Testing
- `yarn test share.test.ts`
- `npx eslint utils/share.ts apps/quote/index.tsx __tests__/share.test.ts` *(fails: ESLint couldn't find config)*
- `node -e "const { chromium } = require('playwright'); ..."` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d796ea88328845b57fa8435bbed