### PR TITLE
feat(kismet): add deauth walkthrough and mitigation notes

### DIFF
--- a/apps/kismet/components/DeauthWalkthrough.tsx
+++ b/apps/kismet/components/DeauthWalkthrough.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React from 'react';
+import capture from '../../../components/apps/kismet/sampleCapture.json';
+
+interface Frame {
+  seq: number;
+  src: string;
+  dst: string;
+  type: string;
+}
+
+const target = capture[0];
+
+const frames: Frame[] = [
+  { seq: 1, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
+  { seq: 2, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
+  { seq: 3, src: target.bssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
+  { seq: 4, src: target.bssid, dst: 'FF:FF:FF:FF:FF:FF', type: 'Deauth' },
+  { seq: 5, src: target.bssid, dst: '11:22:33:44:55:66', type: 'Data' },
+];
+
+const DeauthWalkthrough: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-bold mb-2">Deauthentication Walkthrough</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="pr-2">Seq</th>
+            <th className="pr-2">Source</th>
+            <th className="pr-2">Destination</th>
+            <th>Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          {frames.map((f) => (
+            <tr
+              key={f.seq}
+              className={`odd:bg-gray-800 ${f.type === 'Deauth' ? 'bg-red-900 text-red-100' : ''}`}
+            >
+              <td className="pr-2">{f.seq}</td>
+              <td className="pr-2">{f.src}</td>
+              <td className="pr-2">{f.dst}</td>
+              <td>{f.type}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-4">
+        Frames 3 and 4 show back-to-back deauthentication messages, a pattern often used to
+        forcibly disconnect clients from an access point.
+      </p>
+      <p className="mt-2">
+        For defensive guidance, review the{' '}
+        <a
+          href="/docs/deauth-mitigation.md"
+          className="text-blue-400 underline"
+        >
+          mitigation notes
+        </a>
+        .
+      </p>
+    </div>
+  );
+};
+
+export default DeauthWalkthrough;
+

--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -2,9 +2,15 @@
 
 import React from 'react';
 import KismetApp from '../../components/apps/kismet';
+import DeauthWalkthrough from './components/DeauthWalkthrough';
 
 const KismetPage: React.FC = () => {
-  return <KismetApp />;
+  return (
+    <>
+      <KismetApp />
+      <DeauthWalkthrough />
+    </>
+  );
 };
 
 export default KismetPage;

--- a/docs/deauth-mitigation.md
+++ b/docs/deauth-mitigation.md
@@ -1,0 +1,9 @@
+# Deauthentication Attack Mitigation
+
+Deauthentication floods send forged management frames to disconnect wireless clients. Mitigate this threat by:
+
+- Enabling **802.11w Management Frame Protection** so that deauth frames are authenticated.
+- Monitoring for excessive deauthentication traffic and alerting on anomalies.
+- Using strong encryption (WPA2/WPA3) and rotating keys regularly.
+- Limiting access-point exposure and segmenting networks.
+


### PR DESCRIPTION
## Summary
- illustrate deauthentication sequence in new `DeauthWalkthrough` component
- expose walkthrough on Kismet page and link to mitigation notes
- add mitigation doc detailing ways to defend against deauth floods

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet, vscode, word search, metasploit, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b159b2050083288d00283905ba5f7d