### PR TITLE
feat: add platformer checkpoints

### DIFF
--- a/apps/phaser_matter/gameLogic.ts
+++ b/apps/phaser_matter/gameLogic.ts
@@ -19,13 +19,21 @@ export class GameState {
   }
 
   /**
+   * Returns the current respawn position, preferring the last checkpoint
+   * if one has been recorded.
+   */
+  getRespawnPoint(): Point {
+    return this.checkpoint ? { ...this.checkpoint } : { ...this.spawn };
+  }
+
+  /**
    * Returns the position a player should respawn to when falling below
    * the provided boundary. If the player is above the boundary their
    * current position is returned.
    */
   respawnIfOutOfBounds(player: Point, boundaryY: number): Point {
     if (player.y > boundaryY) {
-      return this.checkpoint ? { ...this.checkpoint } : { ...this.spawn };
+      return this.getRespawnPoint();
     }
     return player;
   }

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -211,7 +211,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
               this.state.setCheckpoint({ x: body.position.x, y: body.position.y });
             }
             if (body.label === 'hazard') {
-              const s = this.state.checkpoint || this.state.spawn;
+              const s = this.state.getRespawnPoint();
               this.player.setPosition(s.x, s.y);
               this.player.setVelocity(0, 0);
             }

--- a/public/apps/phaser_matter/level1.json
+++ b/public/apps/phaser_matter/level1.json
@@ -12,7 +12,8 @@
     { "x": 600, "y": 570, "width": 40, "height": 40 }
   ],
   "checkpoints": [
-    { "x": 700, "y": 540, "width": 20, "height": 60 }
+    { "x": 700, "y": 540, "width": 20, "height": 60 },
+    { "x": 1200, "y": 540, "width": 20, "height": 60 }
   ],
   "bounds": { "width": 1600, "height": 600, "deadZoneWidth": 200, "deadZoneHeight": 100, "fallY": 800 }
 }


### PR DESCRIPTION
## Summary
- support respawn logic with helper in `GameState`
- respawn from hazards via last checkpoint
- add an extra checkpoint marker in Phaser platformer level

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, vscode, kismet)*


------
https://chatgpt.com/codex/tasks/task_e_68b185f6163483288b368342a7ac8d10