### PR TITLE
Add plugin walkthrough for Volatility app

### DIFF
--- a/apps/volatility/components/PluginWalkthrough.tsx
+++ b/apps/volatility/components/PluginWalkthrough.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import plugins from '../../../public/demo-data/volatility/plugins.json';
+
+interface PluginInfo {
+  name: string;
+  description: string;
+  output: string;
+}
+
+const PluginWalkthrough: React.FC = () => {
+  const data = plugins as PluginInfo[];
+  const [index, setIndex] = useState(0);
+  const current = data[index];
+
+  const next = () => setIndex((i) => (i + 1) % data.length);
+  const prev = () => setIndex((i) => (i - 1 + data.length) % data.length);
+
+  return (
+    <div className="space-y-2 text-xs">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">{current.name}</h2>
+        <div className="space-x-2">
+          <button onClick={prev} className="px-2 py-1 bg-gray-700 rounded">
+            Prev
+          </button>
+          <button onClick={next} className="px-2 py-1 bg-gray-700 rounded">
+            Next
+          </button>
+        </div>
+      </div>
+      <p>{current.description}</p>
+      <pre className="bg-black p-2 rounded overflow-auto whitespace-pre-wrap">
+        {current.output}
+      </pre>
+    </div>
+  );
+};
+
+export default PluginWalkthrough;

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MemoryHeatmap from './MemoryHeatmap';
 import PluginBrowser from './PluginBrowser';
+import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthrough';
 import memoryDemo from '../../../public/demo-data/volatility/memory.json';
 
 // pull demo data for various volatility plugins from the memory fixture
@@ -167,7 +168,7 @@ const VolatilityApp = () => {
       <div className="flex-1 flex">
         <div className="flex-1 flex flex-col">
           <div className="flex space-x-2 px-2 bg-gray-900">
-            {['pstree', 'netscan', 'malfind', 'yarascan', 'plugins'].map((tab) => (
+            {['pstree', 'netscan', 'malfind', 'yarascan', 'plugins', 'walkthrough'].map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -255,6 +256,7 @@ const VolatilityApp = () => {
               />
             )}
             {activeTab === 'plugins' && <PluginBrowser />}
+            {activeTab === 'walkthrough' && <PluginWalkthrough />}
           </div>
         </div>
         {finding && (


### PR DESCRIPTION
## Summary
- Add PluginWalkthrough component to showcase common Volatility plugins with canned output and next/prev navigation
- Wire walkthrough into Volatility app via new tab

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint apps/volatility/components/PluginWalkthrough.tsx components/apps/volatility/index.js` (fails: React hook error in unrelated file)
- `yarn test apps/volatility` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b1599c87a483288059a15d051c54d0