### PR TITLE
Add cron-like scan scheduler

### DIFF
--- a/__tests__/scannerSchedule.test.ts
+++ b/__tests__/scannerSchedule.test.ts
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+import {
+  scheduleScan,
+  loadScheduledScans,
+  clearSchedules,
+} from '../scanner/schedule';
+
+describe('scan scheduler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    clearSchedules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('stores scheduled scans in localStorage', () => {
+    const fn = jest.fn();
+    scheduleScan('1', '*/2 * * * * *', fn);
+    expect(loadScheduledScans()).toEqual([
+      { id: '1', schedule: '*/2 * * * * *' },
+    ]);
+  });
+
+  test('triggers scans based on interval', () => {
+    const fn = jest.fn();
+    scheduleScan('1', '*/2 * * * * *', fn);
+    jest.advanceTimersByTime(2000);
+    expect(fn).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(2000);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/scanner/schedule.ts
+++ b/scanner/schedule.ts
@@ -1,0 +1,67 @@
+export interface ScheduledScan {
+  id: string;
+  schedule: string;
+}
+
+interface RunningScan extends ScheduledScan {
+  timer: ReturnType<typeof setInterval>;
+  callback: () => void;
+}
+
+const STORAGE_KEY = 'scanSchedules';
+const runningScans: RunningScan[] = [];
+
+export const loadScheduledScans = (): ScheduledScan[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+};
+
+const persistSchedules = (jobs: ScheduledScan[]) => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
+};
+
+export const cronToInterval = (expr: string): number => {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length === 6) {
+    const sec = parts[0];
+    const match = /^\*\/(\d+)$/.exec(sec);
+    if (match) return parseInt(match[1], 10) * 1000;
+  }
+  if (parts.length >= 5) {
+    const min = parts.length === 5 ? parts[0] : parts[1];
+    const match = /^\*\/(\d+)$/.exec(min);
+    if (match) return parseInt(match[1], 10) * 60 * 1000;
+  }
+  throw new Error('Unsupported cron expression');
+};
+
+export const scheduleScan = (
+  id: string,
+  schedule: string,
+  callback: () => void,
+): ScheduledScan => {
+  const jobs = loadScheduledScans();
+  jobs.push({ id, schedule });
+  persistSchedules(jobs);
+  const interval = cronToInterval(schedule);
+  const timer = setInterval(callback, interval);
+  runningScans.push({ id, schedule, timer, callback });
+  return { id, schedule };
+};
+
+export const startStoredSchedules = (trigger: (id: string) => void) => {
+  loadScheduledScans().forEach(({ id, schedule }) =>
+    scheduleScan(id, schedule, () => trigger(id)),
+  );
+};
+
+export const clearSchedules = () => {
+  runningScans.forEach((j) => clearInterval(j.timer));
+  runningScans.length = 0;
+  persistSchedules([]);
+};


### PR DESCRIPTION
## Summary
- implement basic cron-style scan scheduler with persistence
- add tests verifying schedule storage and timed execution

## Testing
- `yarn test __tests__/nessus.test.ts __tests__/scannerSchedule.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint scanner/schedule.ts __tests__/scannerSchedule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b185a2d074832887757373f84d7320