### PR TITLE
Add skin selection for Flappy Bird

### DIFF
--- a/apps/games/flappy-bird/skins.ts
+++ b/apps/games/flappy-bird/skins.ts
@@ -1,4 +1,7 @@
-export const BIRD_SKINS = ['yellow', 'red', 'blue'];
+export const BIRD_SKINS = ['yellow', 'red', 'blue'] as const;
+export const BIRD_ASSETS = BIRD_SKINS.map(
+  (name) => `/apps/flappy/skins/${name}.svg`
+);
 export type RGB = [number, number, number];
 export const PIPE_SKINS: [RGB, RGB][] = [
   [[34, 139, 34], [144, 238, 144]],

--- a/public/apps/flappy/skins/blue.svg
+++ b/public/apps/flappy/skins/blue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="10" fill="blue" />
+</svg>

--- a/public/apps/flappy/skins/red.svg
+++ b/public/apps/flappy/skins/red.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="10" fill="red" />
+</svg>

--- a/public/apps/flappy/skins/yellow.svg
+++ b/public/apps/flappy/skins/yellow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="10" fill="yellow" />
+</svg>


### PR DESCRIPTION
## Summary
- load bird skin assets from `/apps/flappy/skins`
- allow choosing bird and pipe skins before starting the game
- render bird using selected skin image

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/vscode.test.tsx, __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b185ede8c0832889f034fd24c3c438