### PR TITLE
feat: visualize recon relationships

### DIFF
--- a/__tests__/reconGraph.test.ts
+++ b/__tests__/reconGraph.test.ts
@@ -1,0 +1,23 @@
+import { aggregateRelationships } from '../recon/graph';
+
+describe('aggregateRelationships', () => {
+  it('deduplicates nodes and counts links', () => {
+    const input = [
+      { source: 'a', target: 'b' },
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c', type: 'knows' },
+    ];
+    const result = aggregateRelationships(input);
+    expect(result.nodes).toEqual(
+      expect.arrayContaining([{ id: 'a' }, { id: 'b' }, { id: 'c' }]),
+    );
+    const ab = result.links.find(
+      (l) => l.source === 'a' && l.target === 'b' && !l.type,
+    );
+    expect(ab?.count).toBe(2);
+    const bc = result.links.find(
+      (l) => l.source === 'b' && l.target === 'c' && l.type === 'knows',
+    );
+    expect(bc?.count).toBe(1);
+  });
+});

--- a/pages/recon/graph.tsx
+++ b/pages/recon/graph.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import Meta from '../../components/SEO/Meta';
+import { aggregateRelationships, Relationship } from '../../recon/graph';
+
+const ForceGraph2D = dynamic(
+  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
+  { ssr: false },
+);
+
+const sample: Relationship[] = [
+  { source: 'example.com', target: '93.184.216.34', type: 'RESOLVES_TO' },
+  { source: '93.184.216.34', target: 'Jane Smith', type: 'ASSOCIATED_WITH' },
+  { source: 'example.com', target: '93.184.216.34', type: 'RESOLVES_TO' },
+];
+
+const ReconGraphPage: React.FC = () => {
+  const data = useMemo(() => aggregateRelationships(sample), []);
+
+  return (
+    <>
+      <Meta />
+      <main className="bg-ub-cool-grey text-white min-h-screen p-4">
+        <div className="h-96 w-full bg-black rounded">
+          <ForceGraph2D
+            graphData={{ nodes: data.nodes, links: data.links }}
+            nodeId="id"
+            linkDirectionalArrowLength={4}
+            nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
+              const label = node.id;
+              const fontSize = 12 / globalScale;
+              ctx.fillStyle = 'lightblue';
+              ctx.beginPath();
+              ctx.arc(node.x || 0, node.y || 0, 5, 0, 2 * Math.PI, false);
+              ctx.fill();
+              ctx.font = `${fontSize}px sans-serif`;
+              ctx.fillText(label, (node.x || 0) + 8, (node.y || 0) + 3);
+            }}
+          />
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default ReconGraphPage;

--- a/recon/graph.ts
+++ b/recon/graph.ts
@@ -1,0 +1,48 @@
+export interface Relationship {
+  source: string;
+  target: string;
+  type?: string;
+}
+
+export interface AggregatedGraph {
+  nodes: { id: string }[];
+  links: { source: string; target: string; type?: string; count: number }[];
+}
+
+/**
+ * Aggregate raw relationships into a simple graph structure.
+ * Duplicate nodes are removed and identical links are counted.
+ */
+export function aggregateRelationships(
+  rels: Relationship[],
+): AggregatedGraph {
+  const nodes = new Map<string, { id: string }>();
+  const links = new Map<string, {
+    source: string;
+    target: string;
+    type?: string;
+    count: number;
+  }>();
+
+  rels.forEach((r) => {
+    nodes.set(r.source, { id: r.source });
+    nodes.set(r.target, { id: r.target });
+    const key = `${r.source}->${r.target}${r.type ? `:${r.type}` : ''}`;
+    const existing = links.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      links.set(key, {
+        source: r.source,
+        target: r.target,
+        type: r.type,
+        count: 1,
+      });
+    }
+  });
+
+  return {
+    nodes: Array.from(nodes.values()),
+    links: Array.from(links.values()),
+  };
+}


### PR DESCRIPTION
## Summary
- add relationship aggregation utility for recon data
- introduce `/recon/graph` page rendering interactive force graph
- cover relationship aggregation with unit tests

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b17730fcfc8328a204bba7a0a3aa9c