### PR TITLE
feat(wireshark): add conversation flow graph with PNG export

### DIFF
--- a/apps/wireshark/components/FlowGraph.tsx
+++ b/apps/wireshark/components/FlowGraph.tsx
@@ -1,0 +1,107 @@
+'use client';
+import React, { useEffect, useMemo, useRef } from 'react';
+import dynamic from 'next/dynamic';
+import { toPng } from 'html-to-image';
+
+const CytoscapeComponent = dynamic(
+  async () => {
+    const cytoscape = (await import('cytoscape')).default;
+    const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
+    cytoscape.use(coseBilkent);
+    return (await import('react-cytoscapejs')).default;
+  },
+  { ssr: false }
+);
+
+interface Packet {
+  src: string;
+  dest: string;
+  data?: Uint8Array;
+}
+
+interface FlowGraphProps {
+  packets: Packet[];
+}
+
+const FlowGraph: React.FC<FlowGraphProps> = ({ packets }) => {
+  const cyRef = useRef<any>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { elements, stats } = useMemo(() => {
+    const nodes: Record<string, any> = {};
+    const edges: Record<string, any> = {};
+    let bytes = 0;
+    packets.forEach((p) => {
+      if (!nodes[p.src]) nodes[p.src] = { data: { id: p.src, label: p.src } };
+      if (!nodes[p.dest]) nodes[p.dest] = { data: { id: p.dest, label: p.dest } };
+      const key = `${p.src}_${p.dest}`;
+      if (!edges[key])
+        edges[key] = {
+          data: { id: key, source: p.src, target: p.dest, count: 0 }
+        };
+      edges[key].data.count += 1;
+      bytes += p.data?.length || 0;
+    });
+    const elements = [
+      ...Object.values(nodes),
+      ...Object.values(edges).map((e: any) => ({
+        ...e,
+        data: { ...e.data, label: String(e.data.count) }
+      }))
+    ];
+    const stats = {
+      packets: packets.length,
+      hosts: Object.keys(nodes).length,
+      conversations: Object.keys(edges).length,
+      bytes
+    };
+    return { elements, stats };
+  }, [packets]);
+
+  useEffect(() => {
+    if (cyRef.current) {
+      cyRef.current.layout({ name: 'cose-bilkent' }).run();
+    }
+  }, [elements]);
+
+  const exportPNG = () => {
+    if (!containerRef.current) return;
+    toPng(containerRef.current)
+      .then((dataUrl) => {
+        const link = document.createElement('a');
+        link.download = 'flow-graph.png';
+        link.href = dataUrl;
+        link.click();
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="flex flex-col space-y-2">
+      <div ref={containerRef} className="w-full h-64 bg-black">
+        <CytoscapeComponent
+          elements={elements}
+          style={{ width: '100%', height: '100%' }}
+          cy={(cy) => {
+            cyRef.current = cy;
+          }}
+        />
+      </div>
+      <div className="flex space-x-4 text-xs text-green-400">
+        <span>Packets: {stats.packets}</span>
+        <span>Hosts: {stats.hosts}</span>
+        <span>Conversations: {stats.conversations}</span>
+        <span>Bytes: {stats.bytes}</span>
+        <button
+          onClick={exportPNG}
+          className="ml-auto px-2 py-1 bg-gray-700 rounded"
+        >
+          Export PNG
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FlowGraph;
+

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import Waterfall from './Waterfall';
 import { protocolName, getRowColor } from './utils';
 import DecodeTree from './DecodeTree';
-import FlowDiagram from './FlowDiagram';
+import FlowGraph from '../../../apps/wireshark/components/FlowGraph';
 import filters from './filters.json';
 
 const SMALL_CAPTURE_SIZE = 1024 * 1024; // 1MB threshold
@@ -503,7 +503,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           </div>
         </>
       ) : (
-        <FlowDiagram packets={filteredPackets} />
+        <FlowGraph packets={filteredPackets} />
       )}
       <div aria-live="polite" className="sr-only">
         {announcement}


### PR DESCRIPTION
## Summary
- visualize packet conversations using Cytoscape graph
- allow exporting the graph to PNG
- show packet, host, conversation, and byte stats from PCAP data

## Testing
- `npx eslint --config .eslintrc.cjs apps/wireshark/components/FlowGraph.tsx components/apps/wireshark/index.js` *(fails: A config object is using the "extends" key, which is not supported in flat config system.)*
- `yarn test --passWithNoTests apps/wireshark`

------
https://chatgpt.com/codex/tasks/task_e_68b159898db88328968bb1a81c63889f