### PR TITLE
feat(tetris): add previews and ghost

### DIFF
--- a/public/apps/tetris/index.html
+++ b/public/apps/tetris/index.html
@@ -5,15 +5,32 @@
   <title>Tetris</title>
   <style>
     body { background: #111; color: #fff; font-family: sans-serif; text-align: center; }
-    canvas { background: #222; display: block; margin: 0 auto; }
-    #info { margin-top: 8px; }
-    #leaderboard { margin-top: 8px; }
-    button { margin: 2px; }
+    canvas { background: #222; }
+    #game { display: flex; justify-content: center; gap: 12px; }
+    .side { display: flex; flex-direction: column; gap: 12px; }
+    .side canvas { display: block; margin: 0 auto; }
+    #info { margin-top: 12px; }
+    #leaderboard { margin-top: 12px; }
+    button { margin: 6px; }
   </style>
 </head>
 <body>
   <h1>Tetris</h1>
-  <canvas id="board" width="200" height="400"></canvas>
+  <div id="game">
+    <canvas id="board" width="240" height="480"></canvas>
+    <div class="side">
+      <div>
+        <div>Hold</div>
+        <canvas id="hold"></canvas>
+      </div>
+      <div>
+        <div>Next</div>
+        <canvas id="next1"></canvas>
+        <canvas id="next2"></canvas>
+        <canvas id="next3"></canvas>
+      </div>
+    </div>
+  </div>
   <div id="info"></div>
   <div>
     <button id="mode-sprint">40 Line Sprint</button>


### PR DESCRIPTION
## Summary
- show hold slot and 3-piece next queue with themed colors
- render ghost piece and lock flash
- align board to 6px grid units

## Testing
- `npm test` *(fails: game2048, beef, mimikatz, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7c1eac48328aa771978303ee6bb