### PR TITLE
feat: add metasploit post result tabs and reporting

### DIFF
--- a/apps/metasploit-post/components/ResultCard.tsx
+++ b/apps/metasploit-post/components/ResultCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface ResultCardProps {
+  title: string;
+  output: string;
+}
+
+const ResultCard: React.FC<ResultCardProps> = ({ title, output }) => {
+  const copy = () => navigator.clipboard.writeText(output);
+  return (
+    <div className="bg-gray-800 p-3 rounded mb-2">
+      <div className="flex justify-between items-center mb-2">
+        <h4 className="font-semibold">{title}</h4>
+        <button onClick={copy} className="px-2 py-1 bg-gray-700 rounded">
+          Copy
+        </button>
+      </div>
+      <pre className="whitespace-pre-wrap">{output}</pre>
+    </div>
+  );
+};
+
+export default ResultCard;


### PR DESCRIPTION
## Summary
- add tabbed interface with status badges for hash dump, persistence and enumeration
- display module outputs as copyable result cards
- allow saving accumulated results into a report section

## Testing
- `yarn lint apps/metasploit-post/index.tsx apps/metasploit-post/components/ResultCard.tsx` *(fails: ESLint couldn't find a configuration file)*
- `yarn test apps/metasploit-post --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1e72ffeb883288a6b90c1e8b7347f