### PR TITLE
feat(spotify): add crossfade preview player

### DIFF
--- a/apps/spotify/Visualizer.tsx
+++ b/apps/spotify/Visualizer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  analyser: AnalyserNode | null;
+}
+
+export default function Visualizer({ analyser }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!analyser) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+
+    const draw = () => {
+      requestAnimationFrame(draw);
+      analyser.getByteFrequencyData(dataArray);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const barWidth = canvas.width / bufferLength;
+      for (let i = 0; i < bufferLength; i++) {
+        const value = dataArray[i];
+        const barHeight = (value / 255) * canvas.height;
+        ctx.fillStyle = `rgb(${value}, 100, 150)`;
+        ctx.fillRect(i * barWidth, canvas.height - barHeight, barWidth - 1, barHeight);
+      }
+    };
+    draw();
+  }, [analyser]);
+
+  return <canvas ref={canvasRef} width={300} height={100} className="w-full h-24" />;
+}
+

--- a/apps/spotify/utils/crossfade.ts
+++ b/apps/spotify/utils/crossfade.ts
@@ -1,0 +1,80 @@
+export default class CrossfadePlayer {
+  private ctx: AudioContext | null = null;
+  private gains: [GainNode, GainNode] | null = null;
+  private sources: [AudioBufferSourceNode | null, AudioBufferSourceNode | null] = [null, null];
+  private analyser: AnalyserNode | null = null;
+  private current = 0;
+
+  private ensureContext() {
+    if (this.ctx) return;
+    const Ctor = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext | undefined;
+    if (!Ctor) return;
+    this.ctx = new Ctor();
+    const gainA = this.ctx.createGain();
+    const gainB = this.ctx.createGain();
+    gainA.gain.value = 0;
+    gainB.gain.value = 0;
+    const analyser = this.ctx.createAnalyser();
+    analyser.fftSize = 256;
+    gainA.connect(analyser);
+    gainB.connect(analyser);
+    analyser.connect(this.ctx.destination);
+    this.gains = [gainA, gainB];
+    this.analyser = analyser;
+  }
+
+  async play(url: string, fadeSec = 0) {
+    this.ensureContext();
+    const ctx = this.ctx;
+    const gains = this.gains;
+    if (!ctx || !gains) return;
+    try {
+      const res = await fetch(url);
+      const arr = await res.arrayBuffer();
+      const buffer = await ctx.decodeAudioData(arr);
+      const nextIndex = (this.current + 1) % 2;
+      const src = ctx.createBufferSource();
+      src.buffer = buffer;
+      src.connect(gains[nextIndex]);
+      const now = ctx.currentTime;
+      src.start();
+      if (fadeSec > 0) {
+        gains[nextIndex].gain.setValueAtTime(0, now);
+        gains[nextIndex].gain.linearRampToValueAtTime(1, now + fadeSec);
+        gains[this.current].gain.setValueAtTime(1, now);
+        gains[this.current].gain.linearRampToValueAtTime(0, now + fadeSec);
+        this.sources[this.current]?.stop(now + fadeSec);
+      } else {
+        gains[nextIndex].gain.setValueAtTime(1, now);
+        gains[this.current].gain.setValueAtTime(0, now);
+        this.sources[this.current]?.stop();
+      }
+      this.sources[nextIndex] = src;
+      this.current = nextIndex;
+    } catch {
+      /* ignore load errors */
+    }
+  }
+
+  toggle() {
+    if (!this.ctx) return;
+    if (this.ctx.state === 'running') this.ctx.suspend();
+    else this.ctx.resume();
+  }
+
+  getAnalyser() {
+    return this.analyser;
+  }
+
+  dispose() {
+    this.sources.forEach((s) => s?.stop());
+    this.sources = [null, null];
+    if (this.ctx) {
+      this.ctx.close();
+      this.ctx = null;
+      this.gains = null;
+      this.analyser = null;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- use Web Audio API nodes to crossfade between track previews
- add visualizer canvas and crossfade slider
- switch default playlist to MP3 previews

## Testing
- `npm test` *(fails: BeEF app tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b62ecc88328a0c392e5c39467a2