### PR TITLE
feat: expand calculator with programmer tools

### DIFF
--- a/__tests__/calculator/bitwise.test.js
+++ b/__tests__/calculator/bitwise.test.js
@@ -1,0 +1,52 @@
+const { TextEncoder, TextDecoder } = require('util');
+const { JSDOM } = require('jsdom');
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+function setupDom() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <input id="display" />
+    <button id="toggle-precise"></button>
+    <button id="toggle-scientific"></button>
+    <button id="toggle-programmer"></button>
+    <button id="toggle-history"></button>
+    <div id="scientific"></div>
+    <div id="programmer"></div>
+    <div id="standard"></div>
+    <select id="base-select"></select>
+    <div id="history"></div>
+    <div id="paren-indicator"></div>
+    <button id="print-tape"></button>
+  </body></html>`, { url: 'https://example.com' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.navigator = dom.window.navigator;
+  const { create, all } = require('mathjs');
+  global.math = create(all);
+}
+
+describe('bitwise and base conversion', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    setupDom();
+  });
+
+  test('bitwise operations work', () => {
+    const calc = require('../../apps/calculator/main.js');
+    expect(calc.bitwiseAnd(6, 3)).toBe(2);
+    expect(calc.bitwiseOr(6, 3)).toBe(7);
+    expect(calc.bitwiseXor(6, 3)).toBe(5);
+    expect(calc.bitwiseNot(6)).toBe(~6);
+    expect(calc.shiftLeft(3, 2)).toBe(12);
+    expect(calc.shiftRight(8, 2)).toBe(2);
+  });
+
+  test('base conversions round trip', () => {
+    const calc = require('../../apps/calculator/main.js');
+    const hex = 'FF';
+    const bin = calc.convertBase(hex, 16, 2);
+    expect(calc.convertBase(bin, 2, 16).toUpperCase()).toBe(hex);
+  });
+});

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -30,7 +30,7 @@ export default function Calculator() {
         <button className="btn" data-action="mminus">M&minus;</button>
         <button className="btn" data-action="mr">MR</button>
       </div>
-      <div className="button-grid">
+      <div id="standard" className="button-grid">
         <button className="btn" data-value="7">7</button>
         <button className="btn" data-value="8">8</button>
         <button className="btn" data-value="9">9</button>

--- a/hooks/useOPFS.js
+++ b/hooks/useOPFS.js
@@ -1,0 +1,54 @@
+export async function useOPFS(fileName) {
+  const hasOPFS = !!navigator.storage?.getDirectory;
+  if (!hasOPFS) {
+    return {
+      read: async () => localStorage.getItem(fileName) || '',
+      write: async (text) => localStorage.setItem(fileName, text),
+      append: async (text) => {
+        const prev = localStorage.getItem(fileName) || '';
+        localStorage.setItem(fileName, prev + text);
+      },
+      clear: async () => localStorage.removeItem(fileName),
+      download: async () => {
+        const text = localStorage.getItem(fileName) || '';
+        const blob = new Blob([text], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileName;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+    };
+  }
+  const root = await navigator.storage.getDirectory();
+  const fileHandle = await root.getFileHandle(fileName, { create: true });
+  const read = async () => {
+    const file = await fileHandle.getFile();
+    return await file.text();
+  };
+  const write = async (text) => {
+    const writable = await fileHandle.createWritable();
+    await writable.write(text);
+    await writable.close();
+  };
+  const append = async (text) => {
+    const current = await read();
+    await write(current + text);
+  };
+  const clear = async () => {
+    await write('');
+  };
+  const download = async () => {
+    const text = await read();
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return { read, write, append, clear, download };
+}
+export default useOPFS;


### PR DESCRIPTION
## Summary
- add standard/programmer mode toggle
- support bitwise ops & base conversions
- persist and search tape via OPFS with download
- add tests for bitwise and base conversions

## Testing
- `npm test __tests__/calculator/bitwise.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b12d73308c83288d46731c58266dcc