### PR TITLE
feat: add module tags and tag filtering

### DIFF
--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -53,6 +53,18 @@ const modules: ModuleMetadata[] = [
       },
     ],
   },
+  {
+    name: 'hashdump',
+    description: 'Dump password hashes from the SAM database.',
+    tags: ['credentials', 'dump'],
+    options: [
+      {
+        name: 'SESSION',
+        required: true,
+        description: 'The session to run this module on.',
+      },
+    ],
+  },
 ];
 
 export default modules;

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -19,7 +19,7 @@ export default function PostExploitation() {
     (m) =>
       m.name.toLowerCase().includes(query.toLowerCase()) &&
       (selectedTags.length === 0 ||
-        selectedTags.every((t) => m.tags.includes(t)))
+        m.tags.some((t) => selectedTags.includes(t)))
   );
 
   return (


### PR DESCRIPTION
## Summary
- tag modules with categories for searching
- allow filtering post-exploitation modules by selected tags

## Testing
- `npm test` (fails: game2048, BeEF, mimikatz, Kismet)
- `npm run lint` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68b1939020f08328a0fef3f07b9d5a41