### PR TITLE
Add ThemeLab component for settings presets

### DIFF
--- a/apps/settings/components/ThemeLab.tsx
+++ b/apps/settings/components/ThemeLab.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import { THEME_PRESETS } from '../constants/themes';
+import { THEME_KEY, getTheme, setTheme } from '../../../utils/theme';
+
+const ThemeLab = () => {
+  const [theme, setThemeState] = usePersistentState<string>(
+    THEME_KEY,
+    getTheme(),
+    (v): v is string => typeof v === 'string',
+  );
+  const [fontScale, setFontScale] = usePersistentState<number>(
+    'font-scale',
+    1,
+    (v): v is number => typeof v === 'number',
+  );
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    setTheme(theme);
+    setAnnouncement(`Theme set to ${theme}`);
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--font-multiplier',
+      fontScale.toString(),
+    );
+    setAnnouncement(`Font scale set to ${fontScale.toFixed(2)}`);
+  }, [fontScale]);
+
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <div className="flex space-x-2">
+        {THEME_PRESETS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setThemeState(t.id)}
+            className={`px-3 py-1 rounded ${
+              theme === t.id
+                ? 'bg-ub-orange text-white'
+                : 'bg-ub-cool-grey text-ubt-grey'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center space-x-2">
+        <label htmlFor="theme-lab-font-scale" className="text-ubt-grey">
+          Font Scale
+        </label>
+        <input
+          id="theme-lab-font-scale"
+          type="range"
+          min="0.75"
+          max="1.5"
+          step="0.05"
+          value={fontScale}
+          onChange={(e) => setFontScale(parseFloat(e.target.value))}
+          className="ubuntu-slider"
+        />
+      </div>
+      <div aria-live="polite" role="status" className="sr-only">
+        {announcement}
+      </div>
+    </div>
+  );
+};
+
+export default ThemeLab;

--- a/apps/settings/constants/themes.ts
+++ b/apps/settings/constants/themes.ts
@@ -1,0 +1,11 @@
+export interface ThemePreset {
+  id: string;
+  label: string;
+}
+
+export const THEME_PRESETS: ThemePreset[] = [
+  { id: 'default', label: 'Default' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'neon', label: 'Neon' },
+  { id: 'matrix', label: 'Matrix' },
+];

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -15,6 +15,7 @@ import {
   updateShortcut,
   Shortcut,
 } from '../../utils/shortcutRegistry';
+import ThemeLab from './components/ThemeLab';
 
 export default function Settings() {
   const {
@@ -131,6 +132,7 @@ export default function Settings() {
           backgroundPosition: 'center center',
         }}
       ></div>
+      <ThemeLab />
       <div className="flex justify-center my-4">
         <label className="mr-2 text-ubt-grey">Theme:</label>
         <select


### PR DESCRIPTION
## Summary
- add theme presets constant for settings
- introduce ThemeLab with preset theme buttons and font scale slider
- include aria-live announcements for accessibility

## Testing
- `npm test` (fails: BeEF app, calculator parser, mimikatz, VsCode app, word search generator, kismet, metasploit)
- `npm run lint` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68b14b3f19948328a21679211eecd725