### PR TITLE
refactor: use QRCodeToStringOptions type

### DIFF
--- a/workers/qrEncode.worker.ts
+++ b/workers/qrEncode.worker.ts
@@ -1,8 +1,9 @@
 import QRCode from 'qrcode';
+import type { QRCodeToStringOptions } from 'qrcode';
 
 interface EncodeRequest {
   text: string;
-  opts: QRCode.QRCodeToStringOptions;
+  opts: QRCodeToStringOptions;
 }
 
 self.onmessage = async ({ data }: MessageEvent<EncodeRequest>) => {


### PR DESCRIPTION
## Summary
- refactor qr code worker to use QRCodeToStringOptions type

## Testing
- `yarn test --passWithNoTests workers/qrEncode.worker.ts`
- `yarn lint workers/qrEncode.worker.ts` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b19658597c83289186328a9915f7bf