### PR TITLE
feat(recon-ng): add workspace planner and entity graph menu

### DIFF
--- a/apps/recon-ng/components/DataModelExplorer.tsx
+++ b/apps/recon-ng/components/DataModelExplorer.tsx
@@ -46,6 +46,11 @@ const mockData = {
 
 const DataModelExplorer: React.FC = () => {
   const [selected, setSelected] = useState<EntityNode | null>(null);
+  const [menu, setMenu] = useState<{
+    node: EntityNode;
+    x: number;
+    y: number;
+  } | null>(null);
   const graphData = useMemo(() => mockData, []);
 
   return (
@@ -53,7 +58,16 @@ const DataModelExplorer: React.FC = () => {
       <ForceGraph2D
         graphData={graphData}
         nodeId="id"
+        onBackgroundClick={() => setMenu(null)}
         onNodeClick={(node) => setSelected(node as EntityNode)}
+        onNodeRightClick={(node, event) => {
+          event.preventDefault();
+          setMenu({
+            node: node as EntityNode,
+            x: (event as MouseEvent).clientX,
+            y: (event as MouseEvent).clientY,
+          });
+        }}
         nodeCanvasObject={(node, ctx, globalScale) => {
           const n = node as EntityNode & { x?: number; y?: number };
           const label = n.label;
@@ -67,6 +81,28 @@ const DataModelExplorer: React.FC = () => {
         }}
         linkDirectionalArrowLength={4}
       />
+      {menu && (
+        <div
+          className="fixed z-10 bg-gray-800 text-white text-xs rounded shadow"
+          style={{ top: menu.y, left: menu.x }}
+        >
+          <button
+            className="block w-full px-2 py-1 text-left hover:bg-gray-700"
+            onClick={() => {
+              setSelected(menu.node);
+              setMenu(null);
+            }}
+          >
+            View Details
+          </button>
+          <button
+            className="block w-full px-2 py-1 text-left hover:bg-gray-700"
+            onClick={() => setMenu(null)}
+          >
+            Close
+          </button>
+        </div>
+      )}
       {selected && (
         <div className="absolute top-0 right-0 m-2 max-w-xs rounded bg-gray-800 p-2 text-xs text-white shadow">
           <div className="mb-1 font-bold">{selected.label}</div>

--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -1,21 +1,23 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../../hooks/usePersistentState';
 
 interface ModuleDef {
   deps: string[];
+  tags: string[];
 }
 
 const MODULES: Record<string, ModuleDef> = {
-  'DNS Enumeration': { deps: [] },
-  'WHOIS Lookup': { deps: ['DNS Enumeration'] },
-  'Reverse IP Lookup': { deps: ['WHOIS Lookup'] },
-  'Port Scan': { deps: ['Reverse IP Lookup'] },
+  'DNS Enumeration': { deps: [], tags: ['dns', 'recon'] },
+  'WHOIS Lookup': { deps: ['DNS Enumeration'], tags: ['whois', 'network'] },
+  'Reverse IP Lookup': { deps: ['WHOIS Lookup'], tags: ['ip'] },
+  'Port Scan': { deps: ['Reverse IP Lookup'], tags: ['ports', 'network'] },
 };
 
 const moduleNames = Object.keys(MODULES);
+const WORKSPACES = ['default', 'testing', 'production'];
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
@@ -24,11 +26,25 @@ const ForceGraph2D = dynamic(
 
 const ModulePlanner: React.FC = () => {
   const [plan, setPlan] = usePersistentState<string[]>('reconng-plan', []);
+  const [workspace, setWorkspace] = usePersistentState<string>(
+    'reconng-workspace',
+    WORKSPACES[0],
+  );
+  const [log, setLog] = useState('');
 
   const toggle = (name: string) => {
     setPlan((p) =>
       p.includes(name) ? p.filter((m) => m !== name) : [...p, name],
     );
+  };
+
+  const exportPlan = () => {
+    const lines = [
+      `Workspace: ${workspace}`,
+      'Modules:',
+      ...plan.map((m) => `- ${m}`),
+    ];
+    setLog(lines.join('\n'));
   };
 
   const graphData = useMemo(() => {
@@ -54,18 +70,49 @@ const ModulePlanner: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-4 p-4 bg-gray-900 text-white h-full">
-      <div>
-        {moduleNames.map((m) => (
-          <label key={m} className="block">
-            <input
-              type="checkbox"
-              checked={plan.includes(m)}
-              onChange={() => toggle(m)}
-              className="mr-2"
-            />
-            {m}
-          </label>
-        ))}
+      <div className="flex items-center gap-2">
+        <label htmlFor="workspace">Workspace:</label>
+        <select
+          id="workspace"
+          value={workspace}
+          onChange={(e) => setWorkspace(e.target.value)}
+          className="text-black p-1 rounded"
+        >
+          {WORKSPACES.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {moduleNames.map((m) => {
+          const mod = MODULES[m];
+          const active = plan.includes(m);
+          return (
+            <div
+              key={m}
+              className={`border rounded p-2 cursor-pointer ${
+                active
+                  ? 'bg-blue-900 border-blue-500'
+                  : 'bg-gray-800 border-gray-700'
+              }`}
+              onClick={() => toggle(m)}
+            >
+              <div className="font-bold">{m}</div>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {mod.tags.map((t) => (
+                  <span
+                    key={t}
+                    className="text-xs bg-gray-700 px-1 rounded"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </div>
       {graphData.nodes.length > 0 && (
         <div className="h-64 bg-black rounded">
@@ -82,6 +129,20 @@ const ModulePlanner: React.FC = () => {
           />
         </div>
       )}
+      <div>
+        <button
+          type="button"
+          onClick={exportPlan}
+          className="px-2 py-1 bg-blue-700 rounded"
+        >
+          Export Plan
+        </button>
+        {log && (
+          <pre className="mt-2 bg-black text-green-400 p-2 rounded font-mono whitespace-pre-wrap">
+            {log}
+          </pre>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add workspace selector and tag-based module cards
- include export plan log with monospace formatting
- add node action menu for entity graph exploration

## Testing
- `yarn lint apps/recon-ng/components/DataModelExplorer.tsx apps/recon-ng/components/ModulePlanner.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test apps/recon-ng --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7a5cb1483289d85e1f6d03a6d63