### PR TITLE
feat(weather): add static map overlay

### DIFF
--- a/apps/weather/components/MapOverlay.tsx
+++ b/apps/weather/components/MapOverlay.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+interface MapOverlayProps {
+  lat: number;
+  lon: number;
+  code: number;
+}
+
+const tileUrl = (lat: number, lon: number, zoom = 5) => {
+  const x = Math.floor(((lon + 180) / 360) * Math.pow(2, zoom));
+  const y = Math.floor(
+    ((1 -
+      Math.log(Math.tan((lat * Math.PI) / 180) +
+        1 / Math.cos((lat * Math.PI) / 180)) /
+        Math.PI) /
+      2) *
+      Math.pow(2, zoom),
+  );
+  return `https://tile.openstreetmap.org/${zoom}/${x}/${y}.png`;
+};
+
+const conditionIcon = (code: number) => {
+  if ([0].includes(code)) return '☀️';
+  if ([1, 2, 3].includes(code)) return '☁️';
+  if ([51, 53, 55, 61, 63, 65, 80, 81, 82].includes(code)) return '🌧️';
+  if ([71, 73, 75, 77, 85, 86].includes(code)) return '❄️';
+  if ([95, 96, 99].includes(code)) return '⛈️';
+  return '☀️';
+};
+
+const MapOverlay: React.FC<MapOverlayProps> = ({ lat, lon, code }) => {
+  const url = tileUrl(lat, lon);
+  const icon = conditionIcon(code);
+  return (
+    <div className="relative w-64 h-64 mt-4">
+      <img src={url} alt="Map tile" className="w-full h-full" />
+      <div className="absolute inset-0 flex items-center justify-center text-4xl">
+        <span role="img" aria-label="current weather icon">
+          {icon}
+        </span>
+      </div>
+      <div className="absolute bottom-1 left-1 bg-white/70 text-[10px] px-1 rounded">
+        Weather data © Open-Meteo · Map data © OpenStreetMap contributors
+      </div>
+    </div>
+  );
+};
+
+export default MapOverlay;
+

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../usePersistentState';
+import MapOverlay from '../../apps/weather/components/MapOverlay';
 
 const defaultLocation = {
   latitude: 40.7128,
@@ -227,6 +228,7 @@ const Weather = () => {
   const chartRef = useRef(null);
   const timesRef = useRef(null);
   const [error, setError] = useState('');
+  const [showMap, setShowMap] = useState(false);
   const fetchForecast = async (lat, lon, cityName) => {
     const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=temperature_2m,apparent_temperature&daily=weathercode,temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min&current_weather=true&temperature_unit=${unit === 'metric' ? 'celsius' : 'fahrenheit'}&timezone=auto`;
     try {
@@ -457,6 +459,14 @@ const Weather = () => {
         >
           Pin City
         </button>
+        <button
+          onClick={() => setShowMap(!showMap)}
+          className="bg-white/20 px-4 py-2 rounded"
+          aria-pressed={showMap}
+          aria-label="Toggle map overlay"
+        >
+          {showMap ? 'Hide Map' : 'Show Map'}
+        </button>
       </div>
       {error && <div className="mb-4 text-red-500">{error}</div>}
       <div className="mb-2">{label}</div>
@@ -502,6 +512,13 @@ const Weather = () => {
           );
         })}
       </div>
+      {showMap && (
+        <MapOverlay
+          lat={currentLocation.latitude}
+          lon={currentLocation.longitude}
+          code={data.current_weather.weathercode}
+        />
+      )}
       {/* S6: Accessible hourly temperature chart */}
       <div
         ref={chartRef}


### PR DESCRIPTION
## Summary
- add MapOverlay component with static OpenStreetMap tiles and weather icons
- allow toggling map overlay in weather dashboard
- credit Open-Meteo and OpenStreetMap data sources

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test` *(fails: __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/vscode.test.tsx, __tests__/wordSearch.test.ts, __tests__/kismet.test.tsx, __tests__/metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b6e8ff883288c88af45fbcde13f