### PR TITLE
Add asteroids power-ups

### DIFF
--- a/__tests__/asteroids-utils.test.ts
+++ b/__tests__/asteroids-utils.test.ts
@@ -6,6 +6,9 @@ import {
   splitAsteroidTree,
   updateShipPosition,
   handleBulletAsteroidCollision,
+  spawnPowerUp,
+  applyPowerUp,
+  POWER_UPS,
 } from '../components/apps/asteroids-utils';
 
 describe('wrap', () => {
@@ -69,5 +72,26 @@ describe('updateShipPosition', () => {
     const ship = { x: 115, y: 50, velX: 0, velY: 0, r: 10 };
     updateShipPosition(ship, 100, 100);
     expect(ship.x).toBe(-5);
+  });
+});
+
+describe('power-ups', () => {
+  it('spawns a valid power-up', () => {
+    const list = [];
+    spawnPowerUp(list, 0, 0);
+    expect(list).toHaveLength(1);
+    expect(Object.values(POWER_UPS)).toContain(list[0].type);
+  });
+
+  it('applies effects when collected', () => {
+    const ship = { shield: 0, rapidFire: 0 };
+    let lives = 3;
+    lives = applyPowerUp({ type: POWER_UPS.SHIELD }, ship, lives, 50, 30);
+    expect(ship.shield).toBe(50);
+    expect(lives).toBe(3);
+    lives = applyPowerUp({ type: POWER_UPS.EXTRA_LIFE }, ship, lives);
+    expect(lives).toBe(4);
+    lives = applyPowerUp({ type: POWER_UPS.RAPID_FIRE }, ship, lives, 50, 40);
+    expect(ship.rapidFire).toBe(40);
   });
 });

--- a/components/apps/asteroids-utils.js
+++ b/components/apps/asteroids-utils.js
@@ -1,3 +1,7 @@
+import { POWER_UPS } from '../../games/asteroids/powerups';
+
+export { POWER_UPS };
+
 export function wrap(value, max, margin = 0) {
   const range = max + margin * 2;
   let m = (value + margin) % range;
@@ -68,14 +72,27 @@ export function createGA(handler) {
   };
 }
 
-export const POWER_UPS = {
-  SHIELD: 'shield',
-  RAPID_FIRE: 'rapid-fire',
-};
-
 export function spawnPowerUp(list, x, y) {
-  const type = Math.random() < 0.5 ? POWER_UPS.SHIELD : POWER_UPS.RAPID_FIRE;
+  const types = Object.values(POWER_UPS);
+  const type = types[Math.floor(Math.random() * types.length)];
   list.push({ type, x, y, r: 12, life: 600 });
+}
+
+export function applyPowerUp(powerUp, ship, lives, shieldDuration = 600, rapidFireDuration = 600) {
+  switch (powerUp.type) {
+    case POWER_UPS.SHIELD:
+      ship.shield = shieldDuration;
+      break;
+    case POWER_UPS.RAPID_FIRE:
+      ship.rapidFire = rapidFireDuration;
+      break;
+    case POWER_UPS.EXTRA_LIFE:
+      lives += 1;
+      break;
+    default:
+      break;
+  }
+  return lives;
 }
 
 export function updatePowerUps(list) {

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -8,6 +8,7 @@ import {
   spawnPowerUp,
   updatePowerUps,
   POWER_UPS,
+  applyPowerUp,
   createSeededRNG,
 } from './asteroids-utils';
 import useGameControls from './useGameControls';
@@ -564,8 +565,7 @@ const Asteroids = () => {
       powerUps.forEach((p, i) => {
         const dist = Math.hypot(p.x - ship.x, p.y - ship.y);
         if (dist < p.r + ship.r) {
-        if (p.type === POWER_UPS.SHIELD) ship.shield = SHIELD_DURATION;
-          else ship.rapidFire = 600;
+          lives = applyPowerUp(p, ship, lives, SHIELD_DURATION);
           powerUps.splice(i, 1);
         }
       });

--- a/games/asteroids/powerups/index.ts
+++ b/games/asteroids/powerups/index.ts
@@ -1,0 +1,15 @@
+export const POWER_UPS = {
+  SHIELD: 'shield',
+  RAPID_FIRE: 'rapid-fire',
+  EXTRA_LIFE: 'extra-life',
+} as const;
+
+export type PowerUpType = (typeof POWER_UPS)[keyof typeof POWER_UPS];
+
+export interface PowerUp {
+  type: PowerUpType;
+  x: number;
+  y: number;
+  r: number;
+  life: number;
+}


### PR DESCRIPTION
## Summary
- centralize power-up types for Asteroids
- spawn random power-ups and apply their effects on pickup
- test power-up spawn and effects

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b185d26cb88328a91f820b21fffccf