### PR TITLE
feat(checkers): highlight moves and hint toggle

### DIFF
--- a/apps/checkers/checkers.css
+++ b/apps/checkers/checkers.css
@@ -5,3 +5,7 @@
 .move-square {
   @apply ring-2 ring-yellow-300 bg-yellow-200/40 animate-pulse;
 }
+
+.hint-square {
+  @apply ring-2 ring-blue-400 animate-pulse;
+}

--- a/games/checkers/logic.ts
+++ b/games/checkers/logic.ts
@@ -1,0 +1,48 @@
+import {
+  Board,
+  Move,
+  Color,
+  getPieceMoves,
+  getAllMoves,
+  applyMove,
+  evaluateBoard,
+} from '../../components/apps/checkers/engine';
+
+export const getSelectableMoves = (
+  board: Board,
+  r: number,
+  c: number,
+  enforceCapture = true,
+): Move[] => {
+  const piece = board[r][c];
+  if (!piece) return [];
+  const pieceMoves = getPieceMoves(board, r, c, enforceCapture);
+  const allMoves = getAllMoves(board, piece.color, enforceCapture);
+  const mustCapture = enforceCapture && allMoves.some((m) => m.captured);
+  return mustCapture ? pieceMoves.filter((m) => m.captured) : pieceMoves;
+};
+
+export const getHintMove = (
+  board: Board,
+  color: Color,
+  enforceCapture = true,
+): Move | null => {
+  const moves = getAllMoves(board, color, enforceCapture);
+  if (!moves.length) return null;
+  let best = moves[0];
+  let bestScore = color === 'red' ? -Infinity : Infinity;
+  for (const move of moves) {
+    const { board: newBoard } = applyMove(board, move);
+    const score = evaluateBoard(newBoard);
+    if (color === 'red') {
+      if (score > bestScore) {
+        bestScore = score;
+        best = move;
+      }
+    } else if (score < bestScore) {
+      bestScore = score;
+      best = move;
+    }
+  }
+  return best;
+};


### PR DESCRIPTION
## Summary
- highlight available moves through reusable helpers
- add persistent hint toggle and rendering
- style hint squares in blue

## Testing
- `yarn test` (fails: game2048, beef, mimikatz, vscode)
- `yarn lint` (config missing)


------
https://chatgpt.com/codex/tasks/task_e_68b168e3af4c832894da89e1b0a9e201