### PR TITLE
feat: schedule posts via worker

### DIFF
--- a/workers/postPublisher.ts
+++ b/workers/postPublisher.ts
@@ -1,0 +1,42 @@
+interface Tweet {
+  id: string;
+  text: string;
+  time: number;
+}
+
+interface ScheduleMessage {
+  action: 'setQueue';
+  tweets: Tweet[];
+}
+
+interface PublishResponse {
+  action: 'publish';
+  tweet: Tweet;
+}
+
+type Message = ScheduleMessage;
+
+const timers: Record<string, number> = {};
+
+self.onmessage = ({ data }: MessageEvent<Message>) => {
+  if (data.action === 'setQueue') {
+    // Clear existing timers
+    Object.values(timers).forEach((id) => clearTimeout(id));
+    for (const key in timers) delete timers[key];
+
+    // Schedule new tweets
+    data.tweets.forEach((t) => {
+      const delay = t.time - Date.now();
+      if (delay <= 0) {
+        self.postMessage({ action: 'publish', tweet: t } as PublishResponse);
+      } else {
+        timers[t.id] = self.setTimeout(() => {
+          self.postMessage({ action: 'publish', tweet: t } as PublishResponse);
+          delete timers[t.id];
+        }, delay);
+      }
+    });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add timestamp and queue support to thread composer
- publish queued posts via background worker

## Testing
- `yarn test`
- `yarn lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1770cf7f883288da54a16598d4f24