### PR TITLE
Add noop fallback for InputRemap

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef } from 'react';
 import InputRemap from './Games/common/input-remap/InputRemap';
 import useInputMapping from './Games/common/input-remap/useInputMapping';
 
+const noop: (action: string, key: string) => string | null = () => null;
+
 interface HelpOverlayProps {
   gameId: string;
   onClose: () => void;
@@ -226,7 +228,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
                 .join(', ')}
             </p>
             <div className="mt-2">
-              <InputRemap mapping={mapping} setKey={setKey} actions={info.actions} />
+              <InputRemap mapping={mapping} setKey={setKey ?? noop} actions={info.actions} />
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- ensure HelpOverlay can render InputRemap even if `setKey` is absent by providing a noop fallback

## Testing
- `yarn test` *(fails: game2048, beef, mimikatz, battleship-net)*
- `yarn lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1964d38a88328b62aba6017700aff