### PR TITLE
Remove storage cap in memory game

### DIFF
--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import GameLayout from './GameLayout';
 import { createDeck, PATTERN_THEMES, fisherYatesShuffle } from './memory_utils';
 
-const MAX_STORAGE = 1000; // safeguard against large writes
 const DEFAULT_TIME = { 2: 30, 4: 60, 6: 120 };
 
 // Built-in theme assets that can be used by the memory game.
@@ -176,9 +175,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
       const bestTime = stored.time != null ? Math.min(stored.time, elapsed) : elapsed;
       const updated = { moves: bestMoves, time: bestTime };
       const serialized = JSON.stringify(updated);
-      if (serialized.length < MAX_STORAGE) {
-        window.localStorage.setItem(bestKey, serialized);
-      }
+      window.localStorage.setItem(bestKey, serialized);
       setBest(updated);
     } catch {
       // ignore storage errors


### PR DESCRIPTION
## Summary
- allow memory game to store best results of any size

## Testing
- `node -e "const localStorage = new Map(); const bestKey='big'; const updated={moves:1,time:2,extra:'x'.repeat(5000)}; const serialized=JSON.stringify(updated); localStorage.set(bestKey,serialized); const stored=localStorage.get(bestKey); console.log('serialized length',serialized.length); console.log('stored length',stored.length); console.log('match',serialized===stored);"`
- `npm test`
- `npm test __tests__/memoryGame.test.tsx`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1940bc67883289edc6154ae58f923