### PR TITLE
feat(trash): add secure purge animation

### DIFF
--- a/apps/trash/components/SecurePurge.tsx
+++ b/apps/trash/components/SecurePurge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Props {
+  onComplete: () => void;
+}
+
+const passes = [
+  'Pass 1/3: Overwriting with zeros…',
+  'Pass 2/3: Overwriting with ones…',
+  'Pass 3/3: Overwriting with random data…',
+];
+
+export default function SecurePurge({ onComplete }: Props) {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    if (step < passes.length) {
+      const t = setTimeout(() => setStep(step + 1), 700);
+      return () => clearTimeout(t);
+    }
+    const done = setTimeout(onComplete, 400);
+    return () => clearTimeout(done);
+  }, [step, onComplete]);
+
+  const percent = Math.min(step / passes.length, 1) * 100;
+
+  return (
+    <div className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black bg-opacity-80 text-white">
+      <p className="mb-4">{step < passes.length ? passes[step] : 'Secure purge complete.'}</p>
+      <div className="w-64 h-4 bg-gray-700 rounded overflow-hidden">
+        <div
+          className="h-full bg-ub-orange transition-all duration-500"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="mt-4 text-sm text-center px-4">
+        Secure delete overwrites files multiple times to help prevent recovery.
+      </p>
+    </div>
+  );
+}
+

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import SecurePurge from './components/SecurePurge';
 
 interface TrashItem {
   id: string;
@@ -13,6 +14,7 @@ interface TrashItem {
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const [items, setItems] = useState<TrashItem[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
+  const [secureIndex, setSecureIndex] = useState<number | null>(null);
 
   useEffect(() => {
     const purgeDays = parseInt(localStorage.getItem('trash-purge-days') || '30', 10);
@@ -52,6 +54,21 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     persist(next);
     setSelected(null);
   }, [items, selected]);
+
+  const secureRemove = useCallback(() => {
+    if (selected === null) return;
+    const item = items[selected];
+    if (!window.confirm(`Securely delete ${item.title}?`)) return;
+    setSecureIndex(selected);
+  }, [items, selected]);
+
+  const handleSecureComplete = () => {
+    if (secureIndex === null) return;
+    const next = items.filter((_, i) => i !== secureIndex);
+    persist(next);
+    setSelected(null);
+    setSecureIndex(null);
+  };
 
   const restoreAll = () => {
     if (items.length === 0) return;
@@ -103,20 +120,27 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           >
             Restore All
           </button>
-          <button
-            onClick={remove}
-            disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Delete
-          </button>
-          <button
-            onClick={empty}
-            disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Empty
-          </button>
+            <button
+              onClick={remove}
+              disabled={selected === null}
+              className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            >
+              Delete
+            </button>
+            <button
+              onClick={secureRemove}
+              disabled={selected === null}
+              className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            >
+              Secure Delete
+            </button>
+            <button
+              onClick={empty}
+              disabled={items.length === 0}
+              className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            >
+              Empty
+            </button>
         </div>
       </div>
       <div className="flex flex-wrap content-start p-2 overflow-auto">
@@ -139,6 +163,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           </div>
         ))}
       </div>
+      {secureIndex !== null && <SecurePurge onComplete={handleSecureComplete} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add SecurePurge component with multi-pass overwrite animation and educational copy
- wire up secure delete action in Trash app to trigger the animation

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, wordSearch.test.ts, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b4378b88328963b81305514ae2f