### PR TITLE
feat(hydra): add strategy trainer graph

### DIFF
--- a/apps/hydra/components/StrategyTrainer.tsx
+++ b/apps/hydra/components/StrategyTrainer.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+const CHANCE_PER_ATTEMPT = 0.05; // 5% chance per attempt for simulation
+const STEPS = 20;
+const WIDTH = 300;
+const HEIGHT = 150;
+
+const StrategyTrainer: React.FC = () => {
+  const [parallelism, setParallelism] = useState(4);
+  const [lockout, setLockout] = useState(10);
+
+  const points = useMemo(() => {
+    const pts: { t: number; success: number }[] = [];
+    for (let t = 0; t <= STEPS; t++) {
+      const attempts = Math.min(parallelism * t, lockout);
+      const success = 1 - Math.pow(1 - CHANCE_PER_ATTEMPT, attempts);
+      pts.push({ t, success });
+    }
+    return pts;
+  }, [parallelism, lockout]);
+
+  const path = points
+    .map(
+      (p) => `${(p.t / STEPS) * WIDTH},${HEIGHT - p.success * HEIGHT}`
+    )
+    .join(' ');
+
+  const finalSuccess = points[points.length - 1]?.success ?? 0;
+
+  return (
+    <div className="mt-8 p-4 bg-gray-800 rounded">
+      <h2 className="text-xl mb-4">Strategy Trainer</h2>
+      <div className="mb-4">
+        <label className="block mb-1">
+          Parallelism: {parallelism}
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={16}
+          value={parallelism}
+          onChange={(e) => setParallelism(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block mb-1">
+          Lockout Threshold: {lockout}
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={50}
+          value={lockout}
+          onChange={(e) => setLockout(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+      <svg width={WIDTH} height={HEIGHT} className="bg-black">
+        <polyline
+          points={path}
+          fill="none"
+          stroke="lime"
+          strokeWidth="2"
+        />
+      </svg>
+      <p className="mt-2 text-sm">
+        Estimated success chance: {(finalSuccess * 100).toFixed(1)}%
+      </p>
+    </div>
+  );
+};
+
+export default StrategyTrainer;
+

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from 'react';
 import LegalInterstitial from '../../components/ui/LegalInterstitial';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
 import HydraApp from '../../components/apps/hydra';
+import StrategyTrainer from './components/StrategyTrainer';
 
 const HydraPreview: React.FC = () => {
   const [accepted, setAccepted] = useState(false);
@@ -19,11 +20,10 @@ const HydraPreview: React.FC = () => {
   };
 
   return (
-    <TabbedWindow
-      className="min-h-screen bg-gray-900 text-white"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
-    />
+    <div className="min-h-screen bg-gray-900 text-white">
+      <TabbedWindow initialTabs={[createTab()]} onNewTab={createTab} />
+      <StrategyTrainer />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- simulate hydra success probabilities with adjustable parallelism and lockout
- render dynamic line graph and controls in new StrategyTrainer component
- embed trainer in Hydra preview page

## Testing
- `npx eslint -c .eslintrc.cjs apps/hydra/index.tsx apps/hydra/components/StrategyTrainer.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `yarn test apps/hydra --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1599076d88328ad1e88d1495c7332