### PR TITLE
feat: gate ghidra demo by wasm env

### DIFF
--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import GhidraApp from '../../../components/apps/ghidra';
+
+export default function DemoRunner() {
+  const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (!wasmUrl) {
+      return;
+    }
+    let mounted = true;
+    WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
+      .then(() => {
+        if (mounted) {
+          setEnabled(true);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setEnabled(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [wasmUrl]);
+
+  if (!enabled) {
+    return (
+      <div className="flex flex-col items-center space-y-4">
+        <Image
+          src="/themes/Yaru/apps/ghidra.svg"
+          width={256}
+          height={256}
+          alt="Ghidra screenshot 1"
+        />
+        <Image
+          src="/themes/Yaru/apps/ghidra.svg"
+          width={256}
+          height={256}
+          alt="Ghidra screenshot 2"
+        />
+      </div>
+    );
+  }
+
+  return <GhidraApp />;
+}

--- a/apps/ghidra/index.tsx
+++ b/apps/ghidra/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import GhidraApp from '../../components/apps/ghidra';
+import DemoRunner from './components/DemoRunner';
 
 export default function GhidraPage() {
-  return <GhidraApp />;
+  return <DemoRunner />;
 }


### PR DESCRIPTION
## Summary
- load ghidra wasm and show control flow graph when `NEXT_PUBLIC_GHIDRA_WASM` is set
- fall back to screenshots when wasm is not available

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b159980a3083288b7a2ed34d6cb476