### PR TITLE
feat(mimikatz): add risk confirmation

### DIFF
--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -1,10 +1,50 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import MimikatzApp from '../../components/apps/mimikatz';
 import ExposureExplainer from './components/ExposureExplainer';
 
+const disclaimerUrl = 'https://www.kali.org/docs/policy/disclaimer/';
+
 const MimikatzPage: React.FC = () => {
+  const [confirmed, setConfirmed] = useState(false);
+
+  if (!confirmed) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-80 text-white z-50">
+        <div className="max-w-md p-6 bg-ub-dark rounded shadow text-center space-y-4">
+          <h2 className="text-xl font-bold">High-Risk Command Warning</h2>
+          <p>
+            Mimikatz can execute high-risk commands that may compromise system
+            security. Proceed only if you understand the risks.
+          </p>
+          <a
+            href={disclaimerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-300 underline"
+          >
+            Read the full disclaimer
+          </a>
+          <div className="flex justify-center space-x-4 pt-2">
+            <button
+              onClick={() => setConfirmed(true)}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded"
+            >
+              Proceed
+            </button>
+            <button
+              onClick={() => window.history.back()}
+              className="px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <MimikatzApp />


### PR DESCRIPTION
## Summary
- warn users about high-risk Mimikatz commands with a confirmation dialog
- link to Kali's official disclaimer before proceeding

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/mimikatz/index.tsx`
- `npx jest apps/mimikatz/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b193d57cf083289d4d3e7f0c5efab3