### PR TITLE
feat(ghidra): add guided decompiler tour

### DIFF
--- a/apps/ghidra/components/DecompilerTour.tsx
+++ b/apps/ghidra/components/DecompilerTour.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+
+type PaneKey = 'functions' | 'cfg' | 'decompile' | 'hex';
+
+interface DecompilerTourProps {
+  targets: Record<PaneKey, React.RefObject<HTMLElement>>;
+  onClose: () => void;
+}
+
+const steps: { key: PaneKey; text: string }[] = [
+  { key: 'functions', text: 'Browse detected functions here.' },
+  { key: 'cfg', text: 'The control flow graph visualizes branches.' },
+  { key: 'decompile', text: 'Decompiled source for the selected function.' },
+  { key: 'hex', text: 'Raw hexadecimal bytes of the function.' },
+];
+
+export default function DecompilerTour({ targets, onClose }: DecompilerTourProps) {
+  const [step, setStep] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    const t = steps[step];
+    const el = targets[t.key]?.current;
+    if (!el) return;
+    const update = () => setRect(el.getBoundingClientRect());
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [step, targets]);
+
+  if (!rect) return null;
+
+  const { top, left, width, height } = rect;
+  const message = steps[step].text;
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={onClose}
+      />
+      <div
+        className="absolute border-2 border-yellow-400 pointer-events-none"
+        style={{ top, left, width, height }}
+      />
+      <div
+        className="absolute bg-gray-800 text-white p-4 rounded shadow-lg"
+        style={{ top: top + height + 8, left }}
+      >
+        <p className="mb-2">{message}</p>
+        <div className="text-right space-x-2">
+          <button
+            className="px-2 py-1 bg-gray-700 rounded"
+            onClick={() => {
+              if (step > 0) setStep(step - 1);
+              else onClose();
+            }}
+          >
+            {step > 0 ? 'Back' : 'Close'}
+          </button>
+          <button
+            className="px-2 py-1 bg-gray-700 rounded"
+            onClick={() => {
+              if (step < steps.length - 1) setStep(step + 1);
+              else onClose();
+            }}
+          >
+            {step < steps.length - 1 ? 'Next' : 'Done'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
+import DecompilerTour from '../../apps/ghidra/components/DecompilerTour';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
@@ -69,6 +70,8 @@ export default function GhidraApp() {
   const [liveMessage, setLiveMessage] = useState('');
   const decompileRef = useRef(null);
   const hexRef = useRef(null);
+  const funcTreeRef = useRef(null);
+  const cfgRef = useRef(null);
   const syncing = useRef(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const hexWorkerRef = useRef(null);
@@ -82,6 +85,7 @@ export default function GhidraApp() {
   const capstoneRef = useRef(null);
   const [instructions, setInstructions] = useState([]);
   const [arch, setArch] = useState('x86');
+  const [showTour, setShowTour] = useState(false);
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
@@ -287,16 +291,25 @@ export default function GhidraApp() {
 
   return (
     <div className="w-full h-full flex flex-col bg-gray-900 text-gray-100">
-      <div className="p-2">
+      <div className="p-2 flex space-x-2">
         <button
           onClick={switchEngine}
           className="px-2 py-1 bg-gray-700 rounded"
         >
           Use Capstone
         </button>
+        <button
+          onClick={() => setShowTour(true)}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          Help
+        </button>
       </div>
       <div className="flex flex-1">
-        <div className="w-1/4 border-r border-gray-700 overflow-auto">
+        <div
+          ref={funcTreeRef}
+          className="w-1/4 border-r border-gray-700 overflow-auto"
+        >
           <div className="p-2">
             <input
               type="text"
@@ -323,7 +336,10 @@ export default function GhidraApp() {
             <FunctionTree functions={functions} onSelect={setSelected} selected={selected} />
           )}
         </div>
-        <div className="w-1/4 border-r border-gray-700">
+        <div
+          ref={cfgRef}
+          className="w-1/4 border-r border-gray-700"
+        >
           <ControlFlowGraph
             blocks={currentFunc.blocks}
             selected={null}
@@ -463,6 +479,17 @@ export default function GhidraApp() {
       <div aria-live="polite" role="status" className="sr-only">
         {liveMessage}
       </div>
+      {showTour && (
+        <DecompilerTour
+          targets={{
+            functions: funcTreeRef,
+            cfg: cfgRef,
+            decompile: decompileRef,
+            hex: hexRef,
+          }}
+          onClose={() => setShowTour(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add DecompilerTour overlay to explain ghidra panes
- expose help button to trigger the guided tour

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/ghidra/components/DecompilerTour.tsx components/apps/ghidra/index.js && echo "lint ok"`
- `yarn test apps/ghidra/components/DecompilerTour.tsx components/apps/ghidra/index.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1599997a88328bd6741f8f2791444