### PR TITLE
Add Nikto signature browser

### DIFF
--- a/__tests__/signatureBrowser.test.tsx
+++ b/__tests__/signatureBrowser.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SignatureBrowser from '../apps/nikto/components/SignatureBrowser';
+
+describe('SignatureBrowser', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            {
+              check: 'Apache mod_status Information Disclosure',
+              category: 'Information Disclosure',
+              example: '/server-status',
+            },
+            {
+              check: 'PHP info() page found',
+              category: 'Misconfiguration',
+              example: '/phpinfo.php',
+            },
+          ]),
+      })
+    ) as any;
+  });
+
+  it('searches and filters signatures', async () => {
+    const user = userEvent.setup();
+    render(<SignatureBrowser />);
+
+    await screen.findByText('Apache mod_status Information Disclosure');
+
+    await user.type(screen.getByPlaceholderText(/search/i), 'php');
+    expect(screen.getByText('PHP info() page found')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Apache mod_status Information Disclosure')
+    ).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText(/search/i));
+    await user.selectOptions(screen.getByDisplayValue('All'), 'Misconfiguration');
+    expect(screen.getByText('PHP info() page found')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Apache mod_status Information Disclosure')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/nikto/components/SignatureBrowser.tsx
+++ b/apps/nikto/components/SignatureBrowser.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+interface Signature {
+  check: string;
+  category: string;
+  example: string;
+}
+
+const SignatureBrowser: React.FC = () => {
+  const [signatures, setSignatures] = useState<Signature[]>([]);
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('All');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/nikto-signatures.json');
+        const data = await res.json();
+        if (Array.isArray(data)) {
+          setSignatures(
+            data.filter(
+              (s: any) =>
+                typeof s.check === 'string' &&
+                typeof s.category === 'string' &&
+                typeof s.example === 'string'
+            )
+          );
+        }
+      } catch {
+        // ignore
+      }
+    };
+    load();
+  }, []);
+
+  const categories = useMemo(() => {
+    const cats = Array.from(new Set(signatures.map((s) => s.category))).filter(
+      Boolean
+    ) as string[];
+    return ['All', ...cats];
+  }, [signatures]);
+
+  const filtered = useMemo(() => {
+    return signatures.filter(
+      (s) =>
+        (category === 'All' || s.category === category) &&
+        (s.check.toLowerCase().includes(query.toLowerCase()) ||
+          s.example.toLowerCase().includes(query.toLowerCase()))
+    );
+  }, [signatures, query, category]);
+
+  return (
+    <div className="mt-4" data-testid="signature-browser">
+      <h2 className="text-lg mb-2">Signature Browser</h2>
+      <div className="flex space-x-2 mb-2">
+        <input
+          placeholder="Search"
+          className="p-2 rounded text-black flex-1"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <select
+          className="p-2 rounded text-black"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="bg-gray-700">
+            <th className="p-2">Check</th>
+            <th className="p-2">Category</th>
+            <th className="p-2">Example</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((sig, idx) => (
+            <tr key={idx} className="odd:bg-gray-800">
+              <td className="p-2">{sig.check}</td>
+              <td className="p-2">{sig.category}</td>
+              <td className="p-2 break-all">{sig.example}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default SignatureBrowser;
+

--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import SignatureBrowser from './components/SignatureBrowser';
 
 interface NiktoFinding {
   path: string;
@@ -202,6 +203,7 @@ const NiktoPage: React.FC = () => {
           className="w-full h-64 bg-white"
         />
       </div>
+      <SignatureBrowser />
     </div>
   );
 };

--- a/public/nikto-signatures.json
+++ b/public/nikto-signatures.json
@@ -1,0 +1,22 @@
+[
+  {
+    "check": "Apache mod_status Information Disclosure",
+    "category": "Information Disclosure",
+    "example": "/server-status"
+  },
+  {
+    "check": "PHP info() page found",
+    "category": "Misconfiguration",
+    "example": "/phpinfo.php"
+  },
+  {
+    "check": "Directory listing enabled",
+    "category": "Server",
+    "example": "/"
+  },
+  {
+    "check": "XSS in search parameter",
+    "category": "Cross Site Scripting",
+    "example": "/search.php?q=<script>alert(1)</script>"
+  }
+]


### PR DESCRIPTION
## Summary
- add Nikto signature browser component with search and category filters
- include sample signature data
- wire browser into Nikto app and add tests

## Testing
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, wordSearch.test.ts, kismet.test.tsx, metasploit.test.tsx, vsCode.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b159a681e883288cca6c606e73f1bf