### PR TITLE
feat(autopsy): add HTML report export

### DIFF
--- a/apps/autopsy/components/ReportExport.tsx
+++ b/apps/autopsy/components/ReportExport.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+
+interface Artifact {
+  name: string;
+  type: string;
+  description: string;
+  size: number;
+  plugin: string;
+  timestamp: string;
+}
+
+interface ReportExportProps {
+  caseName?: string;
+  artifacts: Artifact[];
+}
+
+const escapeHtml = (str: string) =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const ReportExport: React.FC<ReportExportProps> = ({ caseName = 'case', artifacts }) => {
+  const htmlReport = useMemo(() => {
+    const rows = artifacts
+      .map(
+        (a) =>
+          `<tr><td>${escapeHtml(a.name)}</td><td>${escapeHtml(a.type)}</td><td>${escapeHtml(a.description)}</td><td>${a.size}</td><td>${escapeHtml(a.plugin)}</td><td>${escapeHtml(a.timestamp)}</td></tr>`
+      )
+      .join('');
+    return `<!DOCTYPE html><html><head><meta charset="utf-8"/><title>${escapeHtml(caseName)} Report</title></head><body><h1>${escapeHtml(caseName)}</h1><table border="1"><tr><th>Name</th><th>Type</th><th>Description</th><th>Size</th><th>Plugin</th><th>Timestamp</th></tr>${rows}</table></body></html>`;
+  }, [artifacts, caseName]);
+
+  const exportReport = () => {
+    const blob = new Blob([htmlReport], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${caseName || 'case'}-report.html`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button
+      onClick={exportReport}
+      className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
+    >
+      Download HTML Report
+    </button>
+  );
+};
+
+export default ReportExport;
+

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
+import ReportExport from '../../../apps/autopsy/components/ReportExport';
 
 const escapeFilename = (str = '') =>
   str
@@ -353,19 +354,6 @@ function Autopsy({ initialArtifacts = null }) {
     );
   };
 
-  const downloadReport = () => {
-    const lines = artifacts.map(
-      (a) => `${a.timestamp} - ${a.name} (${a.size} bytes) [Plugin: ${a.plugin}]`
-    );
-    const report = `Case: ${currentCase}\n` + lines.join('\n');
-    const blob = new Blob([report], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${currentCase || 'case'}-report.txt`;
-    link.click();
-    URL.revokeObjectURL(url);
-  };
 
   useEffect(() => {
     if (artifacts.length > 0) {
@@ -507,12 +495,7 @@ function Autopsy({ initialArtifacts = null }) {
               </div>
             </div>
           )}
-          <button
-            onClick={downloadReport}
-            className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
-          >
-            Download Report
-          </button>
+          <ReportExport caseName={currentCase || 'case'} artifacts={artifacts} />
         </div>
       )}
       {selectedArtifact && (


### PR DESCRIPTION
## Summary
- add ReportExport component to build case HTML and download
- wire Autopsy app to use ReportExport instead of text report

## Testing
- `npm test` *(fails: game2048, beef, calculator parser, mimikatz, vscode, wordSearch, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1599f50c483288bf0ad019ea26d51