### PR TITLE
Fix Wordle lint warnings by updating effect deps

### DIFF
--- a/components/apps/wordle.js
+++ b/components/apps/wordle.js
@@ -32,7 +32,7 @@ function usePersistentState(key, defaultValue) {
     } catch {
       setState(defaultValue);
     }
-  }, [key]);
+  }, [key, defaultValue]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -97,7 +97,7 @@ const Wordle = () => {
       won: 0,
       guessDist: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, fail: 0 },
     }),
-    [dictName]
+    []
   );
   const [stats, setStats] = usePersistentState(
     `wordle-stats-${dictName}`,


### PR DESCRIPTION
## Summary
- refresh persisted state when defaultValue updates
- simplify default statistics memoization

## Testing
- `npx eslint components/apps/wordle.js --max-warnings=0`

------
https://chatgpt.com/codex/tasks/task_e_68b13bd15a98832892f8fb7b99747c54