### PR TITLE
feat(vscode): add sandboxed web preview

### DIFF
--- a/apps/vscode/components/WebPreview.tsx
+++ b/apps/vscode/components/WebPreview.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface Props {
+  code: string;
+  onConsole: (msg: string) => void;
+}
+
+export default function WebPreview({ code, onConsole }: Props) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      const { type, message } = event.data || {};
+      if (typeof type === "string") {
+        onConsole(`${type}: ${message}`);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [onConsole]);
+
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const doc =
+      `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><script>\n` +
+      `const send=(type,message)=>parent.postMessage({type,message},'*');\n` +
+      `[ 'log','warn','info','error'].forEach((key)=>{\n` +
+      ` const original=console[key];\n` +
+      ` console[key]=(...args)=>{\n` +
+      `   send(key,args.map(a=>String(a)).join(' '));\n` +
+      `   original.apply(console,args);\n` +
+      ` };\n` +
+      `});\n` +
+      `window.addEventListener('error',e=>send('error',e.message));\n` +
+      `</script>` +
+      code +
+      `</body></html>`;
+    iframeRef.current.srcdoc = doc;
+  }, [code]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      sandbox="allow-scripts"
+      className="flex-1 border-l"
+    />
+  );
+}

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,15 +1,16 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from "react";
+import WebPreview from "./components/WebPreview";
 
-const PROJECT = 'demo';
+const PROJECT = "demo";
 
 async function saveProject(code: string) {
   try {
     const root = await navigator.storage.getDirectory();
-    const dir = await root.getDirectoryHandle('vscode', { create: true });
+    const dir = await root.getDirectoryHandle("vscode", { create: true });
     const proj = await dir.getDirectoryHandle(PROJECT, { create: true });
-    const file = await proj.getFileHandle('settings.json', { create: true });
+    const file = await proj.getFileHandle("settings.json", { create: true });
     const writable = await file.createWritable();
     await writable.write(JSON.stringify({ code }));
     await writable.close();
@@ -19,9 +20,9 @@ async function saveProject(code: string) {
 async function loadProject(): Promise<string | null> {
   try {
     const root = await navigator.storage.getDirectory();
-    const dir = await root.getDirectoryHandle('vscode');
+    const dir = await root.getDirectoryHandle("vscode");
     const proj = await dir.getDirectoryHandle(PROJECT);
-    const file = await proj.getFileHandle('settings.json');
+    const file = await proj.getFileHandle("settings.json");
     const data = await file.getFile();
     const text = await data.text();
     return (JSON.parse(text) as { code: string }).code;
@@ -31,39 +32,35 @@ async function loadProject(): Promise<string | null> {
 }
 
 export default function VsCode() {
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState("");
   const [lint, setLint] = useState<{ line: number; message: string }[]>([]);
   const [consoleOutput, setConsoleOutput] = useState<string[]>([]);
+  const [preview, setPreview] = useState("");
   const lintWorker = useRef<Worker>();
-  const runWorker = useRef<Worker>();
 
   useEffect(() => {
     loadProject().then(async (saved) => {
       if (saved) setCode(saved);
       else {
-        const res = await fetch('/data/vscode-example/main.js');
+        const res = await fetch("/data/vscode-example/main.js");
         const sample = await res.text();
         setCode(sample);
         saveProject(sample);
       }
     });
 
-    lintWorker.current = new Worker(new URL('../../workers/webLints.worker.ts', import.meta.url), { type: 'module' });
-    runWorker.current = new Worker(new URL('../../workers/jsRunner.ts', import.meta.url), { type: 'module' });
+    lintWorker.current = new Worker(
+      new URL("../../workers/webLints.worker.ts", import.meta.url),
+      { type: "module" },
+    );
 
     lintWorker.current.onmessage = (e) => {
-      if (e.data.type === 'format') setCode(e.data.formatted);
-      if (e.data.type === 'lint') setLint(e.data.messages);
-    };
-
-    runWorker.current.onmessage = (e) => {
-      const { type, message } = e.data;
-      setConsoleOutput((prev) => [...prev, `${type}: ${message}`]);
+      if (e.data.type === "format") setCode(e.data.formatted);
+      if (e.data.type === "lint") setLint(e.data.messages);
     };
 
     return () => {
       lintWorker.current?.terminate();
-      runWorker.current?.terminate();
     };
   }, []);
 
@@ -73,11 +70,15 @@ export default function VsCode() {
     saveProject(val);
   };
 
-  const format = () => lintWorker.current?.postMessage({ type: 'format', code });
-  const lintCodeFn = () => lintWorker.current?.postMessage({ type: 'lint', code });
+  const format = () =>
+    lintWorker.current?.postMessage({ type: "format", code });
+  const lintCodeFn = () =>
+    lintWorker.current?.postMessage({ type: "lint", code });
   const run = () => {
     setConsoleOutput([]);
-    runWorker.current?.postMessage(code);
+    const hasHtml = /<\/?(html|body|script)/i.test(code);
+    const html = hasHtml ? code : `<script>${code}</script>`;
+    setPreview(html);
   };
 
   return (
@@ -90,10 +91,20 @@ export default function VsCode() {
           Lint
         </button>
         <button className="px-2 py-1 bg-white rounded" onClick={run}>
-          Run JS
+          Run
         </button>
       </div>
-      <textarea value={code} onChange={onChange} className="flex-1 font-mono p-2" />
+      <div className="flex flex-1">
+        <textarea
+          value={code}
+          onChange={onChange}
+          className="flex-1 font-mono p-2"
+        />
+        <WebPreview
+          code={preview}
+          onConsole={(m) => setConsoleOutput((prev) => [...prev, m])}
+        />
+      </div>
       <div className="h-40 overflow-auto border-t text-sm p-2 bg-black text-green-400 font-mono">
         {lint.map((m, i) => (
           <div key={i}>{`Line ${m.line}: ${m.message}`}</div>


### PR DESCRIPTION
## Summary
- add WebPreview component to render HTML/JS in iframe and capture console
- integrate WebPreview into VsCode app with Run button

## Testing
- `npm test __tests__/vscode.test.tsx` (fails: fetch not implemented)
- `npm run lint` (fails: ESLint couldn't find configuration)

------
https://chatgpt.com/codex/tasks/task_e_68b14b5ef9f88328b2fe8c3636215d04