### PR TITLE
Add figlet font types and parse fonts on mount

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -7,14 +7,7 @@ import Slant from 'figlet/importable-fonts/Slant.js';
 import Big from 'figlet/importable-fonts/Big.js';
 import { useRouter } from 'next/router';
 
-// preload a small set of fonts
-const fontData: Record<string, any> = {
-  Standard,
-  Slant,
-  Big,
-};
-Object.entries(fontData).forEach(([name, data]) => figlet.parseFont(name, data));
-const fontList = Object.keys(fontData);
+const fontList = ['Standard', 'Slant', 'Big'];
 
 const ramp = '@%#*+=-:. ';
 
@@ -32,20 +25,26 @@ const AsciiArtApp = () => {
   const router = useRouter();
   const [tab, setTab] = useState<'text' | 'image'>('text');
   const [text, setText] = useState('');
-  const [font, setFont] = useState('Standard');
+    const [font, setFont] = useState<figlet.Fonts>('Standard');
   const [output, setOutput] = useState('');
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [imgOutput, setImgOutput] = useState('');
-  const [brightness, setBrightness] = useState(0); // -1 to 1
-  const [contrast, setContrast] = useState(1); // 0 to 2
+    const [imgOutput, setImgOutput] = useState('');
+    const [brightness, setBrightness] = useState(0); // -1 to 1
+    const [contrast, setContrast] = useState(1); // 0 to 2
 
-  // load from query string on first render
-  useEffect(() => {
+    useEffect(() => {
+      figlet.parseFont('Standard', Standard);
+      figlet.parseFont('Slant', Slant);
+      figlet.parseFont('Big', Big);
+    }, []);
+
+    // load from query string on first render
+    useEffect(() => {
     if (!router.isReady) return;
     const { t, f, b, c } = router.query;
     if (typeof t === 'string') setText(t);
-    if (typeof f === 'string' && fontList.includes(f)) setFont(f);
+      if (typeof f === 'string' && fontList.includes(f)) setFont(f as figlet.Fonts);
     if (typeof b === 'string') {
       const br = parseFloat(b);
       if (!Number.isNaN(br) && br >= -1 && br <= 1) setBrightness(br);
@@ -161,7 +160,7 @@ const AsciiArtApp = () => {
           />
           <select
             value={font}
-            onChange={(e) => setFont(e.target.value)}
+            onChange={(e) => setFont(e.target.value as figlet.Fonts)}
             className="px-2 py-1 text-black rounded"
           >
             {fontList.map((f) => (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "incremental": true,
     "types": ["jest", "node"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules", "__tests__"]
 }

--- a/types/figlet-importable-fonts.d.ts
+++ b/types/figlet-importable-fonts.d.ts
@@ -1,0 +1,4 @@
+declare module 'figlet/importable-fonts/*' {
+  const font: string;
+  export default font;
+}


### PR DESCRIPTION
## Summary
- declare types for `figlet/importable-fonts/*`
- include custom type declarations in TypeScript config
- load figlet fonts on component mount instead of module scope

## Testing
- `yarn build` *(fails: Argument of type 'number' is not assignable to parameter of type '0 | 1' in apps/games/battleship/ai.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b13bcee0fc83288292ee677fd148ef