### PR TITLE
feat(nonogram): generate puzzles from PNGs

### DIFF
--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useState } from "react";
+import type { Clue, Grid } from "../../../apps/games/nonogram/logic";
+import { lineToClues } from "../../../apps/games/nonogram/logic";
+
+export interface ParsedPuzzle {
+  grid: Grid;
+  rows: Clue[];
+  cols: Clue[];
+}
+
+// Validate that the given grid matches the supplied clues.
+export const validatePuzzle = (grid: Grid, rows: Clue[], cols: Clue[]) => {
+  const rowsValid = grid.every(
+    (row, i) => JSON.stringify(lineToClues(row)) === JSON.stringify(rows[i])
+  );
+  const colsValid = cols.every((clue, j) => {
+    const column = grid.map((r) => r[j]);
+    return JSON.stringify(lineToClues(column)) === JSON.stringify(clue);
+  });
+  return rowsValid && colsValid;
+};
+
+// Parse a monochrome PNG into a puzzle representation. Works in both
+// browser and Node environments. In Node it relies on `pngjs`.
+export async function parseMonochromePng(
+  input: File | ArrayBuffer
+): Promise<ParsedPuzzle> {
+  const buffer = input instanceof ArrayBuffer ? input : await input.arrayBuffer();
+
+  // Browser implementation using Canvas APIs
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    const blob = new Blob([buffer], { type: "image/png" });
+    const bitmap = await createImageBitmap(blob);
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+    ctx.drawImage(bitmap, 0, 0);
+    const { data } = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+    return dataToPuzzle(data, bitmap.width, bitmap.height);
+  }
+
+  // Node implementation using pngjs
+  const { PNG } = await import("pngjs");
+  const png = PNG.sync.read(Buffer.from(buffer));
+  return dataToPuzzle(png.data, png.width, png.height);
+}
+
+// Convert raw RGBA data into grid/clues
+const dataToPuzzle = (data: Uint8Array, width: number, height: number) => {
+  const grid: Grid = [];
+  for (let y = 0; y < height; y++) {
+    const row: number[] = [];
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const r = data[idx];
+      const g = data[idx + 1];
+      const b = data[idx + 2];
+      const a = data[idx + 3];
+      // treat non-transparent dark pixels as filled
+      const val = a > 127 && (r + g + b) / 3 < 128 ? 1 : 0;
+      row.push(val);
+    }
+    grid.push(row as Grid[number]);
+  }
+  const rows = grid.map(lineToClues);
+  const cols: Clue[] = [];
+  for (let x = 0; x < width; x++) {
+    const column = grid.map((row) => row[x]);
+    cols.push(lineToClues(column));
+  }
+  return { grid, rows, cols };
+};
+
+const cellStyle = (filled: number) =>
+  `w-4 h-4 border border-gray-400 ${filled ? "bg-black" : "bg-white"}`;
+
+const PngImport: React.FC = () => {
+  const [puzzle, setPuzzle] = useState<ParsedPuzzle | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const parsed = await parseMonochromePng(file);
+      if (!validatePuzzle(parsed.grid, parsed.rows, parsed.cols)) {
+        throw new Error("Invalid puzzle");
+      }
+      setPuzzle(parsed);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to parse PNG");
+      setPuzzle(null);
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" accept="image/png" onChange={onFile} />
+      {error && <p className="text-red-600 mt-2">{error}</p>}
+      {puzzle && (
+        <table className="mt-4 border-collapse">
+          <tbody>
+            {puzzle.grid.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j} className={cellStyle(cell)} />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default PngImport;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "pcap-parser": "^0.2.1",
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",
+    "pngjs": "^7.0.0",
     "postcss": "^8.4.21",
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9357,6 +9357,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pngjs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pngjs@npm:7.0.0"
+  checksum: 10c0/0d4c7a0fd476a9c33df7d0a2a73e1d56537628a668841f6995c2bca070cf30819f9254a64363266bc14ef2fee47659dd3b4f2b18eec7ab65143015139f497b38
+  languageName: node
+  linkType: hard
+
 "polished@npm:4":
   version: 4.3.1
   resolution: "polished@npm:4.3.1"
@@ -11586,6 +11593,7 @@ __metadata:
     pdfjs-dist: "npm:^5.4.54"
     phaser: "npm:3.70.0"
     playwright-core: "npm:^1.55.0"
+    pngjs: "npm:^7.0.0"
     postcss: "npm:^8.4.21"
     prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"


### PR DESCRIPTION
## Summary
- parse monochrome PNGs into nonogram puzzles
- verify puzzle consistency and render grid preview
- add pngjs dependency for server-side parsing

## Testing
- `yarn test __tests__/nonogramGame.test.ts __tests__/nonogram.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b176ead03c8328a840aa5cc95d04e2