### PR TITLE
feat(resource-monitor): add performance vitals chart

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -9,7 +9,6 @@ import { displayTodoist } from './components/apps/todoist';
 import { displayWeather } from './components/apps/weather';
 import { displayClipboardManager } from './components/apps/ClipboardManager';
 import { displayFiglet } from './components/apps/figlet';
-import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
 
@@ -73,6 +72,8 @@ const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery')
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
+
+const ResourceMonitorApp = createDynamicApp('resource-monitor', 'Resource Monitor');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
@@ -154,6 +155,8 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayFileExplorer = createDisplay(FileExplorerApp);
 const displayRadare2 = createDisplay(Radare2App);
 const displayAboutAlex = createDisplay(AboutAlexApp);
+
+const displayResourceMonitor = createDisplay(ResourceMonitorApp);
 
 const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);

--- a/apps/resource-monitor/components/VitalsChart.tsx
+++ b/apps/resource-monitor/components/VitalsChart.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const MAX_POINTS = 60;
+
+type Metric = 'fps' | 'heap' | 'longtask' | 'paint';
+
+const COLORS: Record<Metric, string> = {
+  fps: '#00ffff',
+  heap: '#ffd700',
+  longtask: '#ff00ff',
+  paint: '#00ff00',
+};
+
+const LABELS: Record<Metric, string> = {
+  fps: 'FPS',
+  heap: 'Heap (MB)',
+  longtask: 'Long Tasks (ms)',
+  paint: 'Paints',
+};
+
+export default function VitalsChart() {
+  const [visible, setVisible] = usePersistentState<Record<Metric, boolean>>(
+    'resource-monitor:vitals',
+    { fps: true, heap: true, longtask: true, paint: true },
+  );
+
+  const visibleRef = useRef(visible);
+  useEffect(() => {
+    visibleRef.current = visible;
+  }, [visible]);
+
+  const dataRef = useRef<Record<Metric, number[]>>({
+    fps: [],
+    heap: [],
+    longtask: [],
+    paint: [],
+  });
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') return;
+
+    let frameCount = 0;
+    let longTask = 0;
+    let paints = 0;
+
+    const frameObs = new PerformanceObserver((list) => {
+      frameCount += list.getEntries().length;
+    });
+    try {
+      frameObs.observe({ type: 'frame', buffered: true } as any);
+    } catch {
+      /* unsupported */
+    }
+
+    const longObs = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTask += entry.duration;
+      }
+    });
+    try {
+      longObs.observe({ type: 'longtask', buffered: true });
+    } catch {
+      /* unsupported */
+    }
+
+    const paintObs = new PerformanceObserver((list) => {
+      paints += list.getEntries().length;
+    });
+    try {
+      paintObs.observe({ type: 'paint', buffered: true });
+    } catch {
+      /* unsupported */
+    }
+
+    const push = (k: Metric, v: number) => {
+      const arr = dataRef.current[k];
+      arr.push(v);
+      if (arr.length > MAX_POINTS) arr.shift();
+    };
+
+    const draw = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      const w = canvas.width;
+      const h = canvas.height;
+      ctx.clearRect(0, 0, w, h);
+      (Object.keys(dataRef.current) as Metric[]).forEach((metric, idx) => {
+        if (!visibleRef.current[metric]) return;
+        const values = dataRef.current[metric];
+        if (!values.length) return;
+        const max = Math.max(...values, 1);
+        ctx.strokeStyle = COLORS[metric];
+        ctx.beginPath();
+        values.forEach((v, i) => {
+          const x = (i / (MAX_POINTS - 1)) * w;
+          const y = h - (v / max) * h;
+          if (i === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        const latest = values[values.length - 1];
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '12px sans-serif';
+        ctx.fillText(`${LABELS[metric]}: ${latest.toFixed(1)}`, 4, 12 + idx * 14);
+      });
+    };
+
+    const sample = () => {
+      const perf: any = performance;
+      const heap = perf.memory ? perf.memory.usedJSHeapSize / 1048576 : 0;
+      push('fps', frameCount);
+      push('heap', heap);
+      push('longtask', longTask);
+      push('paint', paints);
+      frameCount = 0;
+      longTask = 0;
+      paints = 0;
+      draw();
+    };
+
+    const interval = setInterval(sample, 1000);
+
+    return () => {
+      clearInterval(interval);
+      frameObs.disconnect();
+      longObs.disconnect();
+      paintObs.disconnect();
+    };
+  }, []);
+
+  const toggle = (metric: Metric) => {
+    setVisible({ ...visibleRef.current, [metric]: !visibleRef.current[metric] });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 text-sm">
+        {(Object.keys(LABELS) as Metric[]).map((metric) => (
+          <label key={metric} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={visible[metric]}
+              onChange={() => toggle(metric)}
+            />
+            {LABELS[metric]}
+          </label>
+        ))}
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={600}
+        height={200}
+        role="img"
+        aria-label="Vitals chart"
+        className="bg-ub-dark-grey w-full h-48"
+      />
+    </div>
+  );
+}

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import React from 'react';
+import ResourceMonitor from '../../components/apps/resource-monitor';
+
+const ResourceMonitorPage: React.FC = () => <ResourceMonitor />;
+
+export default ResourceMonitorPage;

--- a/components/apps/resource-monitor.tsx
+++ b/components/apps/resource-monitor.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import React from 'react';
+import VitalsChart from '../../apps/resource-monitor/components/VitalsChart';
+
+const ResourceMonitor: React.FC = () => {
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white p-2">
+      <VitalsChart />
+    </div>
+  );
+};
+
+export default ResourceMonitor;


### PR DESCRIPTION
## Summary
- add VitalsChart component tracking FPS, heap, long tasks and paints
- persist chart visibility with usePersistentState
- register resource monitor as dynamic module

## Testing
- `npm test` *(fails: beef, mimikatz, vscode, wordSearch, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b40a5e88328beb62473f1b9b80a