### PR TITLE
feat(vscode): add filesystem workspace

### DIFF
--- a/__tests__/vscode.test.tsx
+++ b/__tests__/vscode.test.tsx
@@ -2,28 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import VsCode from '../apps/vscode';
 
+jest.mock('@monaco-editor/react', () => function MonacoMock() { return <div data-testid="editor" />; });
+
 describe('VsCode app', () => {
-  it('renders external frame', () => {
+  it('renders open button', () => {
     render(<VsCode />);
-    const frame = screen.getByTitle('VsCode');
-    expect(frame.tagName).toBe('IFRAME');
-    expect(screen.queryByRole('alert')).toBeNull();
-  });
-
-  it('shows banner when cookies are blocked', async () => {
-    const original = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
-    Object.defineProperty(document, 'cookie', {
-      configurable: true,
-      get: () => '',
-      set: () => {},
-    });
-
-    render(<VsCode />);
-    const alert = await screen.findByRole('alert');
-    expect(alert).toBeInTheDocument();
-
-    if (original) {
-      Object.defineProperty(document, 'cookie', original);
-    }
+    expect(screen.getByRole('button', { name: /open/i })).toBeInTheDocument();
   });
 });

--- a/apps/vscode/utils/workspaceFs.ts
+++ b/apps/vscode/utils/workspaceFs.ts
@@ -1,0 +1,22 @@
+export interface WorkspaceFile {
+  handle: FileSystemFileHandle;
+  name: string;
+  content: string;
+}
+
+export async function openWorkspaceFile(): Promise<WorkspaceFile | null> {
+  try {
+    const [handle] = await window.showOpenFilePicker();
+    const file = await handle.getFile();
+    const content = await file.text();
+    return { handle, name: handle.name, content };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveWorkspaceFile(handle: FileSystemFileHandle, content: string) {
+  const writable = await handle.createWritable();
+  await writable.write(content);
+  await writable.close();
+}


### PR DESCRIPTION
## Summary
- use File System Access API for VS Code workspace
- track most recently used files with persistent state
- update Monaco tabs on open/save

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint __tests__/vscode.test.tsx apps/vscode/index.tsx apps/vscode/utils/workspaceFs.ts --ext .ts,.tsx`
- `yarn test __tests__/vscode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b14b5e00d88328a9b1c7796aab953c