### PR TITLE
refactor: improve log key generation

### DIFF
--- a/apps/dsniff/components/StressSandbox.tsx
+++ b/apps/dsniff/components/StressSandbox.tsx
@@ -50,8 +50,8 @@ const StressSandbox: React.FC = () => {
         Capture: {captureMs.toFixed(2)} ms | Replay: {replayMs.toFixed(2)} ms
       </p>
       <ul className="h-40 overflow-auto text-xs bg-black p-1">
-        {logs.slice(0, 100).map((log) => (
-          <li key={log.id}>
+        {logs.slice(0, 100).map((log, i) => (
+          <li key={`${log.protocol}-${log.host}-${log.path}-${i}`}>
             <span className="text-green-400">{log.protocol}</span> {log.host} {log.path}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- ensure unique log list keys in StressSandbox

## Testing
- `yarn test __tests__/dsniff.test.tsx`
- `yarn lint apps/dsniff/components/StressSandbox.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: “game2048” and other suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b19642f6988328b9366176ea50cf0d