### PR TITLE
feat(metasploit): add deterministic target emulator

### DIFF
--- a/apps/metasploit/components/TargetEmulator.test.tsx
+++ b/apps/metasploit/components/TargetEmulator.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TargetEmulator from './TargetEmulator';
+import modules from '../../../components/apps/metasploit/modules.json';
+
+describe('TargetEmulator', () => {
+  it('shows deterministic output and resets', () => {
+    render(<TargetEmulator />);
+    const select = screen.getByLabelText(/select module/i);
+    fireEvent.change(select, { target: { value: modules[0].name } });
+    const first = screen.getByTestId('session-output').textContent;
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    expect(screen.getByTestId('session-output').textContent).toMatch(/Select a module/);
+    fireEvent.change(select, { target: { value: modules[0].name } });
+    const second = screen.getByTestId('session-output').textContent;
+    expect(first).toBe(second);
+  });
+});

--- a/apps/metasploit/components/TargetEmulator.tsx
+++ b/apps/metasploit/components/TargetEmulator.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useState } from 'react';
+import seedrandom from 'seedrandom';
+import modules from '../../../components/apps/metasploit/modules.json';
+
+interface ModuleInfo {
+  name: string;
+  description?: string;
+}
+
+const TargetEmulator: React.FC = () => {
+  const [selected, setSelected] = useState<ModuleInfo | null>(null);
+  const [output, setOutput] = useState('Select a module to run.');
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const mod = modules.find((m: ModuleInfo) => m.name === e.target.value) || null;
+    setSelected(mod);
+    if (mod) {
+      const rng = seedrandom(mod.name);
+      const ip = Array.from({ length: 4 }, () => Math.floor(rng() * 256)).join('.');
+      const port = Math.floor(rng() * 65535);
+      const sessionId = Math.floor(rng() * 1000);
+      const lines = [
+        `msf6 > use ${mod.name}`,
+        `[*] Connecting to ${ip}:${port}`,
+        `[*] Module loaded successfully`,
+        `msf6 exploit(${mod.name}) > run`,
+        `[*] Session ${sessionId} opened`
+      ];
+      setOutput(lines.join('\n'));
+    } else {
+      setOutput('Select a module to run.');
+    }
+  };
+
+  const reset = () => {
+    setSelected(null);
+    setOutput('Select a module to run.');
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <div className="flex items-center space-x-2">
+        <label className="sr-only" htmlFor="module-select">Select module</label>
+        <select
+          id="module-select"
+          aria-label="Select module"
+          value={selected?.name || ''}
+          onChange={handleSelect}
+          className="border p-1"
+        >
+          <option value="">Select a module</option>
+          {modules.slice(0, 50).map((m: ModuleInfo) => (
+            <option key={m.name} value={m.name}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={reset}
+          className="border px-2 py-1"
+        >
+          Reset
+        </button>
+      </div>
+      <pre
+        data-testid="session-output"
+        className="bg-black text-green-500 p-2 h-48 overflow-auto"
+      >
+        {output}
+      </pre>
+    </div>
+  );
+};
+
+export default TargetEmulator;
+

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -2,9 +2,15 @@
 
 import React from 'react';
 import MetasploitApp from '../../components/apps/metasploit';
+import TargetEmulator from './components/TargetEmulator';
 
 const MetasploitPage: React.FC = () => {
-  return <MetasploitApp />;
+  return (
+    <div className="space-y-4">
+      <MetasploitApp />
+      <TargetEmulator />
+    </div>
+  );
 };
 
 export default MetasploitPage;


### PR DESCRIPTION
## Summary
- add TargetEmulator component with seeded RNG output and session reset
- render new emulator on metasploit page

## Testing
- `yarn test apps/metasploit/components/TargetEmulator.test.tsx`
- `npx eslint -c .eslintrc.cjs apps/metasploit/index.tsx apps/metasploit/components/TargetEmulator.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b1598d1ebc832898a02fd7edb01912