### PR TITLE
feat: add Breakout level editor and power-ups

### DIFF
--- a/components/apps/breakout.js
+++ b/components/apps/breakout.js
@@ -1,9 +1,11 @@
 "use client";
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import seedrandom from 'seedrandom';
 import GameLayout from './GameLayout';
 import useCanvasResize from '../../hooks/useCanvasResize';
+import BreakoutEditor from './breakoutEditor';
+import BreakoutLevels from './breakoutLevels';
 
 // Basic canvas dimensions
 const WIDTH = 400;
@@ -11,64 +13,68 @@ const HEIGHT = 300;
 const PADDLE_WIDTH = 60;
 const PADDLE_HEIGHT = 10;
 const BALL_RADIUS = 5;
+const ROWS = 5;
+const COLS = 10;
+const BRICK_WIDTH = WIDTH / COLS;
+const BRICK_HEIGHT = 15;
+const DEFAULT_LAYOUT = Array.from({ length: ROWS }, () => Array(COLS).fill(1));
 
-// Simple Breakout placeholder with a single paddle and ball
+const createBricks = (layout) => {
+  const bricks = [];
+  for (let r = 0; r < layout.length; r += 1) {
+    for (let c = 0; c < layout[r].length; c += 1) {
+      const type = layout[r][c];
+      if (type > 0) {
+        bricks.push({
+          x: c * BRICK_WIDTH,
+          y: 30 + r * (BRICK_HEIGHT + 2),
+          w: BRICK_WIDTH - 2,
+          h: BRICK_HEIGHT,
+          type,
+          alive: true,
+        });
+      }
+    }
+  }
+  return bricks;
+};
+
+// Breakout with level editor, selection, multi-ball and magnet power-up
 const Breakout = () => {
   const canvasRef = useCanvasResize(WIDTH, HEIGHT);
   const paddleX = useRef(WIDTH / 2 - PADDLE_WIDTH / 2);
+  const ballsRef = useRef([]);
+  const bricksRef = useRef([]);
+  const levelRef = useRef(DEFAULT_LAYOUT);
+  const magnetRef = useRef(0);
+  const animationRef = useRef(0);
+  const [selecting, setSelecting] = useState(true);
+
+  const startLevel = (layout) => {
+    const grid = layout || DEFAULT_LAYOUT;
+    levelRef.current = grid;
+    bricksRef.current = createBricks(grid);
+    ballsRef.current = [
+      { x: WIDTH / 2, y: HEIGHT / 2, vx: 2, vy: -2, stuck: false },
+    ];
+    magnetRef.current = 0;
+    setSelecting(false);
+  };
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas || selecting) return undefined;
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    if (!ctx) return undefined;
 
