### PR TITLE
feat(youtube): persist watch-later playlist

### DIFF
--- a/apps/youtube/state/watchLater.ts
+++ b/apps/youtube/state/watchLater.ts
@@ -1,0 +1,31 @@
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export interface Video {
+  id: string;
+  title: string;
+  thumbnail: string;
+  channelName: string;
+  channelId: string;
+}
+
+const WATCH_LATER_KEY = 'youtube:watch-later';
+
+function isVideo(v: any): v is Video {
+  return (
+    v &&
+    typeof v.id === 'string' &&
+    typeof v.title === 'string' &&
+    typeof v.thumbnail === 'string' &&
+    typeof v.channelName === 'string' &&
+    typeof v.channelId === 'string'
+  );
+}
+
+function validate(list: unknown): list is Video[] {
+  return Array.isArray(list) && list.every(isVideo);
+}
+
+export default function useWatchLater() {
+  return usePersistentState<Video[]>(WATCH_LATER_KEY, [], validate);
+}
+


### PR DESCRIPTION
## Summary
- add persistent watch later playlist state
- enable drag-and-drop and keyboard reorder
- ensure playlist loads from storage and add regression tests

## Testing
- `npm test __tests__/youtube.test.tsx`
- `npm test` *(fails: beef app tests, calculator parser, mimikatz API, vscode banner, word search generator, kismet app, metasploit, and more)*
- `npx eslint apps/youtube/state/watchLater.ts components/apps/youtube/index.tsx __tests__/youtube.test.tsx` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b652e70832898ed58e47f9fee04