### PR TITLE
feat(dsniff): add capture/replay stress sandbox

### DIFF
--- a/apps/dsniff/components/StressSandbox.tsx
+++ b/apps/dsniff/components/StressSandbox.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+
+// Tiny sample dataset of captured packets
+const sampleLogs = [
+  { protocol: 'HTTP', host: 'example.com', path: '/index.html' },
+  { protocol: 'HTTPS', host: 'test.com', path: '/login' },
+];
+
+const StressSandbox: React.FC = () => {
+  const [size, setSize] = useState(100);
+  const [logs, setLogs] = useState<typeof sampleLogs>([]);
+  const [captureMs, setCaptureMs] = useState(0);
+  const [replayMs, setReplayMs] = useState(0);
+
+  useEffect(() => {
+    // Simulate capture: repeat the sample logs
+    const captureStart = performance.now();
+    const newLogs = Array.from({ length: size }, (_, i) => ({
+      ...sampleLogs[i % sampleLogs.length],
+      id: i,
+    }));
+    setLogs(newLogs);
+    setCaptureMs(performance.now() - captureStart);
+
+    // Simulate replay: iterate over all logs
+    const replayStart = performance.now();
+    newLogs.forEach(() => {});
+    setReplayMs(performance.now() - replayStart);
+  }, [size]);
+
+  return (
+    <div className="mt-4 p-2 bg-ub-dark text-white rounded">
+      <h2 className="text-lg mb-2">Capture/Replay Stress Sandbox</h2>
+      <p className="text-xs mb-2 italic">
+        Demonstration uses sample data; no real network traffic.
+      </p>
+      <label htmlFor="listSize" className="block text-sm mb-1">
+        List size: {size}
+      </label>
+      <input
+        id="listSize"
+        type="range"
+        min={1}
+        max={5000}
+        value={size}
+        onChange={(e) => setSize(Number(e.target.value))}
+        className="w-full mb-2"
+      />
+      <p className="text-sm mb-2">
+        Capture: {captureMs.toFixed(2)} ms | Replay: {replayMs.toFixed(2)} ms
+      </p>
+      <ul className="h-40 overflow-auto text-xs bg-black p-1">
+        {logs.slice(0, 100).map((log) => (
+          <li key={log.id}>
+            <span className="text-green-400">{log.protocol}</span> {log.host} {log.path}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StressSandbox;
+

--- a/apps/dsniff/index.tsx
+++ b/apps/dsniff/index.tsx
@@ -3,12 +3,14 @@
 import React from 'react';
 import DsniffApp from '../../components/apps/dsniff';
 import CredentialExplainer from './components/CredentialExplainer';
+import StressSandbox from './components/StressSandbox';
 
 const DsniffPage: React.FC = () => {
   return (
     <>
       <DsniffApp />
       <CredentialExplainer />
+      <StressSandbox />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add stress sandbox component to simulate capture/replay on sample logs
- allow list size slider and show capture/replay performance
- render stress sandbox on dsniff page

## Testing
- `yarn test dsniff.test.tsx`
- `ESLINT_USE_FLAT_CONFIG=false yarn lint apps/dsniff/components/StressSandbox.tsx` *(fails: 43 problems (8 errors, 35 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b168d460288328a5c4483a974bbcb6