### PR TITLE
feat(contact): persist drafts and queue send

### DIFF
--- a/apps/contact/state.ts
+++ b/apps/contact/state.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import { sendEmail } from './utils/sendEmail';
+
+interface Draft {
+  name: string;
+  email: string;
+  message: string;
+}
+
+type Status = 'idle' | 'queued' | 'sending' | 'sent' | 'error';
+
+export const useContactState = () => {
+  const [draft, setDraft, resetDraft] = usePersistentState<Draft>(
+    'contact-draft',
+    { name: '', email: '', message: '' },
+  );
+  const [status, setStatus] = useState<Status>('idle');
+  const [queued, setQueued] = useState(false);
+
+  const attemptSend = useCallback(async () => {
+    try {
+      setStatus('sending');
+      await sendEmail(draft);
+      setStatus('sent');
+      resetDraft();
+    } catch {
+      setStatus('error');
+    }
+  }, [draft, resetDraft]);
+
+  const send = useCallback(() => {
+    if (!navigator.onLine) {
+      setStatus('queued');
+      setQueued(true);
+      return;
+    }
+    void attemptSend();
+  }, [attemptSend]);
+
+  useEffect(() => {
+    if (!queued) return;
+    const handleOnline = () => {
+      setQueued(false);
+      void attemptSend();
+    };
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, [queued, attemptSend]);
+
+  return {
+    draft,
+    setDraft,
+    send,
+    status,
+    reset: resetDraft,
+  } as const;
+};
+
+export type ContactState = ReturnType<typeof useContactState>;
+

--- a/apps/contact/utils/sendEmail.ts
+++ b/apps/contact/utils/sendEmail.ts
@@ -1,0 +1,28 @@
+import emailjs from '@emailjs/browser';
+
+export interface EmailData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+let initialized = false;
+
+export const sendEmail = async ({ name, email, message }: EmailData) => {
+  const serviceId = process.env.NEXT_PUBLIC_SERVICE_ID || '';
+  const templateId = process.env.NEXT_PUBLIC_TEMPLATE_ID || '';
+  const userId = process.env.NEXT_PUBLIC_USER_ID || '';
+
+  if (!initialized && userId) {
+    try {
+      emailjs.init(userId);
+    } catch {
+      /* ignore */
+    }
+    initialized = true;
+  }
+
+  return emailjs.send(serviceId, templateId, { name, email, message });
+};
+
+export default sendEmail;


### PR DESCRIPTION
## Summary
- persist contact draft in localStorage via `usePersistentState`
- queue email send when offline and retry once network returns
- wrap EmailJS call in dedicated helper

## Testing
- `yarn test` *(fails: BeEF app, calculator parser, VsCode, word search, kismet, mimikatz)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b44e6088328bd9338846ba1da3b