### PR TITLE
feat: add theme settings page

### DIFF
--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -1,0 +1,35 @@
+import { useState, useEffect, ChangeEvent } from 'react';
+import { getTheme, setTheme } from '../../../utils/theme';
+
+export default function ThemeSettings() {
+  const [theme, setThemeState] = useState('default');
+
+  useEffect(() => {
+    const current = getTheme();
+    setTheme(current);
+    setThemeState(current);
+  }, []);
+
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const next = e.target.value;
+    setThemeState(next);
+    setTheme(next);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Theme</h1>
+      <select
+        value={theme}
+        onChange={handleChange}
+        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+      >
+        <option value="default">Default</option>
+        <option value="dark">Dark</option>
+        <option value="neon">Neon</option>
+        <option value="matrix">Matrix</option>
+      </select>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add settings page for switching UI themes and persist selection

## Testing
- `npm test __tests__/themePersistence.test.ts`
- `npm test __tests__/game2048.test.tsx` *(fails: expected 4 to be 0)*
- `npm test __tests__/beef.test.tsx` *(fails: Unable to find an element with the text: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b17709c07083288e5f6576598f6325