### PR TITLE
feat(quote): add daily notifications

### DIFF
--- a/apps/quote/state.ts
+++ b/apps/quote/state.ts
@@ -1,0 +1,16 @@
+import usePersistentState from '../../hooks/usePersistentState';
+
+export function useQuoteNotification() {
+  const [time, setTime] = usePersistentState<string>(
+    'quote-notify-time',
+    '09:00',
+    (v): v is string => typeof v === 'string',
+  );
+  const [enabled, setEnabled] = usePersistentState<boolean>(
+    'quote-notify-enabled',
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+  return { time, setTime, enabled, setEnabled } as const;
+}
+


### PR DESCRIPTION
## Summary
- persist daily notification settings for quote app
- schedule Notification at chosen time with daily quote
- add UI toggle and time picker

## Testing
- `yarn test apps/quote --passWithNoTests`
- `npx eslint apps/quote/index.tsx apps/quote/state.ts` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b70d85083288b96d1486b4579d9