### PR TITLE
feat(car-racer): add permissioned tilt steering

### DIFF
--- a/public/apps/car-racer/main.js
+++ b/public/apps/car-racer/main.js
@@ -203,12 +203,28 @@ if (!seed) {
   // tilt controls
   let tiltSteer = 0;
   let tiltActive = false;
-  window.addEventListener('deviceorientation', (e) => {
-    if (e.gamma != null) {
+
+  function enableTilt() {
+    if (
+      typeof DeviceOrientationEvent !== 'undefined' &&
+      typeof DeviceOrientationEvent.requestPermission === 'function'
+    ) {
+      DeviceOrientationEvent.requestPermission().then((state) => {
+        if (state === 'granted') tiltActive = true;
+      });
+    } else {
       tiltActive = true;
+    }
+  }
+
+  window.addEventListener('deviceorientation', (e) => {
+    if (!tiltActive) return;
+    if (e.gamma != null) {
       tiltSteer = Math.max(-1, Math.min(1, e.gamma / 30));
     }
   });
+
+  window.addEventListener('click', enableTilt, { once: true });
 
   // ghost storage
   let bestReplay = null;


### PR DESCRIPTION
## Summary
- request DeviceOrientationEvent permission before enabling tilt steering

## Testing
- `yarn test` *(fails: BeEF app updates hook list when refresh is clicked, shows module output when run, switches between modules and payload builder tabs, calculator parser tests, mimikatz api tests, word search generator determinism, VsCode app tests, KismetApp steps through sample capture frames, metasploit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c1fe5348328a082a4f8c0349528