### PR TITLE
Type artifact user field in Autopsy

### DIFF
--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import events from '../events.json';
+import { Artifact } from '../types';
 
 const escapeHtml = (str: string = '') =>
   str
@@ -43,8 +44,9 @@ function KeywordTester() {
     return safe;
   };
 
-  const matches = events.artifacts.filter((a) => {
-    const content = `${a.name} ${a.description} ${a.user || ''}`.toLowerCase();
+  const matches: Artifact[] = (events.artifacts as Artifact[]).filter((a) => {
+    const userPart = 'user' in a ? (a as any).user : '';
+    const content = `${a.name} ${a.description} ${userPart}`.toLowerCase();
     return keywords.some((k) => content.includes(k.toLowerCase()));
   });
 
@@ -72,10 +74,12 @@ function KeywordTester() {
               dangerouslySetInnerHTML={{ __html: highlight(a.name) }}
             />
             <div className="text-gray-400">{a.type}</div>
-            {a.user && (
+            {'user' in a && (
               <div
                 className="text-xs"
-                dangerouslySetInnerHTML={{ __html: `User: ${highlight(a.user)}` }}
+                dangerouslySetInnerHTML={{
+                  __html: `User: ${highlight((a as any).user)}`,
+                }}
               />
             )}
             <div

--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -1,9 +1,18 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import AutopsyApp from '../../components/apps/autopsy';
+import AutopsyAppComponent from '../../components/apps/autopsy';
 import events from './events.json';
 import KeywordTester from './components/KeywordTester';
+import { Artifact } from './types';
+
+interface AutopsyAppProps {
+  initialArtifacts: Artifact[];
+  expandedNodes: string[];
+  onExpandedNodesChange: (nodes: string[]) => void;
+}
+
+const AutopsyApp = AutopsyAppComponent as React.FC<AutopsyAppProps>;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling
@@ -61,7 +70,7 @@ const AutopsyPage: React.FC = () => {
       </div>
       {view === 'autopsy' && (
         <AutopsyApp
-          initialArtifacts={events.artifacts}
+          initialArtifacts={events.artifacts as Artifact[]}
           expandedNodes={expandedNodes}
           onExpandedNodesChange={setExpandedNodes}
         />

--- a/apps/autopsy/types.ts
+++ b/apps/autopsy/types.ts
@@ -1,0 +1,9 @@
+export interface Artifact {
+  name: string;
+  type: string;
+  description: string;
+  size: number;
+  plugin: string;
+  timestamp: string;
+  user?: string;
+}


### PR DESCRIPTION
## Summary
- define `Artifact` interface with optional `user`
- guard and cast `user` access in keyword tester
- type Autopsy app props and cast event artifacts

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/autopsy/index.tsx apps/autopsy/components/KeywordTester.tsx apps/autopsy/types.ts`
- `npx jest apps/autopsy --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b1963ffca08328bf9fbdd2df07e509