### PR TITLE
feat(converter): add starred favorites with sync

### DIFF
--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -39,6 +39,28 @@ export default function usePersistentState<T>(
     }
   }, [key, state]);
 
+  // sync across tabs
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== key) return;
+      try {
+        if (e.newValue !== null) {
+          const parsed = JSON.parse(e.newValue);
+          if (!validator || validator(parsed)) {
+            setState(parsed as T);
+            return;
+          }
+        }
+      } catch {
+        // ignore parse errors
+      }
+      setState(getInitial());
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
   const reset = () => setState(getInitial());
   const clear = () => {
     try {


### PR DESCRIPTION
## Summary
- persist state across tabs with new storage listener
- star conversions and manage favorites list for converter

## Testing
- `yarn lint apps/converter/index.tsx hooks/usePersistentState.ts` *(fails: ESLint couldn't find configuration)*
- `yarn test --passWithNoTests apps/converter/index.tsx hooks/usePersistentState.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b14b6a712483289d6bb394c4aa8346