### PR TITLE
Add history sidebar to Calc app

### DIFF
--- a/__tests__/calc.test.tsx
+++ b/__tests__/calc.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import Calc from '../components/apps/calc';
 
 describe('Calc component', () => {
@@ -63,6 +63,18 @@ describe('Calc component', () => {
     fireEvent.click(getByText('5'));
     fireEvent.click(getByLabelText('toggle sign'));
     expect(getByTestId('calc-display').textContent).toBe('-5');
+  });
+
+  it('stores results in history and can clear them', async () => {
+    window.localStorage.clear();
+    const { getByText, getByLabelText, queryByText } = render(<Calc />);
+    fireEvent.click(getByText('1'));
+    fireEvent.click(getByText('+'));
+    fireEvent.click(getByText('1'));
+    fireEvent.click(getByText('='));
+    expect(getByText('1+1 = 2')).toBeInTheDocument();
+    fireEvent.click(getByLabelText('clear history'));
+    await waitFor(() => expect(queryByText('1+1 = 2')).toBeNull());
   });
 });
 

--- a/calc/history.ts
+++ b/calc/history.ts
@@ -1,0 +1,19 @@
+import usePersistentState from '../hooks/usePersistentState';
+
+export interface HistoryEntry {
+  expr: string;
+  result: string;
+}
+
+export const HISTORY_KEY = 'calc-history';
+
+export function useHistory() {
+  return usePersistentState<HistoryEntry[]>(
+    HISTORY_KEY,
+    () => [],
+    (v): v is HistoryEntry[] =>
+      Array.isArray(v) &&
+      v.every((item) => typeof item?.expr === 'string' && typeof item?.result === 'string'),
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `useHistory` hook and storage for calculator results
- render persistent history list with clear button in Calc app
- test that history records results and can be cleared

## Testing
- `npx eslint -c .eslintrc.cjs calc/history.ts components/apps/archive/Calc/index.tsx __tests__/calc.test.tsx` (warnings)
- `yarn test __tests__/calc.test.ts __tests__/calc.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b17709f1388328997c4f8e74824eb9