### PR TITLE
refactor: centralize YouTube API globals

### DIFF
--- a/apps/youtube/components/ClipMaker.tsx
+++ b/apps/youtube/components/ClipMaker.tsx
@@ -3,13 +3,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import copyToClipboard from '../../../utils/clipboard';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 function extractVideoId(input: string): string {
   try {
     const url = new URL(input);

--- a/apps/youtube/components/ComparePlayers.tsx
+++ b/apps/youtube/components/ComparePlayers.tsx
@@ -2,13 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 function parseVideoId(input: string): string {
   try {
     const url = new URL(input);

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -5,13 +5,6 @@ import useWatchLater, {
   Video as WatchLaterVideo,
 } from '../../../apps/youtube/state/watchLater';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 type Video = WatchLaterVideo;
 
 interface Props {

--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    YT: any;
+    onYouTubeIframeAPIReady: () => void;
+  }
+}


### PR DESCRIPTION
## Summary
- declare YT and onYouTubeIframeAPIReady on the global window
- remove per-component window typings in YouTube components

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: failing suites such as game2048, BeEF app, battleship matchmaking, mimikatz, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b19649964c8328a453f7c8182dfe47