### PR TITLE
feat(hashcat): add rule sandbox with persistent editing

### DIFF
--- a/apps/hashcat/components/RulesSandbox.tsx
+++ b/apps/hashcat/components/RulesSandbox.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const sampleWords = ['password', '123456', 'letmein', 'qwerty'];
+
+function applyRule(rule: string, word: string) {
+  let result = word;
+  for (const ch of rule.trim()) {
+    switch (ch) {
+      case 'c':
+        result = result.charAt(0).toUpperCase() + result.slice(1);
+        break;
+      case 'u':
+        result = result.toUpperCase();
+        break;
+      case 'l':
+        result = result.toLowerCase();
+        break;
+      case 'r':
+        result = result.split('').reverse().join('');
+        break;
+      case 'd':
+        result = result + result;
+        break;
+      default:
+        // unsupported commands are ignored
+        break;
+    }
+  }
+  return result;
+}
+
+const RulesSandbox: React.FC = () => {
+  const [rules, setRules] = usePersistentState<string>(
+    'hashcatRulesSandbox',
+    'c\nu\nr',
+  );
+
+  const ruleLines = useMemo(
+    () =>
+      rules
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l && !l.startsWith('#')),
+    [rules],
+  );
+
+  return (
+    <div className="space-y-2 mt-4">
+      <h2 className="text-xl">Rules Sandbox</h2>
+      <textarea
+        className="w-full h-32 text-black p-2 font-mono"
+        value={rules}
+        onChange={(e) => setRules(e.target.value)}
+        placeholder="Enter hashcat rules, one per line"
+      />
+      <div className="overflow-auto">
+        {ruleLines.length === 0 ? (
+          <div className="text-sm">(no rules)</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left">Word</th>
+                {ruleLines.map((r) => (
+                  <th key={r} className="text-left">
+                    {r}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sampleWords.map((word) => (
+                <tr key={word}>
+                  <td className="font-mono pr-2">{word}</td>
+                  {ruleLines.map((r) => (
+                    <td key={r} className="font-mono pr-2">
+                      {applyRule(r, word)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RulesSandbox;
+

--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import RulesSandbox from './components/RulesSandbox';
 
 interface RuleSets {
   [key: string]: string[];
@@ -162,6 +163,8 @@ const Hashcat: React.FC = () => {
           {rulePreview || '(no rules)'}
         </pre>
       </div>
+
+      <RulesSandbox />
 
       <div>
         <button


### PR DESCRIPTION
## Summary
- add `RulesSandbox` component demonstrating rule transforms on sample words
- persist editable rules with `usePersistentState`
- wire sandbox into Hashcat simulator

## Testing
- `yarn test` *(fails: game2048, beef app, calculator parser, mimikatz, vscode, word search, kismet)*
- `yarn lint apps/hashcat/index.tsx apps/hashcat/components/RulesSandbox.tsx` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b15994e27883288b1a10ca1565c22c