### PR TITLE
feat(converter): add formula explanation with precision tests

### DIFF
--- a/__tests__/converter.spec.ts
+++ b/__tests__/converter.spec.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Converter from '../apps/converter';
+
+describe('converter precision', () => {
+  it('uses fixed decimals when sig figs disabled', () => {
+    render(React.createElement(Converter));
+    const from = screen.getAllByRole('spinbutton')[0] as HTMLInputElement;
+    fireEvent.change(from, { target: { value: '1234' } });
+    const to = screen.getAllByRole('spinbutton')[1] as HTMLInputElement;
+    expect(to.value).toBe('1.23');
+  });
+
+  it('uses significant figures when enabled', () => {
+    render(React.createElement(Converter));
+    const sigFigToggle = screen.getByLabelText('Sig figs');
+    fireEvent.click(sigFigToggle);
+    const from = screen.getAllByRole('spinbutton')[0] as HTMLInputElement;
+    fireEvent.change(from, { target: { value: '1234' } });
+    const to = screen.getAllByRole('spinbutton')[1] as HTMLInputElement;
+    expect(to.value).toBe('1.2');
+  });
+});

--- a/apps/converter/components/FormulaExplanation.tsx
+++ b/apps/converter/components/FormulaExplanation.tsx
@@ -1,0 +1,56 @@
+import { convertUnit } from '../../../components/apps/converter/unitData';
+
+interface FormulaProps {
+  category: string;
+  from: string;
+  to: string;
+  input: number;
+  output: number;
+  precision: number;
+  sigFig: boolean;
+}
+
+const formatNumber = (num: number, precision: number, sigFig: boolean) =>
+  sigFig ? Number(num).toPrecision(precision) : Number(num).toFixed(precision);
+
+export default function FormulaExplanation({
+  category,
+  from,
+  to,
+  input,
+  output,
+  precision,
+  sigFig,
+}: FormulaProps) {
+  const zero = convertUnit(category as any, from as any, to as any, 0);
+  const one = convertUnit(category as any, from as any, to as any, 1);
+  const slope = one - zero;
+  const intercept = zero;
+  const general =
+    intercept === 0
+      ? `${to} = ${from} × ${slope}`
+      : `${to} = ${from} × ${slope} + ${intercept}`;
+  const withValues =
+    intercept === 0
+      ? `${formatNumber(output, precision, sigFig)} = ${formatNumber(
+          input,
+          precision,
+          sigFig,
+        )} × ${slope}`
+      : `${formatNumber(output, precision, sigFig)} = ${formatNumber(
+          input,
+          precision,
+          sigFig,
+        )} × ${slope} + ${intercept}`;
+
+  return (
+    <details className="mt-4">
+      <summary className="cursor-pointer text-lg">Formula</summary>
+      <div className="mt-2 text-sm space-y-1">
+        <div>{general}</div>
+        <div>{withValues}</div>
+      </div>
+    </details>
+  );
+}
+

--- a/apps/converter/index.tsx
+++ b/apps/converter/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { convertUnit, unitMap } from '../../components/apps/converter/unitData';
+import FormulaExplanation from './components/FormulaExplanation';
 
 const currencyRates: Record<string, number> = {
   USD: 1,
@@ -37,6 +38,13 @@ export default function Converter() {
   const [toValue, setToValue] = useState('');
   const [precision, setPrecision] = useState(2);
   const [sigFig, setSigFig] = useState(false);
+  const [explanation, setExplanation] = useState<{
+    category: string;
+    from: string;
+    to: string;
+    input: number;
+    output: number;
+  } | null>(null);
   const [favourites, setFavourites] = useState<string[]>([]);
 
   // load favourites
@@ -68,10 +76,18 @@ export default function Converter() {
     const n = parseFloat(val);
     if (isNaN(n)) {
       setToValue('');
+      setExplanation(null);
       return;
     }
     const converted = convert(category, fromUnit, toUnit, n);
     setToValue(format(converted));
+    setExplanation({
+      category,
+      from: fromUnit,
+      to: toUnit,
+      input: n,
+      output: converted,
+    });
   };
 
   const convertTo = (val: string) => {
@@ -79,10 +95,18 @@ export default function Converter() {
     const n = parseFloat(val);
     if (isNaN(n)) {
       setFromValue('');
+      setExplanation(null);
       return;
     }
     const converted = convert(category, toUnit, fromUnit, n);
     setFromValue(format(converted));
+    setExplanation({
+      category,
+      from: toUnit,
+      to: fromUnit,
+      input: n,
+      output: converted,
+    });
   };
 
   // Recalculate when units or precision change
@@ -129,6 +153,7 @@ export default function Converter() {
     if (!units.includes(toUnit)) setToUnit(units[1] || units[0]);
     setFromValue('');
     setToValue('');
+    setExplanation(null);
   }, [category]);
 
   return (
@@ -218,6 +243,17 @@ export default function Converter() {
           Save
         </button>
       </div>
+      {explanation && (
+        <FormulaExplanation
+          category={explanation.category}
+          from={explanation.from}
+          to={explanation.to}
+          input={explanation.input}
+          output={explanation.output}
+          precision={precision}
+          sigFig={sigFig}
+        />
+      )}
       <div className="mt-6">
         <h3 className="text-lg mb-2">Favourites</h3>
         {favourites.length === 0 ? (


### PR DESCRIPTION
## Summary
- show detailed conversion formulas in a collapsible panel
- wire formula panel to current converter results
- test conversion precision and significant figures

## Testing
- `npm test __tests__/converter.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b14b6966f08328a5f19040c7ae0aa6