### PR TITLE
feat(memory): support selectable grid size

### DIFF
--- a/games/memory/components/SizeSelector.tsx
+++ b/games/memory/components/SizeSelector.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface SizeSelectorProps {
+  value: number;
+  onChange: (size: number) => void;
+}
+
+/**
+ * Dropdown for selecting the memory board size.
+ * Supports 2x2, 4x4 and 6x6 grids. The parent component
+ * owns the state and passes the current value plus a handler.
+ */
+const SizeSelector: React.FC<SizeSelectorProps> = ({ value, onChange }) => {
+  return (
+    <label className="flex items-center space-x-2">
+      <span className="text-sm">Grid</span>
+      <select
+        aria-label="Grid size"
+        className="px-2 py-1 rounded bg-gray-700 text-white"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      >
+        <option value={2}>2x2</option>
+        <option value={4}>4x4</option>
+        <option value={6}>6x6</option>
+      </select>
+    </label>
+  );
+};
+
+export default SizeSelector;

--- a/games/memory/index.tsx
+++ b/games/memory/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import GameShell from '../../components/games/GameShell.jsx';
+import SizeSelector from './components/SizeSelector';
+import { generateBoard } from './utils';
+
+/**
+ * Simplified memory game used in the demos directory. The game focuses on
+ * demonstrating grid size selection and dynamic board generation rather than
+ * providing a full featured experience.
+ */
+const MemoryGame: React.FC = () => {
+  const [size, setSize] = useState(4);
+
+  const cards = useMemo(() => generateBoard(size), [size]);
+
+  return (
+    <GameShell
+      settings={<SizeSelector value={size} onChange={setSize} />}
+    >
+      <div
+        className="grid gap-2 mx-auto"
+        style={{
+          gridTemplateColumns: `repeat(${size}, minmax(0,1fr))`,
+          width: `${size * 80}px`,
+        }}
+      >
+        {cards.map((card, idx) => (
+          <div
+            key={idx}
+            className="h-20 w-20 bg-gray-700 text-white flex items-center justify-center rounded"
+          >
+            {card}
+          </div>
+        ))}
+      </div>
+    </GameShell>
+  );
+};
+
+export default MemoryGame;

--- a/games/memory/utils.ts
+++ b/games/memory/utils.ts
@@ -1,0 +1,27 @@
+// Utility helpers for the memory game
+
+/**
+ * Generate a list of card values for the given board size.
+ * The board contains pairs of items, so size must be even.
+ *
+ * @param size number of rows/cols in the square board
+ */
+export function generateBoard(size: number): string[] {
+  const total = size * size;
+  const pairs = total / 2;
+  const values: string[] = [];
+
+  // simple sequence of letters starting from A
+  for (let i = 0; i < pairs; i++) {
+    const letter = String.fromCharCode(65 + (i % 26));
+    values.push(letter, letter);
+  }
+
+  // shuffle using Fisher-Yates
+  for (let i = values.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [values[i], values[j]] = [values[j], values[i]];
+  }
+
+  return values;
+}


### PR DESCRIPTION
## Summary
- add memory game scaffold with adjustable grid size selector
- generate memory board dynamically based on selected size
- render cards in a responsive grid

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, wordSearch, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b168eae1348328887d1abf05f3d45f