### PR TITLE
Use block-style ref callback for preview refs

### DIFF
--- a/apps/x/components/ThreadComposer.tsx
+++ b/apps/x/components/ThreadComposer.tsx
@@ -132,7 +132,7 @@ export default function ThreadComposer() {
             className="w-full p-2 border rounded bg-transparent"
           />
           <div
-            ref={(el) => (previewRefs.current[i] = el)}
+            ref={(el) => { previewRefs.current[i] = el; }}
             className="p-2 border rounded whitespace-pre-wrap bg-white text-black dark:bg-black dark:text-white"
           >
             {tweet.text || <span className="text-gray-400">Preview...</span>}


### PR DESCRIPTION
## Summary
- use block-style ref callback to assign preview DOM nodes

## Testing
- `npx eslint apps/x/components/ThreadComposer.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn lint apps/x/components/ThreadComposer.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test apps/x/components/ThreadComposer.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b19649215c83289aa89bbef73382bb