### PR TITLE
feat(autopsy): add case walkthrough component with canned data

### DIFF
--- a/apps/autopsy/components/CaseWalkthrough.tsx
+++ b/apps/autopsy/components/CaseWalkthrough.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import caseData from '../data/case.json';
+
+interface TimelineEntry {
+  timestamp: string;
+  event: string;
+  thumbnail: string;
+}
+
+interface FileNode {
+  name: string;
+  thumbnail?: string;
+  children?: FileNode[];
+}
+
+const renderNode = (node: FileNode): React.ReactNode => {
+  if (node.children && node.children.length > 0) {
+    return (
+      <div key={node.name} className="ml-4">
+        <div className="flex items-center font-semibold">
+          {node.thumbnail && (
+            <img src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
+          )}
+          {node.name}
+        </div>
+        <div className="ml-4">
+          {node.children.map((child) => (
+            <div key={child.name}>{renderNode(child)}</div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div key={node.name} className="ml-4 flex items-center">
+      {node.thumbnail && (
+        <img src={node.thumbnail} alt="" className="w-4 h-4 mr-1" />
+      )}
+      {node.name}
+    </div>
+  );
+};
+
+const CaseWalkthrough: React.FC = () => {
+  const { timeline, fileTree } = caseData as {
+    timeline: TimelineEntry[];
+    fileTree: FileNode;
+  };
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-bold mb-2">Timeline</h2>
+        <ul className="space-y-2">
+          {timeline.map((item, idx) => (
+            <li key={idx} className="flex items-center text-sm">
+              <img src={item.thumbnail} alt="" className="w-6 h-6 mr-2" />
+              <span>
+                {new Date(item.timestamp).toLocaleString()} – {item.event}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-lg font-bold mb-2">File Tree</h2>
+        {renderNode(fileTree)}
+      </section>
+    </div>
+  );
+};
+
+export default CaseWalkthrough;
+

--- a/apps/autopsy/data/case.json
+++ b/apps/autopsy/data/case.json
@@ -1,0 +1,79 @@
+{
+  "timeline": [
+    {
+      "timestamp": "2023-08-01T10:00:00Z",
+      "event": "resume.docx created on desktop",
+      "thumbnail": "/themes/Yaru/apps/gedit.png"
+    },
+    {
+      "timestamp": "2023-08-01T12:30:00Z",
+      "event": "photo.jpg taken on phone",
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+    },
+    {
+      "timestamp": "2023-08-01T14:45:00Z",
+      "event": "system.log updated",
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+    },
+    {
+      "timestamp": "2023-08-01T16:15:00Z",
+      "event": "run.exe executed",
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+    },
+    {
+      "timestamp": "2023-08-01T18:20:00Z",
+      "event": "Registry key modified",
+      "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+    }
+  ],
+  "fileTree": {
+    "name": "root",
+    "children": [
+      {
+        "name": "Documents",
+        "children": [
+          {
+            "name": "resume.docx",
+            "thumbnail": "/themes/Yaru/apps/gedit.png"
+          }
+        ]
+      },
+      {
+        "name": "Pictures",
+        "children": [
+          {
+            "name": "photo.jpg",
+            "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+          }
+        ]
+      },
+      {
+        "name": "Logs",
+        "children": [
+          {
+            "name": "system.log",
+            "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+          }
+        ]
+      },
+      {
+        "name": "Temp",
+        "children": [
+          {
+            "name": "run.exe",
+            "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+          }
+        ]
+      },
+      {
+        "name": "Registry",
+        "children": [
+          {
+            "name": "HKCU\\Software\\Example",
+            "thumbnail": "/themes/Yaru/apps/autopsy.svg"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add canned autopsy case data with timeline and file tree
- render timeline and file tree with thumbnails in CaseWalkthrough component

## Testing
- `yarn test __tests__/autopsy.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b1599d94588328ad5be767975552d9