### PR TITLE
feat: add synced YouTube comparison player

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `*.x.com` | X (Twitter) domain equivalents |
 | `*.google.com` | Google services used by demos |
 | `stackblitz.com` | StackBlitz IDE embeds |
+| `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
 | `https://*` / `http://*` / `ws://*` / `wss://*` | Wide dev allowance for external resources; tighten for production |

--- a/apps/youtube/components/ComparePlayers.tsx
+++ b/apps/youtube/components/ComparePlayers.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+declare global {
+  interface Window {
+    YT: any;
+    onYouTubeIframeAPIReady: () => void;
+  }
+}
+
+function parseVideoId(input: string): string {
+  try {
+    const url = new URL(input);
+    if (url.hostname.includes('youtu.be')) {
+      return url.pathname.slice(1);
+    }
+    if (url.searchParams.get('v')) {
+      return url.searchParams.get('v')!;
+    }
+    return input;
+  } catch {
+    return input;
+  }
+}
+
+const ComparePlayers = () => {
+  const leftDiv = useRef<HTMLDivElement>(null);
+  const rightDiv = useRef<HTMLDivElement>(null);
+  const [leftId, setLeftId] = useState('');
+  const [rightId, setRightId] = useState('');
+  const [leftPlayer, setLeftPlayer] = useState<any>(null);
+  const [rightPlayer, setRightPlayer] = useState<any>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (window.YT) {
+      setReady(true);
+      return;
+    }
+    const tag = document.createElement('script');
+    tag.src = 'https://www.youtube.com/iframe_api';
+    window.onYouTubeIframeAPIReady = () => setReady(true);
+    document.body.appendChild(tag);
+  }, []);
+
+  useEffect(() => {
+    if (!ready || !leftId || !leftDiv.current) return;
+    const player = new window.YT.Player(leftDiv.current, {
+      host: 'https://www.youtube-nocookie.com',
+      videoId: leftId,
+      playerVars: { origin: window.location.origin, rel: 0 },
+    });
+    setLeftPlayer(player);
+  }, [ready, leftId]);
+
+  useEffect(() => {
+    if (!ready || !rightId || !rightDiv.current) return;
+    const player = new window.YT.Player(rightDiv.current, {
+      host: 'https://www.youtube-nocookie.com',
+      videoId: rightId,
+      playerVars: { origin: window.location.origin, rel: 0 },
+    });
+    setRightPlayer(player);
+  }, [ready, rightId]);
+
+  const playBoth = () => {
+    if (leftPlayer && rightPlayer) {
+      const t = leftPlayer.getCurrentTime();
+      rightPlayer.seekTo(t, true);
+      leftPlayer.playVideo();
+      rightPlayer.playVideo();
+    }
+  };
+
+  const pauseBoth = () => {
+    leftPlayer?.pauseVideo();
+    rightPlayer?.pauseVideo();
+  };
+
+  const syncRight = () => {
+    if (leftPlayer && rightPlayer) {
+      rightPlayer.seekTo(leftPlayer.getCurrentTime(), true);
+    }
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <div className="mb-4 flex gap-2">
+        <input
+          className="w-full rounded bg-gray-800 p-2"
+          placeholder="Left video ID or URL"
+          value={leftId}
+          onChange={(e) => setLeftId(parseVideoId(e.target.value))}
+        />
+        <input
+          className="w-full rounded bg-gray-800 p-2"
+          placeholder="Right video ID or URL"
+          value={rightId}
+          onChange={(e) => setRightId(parseVideoId(e.target.value))}
+        />
+      </div>
+      <div className="flex flex-col gap-4 md:flex-row">
+        <div className="flex-1">
+          {leftId && <div ref={leftDiv} className="aspect-video w-full" />}
+        </div>
+        <div className="flex-1">
+          {rightId && <div ref={rightDiv} className="aspect-video w-full" />}
+        </div>
+      </div>
+      {leftPlayer && rightPlayer && (
+        <div className="mt-4 flex gap-2">
+          <button className="rounded bg-gray-700 px-3 py-1" onClick={playBoth}>
+            Play
+          </button>
+          <button className="rounded bg-gray-700 px-3 py-1" onClick={pauseBoth}>
+            Pause
+          </button>
+          <button className="rounded bg-gray-700 px-3 py-1" onClick={syncRight}>
+            Sync
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ComparePlayers;
+

--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ const ContentSecurityPolicy = [
   // Allow loading fonts from Google
   "font-src 'self' https://fonts.gstatic.com",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com",
+  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content


### PR DESCRIPTION
## Summary
- add ComparePlayers component with two synchronized YouTube embeds
- allow YouTube iframe API in CSP and document domain

## Testing
- `yarn lint apps/youtube/components/ComparePlayers.tsx next.config.js README.md` *(fails: ESLint couldn't find config)*
- `yarn test apps/youtube/components/ComparePlayers.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b14b65dce88328a7df552dff908113