### PR TITLE
Add OPFS tile editor and ghost replays

### DIFF
--- a/public/apps/platformer/editor.html
+++ b/public/apps/platformer/editor.html
@@ -13,7 +13,13 @@
 </head>
 <body>
   <div id="palette"></div>
-  <button id="exportBtn">Export</button>
+  <div id="fileOps">
+    <input id="filename" placeholder="level.json" />
+    <button id="saveBtn">Save</button>
+    <button id="loadBtn">Load</button>
+    <button id="shareBtn">Share</button>
+    <button id="exportBtn">Export</button>
+  </div>
   <textarea id="output" rows="5"></textarea>
   <p>Left click to paint tiles. Right click to set spawn.</p>
   <canvas id="editor" width="320" height="160"></canvas>


### PR DESCRIPTION
## Summary
- allow saving/loading/sharing platformer maps via OPFS and encoded URLs
- load levels from OPFS or shared data
- record player runs and display ghosts that reset at checkpoints

## Testing
- `npm test` *(fails: beef.test.tsx, mimikatz.test.ts, wordSearch.test.ts, vscode.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c26cdf883289f405182469aae85