### PR TITLE
feat(nikto): add sample xml report renderer

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/apps/nikto/components/ReportRenderer.tsx
+++ b/apps/nikto/components/ReportRenderer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { XMLParser } from 'fast-xml-parser';
+import sampleXml from '../../../public/demo-data/nikto/sample.xml?raw';
+
+interface Issue {
+  host: string;
+  url: string;
+  description: string;
+}
+
+const parser = new XMLParser({ ignoreAttributes: false });
+
+const parseReport = (xml: string): Issue[] => {
+  try {
+    const json = parser.parse(xml);
+    const details = json.niktoscan?.scandetails;
+    const hosts = Array.isArray(details) ? details : details ? [details] : [];
+    const issues: Issue[] = [];
+    hosts.forEach((h: any) => {
+      const host = h['@_targethostname'] || h['@_targetip'] || 'unknown';
+      const items = Array.isArray(h.item) ? h.item : h.item ? [h.item] : [];
+      items.forEach((it: any) => {
+        issues.push({
+          host,
+          url: it.uri || it.url || '',
+          description: it.description || it.namelink || '',
+        });
+      });
+    });
+    return issues;
+  } catch {
+    return [];
+  }
+};
+
+const ReportRenderer: React.FC = () => {
+  const issues = useMemo(() => parseReport(sampleXml), []);
+
+  const grouped = useMemo(
+    () =>
+      issues.reduce<Record<string, { url: string; description: string }[]>>(
+        (acc, i) => {
+          acc[i.host] = acc[i.host] || [];
+          acc[i.host].push({ url: i.url, description: i.description });
+          return acc;
+        },
+        {}
+      ),
+    [issues]
+  );
+
+  const jsonReport = useMemo(() => JSON.stringify(issues, null, 2), [issues]);
+
+  const copyJson = async () => {
+    try {
+      await navigator.clipboard?.writeText(jsonReport);
+    } catch {
+      // ignore
+    }
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([jsonReport], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nikto-issues.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded">
+      <div className="flex gap-2 mb-4">
+        <button
+          type="button"
+          onClick={copyJson}
+          className="px-2 py-1 bg-blue-600 rounded text-sm"
+        >
+          Copy JSON
+        </button>
+        <button
+          type="button"
+          onClick={exportJson}
+          className="px-2 py-1 bg-blue-600 rounded text-sm"
+        >
+          Export JSON
+        </button>
+      </div>
+      {Object.entries(grouped).map(([host, list]) => (
+        <div key={host} className="mb-4">
+          <h3 className="text-lg mb-1">{host}</h3>
+          <ul className="list-disc pl-4 space-y-1 text-sm">
+            {list.map((item, idx) => (
+              <li key={idx}>
+                <span className="text-green-300">{item.url}</span> - {item.description}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ReportRenderer;
+

--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import ReportRenderer from './components/ReportRenderer';
 
 interface NiktoFinding {
   path: string;
@@ -151,9 +152,9 @@ const NiktoPage: React.FC = () => {
                   </tr>
                 ))}
               </React.Fragment>
-            ))}
-          </tbody>
-        </table>
+      ))}
+      </tbody>
+       </table>
       </div>
       {selected && (
         <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto shadow-lg">
@@ -178,6 +179,10 @@ const NiktoPage: React.FC = () => {
           </p>
         </div>
       )}
+      <div>
+        <h2 className="text-lg mb-2">Sample XML Report</h2>
+        <ReportRenderer />
+      </div>
       <div>
         <h2 className="text-lg mb-2">HTML Report Preview</h2>
         <div className="flex space-x-2 mb-2">

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(?:xml)(?:\\?raw)?$': '<rootDir>/__mocks__/fileMock.js',
   },
   testPathIgnorePatterns: ['<rootDir>/playwright/'],
 };

--- a/public/demo-data/nikto/sample.xml
+++ b/public/demo-data/nikto/sample.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<niktoscan>
+  <scandetails targetip="192.168.56.10" targethostname="example.com">
+    <item>
+      <uri>/admin</uri>
+      <description>Admin interface accessible</description>
+    </item>
+    <item>
+      <uri>/cgi-bin/test</uri>
+      <description>Outdated test script</description>
+    </item>
+  </scandetails>
+  <scandetails targetip="192.168.56.20" targethostname="test.local">
+    <item>
+      <uri>/login</uri>
+      <description>Default credentials allow access</description>
+    </item>
+  </scandetails>
+</niktoscan>


### PR DESCRIPTION
## Summary
- parse bundled Nikto XML demo data and group findings per host
- show URL issues with copy/export to JSON options
- wire new report renderer into Nikto app and handle XML modules in Jest

## Testing
- `npx eslint apps/nikto/components/ReportRenderer.tsx apps/nikto/index.tsx jest.config.js` (fails: ESLint couldn't find an eslint.config.js)
- `yarn test __tests__/niktoPage.test.tsx __tests__/niktoReport.test.tsx __tests__/niktoApp.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b159a7ab388328aadba93ce64c2322