### PR TITLE
feat: enable multi-shot turns in Battleship

### DIFF
--- a/__tests__/battleship-logic.test.ts
+++ b/__tests__/battleship-logic.test.ts
@@ -1,0 +1,11 @@
+import { fireShots, CellState } from '../apps/games/battleship/logic';
+
+test('fireShots marks hits and misses for multiple targets', () => {
+  const board: CellState[] = Array(4).fill(null);
+  board[1] = 'ship';
+  board[3] = 'ship';
+  const { board: updated, hits, misses } = fireShots(board, [0, 1, 2, 3]);
+  expect(updated).toEqual(['miss', 'hit', 'miss', 'hit']);
+  expect(hits.sort()).toEqual([1, 3]);
+  expect(misses.sort()).toEqual([0, 2]);
+});

--- a/apps/games/battleship/logic.ts
+++ b/apps/games/battleship/logic.ts
@@ -1,0 +1,29 @@
+export type CellState = 'ship' | 'hit' | 'miss' | null;
+
+/**
+ * Apply multiple shots to the enemy board.
+ * Already-fired locations are ignored.
+ * Returns the updated board and lists of hit and miss indices.
+ */
+export function fireShots(board: CellState[], targets: number[]): {
+  board: CellState[];
+  hits: number[];
+  misses: number[];
+} {
+  const newBoard = board.slice();
+  const hits: number[] = [];
+  const misses: number[] = [];
+
+  for (const idx of targets) {
+    const cell = newBoard[idx];
+    if (cell === 'ship') {
+      newBoard[idx] = 'hit';
+      hits.push(idx);
+    } else if (cell == null) {
+      newBoard[idx] = 'miss';
+      misses.push(idx);
+    }
+  }
+
+  return { board: newBoard, hits, misses };
+}


### PR DESCRIPTION
## Summary
- add reusable `fireShots` helper for applying multiple attacks at once
- allow selecting multiple targets and fire them in one salvo
- cover multi-shot logic with unit tests

## Testing
- `npx jest __tests__/battleship-logic.test.ts __tests__/battleship-ai.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b168debde48328a99c7283bb8a7798