### PR TITLE
feat: schedule tweets in X app

### DIFF
--- a/apps/x/state/scheduled.ts
+++ b/apps/x/state/scheduled.ts
@@ -1,0 +1,14 @@
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export interface ScheduledTweet {
+  id: string;
+  text: string;
+  time: number; // epoch milliseconds
+}
+
+/**
+ * Persist list of scheduled tweets.
+ */
+export default function useScheduledTweets() {
+  return usePersistentState<ScheduledTweet[]>('x-scheduled-tweets', []);
+}


### PR DESCRIPTION
## Summary
- store scheduled tweets with persistent state
- send notification reminders using setTimeout
- enable keyboard controls to manage scheduled tweets

## Testing
- `yarn test --passWithNoTests apps/x/state/scheduled.ts apps/x/index.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b14b61dddc8328973229555aa9825e