### PR TITLE
feat: add metasploit loot viewer

### DIFF
--- a/apps/metasploit/components/LootViewer.tsx
+++ b/apps/metasploit/components/LootViewer.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import templates from './lootTemplates.json';
+
+interface LootArtifact {
+  id: string;
+  host: string;
+  type: string;
+  path?: string;
+  data?: string;
+}
+
+const artifacts = templates as LootArtifact[];
+
+const LootViewer: React.FC = () => {
+  const [index, setIndex] = useState(0);
+  const [favorites, setFavorites] = usePersistentState<string[]>(
+    'metasploit:loot:favorites',
+    [],
+    (v): v is string[] => Array.isArray(v) && v.every((x) => typeof x === 'string'),
+  );
+
+  const artifact = artifacts[index];
+  const total = artifacts.length;
+  const isFavorite = favorites.includes(artifact.id);
+
+  const prev = () => setIndex((i) => (i === 0 ? total - 1 : i - 1));
+  const next = () => setIndex((i) => (i === total - 1 ? 0 : i + 1));
+  const toggleFavorite = () => {
+    setFavorites((f) =>
+      f.includes(artifact.id)
+        ? f.filter((id) => id !== artifact.id)
+        : [...f, artifact.id],
+    );
+  };
+
+  return (
+    <div className="p-4 text-sm bg-ub-grey flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <button onClick={prev} className="px-2 py-1 bg-ub-orange rounded">Prev</button>
+        <span>
+          {index + 1} / {total}
+        </span>
+        <button onClick={next} className="px-2 py-1 bg-ub-orange rounded">Next</button>
+      </div>
+      <div className="bg-black text-green-400 p-2 rounded">
+        <p>
+          <strong>Host:</strong> {artifact.host}
+        </p>
+        <p>
+          <strong>Type:</strong> {artifact.type}
+        </p>
+        {artifact.path && (
+          <p>
+            <strong>Path:</strong> {artifact.path}
+          </p>
+        )}
+        {artifact.data && (
+          <p>
+            <strong>Data:</strong> {artifact.data}
+          </p>
+        )}
+      </div>
+      <button
+        onClick={toggleFavorite}
+        className={`px-2 py-1 rounded ${
+          isFavorite ? 'bg-yellow-400' : 'bg-ub-grey'
+        }`}
+      >
+        {isFavorite ? '★ Favorited' : '☆ Favorite'}
+      </button>
+    </div>
+  );
+};
+
+export default LootViewer;

--- a/apps/metasploit/components/lootTemplates.json
+++ b/apps/metasploit/components/lootTemplates.json
@@ -1,0 +1,5 @@
+[
+  { "id": "ssh-key-1", "host": "10.0.0.2", "type": "ssh_private_key", "path": "/home/user/.ssh/id_rsa" },
+  { "id": "password-1", "host": "10.0.0.3", "type": "password", "data": "admin:admin123" },
+  { "id": "config-1", "host": "10.0.0.4", "type": "config", "data": "db_password=secret" }
+]


### PR DESCRIPTION
## Summary
- add loot viewer component to metasploit app
- include local loot templates and navigation with favorites support

## Testing
- `npm test` (fails: merging two 2s creates one 4, merge triggers animation, score persists in localStorage, skin selection changes tile class, BeEF app tests)
- `npm run lint` (fails: ESLint couldn't find eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68b1598dffa48328bf29eafd8d6757e4