### PR TITLE
feat(trash): add undo stack with restore all

### DIFF
--- a/apps/trash/components/HistoryList.tsx
+++ b/apps/trash/components/HistoryList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { TrashItem } from '../state';
+
+interface Props {
+  history: TrashItem[];
+  onRestore: (index: number) => void;
+  onRestoreAll: () => void;
+}
+
+export default function HistoryList({ history, onRestore, onRestoreAll }: Props) {
+  if (history.length === 0) return null;
+
+  return (
+    <div className="border-t border-black border-opacity-50 p-2 text-xs">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-bold">Recently Deleted</span>
+        <button
+          onClick={onRestoreAll}
+          className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+        >
+          Restore All
+        </button>
+      </div>
+      <ul className="max-h-32 overflow-auto">
+        {history.map((item, idx) => (
+          <li key={item.closedAt} className="flex justify-between items-center py-1">
+            <span className="truncate mr-2" title={item.title}>
+              {item.title}
+            </span>
+            <button
+              onClick={() => onRestore(idx)}
+              className="text-ub-orange hover:underline"
+            >
+              Restore
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -1,0 +1,66 @@
+import { useEffect, useCallback } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+export interface TrashItem {
+  id: string;
+  title: string;
+  icon?: string;
+  image?: string;
+  closedAt: number;
+}
+
+const ITEMS_KEY = 'window-trash';
+const HISTORY_KEY = 'window-trash-history';
+const HISTORY_LIMIT = 20;
+
+export default function useTrashState() {
+  const [items, setItems] = usePersistentState<TrashItem[]>(ITEMS_KEY, []);
+  const [history, setHistory] = usePersistentState<TrashItem[]>(HISTORY_KEY, []);
+
+  useEffect(() => {
+    const purgeDays = parseInt(
+      window.localStorage.getItem('trash-purge-days') || '30',
+      10,
+    );
+    const ms = purgeDays * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    setItems(prev => prev.filter(item => now - item.closedAt <= ms));
+  }, [setItems]);
+
+  const pushHistory = useCallback(
+    (item: TrashItem | TrashItem[]) => {
+      setHistory(prev => {
+        const arr = Array.isArray(item) ? item : [item];
+        const next = [...arr, ...prev];
+        return next.slice(0, HISTORY_LIMIT);
+      });
+    },
+    [setHistory],
+  );
+
+  const restoreFromHistory = useCallback(
+    (index: number) => {
+      setHistory(prev => {
+        const next = [...prev];
+        const [restored] = next.splice(index, 1);
+        if (restored) {
+          setItems(items => [...items, restored]);
+        }
+        return next;
+      });
+    },
+    [setHistory, setItems],
+  );
+
+  const restoreAllFromHistory = useCallback(() => {
+    setHistory(prev => {
+      if (prev.length) {
+        setItems(items => [...items, ...prev]);
+      }
+      return [];
+    });
+  }, [setHistory, setItems]);
+
+  return { items, setItems, history, pushHistory, restoreFromHistory, restoreAllFromHistory };
+}
+


### PR DESCRIPTION
## Summary
- maintain ring-buffered trash history using usePersistentState
- show recently deleted items with restore and restore all actions
- wire trash UI to persistent state and undo history

## Testing
- `npm test` *(fails: Unable to find an element with the text: 1, The global config is readonly, etc.)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b43229c8328848ceb2995290118