### PR TITLE
feat(volatility): warn on incompatible plugin versions

### DIFF
--- a/apps/volatility/components/PluginWalkthrough.tsx
+++ b/apps/volatility/components/PluginWalkthrough.tsx
@@ -1,16 +1,29 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import plugins from '../../../public/demo-data/volatility/plugins.json';
+
+const VOLATILITY_VERSION = '3.0';
 
 interface PluginInfo {
   name: string;
   description: string;
   output: string;
+  minVersion?: string;
 }
 
 const PluginWalkthrough: React.FC = () => {
   const data = plugins as PluginInfo[];
   const [index, setIndex] = useState(0);
   const current = data[index];
+
+  useEffect(() => {
+    data.forEach((p) => {
+      if (p.minVersion && p.minVersion !== VOLATILITY_VERSION) {
+        console.warn(
+          `Plugin ${p.name} requires Volatility ${p.minVersion} but version ${VOLATILITY_VERSION} is loaded.`
+        );
+      }
+    });
+  }, [data]);
 
   const next = () => setIndex((i) => (i + 1) % data.length);
   const prev = () => setIndex((i) => (i - 1 + data.length) % data.length);
@@ -28,6 +41,11 @@ const PluginWalkthrough: React.FC = () => {
           </button>
         </div>
       </div>
+      {current.minVersion && current.minVersion !== VOLATILITY_VERSION && (
+        <p className="text-red-400">
+          Requires Volatility {current.minVersion}
+        </p>
+      )}
       <p>{current.description}</p>
       <pre className="bg-black p-2 rounded overflow-auto whitespace-pre-wrap">
         {current.output}

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -1,5 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import plugins from '../../../public/demo-data/volatility/plugins.json';
+
+const VOLATILITY_VERSION = '3.0';
 
 const PluginBrowser = () => {
   const [category, setCategory] = useState('All');
@@ -9,6 +11,16 @@ const PluginBrowser = () => {
     () => ['All', ...Array.from(new Set(plugins.map((p) => p.category)))],
     []
   );
+
+  useEffect(() => {
+    plugins.forEach((p) => {
+      if (p.minVersion && p.minVersion !== VOLATILITY_VERSION) {
+        console.warn(
+          `Plugin ${p.name} requires Volatility ${p.minVersion} but version ${VOLATILITY_VERSION} is loaded.`
+        );
+      }
+    });
+  }, []);
 
   const filtered = plugins.filter(
     (p) => category === 'All' || p.category === category
@@ -38,6 +50,11 @@ const PluginBrowser = () => {
         >
           <h3 className="font-semibold text-sm">{p.name}</h3>
           <p className="text-[10px] text-gray-400">{p.category}</p>
+          {p.minVersion && p.minVersion !== VOLATILITY_VERSION && (
+            <p className="text-[10px] text-red-400">
+              Requires Volatility {p.minVersion}
+            </p>
+          )}
           <p className="text-xs mb-1">{p.description}</p>
           <a
             href={p.doc}

--- a/public/demo-data/volatility/plugins.json
+++ b/public/demo-data/volatility/plugins.json
@@ -4,6 +4,7 @@
     "category": "Processes",
     "description": "List running processes.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html",
+    "minVersion": "3.0",
     "output": "PID   PPID   Name\n4     0      System\n248   4      smss.exe\n612   248    csrss.exe"
   },
   {
@@ -11,6 +12,7 @@
     "category": "Network",
     "description": "Scan for network connections.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/netscan.html",
+    "minVersion": "3.0",
     "output": "Proto LocalAddr           ForeignAddr         State\nTCP   0.0.0.0:80          0.0.0.0:0           LISTENING\nUDP   127.0.0.1:53        0.0.0.0:0           NONE"
   },
   {
@@ -18,6 +20,8 @@
     "category": "Malware",
     "description": "Find hidden or injected code sections.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/malfind.html",
-    "output": "PID   Address     Protection Description\n612   0x7f12a000  RWX        Injected Code\n700   0x401000    RWX        Suspicious Section"
+    "minVersion": "3.1",
+    "output": "PID   Address     Protection Description\n612   0x7f12a000  RWX        Injected Code\n700   0x401000    RWX  Suspicious Section"
   }
 ]
+


### PR DESCRIPTION
## Summary
- add minimum supported version field to volatility plugin metadata
- surface plugin version requirements and warn when mismatched

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b185c658848328a47eba6d320fab51