### PR TITLE
feat: add offline mimikatz dump parser

### DIFF
--- a/__tests__/mimikatz-offline.test.tsx
+++ b/__tests__/mimikatz-offline.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import MimikatzOffline from '../components/apps/mimikatz/offline';
+
+// Mock FileReader to immediately return sample dump contents
+class FileReaderMock {
+  onload = null;
+  readAsText() {
+    const text = 'alice:pass1\nbob:pass2';
+    if (this.onload) {
+      this.onload({ target: { result: text } });
+    }
+  }
+}
+
+describe('MimikatzOffline', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.FileReader = FileReaderMock;
+  });
+
+  it('parses uploaded dump without network', () => {
+    render(<MimikatzOffline />);
+    const input = screen.getByLabelText('dump file');
+    const file = new File(['dummy'], 'dump.txt', { type: 'text/plain' });
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -98,6 +98,7 @@ const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
 const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
 const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
+const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offline');
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
 const ReaverApp = createDynamicApp('reaver', 'Reaver');
 const HydraApp = createDynamicApp('hydra', 'Hydra');
@@ -182,6 +183,7 @@ const displayVolatility = createDisplay(VolatilityApp);
 const displayMsfPost = createDisplay(MsfPostApp);
 const displayEvidenceVault = createDisplay(EvidenceVaultApp);
 const displayMimikatz = createDisplay(MimikatzApp);
+const displayMimikatzOffline = createDisplay(MimikatzOfflineApp);
 const displayEttercap = createDisplay(EttercapApp);
 const displayReaver = createDisplay(ReaverApp);
 const displayHydra = createDisplay(HydraApp);
@@ -868,6 +870,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayMimikatz,
+  },
+  {
+    id: 'mimikatz-offline',
+    title: 'Mimikatz Offline',
+    icon: './themes/Yaru/apps/mimikatz.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMimikatzOffline,
   },
   {
     id: 'ssh',

--- a/components/apps/mimikatz/offline/index.js
+++ b/components/apps/mimikatz/offline/index.js
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+
+// Offline LSASS dump parser. Processes uploaded files locally
+// without making any network requests.
+const MimikatzOffline = () => {
+  const [creds, setCreds] = useState([]);
+  const [error, setError] = useState('');
+
+  const handleFile = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const text = ev.target.result.toString();
+        const lines = text.split(/\r?\n/);
+        const entries = lines
+          .map((line) => {
+            const match = line.match(/([^\s:]+)[\s:]+([^\s]+)/);
+            return match ? { user: match[1], pass: match[2] } : null;
+          })
+          .filter(Boolean);
+        setCreds(entries);
+        setError('');
+      } catch {
+        setError('Failed to parse dump');
+        setCreds([]);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 overflow-auto">
+      <h1 className="text-xl mb-4">Mimikatz Offline Dump Parser</h1>
+      <p className="text-sm text-yellow-300 mb-4">
+        Process LSASS dump files locally. No network requests are made.
+      </p>
+      <input
+        type="file"
+        accept=".txt,.log,.dmp,.json"
+        onChange={handleFile}
+        className="mb-4"
+        aria-label="dump file"
+      />
+      {error && <div className="text-red-400 mb-2">{error}</div>}
+      {creds.length > 0 && (
+        <table className="text-xs w-full border border-gray-700">
+          <thead>
+            <tr className="bg-gray-800">
+              <th className="px-2 py-1 text-left">Username</th>
+              <th className="px-2 py-1 text-left">Password</th>
+            </tr>
+          </thead>
+          <tbody>
+            {creds.map((c, i) => (
+              <tr key={i} className="odd:bg-gray-800">
+                <td className="px-2 py-1">{c.user}</td>
+                <td className="px-2 py-1">{c.pass}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default MimikatzOffline;
+
+export const displayMimikatzOffline = (addFolder, openApp) => (
+  <MimikatzOffline addFolder={addFolder} openApp={openApp} />
+);


### PR DESCRIPTION
## Summary
- add offline Mimikatz dump parser with file input to process LSASS dumps locally
- expose new offline tool in app configuration
- add unit test for offline dump parsing

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b185ba232083288d140ef548f38e78