### PR TITLE
feat(opfs): accept nullable directory handle

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -9,16 +9,16 @@ export interface OPFSHook {
   ) => Promise<FileSystemDirectoryHandle | null>;
   readFile: (
     name: string,
-    dir?: FileSystemDirectoryHandle,
+    dir?: FileSystemDirectoryHandle | null,
   ) => Promise<string | null>;
   writeFile: (
     name: string,
     data: string | Blob,
-    dir?: FileSystemDirectoryHandle,
+    dir?: FileSystemDirectoryHandle | null,
   ) => Promise<boolean>;
   deleteFile: (
     name: string,
-    dir?: FileSystemDirectoryHandle,
+    dir?: FileSystemDirectoryHandle | null,
   ) => Promise<boolean>;
 }
 
@@ -65,7 +65,7 @@ export default function useOPFS(): OPFSHook {
   );
 
   const readFile = useCallback<OPFSHook['readFile']>(
-    async (name, dir = root) => {
+    async (name, dir: FileSystemDirectoryHandle | null | undefined = root) => {
       if (!dir) return null;
       try {
         const handle = await dir.getFileHandle(name);
@@ -79,7 +79,11 @@ export default function useOPFS(): OPFSHook {
   );
 
   const writeFile = useCallback<OPFSHook['writeFile']>(
-    async (name, data, dir = root) => {
+    async (
+      name,
+      data,
+      dir: FileSystemDirectoryHandle | null | undefined = root,
+    ) => {
       if (!dir) return false;
       try {
         const handle = await dir.getFileHandle(name, { create: true });
@@ -95,7 +99,7 @@ export default function useOPFS(): OPFSHook {
   );
 
   const deleteFile = useCallback<OPFSHook['deleteFile']>(
-    async (name, dir = root) => {
+    async (name, dir: FileSystemDirectoryHandle | null | undefined = root) => {
       if (!dir) return false;
       try {
         await dir.removeEntry(name);


### PR DESCRIPTION
## Summary
- allow readFile, writeFile, and deleteFile to accept nullable directory handles that default to OPFS root

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts, __tests__/battleship-net.test.ts, __tests__/kismet.test.tsx, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b196546f948328a9f47136933581f4