### PR TITLE
chore: include WebWorker lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["jest", "node"]
+    "types": []
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules", "__tests__"]


### PR DESCRIPTION
## Summary
- target ES2021 and WebWorker libs in tsconfig
- remove default type definitions from tsconfig

## Testing
- `yarn test` *(fails: game2048, beef, mimikatz, kismet)*
- `yarn lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1963ec76c832893cb2d290db588a1