### PR TITLE
feat(autopsy): persist expanded nodes

### DIFF
--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -1,15 +1,72 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import AutopsyApp from '../../components/apps/autopsy';
 import events from './events.json';
 import KeywordTester from './components/KeywordTester';
 
 const AutopsyPage: React.FC = () => {
+  // Track which view is active so we can restore UI state when toggling
+  const [view, setView] = useState<'autopsy' | 'keywords'>('autopsy');
+  // Store a list of expanded file tree nodes and sync with the URL hash
+  const [expandedNodes, setExpandedNodes] = useState<string[]>([]);
+
+  // Restore view and expanded nodes from the URL hash on first load
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const viewParam = params.get('view');
+    const expandedParam = params.get('expanded');
+    if (viewParam === 'keywords' || viewParam === 'autopsy') {
+      setView(viewParam);
+    }
+    if (expandedParam) {
+      setExpandedNodes(expandedParam.split(',').filter(Boolean));
+    }
+  }, []);
+
+  // Persist current view/expanded nodes to the URL hash
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    params.set('view', view);
+    if (expandedNodes.length > 0) {
+      params.set('expanded', expandedNodes.join(','));
+    } else {
+      params.delete('expanded');
+    }
+    const newHash = params.toString();
+    window.location.hash = newHash ? `#${newHash}` : '';
+  }, [view, expandedNodes]);
+
   return (
     <div className="space-y-4">
-      <AutopsyApp initialArtifacts={events.artifacts} />
-      <KeywordTester />
+      <div className="flex space-x-2">
+        <button
+          className={`px-2 py-1 rounded ${
+            view === 'autopsy' ? 'bg-ub-grey text-white' : 'bg-ub-orange text-black'
+          }`}
+          onClick={() => setView('autopsy')}
+        >
+          Autopsy
+        </button>
+        <button
+          className={`px-2 py-1 rounded ${
+            view === 'keywords' ? 'bg-ub-grey text-white' : 'bg-ub-orange text-black'
+          }`}
+          onClick={() => setView('keywords')}
+        >
+          Keyword Tester
+        </button>
+      </div>
+      {view === 'autopsy' && (
+        <AutopsyApp
+          initialArtifacts={events.artifacts}
+          expandedNodes={expandedNodes}
+          onExpandedNodesChange={setExpandedNodes}
+        />
+      )}
+      {view === 'keywords' && <KeywordTester />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- preserve Autopsy tree expansion state by syncing to URL hash
- allow switching between Autopsy and Keyword Tester views without losing state

## Testing
- `yarn test` *(fails: game2048, BeEF, mimikatz, kismet, vscode, metasploit)*
- `npx eslint apps/autopsy/index.tsx` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1864d6e8c83289b830b70d8ad5ec7