### PR TITLE
feat: allow optional game pause callbacks

### DIFF
--- a/components/games/GameShell.jsx
+++ b/components/games/GameShell.jsx
@@ -14,8 +14,8 @@ export default function GameShell({
   children,
   controls = null,
   settings = null,
-  onPause,
-  onResume,
+  onPause = () => {},
+  onResume = () => {},
 }) {
   useOrientationGuard();
 
@@ -26,12 +26,12 @@ export default function GameShell({
 
   const pause = useCallback(() => {
     setPaused(true);
-    onPause && onPause();
+    onPause();
   }, [onPause]);
 
   const resume = useCallback(() => {
     setPaused(false);
-    onResume && onResume();
+    onResume();
   }, [onResume]);
 
   const toggleSettings = () => setShowSettings((s) => !s);


### PR DESCRIPTION
## Summary
- default `onPause` and `onResume` handlers in `GameShell`

## Testing
- `npm test` *(fails: __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b19651ccf083288296af029ff83bd0