### PR TITLE
feat(2048): add replay export and download

### DIFF
--- a/games/2048/index.tsx
+++ b/games/2048/index.tsx
@@ -13,6 +13,7 @@ import {
   boardsEqual,
 } from '../../apps/games/_2048/logic';
 import { reset, serialize, deserialize } from '../../apps/games/rng';
+import { startRecording, recordMove, downloadReplay } from './replay';
 
 // limit of undo operations per game
 const UNDO_LIMIT = 5;
@@ -91,6 +92,7 @@ const Game2048 = () => {
     setUndosLeft(UNDO_LIMIT);
     setWon(false);
     setLost(false);
+    startRecording(b);
   }, []);
 
   useEffect(() => {
@@ -122,6 +124,7 @@ const Game2048 = () => {
       const next = fn(board.map((row) => [...row]));
       if (boardsEqual(board, next)) return;
       setHistory((h) => [...h, { board: board.map((row) => [...row]), rng: serialize() }]);
+      recordMove(dir);
       addRandomTile(next);
       const hi = highestTile(next);
       if (hi > best) setBest(hi);
@@ -186,6 +189,12 @@ const Game2048 = () => {
             disabled={!history.length || undosLeft === 0}
           >
             Undo ({undosLeft})
+          </button>
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={downloadReplay}
+          >
+            Download
           </button>
           <select
             className="text-black px-1 rounded"

--- a/games/2048/replay.ts
+++ b/games/2048/replay.ts
@@ -1,0 +1,29 @@
+import { Replay } from '../../utils/replay';
+import { serialize } from '../../apps/games/rng';
+import type { Board } from '../../apps/games/_2048/logic';
+import { shareBlob } from '../../components/apps/Games/common/share';
+
+const recorder = new Replay<string>();
+let startState: { board: Board; rng: string } | null = null;
+
+export function startRecording(board: Board): void {
+  startState = { board: board.map((row) => [...row]), rng: serialize() };
+  recorder.startRecording();
+}
+
+export function recordMove(dir: 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown'): void {
+  recorder.record(dir);
+}
+
+export async function downloadReplay(): Promise<void> {
+  if (!startState) return;
+  const data = {
+    board: startState.board,
+    rng: startState.rng,
+    events: recorder.getEvents().map(({ t, data }) => ({ t, dir: data })),
+  };
+  const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+  await shareBlob(blob, '2048-replay.json');
+}
+
+export default { startRecording, recordMove, downloadReplay };


### PR DESCRIPTION
## Summary
- record 2048 moves with RNG seed and expose export helper
- start recording on game init and log each move
- add UI button to download the recorded replay

## Testing
- `npx eslint -c .eslintrc.cjs games/2048/index.tsx games/2048/replay.ts`
- `yarn test games/2048 --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b168dc449083288f216936491d90c0