### PR TITLE
Add radare2 tutorial overlay

### DIFF
--- a/__tests__/radare2Guide.test.tsx
+++ b/__tests__/radare2Guide.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Radare2 from '../components/apps/radare2';
+import sample from '../apps/radare2/sample.json';
+
+describe('Radare2 tutorial', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('r2HelpDismissed', 'true');
+  });
+
+  it('opens tutorial from help menu', () => {
+    render(<Radare2 initialData={sample} />);
+    expect(screen.queryByText('Radare2 Tutorial')).toBeNull();
+    fireEvent.click(screen.getByText('Help'));
+    expect(screen.getByText('Radare2 Tutorial')).toBeInTheDocument();
+  });
+});

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'r2HelpDismissed';
+
+const STEPS = [
+  'S1: Open the demo binary with \'r2 -A demo.bin\'.',
+  'S2: Seek to the main function using \"s main\".',
+  'S3: Disassemble with \"pdf @ main\" to view instructions.',
+  'S4: List strings using \"iz\".',
+  'S5: Close this tutorial and explore further.',
+];
+
+export default function GuideOverlay({ onClose }) {
+  const [step, setStep] = useState(0);
+  const [dontShow, setDontShow] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  const handleClose = () => {
+    if (dontShow) {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true');
+      } catch {
+        /* ignore storage errors */
+      }
+    }
+    onClose();
+  };
+
+  const prev = () => setStep((s) => Math.max(0, s - 1));
+  const next = () => setStep((s) => Math.min(STEPS.length - 1, s + 1));
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape') handleClose();
+    if (e.key === 'ArrowRight') next();
+    if (e.key === 'ArrowLeft') prev();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      className="absolute inset-0 bg-black bg-opacity-75 text-white flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
+        <h2 className="text-xl font-bold mb-2">Radare2 Tutorial</h2>
+        <p className="mb-4">{STEPS[step]}</p>
+        <div className="flex justify-between mb-4">
+          <button
+            type="button"
+            onClick={prev}
+            disabled={step === 0}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+          >
+            Prev
+          </button>
+          <span>{step + 1} / {STEPS.length}</span>
+          <button
+            type="button"
+            onClick={next}
+            disabled={step === STEPS.length - 1}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+          >
+            Next
+          </button>
+        </div>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={dontShow}
+            onChange={(e) => setDontShow(e.target.checked)}
+          />
+          <span>Don't show again</span>
+        </label>
+        <div className="mt-4 flex justify-between">
+          <a
+            href="/demo-data/radare2/tutorial/basic.r2"
+            className="underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View script
+          </a>
+          <button
+            onClick={handleClose}
+            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -7,6 +7,7 @@ import {
   saveBookmarks,
 } from './utils';
 import GraphView from '../../../apps/radare2/components/GraphView';
+import GuideOverlay from './GuideOverlay';
 
 const Radare2 = ({ initialData = {} }) => {
   const { file = 'demo', hex = '', disasm = [], xrefs = {}, blocks = [] } =
@@ -18,6 +19,7 @@ const Radare2 = ({ initialData = {} }) => {
   const [notes, setNotes] = useState([]);
   const [noteText, setNoteText] = useState('');
   const [bookmarks, setBookmarks] = useState([]);
+  const [showGuide, setShowGuide] = useState(false);
   const disasmRef = useRef(null);
 
   useEffect(() => {
@@ -27,6 +29,16 @@ const Radare2 = ({ initialData = {} }) => {
 
     }
   }, [file]);
+
+  useEffect(() => {
+    try {
+      if (typeof window !== 'undefined' && !localStorage.getItem('r2HelpDismissed')) {
+        setShowGuide(true);
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+  }, []);
 
   const scrollToAddr = (addr) => {
     const idx = disasm.findIndex(
@@ -75,6 +87,7 @@ const Radare2 = ({ initialData = {} }) => {
 
   return (
     <div className="h-full w-full bg-ub-cool-grey text-white p-4 overflow-auto">
+      {showGuide && <GuideOverlay onClose={() => setShowGuide(false)} />}
       <div className="flex gap-2 mb-2 flex-wrap">
         <input
           value={seekAddr}
@@ -105,6 +118,12 @@ const Radare2 = ({ initialData = {} }) => {
           className="px-3 py-1 bg-gray-700 rounded"
         >
           {mode === 'code' ? 'Graph' : 'Code'}
+        </button>
+        <button
+          onClick={() => setShowGuide(true)}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Help
         </button>
       </div>
 

--- a/public/demo-data/radare2/tutorial/basic.r2
+++ b/public/demo-data/radare2/tutorial/basic.r2
@@ -1,0 +1,9 @@
+# radare2 guided script: basics
+# Step 1: open the demo binary
+o demo.bin
+# Step 2: analyze everything
+aaa
+# Step 3: print disassembly of main
+pdf @ main
+# Step 4: list strings
+iz


### PR DESCRIPTION
## Summary
- add guided radare2 script under `public/demo-data`
- introduce tutorial overlay with step-by-step instructions
- expose help button in radare2 app to launch overlay

## Testing
- `yarn test __tests__/radare2.test.js __tests__/radare2Guide.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b185c413dc8328904d7a3cada4aeea