### PR TITLE
Ensure string values for reCAPTCHA verification params

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -76,8 +76,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           'Content-Type': 'application/x-www-form-urlencoded',
         },
         body: new URLSearchParams({
-          secret,
-          response: recaptchaToken,
+          secret: String(secret ?? ''),
+          response: String(recaptchaToken ?? ''),
         }),
       }
     );


### PR DESCRIPTION
## Summary
- ensure reCAPTCHA verification uses string URLSearchParams values

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: game2048, BeEF app, mimikatz api, kismet, metasploit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b19655c0108328aed400b406b7812b