### PR TITLE
Add tag-based filtering for post-exploitation modules

### DIFF
--- a/__tests__/postExploitation.test.tsx
+++ b/__tests__/postExploitation.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PostExploitation from '../pages/post_exploitation';
+
+describe('PostExploitation', () => {
+  it('filters modules by selected tags', () => {
+    render(<PostExploitation />);
+    fireEvent.click(screen.getByLabelText('persistence'));
+    expect(
+      screen.getByRole('button', { name: /persistence_service/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /getsystem/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -1,0 +1,58 @@
+export interface ModuleOption {
+  name: string;
+  required: boolean;
+  description: string;
+}
+
+export interface ModuleMetadata {
+  name: string;
+  description: string;
+  tags: string[];
+  options: ModuleOption[];
+}
+
+const modules: ModuleMetadata[] = [
+  {
+    name: 'getsystem',
+    description: 'Attempt to elevate your privilege to that of local system.',
+    tags: ['privilege', 'elevation'],
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.',
+      },
+    ],
+  },
+  {
+    name: 'keyscan_start',
+    description: 'Start capturing keystrokes.',
+    tags: ['keylogging'],
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.',
+      },
+    ],
+  },
+  {
+    name: 'persistence_service',
+    description: 'Achieve persistence by installing a service.',
+    tags: ['persistence', 'service'],
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.',
+      },
+      {
+        name: 'RPORT',
+        required: false,
+        description: 'Remote port used for callback.',
+      },
+    ],
+  },
+];
+
+export default modules;

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,65 +1,25 @@
 import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
-
-interface ModuleOption {
-  name: string;
-  required: boolean;
-  description: string;
-}
-
-interface Module {
-  name: string;
-  description: string;
-  options: ModuleOption[];
-}
-
-const modules: Module[] = [
-  {
-    name: 'getsystem',
-    description: 'Attempt to elevate your privilege to that of local system.',
-    options: [
-      {
-        name: 'SESSION',
-        required: true,
-        description: 'The session to run this module on.'
-      }
-    ]
-  },
-  {
-    name: 'keyscan_start',
-    description: 'Start capturing keystrokes.',
-    options: [
-      {
-        name: 'SESSION',
-        required: true,
-        description: 'The session to run this module on.'
-      }
-    ]
-  },
-  {
-    name: 'persistence_service',
-    description: 'Achieve persistence by installing a service.',
-    options: [
-      {
-        name: 'SESSION',
-        required: true,
-        description: 'The session to run this module on.'
-      },
-      {
-        name: 'RPORT',
-        required: false,
-        description: 'Remote port used for callback.'
-      }
-    ]
-  }
-];
+import modules, { ModuleMetadata } from '../modules/metadata';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
-  const [selected, setSelected] = useState<Module | null>(null);
+  const [selected, setSelected] = useState<ModuleMetadata | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
-  const filtered = modules.filter((m) =>
-    m.name.toLowerCase().includes(query.toLowerCase())
+  const allTags = Array.from(new Set(modules.flatMap((m) => m.tags))).sort();
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const filtered = modules.filter(
+    (m) =>
+      m.name.toLowerCase().includes(query.toLowerCase()) &&
+      (selectedTags.length === 0 ||
+        selectedTags.every((t) => m.tags.includes(t)))
   );
 
   return (
@@ -87,6 +47,19 @@ export default function PostExploitation() {
             onChange={(e) => setQuery(e.target.value)}
             className="mb-4 w-full rounded border p-2"
           />
+          <div className="mb-4 flex flex-wrap gap-2">
+            {allTags.map((tag) => (
+              <label key={tag} className="flex items-center space-x-1">
+                <input
+                  type="checkbox"
+                  checked={selectedTags.includes(tag)}
+                  onChange={() => toggleTag(tag)}
+                  className="rounded"
+                />
+                <span>{tag}</span>
+              </label>
+            ))}
+          </div>
           <ul className="divide-y rounded border">
             {filtered.map((m) => (
               <li key={m.name}>


### PR DESCRIPTION
## Summary
- add metadata file with tags for post-exploitation modules
- enable filtering modules by selected tags
- test tag-based module filtering

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b17716d4088328a71e1805fa4eb981