### PR TITLE
docs: reference scoped xterm imports

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -7,7 +7,7 @@ This document tracks planned improvements and new features for the desktop portf
 - Replace app imports in `apps.config.js` with the factory and `createDisplay` helper.
 - Register apps and games uniformly with `display*` helpers and small default window sizes.
 - Ensure new utilities have Jest tests mirroring existing ones.
-- Fix terminal build by importing `xterm` styles and registering `FitAddon`.
+- Fix terminal build by importing `@xterm/xterm/css/xterm.css` and registering `FitAddon`.
 - Follow `docs/new-app-checklist.md` for all new apps.
 
 ## Desktop Apps
@@ -23,7 +23,7 @@ This document tracks planned improvements and new features for the desktop portf
 - Register with `createDynamicApp('calc','Calc')` and export `displayCalc`.
 
 ### Terminal
-- Import `xterm/css/xterm.css` and `FitAddon`; call `fitAddon.fit()` on mount and resize.
+- Import `@xterm/xterm/css/xterm.css` and `FitAddon`; call `fitAddon.fit()` on mount and resize.
 - Implement command registry (`help`, `ls`, `cat`, `clear`, `open <app>`, `about`, `date`).
 - Add paste support, auto-complete, and scrollback limit.
 - Keep client-only dynamic import.


### PR DESCRIPTION
## Summary
- document scoped `@xterm/xterm` and CSS path usage
- remove legacy `xterm` style references in tasks doc

## Testing
- `yarn test __tests__/terminal.test.tsx`
- `yarn test` *(fails: game2048, BeEF, mimikatz, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d827d8a883289438d67361423202