### PR TITLE
feat(converter): add time and digital unit conversions

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -19,6 +19,14 @@ describe('Unit conversion', () => {
     expect(convertUnit('currency', 'USD', 'EUR', 10)).toBeCloseTo(9);
   });
 
+  it('converts seconds to minutes', () => {
+    expect(convertUnit('time', 'second', 'minute', 60)).toBeCloseTo(1);
+  });
+
+  it('converts megabytes to kilobytes', () => {
+    expect(convertUnit('digital', 'megabyte', 'kilobyte', 1)).toBeCloseTo(1000);
+  });
+
   it('respects precision when provided', () => {
     expect(
       convertUnit('length', 'meter', 'kilometer', 1234, 2)
@@ -42,5 +50,12 @@ describe('UnitConverter UI', () => {
     const inputs = screen.getAllByRole('spinbutton');
     fireEvent.change(inputs[0], { target: { value: '1000' } });
     expect(inputs[1].value).toBe('1');
+  });
+
+  it('shows new categories in dropdown', () => {
+    render(<UnitConverter />);
+    const select = screen.getByLabelText('Category') as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(expect.arrayContaining(['time', 'digital']));
   });
 });

--- a/components/apps/converter/unitData.js
+++ b/components/apps/converter/unitData.js
@@ -20,6 +20,18 @@ export const unitMap = {
     fahrenheit: 'degF',
     kelvin: 'K',
   },
+  time: {
+    second: 's',
+    minute: 'min',
+    hour: 'hour',
+    day: 'day',
+  },
+  digital: {
+    byte: 'B',
+    kilobyte: 'kB',
+    megabyte: 'MB',
+    gigabyte: 'GB',
+  },
   currency: {
     USD: 'USD',
     EUR: 'EUR',
@@ -45,6 +57,18 @@ export const unitDetails = {
     celsius: { min: -273.15, max: 1e6, precision: 1 },
     fahrenheit: { min: -459.67, max: 1e6, precision: 1 },
     kelvin: { min: 0, max: 1e6, precision: 1 },
+  },
+  time: {
+    second: { min: 0, max: 1e9, precision: 2 },
+    minute: { min: 0, max: 1e7, precision: 2 },
+    hour: { min: 0, max: 1e6, precision: 2 },
+    day: { min: 0, max: 1e5, precision: 2 },
+  },
+  digital: {
+    byte: { min: 0, max: 1e15, precision: 0 },
+    kilobyte: { min: 0, max: 1e12, precision: 2 },
+    megabyte: { min: 0, max: 1e9, precision: 2 },
+    gigabyte: { min: 0, max: 1e6, precision: 2 },
   },
   currency: {
     USD: { min: 0, max: 1e9, precision: 2 },


### PR DESCRIPTION
## Summary
- support time and digital storage units in converter
- show new categories in dropdown
- extend unit tests for conversion coverage

## Testing
- `yarn lint`
- `yarn test __tests__/converter.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1771d56f4832886cfb878f3e5ac69