### PR TITLE
feat(wireshark): add editable color rules

### DIFF
--- a/__tests__/wireshark.test.tsx
+++ b/__tests__/wireshark.test.tsx
@@ -32,17 +32,27 @@ describe('WiresharkApp', () => {
     expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
 
-  it('applies coloring rules for protocols and IPs', async () => {
+  it('applies coloring rules for filter expressions', async () => {
     const packets = [
       { timestamp: '1', src: '1.1.1.1', dest: '2.2.2.2', protocol: 6, info: 'tcp packet' },
       { timestamp: '2', src: '3.3.3.3', dest: '8.8.8.8', protocol: 17, info: 'udp packet' },
     ];
 
+    const user = userEvent.setup();
     render(<WiresharkApp initialPackets={packets} />);
-    const colorInput = screen.getByPlaceholderText(/color rules/i);
-    const rules =
-      '[{"protocol":"TCP","color":"text-red-500"},{"ip":"8.8.8.8","color":"text-blue-500"}]';
-    fireEvent.change(colorInput, { target: { value: rules } });
+
+    const addBtn = screen.getByRole('button', { name: /add rule/i });
+    await user.click(addBtn);
+    let exprInputs = screen.getAllByPlaceholderText(/filter expression/i);
+    let colorInputs = screen.getAllByPlaceholderText(/color class/i);
+    await user.type(exprInputs[0], 'tcp');
+    await user.type(colorInputs[0], 'text-red-500');
+
+    await user.click(addBtn);
+    exprInputs = screen.getAllByPlaceholderText(/filter expression/i);
+    colorInputs = screen.getAllByPlaceholderText(/color class/i);
+    await user.type(exprInputs[1], 'ip.addr == 8.8.8.8');
+    await user.type(colorInputs[1], 'text-blue-500');
 
     const tcpRow = screen.getByText('tcp packet').closest('tr');
     const udpRow = screen.getByText('udp packet').closest('tr');

--- a/apps/wireshark/components/ColorRuleEditor.tsx
+++ b/apps/wireshark/components/ColorRuleEditor.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+interface Rule {
+  expression: string;
+  color: string;
+}
+
+interface Props {
+  rules: Rule[];
+  onChange: (rules: Rule[]) => void;
+}
+
+const ColorRuleEditor: React.FC<Props> = ({ rules, onChange }) => {
+  const handleRuleChange = (
+    index: number,
+    field: keyof Rule,
+    value: string
+  ) => {
+    const updated = rules.map((r, i) => (i === index ? { ...r, [field]: value } : r));
+    onChange(updated);
+  };
+
+  const handleAdd = () => {
+    onChange([...rules, { expression: '', color: '' }]);
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(rules.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="flex flex-col space-y-1">
+      {rules.map((rule, i) => (
+        <div key={i} className="flex space-x-1">
+          <input
+            value={rule.expression}
+            onChange={(e) => handleRuleChange(i, 'expression', e.target.value)}
+            placeholder="Filter expression"
+            className="px-1 py-0.5 bg-gray-800 rounded text-white text-xs"
+          />
+          <input
+            value={rule.color}
+            onChange={(e) => handleRuleChange(i, 'color', e.target.value)}
+            placeholder="Color class"
+            className="px-1 py-0.5 bg-gray-800 rounded text-white text-xs"
+          />
+          <button
+            onClick={() => handleRemove(i)}
+            aria-label="Remove rule"
+            className="px-1 py-0.5 bg-gray-700 rounded text-xs"
+            type="button"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={handleAdd}
+        type="button"
+        className="px-1 py-0.5 bg-gray-700 rounded text-xs"
+      >
+        Add rule
+      </button>
+    </div>
+  );
+};
+
+export default ColorRuleEditor;
+

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Waterfall from './Waterfall';
-import { protocolName, getRowColor } from './utils';
+import { protocolName, getRowColor, matchesDisplayFilter } from './utils';
 import DecodeTree from './DecodeTree';
 import FlowGraph from '../../../apps/wireshark/components/FlowGraph';
 import filters from './filters.json';
 import FilterHelper from '../../../apps/wireshark/components/FilterHelper';
+import ColorRuleEditor from '../../../apps/wireshark/components/ColorRuleEditor';
 
 const SMALL_CAPTURE_SIZE = 1024 * 1024; // 1MB threshold
 
@@ -82,19 +83,6 @@ const parseWithWiregasm = async (buf) => {
   return parseWithCap(buf);
 };
 
-// Determine if a packet matches the active filter expression
-const matchesFilter = (packet, filter) => {
-  if (!filter) return true;
-  const term = filter.toLowerCase();
-  return (
-    packet.src.toLowerCase().includes(term) ||
-    packet.dest.toLowerCase().includes(term) ||
-    protocolName(packet.protocol).toLowerCase().includes(term) ||
-    (packet.info || '').toLowerCase().includes(term) ||
-    (packet.decrypted || '').toLowerCase().includes(term)
-  );
-};
-
 // Basic BPF-style filtering support
 const matchesBpf = (packet, expr) => {
   if (!expr) return true;
@@ -122,7 +110,6 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   const [protocolFilter, setProtocolFilter] = useState('');
   const [filter, setFilter] = useState('');
   const [bpf, setBpf] = useState('');
-  const [colorRuleText, setColorRuleText] = useState('[]');
   const [colorRules, setColorRules] = useState([]);
   const [paused, setPaused] = useState(false);
   const [timeline, setTimeline] = useState([]);
@@ -205,17 +192,6 @@ const WiresharkApp = ({ initialPackets = [] }) => {
     }
   };
 
-  const handleColorRulesChange = (e) => {
-    const text = e.target.value;
-    setColorRuleText(text);
-    try {
-      const parsed = JSON.parse(text);
-      setColorRules(Array.isArray(parsed) ? parsed : []);
-    } catch {
-      // ignore invalid JSON
-    }
-  };
-
   const handleFile = async (file) => {
     try {
       const buffer = await file.arrayBuffer();
@@ -291,7 +267,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
 
   const protocols = Array.from(new Set(packets.map((p) => protocolName(p.protocol))));
   const filteredPackets = packets
-    .filter((p) => matchesFilter(p, filter))
+    .filter((p) => matchesDisplayFilter(p, filter))
     .filter((p) => matchesBpf(p, bpf))
     .filter((p) => !protocolFilter || protocolName(p.protocol) === protocolFilter);
   const hasTlsKeys = !!tlsKeys;
@@ -367,12 +343,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
         >
           Display filter docs
         </a>
-        <input
-          value={colorRuleText}
-          onChange={handleColorRulesChange}
-          placeholder='Color rules JSON'
-          className="px-2 py-1 bg-gray-800 rounded text-white"
-        />
+        <ColorRuleEditor rules={colorRules} onChange={setColorRules} />
         <button
           onClick={handlePause}
           className="px-3 py-1 bg-gray-700 rounded"
@@ -455,7 +426,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
               </thead>
               <tbody>
                 {filteredPackets.map((p, i) => {
-                  const isMatch = matchesFilter(p, filter);
+                  const isMatch = matchesDisplayFilter(p, filter);
                   return (
                     <tr
                       key={i}

--- a/components/apps/wireshark/utils.js
+++ b/components/apps/wireshark/utils.js
@@ -11,13 +11,43 @@ export const protocolName = (proto) => {
   }
 };
 
-// Determine the color class for a packet based on user rules
-export const getRowColor = (packet, rules) => {
-  const proto = protocolName(packet.protocol);
-  const rule = rules.find(
-    (r) =>
-      (r.protocol && r.protocol === proto) ||
-      (r.ip && (packet.src === r.ip || packet.dest === r.ip))
+// Basic display filter engine used for both quick searches and colour rules.
+// Supports protocol keywords (tcp/udp/icmp), ip.addr == x.x.x.x and
+// tcp.port/udp.port == N expressions. Falls back to substring search.
+export const matchesDisplayFilter = (packet, filter) => {
+  if (!filter) return true;
+  const f = filter.trim().toLowerCase();
+  if (f === 'tcp') return packet.protocol === 6;
+  if (f === 'udp') return packet.protocol === 17;
+  if (f === 'icmp') return packet.protocol === 1;
+
+  let m = f.match(/^ip\.addr\s*==\s*(\d+\.\d+\.\d+\.\d+)$/);
+  if (m) {
+    const ip = m[1];
+    return packet.src === ip || packet.dest === ip;
+  }
+  m = f.match(/^tcp\.port\s*==\s*(\d+)$/);
+  if (m) {
+    const num = parseInt(m[1], 10);
+    return packet.protocol === 6 && (packet.sport === num || packet.dport === num);
+  }
+  m = f.match(/^udp\.port\s*==\s*(\d+)$/);
+  if (m) {
+    const num = parseInt(m[1], 10);
+    return packet.protocol === 17 && (packet.sport === num || packet.dport === num);
+  }
+
+  return (
+    packet.src.toLowerCase().includes(f) ||
+    packet.dest.toLowerCase().includes(f) ||
+    protocolName(packet.protocol).toLowerCase().includes(f) ||
+    (packet.info || '').toLowerCase().includes(f) ||
+    (packet.decrypted || '').toLowerCase().includes(f)
   );
+};
+
+// Determine the colour class for a packet based on user rules
+export const getRowColor = (packet, rules) => {
+  const rule = rules.find((r) => matchesDisplayFilter(packet, r.expression));
   return rule ? rule.color : '';
 };


### PR DESCRIPTION
## Summary
- expand display filter engine to handle color rule expressions
- allow users to manage color rules through a dedicated editor
- cover color rule workflow with tests

## Testing
- `npm test __tests__/wireshark.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b177190ea8832895c77893dee18bdc