### PR TITLE
feat: improve Battleship board and accessibility

### DIFF
--- a/components/apps/battleship/GameLayout.js
+++ b/components/apps/battleship/GameLayout.js
@@ -12,6 +12,8 @@ const GameLayout = ({
   onSalvoChange,
   fog,
   onFogChange,
+  colorblind,
+  onColorblindChange,
 }) => {
   return (
     <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
@@ -51,6 +53,15 @@ const GameLayout = ({
             onChange={(e) => onFogChange(e.target.checked)}
           />
           Fog of War
+        </label>
+        <label className="text-sm">
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={colorblind}
+            onChange={(e) => onColorblindChange(e.target.checked)}
+          />
+          Colorblind
         </label>
         {stats && (
           <div className="ml-4 text-sm">


### PR DESCRIPTION
## Summary
- add colorblind mode toggle to Battleship
- animate hit/miss markers with colorblind-friendly colors
- highlight valid ship placement with water gradient boards

## Testing
- `yarn test battleship`
- `yarn lint components/apps/battleship.js components/apps/battleship/GameLayout.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7a8eec083288895a33fcf781c22