### PR TITLE
feat(beef): add defense panel to hook lab

### DIFF
--- a/apps/beef/components/DefensePanel.tsx
+++ b/apps/beef/components/DefensePanel.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export default function DefensePanel() {
+  return (
+    <div className="p-3 mb-4 text-xs bg-ub-warm-grey bg-opacity-40 rounded">
+      <h3 className="text-sm font-bold mb-2">Browser Defenses</h3>
+      <p className="mb-2">
+        Modern browsers enforce <strong>Content Security Policy (CSP)</strong> to restrict
+        the sources a page may load resources from. A simple policy might look like:
+      </p>
+      <pre className="bg-black text-white p-2 mb-2 overflow-x-auto">
+        <code>{`Content-Security-Policy: default-src 'self'; script-src 'nonce-r4nd0m'`}</code>
+      </pre>
+      <p className="mb-2">
+        This header allows scripts only from the current origin that include the correct nonce,
+        blocking injected or third-party code. Learn more on{' '}
+        <a
+          href="https://developer.mozilla.org/docs/Web/HTTP/CSP"
+          target="_blank"
+          rel="noreferrer"
+          className="text-ubt-blue underline"
+        >
+          MDN
+        </a>
+        .
+      </p>
+      <p className="mb-2">
+        Browsers also offer mitigations like the <code>sandbox</code> attribute on iframes
+        and <code>SameSite</code> cookies to reduce cross-site attacks. Example sandbox usage:
+      </p>
+      <pre className="bg-black text-white p-2 mb-2 overflow-x-auto">
+        <code>{`<iframe sandbox="allow-scripts"></iframe>`}</code>
+      </pre>
+      <p>
+        More details:
+        {' '}
+        <a
+          href="https://developer.mozilla.org/docs/Web/HTML/Element/iframe#attr-sandbox"
+          target="_blank"
+          rel="noreferrer"
+          className="text-ubt-blue underline"
+        >
+          iframe sandboxing
+        </a>
+        {' | '}
+        <a
+          href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesite"
+          target="_blank"
+          rel="noreferrer"
+          className="text-ubt-blue underline"
+        >
+          SameSite cookies
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import DefensePanel from '../../../apps/beef/components/DefensePanel';
 
 export default function Beef() {
   const targetPage = `\n<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8"/>\n  <title>Sandboxed Target</title>\n</head>\n<body>\n  <h1>Sandboxed Target Page</h1>\n  <p>This page is isolated and cannot make network requests.</p>\n  <script>document.body.append(' - loaded');<\/script>\n</body>\n</html>`;
@@ -45,6 +46,7 @@ export default function Beef() {
   ];
 
   const [step, setStep] = useState(0);
+  const [showDefense, setShowDefense] = useState(false);
 
   const next = () => {
     if (step < steps.length - 1) {
@@ -65,7 +67,17 @@ export default function Beef() {
 
   return (
     <div className="p-4 text-white bg-ub-cool-grey h-full w-full flex flex-col">
-      <h2 className="text-xl mb-4">{current.title}</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl">{current.title}</h2>
+        <button
+          type="button"
+          onClick={() => setShowDefense(!showDefense)}
+          className="text-xs underline"
+        >
+          {showDefense ? 'Hide Info' : 'Show Info'}
+        </button>
+      </div>
+      {showDefense && <DefensePanel />}
       <p className="mb-4 text-sm">{current.body}</p>
       {current.render && <div className="mb-4">{current.render}</div>}
       <button


### PR DESCRIPTION
## Summary
- add DefensePanel with CSP and browser mitigation examples
- toggle DefensePanel from Hook Lab interface

## Testing
- `npm run lint` *(fails: ESLint couldn't find flat config)*
- `npm test` *(fails: beEF app tests unable to locate hook list)*

------
https://chatgpt.com/codex/tasks/task_e_68b168d899648328ba18bdc64bfb7ef3