### PR TITLE
feat(reconng): add module schemas and offline demo docs

### DIFF
--- a/docs/reconng.md
+++ b/docs/reconng.md
@@ -1,0 +1,26 @@
+# Recon-ng Simulation
+
+> ⚠️ For educational use in authorized lab environments only.
+
+## Module Schemas
+
+Modules are defined in `components/apps/reconng/index.js` as schema objects with:
+
+- `input` – expected target type (`domain` or `ip`).
+- `demo(target)` – returns canned text, nodes and edges for offline runs.
+- `fetchUrl(target)` – optional CORS-friendly endpoint used when **Live fetch** is enabled.
+
+## Offline Demonstration
+
+Static fixtures in `public/reconng-marketplace.json` and `public/reconng-chain.json` supply marketplace modules and example chains. Module runs default to the schema's `demo` output so the simulation works without network access.
+
+## Opt-in Network Requests
+
+Checking the **Live fetch** box sends a limited request to the schema's `fetchUrl`. If the request succeeds, its text replaces the demo output. If it fails, the demo data is shown instead. Remote responses are not stored and the graph remains the example data.
+
+## Data Storage
+
+- API keys are persisted in `localStorage` under the key `reconng-api-keys`.
+- Workspace graphs and entity sets exist only in memory but can be exported as CSV or JSON.
+- Static marketplace and chain data live in the `public/` directory.
+


### PR DESCRIPTION
## Summary
- define Recon-ng module schemas with demo data and optional fetch URLs
- add live fetch toggle and run logic
- document Recon-ng data flow and storage

## Testing
- `npm test __tests__/reconng.test.tsx`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/reconng/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68b13c1a72288328a25ddbaeab31460d