### PR TITLE
feat(sokoban): display minimal push stats

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -1,5 +1,14 @@
 import { defaultLevels } from '../apps/sokoban/levels';
-import { loadLevel, move, undo, redo, isSolved, findHint, wouldDeadlock } from '../apps/sokoban/engine';
+import {
+  loadLevel,
+  move,
+  undo,
+  redo,
+  isSolved,
+  findHint,
+  wouldDeadlock,
+  findMinPushes,
+} from '../apps/sokoban/engine';
 
 describe('sokoban engine', () => {
   test('simple level solvable', () => {
@@ -46,6 +55,12 @@ describe('sokoban engine', () => {
     const state = loadLevel(defaultLevels[0]);
     const hint = findHint(state);
     expect(hint).toBe('ArrowRight');
+  });
+
+  test('minimal pushes computed', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const min = findMinPushes(state);
+    expect(min).toBe(1);
   });
 
   test('preflight corner deadlock', () => {


### PR DESCRIPTION
## Summary
- compute optimal push counts for Sokoban levels using solver logic
- show minimal pushes and completion stats in UI overlay
- test solver to ensure minimal push count is calculated

## Testing
- `npm test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b168f7b4608328829df0156084e007