### PR TITLE
feat: add probability-based Battleship AI

### DIFF
--- a/apps/games/battleship/ai.ts
+++ b/apps/games/battleship/ai.ts
@@ -102,15 +102,22 @@ export class MonteCarloAI {
   hits: Set<number>;
   misses: Set<number>;
   noAdjacency: boolean;
+  lastScores: number[];
 
   constructor(noAdjacency = false) {
     this.hits = new Set();
     this.misses = new Set();
     this.noAdjacency = noAdjacency;
+    this.lastScores = new Array(BOARD_SIZE * BOARD_SIZE).fill(0);
   }
 
   record(idx: number, hit: boolean) {
     (hit ? this.hits : this.misses).add(idx);
+  }
+
+  /** Returns the heat map from the last call to nextMove */
+  getHeatmap() {
+    return this.lastScores;
   }
 
   nextMove(simulations = 200): number | null {
@@ -125,6 +132,7 @@ export class MonteCarloAI {
         if (occ.has(i)) scores[i]++;
       }
     }
+    this.lastScores = scores;
     let best = -1;
     let bestScore = -1;
     for (let i = 0; i < scores.length; i++) {


### PR DESCRIPTION
## Summary
- add heatmap support to MonteCarloAI and surface probabilities in Battleship
- support salvo and fog-of-war modes with menu toggles
- normalize heatmap rendering for clearer feedback

## Testing
- `npm test -- battleship`


------
https://chatgpt.com/codex/tasks/task_e_68b13c1d305c8328a0d030b93a3babc9