### PR TITLE
feat(qr): add preview tabs and drag‑drop scanning

### DIFF
--- a/apps/qr/components/Presets.tsx
+++ b/apps/qr/components/Presets.tsx
@@ -11,9 +11,11 @@ interface WifiData {
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement>;
+  onPayloadChange?: (payload: string) => void;
+  size: number;
 }
 
-const Presets: React.FC<Props> = ({ canvasRef }) => {
+const Presets: React.FC<Props> = ({ canvasRef, onPayloadChange, size }) => {
   const [preset, setPreset] = useState<Preset>('text');
   const [text, setText] = useState('');
   const [url, setUrl] = useState('');
@@ -30,7 +32,8 @@ const Presets: React.FC<Props> = ({ canvasRef }) => {
       value = `WIFI:T:${enc};S:${ssid};P:${password};;`;
     }
     setPayload(value);
-  }, [preset, text, url, wifi]);
+    onPayloadChange?.(value);
+  }, [preset, text, url, wifi, onPayloadChange]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -42,11 +45,11 @@ const Presets: React.FC<Props> = ({ canvasRef }) => {
       return;
     }
 
-    QRCode.toCanvas(canvas, payload, { margin: 1 }).catch(() => {
+    QRCode.toCanvas(canvas, payload, { margin: 1, width: size }).catch(() => {
       const ctx = canvas.getContext('2d');
       if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
     });
-  }, [payload, canvasRef]);
+  }, [payload, canvasRef, size]);
 
   const copyPayload = async () => {
     if (!payload) return;
@@ -152,8 +155,6 @@ const Presets: React.FC<Props> = ({ canvasRef }) => {
           </div>
         </div>
       )}
-
-      <canvas ref={canvasRef} className="h-48 w-48 bg-white" />
     </div>
   );
 };

