### PR TITLE
feat(snake): add speed control and scoreboard

### DIFF
--- a/games/snake/index.tsx
+++ b/games/snake/index.tsx
@@ -10,12 +10,16 @@ const CELL_SIZE = 16;
 const Snake = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [wrap, setWrap] = usePersistentState<boolean>("snake:wrap", false);
+  const [speed, setSpeed] = usePersistentState<number>("snake:speed", 150);
   const [state, setState] = useState<GameState>(() => createState(wrap));
+  const [score, setScore] = useState(0);
+  const [foodAnim, setFoodAnim] = useState(1);
   const runningRef = useRef(true);
 
   // keep state.wrap in sync with persisted wrap
   useEffect(() => {
     setState((s) => ({ ...s, wrap }));
+    setScore(0);
     runningRef.current = true;
   }, [wrap]);
 
@@ -28,11 +32,25 @@ const Snake = () => {
         if (result.gameOver) {
           runningRef.current = false;
         }
+        if (result.ate) {
+          setScore((sc) => sc + 1);
+          setFoodAnim(0);
+        }
         return result.state;
       });
-    }, 150);
+    }, speed);
     return () => clearInterval(id);
-  }, []);
+  }, [speed]);
+
+  // food spawn animation
+  useEffect(() => {
+    if (foodAnim < 1) {
+      const id = requestAnimationFrame(() =>
+        setFoodAnim((f) => Math.min(f + 0.1, 1)),
+      );
+      return () => cancelAnimationFrame(id);
+    }
+  }, [foodAnim]);
 
   // draw
   useEffect(() => {
@@ -40,13 +58,21 @@ const Snake = () => {
     if (!ctx) return;
     ctx.fillStyle = "#111827";
     ctx.fillRect(0, 0, GRID_SIZE * CELL_SIZE, GRID_SIZE * CELL_SIZE);
-    ctx.fillStyle = "#ef4444";
-    ctx.fillRect(state.food.x * CELL_SIZE, state.food.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
-    ctx.fillStyle = "#22c55e";
+    const foodX = state.food.x * CELL_SIZE;
+    const foodY = state.food.y * CELL_SIZE;
+    const size = CELL_SIZE * foodAnim;
+    ctx.fillStyle = "#facc15";
+    ctx.fillRect(
+      foodX + (CELL_SIZE - size) / 2,
+      foodY + (CELL_SIZE - size) / 2,
+      size,
+      size,
+    );
+    ctx.fillStyle = "#3b82f6";
     state.snake.forEach((seg) => {
       ctx.fillRect(seg.x * CELL_SIZE, seg.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
     });
-  }, [state]);
+  }, [state, foodAnim]);
 
   // controls
   const dirRef = useRef(state.dir);
@@ -56,9 +82,12 @@ const Snake = () => {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const dir = dirRef.current;
-      if (e.key === "ArrowUp" && dir.y !== 1) setState((s) => ({ ...s, dir: { x: 0, y: -1 } }));
-      if (e.key === "ArrowDown" && dir.y !== -1) setState((s) => ({ ...s, dir: { x: 0, y: 1 } }));
-      if (e.key === "ArrowLeft" && dir.x !== 1) setState((s) => ({ ...s, dir: { x: -1, y: 0 } }));
+      if (e.key === "ArrowUp" && dir.y !== 1)
+        setState((s) => ({ ...s, dir: { x: 0, y: -1 } }));
+      if (e.key === "ArrowDown" && dir.y !== -1)
+        setState((s) => ({ ...s, dir: { x: 0, y: 1 } }));
+      if (e.key === "ArrowLeft" && dir.x !== 1)
+        setState((s) => ({ ...s, dir: { x: -1, y: 0 } }));
       if (e.key === "ArrowRight" && dir.x !== -1)
         setState((s) => ({ ...s, dir: { x: 1, y: 0 } }));
     };
@@ -77,13 +106,37 @@ const Snake = () => {
     </label>
   );
 
+  const speeds = [
+    { label: "Slow", value: 200 },
+    { label: "Normal", value: 150 },
+    { label: "Fast", value: 100 },
+  ];
+
+  const width = GRID_SIZE * CELL_SIZE;
+
   return (
     <GameShell settings={settings}>
-      <canvas
-        ref={canvasRef}
-        width={GRID_SIZE * CELL_SIZE}
-        height={GRID_SIZE * CELL_SIZE}
-      />
+      <div className="flex flex-col items-center">
+        <div className="flex justify-between mb-2 text-white" style={{ width }}>
+          <div className="flex space-x-2">
+            {speeds.map((s) => (
+              <button
+                key={s.value}
+                onClick={() => setSpeed(s.value)}
+                className={`px-2 py-1 rounded-full text-xs ${
+                  speed === s.value
+                    ? "bg-blue-500 text-white"
+                    : "bg-gray-700 text-gray-200"
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <div>Score: {score}</div>
+        </div>
+        <canvas ref={canvasRef} width={width} height={width} />
+      </div>
     </GameShell>
   );
 };


### PR DESCRIPTION
## Summary
- add speed selector chips and scoreboard to snake
- animate food spawn and use high contrast colors for snake and food

## Testing
- `yarn test __tests__/snake.config.test.ts`
- `yarn lint games/snake/index.tsx` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7bdf27883288219b80c4a17b5e6