### PR TITLE
feat: tag tech quotes and add category filter

### DIFF
--- a/components/apps/quotes_tech.json
+++ b/components/apps/quotes_tech.json
@@ -2,16 +2,19 @@
   {
     "id": 1,
     "quote": "Technology is best when it brings people together.",
-    "author": "Matt Mullenweg"
+    "author": "Matt Mullenweg",
+    "tags": ["technology"]
   },
   {
     "id": 2,
     "quote": "It has become appallingly obvious that our technology has exceeded our humanity.",
-    "author": "Albert Einstein"
+    "author": "Albert Einstein",
+    "tags": ["technology"]
   },
   {
     "id": 3,
     "quote": "Any sufficiently advanced technology is indistinguishable from magic.",
-    "author": "Arthur C. Clarke"
+    "author": "Arthur C. Clarke",
+    "tags": ["technology"]
   }
 ]


### PR DESCRIPTION
## Summary
- add technology tags to tech quotes database
- add category filter dropdown for quote generator

## Testing
- `yarn test` *(fails: merging two 2s creates one 4, merge triggers animation, score persists in localStorage, skin selection changes tile class, updates hook list when refresh is clicked, shows module output when run, switches between modules and payload builder tabs, retrieves module list, executes script template, renders external frame, shows banner when cookies are blocked, steps through sample capture frames)*
- `yarn lint components/apps/quote_generator.js components/apps/quotes_tech.json` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b17728097c832896a290ac903885f1