### PR TITLE
feat(dsniff): enhance credential display and filtering

### DIFF
--- a/__tests__/dsniff.test.tsx
+++ b/__tests__/dsniff.test.tsx
@@ -31,12 +31,12 @@ describe('Dsniff component', () => {
       screen.getByText(/HTTPS\/TLS to encrypt credentials/i)
     ).toBeInTheDocument();
   });
-
-  it('redacts credentials when enabled', async () => {
+  it('obfuscates credentials by default and reveals on click', async () => {
     render(<Dsniff />);
-    expect(await screen.findByText('demo:demo123')).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Redact passwords'));
-    expect(await screen.findByText('demo:***')).toBeInTheDocument();
+    expect(await screen.findByText('***')).toBeInTheDocument();
+    const showBtn = screen.getByText('Show');
+    fireEvent.click(showBtn);
+    expect(await screen.findByText('demo123')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Obfuscate captured credentials with protocol icons and per-entry reveal controls
- Add color-coded protocol filter buttons
- Move domain export to header for quick access

## Testing
- `yarn test __tests__/dsniff.test.tsx`
- `npx eslint components/apps/dsniff/index.js __tests__/dsniff.test.tsx` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e73196048328804ebb8ff662c62b