### PR TITLE
feat: refresh content with periodic background sync

### DIFF
--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -1,4 +1,5 @@
 import { generateSW } from 'workbox-build';
+import fs from 'fs';
 
 async function buildServiceWorker() {
   try {
@@ -10,6 +11,7 @@ async function buildServiceWorker() {
       clientsClaim: true,
       inlineWorkboxRuntime: true,
       navigateFallback: '/offline.html',
+      importScripts: ['workers/service-worker.js'],
       runtimeCaching: [
         {
           urlPattern: ({ request }) => request.destination === 'document',
@@ -20,6 +22,8 @@ async function buildServiceWorker() {
         },
       ],
     });
+    await fs.promises.mkdir('public/workers', { recursive: true });
+    await fs.promises.copyFile('workers/service-worker.js', 'public/workers/service-worker.js');
     console.log(`Generated ${count} files, totaling ${size} bytes.`);
   } catch (err) {
     console.error('Service worker generation failed:', err);


### PR DESCRIPTION
## Summary
- prefetch weather, feed, and portfolio pages via service worker
- use periodic background sync to keep cached content fresh
- copy service worker into build output and fall back to manual refresh when unsupported

## Testing
- `yarn lint workers/service-worker.js pages/_app.jsx scripts/generate-sw.mjs` *(fails: ESLint couldn't find a configuration file)*
- `yarn test __tests__/youtube.test.tsx` *(fails: Unable to find an element with the alt text: Video A)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d70c41c832888c36d597a62db75