### PR TITLE
feat: add hydra session resume

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -20,7 +20,9 @@ jest.mock('child_process', () => ({
 }));
 
 const handler = require('../pages/api/hydra').default;
+const path = require('path');
 const fs = require('fs').promises;
+const sessionDir = path.join(process.cwd(), 'hydra');
 
 test('removes temp files after hydra execution', async () => {
   const req = {
@@ -40,8 +42,8 @@ test('removes temp files after hydra execution', async () => {
   await expect(fs.access(userPath)).rejects.toBeTruthy();
   await expect(fs.access(passPath)).rejects.toBeTruthy();
 });
-
-afterAll(() => {
+afterAll(async () => {
+  await fs.rm(sessionDir, { recursive: true, force: true });
   delete process.env.FEATURE_TOOL_APIS;
   delete process.env.FEATURE_HYDRA;
 });


### PR DESCRIPTION
## Summary
- allow saving hydra restore file and resuming with stored session
- test hydra session resume logic

## Testing
- `npm test __tests__/hydra.api.test.ts __tests__/hydra-api.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b177291ec08328bb347d1eca35599e