### PR TITLE
Use type-only re-export for LeaderboardEntry

### DIFF
--- a/utils/dailyChallenge.ts
+++ b/utils/dailyChallenge.ts
@@ -72,4 +72,4 @@ export const recordCompletion = (
   return board;
 };
 
-export { LeaderboardEntry };
+export type { LeaderboardEntry };


### PR DESCRIPTION
## Summary
- export `LeaderboardEntry` as a type-only re-export in `dailyChallenge`

## Testing
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*
- `yarn test` *(fails: e.g., __tests__/game2048.test.tsx, __tests__/beef.test.tsx, __tests__/mimikatz.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b196569f048328abc290a8aed78381