### PR TITLE
feat(radare2): add zoomable block graph viewer

### DIFF
--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import dynamic from 'next/dynamic';
+
+interface Block {
+  addr: string;
+  edges?: string[];
+}
+
+interface GraphViewProps {
+  blocks: Block[];
+}
+
+const ForceGraph2D = dynamic(
+  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
+  { ssr: false }
+);
+
+const GraphView: React.FC<GraphViewProps> = ({ blocks }) => {
+  const fgRef = useRef<any>();
+
+  const graphData = useMemo(() => {
+    const nodes = blocks.map((b) => ({ id: b.addr }));
+    const links: { source: string; target: string }[] = [];
+    blocks.forEach((b) =>
+      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e }))
+    );
+    return { nodes, links };
+  }, [blocks]);
+
+  useEffect(() => {
+    if (fgRef.current) {
+      fgRef.current.zoomToFit(400, 20);
+    }
+  }, [graphData]);
+
+  const zoomIn = () => {
+    if (!fgRef.current) return;
+    const current = fgRef.current.zoom();
+    fgRef.current.zoom(current * 1.2, 200);
+  };
+
+  const zoomOut = () => {
+    if (!fgRef.current) return;
+    const current = fgRef.current.zoom();
+    fgRef.current.zoom(current / 1.2, 200);
+  };
+
+  return (
+    <div className="h-full w-full">
+      <div className="flex gap-2 mb-2">
+        <button
+          onClick={zoomIn}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          +
+        </button>
+        <button
+          onClick={zoomOut}
+          className="px-2 py-1 bg-gray-700 rounded"
+        >
+          -
+        </button>
+      </div>
+      <div className="h-64 bg-black rounded">
+        <ForceGraph2D ref={fgRef} graphData={graphData} />
+      </div>
+    </div>
+  );
+};
+
+export default GraphView;
+

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -1,5 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
+import React, { useEffect, useRef, useState } from 'react';
 import HexEditor from './HexEditor';
 import {
   loadNotes,
@@ -7,11 +6,7 @@ import {
   loadBookmarks,
   saveBookmarks,
 } from './utils';
-
-const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
-);
+import GraphView from '../../../apps/radare2/components/GraphView';
 
 const Radare2 = ({ initialData = {} }) => {
   const { file = 'demo', hex = '', disasm = [], xrefs = {}, blocks = [] } =
@@ -32,15 +27,6 @@ const Radare2 = ({ initialData = {} }) => {
 
     }
   }, [file]);
-
-  const graphData = useMemo(() => {
-    const nodes = blocks.map((b) => ({ id: b.addr }));
-    const links = [];
-    blocks.forEach((b) =>
-      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e }))
-    );
-    return { nodes, links };
-  }, [blocks]);
 
   const scrollToAddr = (addr) => {
     const idx = disasm.findIndex(
@@ -123,9 +109,7 @@ const Radare2 = ({ initialData = {} }) => {
       </div>
 
       {mode === 'graph' ? (
-        <div className="h-64 bg-black rounded">
-          <ForceGraph2D graphData={graphData} />
-        </div>
+        <GraphView blocks={blocks} />
       ) : (
         <div className="grid md:grid-cols-2 gap-4">
           <HexEditor hex={hex} />


### PR DESCRIPTION
## Summary
- add client-only GraphView with zoom controls for radare2 blocks
- swap ForceGraph2D usage for GraphView in radare2 component

## Testing
- `yarn lint apps/radare2/components/GraphView.tsx components/apps/radare2/index.js` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: 69 failed, 124 skipped, 291 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1599aa1608328bc34b622cf3aa0b0