### PR TITLE
feat(nmap-nse): parse Nmap XML reports

### DIFF
--- a/apps/nmap-nse/components/ReportView.tsx
+++ b/apps/nmap-nse/components/ReportView.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export interface Vulnerability {
+  id: string;
+  output: string;
+}
+
+export interface Service {
+  port: number;
+  name: string;
+  vulnerabilities: Vulnerability[];
+}
+
+export interface Host {
+  address: string;
+  services: Service[];
+  vulnerabilities: Vulnerability[];
+}
+
+export interface Report {
+  hosts: Host[];
+}
+
+const HostSection: React.FC<{ host: Host }> = ({ host }) => {
+  const [note, setNote] = usePersistentState(
+    `nmap-nse:note:${host.address}`,
+    '',
+    (v): v is string => typeof v === 'string'
+  );
+  return (
+    <div className="mb-4 border border-gray-700 p-2 rounded">
+      <h3 className="text-lg font-bold mb-2">{host.address}</h3>
+      {host.services.map((s) => (
+        <div key={s.port} className="ml-4 mb-2">
+          <div className="font-mono">
+            {s.port} {s.name}
+          </div>
+          {s.vulnerabilities.map((v, idx) => (
+            <div key={idx} className="ml-4 text-sm text-red-400">
+              {v.id}: {v.output}
+            </div>
+          ))}
+        </div>
+      ))}
+      {host.vulnerabilities.length > 0 && (
+        <div className="ml-4 text-sm text-red-400 mb-2">
+          {host.vulnerabilities.map((v, idx) => (
+            <div key={idx}>
+              {v.id}: {v.output}
+            </div>
+          ))}
+        </div>
+      )}
+      <textarea
+        className="w-full p-1 rounded text-black"
+        placeholder="Annotations"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+    </div>
+  );
+};
+
+const ReportView: React.FC<{ report: Report }> = ({ report }) => (
+  <div>
+    {report.hosts.map((h) => (
+      <HostSection key={h.address} host={h} />
+    ))}
+  </div>
+);
+
+export default ReportView;
+

--- a/apps/nmap-nse/workers/xmlParser.ts
+++ b/apps/nmap-nse/workers/xmlParser.ts
@@ -1,0 +1,68 @@
+import { XMLParser } from 'fast-xml-parser';
+
+interface Vulnerability {
+  id: string;
+  output: string;
+}
+
+interface Service {
+  port: number;
+  name: string;
+  vulnerabilities: Vulnerability[];
+}
+
+interface Host {
+  address: string;
+  services: Service[];
+  vulnerabilities: Vulnerability[];
+}
+
+interface Report {
+  hosts: Host[];
+}
+
+self.onmessage = ({ data }: MessageEvent<string>) => {
+  try {
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const json = parser.parse(data);
+    const hostData = json?.nmaprun?.host;
+    const hostsArr = Array.isArray(hostData) ? hostData : hostData ? [hostData] : [];
+    const hosts: Host[] = hostsArr.map((host: any) => {
+      const addr = Array.isArray(host.address)
+        ? host.address[0]?.['@_addr']
+        : host.address?.['@_addr'];
+      const address = addr || 'unknown';
+      const ports = host.ports?.port;
+      const portArr = Array.isArray(ports) ? ports : ports ? [ports] : [];
+      const services: Service[] = portArr.map((p: any) => {
+        const port = parseInt(p['@_portid'] || '0', 10);
+        const name = p.service?.['@_name'] || '';
+        const scripts = p.script;
+        const scriptArr = Array.isArray(scripts) ? scripts : scripts ? [scripts] : [];
+        const vulnerabilities: Vulnerability[] = scriptArr.map((s: any) => ({
+          id: s['@_id'] || '',
+          output: s['@_output'] || '',
+        }));
+        return { port, name, vulnerabilities };
+      });
+      const hostScripts = host.hostscript?.script;
+      const hostScriptArr = Array.isArray(hostScripts)
+        ? hostScripts
+        : hostScripts
+        ? [hostScripts]
+        : [];
+      const vulnerabilities: Vulnerability[] = hostScriptArr.map((s: any) => ({
+        id: s['@_id'] || '',
+        output: s['@_output'] || '',
+      }));
+      return { address, services, vulnerabilities };
+    });
+    const report: Report = { hosts };
+    self.postMessage(report);
+  } catch (err: any) {
+    self.postMessage({ error: err?.message || 'Parse failed' });
+  }
+};
+
+export {};
+


### PR DESCRIPTION
## Summary
- add web worker to parse uploaded Nmap XML into hosts, services, and vulnerabilities
- render parsed reports with annotations in `ReportView`
- wire XML upload and worker to existing Nmap NSE page

## Testing
- `yarn test` *(fails: game2048, beef, calculator parser, vscode, word search, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1598ae6648328b0d27cfd84a18b28