### PR TITLE
feat: daily seeded 2048 coach

### DIFF
--- a/apps/games/_2048/ai.ts
+++ b/apps/games/_2048/ai.ts
@@ -78,3 +78,16 @@ export const findBestMove = (board: Board, depth = 2): Direction | null => {
 };
 
 export const findHint = findBestMove;
+
+export const scoreMoves = (
+  board: Board,
+  depth = 2,
+): Partial<Record<Direction, number>> => {
+  const scores: Partial<Record<Direction, number>> = {};
+  for (const { dir, fn } of MOVES) {
+    const next = fn(cloneBoard(board));
+    if (boardsEqual(board, next)) continue;
+    scores[dir] = expectimax(next, depth - 1, false);
+  }
+  return scores;
+};


### PR DESCRIPTION
## Summary
- seed 2048 boards per-day for reproducible puzzles
- show coach overlay with expectimax scores and toggle
- persist best tile per seed in OPFS storage

## Testing
- `npm test` *(fails: merging two 2s creates one 4, BeEF app updates hook list, merge triggers animation, score persists, skin selection, Mimikatz API, word search generator, VsCode app, kismet app, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c1bc6c48328a2f9fdce49d098cf