### PR TITLE
feat(wireshark): add filter presets dropdown

### DIFF
--- a/apps/wireshark/components/FilterHelper.tsx
+++ b/apps/wireshark/components/FilterHelper.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
-
-const EXAMPLE_FILTERS = [
-  'tcp',
-  'udp',
-  'icmp',
-  'http',
-  'tcp.port == 80',
-  'ip.addr == 10.0.0.1',
-];
+import presets from '../filters/presets.json';
 
 interface FilterHelperProps {
   value: string;
@@ -21,7 +13,9 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
     []
   );
 
-  const suggestions = Array.from(new Set([...recent, ...EXAMPLE_FILTERS]));
+  const suggestions = Array.from(
+    new Set([...recent, ...presets.map((p) => p.expression)])
+  );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
@@ -42,8 +36,31 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
     }
   };
 
+  const handlePresetSelect = (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const val = e.target.value;
+    if (!val) return;
+    onChange(val);
+    setRecent((prev) => [val, ...prev.filter((f) => f !== val)].slice(0, 5));
+    e.target.selectedIndex = 0;
+  };
+
   return (
     <>
+      <select
+        onChange={handlePresetSelect}
+        defaultValue=""
+        aria-label="Preset filters"
+        className="px-2 py-1 bg-gray-800 rounded text-white"
+      >
+        <option value="">Preset filters...</option>
+        {presets.map(({ label, expression }) => (
+          <option key={expression} value={expression}>
+            {label}
+          </option>
+        ))}
+      </select>
       <input
         list="display-filter-suggestions"
         value={value}

--- a/apps/wireshark/filters/presets.json
+++ b/apps/wireshark/filters/presets.json
@@ -1,0 +1,10 @@
+[
+  { "label": "TCP", "expression": "tcp" },
+  { "label": "UDP", "expression": "udp" },
+  { "label": "ICMP", "expression": "icmp" },
+  { "label": "HTTP", "expression": "http" },
+  { "label": "HTTP traffic", "expression": "tcp.port == 80" },
+  { "label": "HTTPS traffic", "expression": "tcp.port == 443" },
+  { "label": "DNS queries", "expression": "udp.port == 53" },
+  { "label": "Host 10.0.0.1", "expression": "ip.addr == 10.0.0.1" }
+]

--- a/components/apps/wireshark/filters.json
+++ b/components/apps/wireshark/filters.json
@@ -1,5 +1,0 @@
-[
-  { "label": "HTTP traffic", "expression": "tcp.port == 80" },
-  { "label": "HTTPS traffic", "expression": "tcp.port == 443" },
-  { "label": "DNS queries", "expression": "udp.port == 53" }
-]

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -3,7 +3,6 @@ import Waterfall from './Waterfall';
 import { protocolName, getRowColor } from './utils';
 import DecodeTree from './DecodeTree';
 import FlowGraph from '../../../apps/wireshark/components/FlowGraph';
-import filters from './filters.json';
 import FilterHelper from '../../../apps/wireshark/components/FilterHelper';
 
 const SMALL_CAPTURE_SIZE = 1024 * 1024; // 1MB threshold
@@ -184,13 +183,6 @@ const WiresharkApp = ({ initialPackets = [] }) => {
     }
   };
 
-  const handleFilterSelect = (e) => {
-    const val = e.target.value;
-    setFilter(val);
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('wireshark-filter', val);
-    }
-  };
 
   const handleBpfChange = (e) => {
     setBpf(e.target.value);
@@ -330,19 +322,6 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           aria-label="TLS key file"
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
-        <select
-          value={filters.some((f) => f.expression === filter) ? filter : ''}
-          onChange={handleFilterSelect}
-          aria-label="Common filters"
-          className="px-2 py-1 bg-gray-800 rounded text-white"
-        >
-          <option value="">Choose filter...</option>
-          {filters.map(({ label, expression }) => (
-            <option key={expression} value={expression}>
-              {label}
-            </option>
-          ))}
-        </select>
         <FilterHelper value={filter} onChange={handleFilterChange} />
         <input
           value={bpf}


### PR DESCRIPTION
## Summary
- centralize Wireshark filter presets
- add dropdown in FilterHelper to apply presets instantly
- remove obsolete filter list wiring

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: game2048.test.tsx, mimikatz.test.ts, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1771553e88328a811992322ea7c80