### PR TITLE
feat(checkers): improve board, hints and captures

### DIFF
--- a/apps/checkers/checkers.css
+++ b/apps/checkers/checkers.css
@@ -3,9 +3,9 @@
 }
 
 .move-square {
-  @apply ring-2 ring-yellow-300 bg-yellow-200/40 animate-pulse;
+  @apply ring-2 ring-amber-400 ring-offset-1 ring-offset-black bg-amber-200/30 animate-pulse;
 }
 
 .hint-square {
-  @apply ring-2 ring-blue-400 animate-pulse;
+  @apply ring-2 ring-sky-400 ring-offset-1 ring-offset-black bg-sky-200/30 animate-pulse;
 }


### PR DESCRIPTION
## Summary
- restyle checkers board with dark red/black theme and captured-piece counters
- add soft-highlight move hints with keyboard navigation

## Testing
- `npx eslint --config .eslintrc.cjs apps/checkers/index.tsx apps/checkers/checkers.css` *(fails: File ignored because no matching configuration was supplied)*
- `yarn test __tests__/checkers.validator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7af81308328bc57639c7b0ebe64