### PR TITLE
feat(mimikatz): add blue team panel with mitigation tips

### DIFF
--- a/apps/mimikatz/components/BlueTeamPanel.tsx
+++ b/apps/mimikatz/components/BlueTeamPanel.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface LogEntry {
+  step: string;
+  log: string;
+  mitigation: string;
+  resource?: string;
+}
+
+interface Props {
+  logs: LogEntry[];
+}
+
+const BlueTeamPanel: React.FC<Props> = ({ logs }) => {
+  const [open, setOpen] = useState<Record<number, boolean>>({});
+
+  const toggle = (idx: number) =>
+    setOpen((prev) => ({ ...prev, [idx]: !prev[idx] }));
+
+  return (
+    <div className="space-y-2">
+      {logs.map((entry, idx) => (
+        <div key={idx} className="border border-blue-600 rounded">
+          <button
+            className="w-full text-left p-2 bg-blue-700 hover:bg-blue-600 font-semibold"
+            onClick={() => toggle(idx)}
+          >
+            Step {idx + 1}: {entry.step}
+          </button>
+          {open[idx] && (
+            <div className="p-2 bg-blue-600 text-sm">
+              <p className="mb-1">{entry.log}</p>
+              <p className="mb-1">
+                <span className="font-semibold">Mitigation:</span> {entry.mitigation}
+              </p>
+              {entry.resource && (
+                <a
+                  href={entry.resource}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline text-blue-200"
+                >
+                  Learn more
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BlueTeamPanel;
+

--- a/components/apps/mimikatz/index.js
+++ b/components/apps/mimikatz/index.js
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
 import eventLogsData from './eventLogs.json';
 import lsassDiagrams from './lsass.json';
+import BlueTeamPanel from '../../../apps/mimikatz/components/BlueTeamPanel';
 
 // Storyboard UI showing attack steps and mitigations.
 const MimikatzApp = () => {
   const [tab, setTab] = useState('attack');
   const [logs, setLogs] = useState(eventLogsData);
+
+  const resources = {
+    'Invoke Mimikatz':
+      'https://learn.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/applocker-overview',
+    'Dump LSASS':
+      'https://learn.microsoft.com/en-us/windows-server/security/credential-protection/lsass-protection',
+  };
 
   const handleImport = (e) => {
     const file = e.target.files?.[0];
@@ -74,13 +82,9 @@ const MimikatzApp = () => {
       ) : (
         <div className="p-4 overflow-auto flex-1 bg-ub-cool-grey">
           <h2 className="text-lg mb-2">Mitigation Tips</h2>
-          <ul className="list-disc pl-4 space-y-1">
-            {logs.map((l, idx) => (
-              <li key={idx}>
-                <span className="font-semibold">{l.step}</span>: {l.mitigation}
-              </li>
-            ))}
-          </ul>
+          <BlueTeamPanel
+            logs={logs.map((l) => ({ ...l, resource: resources[l.step] }))}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add collapsible blue team panel showing simulation logs with mitigation tips and resource links
- hook mimikatz app into new panel

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `CI=true yarn test` *(fails: game2048, beef, mimikatz, wordSearch, kismet, and vscode test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b159a1e6488328931e283899ac7904