### PR TITLE
feat: add sudoku elimination helper

### DIFF
--- a/__tests__/sudokuEliminationHelper.test.ts
+++ b/__tests__/sudokuEliminationHelper.test.ts
@@ -1,0 +1,23 @@
+import { analyzeEliminations } from "../games/sudoku/components/EliminationHelper";
+
+describe("analyzeEliminations", () => {
+  test("identifies candidates that can be removed", () => {
+    const board: number[][] = [
+      [5, 3, 0, 0, 7, 0, 0, 0, 0],
+      [6, 0, 0, 1, 9, 5, 0, 0, 0],
+      [0, 9, 8, 0, 0, 0, 0, 6, 0],
+      [8, 0, 0, 0, 6, 0, 0, 0, 3],
+      [4, 0, 0, 8, 0, 3, 0, 0, 1],
+      [7, 0, 0, 0, 2, 0, 0, 0, 6],
+      [0, 6, 0, 0, 0, 0, 2, 8, 0],
+      [0, 0, 0, 4, 1, 9, 0, 0, 5],
+      [0, 0, 0, 0, 8, 0, 0, 7, 9],
+    ];
+    const hints = analyzeEliminations(board);
+    // Cell (1,3) (0-index 0,2) cannot be 5 since row already has 5
+    expect(
+      hints.some((h) => h.r === 0 && h.c === 2 && h.value === 5)
+    ).toBe(true);
+  });
+});
+

--- a/games/sudoku/components/EliminationHelper.tsx
+++ b/games/sudoku/components/EliminationHelper.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import { SIZE, getCandidates } from "../../../apps/games/sudoku";
+
+export interface Elimination {
+  r: number;
+  c: number;
+  value: number;
+  reason: string;
+}
+
+export const analyzeEliminations = (board: number[][]): Elimination[] => {
+  const eliminations: Elimination[] = [];
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      if (board[r][c] !== 0) continue;
+      const candidates = getCandidates(board, r, c);
+      for (let v = 1; v <= SIZE; v++) {
+        if (candidates.includes(v)) continue;
+        let reason = "";
+        if (board[r].includes(v)) {
+          reason = `Row ${r + 1} already has ${v}`;
+        } else {
+          let colHas = false;
+          for (let rr = 0; rr < SIZE; rr++) {
+            if (board[rr][c] === v) {
+              colHas = true;
+              break;
+            }
+          }
+          if (colHas) {
+            reason = `Column ${c + 1} already has ${v}`;
+          } else {
+            const br = Math.floor(r / 3) * 3;
+            const bc = Math.floor(c / 3) * 3;
+            for (let rr = 0; rr < 3; rr++) {
+              for (let cc = 0; cc < 3; cc++) {
+                if (board[br + rr][bc + cc] === v) {
+                  colHas = true;
+                }
+              }
+            }
+            if (colHas) {
+              reason = `Box ${Math.floor(r / 3) + 1}-${Math.floor(c / 3) + 1} already has ${v}`;
+            }
+          }
+        }
+        eliminations.push({ r, c, value: v, reason });
+      }
+    }
+  }
+  return eliminations;
+};
+
+interface Props {
+  board: number[][];
+}
+
+const EliminationHelper: React.FC<Props> = ({ board }) => {
+  const eliminations = analyzeEliminations(board);
+  if (eliminations.length === 0) return <div>No eliminations available</div>;
+  return (
+    <div>
+      <h3 className="font-bold mb-2">Eliminations</h3>
+      <ul className="list-disc pl-5">
+        {eliminations.map((e, i) => (
+          <li key={i}>
+            Cell ({e.r + 1},{e.c + 1}) cannot be {e.value}
+            {e.reason ? ` – ${e.reason}` : ""}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default EliminationHelper;
+


### PR DESCRIPTION
## Summary
- add EliminationHelper for Sudoku to suggest candidate removals
- test elimination analysis

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint games/sudoku/components/EliminationHelper.tsx __tests__/sudokuEliminationHelper.test.ts`
- `yarn test __tests__/sudokuEliminationHelper.test.ts __tests__/sudoku.test.ts __tests__/sudokuSolver.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b176edbaa4832885f04931e0b3cedf