### PR TITLE
feat: cache QR encoding worker

### DIFF
--- a/workers/qrEncode.worker.ts
+++ b/workers/qrEncode.worker.ts
@@ -1,0 +1,20 @@
+import QRCode from 'qrcode';
+
+interface EncodeRequest {
+  text: string;
+  opts: QRCode.QRCodeToStringOptions;
+}
+
+self.onmessage = async ({ data }: MessageEvent<EncodeRequest>) => {
+  const { text, opts } = data;
+  try {
+    const value = text || ' ';
+    const png = await QRCode.toDataURL(value, opts);
+    const svg = await QRCode.toString(value, { ...opts, type: 'svg' });
+    (self as any).postMessage({ png, svg });
+  } catch {
+    (self as any).postMessage({ png: '', svg: '' });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- cache QR encoding worker in QR tool using `useRef` and `useCallback`
- add `qrEncode.worker` implementation and update component to use it
- adapt QR tool test to mock worker and verify preview/batch generation

## Testing
- `yarn lint components/apps/qr_tool/index.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test __tests__/qr_tool.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b13bd077c88328a88e3365deaf1a2c