### PR TITLE
feat(blackjack): add deck composition tracking to trainer

### DIFF
--- a/components/apps/blackjack/engine.js
+++ b/components/apps/blackjack/engine.js
@@ -26,6 +26,7 @@ export class Shoe {
     this.penetration = penetration;
     this.shuffleCount = 0;
     this.runningCount = 0;
+    this.composition = {};
     this.shuffle();
   }
 
@@ -39,6 +40,10 @@ export class Shoe {
     this.dealt = 0;
     this.shuffleCount += 1;
     this.runningCount = 0;
+    this.composition = {};
+    RANKS.forEach((r) => {
+      this.composition[r] = this.decks * 4;
+    });
     // burn one card
     this.draw();
   }
@@ -50,6 +55,7 @@ export class Shoe {
     this.dealt += 1;
     const card = this.cards.pop();
     const v = card.value;
+    if (this.composition[v] !== undefined) this.composition[v] -= 1;
     if (['2', '3', '4', '5', '6'].includes(v)) this.runningCount += 1;
     else if (['10', 'J', 'Q', 'K', 'A'].includes(v)) this.runningCount -= 1;
     return card;

--- a/components/apps/blackjack/index.js
+++ b/components/apps/blackjack/index.js
@@ -165,6 +165,7 @@ const Blackjack = () => {
     }
     return 0;
   });
+  const [practiceFeedback, setPracticeFeedback] = useState('');
   const [dealerPeeking, setDealerPeeking] = useState(false);
 
   const [_, dispatch] = useReducer(gameReducer, {
@@ -249,20 +250,24 @@ const Blackjack = () => {
     setStreak(0);
     setPracticeCard(practiceShoe.current.draw());
     setPractice(true);
+    setPracticeFeedback('');
     ReactGA.event({ category: 'Blackjack', action: 'count_practice_start' });
   };
 
   const submitPractice = () => {
     const guess = parseInt(practiceGuess, 10);
-    if (guess === practiceShoe.current.runningCount) {
+    const actual = practiceShoe.current.runningCount;
+    if (guess === actual) {
       setStreak((s) => {
         const newStreak = s + 1;
         setBestStreak((b) => (newStreak > b ? newStreak : b));
         return newStreak;
       });
+      setPracticeFeedback(`Correct! Count is ${actual}`);
     } else {
       ReactGA.event({ category: 'Blackjack', action: 'count_streak', value: streak });
       setStreak(0);
+      setPracticeFeedback(`Nope. Count is ${actual}`);
     }
     setPracticeGuess('');
     setPracticeCard(practiceShoe.current.draw());
@@ -341,9 +346,15 @@ const Blackjack = () => {
             Exit
           </button>
         </div>
+        {practiceFeedback && <div className="mt-2">{practiceFeedback}</div>}
         <div className="mt-4">Streak: {streak}</div>
         <div className="mt-1">Best: {bestStreak}</div>
         <div className="mt-1">RC: {practiceShoe.current.runningCount}</div>
+        <div className="mt-1 text-xs">
+          {Object.entries(practiceShoe.current.composition)
+            .map(([v, c]) => `${v}:${c}`)
+            .join(' ')}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- track remaining card counts in blackjack shoe for trainer mode
- show deck composition and feedback after count guesses

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/vscode.test.tsx, __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1773559388328b8dc82eca4332e72