### PR TITLE
fix: wrap preview ref assignment

### DIFF
--- a/apps/x/components/ThreadComposer.tsx
+++ b/apps/x/components/ThreadComposer.tsx
@@ -132,7 +132,9 @@ export default function ThreadComposer() {
             className="w-full p-2 border rounded bg-transparent"
           />
           <div
-            ref={(el) => (previewRefs.current[i] = el)}
+            ref={(el) => {
+              previewRefs.current[i] = el;
+            }}
             className="p-2 border rounded whitespace-pre-wrap bg-white text-black dark:bg-black dark:text-white"
           >
             {tweet.text || <span className="text-gray-400">Preview...</span>}


### PR DESCRIPTION
## Summary
- ensure ThreadComposer ref callback doesn't return a value

## Testing
- `yarn test apps/x/components/ThreadComposer.tsx --passWithNoTests`
- `yarn lint apps/x/components/ThreadComposer.tsx` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d82d46088328bf7b3707a887c46a