### PR TITLE
Add PNG download button to QR generator

### DIFF
--- a/apps/qr/index.tsx
+++ b/apps/qr/index.tsx
@@ -1,5 +1,31 @@
 'use client';
+
+import { useRef } from 'react';
 import Presets from './components/Presets';
 
-export default Presets;
+export default function QR() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const downloadPng = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = 'qr.png';
+    link.click();
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full overflow-auto">
+      <Presets canvasRef={canvasRef} />
+      <button
+        type="button"
+        onClick={downloadPng}
+        className="px-2 py-1 bg-blue-600 rounded"
+      >
+        Download PNG
+      </button>
+    </div>
+  );
+}
 


### PR DESCRIPTION
## Summary
- add download button to QR app to save generated code as PNG
- render QR codes to a canvas for export

## Testing
- `yarn lint apps/qr/index.tsx apps/qr/components/Presets.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test apps/qr` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1864c6a188328a5f6516f41c60bc7