### PR TITLE
feat: add network fetch monitoring

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import {
+  onFetchProxy,
+  getActiveFetches,
+  FetchEntry,
+} from '../../../lib/fetchProxy';
+
+const HISTORY_KEY = 'network-insights-history';
+
+const formatBytes = (bytes?: number) =>
+  typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
+
+export default function NetworkInsights() {
+  const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
+  const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+
+  useEffect(() => {
+    const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
+    const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
+      setActive(getActiveFetches());
+      setHistory((h) => [...h, e.detail]);
+    });
+    return () => {
+      unsubStart();
+      unsubEnd();
+    };
+  }, [setHistory]);
+
+  return (
+    <div className="p-2 text-xs text-white">
+      <h2 className="font-bold mb-1">Active Fetches</h2>
+      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded">
+        {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
+        {active.map((f) => (
+          <li key={f.id} className="p-1">
+            <div className="truncate">
+              {f.method} {f.url}
+            </div>
+            <div className="text-gray-400">
+              {((typeof performance !== 'undefined' ? performance.now() : Date.now()) - f.startTime).toFixed(0)}ms elapsed
+            </div>
+          </li>
+        ))}
+      </ul>
+      <h2 className="font-bold mb-1">History</h2>
+      <ul className="divide-y divide-gray-700 border border-gray-700 rounded">
+        {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
+        {history.map((f) => (
+          <li key={f.id} className="p-1">
+            <div className="truncate">
+              {f.method} {f.url}
+              {f.fromServiceWorkerCache && (
+                <span className="ml-2 text-green-400">(SW cache)</span>
+              )}
+            </div>
+            <div className="text-gray-400">
+              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import React from 'react';
+import NetworkInsights from './components/NetworkInsights';
+
+export default function ResourceMonitorApp() {
+  return (
+    <div className="h-full w-full bg-ub-cool-grey overflow-auto">
+      <NetworkInsights />
+    </div>
+  );
+}
+

--- a/lib/fetchProxy.ts
+++ b/lib/fetchProxy.ts
@@ -1,0 +1,131 @@
+export interface FetchLog {
+  id: number;
+  url: string;
+  method: string;
+  startTime: number;
+  endTime?: number;
+  duration?: number;
+  status?: number;
+  requestSize?: number;
+  responseSize?: number;
+  fromServiceWorkerCache?: boolean;
+  error?: unknown;
+}
+
+export type FetchEntry = FetchLog;
+
+const active = new Map<number, FetchLog>();
+let counter = 0;
+
+const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+function bodySize(body: BodyInit | null | undefined): number | undefined {
+  if (body == null) return 0;
+  if (typeof body === 'string') return new TextEncoder().encode(body).length;
+  if (body instanceof Blob) return body.size;
+  if (body instanceof ArrayBuffer) return body.byteLength;
+  if (ArrayBuffer.isView(body)) return body.byteLength;
+  return undefined;
+}
+
+export function getActiveFetches(): FetchLog[] {
+  return Array.from(active.values());
+}
+
+export function onFetchProxy(
+  type: 'start' | 'end',
+  handler: (e: CustomEvent<FetchLog>) => void,
+) {
+  const event = `fetchproxy-${type}`;
+  if (typeof window !== 'undefined') {
+    window.addEventListener(event, handler as EventListener);
+    return () => window.removeEventListener(event, handler as EventListener);
+  }
+  return () => {};
+}
+
+function notify(type: 'start' | 'end', record: FetchLog) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(`fetchproxy-${type}`, { detail: record }));
+  }
+}
+
+if (typeof globalThis.fetch === 'function' && !(globalThis as any).__fetchProxyInstalled) {
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  (globalThis as any).__fetchProxyInstalled = true;
+
+  globalThis.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const id = ++counter;
+    const method =
+      init?.method ||
+      (typeof Request !== 'undefined' && input instanceof Request && input.method) ||
+      'GET';
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : (input as Request).url;
+    const record: FetchLog = {
+      id,
+      url,
+      method,
+      startTime: now(),
+      requestSize: init?.body ? bodySize(init.body) : undefined,
+    };
+    active.set(id, record);
+    notify('start', record);
+
+    try {
+      const response = await originalFetch(input as any, init);
+      const end = now();
+      record.endTime = end;
+      record.duration = end - record.startTime;
+      record.status = response.status;
+      const swHeader =
+        response.headers.get('x-sw-cache') ||
+        response.headers.get('x-service-worker-cache') ||
+        response.headers.get('sw-cache');
+      record.fromServiceWorkerCache = !!swHeader && /hit/i.test(swHeader);
+
+      const finalize = (size?: number) => {
+        if (typeof size === 'number') record.responseSize = size;
+        active.delete(id);
+        notify('end', record);
+      };
+
+      const contentLength = response.headers.get('content-length');
+      if (contentLength) {
+        finalize(Number(contentLength));
+      } else if (
+        typeof (response as any).clone === 'function' &&
+        typeof (response as any).arrayBuffer === 'function'
+      ) {
+        try {
+          response
+            .clone()
+            .arrayBuffer()
+            .then((buf) => finalize(buf.byteLength))
+            .catch(() => finalize());
+        } catch {
+          finalize();
+        }
+      } else {
+        finalize();
+      }
+
+      return response;
+    } catch (err) {
+      const end = now();
+      record.endTime = end;
+      record.duration = end - record.startTime;
+      record.error = err;
+      active.delete(id);
+      notify('end', record);
+      throw err;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- wrap global fetch to track timings, sizes, and cache hits
- show active requests and history in resource monitor with persistent storage

## Testing
- `npm test` *(fails: BeEF app tests cannot locate hook entries)*


------
https://chatgpt.com/codex/tasks/task_e_68b14b4275e08328af68dc05a0732ed2