### PR TITLE
Add Wordle hard mode enforcement and settings toggle

### DIFF
--- a/games/wordle/index.tsx
+++ b/games/wordle/index.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import GameShell from "../../components/games/GameShell";
+import usePersistentState from "../../hooks/usePersistentState";
+import { getWordOfTheDay, dictionaries } from "../../utils/wordle";
+import type { GuessEntry, LetterResult } from "./logic";
+import { evaluateGuess, hardModeViolation } from "./logic";
+
+const WordleGame = () => {
+  const [hardMode, setHardMode] = usePersistentState<boolean>("wordle:hard", false);
+  const wordList = dictionaries.common; // single dictionary for now
+  const solution = useMemo(() => getWordOfTheDay("common"), []);
+
+  const [guesses, setGuesses] = useState<GuessEntry[]>([]);
+  const [guess, setGuess] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const upper = guess.toUpperCase();
+    if (upper.length !== 5) return;
+
+    if (!wordList.includes(upper)) {
+      setMessage("Word not in dictionary.");
+      return;
+    }
+
+    if (hardMode) {
+      const violation = hardModeViolation(upper, guesses);
+      if (violation) {
+        setMessage(violation);
+        return;
+      }
+    }
+
+    const result = evaluateGuess(upper, solution);
+    setGuesses([...guesses, { guess: upper, result }]);
+    setGuess("");
+    setMessage("");
+  };
+
+  const renderCell = (row: number, col: number) => {
+    const entry = guesses[row];
+    const letter = entry ? entry.guess[col] : "";
+    const res: LetterResult | undefined = entry?.result[col];
+    const color =
+      res === "correct"
+        ? "bg-green-600"
+        : res === "present"
+        ? "bg-yellow-500"
+        : res === "absent"
+        ? "bg-gray-700"
+        : "bg-gray-900";
+    return (
+      <div
+        key={col}
+        className={`w-10 h-10 border border-gray-700 flex items-center justify-center text-xl font-bold ${color}`}
+      >
+        {letter}
+      </div>
+    );
+  };
+
+  const settings = (
+    <label className="flex items-center space-x-2">
+      <input
+        type="checkbox"
+        checked={hardMode}
+        onChange={(e) => setHardMode(e.target.checked)}
+      />
+      <span>Hard Mode</span>
+    </label>
+  );
+
+  return (
+    <GameShell settings={settings}>
+      <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 space-y-4 overflow-y-auto">
+        <h1 className="text-xl font-bold">Wordle</h1>
+
+        <div className="grid grid-rows-6 gap-1" role="grid" aria-label="Wordle board">
+          {Array.from({ length: 6 }).map((_, row) => (
+            <div key={row} className="grid grid-cols-5 gap-1" role="row">
+              {Array.from({ length: 5 }).map((_, col) => renderCell(row, col))}
+            </div>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex space-x-2">
+          <input
+            type="text"
+            maxLength={5}
+            value={guess}
+            onChange={(e) => setGuess(e.target.value.toUpperCase())}
+            className="w-32 p-2 text-black text-center uppercase"
+            placeholder="Guess"
+          />
+          <button type="submit" className="px-4 py-2 bg-gray-700 rounded">
+            Enter
+          </button>
+        </form>
+
+        {message && <div className="text-sm text-red-400">{message}</div>}
+      </div>
+    </GameShell>
+  );
+};
+
+export default WordleGame;
+

--- a/games/wordle/logic.ts
+++ b/games/wordle/logic.ts
@@ -1,0 +1,99 @@
+export type LetterResult = 'correct' | 'present' | 'absent';
+
+export interface GuessEntry {
+  guess: string;
+  result: LetterResult[];
+}
+
+/**
+ * Evaluate a guess against the solution producing a result for each letter.
+ * Mimics the classic Wordle scoring rules.
+ */
+export function evaluateGuess(guess: string, answer: string): LetterResult[] {
+  const result: LetterResult[] = Array(5).fill('absent');
+  const answerArr = answer.split('');
+  const used = Array(5).fill(false);
+
+  // First pass for correct placements
+  for (let i = 0; i < 5; i += 1) {
+    if (guess[i] === answerArr[i]) {
+      result[i] = 'correct';
+      used[i] = true;
+    }
+  }
+
+  // Second pass for present letters
+  for (let i = 0; i < 5; i += 1) {
+    if (result[i] === 'correct') continue;
+    const ch = guess[i];
+    const idx = answerArr.findIndex((a, j) => !used[j] && a === ch);
+    if (idx !== -1) {
+      result[i] = 'present';
+      used[idx] = true;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Enforce Wordle hard mode rules. Any letter revealed in previous guesses must
+ * be used in subsequent guesses.
+ *
+ * Returns an error message string if the guess violates hard mode, otherwise
+ * null.
+ */
+export function hardModeViolation(
+  guess: string,
+  previous: GuessEntry[],
+): string | null {
+  const requiredPos: Record<number, string> = {};
+  const forbiddenPos: Record<number, Set<string>> = {};
+  const requiredCounts: Record<string, number> = {};
+
+  previous.forEach(({ guess: g, result }) => {
+    const localCounts: Record<string, number> = {};
+    for (let i = 0; i < 5; i += 1) {
+      const ch = g[i];
+      const res = result[i];
+      if (res === 'correct') {
+        requiredPos[i] = ch;
+        localCounts[ch] = (localCounts[ch] || 0) + 1;
+      } else if (res === 'present') {
+        forbiddenPos[i] = forbiddenPos[i] || new Set();
+        forbiddenPos[i]!.add(ch);
+        localCounts[ch] = (localCounts[ch] || 0) + 1;
+      }
+    }
+    Object.entries(localCounts).forEach(([ch, count]) => {
+      requiredCounts[ch] = Math.max(requiredCounts[ch] || 0, count);
+    });
+  });
+
+  for (const [idxStr, ch] of Object.entries(requiredPos)) {
+    const idx = Number(idxStr);
+    if (guess[idx] !== ch) {
+      return `Hard mode: ${ch} must be in position ${idx + 1}.`;
+    }
+  }
+
+  const guessCounts: Record<string, number> = {};
+  for (let i = 0; i < 5; i += 1) {
+    const ch = guess[i];
+    guessCounts[ch] = (guessCounts[ch] || 0) + 1;
+    if (forbiddenPos[i] && forbiddenPos[i]!.has(ch)) {
+      return `Hard mode: ${ch} cannot be in position ${i + 1}.`;
+    }
+  }
+
+  for (const [ch, count] of Object.entries(requiredCounts)) {
+    if ((guessCounts[ch] || 0) < count) {
+      return `Hard mode: guess must contain ${ch}${count > 1 ? ` (${count}x)` : ''}.`;
+    }
+  }
+
+  return null;
+}
+
+export default { evaluateGuess, hardModeViolation };
+


### PR DESCRIPTION
## Summary
- add Wordle logic for evaluating guesses and enforcing hard mode hints
- create Wordle game wrapper with hard mode setting toggle

## Testing
- `yarn test __tests__/wordle.test.tsx --runTestsByPath` *(fails: Cannot update a component while rendering different component)*

------
https://chatgpt.com/codex/tasks/task_e_68b176e8f630832890fda5c0aa9d2d0d