### PR TITLE
Add credential hygiene visualization for Hydra

### DIFF
--- a/apps/hydra/components/CredentialHygiene.tsx
+++ b/apps/hydra/components/CredentialHygiene.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+
+const weakPasswords = [
+  { pattern: "123456", count: 290491 },
+  { pattern: "password", count: 213139 },
+  { pattern: "123456789", count: 79309 },
+  { pattern: "12345", count: 48750 },
+  { pattern: "qwerty", count: 35552 },
+];
+
+const commonMistakes = [
+  'Simple sequences like "abcd" or "1234".',
+  'Keyboard patterns such as "qwerty" or "asdfgh".',
+  'Leet speak substitutions (e.g., "p@ssw0rd").',
+  "Reused passwords across multiple sites.",
+];
+
+const CredentialHygiene: React.FC = () => {
+  const maxCount = Math.max(...weakPasswords.map((p) => p.count));
+
+  return (
+    <section className="max-w-xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Password Pattern Pitfalls</h2>
+      <p className="mb-4 text-sm text-gray-300">
+        For educational purposes only. These commonly leaked passwords highlight
+        patterns attackers try first. Avoid these predictable choices when
+        creating credentials.
+      </p>
+      <ul className="mb-6">
+        {weakPasswords.map((p) => (
+          <li key={p.pattern} className="mb-2">
+            <div className="flex justify-between text-sm">
+              <span className="font-mono">{p.pattern}</span>
+              <span className="text-gray-400">{p.count.toLocaleString()}</span>
+            </div>
+            <div className="bg-gray-700 h-2 rounded">
+              <div
+                className="bg-red-500 h-2 rounded"
+                style={{ width: `${(p.count / maxCount) * 100}%` }}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <h3 className="text-xl font-semibold mb-2">Common Mistakes</h3>
+      <ul className="list-disc pl-5 mb-6 text-sm text-gray-300">
+        {commonMistakes.map((m) => (
+          <li key={m}>{m}</li>
+        ))}
+      </ul>
+      <p className="text-sm text-gray-300">
+        <strong>Best practices:</strong>{" "}
+        <a
+          href="https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          OWASP Authentication Cheat Sheet
+        </a>{" "}
+        •{" "}
+        <a
+          href="https://pages.nist.gov/800-63-3/sp800-63b.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-400"
+        >
+          NIST Digital Identity Guidelines
+        </a>
+      </p>
+    </section>
+  );
+};
+
+export default CredentialHygiene;

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
-import React, { useRef, useState } from 'react';
-import LegalInterstitial from '../../components/ui/LegalInterstitial';
-import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
-import HydraApp from '../../components/apps/hydra';
+import React, { useRef, useState } from "react";
+import LegalInterstitial from "../../components/ui/LegalInterstitial";
+import TabbedWindow, { TabDefinition } from "../../components/ui/TabbedWindow";
+import HydraApp from "../../components/apps/hydra";
+import CredentialHygiene from "./components/CredentialHygiene";
 
 const HydraPreview: React.FC = () => {
   const [accepted, setAccepted] = useState(false);
@@ -19,11 +20,16 @@ const HydraPreview: React.FC = () => {
   };
 
   return (
-    <TabbedWindow
-      className="min-h-screen bg-gray-900 text-white"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
-    />
+    <>
+      <TabbedWindow
+        className="min-h-screen bg-gray-900 text-white"
+        initialTabs={[createTab()]}
+        onNewTab={createTab}
+      />
+      <div className="bg-gray-900 text-white p-4">
+        <CredentialHygiene />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add CredentialHygiene component to illustrate weak password patterns, common mistakes, and links to best-practice guidance
- render CredentialHygiene below the Hydra simulation for educational context

## Testing
- `npx eslint -c .eslintrc.cjs apps/hydra/index.tsx apps/hydra/components/CredentialHygiene.tsx` (warnings: files ignored because no matching configuration was supplied)
- `npx jest apps/hydra/index.tsx apps/hydra/components/CredentialHygiene.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1599225e08328ab6ac99f130125ff