### PR TITLE
feat: add OPFS storage utilities

### DIFF
--- a/components/apps/Games/common/save/index.ts
+++ b/components/apps/Games/common/save/index.ts
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useRef } from 'react';
 import { createStore, get, set, del, keys } from 'idb-keyval';
+import useOPFS from '../../../../../hooks/useOPFS';
 
 export interface SaveSlot {
   name: string;
@@ -7,40 +9,117 @@ export interface SaveSlot {
 
 const getStore = (gameId: string) => createStore(`game:${gameId}`, 'saves');
 
-export async function saveSlot(gameId: string, slot: SaveSlot): Promise<void> {
-  const store = getStore(gameId);
-  await set(slot.name, slot.data, store);
-}
+export default function useGameSaves(gameId: string) {
+  const { supported, getDir, readFile, writeFile, deleteFile } = useOPFS();
+  const dirRef = useRef<FileSystemDirectoryHandle | null>(null);
 
-export async function loadSlot<T = unknown>(gameId: string, name: string): Promise<T | undefined> {
-  const store = getStore(gameId);
-  return get<T>(name, store);
-}
+  useEffect(() => {
+    if (!supported) return;
+    getDir(`games/${gameId}`).then((d) => {
+      if (d) dirRef.current = d;
+    });
+  }, [supported, gameId, getDir]);
 
-export async function deleteSlot(gameId: string, name: string): Promise<void> {
-  const store = getStore(gameId);
-  await del(name, store);
-}
+  const saveSlot = useCallback(
+    async (slot: SaveSlot) => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        await writeFile(`${slot.name}.json`, JSON.stringify(slot.data), dir);
+      } else {
+        const store = getStore(gameId);
+        await set(slot.name, slot.data, store);
+      }
+    },
+    [supported, gameId, writeFile],
+  );
 
-export async function listSlots(gameId: string): Promise<string[]> {
-  const store = getStore(gameId);
-  const allKeys = await keys(store);
-  return allKeys as string[];
-}
+  const loadSlot = useCallback(
+    async <T = unknown>(name: string): Promise<T | undefined> => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        const txt = await readFile(`${name}.json`, dir);
+        return txt ? (JSON.parse(txt) as T) : undefined;
+      }
+      const store = getStore(gameId);
+      return get<T>(name, store);
+    },
+    [supported, gameId, readFile],
+  );
 
-export async function exportSaves(gameId: string): Promise<SaveSlot[]> {
-  const store = getStore(gameId);
-  const allKeys = await keys(store);
-  const saves: SaveSlot[] = [];
-  for (const key of allKeys) {
-    const data = await get(key, store);
-    saves.push({ name: key as string, data });
-  }
-  return saves;
-}
+  const deleteSlot = useCallback(
+    async (name: string) => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        await deleteFile(`${name}.json`, dir);
+      } else {
+        const store = getStore(gameId);
+        await del(name, store);
+      }
+    },
+    [supported, gameId, deleteFile],
+  );
 
-export async function importSaves(gameId: string, saves: SaveSlot[]): Promise<void> {
-  const store = getStore(gameId);
-  await Promise.all(saves.map((slot) => set(slot.name, slot.data, store)));
+  const listSlots = useCallback(
+    async (): Promise<string[]> => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        const names: string[] = [];
+        for await (const [name, handle] of dir.entries()) {
+          if (handle.kind === 'file' && name.endsWith('.json')) {
+            names.push(name.replace(/\.json$/, ''));
+          }
+        }
+        return names;
+      }
+      const store = getStore(gameId);
+      const allKeys = await keys(store);
+      return allKeys as string[];
+    },
+    [supported, gameId],
+  );
+
+  const exportSaves = useCallback(
+    async (): Promise<SaveSlot[]> => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        const slots: SaveSlot[] = [];
+        for await (const [name, handle] of dir.entries()) {
+          if (handle.kind === 'file' && name.endsWith('.json')) {
+            const txt = await readFile(name, dir);
+            if (txt) slots.push({ name: name.replace(/\.json$/, ''), data: JSON.parse(txt) });
+          }
+        }
+        return slots;
+      }
+      const store = getStore(gameId);
+      const allKeys = await keys(store);
+      const saves: SaveSlot[] = [];
+      for (const key of allKeys) {
+        const data = await get(key, store);
+        saves.push({ name: key as string, data });
+      }
+      return saves;
+    },
+    [supported, gameId, readFile],
+  );
+
+  const importSaves = useCallback(
+    async (saves: SaveSlot[]): Promise<void> => {
+      const dir = dirRef.current;
+      if (supported && dir) {
+        await Promise.all(
+          saves.map((slot) =>
+            writeFile(`${slot.name}.json`, JSON.stringify(slot.data), dir),
+          ),
+        );
+      } else {
+        const store = getStore(gameId);
+        await Promise.all(saves.map((slot) => set(slot.name, slot.data, store)));
+      }
+    },
+    [supported, gameId, writeFile],
+  );
+
+  return { saveSlot, loadSlot, deleteSlot, listSlots, exportSaves, importSaves };
 }
 

