### PR TITLE
Support uploaded figlet fonts

### DIFF
--- a/pages/api/figlet/fonts.ts
+++ b/pages/api/figlet/fonts.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
+  let fonts: { name: string; data: string }[] = [];
+  try {
+    const files = fs.readdirSync(fontsDir).filter((f) => f.toLowerCase().endsWith('.flf'));
+    fonts = files.map((file) => ({
+      name: file.replace(/\.flf$/i, ''),
+      data: fs.readFileSync(path.join(fontsDir, file), 'utf8'),
+    }));
+  } catch {
+    // ignore missing dir or read errors
+  }
+  res.status(200).json({ fonts });
+}


### PR DESCRIPTION
## Summary
- Parse `.flf` fonts from `figlet/fonts` via new API endpoint
- Load server-provided fonts in Figlet app with dropdown menu

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: game2048, BeEF, mimikatz, VsCode suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b17726071c8328ae83403b1f423f61