### PR TITLE
feat: add daily challenge completion tracking and shared leaderboard support

### DIFF
--- a/__tests__/dailyLeaderboard.test.ts
+++ b/__tests__/dailyLeaderboard.test.ts
@@ -1,4 +1,9 @@
-import { getDailySeed, recordScore, getLeaderboard } from '../utils/dailyChallenge';
+import {
+  getDailySeed,
+  recordCompletion,
+  getLeaderboard,
+  hasCompleted,
+} from '../utils/dailyChallenge';
 
 describe('daily challenge and leaderboard', () => {
   beforeEach(() => {
@@ -11,9 +16,22 @@ describe('daily challenge and leaderboard', () => {
     expect(seed1).toBe(seed2);
   });
 
-  test('leaderboard stored via localStorage', () => {
-    recordScore('hangman', 'Alice', 10);
-    recordScore('hangman', 'Bob', 20);
+  test('records completion and leaderboard', () => {
+    recordCompletion(
+      'hangman',
+      'Alice',
+      10,
+      new Date('2024-05-01T10:00:00Z'),
+    );
+    expect(hasCompleted('hangman', new Date('2024-05-01T23:00:00Z'))).toBe(
+      true,
+    );
+    recordCompletion(
+      'hangman',
+      'Bob',
+      20,
+      new Date('2024-05-01T12:00:00Z'),
+    );
     const board = getLeaderboard('hangman');
     expect(board[0]).toEqual({ name: 'Bob', score: 20 });
     expect(board[1]).toEqual({ name: 'Alice', score: 10 });


### PR DESCRIPTION
## Summary
- reuse common leaderboard utilities for daily challenges
- add local completion tracking and broadcast updated leaderboards
- test daily seed determinism and completion recording

## Testing
- `npm test __tests__/dailyLeaderboard.test.ts __tests__/leaderboardAntiCheat.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b168f9c31083288d81f34a0efa067d