--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -1,0 +1,112 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface OPFSHook {
+  supported: boolean;
+  root: FileSystemDirectoryHandle | null;
+  getDir: (
+    path?: string,
+    options?: FileSystemGetDirectoryOptions,
+  ) => Promise<FileSystemDirectoryHandle | null>;
+  readFile: (
+    name: string,
+    dir?: FileSystemDirectoryHandle,
+  ) => Promise<string | null>;
+  writeFile: (
+    name: string,
+    data: string | Blob,
+    dir?: FileSystemDirectoryHandle,
+  ) => Promise<boolean>;
+  deleteFile: (
+    name: string,
+    dir?: FileSystemDirectoryHandle,
+  ) => Promise<boolean>;
+}
+
+export default function useOPFS(): OPFSHook {
+  const supported =
+    typeof navigator !== 'undefined' && !!navigator.storage?.getDirectory;
+
+  const [root, setRoot] = useState<FileSystemDirectoryHandle | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!supported) return;
+    navigator.storage
+      .getDirectory()
+      .then((dir) => {
+        if (!cancelled) setRoot(dir);
+      })
+      .catch(() => {
+        if (!cancelled) setRoot(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [supported]);
+
+  const getDir = useCallback<OPFSHook['getDir']>(
+    async (path = '', options = { create: true }) => {
+      if (!root) return null;
+      try {
+        let dir: FileSystemDirectoryHandle = root;
+        const parts = path
+          .split('/')
+          .map((p) => p.trim())
+          .filter(Boolean);
+        for (const part of parts) {
+          dir = await dir.getDirectoryHandle(part, options);
+        }
+        return dir;
+      } catch {
+        return null;
+      }
+    },
+    [root],
+  );
+
+  const readFile = useCallback<OPFSHook['readFile']>(
+    async (name, dir = root) => {
+      if (!dir) return null;
+      try {
+        const handle = await dir.getFileHandle(name);
+        const file = await handle.getFile();
+        return await file.text();
+      } catch {
+        return null;
+      }
+    },
+    [root],
+  );
+
+  const writeFile = useCallback<OPFSHook['writeFile']>(
+    async (name, data, dir = root) => {
+      if (!dir) return false;
+      try {
+        const handle = await dir.getFileHandle(name, { create: true });
+        const writable = await handle.createWritable();
+        await writable.write(data);
+        await writable.close();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [root],
+  );
+
+  const deleteFile = useCallback<OPFSHook['deleteFile']>(
+    async (name, dir = root) => {
+      if (!dir) return false;
+      try {
+        await dir.removeEntry(name);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [root],
+  );
+
+  return { supported, root, getDir, readFile, writeFile, deleteFile };
+}
+


### PR DESCRIPTION
## Summary
- add `useOPFS` hook exposing persistent file helpers
- mount origin-private file system in File Explorer and persist buffers
- store terminal history and game saves using OPFS

## Testing
- `yarn test` *(fails: youtube.test.tsx, mimikatz.test.ts, wordSearch.test.ts, niktoApp.test.tsx)*
- `yarn lint hooks/useOPFS.ts apps/terminal/index.tsx components/apps/file-explorer.js components/apps/Games/common/save/index.ts` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d6f95048328a65cecbd6f0952eb