### PR TITLE
Rename Chrome app folder and extend AddressBar props

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -3,7 +3,7 @@ import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
 import { displaySettings } from './components/apps/settings';
-import { displayChrome } from './components/apps/Chrome';
+import { displayChrome } from './components/apps/chrome';
 import { displayGedit } from './components/apps/gedit';
 import { displayTodoist } from './components/apps/todoist';
 import { displayWeather } from './components/apps/weather';

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -8,8 +8,8 @@ import React, {
 import { toPng } from 'html-to-image';
 import { Readability } from '@mozilla/readability';
 import DOMPurify from 'dompurify';
-import AddressBar from '../chrome/AddressBar';
-import { getCachedFavicon, cacheFavicon } from '../chrome/bookmarks';
+import AddressBar from './AddressBar';
+import { getCachedFavicon, cacheFavicon } from './bookmarks';
 
 interface Tile {
   title: string;
@@ -93,6 +93,7 @@ const Chrome: React.FC = () => {
   const [tabQuery, setTabQuery] = useState('');
   const [overflowing, setOverflowing] = useState(false);
   const draggingId = useRef<number | null>(null);
+  const dragTabId = useRef<string | null>(null);
   const [tiles, setTiles] = useState<Tile[]>([]);
   const [editingTiles, setEditingTiles] = useState(false);
   const [newTitle, setNewTitle] = useState('');
@@ -701,6 +702,7 @@ const Chrome: React.FC = () => {
           onNavigate={navigate}
           onOpenNewTab={(url) => addTab(url)}
           onOpenNewWindow={(url) => window.open(url, '_blank')}
+          historyList={tabs.find((t) => t.id === activeId)?.history}
         />
         <button onClick={() => addTab()} aria-label="New Tab" className="px-2">
           +


### PR DESCRIPTION
## Summary
- rename `components/apps/Chrome` to `components/apps/chrome`
- add `dragTabId` ref and pass tab history to `AddressBar`
- extend `AddressBar` with new tab/window handlers and optional history

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b1964abb308328a1bd4ea292dbc922