### PR TITLE
feat: add project comparison page

### DIFF
--- a/apps/project-gallery/pages/compare.tsx
+++ b/apps/project-gallery/pages/compare.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { FixedSizeList as List } from 'react-window';
+import projectsData from '../../../data/projects.json';
+
+interface Project {
+  id: number;
+  title: string;
+  description: string;
+  stack: string[];
+  year: number;
+  type: string;
+  thumbnail: string;
+  repo: string;
+  demo: string;
+  snippet: string;
+  language: string;
+}
+
+interface MetricsListProps {
+  project: Project;
+}
+
+const MetricsList: React.FC<MetricsListProps> = ({ project }) => {
+  const metrics = useMemo(
+    () =>
+      Object.entries(project).map(([key, value]) => ({
+        label: key,
+        value: Array.isArray(value) ? value.join(', ') : String(value),
+      })),
+    [project]
+  );
+
+  return (
+    <List height={200} itemCount={metrics.length} itemSize={32} width="100%">
+      {({ index, style }) => {
+        const metric = metrics[index];
+        return (
+          <div style={style} className="flex justify-between px-2">
+            <span className="font-semibold mr-2">{metric.label}</span>
+            <span className="truncate">{metric.value}</span>
+          </div>
+        );
+      }}
+    </List>
+  );
+};
+
+const ProjectPanel: React.FC<{ project?: Project }> = ({ project }) => {
+  if (!project) return <div className="p-4">Project not found</div>;
+  return (
+    <div className="bg-gray-800 rounded text-white p-4 space-y-2 flex-1">
+      <h2 className="text-lg font-bold">{project.title}</h2>
+      <img
+        src={project.thumbnail}
+        alt={project.title}
+        className="w-full h-40 object-cover rounded"
+        loading="lazy"
+      />
+      <MetricsList project={project} />
+    </div>
+  );
+};
+
+const ComparePage: React.FC = () => {
+  const router = useRouter();
+  const { left, right } = router.query;
+
+  const projects = projectsData as Project[];
+  const leftProject = projects.find(
+    (p) => String(p.id) === (Array.isArray(left) ? left[0] : left)
+  );
+  const rightProject = projects.find(
+    (p) => String(p.id) === (Array.isArray(right) ? right[0] : right)
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-900 p-4 text-white">
+      <h1 className="text-2xl font-bold mb-4">Compare Projects</h1>
+      <div className="flex flex-col md:flex-row gap-4">
+        <ProjectPanel project={leftProject} />
+        <ProjectPanel project={rightProject} />
+      </div>
+    </div>
+  );
+};
+
+export default ComparePage;
+

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-github-calendar": "^4.5.9",
     "react-onclickoutside": "^6.12.2",
     "react-twitter-embed": "^4.0.4",
+    "react-window": "^1.8.7",
     "seedrandom": "^3.0.5",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,7 +1342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.26.10":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.26.10":
   version: 7.28.3
   resolution: "@babel/runtime@npm:7.28.3"
   checksum: 10c0/b360f82c2c5114f2a062d4d143d7b4ec690094764853937110585a9497977aed66c102166d0e404766c274e02a50ffb8f6d77fef7251ecf3f607f0e03e6397bc
@@ -8250,6 +8250,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:>=3.1.1 <6":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: 10c0/fd22dbe9a978a2b4f30d6a491fc02fb90792432ad0dab840dc96c1734d2bd7c9cdeb6a26130ec60507eb43230559523615873168bcbe8fafab221c30b11d54c1
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -9693,6 +9700,19 @@ __metadata:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/5c5395a8421fd67752f4eae993b682175a3757e73c338f1d0ec56cf413206ae01c9197d39dfee41d0726f4740703a9a9fdce4ac66d1529dbecf0967f7953be39
+  languageName: node
+  linkType: hard
+
+"react-window@npm:^1.8.7":
+  version: 1.8.11
+  resolution: "react-window@npm:1.8.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    memoize-one: "npm:>=3.1.1 <6"
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/5ae8da1bc5c47d8f0a428b28a600256e2db511975573e52cb65a9b27ed1a0e5b9f7b3bee5a54fb0da93956d782c24010be434be451072f46ba5a89159d2b3944
   languageName: node
   linkType: hard
 
@@ -11424,6 +11444,7 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-onclickoutside: "npm:^6.12.2"
     react-twitter-embed: "npm:^4.0.4"
+    react-window: "npm:^1.8.7"
     seedrandom: "npm:^3.0.5"
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"


### PR DESCRIPTION
## Summary
- add comparison page for project gallery using query parameters
- virtualize project metrics with react-window
- install react-window dependency

## Testing
- `yarn lint` (fails: ESLint couldn't find an eslint.config file)
- `yarn test` (fails: e.g., mimikatz and beef test suites)


------
https://chatgpt.com/codex/tasks/task_e_68b14b2f0adc8328a38b8e77fb198dfa