### PR TITLE
Add attachment uploads with size checks and previews

### DIFF
--- a/apps/contact/components/AttachmentCarousel.tsx
+++ b/apps/contact/components/AttachmentCarousel.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+
+interface AttachmentCarouselProps {
+  attachments: File[];
+  onRemove: (index: number) => void;
+}
+
+const AttachmentCarousel: React.FC<AttachmentCarouselProps> = ({
+  attachments,
+  onRemove,
+}) => {
+  const [index, setIndex] = useState(0);
+  const [urls, setUrls] = useState<string[]>([]);
+
+  useEffect(() => {
+    const newUrls = attachments.map((file) => URL.createObjectURL(file));
+    setUrls(newUrls);
+    return () => {
+      newUrls.forEach((u) => URL.revokeObjectURL(u));
+    };
+  }, [attachments]);
+
+  useEffect(() => {
+    if (index >= attachments.length) {
+      setIndex(attachments.length - 1);
+    }
+  }, [attachments, index]);
+
+  if (!attachments.length) return null;
+
+  const file = attachments[index];
+  const url = urls[index];
+  const isImage = file.type.startsWith('image/');
+
+  const prev = () => setIndex((index - 1 + attachments.length) % attachments.length);
+  const next = () => setIndex((index + 1) % attachments.length);
+
+  return (
+    <div className="mt-4">
+      <div className="relative">
+        {isImage ? (
+          <img src={url} alt={file.name} className="max-h-48 object-contain" />
+        ) : (
+          <div className="p-4 bg-gray-800 rounded">{file.name}</div>
+        )}
+        <button
+          type="button"
+          onClick={() => onRemove(index)}
+          className="absolute top-1 right-1 bg-red-600 text-white px-2 py-1 rounded"
+        >
+          Remove
+        </button>
+      </div>
+      {attachments.length > 1 && (
+        <div className="flex items-center justify-between mt-2">
+          <button
+            type="button"
+            onClick={prev}
+            className="px-2 py-1 bg-gray-700 rounded"
+          >
+            Prev
+          </button>
+          <span className="text-sm">
+            {index + 1} / {attachments.length}
+          </span>
+          <button
+            type="button"
+            onClick={next}
+            className="px-2 py-1 bg-gray-700 rounded"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AttachmentCarousel;

--- a/apps/contact/components/AttachmentUploader.tsx
+++ b/apps/contact/components/AttachmentUploader.tsx
@@ -1,0 +1,64 @@
+import React, { useRef } from 'react';
+
+export const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024; // 5MB per file
+export const MAX_TOTAL_ATTACHMENT_SIZE = 20 * 1024 * 1024; // 20MB total
+
+interface AttachmentUploaderProps {
+  attachments: File[];
+  setAttachments: (files: File[]) => void;
+  onError?: (message: string) => void;
+}
+
+const AttachmentUploader: React.FC<AttachmentUploaderProps> = ({
+  attachments,
+  setAttachments,
+  onError,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    let totalSize = attachments.reduce((sum, f) => sum + f.size, 0);
+    const valid: File[] = [];
+
+    for (const file of Array.from(files)) {
+      if (file.size > MAX_ATTACHMENT_SIZE) {
+        onError?.(`Attachment '${file.name}' exceeds the ${
+          MAX_ATTACHMENT_SIZE / (1024 * 1024)
+        }MB limit.`);
+        continue;
+      }
+      if (totalSize + file.size > MAX_TOTAL_ATTACHMENT_SIZE) {
+        onError?.('Total attachment size exceeds limit.');
+        break;
+      }
+      valid.push(file);
+      totalSize += file.size;
+    }
+
+    if (valid.length) {
+      setAttachments([...attachments, ...valid]);
+    }
+
+    // reset input so same file can be reselected
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="mt-2">
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        onChange={handleChange}
+        className="text-sm"
+      />
+    </div>
+  );
+};
+
+export default AttachmentUploader;


### PR DESCRIPTION
## Summary
- add AttachmentUploader with client-side size limits
- render selected files in AttachmentCarousel with preview and remove options
- integrate attachments into contact form, delaying upload until message send

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/contact/components components/apps/contact/index.tsx && echo 'lint success'`
- `npm test __tests__/contact.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b14b4575d88328946eab955701e0fa