### PR TITLE
Add synced lyrics support to Spotify app

### DIFF
--- a/apps/spotify/Lyrics.tsx
+++ b/apps/spotify/Lyrics.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import CrossfadePlayer from './utils/crossfade';
+import { fetchTimedLyrics, LyricLine } from '../../player/lyrics';
+
+interface LyricsProps {
+  title: string;
+  player: CrossfadePlayer | null;
+}
+
+const Lyrics = ({ title, player }: LyricsProps) => {
+  const [lines, setLines] = useState<LyricLine[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchTimedLyrics(title).then((l) => {
+      if (mounted) setLines(l);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [title]);
+
+  useEffect(() => {
+    let raf: number;
+    const tick = () => {
+      if (!player) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      const t = player.getCurrentTime();
+      const idx = lines.findIndex((line, i) => {
+        const next = lines[i + 1];
+        return t >= line.time && (!next || t < next.time);
+      });
+      if (idx !== -1 && idx !== active) {
+        setActive(idx);
+        const el = containerRef.current?.children[idx] as HTMLElement;
+        el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [player, lines, active]);
+
+  if (!lines.length) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-40 overflow-auto text-sm mt-2 space-y-1"
+    >
+      {lines.map((l, i) => (
+        <p key={i} className={i === active ? 'text-green-400' : ''}>
+          {l.text}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+export default Lyrics;
+

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import CrossfadePlayer from './utils/crossfade';
 import Visualizer from './Visualizer';
+import Lyrics from './Lyrics';
 
 interface Track {
   title: string;
@@ -160,6 +161,7 @@ const SpotifyApp = () => {
         <div className="mt-2">
           <p className="mb-2">{currentTrack.title}</p>
           {analyser && <Visualizer analyser={analyser} />}
+          <Lyrics title={currentTrack.title} player={playerRef.current} />
         </div>
       )}
       {!mini && (

--- a/apps/spotify/utils/crossfade.ts
+++ b/apps/spotify/utils/crossfade.ts
@@ -4,6 +4,7 @@ export default class CrossfadePlayer {
   private sources: [AudioBufferSourceNode | null, AudioBufferSourceNode | null] = [null, null];
   private analyser: AnalyserNode | null = null;
   private current = 0;
+  private startTime = 0;
 
   private ensureContext() {
     if (this.ctx) return;
@@ -38,6 +39,7 @@ export default class CrossfadePlayer {
       src.connect(gains[nextIndex]);
       const now = ctx.currentTime;
       src.start();
+      this.startTime = now;
       if (fadeSec > 0) {
         gains[nextIndex].gain.setValueAtTime(0, now);
         gains[nextIndex].gain.linearRampToValueAtTime(1, now + fadeSec);
@@ -66,6 +68,11 @@ export default class CrossfadePlayer {
     return this.analyser;
   }
 
+  getCurrentTime() {
+    if (!this.ctx) return 0;
+    return this.ctx.currentTime - this.startTime;
+  }
+
   dispose() {
     this.sources.forEach((s) => s?.stop());
     this.sources = [null, null];
@@ -74,6 +81,7 @@ export default class CrossfadePlayer {
       this.ctx = null;
       this.gains = null;
       this.analyser = null;
+      this.startTime = 0;
     }
   }
 }

--- a/player/lyrics.ts
+++ b/player/lyrics.ts
@@ -1,0 +1,40 @@
+export interface LyricLine {
+  time: number;
+  text: string;
+}
+
+// Parse LRC formatted lyrics into timestamped lines
+export function parseLRC(lrc: string): LyricLine[] {
+  const lines: LyricLine[] = [];
+  lrc.split(/\r?\n/).forEach((line) => {
+    const text = line.replace(/\[[^\]]*\]/g, '').trim();
+    if (!text) return;
+    const matches = line.match(/\[(\d+):(\d+)(?:\.(\d+))?\]/g);
+    if (!matches) return;
+    matches.forEach((m) => {
+      const parts = /\[(\d+):(\d+)(?:\.(\d+))?\]/.exec(m);
+      if (!parts) return;
+      const min = Number(parts[1]);
+      const sec = Number(parts[2]);
+      const ms = parts[3] ? Number(parts[3].padEnd(3, '0')) : 0;
+      const time = min * 60 + sec + ms / 1000;
+      lines.push({ time, text });
+    });
+  });
+  return lines.sort((a, b) => a.time - b.time);
+}
+
+// Fetch lyrics from LRCLib API
+export async function fetchTimedLyrics(title: string): Promise<LyricLine[]> {
+  try {
+    const res = await fetch(
+      `https://lrclib.net/api/get?track_name=${encodeURIComponent(title)}`,
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!data || !data.syncedLyrics) return [];
+    return parseLRC(data.syncedLyrics as string);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- fetch timed lyrics via LRCLib and parse LRC
- render and auto-scroll lyrics alongside audio playback
- expose playback time from crossfade player

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: merging two 2s creates one 4, updates hook list when refresh is clicked, retrieves module list, renders external frame, steps through sample capture frames)*

------
https://chatgpt.com/codex/tasks/task_e_68b1770e34208328a3cc993a2bf5f490