### PR TITLE
feat: add area and volume conversions

### DIFF
--- a/__tests__/converter.test.tsx
+++ b/__tests__/converter.test.tsx
@@ -27,6 +27,17 @@ describe('Unit conversion', () => {
     expect(convertUnit('digital', 'megabyte', 'kilobyte', 1)).toBeCloseTo(1000);
   });
 
+  it('converts square meters to square feet', () => {
+    expect(convertUnit('area', 'square meter', 'square foot', 1)).toBeCloseTo(
+      10.7639,
+      4,
+    );
+  });
+
+  it('converts liters to gallons', () => {
+    expect(convertUnit('volume', 'liter', 'gallon', 3.78541)).toBeCloseTo(1, 5);
+  });
+
   it('respects precision when provided', () => {
     expect(
       convertUnit('length', 'meter', 'kilometer', 1234, 2)
@@ -56,6 +67,8 @@ describe('UnitConverter UI', () => {
     render(<UnitConverter />);
     const select = screen.getByLabelText('Category') as HTMLSelectElement;
     const options = Array.from(select.options).map((o) => o.value);
-    expect(options).toEqual(expect.arrayContaining(['time', 'digital']));
+    expect(options).toEqual(
+      expect.arrayContaining(['time', 'digital', 'area', 'volume']),
+    );
   });
 });

--- a/components/apps/converter/unitData.js
+++ b/components/apps/converter/unitData.js
@@ -32,6 +32,20 @@ export const unitMap = {
     megabyte: 'MB',
     gigabyte: 'GB',
   },
+  area: {
+    'square meter': 'm^2',
+    'square kilometer': 'km^2',
+    'square foot': 'ft^2',
+    'square mile': 'mi^2',
+    acre: 'acre',
+  },
+  volume: {
+    liter: 'L',
+    milliliter: 'ml',
+    'cubic meter': 'm^3',
+    'cubic foot': 'ft^3',
+    gallon: 'gal',
+  },
   currency: {
     USD: 'USD',
     EUR: 'EUR',
@@ -69,6 +83,20 @@ export const unitDetails = {
     kilobyte: { min: 0, max: 1e12, precision: 2 },
     megabyte: { min: 0, max: 1e9, precision: 2 },
     gigabyte: { min: 0, max: 1e6, precision: 2 },
+  },
+  area: {
+    'square meter': { min: 0, max: 1e12, precision: 2 },
+    'square kilometer': { min: 0, max: 1e6, precision: 6 },
+    'square foot': { min: 0, max: 1e12, precision: 2 },
+    'square mile': { min: 0, max: 1e8, precision: 6 },
+    acre: { min: 0, max: 1e9, precision: 4 },
+  },
+  volume: {
+    liter: { min: 0, max: 1e9, precision: 2 },
+    milliliter: { min: 0, max: 1e12, precision: 2 },
+    'cubic meter': { min: 0, max: 1e6, precision: 6 },
+    'cubic foot': { min: 0, max: 1e9, precision: 4 },
+    gallon: { min: 0, max: 1e9, precision: 2 },
   },
   currency: {
     USD: { min: 0, max: 1e9, precision: 2 },


### PR DESCRIPTION
## Summary
- expand unit converter with area and volume conversion formulas
- cover new categories in unit conversion tests and dropdown

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b193a1b4ec832883ed262767aafe86