### PR TITLE
feat: add project demo tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services used by demos |
 | `stackblitz.com` | StackBlitz IDE embeds |
+| `codesandbox.io` | CodeSandbox demo embeds |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
 | `https://*` / `http://*` / `ws://*` / `wss://*` | Wide dev allowance for external resources; tighten for production |

--- a/apps/project-gallery/components/DemoTab.tsx
+++ b/apps/project-gallery/components/DemoTab.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+interface DemoTabProps {
+  src?: string;
+}
+
+const DemoTab: React.FC<DemoTabProps> = ({ src }) => {
+  const [url, setUrl] = useState('');
+
+  useEffect(() => {
+    if (src) {
+      setUrl(src);
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const paramSrc = params.get('src');
+      if (paramSrc) setUrl(paramSrc);
+    }
+  }, [src]);
+
+  if (!url) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p>No demo available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={url}
+      title="Project Demo"
+      className="w-full h-full"
+      sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture"
+    />
+  );
+};
+
+export default DemoTab;

--- a/apps/project-gallery/demo.tsx
+++ b/apps/project-gallery/demo.tsx
@@ -1,0 +1,4 @@
+'use client';
+import DemoTab from './components/DemoTab';
+
+export default DemoTab;

--- a/apps/project-gallery/index.tsx
+++ b/apps/project-gallery/index.tsx
@@ -1,0 +1,4 @@
+'use client';
+import ProjectGallery from '../../components/apps/project-gallery';
+
+export default ProjectGallery;

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -135,6 +135,11 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
     openApp && openApp('chrome');
   };
 
+  const openDemoTab = (url: string) => {
+    const href = `/apps/project-gallery/demo?src=${encodeURIComponent(url)}`;
+    window.open(href, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <div className="p-4 h-full overflow-auto bg-ub-cool-grey text-white">
       <div className="flex flex-wrap gap-2 mb-4">
@@ -190,7 +195,22 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
         {filtered.map((project) => (
           <div
             key={project.id}
-            className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
+            role={project.demo ? 'button' : undefined}
+            tabIndex={project.demo ? 0 : undefined}
+            onClick={(e) => {
+              if (!project.demo) return;
+              const target = e.target as HTMLElement;
+              if (target.closest('a,button')) return;
+              openDemoTab(project.demo);
+            }}
+            onKeyDown={(e) => {
+              if (!project.demo) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openDemoTab(project.demo);
+              }
+            }}
+            className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden cursor-pointer"
           >
             <div className="flex flex-col md:flex-row h-48">
               <img

--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const ContentSecurityPolicy = [
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  "frame-src 'self' https://* http://* https://stackblitz.com https://codesandbox.io https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",


### PR DESCRIPTION
## Summary
- allow CodeSandbox demo host in CSP frame-src
- add DemoTab component to sandbox external project demos
- open demo tabs from project cards

## Testing
- `npm test` *(fails: beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, wordSearch.test.ts, kismet.test.tsx, metasploit.test.tsx and others)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b2dc79083289febc1558e0a5201