### PR TITLE
feat(john): add mask builder

### DIFF
--- a/apps/john/components/MaskBuilder.tsx
+++ b/apps/john/components/MaskBuilder.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const CHARSET_SIZES: Record<string, bigint> = {
+  l: 26n,
+  u: 26n,
+  d: 10n,
+  s: 33n,
+  a: 95n,
+};
+
+function calcExpansion(mask: string): bigint {
+  let total = 1n;
+  for (let i = 0; i < mask.length; i += 1) {
+    if (mask[i] === '?' && i + 1 < mask.length) {
+      const size = CHARSET_SIZES[mask[i + 1]] ?? 1n;
+      total *= size;
+      i += 1;
+    }
+  }
+  return total;
+}
+
+const TOKENS = ['?l', '?u', '?d', '?s', '?a'];
+
+const MaskBuilder: React.FC = () => {
+  const [mask, setMask] = useState('');
+  const [saved, setSaved] = usePersistentState<string[]>(
+    'john-masks',
+    [],
+    (v): v is string[] => Array.isArray(v) && v.every((m) => typeof m === 'string'),
+  );
+
+  const size = useMemo(() => calcExpansion(mask), [mask]);
+
+  const addToken = (t: string) => setMask((m) => m + t);
+  const save = () => {
+    if (mask && !saved.includes(mask)) {
+      setSaved([...saved, mask]);
+    }
+  };
+  const remove = (m: string) => setSaved(saved.filter((s) => s !== m));
+
+  return (
+    <div className="bg-gray-800 p-3 rounded flex flex-col gap-2">
+      <h2 className="text-lg">Mask Builder</h2>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={mask}
+          onChange={(e) => setMask(e.target.value)}
+          className="flex-1 text-black px-2 py-1 rounded"
+          placeholder="?l?l?d"
+        />
+        {TOKENS.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => addToken(t)}
+            className="px-2 py-1 bg-gray-700 rounded"
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <p className="text-sm">Expansion size: {size.toLocaleString()}</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={save}
+          className="px-3 py-1 bg-blue-600 rounded"
+        >
+          Save Mask
+        </button>
+        <button
+          type="button"
+          onClick={() => setMask('')}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Clear
+        </button>
+      </div>
+      {saved.length > 0 && (
+        <div>
+          <h3 className="text-md mt-2 mb-1">Saved Masks</h3>
+          <ul className="flex flex-col gap-1">
+            {saved.map((m) => (
+              <li
+                key={m}
+                className="flex justify-between items-center bg-black px-2 py-1 rounded text-sm"
+              >
+                <span className="font-mono">{m}</span>
+                <span className="flex items-center gap-2">
+                  <span className="text-xs">{calcExpansion(m).toLocaleString()}</span>
+                  <button
+                    type="button"
+                    onClick={() => remove(m)}
+                    className="text-red-400"
+                    aria-label="Delete mask"
+                  >
+                    ×
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MaskBuilder;
+

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import MaskBuilder from './components/MaskBuilder';
 
 interface PotEntry {
   hash: string;
@@ -169,6 +170,7 @@ const JohnApp: React.FC = () => {
           </p>
         )}
       </div>
+      <MaskBuilder />
       <div className="mt-auto">
         <h2 className="text-lg mb-1">Potfile</h2>
         <div className="flex gap-2 mb-2">


### PR DESCRIPTION
## Summary
- build client-side mask builder with expansion calculator
- persist saved masks using `usePersistentState`
- show mask builder in John app

## Testing
- `yarn test __tests__/beef.test.tsx` *(fails: Unable to find an element with the text: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b159967a1c83289e514c69c5c285ea