### PR TITLE
Handle missing OPFS directories

### DIFF
--- a/components/apps/Games/common/save/index.ts
+++ b/components/apps/Games/common/save/index.ts
@@ -62,7 +62,8 @@ export default function useGameSaves(gameId: string) {
   const listSlots = useCallback(
     async (): Promise<string[]> => {
       const dir = dirRef.current;
-      if (supported && dir) {
+      if (supported) {
+        if (!dir) return [];
         const names: string[] = [];
         for await (const [name, handle] of dir.entries()) {
           if (handle.kind === 'file' && name.endsWith('.json')) {
@@ -81,7 +82,8 @@ export default function useGameSaves(gameId: string) {
   const exportSaves = useCallback(
     async (): Promise<SaveSlot[]> => {
       const dir = dirRef.current;
-      if (supported && dir) {
+      if (supported) {
+        if (!dir) return [];
         const slots: SaveSlot[] = [];
         for await (const [name, handle] of dir.entries()) {
           if (handle.kind === 'file' && name.endsWith('.json')) {


### PR DESCRIPTION
## Summary
- Avoid OPFS errors when listing or exporting save slots by returning an empty list when the directory handle is missing
- Keep `dir.entries()` loops typed for `@types/wicg-file-system-access`

## Testing
- `yarn test` *(fails: __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1964c853c83288d8cdbed59024016