### PR TITLE
feat(wireshark): add color rule definitions

### DIFF
--- a/__tests__/wireshark.test.tsx
+++ b/__tests__/wireshark.test.tsx
@@ -44,15 +44,15 @@ describe('WiresharkApp', () => {
     const addBtn = screen.getByRole('button', { name: /add rule/i });
     await user.click(addBtn);
     let exprInputs = screen.getAllByPlaceholderText(/filter expression/i);
-    let colorInputs = screen.getAllByPlaceholderText(/color class/i);
+    let colorSelects = screen.getAllByLabelText(/color/i);
     await user.type(exprInputs[0], 'tcp');
-    await user.type(colorInputs[0], 'text-red-500');
+    await user.selectOptions(colorSelects[0], 'Red');
 
     await user.click(addBtn);
     exprInputs = screen.getAllByPlaceholderText(/filter expression/i);
-    colorInputs = screen.getAllByPlaceholderText(/color class/i);
+    colorSelects = screen.getAllByLabelText(/color/i);
     await user.type(exprInputs[1], 'ip.addr == 8.8.8.8');
-    await user.type(colorInputs[1], 'text-blue-500');
+    await user.selectOptions(colorSelects[1], 'Blue');
 
     const tcpRow = screen.getByText('tcp packet').closest('tr');
     const udpRow = screen.getByText('udp packet').closest('tr');

--- a/apps/wireshark/components/ColorRuleEditor.tsx
+++ b/apps/wireshark/components/ColorRuleEditor.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { colorDefinitions } from '../../../components/apps/wireshark/colorDefs';
 
 interface Rule {
   expression: string;
@@ -38,12 +39,19 @@ const ColorRuleEditor: React.FC<Props> = ({ rules, onChange }) => {
             placeholder="Filter expression"
             className="px-1 py-0.5 bg-gray-800 rounded text-white text-xs"
           />
-          <input
+          <select
             value={rule.color}
             onChange={(e) => handleRuleChange(i, 'color', e.target.value)}
-            placeholder="Color class"
+            aria-label="Color"
             className="px-1 py-0.5 bg-gray-800 rounded text-white text-xs"
-          />
+          >
+            <option value="">Select color</option>
+            {colorDefinitions.map((c) => (
+              <option key={c.name} value={c.name}>
+                {c.name}
+              </option>
+            ))}
+          </select>
           <button
             onClick={() => handleRemove(i)}
             aria-label="Remove rule"

--- a/components/apps/wireshark/colorDefs.js
+++ b/components/apps/wireshark/colorDefs.js
@@ -1,0 +1,6 @@
+export const colorDefinitions = [
+  { name: 'Red', className: 'text-red-500' },
+  { name: 'Blue', className: 'text-blue-500' },
+  { name: 'Green', className: 'text-green-500' },
+  { name: 'Yellow', className: 'text-yellow-500' },
+];

--- a/components/apps/wireshark/utils.js
+++ b/components/apps/wireshark/utils.js
@@ -11,6 +11,13 @@ export const protocolName = (proto) => {
   }
 };
 
+import { colorDefinitions } from './colorDefs';
+
+const colorMap = colorDefinitions.reduce((acc, def) => {
+  acc[def.name.toLowerCase()] = def.className;
+  return acc;
+}, {});
+
 // Basic display filter engine used for both quick searches and colour rules.
 // Supports protocol keywords (tcp/udp/icmp), ip.addr == x.x.x.x and
 // tcp.port/udp.port == N expressions. Falls back to substring search.
@@ -49,5 +56,7 @@ export const matchesDisplayFilter = (packet, filter) => {
 // Determine the colour class for a packet based on user rules
 export const getRowColor = (packet, rules) => {
   const rule = rules.find((r) => matchesDisplayFilter(packet, r.expression));
-  return rule ? rule.color : '';
+  if (!rule) return '';
+  const key = rule.color ? rule.color.toLowerCase() : '';
+  return colorMap[key] || rule.color || '';
 };


### PR DESCRIPTION
## Summary
- map named color definitions to tailwind classes
- use dropdown UI for color rules in Wireshark
- test color rules with named colors

## Testing
- `npm test __tests__/wireshark.test.tsx`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1938d8ed48328b722f5f0f7c3b690