### PR TITLE
feat: enhance trash app with dynamic icons

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -787,7 +787,7 @@ const apps = [
   {
     id: 'trash',
     title: 'Trash',
-    icon: './themes/Yaru/system/user-trash-full.png',
+    icon: './themes/Yaru/status/user-trash-symbolic.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: true,

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -5,6 +5,8 @@ import useTrashState from './state';
 import HistoryList from './components/HistoryList';
 import type { TrashItem } from './state';
 
+const DEFAULT_ICON = './themes/Yaru/system/folder.png';
+
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const {
     items,
@@ -16,6 +18,8 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   } = useTrashState();
   const [selected, setSelected] = useState<number | null>(null);
 
+  const notifyChange = () => window.dispatchEvent(new Event('trash-change'));
+
   const restore = useCallback(() => {
     if (selected === null) return;
     const item = items[selected];
@@ -23,6 +27,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     openApp(item.id);
     setItems(items => items.filter((_, i) => i !== selected));
     setSelected(null);
+    notifyChange();
   }, [items, selected, openApp, setItems]);
 
   const remove = useCallback(() => {
@@ -33,6 +38,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     setItems(next);
     pushHistory(item);
     setSelected(null);
+    notifyChange();
   }, [items, selected, setItems, pushHistory]);
 
   const restoreAll = () => {
@@ -41,6 +47,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     items.forEach(item => openApp(item.id));
     setItems([]);
     setSelected(null);
+    notifyChange();
   };
 
   const empty = () => {
@@ -49,6 +56,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     pushHistory(items);
     setItems([]);
     setSelected(null);
+    notifyChange();
   };
 
   const handleKey = useCallback((e: KeyboardEvent) => {
@@ -67,31 +75,46 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     return () => window.removeEventListener('keydown', handleKey);
   }, [handleKey]);
 
+  const handleRestoreFromHistory = useCallback(
+    (idx: number) => {
+      restoreFromHistory(idx);
+      notifyChange();
+    },
+    [restoreFromHistory],
+  );
+
+  const handleRestoreAllFromHistory = useCallback(() => {
+    restoreAllFromHistory();
+    notifyChange();
+  }, [restoreAllFromHistory]);
+
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
       <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
         <span className="font-bold ml-2">Trash</span>
-        <div className="flex">
-          <button
-            onClick={restore}
-            disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Restore
-          </button>
+        <div className="flex items-center">
+          <div className="flex space-x-3 mr-2">
+            <button
+              onClick={restore}
+              disabled={selected === null}
+              className="px-3 py-1 my-1 rounded bg-blue-600 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+            >
+              Restore
+            </button>
+            <button
+              onClick={remove}
+              disabled={selected === null}
+              className="px-3 py-1 my-1 rounded bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+            >
+              Delete
+            </button>
+          </div>
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
             className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
           >
             Restore All
-          </button>
-          <button
-            onClick={remove}
-            disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
-          >
-            Delete
           </button>
           <button
             onClick={empty}
@@ -102,27 +125,39 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           </button>
         </div>
       </div>
-      <div className="flex flex-wrap content-start p-2 overflow-auto flex-1">
-        {items.length === 0 && <div className="w-full text-center mt-10">Trash is empty</div>}
-        {items.map((item, idx) => (
-          <div
-            key={item.closedAt}
-            tabIndex={0}
-            onClick={() => setSelected(idx)}
-            className={`m-2 border p-1 w-32 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
-          >
-            {item.image ? (
-              <img src={item.image} alt={item.title} className="h-20 w-full object-cover" />
-            ) : item.icon ? (
-              <img src={item.icon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
-            ) : null}
-            <p className="text-center text-xs truncate mt-1" title={item.title}>
-              {item.title}
-            </p>
+      <div className="flex-1 overflow-auto">
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center mt-12 space-y-1.5">
+            <img
+              src="./themes/Yaru/status/user-trash-symbolic.svg"
+              alt="Empty trash"
+              className="h-12 w-12 opacity-60"
+            />
+            <span>Trash is empty</span>
           </div>
-        ))}
+        ) : (
+          <ul className="p-2 space-y-1.5">
+            {items.map((item, idx) => (
+              <li
+                key={item.closedAt}
+                tabIndex={0}
+                onClick={() => setSelected(idx)}
+                className={`flex items-center p-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
+              >
+                <img
+                  src={item.icon || DEFAULT_ICON}
+                  alt=""
+                  className="h-6 w-6 mr-2"
+                />
+                <span className="truncate" title={item.title}>
+                  {item.title}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-      <HistoryList history={history} onRestore={restoreFromHistory} onRestoreAll={restoreAllFromHistory} />
+      <HistoryList history={history} onRestore={handleRestoreFromHistory} onRestoreAll={handleRestoreAllFromHistory} />
     </div>
   );
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -70,12 +70,15 @@ export class Desktop extends Component {
         this.setEventListeners();
         this.checkForNewFolders();
         this.checkForAppShortcuts();
+        this.updateTrashIcon();
+        window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
+        window.removeEventListener('trash-change', this.updateTrashIcon);
     }
 
     checkForNewFolders = () => {
@@ -559,6 +562,7 @@ export class Desktop extends Component {
             closedAt: now,
         });
         localStorage.setItem('window-trash', JSON.stringify(trash));
+        this.updateTrashIcon();
 
         // remove app from the app stack
         this.app_stack.splice(this.app_stack.indexOf(objId), 1);
@@ -650,6 +654,21 @@ export class Desktop extends Component {
                 }
             });
             this.updateAppsData();
+        }
+    }
+
+    updateTrashIcon = () => {
+        let trash = [];
+        try { trash = JSON.parse(localStorage.getItem('window-trash') || '[]'); } catch (e) { trash = []; }
+        const appIndex = apps.findIndex(app => app.id === 'trash');
+        if (appIndex !== -1) {
+            const icon = trash.length
+                ? './themes/Yaru/system/user-trash-full.png'
+                : './themes/Yaru/status/user-trash-symbolic.svg';
+            if (apps[appIndex].icon !== icon) {
+                apps[appIndex].icon = icon;
+                this.forceUpdate();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add empty and full trash icons with desktop updates
- show trash items in list view with file-type glyphs
- style restore/delete actions and empty state illustration

## Testing
- `npx eslint -c .eslintrc.cjs apps.config.js apps/trash/index.tsx components/screen/desktop.js` *(fails: config uses unsupported extends)*
- `npm test -- --passWithNoTests trash`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8c66d6c83289bbcff42a9d91513