### PR TITLE
Add Pacman ghost speed sliders

### DIFF
--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import useAssetLoader from '../../hooks/useAssetLoader';
+import SpeedControls from '../../games/pacman/components/SpeedControls';
 
 /**
  * Small Pacman implementation used inside the portfolio. The goal of this
@@ -716,34 +717,7 @@ const Pacman = () => {
         </ul>
       </div>
 
-      <div className="mb-2 flex space-x-4">
-        <label className="flex items-center space-x-1">
-          <span>Scatter</span>
-          <input
-            type="number"
-            step="0.1"
-            min="0.1"
-            className="w-16 px-1 text-black"
-            value={ghostSpeeds.scatter}
-            onChange={(e) =>
-              setGhostSpeeds((s) => ({ ...s, scatter: parseFloat(e.target.value) || 0 }))
-            }
-          />
-        </label>
-        <label className="flex items-center space-x-1">
-          <span>Chase</span>
-          <input
-            type="number"
-            step="0.1"
-            min="0.1"
-            className="w-16 px-1 text-black"
-            value={ghostSpeeds.chase}
-            onChange={(e) =>
-              setGhostSpeeds((s) => ({ ...s, chase: parseFloat(e.target.value) || 0 }))
-            }
-          />
-        </label>
-      </div>
+      <SpeedControls ghostSpeeds={ghostSpeeds} setGhostSpeeds={setGhostSpeeds} />
 
       <canvas
         ref={canvasRef}

--- a/games/pacman/components/SpeedControls.tsx
+++ b/games/pacman/components/SpeedControls.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface GhostSpeeds {
+  scatter: number;
+  chase: number;
+}
+
+interface Props {
+  ghostSpeeds: GhostSpeeds;
+  setGhostSpeeds: React.Dispatch<React.SetStateAction<GhostSpeeds>>;
+}
+
+const SpeedControls: React.FC<Props> = ({ ghostSpeeds, setGhostSpeeds }) => {
+  const handleChange = (key: keyof GhostSpeeds) => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = parseFloat(e.target.value);
+    setGhostSpeeds((s) => ({ ...s, [key]: value }));
+  };
+
+  return (
+    <div className="flex space-x-4 mt-2">
+      <label className="flex flex-col items-center text-sm">
+        <span>Scatter: {ghostSpeeds.scatter.toFixed(1)}</span>
+        <input
+          type="range"
+          min="0.5"
+          max="3"
+          step="0.1"
+          value={ghostSpeeds.scatter}
+          onChange={handleChange('scatter')}
+          className="w-32"
+        />
+      </label>
+      <label className="flex flex-col items-center text-sm">
+        <span>Chase: {ghostSpeeds.chase.toFixed(1)}</span>
+        <input
+          type="range"
+          min="0.5"
+          max="3"
+          step="0.1"
+          value={ghostSpeeds.chase}
+          onChange={handleChange('chase')}
+          className="w-32"
+        />
+      </label>
+    </div>
+  );
+};
+
+export default SpeedControls;
+


### PR DESCRIPTION
## Summary
- Add SpeedControls component with sliders to tune ghost scatter and chase speeds
- Wire Pacman game to use SpeedControls for real-time ghost speed adjustment

## Testing
- `yarn test --passWithNoTests games/pacman/components/SpeedControls.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b168ef12ac832887379d7845ba7be9