### PR TITLE
Add Ettercap filter DSL editor

### DIFF
--- a/apps/ettercap/components/FilterEditor.tsx
+++ b/apps/ettercap/components/FilterEditor.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface SampleFilter {
+  name: string;
+  code: string;
+}
+
+const DEFAULT_SAMPLES: SampleFilter[] = [
+  { name: 'Drop DNS', code: 'drop DNS' },
+  { name: 'Replace example.com', code: 'replace example.com test.com' },
+];
+
+const EXAMPLE_PACKETS = [
+  'DNS query example.com',
+  'HTTP GET /index.html',
+  'SSH handshake from 10.0.0.1',
+];
+
+const applyFilters = (text: string, packets: string[]) => {
+  let result = packets;
+  text
+    .split(/\n+/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [cmd, ...rest] = line.split(/\s+/);
+      if (cmd === 'drop') {
+        const pattern = rest.join(' ');
+        result = result.filter((p) => !p.includes(pattern));
+      } else if (cmd === 'replace') {
+        const [pattern, replacement] = rest;
+        if (pattern && replacement !== undefined) {
+          result = result.map((p) => p.split(pattern).join(replacement));
+        }
+      }
+    });
+  return result;
+};
+
+export default function FilterEditor() {
+  const [samples, setSamples] = usePersistentState<SampleFilter[]>(
+    'ettercap-samples',
+    DEFAULT_SAMPLES,
+  );
+  const [filterText, setFilterText] = usePersistentState(
+    'ettercap-filter-text',
+    DEFAULT_SAMPLES[0].code,
+  );
+  const output = applyFilters(filterText, EXAMPLE_PACKETS);
+
+  const loadSample = useCallback(
+    (idx: number) => setFilterText(samples[idx]?.code || ''),
+    [samples, setFilterText],
+  );
+
+  const saveSample = () => {
+    const name = window.prompt('Sample name');
+    if (!name) return;
+    setSamples((s) => [...s, { name, code: filterText }]);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <label htmlFor="sampleSelect">Samples:</label>
+        <select
+          id="sampleSelect"
+          className="border p-1"
+          onChange={(e) => loadSample(Number(e.target.value))}
+        >
+          {samples.map((s, i) => (
+            <option key={s.name} value={i}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="border px-2 py-1"
+          onClick={saveSample}
+        >
+          Save
+        </button>
+      </div>
+      <textarea
+        className="w-full h-32 border p-2 font-mono"
+        value={filterText}
+        onChange={(e) => setFilterText(e.target.value)}
+      />
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <h3 className="font-bold mb-2">Before</h3>
+          <ul className="bg-gray-100 p-2 font-mono text-sm space-y-1">
+            {EXAMPLE_PACKETS.map((p, i) => (
+              <li key={i}>{p}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-bold mb-2">After</h3>
+          <ul className="bg-gray-100 p-2 font-mono text-sm space-y-1">
+            {output.map((p, i) => (
+              <li key={i}>{p}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/ettercap/index.tsx
+++ b/apps/ettercap/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import FilterEditor from './components/FilterEditor';
+
+export default function EttercapPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Ettercap Filter Editor</h1>
+      <FilterEditor />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create Ettercap app page with simple DSL filter editor
- transform example packets and save custom filters in localStorage

## Testing
- `npm test apps/ettercap/components/FilterEditor.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b159bcbe78832881a9f3176719d78e