### PR TITLE
feat: add profile timeline and map milestones

### DIFF
--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import milestones from '../data/milestones.json';
+import rawMilestones from '../data/milestones.json';
 
-type Milestone = {
-  year: string;
-  description: string;
-};
+const milestones = rawMilestones as Record<string, string>;
 
 const ScrollableTimeline: React.FC = () => (
   <div className="overflow-x-auto" aria-labelledby="timeline-heading">
@@ -12,10 +9,10 @@ const ScrollableTimeline: React.FC = () => (
       Timeline
     </h3>
     <ol className="flex space-x-6">
-      {(milestones as Milestone[]).map((m) => (
-        <li key={m.year} className="flex-shrink-0 w-48">
-          <div className="text-ubt-blue font-bold">{m.year}</div>
-          <p className="text-sm">{m.description}</p>
+      {Object.entries(milestones).map(([year, description]) => (
+        <li key={year} className="flex-shrink-0 w-48">
+          <div className="text-ubt-blue font-bold">{year}</div>
+          <p className="text-sm">{description}</p>
         </li>
       ))}
     </ol>

--- a/data/milestones.json
+++ b/data/milestones.json
@@ -1,8 +1,8 @@
-[
-  { "year": "2012", "description": "Began Nuclear Engineering at Ontario Tech." },
-  { "year": "2016", "description": "Graduated with B. Eng." },
-  { "year": "2020", "description": "Started Networking and I.T. Security program." },
-  { "year": "2021", "description": "Completed first capture-the-flag competition." },
-  { "year": "2023", "description": "Built portfolio showcasing 20+ security projects." },
-  { "year": "2024", "description": "Graduated with BIT in Networking and I.T. Security." }
-]
+{
+  "2012": "Began Nuclear Engineering at Ontario Tech.",
+  "2016": "Graduated with B. Eng.",
+  "2020": "Started Networking and I.T. Security program.",
+  "2021": "Completed first capture-the-flag competition.",
+  "2023": "Built portfolio showcasing 20+ security projects.",
+  "2024": "Graduated with BIT in Networking and I.T. Security."
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,0 +1,10 @@
+import ScrollableTimeline from '../components/ScrollableTimeline';
+
+const ProfilePage = () => (
+  <main className="min-h-screen p-4 bg-gray-900 text-white">
+    <h1 className="mb-4 text-2xl">Timeline</h1>
+    <ScrollableTimeline />
+  </main>
+);
+
+export default ProfilePage;


### PR DESCRIPTION
## Summary
- switch milestone data to key-value mapping for easier lookups
- update ScrollableTimeline to render mapped milestone entries
- add simple profile page showing scrollable timeline

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, mimikatz.test.ts, kismet.test.tsx, metasploit.test.tsx)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b193a9261083289df48c2fe2ec7b00