--- a/apps/qr/components/Scan.tsx
+++ b/apps/qr/components/Scan.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useState } from 'react';
+
+interface Props {
+  onResult: (text: string) => void;
+}
+
+const Scan: React.FC<Props> = ({ onResult }) => {
+  const [preview, setPreview] = useState('');
+  const [error, setError] = useState('');
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (!file || !file.type.startsWith('image/')) {
+        setError('');
+        return;
+      }
+      const url = URL.createObjectURL(file);
+      setPreview(url);
+      setError('');
+      try {
+        if ('BarcodeDetector' in window) {
+          const img = new Image();
+          img.src = url;
+          await img.decode();
+          const detector = new (window as any).BarcodeDetector({
+            formats: ['qr_code'],
+          });
+          const codes = await detector.detect(img);
+          if (codes[0]) onResult(codes[0].rawValue);
+        } else {
+          const { BrowserQRCodeReader } = await import('@zxing/browser');
+          const reader = new BrowserQRCodeReader();
+          const res = await reader.decodeFromImageUrl(url);
+          onResult(res.getText());
+        }
+      } catch {
+        setError('No QR code found');
+      }
+    },
+    [onResult],
+  );
+
+  return (
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className="w-full h-full relative flex items-center justify-center border-2 border-dashed border-gray-500 text-gray-400"
+    >
+      {preview ? (
+        <img src={preview} alt="Dropped" className="max-w-full max-h-full" />
+      ) : (
+        <p>Drop image</p>
+      )}
+      {/* corner anchors */}
+      <svg
+        className="w-6 h-6 absolute top-0 left-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M3 9V3h6" />
+      </svg>
+      <svg
+        className="w-6 h-6 absolute top-0 right-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M21 9V3h-6" />
+      </svg>
+      <svg
+        className="w-6 h-6 absolute bottom-0 left-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M3 15v6h6" />
+      </svg>
+      <svg
+        className="w-6 h-6 absolute bottom-0 right-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M21 15v6h-6" />
+      </svg>
+      {error && (
+        <p className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-red-500">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default Scan;

--- a/apps/qr/index.tsx
+++ b/apps/qr/index.tsx
@@ -1,30 +1,146 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState, useCallback } from 'react';
+import QRCode from 'qrcode';
 import Presets from './components/Presets';
+import Scan from './components/Scan';
 
 export default function QR() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [payload, setPayload] = useState('');
+  const [mode, setMode] = useState<'generate' | 'scan'>('generate');
+  const [size, setSize] = useState(256);
+  const [scanResult, setScanResult] = useState('');
 
-  const downloadPng = () => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const downloadPng = useCallback(async () => {
+    if (!payload) return;
+    const data = await QRCode.toDataURL(payload, { margin: 1, width: size });
     const link = document.createElement('a');
-    link.href = canvas.toDataURL('image/png');
-    link.download = 'qr.png';
+    link.href = data;
+    link.download = `qr-${size}.png`;
     link.click();
-  };
+  }, [payload, size]);
+
+  const downloadSvg = useCallback(async () => {
+    if (!payload) return;
+    const svg = await QRCode.toString(payload, {
+      margin: 1,
+      width: size,
+      type: 'svg',
+    });
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `qr-${size}.svg`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [payload, size]);
 
   return (
     <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full overflow-auto">
-      <Presets canvasRef={canvasRef} />
-      <button
-        type="button"
-        onClick={downloadPng}
-        className="px-2 py-1 bg-blue-600 rounded"
-      >
-        Download PNG
-      </button>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setMode('generate')}
+          className={`px-2 py-1 rounded ${
+            mode === 'generate' ? 'bg-blue-600' : 'bg-gray-600'
+          }`}
+        >
+          Generate
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('scan')}
+          className={`px-2 py-1 rounded ${
+            mode === 'scan' ? 'bg-blue-600' : 'bg-gray-600'
+          }`}
+        >
+          Scan
+        </button>
+      </div>
+
+      <div className="w-64 aspect-square mx-auto">
+        {mode === 'generate' ? (
+          <canvas ref={canvasRef} className="w-full h-full bg-white" />
+        ) : (
+          <Scan onResult={setScanResult} />
+        )}
+      </div>
+
+      {mode === 'generate' && (
+        <>
+          <Presets
+            canvasRef={canvasRef}
+            onPayloadChange={setPayload}
+            size={size}
+          />
+          <div className="flex items-center gap-2">
+            <label htmlFor="qr-size" className="text-sm flex items-center gap-1">
+              Size
+              <select
+                id="qr-size"
+                value={size}
+                onChange={(e) => setSize(parseInt(e.target.value, 10))}
+                className="ml-1 rounded p-1 text-black"
+              >
+                <option value={128}>128</option>
+                <option value={256}>256</option>
+                <option value={512}>512</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={downloadPng}
+              className="p-1 bg-blue-600 rounded"
+              aria-label="Download PNG"
+            >
+              <svg
+                className="w-6 h-6"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M12 3v12" />
+                <path d="M8 11l4 4 4-4" />
+                <path d="M4 19h16" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={downloadSvg}
+              className="p-1 bg-blue-600 rounded"
+              aria-label="Download SVG"
+            >
+              <svg
+                className="w-6 h-6"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M12 3v12" />
+                <path d="M8 11l4 4 4-4" />
+                <path d="M4 19h16" />
+              </svg>
+            </button>
+          </div>
+        </>
+      )}
+
+      {mode === 'scan' && scanResult && (
+        <div className="space-y-2">
+          <p className="break-all text-sm">{scanResult}</p>
+          <button
+            type="button"
+            onClick={() => navigator.clipboard?.writeText(scanResult)}
+            className="px-2 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add tabbed interface for generating or scanning QR codes
- show 1:1 preview tile with drag-drop scanning area and corner anchors
- allow PNG/SVG downloads with selectable size presets

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/qr/index.tsx apps/qr/components/Presets.tsx apps/qr/components/Scan.tsx`
- `npx jest apps/qr --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8d3ce808328bff5d248ce7a0a5f