### PR TITLE
Use undefined for decodeFromVideoDevice in QR scanner

### DIFF
--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -45,7 +45,7 @@ const QRScanner: React.FC = () => {
           ]);
           const codeReader = new BrowserQRCodeReader();
           controlsRef.current = await codeReader.decodeFromVideoDevice(
-            null,
+            undefined,
             videoRef.current!,
             (res, err) => {
               if (res) setResult(res.getText());


### PR DESCRIPTION
## Summary
- fix QR scanner by passing `undefined` as device in `decodeFromVideoDevice`

## Testing
- `yarn test qr`


------
https://chatgpt.com/codex/tasks/task_e_68b1d826752c83289f83f884825efcde