### PR TITLE
feat: enhance project gallery grid and tech filters

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -19,7 +19,7 @@ export default function ProjectGalleryPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const router = useRouter();
 
-  const [stack, setStack] = usePersistentState<string>('pg-stack', '');
+  const [tech, setTech] = usePersistentState<string[]>('pg-tech', []);
   const [year, setYear] = usePersistentState<string>('pg-year', '');
   const [type, setType] = usePersistentState<string>('pg-type', '');
   const [tags, setTags] = usePersistentState<string[]>('pg-tags', []);
@@ -35,22 +35,22 @@ export default function ProjectGalleryPage() {
   // initialize from query string
   useEffect(() => {
     if (!router.isReady) return;
-    const { stack: qsStack, year: qsYear, type: qsType, tags: qsTags } = router.query;
-    if (typeof qsStack === 'string') setStack(qsStack);
+    const { tech: qsTech, year: qsYear, type: qsType, tags: qsTags } = router.query;
+    if (typeof qsTech === 'string') setTech(qsTech.split(','));
     if (typeof qsYear === 'string') setYear(qsYear);
     if (typeof qsType === 'string') setType(qsType);
     if (typeof qsTags === 'string') setTags(qsTags.split(','));
-  }, [router.isReady]);
+  }, [router.isReady, router.query, setTech, setYear, setType, setTags]);
 
   // encode selection in query string
   useEffect(() => {
     const query: Record<string, string> = {};
-    if (stack) query.stack = stack;
+    if (tech.length) query.tech = tech.join(',');
     if (year) query.year = year;
     if (type) query.type = type;
     if (tags.length) query.tags = tags.join(',');
     router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
-  }, [stack, year, type, tags]);
+  }, [router, tech, year, type, tags]);
 
   const stacks = useMemo(
     () => Array.from(new Set(projects.flatMap((p) => p.stack))),
@@ -73,12 +73,12 @@ export default function ProjectGalleryPage() {
     () =>
       projects.filter(
         (p) =>
-          (!stack || p.stack.includes(stack)) &&
+          (!tech.length || tech.every((t) => p.stack.includes(t))) &&
           (!year || String(p.year) === year) &&
           (!type || p.type === type) &&
           (!tags.length || tags.every((t) => p.tags.includes(t)))
       ),
-    [projects, stack, year, type, tags]
+    [projects, tech, year, type, tags]
   );
 
   const pillClass = (active: boolean) =>
@@ -103,8 +103,10 @@ export default function ProjectGalleryPage() {
         {stacks.map((s) => (
           <button
             key={s}
-            onClick={() => setStack(stack === s ? '' : s)}
-            className={pillClass(stack === s)}
+            onClick={() =>
+              setTech(tech.includes(s) ? tech.filter((t) => t !== s) : [...tech, s])
+            }
+            className={pillClass(tech.includes(s))}
           >
             {s}
           </button>
@@ -132,17 +134,32 @@ export default function ProjectGalleryPage() {
           </button>
         ))}
       </div>
-      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
         {filtered.map((p) => (
           <div
             key={p.id}
-            className="border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90"
+            tabIndex={0}
+            className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
             aria-label={`${p.title}: ${p.description}`}
           >
             <img src={p.thumbnail} alt={p.title} className="w-full h-40 object-cover" />
-            <div className="p-2">
+            <div className="p-2 flex-1">
               <h3 className="font-semibold">{p.title}</h3>
               <p className="text-sm">{p.description}</p>
+            </div>
+            <div className="absolute inset-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity bg-black/60 text-white flex flex-col">
+              <div className="p-2 flex flex-wrap gap-1">
+                {p.tags.map((t) => (
+                  <span key={t} className="bg-white text-black rounded px-1 text-xs">
+                    {t}
+                  </span>
+                ))}
+              </div>
+              <div className="mt-auto p-2 text-right">
+                <button className="bg-blue-600 text-white px-2 py-1 rounded">
+                  Quick view
+                </button>
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- add persistent tech filter chips encoded in query string
- revamp gallery layout with equal-height cards and 12px gutters
- reveal tags and quick-view button on hover/focus with keyboard support

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/project-gallery/pages/index.tsx`
- `yarn test apps/project-gallery --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8bf844883289b3ae2a03dc5d609