### PR TITLE
feat(recon-ng): add data model explorer

### DIFF
--- a/apps/recon-ng/components/DataModelExplorer.tsx
+++ b/apps/recon-ng/components/DataModelExplorer.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+
+interface EntityNode {
+  id: string;
+  label: string;
+  data: Record<string, unknown>;
+}
+
+interface EntityLink {
+  source: string;
+  target: string;
+  label?: string;
+}
+
+const ForceGraph2D = dynamic(
+  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
+  { ssr: false }
+);
+
+const mockData = {
+  nodes: [
+    {
+      id: 'domain',
+      label: 'Domain',
+      data: { name: 'example.com', type: 'domain' },
+    },
+    {
+      id: 'ip',
+      label: 'IP Address',
+      data: { address: '1.1.1.1', type: 'ip' },
+    },
+    {
+      id: 'email',
+      label: 'Email',
+      data: { address: 'admin@example.com', type: 'email' },
+    },
+  ] as EntityNode[],
+  links: [
+    { source: 'domain', target: 'ip', label: 'RESOLVES_TO' },
+    { source: 'domain', target: 'email', label: 'HAS_EMAIL' },
+  ] as EntityLink[],
+};
+
+const DataModelExplorer: React.FC = () => {
+  const [selected, setSelected] = useState<EntityNode | null>(null);
+  const graphData = useMemo(() => mockData, []);
+
+  return (
+    <div className="relative h-96 w-full bg-black rounded">
+      <ForceGraph2D
+        graphData={graphData}
+        nodeId="id"
+        onNodeClick={(node) => setSelected(node as EntityNode)}
+        nodeCanvasObject={(node, ctx, globalScale) => {
+          const n = node as EntityNode & { x?: number; y?: number };
+          const label = n.label;
+          const fontSize = 12 / globalScale;
+          ctx.fillStyle = 'lightblue';
+          ctx.beginPath();
+          ctx.arc(n.x ?? 0, n.y ?? 0, 5, 0, 2 * Math.PI, false);
+          ctx.fill();
+          ctx.font = `${fontSize}px sans-serif`;
+          ctx.fillText(label, (n.x ?? 0) + 8, (n.y ?? 0) + 3);
+        }}
+        linkDirectionalArrowLength={4}
+      />
+      {selected && (
+        <div className="absolute top-0 right-0 m-2 max-w-xs rounded bg-gray-800 p-2 text-xs text-white shadow">
+          <div className="mb-1 font-bold">{selected.label}</div>
+          <pre className="whitespace-pre-wrap">
+            {JSON.stringify(selected.data, null, 2)}
+          </pre>
+          <button
+            className="mt-2 text-blue-400 underline"
+            onClick={() => setSelected(null)}
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DataModelExplorer;
+


### PR DESCRIPTION
## Summary
- visualize mock entities and relationships with a force-directed graph
- inspect node details from an interactive panel

## Testing
- `yarn lint apps/recon-ng/components/DataModelExplorer.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test apps/recon-ng/components/DataModelExplorer.test.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b168d567e48328a61bff4f0edc1296