### PR TITLE
feat: add bluetooth and window type definitions

### DIFF
--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  interface Window {
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+export {};

--- a/types/web-bluetooth.d.ts
+++ b/types/web-bluetooth.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="web-bluetooth" />
+export {};


### PR DESCRIPTION
## Summary
- declare ambient web-bluetooth types
- add optional onYouTubeIframeAPIReady to Window

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: ESLint warnings and errors)*
- `yarn test` *(fails: e.g., game2048.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d80fd1d08328a88b5ad91b302612