### PR TITLE
feat(terminal): add tabbed session manager

### DIFF
--- a/__tests__/tabbedwindow.test.tsx
+++ b/__tests__/tabbedwindow.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TabbedWindow, { TabDefinition } from '../components/ui/TabbedWindow';
+
+describe('TabbedWindow keyboard shortcuts', () => {
+  const createTab = (label: string): TabDefinition => ({
+    id: label,
+    title: label,
+    content: <div>{label}</div>,
+  });
+
+  const setup = () => {
+    return render(
+      <TabbedWindow
+        initialTabs={[createTab('one'), createTab('two')]}
+        onNewTab={() => createTab('new')}
+      />,
+    );
+  };
+
+  it('creates a new tab with Ctrl+Shift+T', () => {
+    const { container, getAllByText } = setup();
+    const root = container.firstChild as HTMLElement;
+    fireEvent.keyDown(root, { key: 't', ctrlKey: true, shiftKey: true });
+    expect(getAllByText('new').length).toBeGreaterThan(0);
+  });
+
+  it('switches tabs with Ctrl+Tab and Ctrl+Shift+Tab', () => {
+    const { container, getByText } = setup();
+    const root = container.firstChild as HTMLElement;
+    const getContent = (label: string) => getByText(label, { selector: 'div' }).parentElement;
+    // start on first tab
+    expect(getContent('one')).toHaveClass('block');
+    fireEvent.keyDown(root, { key: 'Tab', ctrlKey: true });
+    expect(getContent('two')).toHaveClass('block');
+    fireEvent.keyDown(root, { key: 'Tab', ctrlKey: true, shiftKey: true });
+    expect(getContent('one')).toHaveClass('block');
+  });
+
+  it('closes a tab with Ctrl+W', () => {
+    const { container, queryByText } = setup();
+    const root = container.firstChild as HTMLElement;
+    fireEvent.keyDown(root, { key: 'w', ctrlKey: true });
+    expect(queryByText('one')).toBeNull();
+  });
+});

--- a/apps/terminal/tabs.tsx
+++ b/apps/terminal/tabs.tsx
@@ -1,0 +1,29 @@
+import React, { useRef } from 'react';
+import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import TerminalApp from '.';
+
+type TerminalTabsProps = {
+  openApp?: (id: string) => void;
+};
+
+const TerminalTabs: React.FC<TerminalTabsProps> = ({ openApp }) => {
+  const countRef = useRef(1);
+  const createTab = (): TabDefinition => {
+    const id = Date.now().toString();
+    return {
+      id,
+      title: `Session ${countRef.current++}`,
+      content: <TerminalApp openApp={openApp} />,
+    };
+  };
+
+  return (
+    <TabbedWindow
+      className="h-full"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
+  );
+};
+
+export default TerminalTabs;

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const Terminal = dynamic(() => import('../../apps/terminal'), {
+const Terminal = dynamic(() => import('../../apps/terminal/tabs'), {
   ssr: false,
   loading: () => (
     <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -121,6 +121,25 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       closeTab(activeId);
       return;
     }
+    if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 't') {
+      e.preventDefault();
+      addTab();
+      return;
+    }
+    if (e.ctrlKey && e.key === 'Tab') {
+      e.preventDefault();
+      setTabs((prev) => {
+        if (prev.length === 0) return prev;
+        const idx = prev.findIndex((t) => t.id === activeId);
+        const nextIdx = e.shiftKey
+          ? (idx - 1 + prev.length) % prev.length
+          : (idx + 1) % prev.length;
+        const nextTab = prev[nextIdx];
+        setActiveId(nextTab.id);
+        return prev;
+      });
+      return;
+    }
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       e.preventDefault();
       setTabs((prev) => {


### PR DESCRIPTION
## Summary
- add TabbedWindow keyboard shortcuts for creating and switching tabs
- integrate a terminal session manager with tabbed sessions
- cover tabbed window shortcuts with tests

## Testing
- `yarn test __tests__/tabbedwindow.test.tsx __tests__/terminal.test.tsx`
- `yarn lint components/ui/TabbedWindow.tsx apps/terminal/tabs.tsx components/apps/terminal.tsx __tests__/tabbedwindow.test.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*


------
https://chatgpt.com/codex/tasks/task_e_68b1770b766c83289a914eaec88f60cf