### PR TITLE
feat(john): add format zoo with example hashes

### DIFF
--- a/apps/john/components/FormatZoo.tsx
+++ b/apps/john/components/FormatZoo.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface FormatEntry {
+  format: string;
+  example: string;
+  salt: string | null;
+}
+
+const FormatZoo: React.FC = () => {
+  const [formats, setFormats] = useState<FormatEntry[]>([]);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    fetch('/john-formats.json')
+      .then((res) => res.json())
+      .then(setFormats)
+      .catch(() => setFormats([]));
+  }, []);
+
+  const filtered = formats.filter((f) =>
+    f.format.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className="mt-4">
+      <h2 className="text-lg mb-2">Format Zoo</h2>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search format"
+        className="mb-2 px-2 py-1 rounded text-black"
+      />
+      <ul className="space-y-2 max-h-64 overflow-auto">
+        {filtered.map((f) => (
+          <li key={f.format} className="bg-black p-2 rounded">
+            <p className="font-semibold">{f.format}</p>
+            <p className="text-sm text-gray-400">Salt: {f.salt || 'None'}</p>
+            <p className="font-mono text-xs break-all">{f.example}</p>
+          </li>
+        ))}
+        {filtered.length === 0 && <li>No formats found</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default FormatZoo;

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import FormatZoo from './components/FormatZoo';
 
 interface PotEntry {
   hash: string;
@@ -169,6 +170,7 @@ const JohnApp: React.FC = () => {
           </p>
         )}
       </div>
+      <FormatZoo />
       <div className="mt-auto">
         <h2 className="text-lg mb-1">Potfile</h2>
         <div className="flex gap-2 mb-2">

--- a/public/john-formats.json
+++ b/public/john-formats.json
@@ -1,0 +1,27 @@
+[
+  {
+    "format": "Raw-MD5",
+    "example": "5f4dcc3b5aa765d61d8327deb882cf99",
+    "salt": null
+  },
+  {
+    "format": "Raw-SHA1",
+    "example": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+    "salt": null
+  },
+  {
+    "format": "bcrypt",
+    "example": "$2b$12$TwqKISeBNtB7o4NKjalzPOuq6vCFPlwMby5tt6pTG5Vhk3TWqIUwm",
+    "salt": "TwqKISeBNtB7o4NKjalzPO"
+  },
+  {
+    "format": "md5crypt",
+    "example": "$1$salt1234$HJCsv4hSeVLHo3hVyl4nh0",
+    "salt": "salt1234"
+  },
+  {
+    "format": "sha512crypt",
+    "example": "$6$saltsalt$qFmFH.bQmmtXzyBY0s9v7Oicd2z4XSIecDzlB5KiA2/jctKu9YterLp8wwnSq.qc.eoxqOmSuNp2xS0ktL3nh/",
+    "salt": "saltsalt"
+  }
+]


### PR DESCRIPTION
## Summary
- add searchable FormatZoo component for John the Ripper demo
- list hash formats with salt examples in public JSON
- show format zoo inside John app

## Testing
- `yarn lint` *(fails: ESLint couldn't find config file)*
- `yarn test` *(fails: multiple test suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1599603948328b97f3a58dc18708d