### PR TITLE
feat(asteroids): introduce power-up system

### DIFF
--- a/components/apps/asteroids-utils.js
+++ b/components/apps/asteroids-utils.js
@@ -68,24 +68,6 @@ export function createGA(handler) {
   };
 }
 
-export const POWER_UPS = {
-  SHIELD: 'shield',
-  RAPID_FIRE: 'rapid-fire',
-};
-
-export function spawnPowerUp(list, x, y) {
-  const type = Math.random() < 0.5 ? POWER_UPS.SHIELD : POWER_UPS.RAPID_FIRE;
-  list.push({ type, x, y, r: 12, life: 600 });
-}
-
-export function updatePowerUps(list) {
-  for (let i = list.length - 1; i >= 0; i -= 1) {
-    const p = list[i];
-    p.life -= 1;
-    if (p.life <= 0) list.splice(i, 1);
-  }
-}
-
 // Simple seeded RNG using Mulberry32 algorithm
 export function createSeededRNG(seed) {
   let t = seed >>> 0;

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -5,11 +5,15 @@ import {
   spawnBullet,
   updateBullets,
   createGA,
-  spawnPowerUp,
-  updatePowerUps,
-  POWER_UPS,
   createSeededRNG,
 } from './asteroids-utils';
+import {
+  POWER_UPS,
+  SHIELD_DURATION,
+  spawnPowerUp,
+  updatePowerUps,
+  applyPowerUp,
+} from '../../games/asteroids/powerups';
 import useGameControls from './useGameControls';
 import GameLayout from './GameLayout';
 import { vibrate } from './Games/common/haptics';
@@ -23,7 +27,6 @@ const COLLISION_COOLDOWN = 60; // frames
 const MULTIPLIER_TIMEOUT = 180; // frames
 const MAX_MULTIPLIER = 5;
 const EXHAUST_COLOR = '#ffa500';
-const SHIELD_DURATION = 600; // frames
 const RADAR_COLORS = { outline: '#0f0', ship: '#fff', asteroid: '#0f0', ufo: '#f00' };
 const DEFAULT_MAP = {
   up: 'ArrowUp',
@@ -206,10 +209,7 @@ const Asteroids = () => {
     const upgrades = [...(saveDataRef.current.upgrades || [])];
 
     const applyUpgrades = () => {
-      upgrades.forEach((u) => {
-        if (u === POWER_UPS.SHIELD) ship.shield = SHIELD_DURATION;
-        if (u === POWER_UPS.RAPID_FIRE) ship.rapidFire = 600;
-      });
+      upgrades.forEach((u) => applyPowerUp(ship, u));
     };
 
     const chooseUpgrade = () => {
@@ -564,8 +564,7 @@ const Asteroids = () => {
       powerUps.forEach((p, i) => {
         const dist = Math.hypot(p.x - ship.x, p.y - ship.y);
         if (dist < p.r + ship.r) {
-        if (p.type === POWER_UPS.SHIELD) ship.shield = SHIELD_DURATION;
-          else ship.rapidFire = 600;
+          applyPowerUp(ship, p.type);
           powerUps.splice(i, 1);
         }
       });

--- a/games/asteroids/powerups.ts
+++ b/games/asteroids/powerups.ts
@@ -1,0 +1,49 @@
+// Power-up definitions and helpers for the Asteroids game.
+
+// Available power-up types.
+export enum POWER_UPS {
+  SHIELD = 'shield',
+  RAPID_FIRE = 'rapid-fire',
+}
+
+export interface PowerUp {
+  type: POWER_UPS;
+  x: number;
+  y: number;
+  r: number;
+  life: number;
+}
+
+// Duration values (in frames) for the various power-ups.
+export const SHIELD_DURATION = 600;
+export const RAPID_FIRE_DURATION = 600;
+
+/** Spawn a new power-up of random type at the given position. */
+export function spawnPowerUp(list: PowerUp[], x: number, y: number): void {
+  const type = Math.random() < 0.5 ? POWER_UPS.SHIELD : POWER_UPS.RAPID_FIRE;
+  list.push({ type, x, y, r: 12, life: 600 });
+}
+
+/** Update existing power-ups, removing any that expire. */
+export function updatePowerUps(list: PowerUp[]): void {
+  for (let i = list.length - 1; i >= 0; i -= 1) {
+    const p = list[i];
+    p.life -= 1;
+    if (p.life <= 0) list.splice(i, 1);
+  }
+}
+
+/** Apply the effect of the given power-up to the player's ship. */
+export function applyPowerUp(ship: any, type: POWER_UPS): void {
+  switch (type) {
+    case POWER_UPS.SHIELD:
+      ship.shield = SHIELD_DURATION;
+      break;
+    case POWER_UPS.RAPID_FIRE:
+      ship.rapidFire = RAPID_FIRE_DURATION;
+      break;
+    default:
+      break;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated power-up module for Asteroids
- integrate power-up spawning and effects into game loop

## Testing
- `npm test` *(fails: merging two 2s creates one 4)*
- `npm run lint` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b1773304d48328b1fea8841c4a4342