### PR TITLE
feat: add wireshark filter autocomplete

### DIFF
--- a/apps/wireshark/components/FilterHelper.tsx
+++ b/apps/wireshark/components/FilterHelper.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const EXAMPLE_FILTERS = [
+  'tcp',
+  'udp',
+  'icmp',
+  'http',
+  'tcp.port == 80',
+  'ip.addr == 10.0.0.1',
+];
+
+interface FilterHelperProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
+  const [recent, setRecent] = usePersistentState<string[]>(
+    'wireshark:recent-filters',
+    []
+  );
+
+  const suggestions = Array.from(new Set([...recent, ...EXAMPLE_FILTERS]));
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const val = e.target.value.trim();
+    if (!val) return;
+    setRecent((prev) => [val, ...prev.filter((f) => f !== val)].slice(0, 5));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      const val = e.currentTarget.value.trim();
+      if (val) {
+        setRecent((prev) => [val, ...prev.filter((f) => f !== val)].slice(0, 5));
+      }
+    }
+  };
+
+  return (
+    <>
+      <input
+        list="display-filter-suggestions"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder="Quick search (e.g. tcp)"
+        aria-label="Quick search"
+        className="px-2 py-1 bg-gray-800 rounded text-white"
+      />
+      <datalist id="display-filter-suggestions">
+        {suggestions.map((f) => (
+          <option key={f} value={f} />
+        ))}
+      </datalist>
+    </>
+  );
+};
+
+export default FilterHelper;
+

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -4,6 +4,7 @@ import { protocolName, getRowColor } from './utils';
 import DecodeTree from './DecodeTree';
 import FlowDiagram from './FlowDiagram';
 import filters from './filters.json';
+import FilterHelper from '../../../apps/wireshark/components/FilterHelper';
 
 const SMALL_CAPTURE_SIZE = 1024 * 1024; // 1MB threshold
 
@@ -120,7 +121,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   const [tlsKeys, setTlsKeys] = useState('');
   const [protocolFilter, setProtocolFilter] = useState('');
   const [filter, setFilter] = useState('');
-   const [bpf, setBpf] = useState('');
+  const [bpf, setBpf] = useState('');
   const [colorRuleText, setColorRuleText] = useState('[]');
   const [colorRules, setColorRules] = useState([]);
   const [paused, setPaused] = useState(false);
@@ -176,8 +177,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
     }
   }, [timeline, paused]);
 
-  const handleFilterChange = (e) => {
-    const val = e.target.value;
+  const handleFilterChange = (val) => {
     setFilter(val);
     if (typeof window !== 'undefined') {
       window.localStorage.setItem('wireshark-filter', val);
@@ -343,13 +343,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             </option>
           ))}
         </select>
-        <input
-          value={filter}
-          onChange={handleFilterChange}
-          placeholder="Quick search (e.g. tcp)"
-          aria-label="Quick search"
-          className="px-2 py-1 bg-gray-800 rounded text-white"
-        />
+        <FilterHelper value={filter} onChange={handleFilterChange} />
         <input
           value={bpf}
           onChange={handleBpfChange}


### PR DESCRIPTION
## Summary
- add FilterHelper component providing example display filters and recent history
- integrate autocomplete helper with Wireshark UI for faster filter selection

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, wordSearch.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b15989feb48328950d1ac03c7cbfb5