### PR TITLE
feat(vscode): add snippets and tasks

### DIFF
--- a/apps/vscode/state/snippets.ts
+++ b/apps/vscode/state/snippets.ts
@@ -1,0 +1,46 @@
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export interface Snippet {
+  prefix: string;
+  body: string;
+  description?: string;
+}
+
+interface SnippetMap {
+  [language: string]: Snippet[];
+}
+
+const KEY = 'vscode:snippets';
+
+export function useSnippets(language: string) {
+  const [map, setMap] = usePersistentState<SnippetMap>(KEY, {});
+
+  const addSnippet = (snippet: Snippet) => {
+    setMap((prev) => {
+      const list = prev[language] ? [...prev[language], snippet] : [snippet];
+      return { ...prev, [language]: list };
+    });
+  };
+
+  const updateSnippet = (index: number, snippet: Snippet) => {
+    setMap((prev) => {
+      const list = [...(prev[language] || [])];
+      list[index] = snippet;
+      return { ...prev, [language]: list };
+    });
+  };
+
+  const removeSnippet = (index: number) => {
+    setMap((prev) => {
+      const list = (prev[language] || []).filter((_, i) => i !== index);
+      return { ...prev, [language]: list };
+    });
+  };
+
+  return {
+    snippets: map[language] || [],
+    addSnippet,
+    updateSnippet,
+    removeSnippet,
+  } as const;
+}

--- a/apps/vscode/utils/taskRunner.ts
+++ b/apps/vscode/utils/taskRunner.ts
@@ -1,0 +1,34 @@
+const PROJECT_DIR = 'vscode';
+
+export interface Task {
+  label: string;
+  command: string;
+  language?: string;
+}
+
+export async function loadTasks(project: string, language: string): Promise<Task[]> {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle(PROJECT_DIR);
+    const proj = await dir.getDirectoryHandle(project);
+    const file = await proj.getFileHandle('tasks.json');
+    const text = await (await file.getFile()).text();
+    const json = JSON.parse(text);
+    const tasks: Task[] = Array.isArray(json.tasks) ? json.tasks : [];
+    return tasks.filter((t) => !t.language || t.language === language);
+  } catch {
+    return [];
+  }
+}
+
+export async function runTask(task: Task): Promise<string> {
+  try {
+    // tiny tasks: execute command as Function
+    const fn = new Function(task.command);
+    const result = await fn();
+    if (typeof result === 'string') return result;
+    return JSON.stringify(result);
+  } catch (e) {
+    return `Error: ${(e as Error).message}`;
+  }
+}


### PR DESCRIPTION
## Summary
- store code snippets per language with persistent state
- parse tasks.json and execute tiny tasks
- extend VSCode sample to manage snippets and tasks per language

## Testing
- `npm test` *(fails: unable to find an element, fetch not implemented, type errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b5fa3188328b4484b6fb04bb3ff