### PR TITLE
Add noop fallback for InputRemap

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -170,6 +170,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
   const overlayRef = useRef<HTMLDivElement>(null);
   const prevFocus = useRef<HTMLElement | null>(null);
+  const noop = () => null;
 
   useEffect(() => {
     if (!overlayRef.current) return;
@@ -226,7 +227,11 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
                 .join(', ')}
             </p>
             <div className="mt-2">
-              <InputRemap mapping={mapping} setKey={setKey} actions={info.actions} />
+              <InputRemap
+                mapping={mapping}
+                setKey={setKey ?? noop}
+                actions={info.actions}
+              />
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- prevent undefined handler by providing noop fallback before passing setKey to `InputRemap`

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet, metasploit)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d8363318832895a99221f8a2f126