### PR TITLE
feat(pinball): add accelerometer tilt detection

### DIFF
--- a/__tests__/pinballTilt.test.ts
+++ b/__tests__/pinballTilt.test.ts
@@ -1,0 +1,11 @@
+import { shouldTilt } from '../apps/pinball/tilt';
+
+describe('pinball tilt sensor', () => {
+  test('detects when acceleration exceeds threshold', () => {
+    expect(shouldTilt({ x: 10, y: 0, z: 0 }, 5)).toBe(true);
+  });
+
+  test('does not trigger below threshold', () => {
+    expect(shouldTilt({ x: 1, y: 1, z: 1 }, 5)).toBe(false);
+  });
+});

--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Engine, Render, World, Bodies, Body, Runner } from 'matter-js';
+import { useTiltSensor } from './tilt';
 
 const themes: Record<string, { bg: string; flipper: string }> = {
   classic: { bg: '#0b3d91', flipper: '#ffd700' },
@@ -20,6 +21,16 @@ export default function Pinball() {
   const [bounce, setBounce] = useState(0.5);
   const [tilt, setTilt] = useState(false);
   const nudgesRef = useRef<number[]>([]);
+
+  const handleTilt = useCallback(() => {
+    setTilt(true);
+    setTimeout(() => {
+      setTilt(false);
+      nudgesRef.current = [];
+    }, 3000);
+  }, []);
+
+  useTiltSensor(25, handleTilt);
 
   useEffect(() => {
     if (!canvasRef.current) return;

--- a/apps/pinball/tilt.ts
+++ b/apps/pinball/tilt.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export const shouldTilt = (
+  acc: DeviceMotionEventAcceleration | null,
+  threshold: number,
+): boolean => {
+  if (!acc) return false;
+  const { x = 0, y = 0, z = 0 } = acc;
+  const magnitude = Math.sqrt(x * x + y * y + z * z);
+  return magnitude > threshold;
+};
+
+export const useTiltSensor = (
+  threshold: number,
+  onTilt: () => void,
+): void => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (e: DeviceMotionEvent) => {
+      if (shouldTilt(e.accelerationIncludingGravity, threshold)) onTilt();
+    };
+    let listening = false;
+    const start = () => {
+      window.addEventListener('devicemotion', handler);
+      listening = true;
+    };
+    const D = (window as any).DeviceMotionEvent;
+    if (typeof D?.requestPermission === 'function') {
+      D.requestPermission().then((res: string) => {
+        if (res === 'granted') start();
+      });
+    } else if (D) {
+      start();
+    }
+    return () => {
+      if (listening) window.removeEventListener('devicemotion', handler);
+    };
+  }, [threshold, onTilt]);
+};


### PR DESCRIPTION
## Summary
- monitor device motion for pinball tilt
- integrate tilt penalty when acceleration threshold exceeded
- test tilt detection logic

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b185ef73488328a04b126a89c85b9b