### PR TITLE
feat(battleship): add matchmaking server and move sync

### DIFF
--- a/__tests__/battleship-net.test.ts
+++ b/__tests__/battleship-net.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+
+import WebSocket from 'ws';
+import { once } from 'events';
+import { createMatchmakingServer } from '../apps/games/battleship/net/server';
+
+describe('battleship matchmaking server', () => {
+  test('pairs players and relays moves', async () => {
+    const server = createMatchmakingServer(0);
+    await once(server, 'listening');
+    const { port } = server.address() as any;
+    const url = `ws://localhost:${port}`;
+
+    const a = new WebSocket(url);
+    const b = new WebSocket(url);
+
+    const startA = JSON.parse((await once(a, 'message'))[0].toString());
+    const startB = JSON.parse((await once(b, 'message'))[0].toString());
+    expect(startA.type).toBe('start');
+    expect(startB.type).toBe('start');
+
+    a.send(JSON.stringify({ type: 'move', index: 5 }));
+    const moveForB = JSON.parse((await once(b, 'message'))[0].toString());
+    expect(moveForB).toEqual({ type: 'move', index: 5 });
+
+    b.send(JSON.stringify({ type: 'move', index: 7 }));
+    const moveForA = JSON.parse((await once(a, 'message'))[0].toString());
+    expect(moveForA).toEqual({ type: 'move', index: 7 });
+
+    a.close();
+    b.close();
+    server.close();
+    await Promise.all([
+      once(a, 'close'),
+      once(b, 'close'),
+      once(server, 'close'),
+    ]);
+  }, 10000);
+});

--- a/apps/games/battleship/net/server.ts
+++ b/apps/games/battleship/net/server.ts
@@ -1,0 +1,76 @@
+import { WebSocketServer, WebSocket } from 'ws';
+
+export interface StartMessage {
+  type: 'start';
+  player: 1 | 2;
+}
+
+export interface MoveMessage {
+  type: 'move';
+  index: number;
+}
+
+export interface EndMessage {
+  type: 'end';
+}
+
+export type Message = StartMessage | MoveMessage | EndMessage;
+
+/**
+ * Creates a simple matchmaking WebSocket server for Battleship.
+ * Players connect and are paired in the order they arrive. Moves sent by one
+ * player are forwarded to their opponent to keep both boards in sync.
+ */
+export function createMatchmakingServer(port = 0) {
+  const wss = new WebSocketServer({ port });
+
+  let waiting: WebSocket | null = null;
+  const pairs = new Map<WebSocket, WebSocket>();
+
+  wss.on('connection', (ws: WebSocket) => {
+    // Pair with a waiting player or wait for an opponent.
+    if (waiting) {
+      const opp = waiting;
+      waiting = null;
+      pairs.set(ws, opp);
+      pairs.set(opp, ws);
+      opp.send(JSON.stringify({ type: 'start', player: 1 } as StartMessage));
+      ws.send(JSON.stringify({ type: 'start', player: 2 } as StartMessage));
+    } else {
+      waiting = ws;
+    }
+
+    ws.on('message', (data) => {
+      let msg: Message;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      if (msg.type === 'move') {
+        const opp = pairs.get(ws);
+        if (opp && opp.readyState === WebSocket.OPEN) {
+          opp.send(JSON.stringify({ type: 'move', index: msg.index } as MoveMessage));
+        }
+      }
+    });
+
+    const cleanup = () => {
+      const opp = pairs.get(ws);
+      pairs.delete(ws);
+      if (opp) {
+        pairs.delete(opp);
+        if (opp.readyState === WebSocket.OPEN) {
+          opp.send(JSON.stringify({ type: 'end' } as EndMessage));
+        }
+      } else if (waiting === ws) {
+        waiting = null;
+      }
+    };
+
+    ws.on('close', cleanup);
+    ws.on('error', cleanup);
+  });
+
+  return wss;
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -33,35 +33,39 @@ class ImageMock {
 // @ts-ignore - allow overriding the global Image for the test env
 global.Image = ImageMock as unknown as typeof Image;
 
-// Provide a minimal canvas mock so libraries like xterm.js can run under JSDOM
-// @ts-ignore
-HTMLCanvasElement.prototype.getContext = () => ({
-  fillRect: () => {},
-  clearRect: () => {},
-  getImageData: () => ({ data: new Uint8ClampedArray() } as ImageData),
-  putImageData: () => {},
-  createImageData: () => new ImageData(0, 0),
-  setTransform: () => {},
-  drawImage: () => {},
-  save: () => {},
-  restore: () => {},
-  beginPath: () => {},
-  moveTo: () => {},
-  lineTo: () => {},
-  closePath: () => {},
-  stroke: () => {},
-  translate: () => {},
-  scale: () => {},
-  rotate: () => {},
-  arc: () => {},
-  fill: () => {},
-  fillText: () => {},
-  measureText: () => ({ width: 0 } as TextMetrics),
-  transform: () => {},
-  rect: () => {},
-  clip: () => {},
-  createLinearGradient: () => ({ addColorStop: () => {} } as unknown as CanvasGradient),
-});
+// Provide a minimal canvas mock so libraries like xterm.js can run under JSDOM.
+// In non-browser environments (like Jest's node environment) HTMLCanvasElement may
+// not exist, so guard against it before patching the prototype.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  // @ts-ignore
+  HTMLCanvasElement.prototype.getContext = () => ({
+    fillRect: () => {},
+    clearRect: () => {},
+    getImageData: () => ({ data: new Uint8ClampedArray() } as ImageData),
+    putImageData: () => {},
+    createImageData: () => new ImageData(0, 0),
+    setTransform: () => {},
+    drawImage: () => {},
+    save: () => {},
+    restore: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    closePath: () => {},
+    stroke: () => {},
+    translate: () => {},
+    scale: () => {},
+    rotate: () => {},
+    arc: () => {},
+    fill: () => {},
+    fillText: () => {},
+    measureText: () => ({ width: 0 } as TextMetrics),
+    transform: () => {},
+    rect: () => {},
+    clip: () => {},
+    createLinearGradient: () => ({ addColorStop: () => {} } as unknown as CanvasGradient),
+  });
+}
 
 // Basic matchMedia mock for libraries that expect it
 if (typeof window !== 'undefined' && !window.matchMedia) {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "three": "^0.179.1",
     "turndown": "^7.2.1",
     "workbox-window": "^7.3.0",
+    "ws": "^8.18.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11611,6 +11611,7 @@ __metadata:
     wait-on: "npm:^8.0.4"
     workbox-build: "npm:^7.3.0"
     workbox-window: "npm:^7.3.0"
+    ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- add WebSocket matchmaking server for Battleship
- relay player moves between paired clients
- fix Jest setup for Node environment tests

## Testing
- `yarn test __tests__/battleship-net.test.ts`
- `yarn test` *(fails: game2048, beef, mimikatz, kismet, vscode)*

------
https://chatgpt.com/codex/tasks/task_e_68b177344c8483288e129f82b0bd02d3