### PR TITLE
feat: add wrap option for snake

### DIFF
--- a/games/snake/index.tsx
+++ b/games/snake/index.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useRef, useEffect, useState } from "react";
+import GameShell from "../../components/games/GameShell";
+import usePersistentState from "../../hooks/usePersistentState";
+import { GRID_SIZE, createState, step, GameState } from "./logic";
+
+const CELL_SIZE = 16;
+
+const Snake = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [wrap, setWrap] = usePersistentState<boolean>("snake:wrap", false);
+  const [state, setState] = useState<GameState>(() => createState(wrap));
+  const runningRef = useRef(true);
+
+  // keep state.wrap in sync with persisted wrap
+  useEffect(() => {
+    setState((s) => ({ ...s, wrap }));
+    runningRef.current = true;
+  }, [wrap]);
+
+  // game loop
+  useEffect(() => {
+    const id = setInterval(() => {
+      setState((s) => {
+        if (!runningRef.current) return s;
+        const result = step(s);
+        if (result.gameOver) {
+          runningRef.current = false;
+        }
+        return result.state;
+      });
+    }, 150);
+    return () => clearInterval(id);
+  }, []);
+
+  // draw
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
+    ctx.fillStyle = "#111827";
+    ctx.fillRect(0, 0, GRID_SIZE * CELL_SIZE, GRID_SIZE * CELL_SIZE);
+    ctx.fillStyle = "#ef4444";
+    ctx.fillRect(state.food.x * CELL_SIZE, state.food.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+    ctx.fillStyle = "#22c55e";
+    state.snake.forEach((seg) => {
+      ctx.fillRect(seg.x * CELL_SIZE, seg.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+    });
+  }, [state]);
+
+  // controls
+  const dirRef = useRef(state.dir);
+  useEffect(() => {
+    dirRef.current = state.dir;
+  }, [state.dir]);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const dir = dirRef.current;
+      if (e.key === "ArrowUp" && dir.y !== 1) setState((s) => ({ ...s, dir: { x: 0, y: -1 } }));
+      if (e.key === "ArrowDown" && dir.y !== -1) setState((s) => ({ ...s, dir: { x: 0, y: 1 } }));
+      if (e.key === "ArrowLeft" && dir.x !== 1) setState((s) => ({ ...s, dir: { x: -1, y: 0 } }));
+      if (e.key === "ArrowRight" && dir.x !== -1)
+        setState((s) => ({ ...s, dir: { x: 1, y: 0 } }));
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const settings = (
+    <label className="flex items-center space-x-2">
+      <input
+        type="checkbox"
+        checked={wrap}
+        onChange={(e) => setWrap(e.target.checked)}
+      />
+      <span>Wrap edges</span>
+    </label>
+  );
+
+  return (
+    <GameShell settings={settings}>
+      <canvas
+        ref={canvasRef}
+        width={GRID_SIZE * CELL_SIZE}
+        height={GRID_SIZE * CELL_SIZE}
+      />
+    </GameShell>
+  );
+};
+
+export default Snake;

--- a/games/snake/logic.ts
+++ b/games/snake/logic.ts
@@ -1,0 +1,81 @@
+export const GRID_SIZE = 20;
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface GameState {
+  snake: Point[];
+  dir: Point;
+  food: Point;
+  wrap: boolean;
+}
+
+export const randomFood = (snake: Point[]): Point => {
+  let pos: Point;
+  do {
+    pos = {
+      x: Math.floor(Math.random() * GRID_SIZE),
+      y: Math.floor(Math.random() * GRID_SIZE),
+    };
+  } while (snake.some((s) => s.x === pos.x && s.y === pos.y));
+  return pos;
+};
+
+export const createState = (wrap = false): GameState => {
+  const start = {
+    x: Math.floor(GRID_SIZE / 2),
+    y: Math.floor(GRID_SIZE / 2),
+  };
+  return {
+    snake: [start],
+    dir: { x: 1, y: 0 },
+    food: randomFood([start]),
+    wrap,
+  };
+};
+
+export const step = (
+  state: GameState,
+): { state: GameState; gameOver: boolean; ate: boolean } => {
+  const snake = [...state.snake];
+  let headX = snake[0].x + state.dir.x;
+  let headY = snake[0].y + state.dir.y;
+
+  if (state.wrap) {
+    headX = (headX + GRID_SIZE) % GRID_SIZE;
+    headY = (headY + GRID_SIZE) % GRID_SIZE;
+  } else if (
+    headX < 0 ||
+    headY < 0 ||
+    headX >= GRID_SIZE ||
+    headY >= GRID_SIZE
+  ) {
+    return { state, gameOver: true, ate: false };
+  }
+
+  if (snake.some((seg) => seg.x === headX && seg.y === headY)) {
+    return { state, gameOver: true, ate: false };
+  }
+
+  snake.unshift({ x: headX, y: headY });
+
+  let food = state.food;
+  let ate = false;
+  if (headX === food.x && headY === food.y) {
+    ate = true;
+    food = randomFood(snake);
+  } else {
+    snake.pop();
+  }
+
+  return { state: { ...state, snake, food }, gameOver: false, ate };
+};
+
+export default {
+  GRID_SIZE,
+  randomFood,
+  createState,
+  step,
+};


### PR DESCRIPTION
## Summary
- add snake game logic with optional edge wrapping
- expose "Wrap edges" setting for snake game

## Testing
- `yarn test` *(fails: game2048, beef, mimikatz, vscode, wordSearch, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b168f57c388328bc8a072cde86e03d