### PR TITLE
feat: add remappable touch controls

### DIFF
--- a/games/common/controls.tsx
+++ b/games/common/controls.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import useGameInput from '../../hooks/useGameInput';
+
+const DEFAULT_MAP = {
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  action: 'Space',
+  pause: 'Escape',
+};
+
+type Action = keyof typeof DEFAULT_MAP;
+
+type InputEvent = {
+  action: Action;
+  type: string;
+};
+
+type ControlsProps = {
+  onInput?: (e: InputEvent) => void;
+  onContrastChange?: (enabled: boolean) => void;
+};
+
+export default function Controls({ onInput, onContrastChange }: ControlsProps) {
+  const [keymap, setKeymap] = usePersistentState<Record<Action, string>>(
+    'game-keymap',
+    DEFAULT_MAP,
+  );
+  const [highContrast, setHighContrast] = usePersistentState<boolean>(
+    'game-high-contrast',
+    false,
+  );
+  const [remapping, setRemapping] = useState<Action | null>(null);
+  const [message, setMessage] = useState('');
+
+  useGameInput({ onInput });
+
+  useEffect(() => {
+    onContrastChange && onContrastChange(highContrast);
+  }, [highContrast, onContrastChange]);
+
+  useEffect(() => {
+    if (!remapping) return;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      const next = { ...keymap, [remapping]: e.key } as Record<Action, string>;
+      setKeymap(next);
+      setRemapping(null);
+      setMessage(`${remapping} mapped to ${e.key}`);
+    };
+    window.addEventListener('keydown', handler, { once: true });
+    return () => window.removeEventListener('keydown', handler);
+  }, [remapping, keymap, setKeymap]);
+
+  const startRemap = (action: Action) => setRemapping(action);
+
+  const handleTouch = (action: Action) => () => {
+    onInput && onInput({ action, type: 'touch' });
+    setMessage(`${action} activated`);
+  };
+
+  const toggleContrast = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setHighContrast(e.target.checked);
+    setMessage(
+      `High contrast ${e.target.checked ? 'enabled' : 'disabled'}`,
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {(Object.keys(DEFAULT_MAP) as Action[]).map((action) => (
+          <button
+            key={action}
+            onClick={() => startRemap(action)}
+            className="px-2 py-1 border rounded"
+            aria-pressed={remapping === action}
+          >
+            {remapping === action
+              ? `Press key for ${action}`
+              : `${action}: ${keymap[action]}`}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {(Object.keys(DEFAULT_MAP) as Action[]).map((action) => (
+          <button
+            key={action}
+            onClick={handleTouch(action)}
+            className="px-4 py-2 border rounded"
+            aria-label={action}
+          >
+            {action}
+          </button>
+        ))}
+      </div>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={highContrast}
+          onChange={toggleContrast}
+        />
+        <span>High contrast tiles</span>
+      </label>
+      <div className="sr-only" aria-live="polite">
+        {message}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add configurable key mapping with persistent storage
- support touch buttons and high-contrast toggle with live announcements

## Testing
- `yarn lint games/common/controls.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: game2048 and others, mimikatz, vscode, wordSearch)*

------
https://chatgpt.com/codex/tasks/task_e_68b168da43e48328813a0c7a929f9193