### PR TITLE
feat: enable template import and export

### DIFF
--- a/templates/export/report-templates.json
+++ b/templates/export/report-templates.json
@@ -1,0 +1,10 @@
+{
+  "executive": {
+    "name": "Executive Summary",
+    "template": "Executive Summary\n\nFindings:\n{{#findings}}- {{title}} ({{severity}})\n{{/findings}}"
+  },
+  "detailed": {
+    "name": "Detailed Report",
+    "template": "Detailed Report\n\n{{#findings}}{{index}}. {{title}}\nSeverity: {{severity}}\n{{description}}\n\n{{/findings}}"
+  }
+}


### PR DESCRIPTION
## Summary
- export recon-ng report templates to JSON
- add Import/Share dialog to load or copy templates

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b17723eec483288b3339bc2053b02d