### PR TITLE
feat(chrome): add customizable start tiles

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -13,6 +13,12 @@ import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
+export const chromeDefaultTiles = [
+  { title: 'MDN', url: 'https://developer.mozilla.org/' },
+  { title: 'Wikipedia', url: 'https://en.wikipedia.org' },
+  { title: 'Example', url: 'https://example.com' },
+];
+
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
 // VSCode app uses a Stack iframe, so no editor dependencies are required


### PR DESCRIPTION
## Summary
- define default Chrome tiles in app config
- add editable tile grid with OPFS persistence
- support JSON import/export for tile layouts

## Testing
- `yarn test` *(fails: youtube.test.tsx, wordSearch.test.ts, mimikatz.test.ts, niktoApp.test.tsx)*
- `yarn lint` *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d726c3883288ec55ec1d2df0fea