### PR TITLE
feat(mimikatz): add offline dump parser

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -98,6 +98,7 @@ const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
 const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
 const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
+const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offline');
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
 const ReaverApp = createDynamicApp('reaver', 'Reaver');
 const HydraApp = createDynamicApp('hydra', 'Hydra');
@@ -182,6 +183,7 @@ const displayVolatility = createDisplay(VolatilityApp);
 const displayMsfPost = createDisplay(MsfPostApp);
 const displayEvidenceVault = createDisplay(EvidenceVaultApp);
 const displayMimikatz = createDisplay(MimikatzApp);
+const displayMimikatzOffline = createDisplay(MimikatzOfflineApp);
 const displayEttercap = createDisplay(EttercapApp);
 const displayReaver = createDisplay(ReaverApp);
 const displayHydra = createDisplay(HydraApp);
@@ -868,6 +870,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMimikatz,
+  },
+  {
+    id: 'mimikatz/offline',
+    title: 'Mimikatz Offline',
+    icon: './themes/Yaru/apps/mimikatz.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMimikatzOffline,
   },
   {
     id: 'ssh',

--- a/apps/mimikatz/offline/index.tsx
+++ b/apps/mimikatz/offline/index.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import MimikatzOffline from '../../../components/apps/mimikatz/offline';
+
+const MimikatzOfflineApp: React.FC = () => {
+  return <MimikatzOffline />;
+};
+
+export default MimikatzOfflineApp;

--- a/components/apps/mimikatz/offline/index.js
+++ b/components/apps/mimikatz/offline/index.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+
+const parseDump = (text) => {
+  const lines = text.split(/\r?\n/);
+  const creds = [];
+  let current = {};
+  const userRegex = /user(?:name)?\s*[:=]\s*(\S+)/i;
+  const passRegex = /pass(?:word)?\s*[:=]\s*(\S+)/i;
+
+  lines.forEach((line) => {
+    const u = line.match(userRegex);
+    const p = line.match(passRegex);
+    if (u) current.user = u[1];
+    if (p) current.password = p[1];
+    if (current.user && current.password) {
+      creds.push(current);
+      current = {};
+    }
+  });
+  return creds;
+};
+
+const MimikatzOffline = () => {
+  const [credentials, setCredentials] = useState([]);
+  const [error, setError] = useState('');
+
+  const handleFile = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file
+      .text()
+      .then((text) => {
+        const parsed = parseDump(text);
+        setCredentials(parsed);
+        setError(parsed.length ? '' : 'No credentials found');
+      })
+      .catch(() => {
+        setError('Failed to read file');
+        setCredentials([]);
+      });
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col p-4 bg-ub-cool-grey text-white">
+      <h1 className="text-xl mb-4">Mimikatz Offline</h1>
+      <input
+        type="file"
+        accept=".txt,.log,application/octet-stream"
+        onChange={handleFile}
+        className="mb-4"
+      />
+      {error && <div className="text-red-400 text-sm mb-2">{error}</div>}
+      <ul className="space-y-2 overflow-auto">
+        {credentials.map((c, idx) => (
+          <li key={idx} className="bg-ub-dark p-2 rounded">
+            <div>User: {c.user}</div>
+            <div>Password: {c.password}</div>
+          </li>
+        ))}
+      </ul>
+      {!credentials.length && !error && (
+        <div className="text-sm text-gray-300">No credentials parsed</div>
+      )}
+    </div>
+  );
+};
+
+export default MimikatzOffline;
+
+export const displayMimikatzOffline = (addFolder, openApp) => {
+  return <MimikatzOffline addFolder={addFolder} openApp={openApp} />;
+};
+

--- a/pages/apps/mimikatz/offline.tsx
+++ b/pages/apps/mimikatz/offline.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const MimikatzOffline = dynamic(() => import('../../../apps/mimikatz/offline'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function MimikatzOfflinePage() {
+  return <MimikatzOffline />;
+}


### PR DESCRIPTION
## Summary
- add offline Mimikatz dump parser with file upload support
- register Mimikatz offline app in configuration

## Testing
- `FEATURE_TOOL_APIS=enabled yarn test __tests__/mimikatz.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b17728074c832894c8e0767113a2b0