### PR TITLE
Add sortable remediation table to Metasploit post module

### DIFF
--- a/apps/metasploit-post/components/RemediationTable.tsx
+++ b/apps/metasploit-post/components/RemediationTable.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import issues from '../issues.json';
+
+interface Issue {
+  id: number;
+  issue: string;
+  remediation: string;
+  severity: string;
+}
+
+type SortKey = keyof Issue;
+
+const RemediationTable: React.FC = () => {
+  const data: Issue[] = issues as Issue[];
+  const [sortConfig, setSortConfig] = useState<{ key: SortKey; direction: 'asc' | 'desc' }>(
+    { key: 'issue', direction: 'asc' }
+  );
+
+  const sorted = useMemo(() => {
+    const sortedData = [...data].sort((a, b) => {
+      const aVal = a[sortConfig.key];
+      const bVal = b[sortConfig.key];
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortConfig.direction === 'asc' ? aVal - bVal : bVal - aVal;
+      }
+      return sortConfig.direction === 'asc'
+        ? String(aVal).localeCompare(String(bVal))
+        : String(bVal).localeCompare(String(aVal));
+    });
+    return sortedData;
+  }, [data, sortConfig]);
+
+  const requestSort = (key: SortKey) => {
+    setSortConfig((prev) =>
+      prev.key === key
+        ? { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+        : { key, direction: 'asc' }
+    );
+  };
+
+  const indicator = (key: SortKey) => {
+    if (sortConfig.key !== key) return null;
+    return sortConfig.direction === 'asc' ? '▲' : '▼';
+  };
+
+  return (
+    <div className="mt-4">
+      <h3 className="font-semibold mb-2">Remediation Tips</h3>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr>
+            <th className="cursor-pointer" onClick={() => requestSort('issue')}>
+              Issue {indicator('issue')}
+            </th>
+            <th className="cursor-pointer" onClick={() => requestSort('remediation')}>
+              Remediation {indicator('remediation')}
+            </th>
+            <th className="cursor-pointer" onClick={() => requestSort('severity')}>
+              Severity {indicator('severity')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((item) => (
+            <tr key={item.id} className="border-t border-gray-700">
+              <td className="py-1 pr-2">{item.issue}</td>
+              <td className="py-1 pr-2 text-yellow-300">{item.remediation}</td>
+              <td className="py-1 pr-2">{item.severity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RemediationTable;
+

--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import modules from './modules.json';
 import privTree from './priv-esc.json';
+import RemediationTable from './components/RemediationTable';
 
 interface ModuleOption {
   name: string;
@@ -243,6 +244,7 @@ const MetasploitPost: React.FC = () => {
             <h3 className="font-semibold mb-2">Privilege Escalation Tree</h3>
             <PrivTree node={privTree as PrivNode} />
           </div>
+          <RemediationTable />
           <EvidenceVault />
         </div>
       </div>

--- a/apps/metasploit-post/issues.json
+++ b/apps/metasploit-post/issues.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "issue": "Weak SSH password policy",
+    "remediation": "Enforce strong SSH passwords and lockout policy",
+    "severity": "High"
+  },
+  {
+    "id": 2,
+    "issue": "Anonymous FTP enabled",
+    "remediation": "Disable anonymous FTP or restrict permissions",
+    "severity": "Medium"
+  },
+  {
+    "id": 3,
+    "issue": "Outdated Apache version",
+    "remediation": "Update Apache to the latest version",
+    "severity": "Low"
+  }
+]


### PR DESCRIPTION
## Summary
- map issues to remediation tips with local JSON data
- show issues in sortable remediation table
- expose remediation table in Metasploit Post page

## Testing
- `yarn test apps/metasploit-post/components/RemediationTable.tsx --passWithNoTests`
- `yarn lint apps/metasploit-post/index.tsx apps/metasploit-post/components/RemediationTable.tsx` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b1598fc2ec832881b7bcfe557a8a2e