### PR TITLE
Add plugin catalog indexing and installation

### DIFF
--- a/__tests__/pluginManager.test.tsx
+++ b/__tests__/pluginManager.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PluginManager from '../components/apps/plugin-manager';
+
+describe('PluginManager', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (global as any).fetch = jest.fn((url: string) => {
+      if (url === '/api/plugins') {
+        return Promise.resolve({
+          json: () => Promise.resolve([{ id: 'demo', file: 'demo.txt' }]),
+        });
+      }
+      if (url === '/api/plugins/demo.txt') {
+        return Promise.resolve({ text: () => Promise.resolve('content') });
+      }
+      return Promise.reject(new Error('unknown url'));
+    });
+  });
+
+  test('installs plugin from catalog', async () => {
+    render(<PluginManager />);
+    const button = await screen.findByText('Install');
+    fireEvent.click(button);
+    await waitFor(() =>
+      expect(localStorage.getItem('installedPlugins')).toContain('demo')
+    );
+    expect(button.textContent).toBe('Installed');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const BeefApp = createDynamicApp('beef', 'BeEF');
 const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
+const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -168,6 +169,7 @@ const displayInputLab = createDisplay(InputLabApp);
 const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
+const displayPluginManager = createDisplay(PluginManagerApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBluetooth = createDisplay(BluetoothApp);
@@ -833,6 +835,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayAutopsy,
+  },
+  {
+    id: 'plugin-manager',
+    title: 'Plugin Manager',
+    icon: './themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPluginManager,
   },
   {    id: 'reaver',
     title: 'Reaver',

--- a/apps/plugin-manager/index.tsx
+++ b/apps/plugin-manager/index.tsx
@@ -1,0 +1,6 @@
+'use client';
+import PluginManager from '../../components/apps/plugin-manager';
+
+export default function PluginManagerApp() {
+  return <PluginManager />;
+}

--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface PluginInfo { id: string; file: string; }
+
+export default function PluginManager() {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [installed, setInstalled] = useState<Record<string, string>>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        return JSON.parse(localStorage.getItem('installedPlugins') || '{}');
+      } catch {
+        return {};
+      }
+    }
+    return {};
+  });
+
+  useEffect(() => {
+    fetch('/api/plugins')
+      .then((res) => res.json())
+      .then(setPlugins)
+      .catch(() => setPlugins([]));
+  }, []);
+
+  const install = async (plugin: PluginInfo) => {
+    const res = await fetch(`/api/plugins/${plugin.file}`);
+    const text = await res.text();
+    const updated = { ...installed, [plugin.id]: text };
+    setInstalled(updated);
+    localStorage.setItem('installedPlugins', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-xl mb-4">Plugin Catalog</h1>
+      <ul>
+        {plugins.map((p) => (
+          <li key={p.id} className="flex items-center mb-2">
+            <span className="flex-grow">{p.id}</span>
+            <button
+              className="bg-ub-orange px-2 py-1 rounded disabled:opacity-50"
+              onClick={() => install(p)}
+              disabled={installed[p.id] !== undefined}
+            >
+              {installed[p.id] ? 'Installed' : 'Install'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/api/plugins/[name].ts
+++ b/pages/api/plugins/[name].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { name } = req.query;
+  const filename = Array.isArray(name) ? name.join('/') : name;
+  const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');
+  const filePath = path.join(catalogDir, filename || '');
+  if (!filePath.startsWith(catalogDir)) {
+    res.status(400).end('Invalid path');
+    return;
+  }
+  try {
+    const data = fs.readFileSync(filePath);
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.send(data);
+  } catch {
+    res.status(404).end('Not found');
+  }
+}

--- a/pages/api/plugins/index.ts
+++ b/pages/api/plugins/index.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');
+  try {
+    const files = fs.readdirSync(catalogDir);
+    const plugins = files
+      .filter((f) => !f.startsWith('.'))
+      .map((f) => ({ id: path.parse(f).name, file: f }));
+    res.status(200).json(plugins);
+  } catch {
+    res.status(200).json([]);
+  }
+}

--- a/plugins/catalog/demo.txt
+++ b/plugins/catalog/demo.txt
@@ -1,0 +1,1 @@
+demo plugin content


### PR DESCRIPTION
## Summary
- index plugin packages in plugins/catalog via new API
- add Plugin Manager app to download and store plugins
- expose endpoint to fetch plugin archives

## Testing
- `npm test __tests__/pluginManager.test.tsx __tests__/autopsy.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b177216bf48328b6db952144ac83a2