### PR TITLE
feat: add doc pip media controller extension

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,57 @@
+let pipUrl = chrome.runtime.getURL('pip.html');
+
+async function openPip() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab) return;
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: (url) => {
+      if (!window.documentPictureInPicture) return;
+      window.documentPictureInPicture.requestWindow({ width: 320, height: 60 }).then((win) => {
+        win.location.href = url;
+      });
+    },
+    args: [pipUrl],
+  });
+}
+
+chrome.action.onClicked.addListener(openPip);
+
+async function queryAllTabs() {
+  const tabs = await chrome.tabs.query({});
+  const results = [];
+  for (const tab of tabs) {
+    try {
+      const medias = await chrome.tabs.sendMessage(tab.id, { type: 'status' });
+      results.push({ tabId: tab.id, medias });
+    } catch (e) {
+      // ignore tabs without the content script
+    }
+  }
+  return results;
+}
+
+function broadcast(action) {
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      chrome.tabs.sendMessage(tab.id, { type: action });
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'query') {
+    queryAllTabs().then((data) => sendResponse(data));
+    return true;
+  }
+  if (msg.type === 'control') {
+    broadcast(msg.action);
+  }
+});
+
+function notify() {
+  chrome.runtime.sendMessage({ type: 'refresh' });
+}
+
+chrome.tabs.onActivated.addListener(notify);
+chrome.tabs.onUpdated.addListener(notify);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,44 @@
+function getMedias() {
+  return Array.from(document.querySelectorAll('video, audio'));
+}
+
+function propagate(message) {
+  document.querySelectorAll('iframe').forEach((frame) => {
+    try {
+      frame.contentWindow.postMessage(message, '*');
+    } catch (e) {
+      // ignore cross-origin access errors
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'status') {
+    const list = getMedias().map((m) => ({ src: m.currentSrc || m.src, playing: !m.paused }));
+    propagate({ type: 'status' });
+    sendResponse(list);
+  } else if (msg.type === 'play' || msg.type === 'pause') {
+    getMedias().forEach((m) => {
+      try {
+        msg.type === 'play' ? m.play() : m.pause();
+      } catch (e) {}
+    });
+    propagate({ type: msg.type });
+  }
+});
+
+window.addEventListener('message', (ev) => {
+  const data = ev.data;
+  if (!data || !data.type) return;
+  if (data.type === 'play' || data.type === 'pause') {
+    getMedias().forEach((m) => {
+      try {
+        data.type === 'play' ? m.play() : m.pause();
+      } catch (e) {}
+    });
+    propagate({ type: data.type });
+  } else if (data.type === 'status') {
+    const list = getMedias().map((m) => ({ src: m.currentSrc || m.src, playing: !m.paused }));
+    ev.source.postMessage({ type: 'statusResponse', list }, '*');
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Doc PiP Media Controller",
+  "version": "1.0",
+  "description": "Omnibox with play/pause to control media across tabs using Document PiP.",
+  "permissions": ["tabs", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_title": "Media Controller"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle",
+      "all_frames": true
+    }
+  ]
+}

--- a/chrome-extension/pip.html
+++ b/chrome-extension/pip.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    #controls { display: flex; gap: 4px; align-items: center; padding: 4px; }
+    input { flex: 1; padding: 2px 4px; font-size: 12px; }
+    button { padding: 2px 6px; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <input id="omnibox" placeholder="Search or URL" />
+    <button id="play">▶</button>
+    <button id="pause">❚❚</button>
+  </div>
+  <script src="pip.js"></script>
+</body>
+</html>

--- a/chrome-extension/pip.js
+++ b/chrome-extension/pip.js
@@ -1,0 +1,28 @@
+const omnibox = document.getElementById('omnibox');
+const playBtn = document.getElementById('play');
+const pauseBtn = document.getElementById('pause');
+
+function refresh() {
+  chrome.runtime.sendMessage({ type: 'query' }, (response) => {
+    if (!Array.isArray(response)) return;
+    const anyPlaying = response.some((tab) => tab.medias.some((m) => m.playing));
+    playBtn.disabled = anyPlaying;
+    pauseBtn.disabled = !anyPlaying;
+  });
+}
+
+playBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'control', action: 'play' });
+});
+
+pauseBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'control', action: 'pause' });
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'refresh') {
+    refresh();
+  }
+});
+
+refresh();


### PR DESCRIPTION
## Summary
- add Chrome extension manifest and background service worker to launch a Doc-PiP window and relay media controls
- render omnibox and play/pause buttons inside PiP window
- control media elements across tabs and iframes via postMessage

## Testing
- `yarn test` *(fails: youtube.test.tsx, mimikatz.test.ts, wordSearch.test.ts, niktoApp.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d72ddec83288369d27fff14341a