### PR TITLE
feat(terminal): add script runner and script management UI

### DIFF
--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import runScript, { ScriptController } from '../utils/scriptRunner';
+
+interface ScriptsProps {
+  runCommand: (cmd: string) => Promise<any> | any;
+}
+
+const Scripts = ({ runCommand }: ScriptsProps) => {
+  const [scripts, setScripts] = usePersistentState<Record<string, string>>(
+    'terminal-scripts',
+    {},
+  );
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+  const [controller, setController] = useState<ScriptController | null>(null);
+
+  const save = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setScripts({ ...scripts, [trimmed]: code });
+    setName('');
+    setCode('');
+  };
+
+  const run = (n: string) => {
+    const content = scripts[n];
+    if (!content) return;
+    const ctrl = runScript(content, runCommand);
+    setController(ctrl);
+    ctrl.finished.finally(() => setController(null));
+  };
+
+  const cancel = () => controller?.cancel();
+
+  const remove = (n: string) => {
+    const updated = { ...scripts };
+    delete updated[n];
+    setScripts(updated);
+  };
+
+  return (
+    <div className="p-2 space-y-2 text-sm">
+      <div className="space-y-1">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="script name"
+          className="w-full border p-1"
+        />
+        <textarea
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder={"echo hello\nsleep 1000\necho done"}
+          className="w-full border p-1 h-32"
+        />
+        <button
+          onClick={save}
+          className="bg-blue-500 text-white px-2 py-1 rounded"
+        >
+          Save
+        </button>
+        {controller && (
+          <button
+            onClick={cancel}
+            className="ml-2 bg-red-500 text-white px-2 py-1 rounded"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+      <ul className="space-y-1">
+        {Object.keys(scripts).map((n) => (
+          <li key={n} className="flex items-center gap-2">
+            <span className="flex-1 truncate">{n}</span>
+            <button
+              onClick={() => run(n)}
+              className="bg-green-600 text-white px-2 py-0.5 rounded"
+            >
+              Run
+            </button>
+            <button
+              onClick={() => remove(n)}
+              className="bg-gray-600 text-white px-2 py-0.5 rounded"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Scripts;

--- a/apps/terminal/utils/scriptRunner.ts
+++ b/apps/terminal/utils/scriptRunner.ts
@@ -1,0 +1,78 @@
+export interface CommandStep {
+  type: 'command';
+  command: string;
+}
+
+export interface SleepStep {
+  type: 'sleep';
+  ms: number;
+}
+
+export type ScriptStep = CommandStep | SleepStep;
+
+/**
+ * Parse simple DSL scripts.
+ * Supports lines of commands and `sleep <ms>` to pause.
+ * Lines beginning with `#` are treated as comments.
+ */
+export function parseScript(source: string): ScriptStep[] {
+  return source
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'))
+    .map((line) => {
+      const sleepMatch = line.match(/^sleep\s+(\d+)$/i);
+      if (sleepMatch) {
+        return { type: 'sleep', ms: parseInt(sleepMatch[1], 10) } as SleepStep;
+      }
+      return { type: 'command', command: line } as CommandStep;
+    });
+}
+
+export interface ScriptController {
+  cancel: () => void;
+  finished: Promise<void>;
+}
+
+/**
+ * Run a script using the provided command executor.
+ * Returns a controller that can cancel execution.
+ */
+export function runScript(
+  source: string,
+  exec: (command: string) => Promise<any> | any,
+): ScriptController {
+  const steps = parseScript(source);
+  let aborted = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let rejectFn: ((reason?: any) => void) | undefined;
+
+  const finished = new Promise<void>(async (resolve, reject) => {
+    rejectFn = reject;
+    try {
+      for (const step of steps) {
+        if (aborted) break;
+        if (step.type === 'command') {
+          await exec(step.command);
+        } else {
+          await new Promise<void>((res) => {
+            timeout = setTimeout(res, step.ms);
+          });
+        }
+      }
+      if (!aborted) resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+
+  const cancel = () => {
+    aborted = true;
+    if (timeout) clearTimeout(timeout);
+    rejectFn?.(new Error('canceled'));
+  };
+
+  return { cancel, finished };
+}
+
+export default runScript;


### PR DESCRIPTION
## Summary
- add tiny DSL parser and cancelable execution for terminal scripts
- persist scripts using `usePersistentState`
- new `Scripts` UI to save, run, and delete scripts

## Testing
- `npm test` (fails: mimikatz.api, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b14b4c2a1c8328a59060fe2d2c1553