### PR TITLE
feat(reconng): add report templates

### DIFF
--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface Finding {
+  title: string;
+  description: string;
+  severity: string;
+}
+
+const mockFindings: Finding[] = [
+  {
+    title: 'Open Port 80',
+    description: 'HTTP service detected on port 80',
+    severity: 'Low',
+  },
+  {
+    title: 'Deprecated TLS Version',
+    description: 'Server supports TLS 1.0',
+    severity: 'Medium',
+  },
+  {
+    title: 'SQL Injection',
+    description: 'User parameter vulnerable to injection',
+    severity: 'High',
+  },
+];
+
+const templates = {
+  executive: {
+    name: 'Executive Summary',
+    render: (findings: Finding[]) =>
+      `Executive Summary\n\nFindings:\n${findings
+        .map((f) => `- ${f.title} (${f.severity})`)
+        .join('\n')}`,
+  },
+  detailed: {
+    name: 'Detailed Report',
+    render: (findings: Finding[]) =>
+      `Detailed Report\n\n${findings
+        .map(
+          (f, i) =>
+            `${i + 1}. ${f.title}\nSeverity: ${f.severity}\n${f.description}`,
+        )
+        .join('\n\n')}`,
+  },
+};
+
+type TemplateKey = keyof typeof templates;
+
+export default function ReportTemplates() {
+  const [template, setTemplate] = usePersistentState('reconng-report-template', 'executive');
+
+  const templateKey = template as TemplateKey;
+  const report = useMemo(
+    () => templates[templateKey].render(mockFindings),
+    [templateKey],
+  );
+
+  const exportReport = () => {
+    const blob = new Blob([report], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${templateKey}-report.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 mb-2">
+        <label htmlFor="template">Template</label>
+        <select
+          id="template"
+          value={templateKey}
+          onChange={(e) => setTemplate(e.target.value)}
+          className="bg-gray-800 px-2 py-1"
+        >
+          {Object.entries(templates).map(([key, t]) => (
+            <option key={key} value={key}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={exportReport}
+          className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
+        >
+          Export
+        </button>
+      </div>
+      <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap text-sm">
+        {report}
+      </pre>
+    </div>
+  );
+}
+

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../hooks/usePersistentState';
+import ReportTemplates from './components/ReportTemplates';
 
 const CytoscapeComponent = dynamic(
   async () => {
@@ -408,6 +409,13 @@ const ReconNG = () => {
         </button>
         <button
           type="button"
+          onClick={() => setView('reports')}
+          className={`px-2 py-1 ${view === 'reports' ? 'bg-blue-600' : 'bg-gray-800'}`}
+        >
+          Reports
+        </button>
+        <button
+          type="button"
           onClick={() => setView('settings')}
           className={`px-2 py-1 ${view === 'settings' ? 'bg-blue-600' : 'bg-gray-800'}`}
         >
@@ -525,6 +533,7 @@ const ReconNG = () => {
           </div>
         </>
       )}
+      {view === 'reports' && <ReportTemplates />}
       {view === 'settings' && (
         <div className="flex-1 overflow-auto">
           {allModules.map((m) => (


### PR DESCRIPTION
## Summary
- add report templates component with mock findings and export
- store last used template and expose reports view in Recon-ng app

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: game2048, beef, mimikatz, kismet, vscode, snake.config, frogger.config, wordSearch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b168d744cc8328b8daef33b514d88d