### PR TITLE
Add Frogger level layouts and random theme selection

### DIFF
--- a/apps/games/frogger/config.ts
+++ b/apps/games/frogger/config.ts
@@ -86,3 +86,8 @@ export const getDefaultSkin = (): SkinName => {
   if (m < 9) return 'summer';
   return 'autumn';
 };
+
+export const getRandomSkin = (): SkinName => {
+  const names = Object.keys(SKINS) as SkinName[];
+  return names[Math.floor(Math.random() * names.length)];
+};

--- a/apps/games/frogger/levels.ts
+++ b/apps/games/frogger/levels.ts
@@ -1,0 +1,70 @@
+import type { LaneConfiguration } from './config';
+
+/**
+ * Predefined level layouts for Frogger.
+ * Each level specifies the arrangement of car and log lanes.
+ * Higher levels introduce additional lanes and faster defaults.
+ */
+export const LEVELS: LaneConfiguration[] = [
+  {
+    cars: [
+      { y: 4, dir: 1, speed: 1, spawnRate: 2, length: 1 },
+      { y: 5, dir: -1, speed: 1.2, spawnRate: 1.8, length: 1 },
+    ],
+    logs: [
+      { y: 1, dir: -1, speed: 0.5, spawnRate: 2.5, length: 2 },
+      { y: 2, dir: 1, speed: 0.7, spawnRate: 2.2, length: 2 },
+    ],
+  },
+  {
+    cars: [
+      { y: 4, dir: 1, speed: 1, spawnRate: 2, length: 1 },
+      { y: 5, dir: -1, speed: 1.2, spawnRate: 1.8, length: 1 },
+      { y: 6, dir: 1, speed: 1.3, spawnRate: 1.6, length: 1 },
+    ],
+    logs: [
+      { y: 1, dir: -1, speed: 0.6, spawnRate: 2.2, length: 2 },
+      { y: 2, dir: 1, speed: 0.8, spawnRate: 2, length: 2 },
+    ],
+  },
+  {
+    cars: [
+      { y: 3, dir: -1, speed: 1.2, spawnRate: 1.8, length: 1 },
+      { y: 4, dir: 1, speed: 1.3, spawnRate: 1.7, length: 1 },
+      { y: 5, dir: -1, speed: 1.5, spawnRate: 1.6, length: 1 },
+      { y: 6, dir: 1, speed: 1.6, spawnRate: 1.5, length: 1 },
+    ],
+    logs: [
+      { y: 1, dir: -1, speed: 0.7, spawnRate: 1.9, length: 3 },
+      { y: 2, dir: 1, speed: 0.9, spawnRate: 1.8, length: 2 },
+    ],
+  },
+  {
+    cars: [
+      { y: 3, dir: 1, speed: 1.4, spawnRate: 1.6, length: 1 },
+      { y: 4, dir: -1, speed: 1.6, spawnRate: 1.5, length: 1 },
+      { y: 5, dir: 1, speed: 1.8, spawnRate: 1.4, length: 1 },
+      { y: 6, dir: -1, speed: 1.9, spawnRate: 1.3, length: 2 },
+    ],
+    logs: [
+      { y: 1, dir: -1, speed: 0.8, spawnRate: 1.7, length: 3 },
+      { y: 2, dir: 1, speed: 1.0, spawnRate: 1.6, length: 2 },
+    ],
+  },
+  {
+    cars: [
+      { y: 3, dir: 1, speed: 1.6, spawnRate: 1.4, length: 1 },
+      { y: 4, dir: -1, speed: 1.8, spawnRate: 1.3, length: 1 },
+      { y: 5, dir: 1, speed: 2, spawnRate: 1.2, length: 2 },
+      { y: 6, dir: -1, speed: 2.2, spawnRate: 1.1, length: 2 },
+    ],
+    logs: [
+      { y: 1, dir: -1, speed: 0.9, spawnRate: 1.5, length: 3 },
+      { y: 2, dir: 1, speed: 1.1, spawnRate: 1.4, length: 3 },
+    ],
+  },
+];
+
+export const getLevelConfig = (level: number): LaneConfiguration =>
+  LEVELS[(level - 1) % LEVELS.length];
+

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -4,8 +4,9 @@ import { vibrate } from './Games/common/haptics';
 import {
   generateLaneConfig,
   SKINS,
-  getDefaultSkin,
+  getRandomSkin,
 } from '../../apps/games/frogger/config';
+import { getLevelConfig } from '../../apps/games/frogger/levels';
 
 const WIDTH = 7;
 const HEIGHT = 8;
@@ -114,7 +115,11 @@ const updateLogs = (prev, frogPos, dt) => {
 const Frogger = () => {
   const [frog, setFrog] = useState(initialFrog);
   const frogRef = useRef(frog);
-  const initialLanes = generateLaneConfig(1, DIFFICULTY_MULTIPLIERS.normal);
+  const initialLanes = generateLaneConfig(
+    1,
+    DIFFICULTY_MULTIPLIERS.normal,
+    getLevelConfig(1),
+  );
   const [cars, setCars] = useState(
     initialLanes.cars.map((l, i) => initLane(l, i + 1)),
   );
@@ -145,7 +150,7 @@ const Frogger = () => {
   const splashesRef = useRef([]);
   const [slowTime, setSlowTime] = useState(false);
   const slowTimeRef = useRef(slowTime);
-  const [skin, setSkin] = useState(getDefaultSkin());
+  const [skin, setSkin] = useState(getRandomSkin);
   const [showHitboxes, setShowHitboxes] = useState(false);
   const deathStreakRef = useRef(0);
   const safeFlashRef = useRef(0);
@@ -272,7 +277,8 @@ const Frogger = () => {
     (full = false, diff = difficulty, lvl = level) => {
       setFrog(initialFrog);
       const mult = DIFFICULTY_MULTIPLIERS[diff];
-      const lanes = generateLaneConfig(lvl, mult);
+      const base = getLevelConfig(lvl);
+      const lanes = generateLaneConfig(lvl, mult, base);
       setCars(lanes.cars.map((l, i) => initLane(l, i + 1)));
       setLogs(lanes.logs.map((l, i) => initLane(l, i + 101)));
       setStatus('');
@@ -281,6 +287,7 @@ const Frogger = () => {
         setLives(3);
         setPads(PAD_POSITIONS.map(() => false));
         setLevel(1);
+        setSkin(getRandomSkin());
         nextLife.current = 500;
         deathStreakRef.current = 0;
         ReactGA.event({


### PR DESCRIPTION
## Summary
- add predefined Frogger level layouts and helper to cycle through them
- randomize Frogger skin on game start and full reset
- integrate level layouts into game reset logic

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b185fdf3788328a83b8d596c570ca0