### PR TITLE
feat: add tetris piece generation modes

### DIFF
--- a/games/tetris/logic.ts
+++ b/games/tetris/logic.ts
@@ -1,0 +1,38 @@
+export type Tetromino = 'I' | 'J' | 'L' | 'O' | 'S' | 'T' | 'Z';
+export type RandomMode = 'seven-bag' | 'true-random';
+
+const PIECES: Tetromino[] = ['I','J','L','O','S','T','Z'];
+
+const shuffle = (arr: Tetromino[]): Tetromino[] => {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+};
+
+export class PieceGenerator {
+  private bag: Tetromino[] = [];
+  private mode: RandomMode;
+
+  constructor(mode: RandomMode = 'seven-bag') {
+    this.mode = mode;
+  }
+
+  setMode(mode: RandomMode) {
+    this.mode = mode;
+    if (mode === 'seven-bag') {
+      this.bag = [];
+    }
+  }
+
+  next(): Tetromino {
+    if (this.mode === 'seven-bag') {
+      if (this.bag.length === 0) {
+        this.bag = shuffle([...PIECES]);
+      }
+      return this.bag.pop()!;
+    }
+    return PIECES[Math.floor(Math.random() * PIECES.length)];
+  }
+}


### PR DESCRIPTION
## Summary
- add PieceGenerator to support seven-bag and true-random sequences
- allow Tetris app to toggle generator modes and reset bag on restart

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vsCode, wordSearch, metasploit, kismet)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b168fc3c2883288e44d1b2c0a365e7