### PR TITLE
chore(autopsy): add artifact typing

### DIFF
--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -44,7 +44,10 @@ function KeywordTester() {
   };
 
   const matches = events.artifacts.filter((a) => {
-    const content = `${a.name} ${a.description} ${a.user || ''}`.toLowerCase();
+    const artifact = a as any;
+    const content = `${artifact.name} ${artifact.description} ${
+      'user' in artifact ? artifact.user : ''
+    }`.toLowerCase();
     return keywords.some((k) => content.includes(k.toLowerCase()));
   });
 
@@ -62,28 +65,33 @@ function KeywordTester() {
         <div className="text-sm">Loaded {keywords.length} keywords</div>
       )}
       <div className="grid gap-2 md:grid-cols-2">
-        {matches.map((a, idx) => (
-          <div
-            key={`${a.name}-${idx}`}
-            className="p-2 bg-ub-grey rounded text-sm"
-          >
+        {matches.map((a, idx) => {
+          const artifact = a as any;
+          return (
             <div
-              className="font-bold"
-              dangerouslySetInnerHTML={{ __html: highlight(a.name) }}
-            />
-            <div className="text-gray-400">{a.type}</div>
-            {a.user && (
+              key={`${artifact.name}-${idx}`}
+              className="p-2 bg-ub-grey rounded text-sm"
+            >
+              <div
+                className="font-bold"
+                dangerouslySetInnerHTML={{ __html: highlight(artifact.name) }}
+              />
+              <div className="text-gray-400">{artifact.type}</div>
+              {'user' in artifact && (
+                <div
+                  className="text-xs"
+                  dangerouslySetInnerHTML={{
+                    __html: `User: ${highlight(artifact.user)}`,
+                  }}
+                />
+              )}
               <div
                 className="text-xs"
-                dangerouslySetInnerHTML={{ __html: `User: ${highlight(a.user)}` }}
+                dangerouslySetInnerHTML={{ __html: highlight(artifact.description) }}
               />
-            )}
-            <div
-              className="text-xs"
-              dangerouslySetInnerHTML={{ __html: highlight(a.description) }}
-            />
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -1,9 +1,16 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import AutopsyApp from '../../components/apps/autopsy';
+import AutopsyAppComponent from '../../components/apps/autopsy';
 import events from './events.json';
 import KeywordTester from './components/KeywordTester';
+import type { Artifact } from './types';
+
+const AutopsyApp = AutopsyAppComponent as React.ComponentType<{
+  initialArtifacts: Artifact[];
+  expandedNodes: string[];
+  onExpandedNodesChange: (nodes: string[]) => void;
+}>;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling
@@ -61,7 +68,7 @@ const AutopsyPage: React.FC = () => {
       </div>
       {view === 'autopsy' && (
         <AutopsyApp
-          initialArtifacts={events.artifacts}
+          initialArtifacts={events.artifacts as Artifact[]}
           expandedNodes={expandedNodes}
           onExpandedNodesChange={setExpandedNodes}
         />

--- a/apps/autopsy/types.ts
+++ b/apps/autopsy/types.ts
@@ -1,0 +1,9 @@
+export interface Artifact {
+  name: string;
+  type: string;
+  description: string;
+  size: number;
+  plugin: string;
+  timestamp: string;
+  user?: string;
+}


### PR DESCRIPTION
## Summary
- guard optional `user` field in `KeywordTester`
- define `Artifact` interface for autopsy data
- type `AutopsyApp` props and cast loaded artifacts

## Testing
- `yarn test __tests__/mimikatz.test.ts` *(fails: Expected 200 Received 501)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d810f52c8328a6068d0b9cc54cf1