### PR TITLE
feat: add background slideshow

### DIFF
--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function BackgroundSlideshow() {
+  const { setWallpaper } = useSettings();
+  const [available, setAvailable] = useState<string[]>([]);
+  const [selected, setSelected] = usePersistentState<string[]>(
+    'bg-slideshow-selected',
+    [],
+  );
+  const [intervalMs, setIntervalMs] = usePersistentState<number>(
+    'bg-slideshow-interval',
+    30000,
+  );
+  const [playing, setPlaying] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const indexRef = useRef(0);
+
+  useEffect(() => {
+    fetch('/api/wallpapers')
+      .then((res) => res.json())
+      .then((files: string[]) => setAvailable(files))
+      .catch(() => setAvailable([]));
+  }, []);
+
+  useEffect(() => {
+    if (!playing || selected.length === 0) {
+      if (timerRef.current) clearInterval(timerRef.current);
+      return;
+    }
+    const run = () => {
+      const file = selected[indexRef.current % selected.length];
+      const base = file.replace(/\.[^.]+$/, '');
+      setWallpaper(base);
+      indexRef.current = (indexRef.current + 1) % selected.length;
+    };
+    run();
+    timerRef.current = setInterval(run, intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [playing, intervalMs, selected, setWallpaper]);
+
+  const toggle = (file: string) => {
+    setSelected((prev) =>
+      prev.includes(file)
+        ? prev.filter((f) => f !== file)
+        : [...prev, file],
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-ubt-grey">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {available.map((file) => (
+          <label key={file} className="flex flex-col items-center cursor-pointer">
+            <img
+              src={`/images/wallpapers/${file}`}
+              alt={file}
+              className="w-24 h-16 object-cover mb-1 border border-ubt-cool-grey"
+            />
+            <input
+              type="checkbox"
+              checked={selected.includes(file)}
+              onChange={() => toggle(file)}
+            />
+          </label>
+        ))}
+      </div>
+      <div className="flex items-center space-x-2">
+        <label htmlFor="interval">Interval (s):</label>
+        <input
+          id="interval"
+          type="number"
+          min={5}
+          value={Math.round(intervalMs / 1000)}
+          onChange={(e) => setIntervalMs(Number(e.target.value) * 1000)}
+          className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        />
+      </div>
+      <button
+        onClick={() => setPlaying((p) => !p)}
+        disabled={selected.length === 0}
+        className="px-4 py-2 rounded bg-ub-cool-grey border border-ubt-cool-grey hover:bg-ubt-cool-grey disabled:opacity-50"
+      >
+        {playing ? 'Pause' : 'Start'}
+      </button>
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useSettings } from '../../hooks/useSettings';
+import BackgroundSlideshow from './components/BackgroundSlideshow';
 import {
   resetSettings,
   defaults,
@@ -170,6 +171,9 @@ export default function Settings() {
           }
           className="ubuntu-slider"
         />
+      </div>
+      <div className="flex justify-center my-4">
+        <BackgroundSlideshow />
       </div>
       <div className="flex justify-center my-4">
         <label className="mr-2 text-ubt-grey">Icon Size:</label>

--- a/pages/api/wallpapers.ts
+++ b/pages/api/wallpapers.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<string[]>) {
+  const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
+  try {
+    const files = fs
+      .readdirSync(dir)
+      .filter((file) => /\.(?:png|jpe?g|webp|gif)$/i.test(file));
+    res.status(200).json(files);
+  } catch {
+    res.status(200).json([]);
+  }
+}

--- a/public/images/wallpapers/wall-1.webp
+++ b/public/images/wallpapers/wall-1.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-1.webp

--- a/public/images/wallpapers/wall-2.webp
+++ b/public/images/wallpapers/wall-2.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-2.webp

--- a/public/images/wallpapers/wall-3.webp
+++ b/public/images/wallpapers/wall-3.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-3.webp

--- a/public/images/wallpapers/wall-4.webp
+++ b/public/images/wallpapers/wall-4.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-4.webp

--- a/public/images/wallpapers/wall-5.webp
+++ b/public/images/wallpapers/wall-5.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-5.webp

--- a/public/images/wallpapers/wall-6.webp
+++ b/public/images/wallpapers/wall-6.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-6.webp

--- a/public/images/wallpapers/wall-7.webp
+++ b/public/images/wallpapers/wall-7.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-7.webp

--- a/public/images/wallpapers/wall-8.webp
+++ b/public/images/wallpapers/wall-8.webp
@@ -1,0 +1,1 @@
+../../wallpapers/wall-8.webp


### PR DESCRIPTION
## Summary
- add background slideshow component with interval and pause controls
- expose wallpaper file list via API route
- display slideshow in Settings

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config)*
- `yarn test` *(fails: __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/wordSearch.test.ts, __tests__/kismet.test.tsx, __tests__/vscode.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b403ec08328a8fc3f6a174719ad