-    const ball = { x: WIDTH / 2, y: HEIGHT / 2, vx: 2, vy: -2 };
-    let animationId;
-
-    const draw = () => {
-      ctx.clearRect(0, 0, WIDTH, HEIGHT);
-
-      // Draw paddle
-      ctx.fillStyle = '#fff';
-      ctx.fillRect(paddleX.current, HEIGHT - 20, PADDLE_WIDTH, PADDLE_HEIGHT);
-
-      // Draw ball
-      ctx.beginPath();
-      ctx.arc(ball.x, ball.y, BALL_RADIUS, 0, Math.PI * 2);
-      ctx.fill();
-
-      // Move ball
-      ball.x += ball.vx;
-      ball.y += ball.vy;
-
-      // Wall collisions
-      if (ball.x < BALL_RADIUS || ball.x > WIDTH - BALL_RADIUS) {
-        ball.vx *= -1;
-      }
-      if (ball.y < BALL_RADIUS) {
-        ball.vy *= -1;
-      }
-
-      // Paddle collision
-      if (
-        ball.y >= HEIGHT - 20 - BALL_RADIUS &&
-        ball.x >= paddleX.current &&
-        ball.x <= paddleX.current + PADDLE_WIDTH
-      ) {
-        ball.vy *= -1;
-        ball.y = HEIGHT - 20 - BALL_RADIUS;
-      }
-
-      // Reset if ball falls below
-      if (ball.y > HEIGHT + BALL_RADIUS) {
-        ball.x = WIDTH / 2;
-        ball.y = HEIGHT / 2;
-        ball.vx = 2;
-        ball.vy = -2;
-      }
-
-      animationId = requestAnimationFrame(draw);
+    const release = () => {
+      ballsRef.current.forEach((b) => {
+        if (b.stuck) {
+          b.stuck = false;
+          b.vy = -2;
+          b.vx = 2 * (Math.random() - 0.5);
+        }
+      });
     };
 
     const handleMove = (e) => {
@@ -84,26 +90,127 @@ const Breakout = () => {
       if (e.key === 'ArrowLeft') {
         paddleX.current = Math.max(0, paddleX.current - 20);
       } else if (e.key === 'ArrowRight') {
-        paddleX.current = Math.min(
-          WIDTH - PADDLE_WIDTH,
-          paddleX.current + 20,
-        );
+        paddleX.current = Math.min(WIDTH - PADDLE_WIDTH, paddleX.current + 20);
+      } else if (e.key === ' ') {
+        release();
       }
     };
 
     canvas.addEventListener('mousemove', handleMove);
+    canvas.addEventListener('click', release);
     window.addEventListener('keydown', handleKey);
-    draw();
 
+    const draw = () => {
+      ctx.clearRect(0, 0, WIDTH, HEIGHT);
+      magnetRef.current = Math.max(0, magnetRef.current - 1);
+
+      // Draw paddle
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(paddleX.current, HEIGHT - 20, PADDLE_WIDTH, PADDLE_HEIGHT);
+
+      // Draw bricks
+      bricksRef.current.forEach((br) => {
+        if (!br.alive) return;
+        ctx.fillStyle =
+          br.type === 1 ? '#999' : br.type === 2 ? '#0f0' : '#f00';
+        ctx.fillRect(br.x, br.y, br.w, br.h);
+      });
+
+      // Update balls
+      ballsRef.current.forEach((ball) => {
+        if (ball.stuck) {
+          ball.x = paddleX.current + ball.offset;
+          ball.y = HEIGHT - 20 - BALL_RADIUS;
+        } else {
+          ball.x += ball.vx;
+          ball.y += ball.vy;
+        }
+
+        // Wall collisions
+        if (ball.x < BALL_RADIUS || ball.x > WIDTH - BALL_RADIUS) {
+          ball.vx *= -1;
+        }
+        if (ball.y < BALL_RADIUS) {
+          ball.vy *= -1;
+        }
+
+        // Paddle collision
+        if (
+          !ball.stuck &&
+          ball.y >= HEIGHT - 20 - BALL_RADIUS &&
+          ball.x >= paddleX.current &&
+          ball.x <= paddleX.current + PADDLE_WIDTH
+        ) {
+          ball.vy *= -1;
+          ball.y = HEIGHT - 20 - BALL_RADIUS;
+          if (magnetRef.current > 0) {
+            ball.stuck = true;
+            ball.offset = BALL_RADIUS;
+          }
+        }
+
+        // Brick collisions
+        bricksRef.current.forEach((br) => {
+          if (!br.alive) return;
+          if (
+            ball.x > br.x &&
+            ball.x < br.x + br.w &&
+            ball.y > br.y &&
+            ball.y < br.y + br.h
+          ) {
+            br.alive = false;
+            ball.vy *= -1;
+            if (br.type === 2) {
+              ballsRef.current.push({
+                x: ball.x,
+                y: ball.y,
+                vx: -ball.vx,
+                vy: ball.vy,
+                stuck: false,
+              });
+            } else if (br.type === 3) {
+              magnetRef.current = 300;
+            }
+          }
+        });
+
+        // Draw ball
+        ctx.beginPath();
+        ctx.arc(ball.x, ball.y, BALL_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      // Remove lost balls
+      ballsRef.current = ballsRef.current.filter(
+        (b) => b.y < HEIGHT + BALL_RADIUS,
+      );
+      if (ballsRef.current.length === 0) {
+        startLevel(levelRef.current);
+        return;
+      }
+
+      animationRef.current = requestAnimationFrame(draw);
+    };
+
+    animationRef.current = requestAnimationFrame(draw);
     return () => {
-      cancelAnimationFrame(animationId);
+      cancelAnimationFrame(animationRef.current);
       canvas.removeEventListener('mousemove', handleMove);
+      canvas.removeEventListener('click', release);
       window.removeEventListener('keydown', handleKey);
     };
-  }, [canvasRef]);
+  }, [canvasRef, selecting]);
+
+  const handleSelect = (layout) => {
+    startLevel(layout);
+  };
 
   return (
-    <GameLayout gameId="breakout">
+    <GameLayout
+      gameId="breakout"
+      editor={<BreakoutEditor onLoad={handleSelect} />}
+    >
+      {selecting && <BreakoutLevels onSelect={handleSelect} />}
       <canvas ref={canvasRef} className="w-full h-full bg-black" />
     </GameLayout>
   );

--- a/components/apps/breakoutEditor.js
+++ b/components/apps/breakoutEditor.js
@@ -1,0 +1,115 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from 'react';
+import useOPFS from '../../hooks/useOPFS';
+
+const ROWS = 5;
+const COLS = 10;
+
+/**
+ * Simple level editor for Breakout.
+ * Allows creating a brick layout and storing it in OPFS as JSON.
+ * Cells cycle through: 0-empty, 1-normal, 2-multi-ball, 3-magnet.
+ */
+export default function BreakoutEditor({ onLoad }) {
+  const [grid, setGrid] = useState(
+    Array.from({ length: ROWS }, () => Array(COLS).fill(0)),
+  );
+  const [name, setName] = useState('level1');
+  const { supported, getDir, writeFile } = useOPFS();
+  const dirRef = useRef(null);
+
+  useEffect(() => {
+    if (supported) {
+      getDir('breakout-levels').then((d) => {
+        dirRef.current = d;
+      });
+    }
+  }, [supported, getDir]);
+
+  const cycleCell = (r, c) => {
+    setGrid((g) => {
+      const copy = g.map((row) => row.slice());
+      copy[r][c] = (copy[r][c] + 1) % 4;
+      return copy;
+    });
+  };
+
+  const save = async () => {
+    if (!dirRef.current) return;
+    await writeFile(`${name}.json`, JSON.stringify(grid), dirRef.current);
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(grid)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${name}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const play = () => {
+    if (onLoad) onLoad(grid);
+  };
+
+  return (
+    <div className="text-white space-y-2">
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${COLS}, 20px)` }}
+      >
+        {grid.map((row, r) =>
+          row.map((cell, c) => (
+            <div
+              key={`${r}-${c}`}
+              onClick={() => cycleCell(r, c)}
+              className={
+                cell === 0
+                  ? 'bg-gray-800'
+                  : cell === 1
+                    ? 'bg-blue-500'
+                    : cell === 2
+                      ? 'bg-green-500'
+                      : 'bg-red-500'
+              }
+              style={{ width: 20, height: 10 }}
+            />
+          )),
+        )}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="text-black px-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={save}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={exportJson}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          Export
+        </button>
+        <button
+          type="button"
+          onClick={play}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          Play
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/breakoutLevels.js
+++ b/components/apps/breakoutLevels.js
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from 'react';
+import useOPFS from '../../hooks/useOPFS';
+
+/**
+ * Level selection overlay for Breakout.
+ * Lists saved layouts from OPFS and allows loading them.
+ */
+export default function BreakoutLevels({ onSelect }) {
+  const { supported, getDir, readFile } = useOPFS();
+  const [levels, setLevels] = useState([]);
+  const dirRef = useRef(null);
+
+  useEffect(() => {
+    if (supported) {
+      getDir('breakout-levels').then(async (d) => {
+        dirRef.current = d;
+        if (d) {
+          const arr = [];
+          for await (const [name, handle] of d.entries()) {
+            if (handle.kind === 'file' && name.endsWith('.json')) {
+              arr.push(name.replace(/\.json$/, ''));
+            }
+          }
+          setLevels(arr);
+        }
+      });
+    }
+  }, [supported, getDir]);
+
+  const load = async (name) => {
+    if (!dirRef.current) return;
+    const txt = await readFile(`${name}.json`, dirRef.current);
+    if (txt && onSelect) {
+      onSelect(JSON.parse(txt));
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-75 text-white space-y-2">
+      <div>Choose Level</div>
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className="px-2 py-1 bg-gray-700 rounded"
+      >
+        Default
+      </button>
+      {levels.map((lvl) => (
+        <button
+          key={lvl}
+          type="button"
+          onClick={() => load(lvl)}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          {lvl}
+        </button>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add level editor with OPFS persistence and JSON export
- enable level selection from stored layouts
- implement Breakout multi-ball and magnet power-ups

## Testing
- `yarn test __tests__/breakoutSeed.test.ts`
- `yarn lint components/apps/breakout.js components/apps/breakoutEditor.js components/apps/breakoutLevels.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c1f856083288205a17b61c32c63