### PR TITLE
feat: persist chrome tabs with profiles and sandbox settings

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Persist state in the Origin Private File System.
+ * @param path File path within OPFS
+ * @param initial Initial value
+ */
+export default function useOPFS<T>(path: string, initial: T) {
+  const [state, setState] = useState<T>(initial);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (typeof window === 'undefined' || !(navigator as any).storage?.getDirectory) {
+      return;
+    }
+    (async () => {
+      try {
+        const root = await (navigator as any).storage.getDirectory();
+        const handle = await root.getFileHandle(path);
+        const file = await handle.getFile();
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        if (!cancelled) setState(parsed);
+      } catch {
+        // ignore missing file or parse errors
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !(navigator as any).storage?.getDirectory) {
+      return;
+    }
+    (async () => {
+      try {
+        const root = await (navigator as any).storage.getDirectory();
+        const handle = await root.getFileHandle(path, { create: true });
+        const writable = await handle.createWritable();
+        await writable.write(JSON.stringify(state));
+        await writable.close();
+      } catch {
+        // ignore write errors
+      }
+    })();
+  }, [path, state]);
+
+  return [state, setState] as const;
+}


### PR DESCRIPTION
## Summary
- manage per-tab profiles and sandbox flags
- persist chrome tab state to OPFS
- add UI for profile selection and sandbox flag toggling

## Testing
- `yarn lint components/apps/Chrome/index.tsx hooks/useOPFS.ts` *(fails: ESLint couldn't find config)*
- `yarn test components/apps/Chrome/index.tsx hooks/useOPFS.ts --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d718bc08328b5d1cf486c1afc76