### PR TITLE
Handle missing directory for game save slots

### DIFF
--- a/components/apps/Games/common/save/index.ts
+++ b/components/apps/Games/common/save/index.ts
@@ -62,7 +62,8 @@ export default function useGameSaves(gameId: string) {
   const listSlots = useCallback(
     async (): Promise<string[]> => {
       const dir = dirRef.current;
-      if (supported && dir) {
+      if (supported) {
+        if (!dir) return [];
         const names: string[] = [];
         for await (const [name, handle] of dir.entries()) {
           if (handle.kind === 'file' && name.endsWith('.json')) {
@@ -81,7 +82,8 @@ export default function useGameSaves(gameId: string) {
   const exportSaves = useCallback(
     async (): Promise<SaveSlot[]> => {
       const dir = dirRef.current;
-      if (supported && dir) {
+      if (supported) {
+        if (!dir) return [];
         const slots: SaveSlot[] = [];
         for await (const [name, handle] of dir.entries()) {
           if (handle.kind === 'file' && name.endsWith('.json')) {


### PR DESCRIPTION
## Summary
- Return empty list if OPFS directory is missing before iterating in `listSlots`
- Return empty list if OPFS directory is missing before iterating in `exportSaves`

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, battleship-net, kismet, metasploit)*
- `npm test __tests__/saveSlots.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1d834d24c8328b08268809892329b