### PR TITLE
feat(solitaire): toggle draw mode and persist preference

### DIFF
--- a/__tests__/solitaireLogic.test.ts
+++ b/__tests__/solitaireLogic.test.ts
@@ -1,0 +1,17 @@
+import { initGame, draw, setDrawMode } from '../apps/games/solitaire/logic';
+import { reset } from '../apps/games/rng';
+
+describe('solitaire logic draw mode', () => {
+  test('switching modes resets waste and changes draw count', () => {
+    reset();
+    const state = initGame('draw3');
+    draw(state);
+    expect(state.waste.length).toBe(3);
+    setDrawMode(state, 'draw1');
+    expect(state.drawMode).toBe('draw1');
+    expect(state.waste.length).toBe(0);
+    draw(state);
+    expect(state.waste.length).toBe(1);
+  });
+});
+

--- a/apps/games/solitaire/logic.ts
+++ b/apps/games/solitaire/logic.ts
@@ -13,6 +13,7 @@ export interface GameState {
   waste: Card[];
   foundations: Record<Suit, Card[]>;
   tableau: Card[][];
+  drawMode: 'draw1' | 'draw3';
 }
 
 const suits: Suit[] = ['♠', '♥', '♦', '♣'];
@@ -34,7 +35,7 @@ const shuffle = (deck: Card[]) => {
   }
 };
 
-export const initGame = (): GameState => {
+export const initGame = (drawMode: 'draw1' | 'draw3' = 'draw1'): GameState => {
   const deck = createDeck();
   shuffle(deck);
   const tableau: Card[][] = [];
@@ -57,15 +58,29 @@ export const initGame = (): GameState => {
       '♣': [],
     },
     tableau,
+    drawMode,
   };
 };
 
-export const draw = (state: GameState, mode: 'draw1' | 'draw3') => {
+export const setDrawMode = (state: GameState, mode: 'draw1' | 'draw3') => {
+  if (state.drawMode === mode) return;
+  state.drawMode = mode;
+  state.stock = [...state.stock, ...state.waste.reverse()].map((c) => ({
+    ...c,
+    faceDown: true,
+  }));
+  state.waste = [];
+};
+
+export const toggleDrawMode = (state: GameState) =>
+  setDrawMode(state, state.drawMode === 'draw1' ? 'draw3' : 'draw1');
+
+export const draw = (state: GameState) => {
   if (state.stock.length === 0) {
     state.stock = state.waste.reverse().map((c) => ({ ...c, faceDown: true }));
     state.waste = [];
   }
-  const count = Math.min(mode === 'draw1' ? 1 : 3, state.stock.length);
+  const count = Math.min(state.drawMode === 'draw1' ? 1 : 3, state.stock.length);
   for (let i = 0; i < count; i += 1) {
     const card = state.stock.shift()!;
     card.faceDown = false;

--- a/apps/solitaire/index.tsx
+++ b/apps/solitaire/index.tsx
@@ -10,22 +10,27 @@ import {
   cardToString,
   Suit,
   Card,
+  setDrawMode,
 } from '../games/solitaire/logic';
 
 const Solitaire = () => {
-  const [state, setState] = useState<GameState>(() => initGame());
-  const [drawMode, setDrawMode] = useState<'draw1' | 'draw3'>('draw1');
+  const getStoredMode = (): 'draw1' | 'draw3' => {
+    if (typeof window === 'undefined') return 'draw1';
+    return (localStorage.getItem('solitaire-mode') as 'draw1' | 'draw3' | null) || 'draw1';
+  };
+
+  const [state, setState] = useState<GameState>(() => initGame(getStoredMode()));
   const [hint, setHint] = useState<string | null>(null);
 
   const refresh = () => setState({ ...state });
 
   const onDraw = () => {
-    draw(state, drawMode);
+    draw(state);
     refresh();
   };
 
   const onReset = () => {
-    setState(initGame());
+    setState(initGame(state.drawMode));
     setHint(null);
   };
 
@@ -58,8 +63,13 @@ const Solitaire = () => {
         <label htmlFor="draw-mode">Draw:</label>
         <select
           id="draw-mode"
-          value={drawMode}
-          onChange={(e) => setDrawMode(e.target.value as 'draw1' | 'draw3')}
+          value={state.drawMode}
+          onChange={(e) => {
+            const mode = e.target.value as 'draw1' | 'draw3';
+            setDrawMode(state, mode);
+            localStorage.setItem('solitaire-mode', mode);
+            refresh();
+          }}
           className="rounded border p-1"
         >
           <option value="draw1">1</option>


### PR DESCRIPTION
## Summary
- track draw mode in solitaire game state and reset stock when switching modes
- persist draw mode selection in solitaire UI using localStorage
- test draw mode toggle behavior

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/solitaire/index.tsx apps/games/solitaire/logic.ts __tests__/solitaireLogic.test.ts`
- `yarn test` *(fails: merging two 2s creates one 4, etc.)*
- `CI=1 yarn test __tests__/solitaireLogic.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b168f8aac0832891ac094fbc40392d