### PR TITLE
feat(spotify): add mood slider

### DIFF
--- a/apps/spotify/components/MoodTuner.tsx
+++ b/apps/spotify/components/MoodTuner.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface Playlists {
+  [mood: string]: string;
+}
+
+const MoodTuner = () => {
+  const [playlists, setPlaylists] = useState<Playlists>({});
+  const [mood, setMood] = usePersistentState<string>('spotify-mood', '');
+  const [isPlaying, setIsPlaying] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Load playlists from public JSON
+  useEffect(() => {
+    fetch('/spotify-playlists.json')
+      .then((res) => res.json())
+      .then((data: Playlists) => {
+        setPlaylists(data);
+        const moods = Object.keys(data);
+        if (!mood && moods.length) {
+          setMood(moods[0]);
+        }
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Ensure selected mood exists after playlists load
+  useEffect(() => {
+    const moods = Object.keys(playlists);
+    if (moods.length && !playlists[mood]) {
+      setMood(moods[0]);
+    }
+  }, [playlists, mood, setMood]);
+
+  const post = useCallback((cmd: string) => {
+    iframeRef.current?.contentWindow?.postMessage({ command: cmd }, '*');
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    setIsPlaying((playing) => {
+      post(playing ? 'pause' : 'play');
+      return !playing;
+    });
+  }, [post]);
+
+  const next = useCallback(() => post('next'), [post]);
+  const previous = useCallback(() => post('previous'), [post]);
+
+  // Update play state from Spotify messages
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (!e.origin.includes('spotify')) return;
+      const data = e.data;
+      if (Array.isArray(data) && data[0] === 'playback_update') {
+        setIsPlaying(!data[1]?.is_paused);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  // Hotkeys
+  useEffect(() => {
+    const handleKeys = (e: KeyboardEvent) => {
+      if (e.key === ' ') {
+        e.preventDefault();
+        togglePlay();
+      } else if (e.key.toLowerCase() === 'n') {
+        next();
+      } else if (e.key.toLowerCase() === 'p') {
+        previous();
+      }
+    };
+    window.addEventListener('keydown', handleKeys);
+    return () => window.removeEventListener('keydown', handleKeys);
+  }, [togglePlay, next, previous]);
+
+  const moods = Object.keys(playlists);
+  const index = moods.indexOf(mood);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey flex flex-col">
+      <div className="p-2 flex items-center gap-2 bg-black bg-opacity-30">
+        <input
+          type="range"
+          min={0}
+          max={Math.max(0, moods.length - 1)}
+          value={index >= 0 ? index : 0}
+          onChange={(e) => setMood(moods[Number(e.target.value)])}
+          className="flex-1"
+        />
+        <span className="capitalize text-white min-w-[4rem] text-center">{mood}</span>
+      </div>
+      {mood && playlists[mood] && (
+        <>
+          <iframe
+            ref={iframeRef}
+            src={`https://open.spotify.com/embed/playlist/${playlists[mood]}?utm_source=generator&theme=0`}
+            title={mood}
+            width="100%"
+            height="152"
+            frameBorder="0"
+            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            loading="lazy"
+          />
+          <div className="flex justify-center space-x-4 p-2 bg-black bg-opacity-30 text-white">
+            <button onClick={previous} title="Prev (P)" className="flex items-center gap-1">
+              ⏮<span className="text-xs">(P)</span>
+            </button>
+            <button onClick={togglePlay} title="Play/Pause (Space)" className="flex items-center gap-1">
+              {isPlaying ? '⏸' : '▶'}<span className="text-xs">(Space)</span>
+            </button>
+            <button onClick={next} title="Next (N)" className="flex items-center gap-1">
+              ⏭<span className="text-xs">(N)</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default MoodTuner;
+

--- a/public/spotify-playlists.json
+++ b/public/spotify-playlists.json
@@ -1,5 +1,8 @@
 {
   "chill": "37i9dQZF1DX4WYpdgoIcn6",
   "focus": "37i9dQZF1DX8Uebhn9wzrS",
-  "energize": "37i9dQZF1DX1g0iEXLFycr"
+  "energize": "37i9dQZF1DX1g0iEXLFycr",
+  "happy": "37i9dQZF1DXdPec7aLTmlC",
+  "sad": "37i9dQZF1DWSqBruwoIXkA",
+  "sleep": "37i9dQZF1DWYppxIAzv8YB"
 }


### PR DESCRIPTION
## Summary
- extend Spotify playlists with new mood options
- implement mood slider with persistent selection and playback hotkeys

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/spotify/components/MoodTuner.tsx`
- `yarn test apps/spotify --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b14b6206b88328a157d65ca618de14