### PR TITLE
Add CLI progress bar script

### DIFF
--- a/john/status.js
+++ b/john/status.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+function renderProgressBar(completed, total) {
+  const percent = total === 0 ? 0 : (completed / total);
+  const barLength = 20;
+  const filled = Math.round(barLength * percent);
+  const bar = '█'.repeat(filled) + '-'.repeat(barLength - filled);
+  return { percent: (percent * 100).toFixed(2), bar };
+}
+
+function main() {
+  const [completedStr, totalStr] = process.argv.slice(2);
+  if (!completedStr || !totalStr) {
+    console.error('Usage: node john/status.js <completed> <total>');
+    process.exit(1);
+  }
+  const completed = Number(completedStr);
+  const total = Number(totalStr);
+  if (Number.isNaN(completed) || Number.isNaN(total)) {
+    console.error('Both completed and total must be numbers');
+    process.exit(1);
+  }
+  const { percent, bar } = renderProgressBar(completed, total);
+  console.log(`Progress: ${percent}% [${bar}]`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add simple node script to compute completion percentage and render progress bar

## Testing
- `node john/status.js 30 100`
- `CI=1 npm test` *(fails: game2048, beef, mimikatz, vscode, kismet, metasploit, etc.)*
- `npm run lint` *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b185ccb08c8328bc3a8efa0a49b62b