### PR TITLE
feat: add web-based code tools

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,20 +1,107 @@
 'use client';
 
-import ExternalFrame from '../../components/ExternalFrame';
+import { useEffect, useRef, useState } from 'react';
 
+const PROJECT = 'demo';
 
-export default function VsCode() {
-  return (
-    <ExternalFrame
-      src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-      title="VsCode"
-      className="h-full w-full bg-ub-cool-grey"
-      allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-      allowFullScreen
-      frameBorder="0"
-      prefetch={false}
-
-    />
-  );
+async function saveProject(code: string) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle('vscode', { create: true });
+    const proj = await dir.getDirectoryHandle(PROJECT, { create: true });
+    const file = await proj.getFileHandle('settings.json', { create: true });
+    const writable = await file.createWritable();
+    await writable.write(JSON.stringify({ code }));
+    await writable.close();
+  } catch {}
 }
 
+async function loadProject(): Promise<string | null> {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle('vscode');
+    const proj = await dir.getDirectoryHandle(PROJECT);
+    const file = await proj.getFileHandle('settings.json');
+    const data = await file.getFile();
+    const text = await data.text();
+    return (JSON.parse(text) as { code: string }).code;
+  } catch {
+    return null;
+  }
+}
+
+export default function VsCode() {
+  const [code, setCode] = useState('');
+  const [lint, setLint] = useState<{ line: number; message: string }[]>([]);
+  const [consoleOutput, setConsoleOutput] = useState<string[]>([]);
+  const lintWorker = useRef<Worker>();
+  const runWorker = useRef<Worker>();
+
+  useEffect(() => {
+    loadProject().then(async (saved) => {
+      if (saved) setCode(saved);
+      else {
+        const res = await fetch('/data/vscode-example/main.js');
+        const sample = await res.text();
+        setCode(sample);
+        saveProject(sample);
+      }
+    });
+
+    lintWorker.current = new Worker(new URL('../../workers/webLints.worker.ts', import.meta.url), { type: 'module' });
+    runWorker.current = new Worker(new URL('../../workers/jsRunner.ts', import.meta.url), { type: 'module' });
+
+    lintWorker.current.onmessage = (e) => {
+      if (e.data.type === 'format') setCode(e.data.formatted);
+      if (e.data.type === 'lint') setLint(e.data.messages);
+    };
+
+    runWorker.current.onmessage = (e) => {
+      const { type, message } = e.data;
+      setConsoleOutput((prev) => [...prev, `${type}: ${message}`]);
+    };
+
+    return () => {
+      lintWorker.current?.terminate();
+      runWorker.current?.terminate();
+    };
+  }, []);
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    setCode(val);
+    saveProject(val);
+  };
+
+  const format = () => lintWorker.current?.postMessage({ type: 'format', code });
+  const lintCodeFn = () => lintWorker.current?.postMessage({ type: 'lint', code });
+  const run = () => {
+    setConsoleOutput([]);
+    runWorker.current?.postMessage(code);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      <div className="flex space-x-2 p-2 bg-gray-200">
+        <button className="px-2 py-1 bg-white rounded" onClick={format}>
+          Format
+        </button>
+        <button className="px-2 py-1 bg-white rounded" onClick={lintCodeFn}>
+          Lint
+        </button>
+        <button className="px-2 py-1 bg-white rounded" onClick={run}>
+          Run JS
+        </button>
+      </div>
+      <textarea value={code} onChange={onChange} className="flex-1 font-mono p-2" />
+      <div className="h-40 overflow-auto border-t text-sm p-2 bg-black text-green-400 font-mono">
+        {lint.map((m, i) => (
+          <div key={i}>{`Line ${m.line}: ${m.message}`}</div>
+        ))}
+        {consoleOutput.map((m, i) => (
+          <div key={`c${i}`}>{m}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/data/vscode-example/main.js
+++ b/data/vscode-example/main.js
@@ -1,0 +1,5 @@
+function greet(name) {
+  console.log('Hello ' + name)
+}
+
+greet('World')

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",
     "postcss": "^8.4.21",
+    "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
     "react": "18.3.1",

--- a/workers/jsRunner.ts
+++ b/workers/jsRunner.ts
@@ -1,0 +1,24 @@
+self.onmessage = (e: MessageEvent<string>) => {
+  const code = e.data;
+  const send = (type: string, message: string) => {
+    (self as any).postMessage({ type, message });
+  };
+  const original: Record<string, any> = {};
+  ['log', 'error', 'warn', 'info'].forEach((key) => {
+    original[key] = console[key as keyof Console];
+    (console as any)[key] = (...args: any[]) => {
+      send('console', args.map((a) => String(a)).join(' '));
+      original[key](...args);
+    };
+  });
+  try {
+    const result = new Function(code)();
+    if (result !== undefined) {
+      send('result', String(result));
+    }
+  } catch (err: any) {
+    send('error', err.message || String(err));
+  } finally {
+    Object.assign(console, original);
+  }
+};

--- a/workers/webLints.worker.ts
+++ b/workers/webLints.worker.ts
@@ -1,0 +1,36 @@
+const lintCode = (code: string) => {
+  const messages: { line: number; message: string }[] = [];
+  const lines = code.split('\n');
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim();
+    if (
+      trimmed &&
+      !trimmed.endsWith(';') &&
+      !trimmed.endsWith('{') &&
+      !trimmed.endsWith('}') &&
+      !trimmed.startsWith('//')
+    ) {
+      messages.push({ line: idx + 1, message: 'Missing semicolon' });
+    }
+    if (/\bvar\s+/.test(trimmed)) {
+      messages.push({ line: idx + 1, message: 'Unexpected var, use let or const' });
+    }
+  });
+  return messages;
+};
+
+self.onmessage = async (e: MessageEvent<{ type: string; code: string }>) => {
+  const { type, code } = e.data;
+  if (type === 'format') {
+    const prettier = (await import('prettier/standalone')).default;
+    const parserBabel = (await import('prettier/plugins/babel')).default;
+    const formatted = await prettier.format(code, {
+      parser: 'babel',
+      plugins: [parserBabel],
+    });
+    (self as any).postMessage({ type: 'format', formatted });
+  } else if (type === 'lint') {
+    const messages = lintCode(code);
+    (self as any).postMessage({ type: 'lint', messages });
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9281,6 +9281,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
+  languageName: node
+  linkType: hard
+
 "pretty-bytes@npm:^5.3.0":
   version: 5.6.0
   resolution: "pretty-bytes@npm:5.6.0"
@@ -11298,6 +11307,7 @@ __metadata:
     phaser: "npm:3.70.0"
     playwright-core: "npm:^1.55.0"
     postcss: "npm:^8.4.21"
+    prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     qrcode: "npm:^1.5.4"
     react: "npm:18.3.1"


### PR DESCRIPTION
## Summary
- add VSCode app with toolbar to format, lint, and run JS
- execute code in worker and collect console output
- load sample project and persist code in OPFS

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/vscode/index.tsx workers/jsRunner.ts workers/webLints.worker.ts data/vscode-example/main.js`
- `yarn test apps/vscode/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b12d778c1c8328a823566d6b72d61a