### PR TITLE
fix: include pcap summary in effect deps

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -205,7 +205,7 @@ const Dsniff = () => {
         }, idx * 1000);
       });
     }
-  }, [urlsnarfLogs, prefersReduced]);
+  }, [urlsnarfLogs, prefersReduced, pcapSummary]);
 
   const addFilter = () => {
     if (newValue.trim()) {


### PR DESCRIPTION
## Summary
- add `pcapSummary` to Dsniff timeline effect dependencies

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint components/apps/dsniff/index.js`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/dsniff/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b13bcfe8c88328b4c74ae265bc58db