### PR TITLE
feat(spotify): add PiP playback controls

### DIFF
--- a/apps/spotify/components/PipPlayer.tsx
+++ b/apps/spotify/components/PipPlayer.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePipPortal } from '../../../components/common/PipPortal';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface PipPlayerProps {
+  onTogglePlay: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  disabled?: boolean;
+}
+
+const PipPlayer = ({
+  onTogglePlay,
+  onNext,
+  onPrevious,
+  disabled = false,
+}: PipPlayerProps)  => {
+  const { open, close, isOpen } = usePipPortal();
+  const [minimized, setMinimized] = usePersistentState(
+    'spotify-pip-minimized',
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+
+  useEffect(() => {
+    if (minimized) {
+      const Controls = () => (
+        <div
+          style={{
+            padding: 8,
+            background: 'black',
+            color: 'white',
+            fontFamily: 'sans-serif',
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+          }}
+        >
+          <button onClick={onPrevious} disabled={disabled} aria-label="Previous">
+            ⏮
+          </button>
+          <button onClick={onTogglePlay} disabled={disabled} aria-label="Play/Pause">
+            ⏯
+          </button>
+          <button onClick={onNext} disabled={disabled} aria-label="Next">
+            ⏭
+          </button>
+        </div>
+      );
+      open(<Controls />).then((win) => {
+        if (!win) setMinimized(false);
+      }).catch(() => setMinimized(false));
+    } else {
+      close();
+    }
+  }, [minimized, open, close, onNext, onPrevious, onTogglePlay, disabled, setMinimized]);
+
+  useEffect(() => {
+    if (!isOpen && minimized) setMinimized(false);
+  }, [isOpen, minimized, setMinimized]);
+
+  if (minimized) {
+    return (
+      <button onClick={() => setMinimized(false)} className="border px-2 py-1 rounded">
+        Restore
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-x-2">
+      <button onClick={onPrevious} title="Previous" disabled={disabled}>
+        ⏮
+      </button>
+      <button onClick={onTogglePlay} title="Play/Pause" disabled={disabled}>
+        ⏯
+      </button>
+      <button onClick={onNext} title="Next" disabled={disabled}>
+        ⏭
+      </button>
+      <button onClick={() => setMinimized(true)} className="border px-2 py-1 rounded">
+        PiP
+      </button>
+    </div>
+  );
+};
+
+export default PipPlayer;
+

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
+import PipPlayer from './components/PipPlayer';
 
 interface Track {
   title: string;
@@ -117,17 +118,7 @@ const SpotifyApp = () => {
       onKeyDown={handleKey}
     >
       <div className="flex items-center justify-between mb-2">
-        <div className="space-x-2">
-          <button onClick={previous} title="Previous" disabled={!queue.length}>
-            ⏮
-          </button>
-          <button onClick={togglePlay} title="Play/Pause" disabled={!queue.length}>
-            ⏯
-          </button>
-          <button onClick={next} title="Next" disabled={!queue.length}>
-            ⏭
-          </button>
-        </div>
+        <PipPlayer onTogglePlay={togglePlay} onNext={next} onPrevious={previous} disabled={!queue.length} />
         <div className="space-x-4 text-sm flex items-center">
           <label className="flex items-center space-x-1">
             <span>Crossfade</span>


### PR DESCRIPTION
## Summary
- add `PipPlayer` component that renders playback controls in a document PiP window and persists minimized state
- integrate `PipPlayer` into Spotify app

## Testing
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b6545e883289b926dd28daad3cd