### PR TITLE
feat(blackjack): add adjustable penetration slider

### DIFF
--- a/__tests__/blackjack.test.ts
+++ b/__tests__/blackjack.test.ts
@@ -177,4 +177,13 @@ describe('Counting and penetration', () => {
     const game = new BlackjackGame({ decks: 1, bankroll: 1000, penetration: 0.6 });
     expect(game.shoe.penetration).toBe(0.6);
   });
+
+  test('Shoe.setPenetration adjusts shuffle point', () => {
+    const shoe = new Shoe(1, 0.75);
+    const original = shoe.shufflePoint;
+    shoe.setPenetration(0.5);
+    expect(shoe.penetration).toBe(0.5);
+    expect(shoe.shufflePoint).toBe(Math.floor(shoe.cards.length * 0.5));
+    expect(shoe.shufflePoint).not.toBe(original);
+  });
 });

--- a/components/apps/blackjack/engine.js
+++ b/components/apps/blackjack/engine.js
@@ -29,13 +29,20 @@ export class Shoe {
     this.shuffle();
   }
 
+  setPenetration(pen) {
+    this.penetration = pen;
+    if (this.cards) {
+      this.shufflePoint = Math.floor(this.cards.length * this.penetration);
+    }
+  }
+
   shuffle() {
     this.cards = [];
     for (let i = 0; i < this.decks; i += 1) {
       this.cards.push(...buildDeck());
     }
     shuffleArray(this.cards);
-    this.shufflePoint = Math.floor(this.cards.length * this.penetration);
+    this.setPenetration(this.penetration);
     this.dealt = 0;
     this.shuffleCount += 1;
     this.runningCount = 0;

--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useReducer } from 'react';
 import ReactGA from 'react-ga4';
 import { BlackjackGame, handValue, basicStrategy, cardValue, Shoe } from './engine';
+import PenetrationSlider from '../../../games/blackjack/components/PenetrationSlider';
 
 const CHIP_VALUES = [1, 5, 25, 100];
 const CHIP_COLORS = {
@@ -153,7 +154,7 @@ const Blackjack = () => {
   const [showCount, setShowCount] = useState(false);
   const [runningCount, setRunningCount] = useState(0);
   const [practice, setPractice] = useState(false);
-  const practiceShoe = useRef(new Shoe(1));
+  const practiceShoe = useRef(new Shoe(1, penetration));
   const [practiceCard, setPracticeCard] = useState(null);
   const [practiceGuess, setPracticeGuess] = useState('');
   const [streak, setStreak] = useState(0);
@@ -184,8 +185,8 @@ const Blackjack = () => {
   };
 
   useEffect(() => {
-    gameRef.current.shoe.penetration = penetration;
-    gameRef.current.shoe.shufflePoint = Math.floor(gameRef.current.shoe.cards.length * penetration);
+    gameRef.current.shoe.setPenetration(penetration);
+    practiceShoe.current.setPenetration(penetration);
   }, [penetration]);
 
   useEffect(() => {
@@ -368,22 +369,7 @@ const Blackjack = () => {
           <button className="px-2 py-1 bg-gray-700" onClick={startPractice}>
             Practice Count
           </button>
-          <label className="flex items-center space-x-1">
-            <span className="text-sm">Pen</span>
-            <input
-              type="range"
-              step="0.05"
-              min="0.5"
-              max="0.95"
-              value={penetration}
-              onChange={(e) => {
-                const val = parseFloat(e.target.value);
-                if (!Number.isNaN(val)) setPenetration(val);
-              }}
-              className="w-24"
-            />
-            <span className="text-sm">{(penetration * 100).toFixed(0)}%</span>
-          </label>
+          <PenetrationSlider penetration={penetration} onChange={setPenetration} />
         </div>
       {playerHands.length === 0 ? (
         <div className="mb-4">

--- a/games/blackjack/components/PenetrationSlider.tsx
+++ b/games/blackjack/components/PenetrationSlider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+
+interface PenetrationSliderProps {
+  penetration: number;
+  onChange: (val: number) => void;
+}
+
+export default function PenetrationSlider({ penetration, onChange }: PenetrationSliderProps) {
+  return (
+    <label className="flex items-center space-x-1">
+      <span className="text-sm">Pen</span>
+      <input
+        type="range"
+        step="0.05"
+        min="0.5"
+        max="0.95"
+        value={penetration}
+        onChange={(e) => {
+          const val = parseFloat(e.target.value);
+          if (!Number.isNaN(val)) onChange(val);
+        }}
+        className="w-24"
+      />
+      <span className="text-sm">{(penetration * 100).toFixed(0)}%</span>
+    </label>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dedicated `PenetrationSlider` component for blackjack
- sync penetration with card counting practice shoe
- add `Shoe.setPenetration` helper and unit tests

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, wordSearch.test.ts, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b168e0740c83289fc3e7027965c67f