### PR TITLE
feat: add terminal session tabs with shortcuts

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -33,8 +33,9 @@ jest.mock(
 jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
 
 import React, { createRef, act } from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import Terminal from '../apps/terminal';
+import TerminalTabs from '../apps/terminal/tabs';
 
 describe('Terminal component', () => {
   const openApp = jest.fn();
@@ -58,5 +59,21 @@ describe('Terminal component', () => {
       ref.current.runCommand('open calculator');
     });
     expect(openApp).toHaveBeenCalledWith('calculator');
+  });
+
+  it('supports tab management shortcuts', async () => {
+    const { container } = render(<TerminalTabs openApp={openApp} />);
+    await act(async () => {});
+    const root = container.firstChild as HTMLElement;
+    root.focus();
+    fireEvent.keyDown(root, { ctrlKey: true, key: 't' });
+    expect(container.querySelectorAll('.flex.items-center.px-2.py-1.cursor-pointer').length).toBe(2);
+
+    fireEvent.keyDown(root, { ctrlKey: true, key: 'Tab' });
+    const headers = container.querySelectorAll('.flex.items-center.px-2.py-1.cursor-pointer');
+    expect(headers[0].className).toContain('bg-gray-700');
+
+    fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
+    expect(container.querySelectorAll('.flex.items-center.px-2.py-1.cursor-pointer').length).toBe(1);
   });
 });

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React, { useRef } from 'react';
+import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
+import Terminal, { TerminalProps } from '..';
+
+const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
+  const countRef = useRef(1);
+
+  const createTab = (): TabDefinition => {
+    const id = Date.now().toString();
+    return {
+      id,
+      title: `Session ${countRef.current++}`,
+      content: <Terminal openApp={openApp} />,
+    };
+  };
+
+  return (
+    <TabbedWindow
+      className="h-full w-full"
+      initialTabs={[createTab()]}
+      onNewTab={createTab}
+    />
+  );
+};
+
+export default TerminalTabs;

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 
-// Lazily load the heavy terminal app on the client only.
-const TerminalApp = dynamic(() => import('../../apps/terminal'), {
+// Lazily load the heavy terminal app with session tabs on the client only.
+const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
   ssr: false,
   loading: () => (
     <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -121,6 +121,25 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       closeTab(activeId);
       return;
     }
+    if (e.ctrlKey && e.key.toLowerCase() === 't') {
+      e.preventDefault();
+      addTab();
+      return;
+    }
+    if (e.ctrlKey && e.key === 'Tab') {
+      e.preventDefault();
+      setTabs((prev) => {
+        if (prev.length === 0) return prev;
+        const idx = prev.findIndex((t) => t.id === activeId);
+        const nextIdx = e.shiftKey
+          ? (idx - 1 + prev.length) % prev.length
+          : (idx + 1) % prev.length;
+        const nextTab = prev[nextIdx];
+        setActiveId(nextTab.id);
+        return prev;
+      });
+      return;
+    }
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       e.preventDefault();
       setTabs((prev) => {


### PR DESCRIPTION
## Summary
- add tabbed session manager for the terminal app
- support Ctrl+T/Ctrl+Tab/Ctrl+W shortcuts in TabbedWindow
- test tab creation, switching and closing via keyboard

## Testing
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b193ba5678832880e0c3ec01c9757c