### PR TITLE
feat(chrome): add readability reading mode

### DIFF
--- a/apps/chrome/components/ReadingMode.tsx
+++ b/apps/chrome/components/ReadingMode.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Readability } from '@mozilla/readability';
+import DOMPurify from 'dompurify';
+import { createStore, set as idbSet } from 'idb-keyval';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const snapshotStore = createStore('reading-mode', 'snapshots');
+
+type Mode = 'live' | 'snapshot';
+
+const isMode = (v: unknown): v is Mode => v === 'live' || v === 'snapshot';
+
+const ReadingMode = () => {
+  const [mode, setMode] = usePersistentState<Mode>(
+    'reading-mode-mode',
+    'live',
+    isMode,
+  );
+  const [snapshot, setSnapshot] = usePersistentState<string>(
+    'reading-mode-snapshot',
+    '',
+    (v): v is string => typeof v === 'string',
+  );
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const doc = document.cloneNode(true) as Document;
+    const article = new Readability(doc).parse();
+    const cleaned = article ? DOMPurify.sanitize(article.content) : '';
+    setContent(cleaned);
+  }, []);
+
+  const saveSnapshot = useCallback(async () => {
+    await idbSet('last', content, snapshotStore);
+    setSnapshot(content);
+    setMode('snapshot');
+  }, [content, setSnapshot, setMode]);
+
+  const displayed = mode === 'snapshot' ? snapshot : content;
+
+  return (
+    <div className="p-4 h-full overflow-auto">
+      <div className="mb-4 space-x-2">
+        <button
+          className="border px-2 py-1 rounded"
+          onClick={() => setMode(mode === 'live' ? 'snapshot' : 'live')}
+        >
+          {mode === 'live' ? 'Show Saved' : 'Show Live'}
+        </button>
+        <button
+          className="border px-2 py-1 rounded"
+          onClick={saveSnapshot}
+          disabled={!content}
+        >
+          Save snapshot
+        </button>
+      </div>
+      <article dangerouslySetInnerHTML={{ __html: displayed }} />
+    </div>
+  );
+};
+
+export default ReadingMode;
+


### PR DESCRIPTION
## Summary
- add reading mode component integrating Mozilla Readability
- persist reading mode state and snapshots
- allow saving cleaned HTML to IndexedDB

## Testing
- `yarn test` *(fails: beef.test.tsx, mimikatz.test.ts, kismet.test.tsx, metasploit.test.tsx, vscode.test.tsx, wordSearch.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b466c208328bf5fc318871325df