### PR TITLE
feat(scanner): add cron scheduler

### DIFF
--- a/__tests__/schedule.test.ts
+++ b/__tests__/schedule.test.ts
@@ -1,0 +1,31 @@
+import { ScanScheduler } from '../scanner/schedule';
+
+describe('ScanScheduler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('persists jobs in localStorage', () => {
+    const scheduler = new ScanScheduler();
+    scheduler.addScan('1', '*/5 * * * *', () => {});
+    const stored = JSON.parse(localStorage.getItem('scanSchedules') || '[]');
+    expect(stored).toEqual([{ id: '1', cron: '*/5 * * * *' }]);
+  });
+
+  test('triggers callbacks on schedule', () => {
+    const scheduler = new ScanScheduler();
+    const cb = jest.fn();
+    scheduler.addScan('1', '* * * * *', cb);
+    scheduler.start();
+    expect(cb).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(60 * 1000);
+    expect(cb).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(60 * 1000);
+    expect(cb).toHaveBeenCalledTimes(2);
+    scheduler.stop();
+  });
+});

--- a/scanner/schedule.ts
+++ b/scanner/schedule.ts
@@ -1,0 +1,99 @@
+export type ScanCallback = () => void;
+
+interface StoredJob {
+  id: string;
+  cron: string;
+}
+
+interface Job extends StoredJob {
+  callback: ScanCallback;
+  lastRun?: number;
+}
+
+const STORAGE_KEY = 'scanSchedules';
+
+function parseField(field: string, value: number): boolean {
+  if (field === '*' || field === undefined) return true;
+  if (field.startsWith('*/')) {
+    const step = parseInt(field.slice(2), 10);
+    if (!step) return false;
+    return value % step === 0;
+  }
+  return field.split(',').some((part) => parseInt(part, 10) === value);
+}
+
+function cronMatch(expr: string, date: Date): boolean {
+  const [min, hour, dom, month, dow] = expr.trim().split(/\s+/);
+  return (
+    parseField(min, date.getMinutes()) &&
+    parseField(hour, date.getHours()) &&
+    parseField(dom, date.getDate()) &&
+    parseField(month, date.getMonth() + 1) &&
+    parseField(dow, date.getDay())
+  );
+}
+
+export class ScanScheduler {
+  private jobs: Job[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.loadStoredJobs();
+  }
+
+  private loadStoredJobs() {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored: StoredJob[] = JSON.parse(
+        localStorage.getItem(STORAGE_KEY) || '[]'
+      );
+      stored.forEach((j) =>
+        this.jobs.push({ ...j, callback: () => {}, lastRun: undefined })
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private saveJobs() {
+    if (typeof window === 'undefined') return;
+    const stored: StoredJob[] = this.jobs.map(({ id, cron }) => ({ id, cron }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  }
+
+  addScan(id: string, cron: string, callback: ScanCallback) {
+    this.jobs.push({ id, cron, callback });
+    this.saveJobs();
+  }
+
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.check(), 60 * 1000);
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private check() {
+    const now = new Date();
+    for (const job of this.jobs) {
+      if (
+        cronMatch(job.cron, now) &&
+        (!job.lastRun || now.getTime() - job.lastRun >= 60 * 1000)
+      ) {
+        job.lastRun = now.getTime();
+        try {
+          job.callback();
+        } catch {
+          /* swallow */
+        }
+      }
+    }
+  }
+}
+
+export default ScanScheduler;


### PR DESCRIPTION
## Summary
- add cron-style ScanScheduler for interval-based scanning
- persist scheduled scans in localStorage
- cover scheduler with unit tests

## Testing
- `npx jest __tests__/schedule.test.ts --runTestsByPath`
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, etc.)*
- `npx eslint scanner/schedule.ts __tests__/schedule.test.ts` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1771f04848328b8f79926b08a38c5