### PR TITLE
Add chart.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
+    "chart.js": "^4.5.0",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
     "cytoscape": "^3.33.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,6 +2195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kurkle/color@npm:^0.3.0":
+  version: 0.3.4
+  resolution: "@kurkle/color@npm:0.3.4"
+  checksum: 10c0/0e9fd55c614b005c5f0c4c755bca19ec0293bc7513b4ea3ec1725234f9c2fa81afbc78156baf555c8b9cb0d305619253c3f5bca016067daeebb3d00ebb4ea683
+  languageName: node
+  linkType: hard
+
 "@mixmark-io/domino@npm:^2.2.0":
   version: 2.2.0
   resolution: "@mixmark-io/domino@npm:2.2.0"
@@ -4430,6 +4437,15 @@ __metadata:
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
   checksum: 10c0/57a09a86371331e0be35d9083ba429e86c4f4648ecbe27455dbfb343037c16ee6fdc7f6b61f433a57cc5ded5561d71c56a150e018f40c2ffb7bc93a26dae341e
+  languageName: node
+  linkType: hard
+
+"chart.js@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "chart.js@npm:4.5.0"
+  dependencies:
+    "@kurkle/color": "npm:^0.3.0"
+  checksum: 10c0/f12c7f9a238ee7ce6d3f7111628e9daba86bb8ff8e54cfe63525fde6ded9003c72c4c8d2c7d5702539dc0aff7e682dfec058660ade8d03a970da002656d4ac91
   languageName: node
   linkType: hard
 
@@ -11610,6 +11626,7 @@ __metadata:
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
+    chart.js: "npm:^4.5.0"
     chess.js: "npm:^1.0.0"
     chrono-node: "npm:^2.8.4"
     cytoscape: "npm:^3.33.1"


### PR DESCRIPTION
## Summary
- add chart.js to project dependencies for simulator charts

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: e.g., __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/battleship-net.test.ts, __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b19651522c832881199332f4dd4c93