### PR TITLE
feat(bluetooth): auto pair known devices

### DIFF
--- a/components/apps/bluetooth/index.tsx
+++ b/components/apps/bluetooth/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import FormError from "../../ui/FormError";
 
 interface DeviceInfo {
@@ -18,6 +18,20 @@ const BluetoothApp: React.FC = () => {
   const [showPermissionModal, setShowPermissionModal] = useState(false);
   const [pairingDevice, setPairingDevice] = useState<DeviceInfo | null>(null);
   const [pairedDevice, setPairedDevice] = useState("");
+  const [knownDevices, setKnownDevices] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadKnown = async () => {
+      try {
+        const res = await fetch("/bluetooth/known_devices.json");
+        const data: string[] = await res.json();
+        setKnownDevices(data);
+      } catch {
+        // ignore failures loading known devices
+      }
+    };
+    loadKnown();
+  }, []);
 
   const loadData = async () => {
     try {
@@ -25,6 +39,8 @@ const BluetoothApp: React.FC = () => {
       const data: DeviceInfo[] = await res.json();
       setDevices(data);
       setError("");
+      const nearbyKnown = data.find((d) => knownDevices.includes(d.address));
+      if (nearbyKnown) setPairingDevice(nearbyKnown);
     } catch {
       setError("Failed to load scan data.");
     }

--- a/public/bluetooth/known_devices.json
+++ b/public/bluetooth/known_devices.json
@@ -1,0 +1,4 @@
+[
+  "AA:BB:CC:DD:EE:02",
+  "AA:BB:CC:DD:EE:05"
+]


### PR DESCRIPTION
## Summary
- load known device addresses from `bluetooth/known_devices.json`
- start pairing automatically when a known device is detected

## Testing
- `npx eslint components/apps/bluetooth/index.tsx`
- `yarn test --passWithNoTests components/apps/bluetooth/index.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b17715c97c8328ade0e1202c107bea