### PR TITLE
fix: specify default camera in QR scanner

### DIFF
--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -45,7 +45,7 @@ const QRScanner: React.FC = () => {
           ]);
           const codeReader = new BrowserQRCodeReader();
           controlsRef.current = await codeReader.decodeFromVideoDevice(
-            null,
+            undefined,
             videoRef.current!,
             (res, err) => {
               if (res) setResult(res.getText());


### PR DESCRIPTION
## Summary
- use `undefined` when decoding QR codes to select default video device

## Testing
- `yarn test __tests__/game2048.test.tsx __tests__/beef.test.tsx __tests__/mimikatz.test.ts __tests__/kismet.test.tsx` *(fails: mimikatz.api retrieves module list, mimikatz api executes script template, KismetApp steps through sample capture frames, merging two 2s creates one 4, merge triggers animation, score persists in localStorage, skin selection changes tile class, BeEF app updates hook list when refresh is clicked, BeEF app shows module output when run, BeEF app switches between modules and payload builder tabs)*
- `yarn lint components/apps/qr/index.tsx` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b19645eafc8328bb9f1298b52d1b50