### PR TITLE
feat(volatility): warn on incompatible plugin versions

### DIFF
--- a/__tests__/volatilityPluginBrowser.test.tsx
+++ b/__tests__/volatilityPluginBrowser.test.tsx
@@ -21,9 +21,17 @@ describe('Volatility PluginBrowser', () => {
     });
     expect(screen.getByText('netscan')).toBeInTheDocument();
     expect(screen.queryByText('pslist')).toBeNull();
+    expect(
+      screen.getByText(/Incompatible with Volatility 3.0/i)
+    ).toBeInTheDocument();
 
     // display plugin output
     fireEvent.click(screen.getByText('netscan'));
     expect(screen.getByText(/Proto LocalAddr/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Plugin targets Volatility 2.0; app supports 3.0./i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import plugins from '../../../public/demo-data/volatility/plugins.json';
 
+const SUPPORTED_VERSION = '3.0';
+
 const PluginBrowser = () => {
   const [category, setCategory] = useState('All');
   const [selected, setSelected] = useState(null);
@@ -13,6 +15,8 @@ const PluginBrowser = () => {
   const filtered = plugins.filter(
     (p) => category === 'All' || p.category === category
   );
+
+  const isIncompatible = (p) => p.version && p.version !== SUPPORTED_VERSION;
 
   return (
     <div className="space-y-3">
@@ -38,6 +42,14 @@ const PluginBrowser = () => {
         >
           <h3 className="font-semibold text-sm">{p.name}</h3>
           <p className="text-[10px] text-gray-400">{p.category}</p>
+          {p.version && (
+            <p className="text-[10px] text-gray-400">v{p.version}</p>
+          )}
+          {isIncompatible(p) && (
+            <p className="text-[10px] text-red-400">
+              Incompatible with Volatility {SUPPORTED_VERSION}
+            </p>
+          )}
           <p className="text-xs mb-1">{p.description}</p>
           <a
             href={p.doc}
@@ -50,9 +62,16 @@ const PluginBrowser = () => {
         </div>
       ))}
       {selected && (
-        <pre className="text-xs bg-black p-3 rounded overflow-auto">
-          {selected.output}
-        </pre>
+        <>
+          {isIncompatible(selected) && (
+            <p className="text-red-400 text-xs">
+              Plugin targets Volatility {selected.version}; app supports {SUPPORTED_VERSION}.
+            </p>
+          )}
+          <pre className="text-xs bg-black p-3 rounded overflow-auto">
+            {selected.output}
+          </pre>
+        </>
       )}
     </div>
   );

--- a/public/demo-data/volatility/plugins.json
+++ b/public/demo-data/volatility/plugins.json
@@ -4,20 +4,24 @@
     "category": "Processes",
     "description": "List running processes.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html",
-    "output": "PID   PPID   Name\n4     0      System\n248   4      smss.exe\n612   248    csrss.exe"
+    "output": "PID   PPID   Name\\n4     0      System\\n248   4      smss.exe\\n612   248    csrss.exe",
+    "version": "3.0"
   },
   {
     "name": "netscan",
     "category": "Network",
     "description": "Scan for network connections.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/netscan.html",
-    "output": "Proto LocalAddr           ForeignAddr         State\nTCP   0.0.0.0:80          0.0.0.0:0           LISTENING\nUDP   127.0.0.1:53        0.0.0.0:0           NONE"
+    "output": "Proto LocalAddr           ForeignAddr         State\\nTCP   0.0.0.0:80          0.0.0.0:0           LISTENING\\nUDP   127.0.0.1:53        0.0.0.0:0           NONE",
+    "version": "2.0"
   },
   {
     "name": "malfind",
     "category": "Malware",
     "description": "Find hidden or injected code sections.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/malfind.html",
-    "output": "PID   Address     Protection Description\n612   0x7f12a000  RWX        Injected Code\n700   0x401000    RWX        Suspicious Section"
+    "output": "PID   Address     Protection Description\\n612   0x7f12a000  RWX        Injected Code\\n700   0x401000    RWX        Suspicious Section",
+    "version": "3.0"
   }
 ]
+


### PR DESCRIPTION
## Summary
- read plugin metadata to display plugin versions
- highlight plugins incompatible with the current Volatility version
- test plugin browser warnings

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet, metasploit, vscode)*
- `npm test __tests__/volatilityPluginBrowser.test.tsx`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1772bed708328b7fc131ac0ab9c1b