### PR TITLE
Add DPS charts for tower defense

### DIFF
--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Tower, getTowerDPS } from '..';
+
+interface DpsChartsProps {
+  towers: (Tower & { type?: string })[];
+}
+
+const DpsCharts = ({ towers }: DpsChartsProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpsMap: Record<string, number> = {};
+    towers.forEach((t) => {
+      const type = (t as any).type || 'single';
+      dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
+    });
+
+    const entries = Object.entries(dpsMap);
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    if (!entries.length) return;
+    const max = Math.max(...entries.map(([, d]) => d), 1);
+    const barWidth = w / entries.length;
+
+    entries.forEach(([type, dps], i) => {
+      const height = (dps / max) * (h - 20);
+      const x = i * barWidth + 5;
+      const y = h - height - 20;
+      ctx.fillStyle = '#00ff00';
+      ctx.fillRect(x, y, barWidth - 10, height);
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '12px sans-serif';
+      ctx.fillText(`${type}: ${dps.toFixed(1)}`, x, h - 5);
+    });
+  }, [towers]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={300}
+      height={120}
+      className="bg-ub-dark-grey"
+      role="img"
+      aria-label="Tower DPS chart"
+    />
+  );
+};
+
+export default DpsCharts;

--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import GameLayout from '../../components/apps/GameLayout';
+import DpsCharts from '../games/tower-defense/components/DpsCharts';
 import {
   ENEMY_TYPES,
   Tower,
@@ -253,6 +254,7 @@ const TowerDefense = () => {
           className="bg-black"
           onClick={handleCanvasClick}
         />
+        {!editing && <DpsCharts towers={towers} />}
       </div>
     </GameLayout>
   );


### PR DESCRIPTION
## Summary
- add DpsCharts component to aggregate and visualize tower DPS
- render DPS chart during tower-defense gameplay

## Testing
- `yarn test __tests__/tower-defense.test.ts`
- `yarn lint apps/tower-defense/index.tsx apps/games/tower-defense/components/DpsCharts.tsx` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b168fe2d0c832898c98347cb3bd61d