### PR TITLE
feat(weather): persist cities and show cached data

### DIFF
--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import useWeatherState, { City } from './state';
+
+interface ReadingUpdate {
+  temp: number;
+  condition: number;
+  time: number;
+}
+
+function CityTile({ city }: { city: City }) {
+  return (
+    <div>
+      <div className="font-bold mb-2">{city.name}</div>
+      {city.lastReading ? (
+        <div>
+          {Math.round(city.lastReading.temp)}°C
+        </div>
+      ) : (
+        <div className="opacity-70">No data</div>
+      )}
+    </div>
+  );
+}
+
+export default function WeatherApp() {
+  const [cities, setCities] = useWeatherState();
+  const [name, setName] = useState('');
+  const [lat, setLat] = useState('');
+  const [lon, setLon] = useState('');
+  const [offline, setOffline] = useState(
+    typeof navigator !== 'undefined' ? !navigator.onLine : false,
+  );
+  const dragSrc = useRef<number | null>(null);
+
+  useEffect(() => {
+    const onOnline = () => setOffline(false);
+    const onOffline = () => setOffline(true);
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (offline) return;
+    cities.forEach((city, i) => {
+      fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current_weather=true`,
+      )
+        .then((res) => res.json())
+        .then((data) => {
+          const reading: ReadingUpdate = {
+            temp: data.current_weather.temperature,
+            condition: data.current_weather.weathercode,
+            time: Date.now(),
+          };
+          setCities((prev) => {
+            const next = [...prev];
+            if (!next[i]) return prev;
+            next[i] = { ...next[i], lastReading: reading };
+            return next;
+          });
+        })
+        .catch(() => {
+          // ignore fetch errors
+        });
+    });
+  }, [offline, cities.length, setCities]);
+
+  const addCity = () => {
+    const latNum = parseFloat(lat);
+    const lonNum = parseFloat(lon);
+    if (!name || Number.isNaN(latNum) || Number.isNaN(lonNum)) return;
+    setCities([
+      ...cities,
+      { id: `${name}-${lat}-${lon}`, name, lat: latNum, lon: lonNum },
+    ]);
+    setName('');
+    setLat('');
+    setLon('');
+  };
+
+  const onDragStart = (i: number) => {
+    dragSrc.current = i;
+  };
+
+  const onDrop = (i: number) => {
+    const src = dragSrc.current;
+    dragSrc.current = null;
+    if (src === null || src === i) return;
+    setCities((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(src, 1);
+      next.splice(i, 0, moved);
+      return next;
+    });
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <div className="flex gap-2 mb-4">
+        <input
+          className="text-black px-1"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="text-black px-1 w-20"
+          placeholder="Lat"
+          value={lat}
+          onChange={(e) => setLat(e.target.value)}
+        />
+        <input
+          className="text-black px-1 w-20"
+          placeholder="Lon"
+          value={lon}
+          onChange={(e) => setLon(e.target.value)}
+        />
+        <button className="bg-blue-600 px-2 rounded" onClick={addCity}>
+          Add
+        </button>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {cities.map((city, i) => (
+          <div
+            key={city.id}
+            draggable
+            onDragStart={() => onDragStart(i)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => onDrop(i)}
+            className="bg-white/10 p-4 rounded"
+          >
+            <CityTile city={city} />
+          </div>
+        ))}
+      </div>
+      {offline && (
+        <div className="mt-4 text-sm">Offline - showing cached data</div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import usePersistentState from '../../hooks/usePersistentState';
+
+export interface WeatherReading {
+  temp: number;
+  condition: number;
+  time: number;
+}
+
+export interface City {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  lastReading?: WeatherReading;
+}
+
+const isWeatherReading = (v: any): v is WeatherReading =>
+  v && typeof v.temp === 'number' && typeof v.condition === 'number' && typeof v.time === 'number';
+
+const isCity = (v: any): v is City =>
+  v &&
+  typeof v.id === 'string' &&
+  typeof v.name === 'string' &&
+  typeof v.lat === 'number' &&
+  typeof v.lon === 'number' &&
+  (v.lastReading === undefined || isWeatherReading(v.lastReading));
+
+const isCityArray = (v: unknown): v is City[] => Array.isArray(v) && v.every(isCity);
+
+export default function useWeatherState() {
+  return usePersistentState<City[]>('weather-cities', [], isCityArray);
+}
+

--- a/pages/apps/weather.tsx
+++ b/pages/apps/weather.tsx
@@ -7,5 +7,3 @@ const WeatherApp = dynamic(() => import('../../apps/weather'), {
 
 export default WeatherApp;
 
-export const displayWeather = () => <WeatherApp />;
-


### PR DESCRIPTION
## Summary
- persist weather cities with last readings using `usePersistentState`
- display cities as reorderable tiles
- surface cached readings and offline banner when network is unavailable

## Testing
- `npx eslint -c .eslintrc.cjs apps/weather/index.tsx apps/weather/state.ts pages/apps/weather.tsx components/apps/weather.js` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `yarn test apps/weather --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b14b6d3a0c8328b98f9d7c00b2e230