### PR TITLE
Add radare2 command cheatsheet with copy support

### DIFF
--- a/apps/radare2/components/CommandCheatsheet.tsx
+++ b/apps/radare2/components/CommandCheatsheet.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+
+interface CommandItem {
+  cmd: string;
+  desc: string;
+}
+
+const commands: CommandItem[] = [
+  { cmd: "aaa", desc: "analyze all" },
+  { cmd: "afl", desc: "list functions" },
+  { cmd: "pdf @ addr", desc: "disassemble function at addr" },
+  { cmd: "pd @ addr", desc: "disassemble code at addr" },
+  { cmd: "px @ addr", desc: "hexdump at addr" },
+  { cmd: "s addr", desc: "seek to address" },
+  { cmd: "VV", desc: "visual mode graph" },
+  { cmd: "dr", desc: "show registers" },
+  { cmd: "db addr", desc: "set breakpoint" },
+  { cmd: "dc", desc: "continue execution" },
+];
+
+const CommandCheatsheet: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const [search, setSearch] = useState("");
+  const filtered = commands.filter(
+    (c) =>
+      c.cmd.toLowerCase().includes(search.toLowerCase()) ||
+      c.desc.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const copy = (cmd: string) => {
+    navigator.clipboard?.writeText(cmd);
+  };
+
+  return (
+    <div className="absolute inset-0 bg-ub-cool-grey bg-opacity-95 p-4 overflow-auto">
+      <div className="flex mb-4">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="search commands"
+          className="flex-1 px-2 py-1 bg-gray-800 text-white rounded"
+        />
+        <button
+          onClick={onClose}
+          className="ml-2 px-3 py-1 bg-gray-700 rounded"
+        >
+          Close
+        </button>
+      </div>
+      <ul>
+        {filtered.map((c) => (
+          <li key={c.cmd} className="flex items-center mb-2">
+            <code className="bg-gray-800 px-2 py-1 rounded mr-2">{c.cmd}</code>
+            <span className="flex-1">{c.desc}</span>
+            <button
+              onClick={() => copy(c.cmd)}
+              className="px-2 py-1 bg-gray-700 rounded"
+            >
+              Copy
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CommandCheatsheet;

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -1,35 +1,36 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
-import HexEditor from './HexEditor';
-import {
-  loadNotes,
-  saveNotes,
-  loadBookmarks,
-  saveBookmarks,
-} from './utils';
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import HexEditor from "./HexEditor";
+import { loadNotes, saveNotes, loadBookmarks, saveBookmarks } from "./utils";
+import CommandCheatsheet from "../../../apps/radare2/components/CommandCheatsheet";
 
 const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
+  () => import("react-force-graph").then((mod) => mod.ForceGraph2D),
+  { ssr: false },
 );
 
 const Radare2 = ({ initialData = {} }) => {
-  const { file = 'demo', hex = '', disasm = [], xrefs = {}, blocks = [] } =
-    initialData;
-  const [mode, setMode] = useState('code');
-  const [seekAddr, setSeekAddr] = useState('');
-  const [findTerm, setFindTerm] = useState('');
+  const {
+    file = "demo",
+    hex = "",
+    disasm = [],
+    xrefs = {},
+    blocks = [],
+  } = initialData;
+  const [mode, setMode] = useState("code");
+  const [seekAddr, setSeekAddr] = useState("");
+  const [findTerm, setFindTerm] = useState("");
   const [currentAddr, setCurrentAddr] = useState(null);
   const [notes, setNotes] = useState([]);
-  const [noteText, setNoteText] = useState('');
+  const [noteText, setNoteText] = useState("");
   const [bookmarks, setBookmarks] = useState([]);
+  const [showCheatsheet, setShowCheatsheet] = useState(false);
   const disasmRef = useRef(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       setNotes(loadNotes(file));
       setBookmarks(loadBookmarks(file));
-
     }
   }, [file]);
 
@@ -37,19 +38,19 @@ const Radare2 = ({ initialData = {} }) => {
     const nodes = blocks.map((b) => ({ id: b.addr }));
     const links = [];
     blocks.forEach((b) =>
-      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e }))
+      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e })),
     );
     return { nodes, links };
   }, [blocks]);
 
   const scrollToAddr = (addr) => {
     const idx = disasm.findIndex(
-      (l) => l.addr.toLowerCase() === addr.toLowerCase()
+      (l) => l.addr.toLowerCase() === addr.toLowerCase(),
     );
     if (idx >= 0) {
       setCurrentAddr(disasm[idx].addr);
       const el = document.getElementById(`asm-${idx}`);
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   };
 
@@ -62,12 +63,12 @@ const Radare2 = ({ initialData = {} }) => {
     const idx = disasm.findIndex(
       (l) =>
         l.text.toLowerCase().includes(findTerm.toLowerCase()) ||
-        l.addr.toLowerCase() === findTerm.toLowerCase()
+        l.addr.toLowerCase() === findTerm.toLowerCase(),
     );
     if (idx >= 0) {
       setCurrentAddr(disasm[idx].addr);
       const el = document.getElementById(`asm-${idx}`);
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   };
 
@@ -76,7 +77,7 @@ const Radare2 = ({ initialData = {} }) => {
     const next = [...notes, { addr: currentAddr, text: noteText.trim() }];
     setNotes(next);
     saveNotes(file, next);
-    setNoteText('');
+    setNoteText("");
   };
 
   const toggleBookmark = (addr) => {
@@ -88,7 +89,7 @@ const Radare2 = ({ initialData = {} }) => {
   };
 
   return (
-    <div className="h-full w-full bg-ub-cool-grey text-white p-4 overflow-auto">
+    <div className="h-full w-full bg-ub-cool-grey text-white p-4 overflow-auto relative">
       <div className="flex gap-2 mb-2 flex-wrap">
         <input
           value={seekAddr}
@@ -96,10 +97,7 @@ const Radare2 = ({ initialData = {} }) => {
           placeholder="seek 0x..."
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
-        <button
-          onClick={handleSeek}
-          className="px-3 py-1 bg-gray-700 rounded"
-        >
+        <button onClick={handleSeek} className="px-3 py-1 bg-gray-700 rounded">
           Seek
         </button>
         <input
@@ -108,21 +106,24 @@ const Radare2 = ({ initialData = {} }) => {
           placeholder="find"
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
-        <button
-          onClick={handleFind}
-          className="px-3 py-1 bg-gray-700 rounded"
-        >
+        <button onClick={handleFind} className="px-3 py-1 bg-gray-700 rounded">
           Find
         </button>
         <button
-          onClick={() => setMode((m) => (m === 'code' ? 'graph' : 'code'))}
+          onClick={() => setMode((m) => (m === "code" ? "graph" : "code"))}
           className="px-3 py-1 bg-gray-700 rounded"
         >
-          {mode === 'code' ? 'Graph' : 'Code'}
+          {mode === "code" ? "Graph" : "Code"}
+        </button>
+        <button
+          onClick={() => setShowCheatsheet(true)}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Cheatsheet
         </button>
       </div>
 
-      {mode === 'graph' ? (
+      {mode === "graph" ? (
         <div className="h-64 bg-black rounded">
           <ForceGraph2D graphData={graphData} />
         </div>
@@ -139,7 +140,7 @@ const Radare2 = ({ initialData = {} }) => {
                   key={line.addr}
                   id={`asm-${idx}`}
                   className={`cursor-pointer ${
-                    currentAddr === line.addr ? 'bg-gray-700' : ''
+                    currentAddr === line.addr ? "bg-gray-700" : ""
                   }`}
                   onClick={() => setCurrentAddr(line.addr)}
                 >
@@ -150,7 +151,7 @@ const Radare2 = ({ initialData = {} }) => {
                     }}
                     className="mr-1"
                   >
-                    {bookmarks.includes(line.addr) ? '★' : '☆'}
+                    {bookmarks.includes(line.addr) ? "★" : "☆"}
                   </button>
                   {line.addr}: {line.text}
                 </li>
@@ -164,7 +165,7 @@ const Radare2 = ({ initialData = {} }) => {
         <div className="mt-4">
           <h2 className="text-lg">Xrefs for {currentAddr}</h2>
           <p className="mb-2">
-            {(xrefs[currentAddr] || []).join(', ') || 'None'}
+            {(xrefs[currentAddr] || []).join(", ") || "None"}
           </p>
           <textarea
             value={noteText}
@@ -192,6 +193,10 @@ const Radare2 = ({ initialData = {} }) => {
             ))}
           </ul>
         </div>
+      )}
+
+      {showCheatsheet && (
+        <CommandCheatsheet onClose={() => setShowCheatsheet(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add CommandCheatsheet component with searchable command map and quick copy buttons
- integrate cheat sheet toggle in Radare2 viewer

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/radare2/components/CommandCheatsheet.tsx components/apps/radare2/index.js`
- `yarn test --passWithNoTests apps/radare2/components/CommandCheatsheet.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1599b1ffc8328bffdbb8abbfe04cb