### PR TITLE
refactor settings into tabs

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,16 +1,16 @@
-'use client';
+"use client";
 
-import { useState, useRef } from 'react';
-import { useSettings } from '../../hooks/useSettings';
-import BackgroundSlideshow from './components/BackgroundSlideshow';
+import { useState, useRef } from "react";
+import { useSettings } from "../../hooks/useSettings";
+import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
   defaults,
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
-} from '../../utils/settingsStore';
-import { getTheme, setTheme } from '../../utils/theme';
-import KeymapOverlay from './components/KeymapOverlay';
+} from "../../utils/settingsStore";
+import { getTheme, setTheme } from "../../utils/theme";
+import KeymapOverlay from "./components/KeymapOverlay";
 
 export default function Settings() {
   const {
@@ -30,26 +30,34 @@ export default function Settings() {
   const [theme, setThemeState] = useState<string>(getTheme());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const tabs = [
+    { id: "appearance", label: "Appearance" },
+    { id: "accessibility", label: "Accessibility" },
+    { id: "privacy", label: "Privacy" },
+  ] as const;
+  type TabId = (typeof tabs)[number]["id"];
+  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+
   const wallpapers = [
-    'wall-1',
-    'wall-2',
-    'wall-3',
-    'wall-4',
-    'wall-5',
-    'wall-6',
-    'wall-7',
-    'wall-8',
+    "wall-1",
+    "wall-2",
+    "wall-3",
+    "wall-4",
+    "wall-5",
+    "wall-6",
+    "wall-7",
+    "wall-8",
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
     const data = await exportSettingsData();
-    const blob = new Blob([data], { type: 'application/json' });
+    const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'settings.json';
+    a.download = "settings.json";
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -72,7 +80,7 @@ export default function Settings() {
         setTheme(parsed.theme);
       }
     } catch (err) {
-      console.error('Invalid settings', err);
+      console.error("Invalid settings", err);
     }
   };
 
@@ -84,153 +92,199 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
-    setThemeState('default');
-    setTheme('default');
+    setThemeState("default");
+    setTheme("default");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
-      <div
-        className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-        style={{
-          backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-          backgroundSize: 'cover',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'center center',
-        }}
-      ></div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey">Theme:</label>
-        <select
-          value={theme}
-          onChange={(e) => {
-            setThemeState(e.target.value);
-            setTheme(e.target.value);
-          }}
-          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-        >
-          <option value="default">Default</option>
-          <option value="dark">Dark</option>
-          <option value="neon">Neon</option>
-          <option value="matrix">Matrix</option>
-        </select>
+      <div className="flex justify-center border-b border-gray-900">
+        <div role="tablist" className="flex">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={activeTab === t.id}
+              tabIndex={activeTab === t.id ? 0 : -1}
+              onClick={() => setActiveTab(t.id)}
+              className={`px-4 py-2 focus:outline-none ${
+                activeTab === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey">Accent:</label>
-        <input
-          type="color"
-          aria-label="Accent color picker"
-          value={accent}
-          onChange={(e) => setAccent(e.target.value)}
-          className="w-10 h-10 border border-ubt-cool-grey bg-ub-cool-grey"
-        />
-      </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey">Wallpaper:</label>
-        <input
-          type="range"
-          min="0"
-          max={wallpapers.length - 1}
-          step="1"
-          value={wallpapers.indexOf(wallpaper)}
-          onChange={(e) =>
-            changeBackground(wallpapers[parseInt(e.target.value, 10)])
-          }
-          className="ubuntu-slider"
-        />
-      </div>
-      <div className="flex justify-center my-4">
-        <BackgroundSlideshow />
-      </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey">Icon Size:</label>
-        <input
-          type="range"
-          min="0.75"
-          max="1.5"
-          step="0.05"
-          value={fontScale}
-          onChange={(e) => setFontScale(parseFloat(e.target.value))}
-          className="ubuntu-slider"
-        />
-      </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey">Density:</label>
-        <select
-          value={density}
-          onChange={(e) => setDensity(e.target.value as any)}
-          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-        >
-          <option value="regular">Regular</option>
-          <option value="compact">Compact</option>
-        </select>
-      </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey flex items-center">
-          <input
-            type="checkbox"
-            checked={reducedMotion}
-            onChange={(e) => setReducedMotion(e.target.checked)}
-            className="mr-2"
-          />
-          Reduced Motion
-        </label>
-      </div>
-      <div className="flex justify-center my-4">
-        <label className="mr-2 text-ubt-grey flex items-center">
-          <input
-            type="checkbox"
-            checked={highContrast}
-            onChange={(e) => setHighContrast(e.target.checked)}
-            className="mr-2"
-          />
-          High Contrast
-        </label>
-      </div>
-      <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
-        {wallpapers.map((name) => (
+      {activeTab === "appearance" && (
+        <>
           <div
-            key={name}
-            role="button"
-            aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
-            aria-pressed={name === wallpaper}
-            tabIndex={0}
-            onClick={() => changeBackground(name)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                changeBackground(name);
-              }
-            }}
-            className={
-              (name === wallpaper ? ' border-yellow-700 ' : ' border-transparent ') +
-              ' md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80'
-            }
+            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
             style={{
-              backgroundImage: `url(/wallpapers/${name}.webp)`,
-              backgroundSize: 'cover',
-              backgroundRepeat: 'no-repeat',
-              backgroundPosition: 'center center',
+              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+              backgroundSize: "cover",
+              backgroundRepeat: "no-repeat",
+              backgroundPosition: "center center",
             }}
           ></div>
-        ))}
-      </div>
-      <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
-        <button onClick={handleExport} className="px-4 py-2 rounded bg-ub-orange text-white">
-          Export Settings
-        </button>
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className="px-4 py-2 rounded bg-ub-orange text-white"
-        >
-          Import Settings
-        </button>
-        <button onClick={handleReset} className="px-4 py-2 rounded bg-ub-orange text-white">
-          Reset Desktop
-        </button>
-      </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Theme:</label>
+            <select
+              value={theme}
+              onChange={(e) => {
+                setThemeState(e.target.value);
+                setTheme(e.target.value);
+              }}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="default">Default</option>
+              <option value="dark">Dark</option>
+              <option value="neon">Neon</option>
+              <option value="matrix">Matrix</option>
+            </select>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Accent:</label>
+            <input
+              type="color"
+              aria-label="Accent color picker"
+              value={accent}
+              onChange={(e) => setAccent(e.target.value)}
+              className="w-10 h-10 border border-ubt-cool-grey bg-ub-cool-grey"
+            />
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Wallpaper:</label>
+            <input
+              type="range"
+              min="0"
+              max={wallpapers.length - 1}
+              step="1"
+              value={wallpapers.indexOf(wallpaper)}
+              onChange={(e) =>
+                changeBackground(wallpapers[parseInt(e.target.value, 10)])
+              }
+              className="ubuntu-slider"
+            />
+          </div>
+          <div className="flex justify-center my-4">
+            <BackgroundSlideshow />
+          </div>
+          <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
+            {wallpapers.map((name) => (
+              <div
+                key={name}
+                role="button"
+                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                aria-pressed={name === wallpaper}
+                tabIndex={0}
+                onClick={() => changeBackground(name)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    changeBackground(name);
+                  }
+                }}
+                className={
+                  (name === wallpaper
+                    ? " border-yellow-700 "
+                    : " border-transparent ") +
+                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+                }
+                style={{
+                  backgroundImage: `url(/wallpapers/${name}.webp)`,
+                  backgroundSize: "cover",
+                  backgroundRepeat: "no-repeat",
+                  backgroundPosition: "center center",
+                }}
+              ></div>
+            ))}
+          </div>
+        </>
+      )}
+      {activeTab === "accessibility" && (
+        <>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Icon Size:</label>
+            <input
+              type="range"
+              min="0.75"
+              max="1.5"
+              step="0.05"
+              value={fontScale}
+              onChange={(e) => setFontScale(parseFloat(e.target.value))}
+              className="ubuntu-slider"
+            />
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Density:</label>
+            <select
+              value={density}
+              onChange={(e) => setDensity(e.target.value as any)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="regular">Regular</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey flex items-center">
+              <input
+                type="checkbox"
+                checked={reducedMotion}
+                onChange={(e) => setReducedMotion(e.target.checked)}
+                className="mr-2"
+              />
+              Reduced Motion
+            </label>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey flex items-center">
+              <input
+                type="checkbox"
+                checked={highContrast}
+                onChange={(e) => setHighContrast(e.target.checked)}
+                className="mr-2"
+              />
+              High Contrast
+            </label>
+          </div>
+          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+            <button
+              onClick={() => setShowKeymap(true)}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Edit Shortcuts
+            </button>
+          </div>
+        </>
+      )}
+      {activeTab === "privacy" && (
+        <>
+          <div className="flex justify-center my-4 space-x-4">
+            <button
+              onClick={handleExport}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Export Settings
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Import Settings
+            </button>
+            <button
+              onClick={handleReset}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Reset Desktop
+            </button>
+          </div>
+        </>
+      )}
       <input
         type="file"
         accept="application/json"
@@ -238,20 +292,11 @@ export default function Settings() {
         onChange={(e) => {
           const file = e.target.files && e.target.files[0];
           if (file) handleImport(file);
-          e.target.value = '';
+          e.target.value = "";
         }}
         className="hidden"
       />
-      <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-        <button
-          onClick={() => setShowKeymap(true)}
-          className="px-4 py-2 rounded bg-ub-orange text-white"
-        >
-          Edit Shortcuts
-        </button>
-      </div>
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- refactor settings page to include tab navigation
- organize appearance, accessibility, and privacy options

## Testing
- `npx prettier apps/settings/index.tsx --check`
- `yarn lint apps/settings/index.tsx` *(fails: ESLint couldn't find an eslint.config.js)*
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1863960ec8328941f26fe9d3545f2