### PR TITLE
feat(word-search): import custom word lists

### DIFF
--- a/apps/word_search/generator.ts
+++ b/apps/word_search/generator.ts
@@ -78,10 +78,12 @@ export function generateGrid(
     const word = w.toUpperCase();
     for (let attempt = 0; attempt < 200; attempt += 1) {
       const dir = directions[Math.floor(rng() * directions.length)];
-      const maxRow = dir.dy > 0 ? size - word.length : dir.dy < 0 ? word.length - 1 : size - 1;
-      const maxCol = dir.dx > 0 ? size - word.length : dir.dx < 0 ? word.length - 1 : size - 1;
-      const startRow = Math.floor(rng() * (maxRow + 1));
-      const startCol = Math.floor(rng() * (maxCol + 1));
+      const minRow = dir.dy < 0 ? word.length - 1 : 0;
+      const maxRow = dir.dy > 0 ? size - word.length : size - 1;
+      const minCol = dir.dx < 0 ? word.length - 1 : 0;
+      const maxCol = dir.dx > 0 ? size - word.length : size - 1;
+      const startRow = Math.floor(rng() * (maxRow - minRow + 1)) + minRow;
+      const startCol = Math.floor(rng() * (maxCol - minCol + 1)) + minCol;
       let ok = true;
       const positions: Position[] = [];
       for (let i = 0; i < word.length; i += 1) {

--- a/games/word-search/components/ListImport.tsx
+++ b/games/word-search/components/ListImport.tsx
@@ -1,0 +1,51 @@
+import React, { useRef } from 'react';
+
+interface ListImportProps {
+  onImport: (words: string[]) => void;
+}
+
+const ListImport: React.FC<ListImportProps> = ({ onImport }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const words = text
+        .split(/[\s,]+/)
+        .map((w) => w.trim().toUpperCase())
+        .filter((w) => w && /^[A-Z]+$/.test(w));
+      if (words.length) {
+        onImport(words);
+      }
+    } catch {
+      // ignore read errors
+    } finally {
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        className="px-2 py-1 bg-purple-700 text-white rounded"
+      >
+        Import List
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".txt"
+        className="hidden"
+        onChange={handleFile}
+      />
+    </>
+  );
+};
+
+export default ListImport;


### PR DESCRIPTION
## Summary
- allow uploading text files of words for word search
- support custom word packs and generate puzzles from uploads
- fix word placement bounds in generator

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/word_search/index.tsx games/word-search/components/ListImport.tsx apps/word_search/generator.ts`
- `npx --no-install yarn test __tests__/wordSearch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b168feefc88328be33e0036fb718a7