### PR TITLE
feat: check for new nmap nse scripts

### DIFF
--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -17,6 +17,7 @@ const NmapNSE: React.FC = () => {
   const workerRef = useRef<Worker>();
   const [report, setReport] = useState<Report | null>(null);
   const [parseError, setParseError] = useState('');
+  const [updates, setUpdates] = useState<string[]>([]);
   const copyExample = useCallback((text: string) => {
     if (typeof window !== 'undefined') {
       try {
@@ -76,6 +77,21 @@ const NmapNSE: React.FC = () => {
     load();
   }, []);
 
+  useEffect(() => {
+    const check = async () => {
+      try {
+        const res = await fetch('/api/nse/update');
+        const json = await res.json();
+        if (Array.isArray(json.updates)) {
+          setUpdates(json.updates);
+        }
+      } catch (e) {
+        // ignore
+      }
+    };
+    check();
+  }, []);
+
   const queryLower = query.toLowerCase();
   const filtered: [string, Script[]][] = Object.entries(data).flatMap(
     ([category, scripts]) => {
@@ -106,6 +122,11 @@ const NmapNSE: React.FC = () => {
         Script details use static demo data for learning purposes only. Links open
         in isolated tabs.
       </p>
+      {updates.length > 0 && (
+        <div className="mb-4 p-2 bg-yellow-700 text-black rounded" role="alert">
+          New scripts available: {updates.join(', ')}
+        </div>
+      )}
       {filtered.map(([category, scripts]) => (
         <div key={category} className="mb-6">
           <h2 className="text-xl mb-2 capitalize">{category}</h2>

--- a/pages/api/nse/update.ts
+++ b/pages/api/nse/update.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs/promises';
+import path from 'path';
+
+interface UpdateResponse {
+  updates: string[];
+  error?: string;
+}
+
+const SCRIPT_DB_URL = 'https://raw.githubusercontent.com/nmap/nmap/master/scripts/script.db';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<UpdateResponse>
+) {
+  try {
+    const resp = await fetch(SCRIPT_DB_URL);
+    if (!resp.ok) {
+      throw new Error('Failed to fetch script database');
+    }
+    const text = await resp.text();
+    const remoteScripts = new Set<string>();
+    const regex = /filename\s*=\s*"([^"]+)"/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const name = match[1].replace(/\.nse$/, '');
+      remoteScripts.add(name);
+    }
+
+    const localPath = path.join(
+      process.cwd(),
+      'public',
+      'demo-data',
+      'nmap',
+      'scripts.json'
+    );
+    const localText = await fs.readFile(localPath, 'utf-8');
+    const localJson = JSON.parse(localText) as Record<string, { name: string }[]>;
+    const localScripts = new Set<string>();
+    Object.values(localJson).forEach((arr) => {
+      arr.forEach((s) => localScripts.add(s.name));
+    });
+
+    const updates = Array.from(remoteScripts).filter(
+      (name) => !localScripts.has(name)
+    );
+
+    res.status(200).json({ updates });
+  } catch (e: any) {
+    res.status(500).json({ updates: [], error: e.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to compare local demo scripts with upstream Nmap script DB
- flag available NSE script updates in the Nmap NSE app

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, kismet.test.tsx, vscode.test.tsx)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b17729c69c83289b0a61c83b93ae03