### PR TITLE
feat(reaver): log attempts and rate

### DIFF
--- a/apps/reaver/log.ts
+++ b/apps/reaver/log.ts
@@ -1,0 +1,38 @@
+export interface LogEntry {
+  timestamp: number;
+  attempts: number;
+  rate: number;
+}
+
+const STORAGE_KEY = 'reaver-log';
+
+export const logAttempt = (attempts: number, rate: number) => {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const entries: LogEntry[] = raw ? JSON.parse(raw) : [];
+    entries.push({ timestamp: Date.now(), attempts, rate });
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignore logging errors
+  }
+};
+
+export const readLog = (): LogEntry[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as LogEntry[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const clearLog = () => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+};


### PR DESCRIPTION
## Summary
- log each PIN attempt and attack rate to `localStorage` via new `reaver/log` module
- reset logs when simulator starts to track clean sessions
- show live attempt count, progress bar, and estimated time remaining during the attack

## Testing
- `npx eslint apps/reaver/index.tsx apps/reaver/log.ts` *(failed: ESLint couldn't find a config file)*
- `yarn test apps/reaver --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b17722b328832882ef61d4b87fba4b