### PR TITLE
feat: add document picture-in-picture pinning

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -5,6 +5,7 @@ import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
+import useDocPiP from '../../hooks/useDocPiP';
 
 export class Window extends Component {
     constructor(props) {
@@ -501,7 +502,15 @@ export class Window extends Component {
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
                         />
-                        <WindowEditButtons minimize={this.minimizeWindow} maximize={this.maximizeWindow} isMaximised={this.state.maximized} close={this.closeWindow} id={this.id} allowMaximize={this.props.allowMaximize !== false} />
+                        <WindowEditButtons
+                            minimize={this.minimizeWindow}
+                            maximize={this.maximizeWindow}
+                            isMaximised={this.state.maximized}
+                            close={this.closeWindow}
+                            id={this.id}
+                            allowMaximize={this.props.allowMaximize !== false}
+                            pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
+                        />
                         {(this.id === "settings"
                             ? <Settings />
                             : <WindowMainScreen screen={this.props.screen} title={this.props.title}
@@ -568,8 +577,27 @@ export class WindowXBorder extends Component {
 
 // Window's Edit Buttons
 export function WindowEditButtons(props) {
+    const { togglePin } = useDocPiP(props.pip || (() => null));
+    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center">
+            {pipSupported && props.pip && (
+                <button
+                    type="button"
+                    aria-label="Window pin"
+                    className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+                    onClick={togglePin}
+                >
+                    <NextImage
+                        src="/themes/Yaru/window/window-pin-symbolic.svg"
+                        alt="Kali window pin"
+                        className="h-5 w-5 inline"
+                        width={20}
+                        height={20}
+                        sizes="20px"
+                    />
+                </button>
+            )}
             <button
                 type="button"
                 aria-label="Window minimize"

--- a/hooks/useDocPiP.ts
+++ b/hooks/useDocPiP.ts
@@ -1,0 +1,28 @@
+import React, { useCallback, useEffect } from 'react';
+import { usePipPortal } from '../components/common/PipPortal';
+
+export default function useDocPiP(render: () => React.ReactNode) {
+  const { open, close, isOpen } = usePipPortal();
+
+  const pin = useCallback(async () => {
+    await open(render());
+  }, [open, render]);
+
+  const unpin = useCallback(() => {
+    close();
+  }, [close]);
+
+  const togglePin = useCallback(async () => {
+    if (isOpen) {
+      unpin();
+    } else {
+      await pin();
+    }
+  }, [isOpen, pin, unpin]);
+
+  useEffect(() => {
+    return () => close();
+  }, [close]);
+
+  return { isPinned: isOpen, pin, unpin, togglePin };
+}

--- a/public/themes/Yaru/window/window-pin-symbolic.svg
+++ b/public/themes/Yaru/window/window-pin-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <path d="M16 9V4h-1V2H9v2H8v5L5 12v2h6v7l1 1 1-1v-7h6v-2l-3-3Z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add optional pin control in window chrome
- support document PiP via hook and portal context
- include pin icon asset

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration file)*
- `yarn test` *(fails: youtube, mimikatz, wordSearch, niktoApp, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d6eb9388328a3f5ac4253728482