### PR TITLE
feat(kismet): highlight newly discovered networks

### DIFF
--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -1,13 +1,24 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import KismetApp from '../../components/apps/kismet';
 import DeauthWalkthrough from './components/DeauthWalkthrough';
 
 const KismetPage: React.FC = () => {
+  const handleNetworkDiscovered = useCallback(
+    (net: { ssid: string; bssid: string; discoveredAt: number }) => {
+      console.log(
+        `Network ${net.ssid || net.bssid} discovered at ${new Date(
+          net.discoveredAt,
+        ).toLocaleTimeString()}`,
+      );
+    },
+    [],
+  );
+
   return (
     <>
-      <KismetApp />
+      <KismetApp onNetworkDiscovered={handleNetworkDiscovered} />
       <DeauthWalkthrough />
     </>
   );


### PR DESCRIPTION
## Summary
- highlight new networks briefly when they appear in Kismet
- log discovery timestamps for networks in Kismet page

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: kismet, vscode, mimikatz, game2048, beef test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b18649d9ac8328975b2204d6281893