### PR TITLE
feat(lane-runner): add difficulty curve presets

### DIFF
--- a/__tests__/laneRunner.test.ts
+++ b/__tests__/laneRunner.test.ts
@@ -1,4 +1,9 @@
-import { detectCollision, updateScore, canUseTilt } from '../components/apps/lane-runner';
+import {
+  detectCollision,
+  updateScore,
+  canUseTilt,
+  CURVE_PRESETS,
+} from '../components/apps/lane-runner';
 
 describe('lane runner', () => {
   test('collision ends run', () => {
@@ -21,5 +26,12 @@ describe('lane runner', () => {
     const allowed = await canUseTilt();
     expect(allowed).toBe(false);
     (global as any).DeviceOrientationEvent = original;
+  });
+
+  test('curve presets map progress to expected values', () => {
+    const t = 0.5;
+    expect(CURVE_PRESETS.linear(t)).toBeCloseTo(0.5);
+    expect(CURVE_PRESETS['ease-in'](t)).toBeCloseTo(0.25);
+    expect(CURVE_PRESETS['ease-out'](t)).toBeCloseTo(Math.sqrt(0.5));
   });
 });


### PR DESCRIPTION
## Summary
- add adjustable difficulty curve presets that tweak obstacle gap and lane speed
- persist chosen preset and expose selector in Lane Runner UI
- test curve helpers

## Testing
- `yarn test __tests__/laneRunner.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b176ef12a48328a76b8f9a932bcb4d