### PR TITLE
feat: add artifact browser for mimikatz

### DIFF
--- a/apps/mimikatz/components/ArtifactBrowser.tsx
+++ b/apps/mimikatz/components/ArtifactBrowser.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import artifactsData from '../data/artifacts.json';
+
+interface Artifact {
+  name: string;
+  value?: string;
+  children?: Artifact[];
+}
+
+const filterNode = (node: Artifact, q: string): Artifact | null => {
+  const match = node.name.toLowerCase().includes(q);
+  const children = node.children
+    ?.map((child) => filterNode(child, q))
+    .filter((c): c is Artifact => Boolean(c));
+  if (match || (children && children.length)) {
+    return { ...node, children };
+  }
+  return null;
+};
+
+const TreeNode: React.FC<{ node: Artifact }> = ({ node }) => {
+  const hasChildren = node.children && node.children.length > 0;
+  if (hasChildren) {
+    return (
+      <li>
+        <details>
+          <summary className="cursor-pointer select-none">{node.name}</summary>
+          <ul className="pl-4">
+            {node.children!.map((c) => (
+              <TreeNode key={c.name} node={c} />
+            ))}
+          </ul>
+        </details>
+      </li>
+    );
+  }
+  return (
+    <li>
+      <span>
+        {node.name}
+        {node.value ? `: ${node.value}` : ''}
+      </span>
+    </li>
+  );
+};
+
+const ArtifactBrowser: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return artifactsData as Artifact[];
+    return (artifactsData as Artifact[])
+      .map((n) => filterNode(n, q))
+      .filter((n): n is Artifact => Boolean(n));
+  }, [query]);
+
+  return (
+    <div className="p-4 bg-gray-900 text-white min-h-screen overflow-auto">
+      <h1 className="text-xl mb-2">Hive Artifacts</h1>
+      <input
+        type="text"
+        placeholder="Search..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="mb-4 p-1 w-full text-black"
+      />
+      <ul>
+        {filtered.map((node) => (
+          <TreeNode key={node.name} node={node} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ArtifactBrowser;

--- a/apps/mimikatz/data/artifacts.json
+++ b/apps/mimikatz/data/artifacts.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "SAM",
+    "children": [
+      {
+        "name": "Domains",
+        "children": [
+          {
+            "name": "Account",
+            "children": [
+              {
+                "name": "Users",
+                "children": [
+                  { "name": "000001F4", "value": "Administrator:FAKEHASH1" },
+                  { "name": "000001F5", "value": "Guest:FAKEHASH2" }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "SECURITY",
+    "children": [
+      {
+        "name": "Policy",
+        "children": [
+          {
+            "name": "Secrets",
+            "children": [
+              { "name": "L$MACHINE.ACC", "value": "DEADBEEF" },
+              { "name": "L$WEBSITE", "value": "0123456789ABCDEF" }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import MimikatzApp from '../../components/apps/mimikatz';
+import ArtifactBrowser from './components/ArtifactBrowser';
 
 const MimikatzPage: React.FC = () => {
-  return <MimikatzApp />;
+  return <ArtifactBrowser />;
 };
 
 export default MimikatzPage;
-


### PR DESCRIPTION
## Summary
- add faux SAM/SECURITY hive data for artifact browsing
- new ArtifactBrowser component with tree view and search
- render ArtifactBrowser as mimikatz page

## Testing
- `yarn test` *(fails: game2048, beef, calculator parser, mimikatz, kismet, word search, vs code)*
- `yarn lint apps/mimikatz/index.tsx apps/mimikatz/components/ArtifactBrowser.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b159a0f6ec8328b90dc882be000af8