### PR TITLE
chore(types): add web bluetooth and window declarations

### DIFF
--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  interface Window {
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+export {};

--- a/types/web-bluetooth.d.ts
+++ b/types/web-bluetooth.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="web-bluetooth" />
+export {};


### PR DESCRIPTION
## Summary
- add web bluetooth global type reference
- add window interface for YouTube Iframe API

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint types/web-bluetooth.d.ts types/global-window.d.ts`
- `yarn test` *(fails: game2048, beef, mimikatz, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b1963f5ebc8328bff307688b0efdab