### PR TITLE
feat(vscode): use monaco with OPFS autosave

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -3,27 +3,12 @@ import { render, screen } from '@testing-library/react';
 import VsCode from '../apps/vscode';
 
 describe('VsCode app', () => {
-  it('renders external frame', () => {
+  it('renders editor and folder button', () => {
     render(<VsCode />);
-    const frame = screen.getByTitle('VsCode');
-    expect(frame.tagName).toBe('IFRAME');
-    expect(screen.queryByRole('alert')).toBeNull();
-  });
-
-  it('shows banner when cookies are blocked', async () => {
-    const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
-    Object.defineProperty(document, 'cookie', {
-      configurable: true,
-      get: () => '',
-      set: () => {},
-    });
-
-    render(<VsCode />);
-    const alert = await screen.findByRole('alert');
-    expect(alert).toBeInTheDocument();
-
-    if (original) {
-      Object.defineProperty(document, 'cookie', original);
-    }
+    expect(
+      screen.getByRole('button', { name: /open folder/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('monaco-container')).toBeInTheDocument();
   });
 });
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -15,7 +15,7 @@ import { displayNikto } from './components/apps/nikto';
 
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
-// VSCode app uses a Stack iframe, so no editor dependencies are required
+// VSCode app now uses Monaco editor with filesystem access
 const VsCodeApp = createDynamicApp('vscode', 'VsCode');
 const YouTubeApp = createDynamicApp('youtube', 'YouTube');
 const CalculatorApp = createDynamicApp('calculator', 'Calculator');
@@ -617,7 +617,7 @@ const apps = [
     screen: displayTerminal,
   },
   {
-    // VSCode app uses a Stack iframe, so no editor dependencies are required
+    // VSCode app now uses Monaco editor with filesystem access
     id: 'vscode',
     title: 'Visual Studio Code',
     icon: './themes/Yaru/apps/vscode.png',

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,20 +1,106 @@
 'use client';
 
-import ExternalFrame from '../../components/ExternalFrame';
+import React, { useRef, useState } from 'react';
 
+interface FileEntry {
+  name: string;
+  handle: FileSystemFileHandle;
+}
 
 export default function VsCode() {
-  return (
-    <ExternalFrame
-      src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-      title="VsCode"
-      className="h-full w-full bg-ub-cool-grey"
-      allow="accelerometer; camera; microphone; gyroscope; clipboard-write"
-      allowFullScreen
-      frameBorder="0"
-      prefetch={false}
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const monacoRef = useRef<any>(null);
+  const modelRef = useRef<any>(null);
+  const rootRef = useRef<FileSystemDirectoryHandle | null>(null);
+  const activeFileRef = useRef<string>('');
+  const [files, setFiles] = useState<FileEntry[]>([]);
 
-    />
+  async function initMonaco() {
+    if (monacoRef.current) return;
+
+    const monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+
+    self.MonacoEnvironment = {
+      getWorker(_: any, label: string) {
+        if (label === 'typescript' || label === 'javascript') {
+          return new Worker(
+            new URL(
+              'monaco-editor/esm/vs/language/typescript/ts.worker?worker',
+              import.meta.url,
+            ),
+          );
+        }
+        return new Worker(
+          new URL('monaco-editor/esm/vs/editor/editor.worker?worker', import.meta.url),
+        );
+      },
+    } as any;
+
+    monacoRef.current = monaco;
+    modelRef.current = monaco.editor.createModel('', 'typescript');
+    const editor = monaco.editor.create(editorRef.current!, {
+      model: modelRef.current,
+      theme: 'vs-dark',
+      automaticLayout: true,
+    });
+
+    modelRef.current.onDidChangeContent(async () => {
+      if (!activeFileRef.current) return;
+      try {
+        const root =
+          rootRef.current || (rootRef.current = await (navigator as any).storage.getDirectory());
+        const file = await root.getFileHandle(activeFileRef.current, { create: true });
+        const writable = await file.createWritable();
+        await writable.write(modelRef.current.getValue());
+        await writable.close();
+      } catch {
+        // ignore write errors
+      }
+    });
+
+    return editor;
+  }
+
+  async function openFolder() {
+    if (!('showDirectoryPicker' in window)) return;
+    const dir = await (window as any).showDirectoryPicker();
+    const entries: FileEntry[] = [];
+    for await (const [name, handle] of dir.entries()) {
+      if (handle.kind === 'file') entries.push({ name, handle });
+    }
+    setFiles(entries);
+    await initMonaco();
+  }
+
+  async function openFile(file: FileEntry) {
+    await initMonaco();
+    const data = await file.handle.getFile();
+    const text = await data.text();
+    activeFileRef.current = file.name;
+    modelRef.current?.setValue(text);
+  }
+
+  return (
+    <div className="flex h-full w-full">
+      <div className="w-48 border-r border-gray-700 overflow-auto">
+        <button onClick={openFolder} className="w-full p-2 text-left hover:bg-ub-grey">
+          Open Folder
+        </button>
+        <ul>
+          {files.map((f) => (
+            <li key={f.name}>
+              <button
+                onClick={() => openFile(f)}
+                className="w-full p-1 text-left hover:bg-ub-grey"
+              >
+                {f.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div ref={editorRef} data-testid="monaco-container" className="flex-1" />
+    </div>
   );
 }
 

--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,4 +1,4 @@
-// VSCode app uses a Stack iframe, so no editor dependencies are required
+// VSCode-like editor implemented with Monaco and filesystem access
 import dynamic from 'next/dynamic';
 
 const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -1,0 +1,11 @@
+# VSCode App
+
+The VSCode app is a lightweight editor powered by the Monaco editor.
+
+## Usage
+
+1. Click **Open Folder** and choose a directory using the browser's file picker.
+2. Files in the selected folder appear in the sidebar. Select a file to open it.
+3. Edits are automatically saved to the Origin Private File System (OPFS).
+4. TypeScript and JavaScript language features are enabled through Monaco workers.
+

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "idb-keyval": "^6.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
+    "monaco-editor": "^0.47.0",
     "next": "^15.0.0",
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8394,6 +8394,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:^0.47.0":
+  version: 0.47.0
+  resolution: "monaco-editor@npm:0.47.0"
+  checksum: 10c0/bbe4fc284a7803e4ed0fa69b6e31c41ef6f5d259722e8a876ce2850b7139e68eff3a6435306e11eff848db8662b818e40f9cafc6f7a53d4a4551fed362d5dc02
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -11292,6 +11299,7 @@ __metadata:
     jest-environment-jsdom: "npm:30.0.5"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
+    monaco-editor: "npm:^0.47.0"
     next: "npm:^15.0.0"
     pa11y: "npm:^9.0.0"
     pdfjs-dist: "npm:^5.4.54"


### PR DESCRIPTION
## Summary
- replace StackBlitz iframe with Monaco editor and enable TS/JS workers
- allow opening folders via `showDirectoryPicker` and list files
- autosave edits to OPFS and document usage

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/vscode/index.tsx components/apps/vscode.js apps.config.js __tests__/vscode.test.tsx`
- `yarn test __tests__/vscode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b12d765ab08328bb8bd47755c70376