### PR TITLE
refactor: centralize window typings

### DIFF
--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -14,12 +14,6 @@ import useScheduledTweets, {
   ScheduledTweet,
 } from './state/scheduled';
 
-declare global {
-  interface Window {
-    twttr?: any;
-  }
-}
-
 export default function XTimeline() {
   const { accent } = useSettings();
   const [profilePresets, setProfilePresets] = usePersistentState<string[]>(

--- a/apps/youtube/components/ClipMaker.tsx
+++ b/apps/youtube/components/ClipMaker.tsx
@@ -3,13 +3,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import copyToClipboard from '../../../utils/clipboard';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 function extractVideoId(input: string): string {
   try {
     const url = new URL(input);

--- a/apps/youtube/components/ComparePlayers.tsx
+++ b/apps/youtube/components/ComparePlayers.tsx
@@ -2,13 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 function parseVideoId(input: string): string {
   try {
     const url = new URL(input);

--- a/components/PipPortal.tsx
+++ b/components/PipPortal.tsx
@@ -1,18 +1,8 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-declare global {
-  interface Window {
-    documentPictureInPicture?: {
-      requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
-    };
-  }
-
-  interface PictureInPictureWindowOptions {
-    width?: number;
-    height?: number;
-  }
-}
+// The Document Picture-in-Picture API is still experimental and the
+// TypeScript definitions do not ship with the DOM lib yet.
 
 interface PipPortalContextValue {
   open: (content: React.ReactNode) => Promise<void>;

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -5,13 +5,6 @@ import useWatchLater, {
   Video as WatchLaterVideo,
 } from '../../../apps/youtube/state/watchLater';
 
-declare global {
-  interface Window {
-    YT: any;
-    onYouTubeIframeAPIReady: () => void;
-  }
-}
-
 type Video = WatchLaterVideo;
 
 interface Props {

--- a/components/common/PipPortal.tsx
+++ b/components/common/PipPortal.tsx
@@ -2,21 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useRef, useSt
 import { createPortal } from 'react-dom';
 
 // The Document Picture-in-Picture API is still experimental and the
-// TypeScript definitions do not ship with the DOM lib yet. Declare the
-// pieces we need so that the rest of the application can type-check.
-declare global {
-  interface Window {
-    documentPictureInPicture?: {
-      requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
-    };
-  }
-
-  interface PictureInPictureWindowOptions {
-    width?: number;
-    height?: number;
-  }
-}
-
+// TypeScript definitions do not ship with the DOM lib yet.
 interface PipPortalContextValue {
   open: (content: React.ReactNode) => Promise<Window | null>;
   close: () => void;

--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -1,0 +1,18 @@
+export {};
+
+declare global {
+  interface PictureInPictureWindowOptions {
+    width?: number;
+    height?: number;
+  }
+
+  interface Window {
+    YT: any;
+    onYouTubeIframeAPIReady: () => void;
+    twttr?: any;
+    documentPictureInPicture?: {
+      requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
+    };
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize Window-related globals in `types/global-window.d.ts`
- drop scattered `declare global` blocks in components

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: KismetApp › steps through sample capture frames)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d82e8f5c8328a96e22f4055a2622