### PR TITLE
feat(nonogram): add random hints with usage limits

### DIFF
--- a/__tests__/nonogramGame.test.ts
+++ b/__tests__/nonogramGame.test.ts
@@ -1,10 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  checkContradictions,
-  autoFill,
-  createHintSystem,
-} from '../apps/games/nonogram/logic';
+import { checkContradictions, autoFill } from '../apps/games/nonogram/logic';
+import { createHintSystem, revealRandomCell } from '../apps/games/nonogram/hints';
 import {
   parsePack,
   loadPackFromJSON,
@@ -46,13 +43,29 @@ describe('games/nonogram logic', () => {
   });
 
   test('hint system enforces usage limit', () => {
-    const rows = [[1]];
-    const cols = [[1]];
-    const grid = [[0]];
+    const grid = [[0]] as (0 | 1 | -1)[][];
+    const solution = [[1]] as (0 | 1)[][];
     const hints = createHintSystem(1);
-    expect(hints.useHint(rows, cols, grid)).toEqual({ i: 0, j: 0, value: 1 });
-    expect(hints.useHint(rows, cols, grid)).toBeNull();
+    expect(hints.useHint(grid, solution)).toEqual({ i: 0, j: 0, value: 1 });
+    expect(hints.useHint(grid, solution)).toBeNull();
     expect(hints.remaining()).toBe(0);
+  });
+
+  test('random hint reveals a correct cell', () => {
+    const grid = [
+      [0, 0],
+      [0, 0],
+    ] as (0 | 1 | -1)[][];
+    const solution = [
+      [1, 0],
+      [0, 1],
+    ] as (0 | 1)[][];
+    const hint = revealRandomCell(grid, solution);
+    expect(hint).not.toBeNull();
+    if (hint) {
+      expect(solution[hint.i][hint.j]).toBe(1);
+      expect(grid[hint.i][hint.j]).not.toBe(1);
+    }
   });
 
   test('loads puzzle packs from JSON files', () => {

--- a/apps/games/nonogram/hints.ts
+++ b/apps/games/nonogram/hints.ts
@@ -1,0 +1,40 @@
+import type { Grid } from './logic';
+
+export interface Hint {
+  i: number;
+  j: number;
+  value: 1;
+}
+
+// Reveal a random correct filled cell from the solution that is not yet filled in the grid
+export const revealRandomCell = (grid: Grid, solution: Grid): Hint | null => {
+  const candidates: { i: number; j: number }[] = [];
+  for (let i = 0; i < solution.length; i++) {
+    for (let j = 0; j < solution[i].length; j++) {
+      if (solution[i][j] === 1 && grid[i][j] !== 1) {
+        candidates.push({ i, j });
+      }
+    }
+  }
+  if (!candidates.length) return null;
+  const pick = candidates[Math.floor(Math.random() * candidates.length)];
+  return { i: pick.i, j: pick.j, value: 1 };
+};
+
+// Hint system that limits the number of hints available per puzzle
+export const createHintSystem = (maxHints: number) => {
+  let used = 0;
+  return {
+    useHint(grid: Grid, solution: Grid): Hint | null {
+      if (used >= maxHints) return null;
+      const hint = revealRandomCell(grid, solution);
+      if (hint) used += 1;
+      return hint;
+    },
+    remaining(): number {
+      return maxHints - used;
+    },
+  };
+};
+
+export default { revealRandomCell, createHintSystem };

--- a/apps/games/nonogram/logic.ts
+++ b/apps/games/nonogram/logic.ts
@@ -149,22 +149,6 @@ export const autoFill = (grid: Grid, rows: Clue[], cols: Clue[]): Grid => {
   return g;
 };
 
-// Simple hint system with limited uses
-export const createHintSystem = (maxHints: number) => {
-  let used = 0;
-  return {
-    useHint(rows: Clue[], cols: Clue[], grid: Grid) {
-      if (used >= maxHints) return null;
-      const hint = findHint(rows, cols, grid);
-      if (hint) used += 1;
-      return hint;
-    },
-    remaining() {
-      return maxHints - used;
-    },
-  };
-};
-
 export default {
   lineToClues,
   generateLinePatterns,
@@ -175,5 +159,4 @@ export default {
   checkContradictions,
   toggleCross,
   autoFill,
-  createHintSystem,
 };


### PR DESCRIPTION
## Summary
- add hint utilities to reveal a random correct cell
- track hint usage and enforce per-puzzle limits
- test random hint functionality and usage limits

## Testing
- `yarn test __tests__/nonogramGame.test.ts __tests__/nonogram.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b185e791e48328a653a19241b6d243