### PR TITLE
feat(simon): add tempo selector

### DIFF
--- a/games/simon/components/TempoSelector.tsx
+++ b/games/simon/components/TempoSelector.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const MIN_TEMPO = 60;
+const MAX_TEMPO = 140;
+
+export default function TempoSelector({
+  onChange,
+}: {
+  onChange?: (tempo: number) => void;
+}) {
+  const [tempo, setTempo] = usePersistentState<number>('simon:tempo', 100);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    setTempo(value);
+    onChange?.(value);
+  };
+
+  return (
+    <label className="flex items-center space-x-2">
+      <input
+        type="range"
+        min={MIN_TEMPO}
+        max={MAX_TEMPO}
+        value={tempo}
+        onChange={handleChange}
+      />
+      <span>{tempo} BPM</span>
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary
- add tempo selector component for Simon game
- persist user-selected tempo in local storage

## Testing
- `yarn test __tests__/simonSeed.test.ts __tests__/simonAudio.test.ts`
- `npx eslint games/simon/components/TempoSelector.tsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b168f3f2cc83289aab85b80a4f68d1