### PR TITLE
feat(calculator): add mode switcher and parser

### DIFF
--- a/apps/calculator/components/ModeSwitcher.tsx
+++ b/apps/calculator/components/ModeSwitcher.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+type Mode = 'basic' | 'scientific' | 'programmer';
+
+const MODES: Mode[] = ['basic', 'scientific', 'programmer'];
+
+interface Props {
+  onChange?: (mode: Mode) => void;
+}
+
+export default function ModeSwitcher({ onChange }: Props) {
+  const [mode, setMode] = usePersistentState<Mode>(
+    'calc-mode',
+    () => 'basic',
+    (v): v is Mode => typeof v === 'string' && MODES.includes(v as Mode),
+  );
+
+  useEffect(() => {
+    onChange?.(mode);
+    // Notify legacy scripts about mode change
+    document.dispatchEvent(new CustomEvent('mode-change', { detail: mode }));
+  }, [mode, onChange]);
+
+  return (
+    <div className="mode-switcher">
+      {MODES.map((m) => (
+        <button
+          key={m}
+          aria-pressed={mode === m}
+          onClick={() => setMode(m)}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export type { Mode };

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -1,8 +1,20 @@
 'use client';
 import { useEffect } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import ModeSwitcher from './components/ModeSwitcher';
 import './styles.css';
 
 export default function Calculator() {
+  const [tape, setTape] = usePersistentState<{expr: string; result: string}[]>('calc-tape', () => [], (v): v is {expr: string; result: string}[] => Array.isArray(v) && v.every(item => typeof item?.expr === 'string' && typeof item?.result === 'string'));
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      setTape(prev => [e.detail, ...prev].slice(0,10));
+    };
+    document.addEventListener('tape-add', handler);
+    return () => document.removeEventListener('tape-add', handler);
+  }, [setTape]);
+
   useEffect(() => {
     const load = async () => {
       if (typeof window !== 'undefined' && !(window as any).math) {
@@ -38,7 +50,8 @@ export default function Calculator() {
 
   return (
     <div className="calculator">
-      <input id="display" className="display" />
+      <ModeSwitcher />
+            <input id="display" className="display" />
       <button id="toggle-precise" className="toggle" aria-pressed="false">Precise Mode: Off</button>
       <button id="toggle-scientific" className="toggle" aria-pressed="false">Scientific</button>
       <button id="toggle-programmer" className="toggle" aria-pressed="false">Programmer</button>

--- a/apps/calculator/main.js
+++ b/apps/calculator/main.js
@@ -62,6 +62,14 @@ function setProgrammerMode(on) {
 
 progToggle?.addEventListener('click', () => setProgrammerMode(!programmerMode));
 
+document.addEventListener('mode-change', (e) => {
+  const mode = e.detail;
+  setProgrammerMode(mode === 'programmer');
+  scientificMode = mode === 'scientific';
+  scientific?.classList.toggle('hidden', !scientificMode);
+  sciToggle?.setAttribute('aria-pressed', scientificMode.toString());
+});
+
 historyToggle?.addEventListener('click', () => {
   const isHidden = historyEl.classList.toggle('hidden');
   historyToggle?.setAttribute('aria-pressed', (!isHidden).toString());
@@ -513,6 +521,7 @@ function addHistory(expr, result) {
   history = history.slice(0, 10);
   saveHistory();
   renderHistory();
+  document.dispatchEvent(new CustomEvent('tape-add', { detail: { expr, result } }));
 }
 
 function loadHistory() {

--- a/apps/calculator/utils/parser.ts
+++ b/apps/calculator/utils/parser.ts
@@ -1,0 +1,41 @@
+import { create, all } from 'mathjs';
+
+const math = create(all);
+
+export interface EvalOptions {
+  /** Base for numeric literals and result formatting */
+  base?: number;
+}
+
+function convertBase(val: string, from: number, to: number) {
+  const num = parseInt(val, from);
+  if (Number.isNaN(num)) return '0';
+  return num.toString(to);
+}
+
+function preprocess(expr: string, base: number) {
+  // insert space before units so mathjs can parse them
+  let normalized = expr.replace(/([0-9A-F.]+)([A-Za-z]+)/g, '$1 $2');
+  // when using a base other than 10, convert all integer literals
+  if (base !== 10) {
+    normalized = normalized.replace(/\b[0-9A-F]+\b/gi, (m) => parseInt(m, base).toString());
+  }
+  return normalized;
+}
+
+export function evaluate(expression: string, opts: EvalOptions = {}) {
+  const base = opts.base ?? 10;
+  const prepared = preprocess(expression, base);
+  const result = math.evaluate(prepared);
+  if (math.isUnit(result)) {
+    return result.toString();
+  }
+  // stringify numbers or BigNumbers
+  const value = math.isBigNumber(result) ? result.toString() : String(result);
+  if (base !== 10) {
+    return convertBase(value, 10, base).toUpperCase();
+  }
+  return value;
+}
+
+export { convertBase };


### PR DESCRIPTION
## Summary
- add persistent mode switcher component
- implement parser util with base and unit conversion
- wire up history tape persistence and dispatch mode changes

## Testing
- `npm test` *(fails: BeEF app, calculator parser, mimikatz API, and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b486e0883289c607d8fc1414326