### PR TITLE
feat: add persistent theme switcher

### DIFF
--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -1,19 +1,28 @@
-import { useState, useEffect, ChangeEvent } from 'react';
+"use client";
+
+import { useEffect, ChangeEvent } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState.js';
 import { getTheme, setTheme } from '../../../utils/theme';
 
 export default function ThemeSettings() {
-  const [theme, setThemeState] = useState('default');
+  // Persist theme selection in localStorage so it survives reloads
+  const [theme, setThemeState] = usePersistentState('app:theme', 'default');
 
+  // Initialize and sync theme with user preference or system settings
   useEffect(() => {
     const current = getTheme();
-    setTheme(current);
     setThemeState(current);
+    setTheme(current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Apply theme whenever selection changes
+  useEffect(() => {
+    setTheme(theme);
+  }, [theme]);
+
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const next = e.target.value;
-    setThemeState(next);
-    setTheme(next);
+    setThemeState(e.target.value);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add client-side theme settings page with persistent local storage
- apply selected theme to document and reuse across sessions

## Testing
- `npm test __tests__/themePersistence.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint pages/ui/settings/theme.tsx && echo 'eslint success'`


------
https://chatgpt.com/codex/tasks/task_e_68b193be58a08328bc312259531521de