### PR TITLE
docs: log bare-fs warning justification

### DIFF
--- a/test-log.md
+++ b/test-log.md
@@ -26,3 +26,9 @@ Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All
 - `yarn build` failed: Module not found: Can't resolve '../../ui/FormError' in `components/apps/serial-terminal.tsx`.
 - `yarn export` failed: `next export` has been removed; configure `output: 'export'` in next.config.js.
 - `yarn test` reported failing tests: `hashcat.test.tsx`, `beef.test.tsx`, `mimikatz.test.ts`.
+
+## bare-fs warning (2025-08-29)
+
+- `yarn why bare-fs` shows the module is required by `tar-fs@3.1.0` via `@puppeteer/browsers@2.10.7`.
+- Latest versions (`@puppeteer/browsers@2.10.8`, `tar-fs@3.1.0`) still depend on `bare-fs@4.2.1`, so the warning remains.
+- `puppeteer` and `puppeteer-core` require this chain; removing them would break existing tooling, so the warning is ignored.


### PR DESCRIPTION
## Summary
- note bare-fs warning comes via tar-fs/@puppeteer browsers
- explain that newer versions still include bare-fs
- document decision to ignore warning

## Testing
- `yarn test` *(fails: unable to find element with text 1 in __tests__/beef.test.tsx, cannot find module '@monaco-editor/react' from __tests__/projectGallery.test.tsx, global config is readonly errors in calculator tests, and other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b13bd3e5b08328b363097f3094ed41