### PR TITLE
feat: add tags to quotes database and category filter

### DIFF
--- a/components/apps/quotes_tech.json
+++ b/components/apps/quotes_tech.json
@@ -2,16 +2,19 @@
   {
     "id": 1,
     "quote": "Technology is best when it brings people together.",
-    "author": "Matt Mullenweg"
+    "author": "Matt Mullenweg",
+    "tags": ["technology"]
   },
   {
     "id": 2,
     "quote": "It has become appallingly obvious that our technology has exceeded our humanity.",
-    "author": "Albert Einstein"
+    "author": "Albert Einstein",
+    "tags": ["technology"]
   },
   {
     "id": 3,
     "quote": "Any sufficiently advanced technology is indistinguishable from magic.",
-    "author": "Arthur C. Clarke"
+    "author": "Arthur C. Clarke",
+    "tags": ["technology"]
   }
 ]

--- a/quotes/database.json
+++ b/quotes/database.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "quote": "Your heart is the size of an ocean. Go find yourself in its hidden depths.",
+    "author": "Rumi",
+    "tags": ["love"]
+  },
+  {
+    "id": 2,
+    "quote": "Thinking is the capital, Enterprise is the way, Hard Work is the solution.",
+    "author": "Abdul Kalam",
+    "tags": ["inspirational"]
+  },
+  {
+    "id": 3,
+    "quote": "It has become appallingly obvious that our technology has exceeded our humanity.",
+    "author": "Albert Einstein",
+    "tags": ["technology"]
+  },
+  {
+    "id": 4,
+    "quote": "A computer once beat me at chess, but it was no match for me at kick boxing.",
+    "author": "Emo Philips",
+    "tags": ["humor", "technology"]
+  }
+]


### PR DESCRIPTION
## Summary
- tag quote datasets and add dedicated quote database
- allow filtering quotes by category on generator page

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: 8 errors)*
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b185b3a0d8832897284a0bc1dd5892