### PR TITLE
feat(nessus): add trend chart for report history

### DIFF
--- a/apps/nessus/components/TrendChart.tsx
+++ b/apps/nessus/components/TrendChart.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const severities = ['Critical', 'High', 'Medium', 'Low', 'Info'] as const;
+type Severity = (typeof severities)[number];
+
+interface Finding {
+  severity: Severity;
+}
+
+interface Scan {
+  findings: Finding[];
+}
+
+interface Entry {
+  label: string;
+  counts: Record<Severity, number>;
+}
+
+const colors: Record<Severity, string> = {
+  Critical: '#dc2626',
+  High: '#f97316',
+  Medium: '#eab308',
+  Low: '#16a34a',
+  Info: '#6b7280',
+};
+
+export default function TrendChart() {
+  const [history, setHistory, , clear] = usePersistentState<Entry[]>(
+    'nessus:history',
+    [],
+  );
+
+  const importReport = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const json: Scan = JSON.parse(reader.result as string);
+          const counts: Record<Severity, number> = {
+            Critical: 0,
+            High: 0,
+            Medium: 0,
+            Low: 0,
+            Info: 0,
+          };
+          for (const f of json.findings) {
+            counts[f.severity] += 1;
+          }
+          setHistory((h) => [...h, { label: file.name, counts }]);
+        } catch {
+          // ignore parse errors
+        }
+      };
+      reader.readAsText(file);
+    },
+    [setHistory],
+  );
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) importReport(file);
+    e.target.value = '';
+  };
+
+  const max = Math.max(
+    1,
+    ...history.flatMap((h) => Object.values(h.counts)),
+  );
+  const width = 300;
+  const height = 120;
+  const step = history.length > 1 ? width / (history.length - 1) : width;
+
+  const lines = severities.map((sev) => {
+    const d = history
+      .map((h, i) => {
+        const x = i * step;
+        const y = height - (h.counts[sev] / max) * height;
+        return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+      })
+      .join(' ');
+    return (
+      <path
+        key={sev}
+        d={d}
+        fill="none"
+        stroke={colors[sev]}
+        strokeWidth={2}
+      />
+    );
+  });
+
+  const latest = history[history.length - 1];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <input type="file" accept="application/json" onChange={handleFile} />
+        {history.length > 0 && (
+          <button
+            type="button"
+            onClick={clear}
+            className="px-2 py-1 bg-gray-700 rounded"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      {history.length > 0 && (
+        <>
+          <svg
+            width={width}
+            height={height}
+            className="bg-gray-800 rounded"
+          >
+            {lines}
+          </svg>
+          {latest && (
+            <svg
+              width={width}
+              height={height}
+              className="bg-gray-800 rounded"
+            >
+              {severities.map((sev, i) => {
+                const barWidth = width / severities.length - 4;
+                const x = i * (barWidth + 4);
+                const barHeight = (latest.counts[sev] / max) * height;
+                const y = height - barHeight;
+                return (
+                  <rect
+                    key={sev}
+                    x={x}
+                    y={y}
+                    width={barWidth}
+                    height={barHeight}
+                    fill={colors[sev]}
+                  />
+                );
+              })}
+            </svg>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/apps/nessus/index.tsx
+++ b/apps/nessus/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { toPng } from 'html-to-image';
+import TrendChart from './components/TrendChart';
 
 interface Plugin {
   id: number;
@@ -192,6 +193,10 @@ const Nessus: React.FC = () => {
         >
           Export
         </button>
+      </section>
+      <section>
+        <h2 className="text-xl mb-2">Trends</h2>
+        <TrendChart />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add TrendChart component to import Nessus report JSON and persist severity counts
- visualize history with line and bar charts
- display trend section in Nessus demo

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, metasploit, etc.)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b159a3950c83289b92907e82bb276f