### PR TITLE
feat(metasploit): add loading spinner

### DIFF
--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -1,13 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import MetasploitApp from '../../components/apps/metasploit';
 import TargetEmulator from './components/TargetEmulator';
 
 const MetasploitPage: React.FC = () => {
+  const [loading, setLoading] = useState(false);
   return (
     <div className="space-y-4">
-      <MetasploitApp />
+      {loading && (
+        <div className="flex justify-center" aria-label="Command running">
+          <div className="h-8 w-8 border-4 border-blue-400 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+      <MetasploitApp onLoadingChange={setLoading} />
       <TargetEmulator />
     </div>
   );

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -18,6 +18,7 @@ const banner = `Metasploit Framework Console (mock)\nFor legal and ethical use o
 
 const MetasploitApp = ({
   demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true',
+  onLoadingChange = () => {},
 } = {}) => {
   const [command, setCommand] = useState('');
   const [output, setOutput] = usePersistentState('metasploit-history', banner);
@@ -37,6 +38,10 @@ const MetasploitApp = ({
   const [timeline, setTimeline] = useState([]);
   const [replaying, setReplaying] = useState(false);
   const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    onLoadingChange(loading);
+  }, [loading, onLoadingChange]);
 
   const workerRef = useRef();
   const moduleRaf = useRef();
@@ -142,23 +147,28 @@ const MetasploitApp = ({
   };
 
   const runDemo = async () => {
-    const exploit = modules[0];
-    const post = modules.find((m) => m.type === 'post');
-    if (!exploit || !post) return;
-    setOutput(
-      (prev) =>
-        `${prev}\nmsf6 > use ${exploit.name}\n${exploit.transcript || ''}`
-    );
-    await new Promise((r) => setTimeout(r, 500));
-    setOutput(
-      (prev) =>
-        `${prev}\nmsf6 exploit(${exploit.name}) > sessions -i 1\n[*] Session 1 opened`
-    );
-    await new Promise((r) => setTimeout(r, 500));
-    setOutput(
-      (prev) =>
-        `${prev}\nmsf6 exploit(${exploit.name}) > run ${post.name}\n${post.transcript || ''}`
-    );
+    setLoading(true);
+    try {
+      const exploit = modules[0];
+      const post = modules.find((m) => m.type === 'post');
+      if (!exploit || !post) return;
+      setOutput(
+        (prev) =>
+          `${prev}\nmsf6 > use ${exploit.name}\n${exploit.transcript || ''}`
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      setOutput(
+        (prev) =>
+          `${prev}\nmsf6 exploit(${exploit.name}) > sessions -i 1\n[*] Session 1 opened`
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      setOutput(
+        (prev) =>
+          `${prev}\nmsf6 exploit(${exploit.name}) > run ${post.name}\n${post.transcript || ''}`
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   const showModule = (mod) => {


### PR DESCRIPTION
## Summary
- show loading spinner on Metasploit page while commands execute
- expose Metasploit app loading state via callback and wrap demo in loading state

## Testing
- `yarn test apps/metasploit/components/TargetEmulator.test.tsx`
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx)*
- `npx eslint apps/metasploit/index.tsx components/apps/metasploit/index.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b18640fee08328bdc775f378c474fd