### PR TITLE
feat(quote): add canvas posterizer

### DIFF
--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Quote {
+  content: string;
+  author: string;
+}
+
+const hexToRgb = (hex: string) => {
+  const parsed = hex.replace('#', '');
+  const bigint = parseInt(parsed, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+};
+
+const luminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
+  const a = [r, g, b].map((v) => {
+    const val = v / 255;
+    return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
+  });
+  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+};
+
+const contrastRatio = (c1: string, c2: string) => {
+  const L1 = luminance(hexToRgb(c1));
+  const L2 = luminance(hexToRgb(c2));
+  const light = Math.max(L1, L2);
+  const dark = Math.min(L1, L2);
+  return (light + 0.05) / (dark + 0.05);
+};
+
+export default function Posterizer({ quote }: { quote: Quote | null }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [bg, setBg] = useState('#000000');
+  const [fg, setFg] = useState('#ffffff');
+  const [font, setFont] = useState('serif');
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !quote) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.fillStyle = fg;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const padding = 20;
+    const maxWidth = width - padding * 2;
+
+    const drawText = (text: string, y: number, size: number) => {
+      ctx.font = `${size}px ${font}`;
+      const words = text.split(' ');
+      let line = '';
+      let lines: string[] = [];
+      words.forEach((word) => {
+        const testLine = line + word + ' ';
+        const metrics = ctx.measureText(testLine);
+        if (metrics.width > maxWidth && line) {
+          lines.push(line);
+          line = word + ' ';
+        } else {
+          line = testLine;
+        }
+      });
+      lines.push(line);
+      const totalHeight = lines.length * size * 1.2;
+      let currentY = y - totalHeight / 2 + size / 2;
+      lines.forEach((l) => {
+        ctx.fillText(l.trim(), width / 2, currentY);
+        currentY += size * 1.2;
+      });
+      return currentY;
+    };
+
+    const nextY = drawText(quote.content, height / 2, 24);
+    ctx.font = `20px ${font}`;
+    ctx.fillText(`- ${quote.author}`, width / 2, nextY + 20);
+  }, [quote, bg, fg, font]);
+
+  const ratio = contrastRatio(bg, fg);
+  const accessible = ratio >= 4.5;
+
+  const download = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const link = document.createElement('a');
+    link.download = 'quote.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      <canvas ref={canvasRef} width={600} height={400} className="border" />
+      <div className="flex flex-wrap gap-2 justify-center">
+        <label className="flex items-center gap-1">
+          BG
+          <input type="color" value={bg} onChange={(e) => setBg(e.target.value)} />
+        </label>
+        <label className="flex items-center gap-1">
+          FG
+          <input type="color" value={fg} onChange={(e) => setFg(e.target.value)} />
+        </label>
+        <input
+          type="text"
+          value={font}
+          onChange={(e) => setFont(e.target.value)}
+          className="px-2 py-1 rounded text-black"
+          placeholder="Font"
+        />
+        <span className={accessible ? 'text-green-400' : 'text-red-400'}>
+          Contrast: {ratio.toFixed(2)}
+        </span>
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={download}
+          disabled={!accessible}
+        >
+          Download PNG
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -4,6 +4,7 @@ import Filter from 'bad-words';
 import { toPng } from 'html-to-image';
 import offlineQuotes from '../../components/apps/quotes.json';
 import share, { canShare } from '../../utils/share';
+import Posterizer from './components/Posterizer';
 
 interface Quote {
   content: string;
@@ -60,6 +61,7 @@ export default function QuoteApp() {
   const [search, setSearch] = useState('');
   const [favorites, setFavorites] = useState<string[]>([]);
   const [dailyQuote, setDailyQuote] = useState<Quote | null>(null);
+  const [posterize, setPosterize] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -208,6 +210,12 @@ export default function QuoteApp() {
           <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded" onClick={shareCard}>
             Share as Card
           </button>
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={() => setPosterize((p) => !p)}
+          >
+            {posterize ? 'Close Posterizer' : 'Posterize'}
+          </button>
           {canShare() && (
             <button className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded" onClick={shareQuote}>
               Share
@@ -218,6 +226,11 @@ export default function QuoteApp() {
             <input type="file" accept="application/json" className="hidden" onChange={importQuotes} />
           </label>
         </div>
+        {posterize && (
+          <div className="mt-4 w-full">
+            <Posterizer quote={current} />
+          </div>
+        )}
         <div className="mt-4 flex flex-col w-full gap-2">
           <input
             value={search}


### PR DESCRIPTION
## Summary
- add Posterizer component to render quotes on canvas with color/font options
- provide contrast check and PNG download
- integrate Posterizer with quote app

## Testing
- `npx eslint -c .eslintrc.cjs apps/quote/index.tsx apps/quote/components/Posterizer.tsx` (warnings: file ignored due to config)
- `yarn test apps/quote` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b14b6ffe1083288712dc9299b79ce4