### PR TITLE
Add client-side workload visualizer to Hashcat simulator

### DIFF
--- a/apps/hashcat/components/WorkloadVisualizer.tsx
+++ b/apps/hashcat/components/WorkloadVisualizer.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const profileFns = {
+  light: (t: number) => 30 + 10 * Math.sin(t / 5),
+  medium: (t: number) => 50 + 20 * Math.sin(t / 7),
+  heavy: (t: number) => 70 + 25 * Math.sin(t / 9),
+};
+
+const profileOptions = [
+  { value: 'light', label: 'Light' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'heavy', label: 'Heavy' },
+];
+
+export default function WorkloadVisualizer() {
+  const [profile, setProfile] = useState('light');
+  const data = useMemo(() => {
+    const fn = profileFns[profile as keyof typeof profileFns];
+    return Array.from({ length: 60 }, (_, i) => ({
+      t: i,
+      v: Math.min(100, Math.max(0, fn(i))),
+    }));
+  }, [profile]);
+
+  const points = data
+    .map((p, i) => `${(i / (data.length - 1)) * 100},${100 - p.v}`)
+    .join(' ');
+
+  return (
+    <div className="space-y-2" aria-label="workload visualizer">
+      <label>
+        Profile
+        <select
+          className="ml-2 text-black p-1 rounded"
+          value={profile}
+          onChange={(e) => setProfile(e.target.value)}
+        >
+          {profileOptions.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <svg
+        viewBox="0 0 100 100"
+        className="w-full h-40 bg-gray-800"
+        role="img"
+        aria-label="workload profile chart"
+      >
+        <polyline
+          fill="none"
+          stroke="#4ade80"
+          strokeWidth={1}
+          points={points}
+        />
+      </svg>
+    </div>
+  );
+}
+

--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import WorkloadVisualizer from './components/WorkloadVisualizer';
 
 interface RuleSets {
   [key: string]: string[];
@@ -183,6 +184,9 @@ const Hashcat: React.FC = () => {
         <div className="mt-2 text-sm">
           Speed: {speed.toFixed(0)} H/s | ETA: {eta} | Recovered: {recovered}/{total}
         </div>
+      </div>
+      <div className="mt-4">
+        <WorkloadVisualizer />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- simulate light, medium, and heavy workload profiles entirely client-side
- chart selected profile with an SVG line graph
- integrate visualizer into Hashcat simulator

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/hashcat/index.tsx apps/hashcat/components/WorkloadVisualizer.tsx`
- `npx jest apps/hashcat --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1599465808328a23d95f9063d80ed