### PR TITLE
Add audit simulator for weak password detection

### DIFF
--- a/apps/john/components/AuditSimulator.tsx
+++ b/apps/john/components/AuditSimulator.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface UserRecord {
+  username: string;
+  password: string;
+}
+
+interface Finding {
+  user: UserRecord;
+  tip: string;
+}
+
+const SAMPLE_USERS: UserRecord[] = [
+  { username: 'alice', password: 'password123' },
+  { username: 'bob', password: 'letmein' },
+  { username: 'charlie', password: 'S3curePass!' },
+  { username: 'dave', password: '123456' },
+];
+
+const WEAK_PASSWORDS = new Set([
+  'password',
+  'password123',
+  '123456',
+  'qwerty',
+  'letmein',
+  'admin',
+  'welcome',
+]);
+
+const AuditSimulator: React.FC = () => {
+  const [findings, setFindings] = useState<Finding[]>([]);
+
+  const runAudit = () => {
+    const results: Finding[] = SAMPLE_USERS.filter((u) => isWeak(u.password)).map(
+      (u) => ({
+        user: u,
+        tip: 'Use a longer, unique passphrase with numbers and symbols.',
+      })
+    );
+    setFindings(results);
+  };
+
+  const isWeak = (pwd: string) => {
+    const lower = pwd.toLowerCase();
+    if (pwd.length < 8) return true;
+    return WEAK_PASSWORDS.has(lower);
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded text-white">
+      <button
+        type="button"
+        onClick={runAudit}
+        className="px-3 py-1 bg-blue-600 rounded"
+      >
+        Run Audit
+      </button>
+      {findings.length > 0 && (
+        <div className="mt-4">
+          <h3 className="text-lg mb-2">Weak Password Findings</h3>
+          <ul className="space-y-2">
+            {findings.map(({ user, tip }) => (
+              <li key={user.username} className="bg-gray-900 p-2 rounded">
+                <p>
+                  <span className="font-mono">{user.username}</span> uses
+                  <span className="text-red-400"> {user.password}</span>
+                </p>
+                <p className="text-yellow-300 text-sm">Tip: {tip}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AuditSimulator;
+

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import AuditSimulator from './components/AuditSimulator';
 
 interface PotEntry {
   hash: string;
@@ -169,6 +170,7 @@ const JohnApp: React.FC = () => {
           </p>
         )}
       </div>
+      <AuditSimulator />
       <div className="mt-auto">
         <h2 className="text-lg mb-1">Potfile</h2>
         <div className="flex gap-2 mb-2">


### PR DESCRIPTION
## Summary
- add AuditSimulator component with sample user database and remediation tips
- integrate AuditSimulator into john page

## Testing
- `npm test` (fails: game2048, beef, mimikatz, vscode, wordSearch, kismet, etc.)
- `npm run lint` (fails: ESLint couldn't find config)

------
https://chatgpt.com/codex/tasks/task_e_68b15997735483289f36b91f6403655c