### PR TITLE
feat: project gallery filter UI

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface Project {
+  id: number;
+  title: string;
+  description: string;
+  stack: string[];
+  year: number;
+  type: string;
+  thumbnail: string;
+}
+
+export default function ProjectGalleryPage() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const router = useRouter();
+
+  const [stack, setStack] = usePersistentState<string>('pg-stack', '');
+  const [year, setYear] = usePersistentState<string>('pg-year', '');
+  const [type, setType] = usePersistentState<string>('pg-type', '');
+
+  // load projects
+  useEffect(() => {
+    fetch('/projects.json')
+      .then((r) => r.json())
+      .then((data) => setProjects(data as Project[]))
+      .catch(() => setProjects([]));
+  }, []);
+
+  // initialize from query string
+  useEffect(() => {
+    if (!router.isReady) return;
+    const { stack: qsStack, year: qsYear, type: qsType } = router.query;
+    if (typeof qsStack === 'string') setStack(qsStack);
+    if (typeof qsYear === 'string') setYear(qsYear);
+    if (typeof qsType === 'string') setType(qsType);
+  }, [router.isReady]);
+
+  // encode selection in query string
+  useEffect(() => {
+    const query: Record<string, string> = {};
+    if (stack) query.stack = stack;
+    if (year) query.year = year;
+    if (type) query.type = type;
+    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
+  }, [stack, year, type]);
+
+  const stacks = useMemo(
+    () => Array.from(new Set(projects.flatMap((p) => p.stack))),
+    [projects]
+  );
+  const years = useMemo(
+    () => Array.from(new Set(projects.map((p) => p.year))).sort((a, b) => b - a),
+    [projects]
+  );
+  const types = useMemo(
+    () => Array.from(new Set(projects.map((p) => p.type))),
+    [projects]
+  );
+
+  const filtered = useMemo(
+    () =>
+      projects.filter(
+        (p) =>
+          (!stack || p.stack.includes(stack)) &&
+          (!year || String(p.year) === year) &&
+          (!type || p.type === type)
+      ),
+    [projects, stack, year, type]
+  );
+
+  const pillClass = (active: boolean) =>
+    `px-3 py-1 rounded-full border ${active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'}`;
+
+  return (
+    <div className="p-4 space-y-4 text-black">
+      <div className="flex flex-wrap gap-2">
+        {stacks.map((s) => (
+          <button
+            key={s}
+            onClick={() => setStack(stack === s ? '' : s)}
+            className={pillClass(stack === s)}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {years.map((y) => (
+          <button
+            key={y}
+            onClick={() => setYear(year === String(y) ? '' : String(y))}
+            className={pillClass(year === String(y))}
+          >
+            {y}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {types.map((t) => (
+          <button
+            key={t}
+            onClick={() => setType(type === t ? '' : t)}
+            className={pillClass(type === t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {filtered.map((p) => (
+          <div key={p.id} className="border rounded overflow-hidden">
+            <img src={p.thumbnail} alt={p.title} className="w-full h-40 object-cover" />
+            <div className="p-2">
+              <h3 className="font-semibold">{p.title}</h3>
+              <p className="text-sm">{p.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/pages/apps/project-gallery.tsx
+++ b/pages/apps/project-gallery.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default ProjectGalleryApp;

--- a/public/projects.json
+++ b/public/projects.json
@@ -1,35 +1,28 @@
 [
   {
     "id": 1,
-    "title": "Portfolio Website",
-    "description": "Personal website built with Next.js and Tailwind CSS.",
-    "stack": ["Next.js", "Tailwind", "TypeScript"],
-    "year": 2023,
+    "title": "Alpha",
+    "description": "Example project Alpha",
+    "stack": ["JS"],
+    "year": 2021,
     "type": "web",
-    "thumbnail": "https://via.placeholder.com/400x300?text=Portfolio",
-    "repo": "https://github.com/example/portfolio",
-    "demo": "https://portfolio.example.com"
+    "thumbnail": "/demo/alpha.png",
+    "repo": "https://example.com/alpha",
+    "demo": "https://example.com/alpha-demo",
+    "snippet": "console.log('Alpha');",
+    "language": "javascript"
   },
   {
     "id": 2,
-    "title": "Weather Widget",
-    "description": "A widget to display current weather conditions.",
-    "stack": ["React", "API"],
+    "title": "Beta",
+    "description": "Example project Beta",
+    "stack": ["TS"],
     "year": 2022,
-    "type": "widget",
-    "thumbnail": "https://via.placeholder.com/400x300?text=Weather",
-    "repo": "https://github.com/example/weather-widget",
-    "demo": "https://weather.example.com"
-  },
-  {
-    "id": 3,
-    "title": "CLI Helper",
-    "description": "Command line tool for automation.",
-    "stack": ["Node.js"],
-    "year": 2021,
-    "type": "cli",
-    "thumbnail": "https://via.placeholder.com/400x300?text=CLI",
-    "repo": "https://github.com/example/cli-helper",
-    "demo": ""
+    "type": "app",
+    "thumbnail": "/demo/beta.png",
+    "repo": "https://example.com/beta",
+    "demo": "https://example.com/beta-demo",
+    "snippet": "console.log('Beta');",
+    "language": "typescript"
   }
 ]


### PR DESCRIPTION
## Summary
- move project metadata to public/projects.json
- add project gallery page with pill filters and query string state

## Testing
- `npm test` *(fails: BeEF app, mimikatz API, vscode app, word search generator, kismet app, metasploit app)*
- `npx eslint apps/project-gallery/pages/index.tsx pages/apps/project-gallery.tsx` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b2d52848328acc6ed6bccbdaa56