### PR TITLE
Validate Hydra target before starting

### DIFF
--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -30,6 +30,21 @@ describe('Hydra wordlists', () => {
   });
 });
 
+describe('Hydra target validation', () => {
+  it('disables run button for empty or malformed targets', () => {
+    render(<HydraApp />);
+    const targetInput = screen.getByPlaceholderText('192.168.0.1');
+    const runBtn = screen.getByText('Run Hydra');
+    expect(runBtn).toBeDisabled();
+
+    fireEvent.change(targetInput, { target: { value: 'not a host' } });
+    expect(runBtn).toBeDisabled();
+
+    fireEvent.change(targetInput, { target: { value: '1.2.3.4' } });
+    expect(runBtn).not.toBeDisabled();
+  });
+});
+
 describe('Hydra pause and resume', () => {
   beforeEach(() => {
     localStorage.setItem(

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -16,7 +16,11 @@ const HydraPreview: React.FC = () => {
 
   const createTab = (): TabDefinition => {
     const id = Date.now().toString();
-    return { id, title: `Run ${countRef.current++}`, content: <HydraApp /> };
+    return {
+      id,
+      title: `Run ${countRef.current++}`,
+      content: <HydraApp key={id} />,
+    };
   };
 
   return (

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import Stepper from './Stepper';
 import AttemptTimeline from './Timeline';
 
@@ -68,6 +68,16 @@ const HydraApp = () => {
 
   const LOCKOUT_THRESHOLD = 10;
   const BACKOFF_THRESHOLD = 5;
+
+  const isTargetValid = useMemo(() => {
+    const trimmed = target.trim();
+    if (!trimmed) return false;
+    const [host, port] = trimmed.split(':');
+    if (port && !/^\d+$/.test(port)) return false;
+    const ipv4 = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$/;
+    const hostname = /^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/;
+    return ipv4.test(host) || hostname.test(host);
+  }, [target]);
 
   useEffect(() => {
     setUserLists(loadWordlists('hydraUserLists'));
@@ -269,8 +279,8 @@ const HydraApp = () => {
   const runHydra = async () => {
     const user = selectedUserList;
     const pass = selectedPassList;
-    if (!target || !user || !pass) {
-      setOutput('Please provide target, user list and password list');
+    if (!isTargetValid || !user || !pass) {
+      setOutput('Please provide a valid target, user list and password list');
       return;
     }
 
@@ -510,7 +520,7 @@ const HydraApp = () => {
         </div>
         <button
           onClick={runHydra}
-          disabled={running}
+          disabled={running || !isTargetValid}
           className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
         >
           {running ? 'Running...' : 'Run Hydra'}


### PR DESCRIPTION
## Summary
- ensure Hydra target input is non-empty and well formatted
- disable Run Hydra button until target is valid
- add regression test for target validation and key tabs uniquely

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b193d6822483289d9c4d09b71bca8e