### PR TITLE
feat: add unbeatable toggle for tic tac toe

### DIFF
--- a/__tests__/tictactoe.test.ts
+++ b/__tests__/tictactoe.test.ts
@@ -1,4 +1,5 @@
-import { minimax, checkWinner, createBoard } from '../apps/games/tictactoe/logic';
+import { minimax } from '../apps/games/tictactoe/ai';
+import { checkWinner, createBoard } from '../apps/games/tictactoe/logic';
 
 describe('tic tac toe AI', () => {
   const simulate = (firstMove: number) => {

--- a/apps/games/tictactoe/ai.ts
+++ b/apps/games/tictactoe/ai.ts
@@ -1,0 +1,52 @@
+import { Board, Player, checkWinner } from './logic';
+
+const boardKey = (board: Board): string => board.map((c) => c || '-').join('');
+
+const memo = new Map<string, { score: number; index?: number }>();
+
+export const minimax = (
+  board: Board,
+  player: Player,
+  size = Math.sqrt(board.length),
+  misere = false,
+  depth = 0,
+): { index: number; score: number } => {
+  const winner = checkWinner(board, size, misere).winner;
+  if (winner === 'O') return { score: 10 - depth, index: -1 };
+  if (winner === 'X') return { score: depth - 10, index: -1 };
+  if (winner === 'draw') return { score: 0, index: -1 };
+
+  const key = player + (misere ? 'M' : 'N') + boardKey(board);
+  const cached = memo.get(key);
+  if (cached && cached.index !== undefined) return cached as any;
+
+  let best: { index: number; score: number } = {
+    index: -1,
+    score: player === 'O' ? -Infinity : Infinity,
+  };
+
+  for (let i = 0; i < board.length; i++) {
+    if (!board[i]) {
+      board[i] = player;
+      const result = minimax(
+        board,
+        player === 'O' ? 'X' : 'O',
+        size,
+        misere,
+        depth + 1,
+      );
+      board[i] = null;
+      if (player === 'O') {
+        if (result.score > best.score) best = { index: i, score: result.score };
+      } else if (result.score < best.score) {
+        best = { index: i, score: result.score };
+      }
+    }
+  }
+
+  memo.set(key, best);
+  return best;
+};
+
+export default minimax;
+

--- a/apps/games/tictactoe/logic.ts
+++ b/apps/games/tictactoe/logic.ts
@@ -2,8 +2,6 @@ export type Player = 'X' | 'O';
 export type Cell = Player | null;
 export type Board = Cell[];
 
-const boardKey = (board: Board): string => board.map((c) => c || '-').join('');
-
 const generateLines = (size: number): number[][] => {
   const lines: number[][] = [];
   // rows
@@ -39,49 +37,7 @@ export const checkWinner = (
   return { winner: null, line: [] };
 };
 
-const memo = new Map<string, { score: number; index?: number }>();
-
-export const minimax = (
-  board: Board,
-  player: Player,
-  size = Math.sqrt(board.length),
-  misere = false,
-  depth = 0,
-): { index: number; score: number } => {
-  const winner = checkWinner(board, size, misere).winner;
-  if (winner === 'O') return { score: 10 - depth, index: -1 };
-  if (winner === 'X') return { score: depth - 10, index: -1 };
-  if (winner === 'draw') return { score: 0, index: -1 };
-
-  const key = player + (misere ? 'M' : 'N') + boardKey(board);
-  const cached = memo.get(key);
-  if (cached && cached.index !== undefined) return cached as any;
-
-  let best: { index: number; score: number } = {
-    index: -1,
-    score: player === 'O' ? -Infinity : Infinity,
-  };
-  for (let i = 0; i < board.length; i++) {
-    if (!board[i]) {
-      board[i] = player;
-      const result = minimax(
-        board,
-        player === 'O' ? 'X' : 'O',
-        size,
-        misere,
-        depth + 1,
-      );
-      board[i] = null;
-      if (player === 'O') {
-        if (result.score > best.score) best = { index: i, score: result.score };
-      } else if (result.score < best.score) {
-        best = { index: i, score: result.score };
-      }
-    }
-  }
-  memo.set(key, best);
-  return best;
-};
-
 export const createBoard = (size: number): Board =>
   Array(size * size).fill(null);
+
+export { minimax } from './ai';

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, tictactoeUnbeatable, setTictactoeUnbeatable } = useSettings();
     const [theme, setThemeState] = useState(getTheme());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -149,6 +149,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Pong Spin
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={tictactoeUnbeatable}
+                        onChange={(e) => setTictactoeUnbeatable(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Unbeatable TicTacToe
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/apps/tictactoe.js
+++ b/components/apps/tictactoe.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import GameLayout from './GameLayout';
-import { checkWinner, minimax, createBoard } from '../../apps/games/tictactoe/logic';
+import { checkWinner, createBoard } from '../../apps/games/tictactoe/logic';
+import { minimax } from '../../apps/games/tictactoe/ai';
+import { useSettings } from '../../hooks/useSettings';
 
 const SKINS = {
   classic: { X: 'X', O: 'O' },
@@ -27,6 +29,7 @@ const TicTacToe = () => {
   });
 
   const variantKey = `${mode}-${size}`;
+  const { tictactoeUnbeatable } = useSettings();
   const recordResult = (res) => {
     setStats((prev) => {
       const cur = prev[variantKey] || { wins: 0, losses: 0, draws: 0 };
@@ -82,7 +85,12 @@ const TicTacToe = () => {
     const isPlayerTurn =
       (player === 'X' && filled % 2 === 0) || (player === 'O' && filled % 2 === 1);
     if (!isPlayerTurn) {
-      const move = minimax(board.slice(), ai, size, mode === 'misere').index;
+      const available = board
+        .map((c, i) => (c ? -1 : i))
+        .filter((i) => i !== -1);
+      const move = tictactoeUnbeatable
+        ? minimax(board.slice(), ai, size, mode === 'misere').index
+        : available[Math.floor(Math.random() * available.length)];
       if (move >= 0) {
         const newBoard = board.slice();
         newBoard[move] = ai;
@@ -91,7 +99,7 @@ const TicTacToe = () => {
     } else {
       setStatus(`${SKINS[skin][player]}'s turn`);
     }
-  }, [board, player, ai, size, skin, mode]);
+  }, [board, player, ai, size, skin, mode, tictactoeUnbeatable]);
 
   const currentSkin = SKINS[skin];
 
@@ -207,7 +215,8 @@ const TicTacToe = () => {
   );
 };
 
-export { checkWinner, minimax } from '../../apps/games/tictactoe/logic';
+export { checkWinner } from '../../apps/games/tictactoe/logic';
+export { minimax } from '../../apps/games/tictactoe/ai';
 
 export default function TicTacToeApp() {
   return (

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -16,6 +16,8 @@ import {
   setLargeHitAreas as saveLargeHitAreas,
   getPongSpin as loadPongSpin,
   setPongSpin as savePongSpin,
+  getTictactoeUnbeatable as loadTictactoeUnbeatable,
+  setTictactoeUnbeatable as saveTictactoeUnbeatable,
   defaults,
 } from '../utils/settingsStore';
 type Density = 'regular' | 'compact';
@@ -45,6 +47,7 @@ interface SettingsContextValue {
   highContrast: boolean;
   largeHitAreas: boolean;
   pongSpin: boolean;
+  tictactoeUnbeatable: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -53,6 +56,7 @@ interface SettingsContextValue {
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
+  setTictactoeUnbeatable: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -64,6 +68,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
+  tictactoeUnbeatable: defaults.tictactoeUnbeatable,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -72,6 +77,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
+  setTictactoeUnbeatable: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -83,6 +89,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
+  const [tictactoeUnbeatable, setTictactoeUnbeatable] = useState<boolean>(defaults.tictactoeUnbeatable);
 
   useEffect(() => {
     (async () => {
@@ -94,6 +101,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
+      setTictactoeUnbeatable(await loadTictactoeUnbeatable());
     })();
   }, []);
 
@@ -165,8 +173,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     savePongSpin(pongSpin);
   }, [pongSpin]);
 
+  useEffect(() => {
+    saveTictactoeUnbeatable(tictactoeUnbeatable);
+  }, [tictactoeUnbeatable]);
+
   return (
-    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas, setPongSpin }}>
+    <SettingsContext.Provider value={{ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, tictactoeUnbeatable, setAccent, setWallpaper, setDensity, setReducedMotion, setFontScale, setHighContrast, setLargeHitAreas, setPongSpin, setTictactoeUnbeatable }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -10,6 +10,7 @@ const DEFAULT_SETTINGS = {
   highContrast: false,
   largeHitAreas: false,
   pongSpin: true,
+  tictactoeUnbeatable: true,
 };
 
 export async function getAccent() {
@@ -83,6 +84,17 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getTictactoeUnbeatable() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.tictactoeUnbeatable;
+  const val = window.localStorage.getItem('tictactoe-unbeatable');
+  return val === null ? DEFAULT_SETTINGS.tictactoeUnbeatable : val === 'true';
+}
+
+export async function setTictactoeUnbeatable(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('tictactoe-unbeatable', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -106,10 +118,21 @@ export async function resetSettings() {
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
+  window.localStorage.removeItem('tictactoe-unbeatable');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin] = await Promise.all([
+  const [
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    tictactoeUnbeatable,
+  ] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
@@ -118,9 +141,21 @@ export async function exportSettings() {
     getHighContrast(),
     getLargeHitAreas(),
     getPongSpin(),
+    getTictactoeUnbeatable(),
   ]);
   const theme = getTheme();
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme });
+  return JSON.stringify({
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    tictactoeUnbeatable,
+    theme,
+  });
 }
 
 export async function importSettings(json) {
@@ -132,7 +167,18 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme } = settings;
+  const {
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    tictactoeUnbeatable,
+    theme,
+  } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
@@ -141,6 +187,8 @@ export async function importSettings(json) {
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
+  if (tictactoeUnbeatable !== undefined)
+    await setTictactoeUnbeatable(tictactoeUnbeatable);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- implement minimax solver in `apps/games/tictactoe/ai.ts`
- add `tictactoeUnbeatable` option stored in settings and exposed in the settings app
- make TicTacToe AI use minimax only when unbeatable mode is enabled

## Testing
- `npm test __tests__/tictactoe.test.ts`
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, battleship-net.test.ts, kismet.test.tsx, metasploit.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1935dcac0832894fc5b48bd00a22a