### PR TITLE
feat(pong): add spin toggle

### DIFF
--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -2,7 +2,8 @@ import React, { useRef, useEffect, useState, useCallback } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import useGameControls from './useGameControls';
 import usePersistentState from '../../hooks/usePersistentState';
-import { computeBallSpin } from '../../utils/physics';
+import { useSettings } from '../../hooks/useSettings';
+import { getBallSpin } from '../../games/pong/physics';
 
 // Basic timing constants so the simulation is consistent across refresh rates
 const FRAME_TIME = 1000 / 60; // ideal frame time in ms
@@ -38,6 +39,7 @@ const Pong = () => {
   const [paused, setPaused] = useState(false);
   const pausedRef = useRef(false);
   const [rally, setRally] = useState(0);
+  const { pongSpin } = useSettings();
   const [highScore, setHighScore] = usePersistentState(
     'pong_highscore',
     0,
@@ -112,7 +114,7 @@ const Pong = () => {
       window.removeEventListener('keydown', send);
       window.removeEventListener('keyup', send);
     };
-  }, [mode]);
+  }, [mode, pongSpin]);
 
   // Main game effect
   useEffect(() => {
@@ -405,18 +407,19 @@ const Pong = () => {
 
       const paddleCollision = (pad, dir) => {
         setRally((r) => r + 1);
-        const { spin, relative } = computeBallSpin(
+        const { spin, relative } = getBallSpin(
           ball.y,
           pad.y,
           paddleHeight,
-          pad.vy
+          pad.vy,
+          pongSpin,
         );
         ball.vx = Math.abs(ball.vx) * dir;
         ball.vy += spin;
         if (!prefersReducedMotion) {
           pad.scale = 1.2;
           pad.widthScale = 0.8;
-          pad.rot = relative * 0.3;
+          pad.rot = pongSpin ? relative * 0.3 : 0;
           ball.scale = 1.2;
         }
         const impact = Math.hypot(ball.vx, ball.vy);

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin } = useSettings();
     const [theme, setThemeState] = useState(getTheme());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -138,6 +138,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     High Contrast
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={pongSpin}
+                        onChange={(e) => setPongSpin(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Pong Spin
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/games/pong/physics.ts
+++ b/games/pong/physics.ts
@@ -1,0 +1,25 @@
+import { computeBallSpin } from '../../utils/physics';
+
+export interface SpinResult {
+  spin: number;
+  relative: number;
+}
+
+/**
+ * Compute ball spin for Pong with optional spin effect.
+ * Returns zero spin when disabled but still provides relative impact position.
+ */
+export function getBallSpin(
+  ballY: number,
+  paddleY: number,
+  paddleHeight: number,
+  paddleVy: number,
+  enabled: boolean,
+): SpinResult {
+  if (!enabled) {
+    const padCenter = paddleY + paddleHeight / 2;
+    const relative = (ballY - padCenter) / (paddleHeight / 2);
+    return { spin: 0, relative };
+  }
+  return computeBallSpin(ballY, paddleY, paddleHeight, paddleVy);
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -14,6 +14,8 @@ import {
   setHighContrast as saveHighContrast,
   getLargeHitAreas as loadLargeHitAreas,
   setLargeHitAreas as saveLargeHitAreas,
+  getPongSpin as loadPongSpin,
+  setPongSpin as savePongSpin,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -42,6 +44,7 @@ interface SettingsContextValue {
   fontScale: number;
   highContrast: boolean;
   largeHitAreas: boolean;
+  pongSpin: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -49,6 +52,7 @@ interface SettingsContextValue {
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
+  setPongSpin: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -59,6 +63,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
+  pongSpin: defaults.pongSpin,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -66,6 +71,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setFontScale: () => {},
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
+  setPongSpin: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -76,6 +82,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
+  const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
 
   useEffect(() => {
     (async () => {
@@ -86,6 +93,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
+      setPongSpin(await loadPongSpin());
     })();
   }, []);
 
@@ -153,8 +161,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveLargeHitAreas(largeHitAreas);
   }, [largeHitAreas]);
 
+  useEffect(() => {
+    savePongSpin(pongSpin);
+  }, [pongSpin]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas, setPongSpin }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   fontScale: 1,
   highContrast: false,
   largeHitAreas: false,
+  pongSpin: true,
 };
 
 export async function getAccent() {
@@ -82,6 +83,17 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getPongSpin() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
+  const val = window.localStorage.getItem('pong-spin');
+  return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
+}
+
+export async function setPongSpin(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -93,10 +105,11 @@ export async function resetSettings() {
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
+  window.localStorage.removeItem('pong-spin');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas] = await Promise.all([
+  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
@@ -104,9 +117,10 @@ export async function exportSettings() {
     getFontScale(),
     getHighContrast(),
     getLargeHitAreas(),
+    getPongSpin(),
   ]);
   const theme = getTheme();
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, theme });
+  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme });
 }
 
 export async function importSettings(json) {
@@ -118,7 +132,7 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, theme } = settings;
+  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
@@ -126,6 +140,7 @@ export async function importSettings(json) {
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
+  if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add optional spin physics for Pong ball collisions
- allow enabling/disabling Pong spin in global settings

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, vscode.test.tsx, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b168f14d488328b115f743d335e6c0