### PR TITLE
feat: export network metrics

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -7,6 +7,7 @@ import {
   getActiveFetches,
   FetchEntry,
 } from '../../../lib/fetchProxy';
+import { exportMetrics } from '../export';
 
 const HISTORY_KEY = 'network-insights-history';
 
@@ -45,7 +46,15 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <h2 className="font-bold mb-1">History</h2>
+      <div className="flex items-center mb-1">
+        <h2 className="font-bold">History</h2>
+        <button
+          onClick={() => exportMetrics(history)}
+          className="ml-auto px-2 py-1 bg-ub-dark-grey rounded"
+        >
+          Export
+        </button>
+      </div>
       <ul className="divide-y divide-gray-700 border border-gray-700 rounded">
         {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
         {history.map((f) => (

--- a/apps/resource-monitor/export.ts
+++ b/apps/resource-monitor/export.ts
@@ -1,0 +1,17 @@
+import { FetchEntry } from '../../lib/fetchProxy';
+
+export function serializeMetrics(entries: FetchEntry[]): string {
+  return JSON.stringify(entries, null, 2);
+}
+
+export function exportMetrics(entries: FetchEntry[], filename = 'network-insights.json'): void {
+  const blob = new Blob([serializeMetrics(entries)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add serialization/export helper for network insights metrics
- add export button to download stored fetch metrics

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx, metasploit.test.tsx)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b17714927883289b06b1de71ff1ae3