### PR TITLE
feat(volatility): add triage filters with persistence

### DIFF
--- a/apps/volatility/components/TriageFilters.tsx
+++ b/apps/volatility/components/TriageFilters.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import usePersistentState from '../../../components/usePersistentState.js';
+
+// Static dataset illustrating possible suspicious markers
+const markers = [
+  { id: 1, description: 'Unsigned DLL loaded in system process', severity: 'suspicious' },
+  { id: 2, description: 'Process hollowing detected', severity: 'malicious' },
+  { id: 3, description: 'Hidden network listener', severity: 'suspicious' },
+  { id: 4, description: 'Execution from writable memory region', severity: 'malicious' },
+  { id: 5, description: 'Unusual parent-child process relationship', severity: 'informational' },
+];
+
+const severities = ['informational', 'suspicious', 'malicious'] as const;
+
+type Severity = typeof severities[number];
+
+type Marker = {
+  id: number;
+  description: string;
+  severity: Severity;
+};
+
+const TriageFilters: React.FC = () => {
+  const [activeFilters, setActiveFilters] = usePersistentState<Severity[]>(
+    'volatility-triage-filters',
+    [...severities]
+  );
+
+  const toggleFilter = (sev: Severity) => {
+    setActiveFilters((prev: Severity[]) =>
+      prev.includes(sev)
+        ? prev.filter((s) => s !== sev)
+        : [...prev, sev]
+    );
+  };
+
+  const filteredMarkers = (markers as Marker[]).filter((m) =>
+    activeFilters.includes(m.severity)
+  );
+
+  return (
+    <div className="p-4 bg-gray-900 text-white rounded-md space-y-3">
+      <h2 className="text-sm font-semibold">Suspicious Markers</h2>
+      <div className="flex space-x-4 text-xs">
+        {severities.map((sev) => (
+          <label key={sev} className="flex items-center space-x-1">
+            <input
+              type="checkbox"
+              className="accent-blue-500"
+              checked={activeFilters.includes(sev)}
+              onChange={() => toggleFilter(sev)}
+            />
+            <span className="capitalize">{sev}</span>
+          </label>
+        ))}
+      </div>
+      <ul className="text-xs list-disc pl-5 space-y-1">
+        {filteredMarkers.map((marker) => (
+          <li key={marker.id} className="flex items-center justify-between">
+            <span>{marker.description}</span>
+            <span
+              className={
+                marker.severity === 'malicious'
+                  ? 'text-red-400'
+                  : marker.severity === 'suspicious'
+                  ? 'text-yellow-400'
+                  : 'text-blue-400'
+              }
+            >
+              {marker.severity}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TriageFilters;
+

--- a/apps/volatility/index.tsx
+++ b/apps/volatility/index.tsx
@@ -2,9 +2,16 @@
 
 import React from 'react';
 import VolatilityApp from '../../components/apps/volatility';
+import TriageFilters from './components/TriageFilters';
 
 const VolatilityPage: React.FC = () => {
-  return <VolatilityApp />;
+  return (
+    <div className="space-y-4">
+      <VolatilityApp />
+      {/* Demonstration of triage filter component */}
+      <TriageFilters />
+    </div>
+  );
 };
 
 export default VolatilityPage;


### PR DESCRIPTION
## Summary
- add TriageFilters component with persistent selections and demo data for suspicious markers
- render triage filters on Volatility page

## Testing
- `npx eslint apps/volatility/index.tsx apps/volatility/components/TriageFilters.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, kismet.test.tsx, metasploit.test.tsx, wordSearch.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1599d139c832898a1fd196993470e