### PR TITLE
feat(ettercap): add demo ui and arp diagram

### DIFF
--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useState } from 'react';
+import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
+
+interface NodeData {
+  x: number;
+  y: number;
+  label: string;
+}
+
+const initialNodes: Record<string, NodeData> = {
+  victim: { x: 40, y: 120, label: 'Victim' },
+  attacker: { x: 150, y: 40, label: 'Attacker' },
+  gateway: { x: 260, y: 120, label: 'Gateway' },
+};
+
+export default function ArpDiagram() {
+  const [nodes, setNodes] = useState<Record<string, NodeData>>(initialNodes);
+
+  const handleDrag = (key: string) => (_: DraggableEvent, data: DraggableData) => {
+    setNodes((n) => ({ ...n, [key]: { ...n[key], x: data.x, y: data.y } }));
+  };
+
+  const getLine = (from: string, to: string) => {
+    const a = nodes[from];
+    const b = nodes[to];
+    return `M${a.x + 20} ${a.y + 20} L${b.x + 20} ${b.y + 20}`;
+  };
+
+  return (
+    <div className="relative w-[320px] h-[200px] bg-gray-800 rounded mt-4">
+      <svg className="absolute inset-0 pointer-events-none" width={320} height={200}>
+        <path d={getLine('victim', 'gateway')} stroke="#fbbf24" strokeWidth={2} />
+        <path d={getLine('attacker', 'victim')} stroke="#f87171" strokeWidth={2} />
+        <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
+      </svg>
+      {Object.entries(nodes).map(([key, node]) => (
+        <Draggable
+          key={key}
+          grid={[6, 6]}
+          bounds="parent"
+          position={{ x: node.x, y: node.y }}
+          onDrag={handleDrag(key)}
+        >
+          <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
+            {node.label}
+          </div>
+        </Draggable>
+      ))}
+    </div>
+  );
+}
+

--- a/apps/ettercap/components/LogPane.tsx
+++ b/apps/ettercap/components/LogPane.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React, { useState } from 'react';
+
+export interface LogEntry {
+  id: number;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+}
+
+const levelColors: Record<LogEntry['level'], string> = {
+  info: 'bg-blue-600',
+  warn: 'bg-yellow-600',
+  error: 'bg-red-600',
+};
+
+export default function LogPane({ logs }: { logs: LogEntry[] }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="mt-4 border rounded bg-gray-900 text-white text-sm">
+      <div className="flex items-center justify-between px-2 py-1 bg-gray-800">
+        <span className="font-bold">Logs</span>
+        <button
+          type="button"
+          className="text-xs underline"
+          onClick={() => setCollapsed((c) => !c)}
+        >
+          {collapsed ? 'Expand' : 'Collapse'}
+        </button>
+      </div>
+      {!collapsed && (
+        <ul className="max-h-40 overflow-auto">
+          {logs.map((log) => (
+            <li
+              key={log.id}
+              className="flex items-start gap-2 px-2 py-1 border-b border-gray-700 last:border-0"
+            >
+              <span
+                className={`${levelColors[log.level]} text-white px-1 rounded text-[10px] font-bold`}
+              >
+                {log.level.toUpperCase()}
+              </span>
+              <span className="flex-1 break-all whitespace-pre-wrap">{log.message}</span>
+              <button
+                type="button"
+                aria-label="Copy log line"
+                className="text-xs underline"
+                onClick={() => navigator.clipboard.writeText(log.message)}
+              >
+                Copy
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/apps/ettercap/index.tsx
+++ b/apps/ettercap/index.tsx
@@ -1,59 +1,60 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import FilterEditor from './components/FilterEditor';
+import LogPane, { LogEntry } from './components/LogPane';
+import ArpDiagram from './components/ArpDiagram';
+
+const MODES = ['Unified', 'Sniff', 'ARP'];
 
 export default function EttercapPage() {
-  const [showModal, setShowModal] = useState(false);
-  const [captureEnabled, setCaptureEnabled] = useState(false);
+  const [mode, setMode] = useState('Unified');
+  const [started, setStarted] = useState(false);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
 
-  const handleEnableClick = () => {
-    setShowModal(true);
-  };
-
-  const confirmEnable = () => {
-    setCaptureEnabled(true);
-    setShowModal(false);
-  };
+  useEffect(() => {
+    if (!started) return;
+    const id = setInterval(() => {
+      const levels: LogEntry['level'][] = ['info', 'warn', 'error'];
+      const level = levels[Math.floor(Math.random() * levels.length)];
+      const message = `Sample ${level} message ${new Date().toLocaleTimeString()}`;
+      setLogs((l) => [...l, { id: Date.now(), level, message }]);
+    }, 2000);
+    return () => clearInterval(id);
+  }, [started]);
 
   return (
-    <div className="relative p-4">
-      <h1 className="mb-4 text-xl font-bold">Ettercap Filter Editor</h1>
-      <button
-        type="button"
-        className="mb-4 border px-2 py-1"
-        onClick={handleEnableClick}
-        disabled={captureEnabled}
-      >
-        {captureEnabled ? 'Packet Capture Enabled' : 'Enable Packet Capture'}
-      </button>
-      <FilterEditor />
-      {showModal && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/70">
-          <div className="w-72 rounded bg-white p-4 text-black">
-            <p className="mb-4 text-sm">
-              Enabling packet capture may impact network performance and could
-              expose sensitive information. Do you want to proceed?
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                className="border px-2 py-1"
-                onClick={() => setShowModal(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="border px-2 py-1"
-                onClick={confirmEnable}
-              >
-                Enable
-              </button>
-            </div>
-          </div>
+    <div className="p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex gap-2">
+          {MODES.map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={`px-3 py-1 rounded-full border text-sm ${
+                mode === m ? 'bg-blue-600 text-white' : 'bg-gray-800 text-white'
+              }`}
+            >
+              {m}
+            </button>
+          ))}
         </div>
-      )}
+        <button
+          type="button"
+          className="px-4 py-2 rounded bg-green-600 text-white"
+          onClick={() => setStarted(true)}
+          disabled={started}
+        >
+          {started ? 'Demo running' : 'Start demo'}
+        </button>
+      </div>
+
+      {started && <LogPane logs={logs} />}
+      {started && <ArpDiagram />}
+
+      <h1 className="mt-6 mb-4 text-xl font-bold">Ettercap Filter Editor</h1>
+      <FilterEditor />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add mode selector and demo starter banner for Ettercap
- include live log pane with severity badges and copy support
- add draggable ARP diagram with 6px snap grid

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet)*
- `npm run lint` *(fails: ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d89ce340832887db3f5cf188ba75