### PR TITLE
Persist game state and sync settings across tabs

### DIFF
--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useReducer } from 'react';
 import ReactGA from 'react-ga4';
 import { BlackjackGame, handValue, basicStrategy, cardValue, Shoe } from './engine';
+import { useBestStreak } from '../../../games/blackjack/state';
 
 const CHIP_VALUES = [1, 5, 25, 100];
 const CHIP_COLORS = {
@@ -157,13 +158,7 @@ const Blackjack = () => {
   const [practiceCard, setPracticeCard] = useState(null);
   const [practiceGuess, setPracticeGuess] = useState('');
   const [streak, setStreak] = useState(0);
-  const [bestStreak, setBestStreak] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('bj_best_streak');
-      return stored ? parseInt(stored, 10) : 0;
-    }
-    return 0;
-  });
+  const [bestStreak, setBestStreak] = useBestStreak();
   const [dealerPeeking, setDealerPeeking] = useState(false);
 
   const [_, dispatch] = useReducer(gameReducer, {
@@ -188,11 +183,7 @@ const Blackjack = () => {
     gameRef.current.shoe.shufflePoint = Math.floor(gameRef.current.shoe.cards.length * penetration);
   }, [penetration]);
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('bj_best_streak', bestStreak.toString());
-    }
-  }, [bestStreak]);
+  // bestStreak persists via useBestStreak
 
   const start = () => {
     try {

--- a/components/hooks/usePersistentState.js
+++ b/components/hooks/usePersistentState.js
@@ -19,6 +19,23 @@ export default function usePersistentState(key, initialValue) {
     }
   }, [key, state]);
 
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key !== key) return;
+      try {
+        if (e.newValue === null) {
+          setState(initialValue);
+        } else {
+          setState(JSON.parse(e.newValue));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [key]);
+
   return [state, setState];
 }
 

--- a/components/usePersistentState.js
+++ b/components/usePersistentState.js
@@ -24,6 +24,23 @@ export default function usePersistentState(key, initialValue) {
     }
   }, [key, state]);
 
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key !== key) return;
+      try {
+        if (e.newValue === null) {
+          setState(initialValue);
+        } else {
+          setState(JSON.parse(e.newValue));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [key]);
+
   return [state, setState];
 }
 

--- a/games/2048/state.ts
+++ b/games/2048/state.ts
@@ -1,0 +1,54 @@
+import usePersistentState from '../../hooks/usePersistentState';
+import { Board, SIZE } from '../../apps/games/_2048/logic';
+
+export type HistoryEntry = { board: Board; rng: string };
+
+const emptyBoard = (): Board => Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
+
+export const UNDO_LIMIT = 5;
+
+export interface GameState {
+  board: Board;
+  history: HistoryEntry[];
+  undosLeft: number;
+  skin: 'classic' | 'neon';
+  best: number;
+  won: boolean;
+  lost: boolean;
+  rng: string;
+}
+
+const initialState: GameState = {
+  board: emptyBoard(),
+  history: [],
+  undosLeft: UNDO_LIMIT,
+  skin: 'classic',
+  best: 0,
+  won: false,
+  lost: false,
+  rng: '',
+};
+
+const isBoard = (b: any): b is Board =>
+  Array.isArray(b) && b.length === SIZE && b.every(row => Array.isArray(row) && row.length === SIZE && row.every(cell => typeof cell === 'number'));
+
+const validate = (v: unknown): v is GameState => {
+  if (typeof v !== 'object' || v === null) return false;
+  const s = v as GameState;
+  return (
+    isBoard(s.board) &&
+    Array.isArray(s.history) &&
+    typeof s.undosLeft === 'number' &&
+    (s.skin === 'classic' || s.skin === 'neon') &&
+    typeof s.best === 'number' &&
+    typeof s.won === 'boolean' &&
+    typeof s.lost === 'boolean' &&
+    typeof s.rng === 'string'
+  );
+};
+
+export default function useGameState() {
+  return usePersistentState<GameState>('game-2048-state', initialState, validate);
+}
+
+export { emptyBoard };

--- a/games/blackjack/state.ts
+++ b/games/blackjack/state.ts
@@ -1,0 +1,6 @@
+import usePersistentState from '../../hooks/usePersistentState';
+
+export const useBestStreak = () =>
+  usePersistentState<number>('bj_best_streak', 0, (v): v is number => typeof v === 'number');
+
+export type BestStreakState = ReturnType<typeof useBestStreak>;


### PR DESCRIPTION
## Summary
- add cross-tab sync to `usePersistentState`
- persist 2048 progress with resume option
- store Blackjack best streak with `usePersistentState`

## Testing
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, wordSearch.test.ts, kismet.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b168dabd408328bf36452622d5ca14