### PR TITLE
feat(wordle): add animations and sharing

### DIFF
--- a/games/wordle/components/Keyboard.tsx
+++ b/games/wordle/components/Keyboard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { LetterResult } from '../logic';
+
+interface KeyboardProps {
+  onKey: (key: string) => void;
+  letterHints: Record<string, LetterResult | undefined>;
+}
+
+const rows = [
+  'QWERTYUIOP'.split(''),
+  'ASDFGHJKL'.split(''),
+  ['ENTER', ...'ZXCVBNM'.split(''), 'BACK'],
+];
+
+const getKeyColor = (res?: LetterResult) =>
+  res === 'correct'
+    ? 'bg-green-600'
+    : res === 'present'
+    ? 'bg-yellow-500'
+    : res === 'absent'
+    ? 'bg-gray-700'
+    : 'bg-gray-500';
+
+const Keyboard: React.FC<KeyboardProps> = ({ onKey, letterHints }) => (
+  <div className="select-none flex flex-col gap-1.5">
+    {rows.map((row, rIdx) => (
+      <div key={rIdx} className="flex justify-center gap-1.5">
+        {row.map((key) => (
+          <button
+            key={key}
+            onClick={() => onKey(key)}
+            className={`h-12 px-2 rounded text-sm font-semibold text-white ${getKeyColor(
+              letterHints[key]
+            )}`}
+          >
+            {key === 'BACK' ? '⌫' : key}
+          </button>
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+export default Keyboard;

--- a/games/wordle/index.tsx
+++ b/games/wordle/index.tsx
@@ -1,23 +1,42 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import GameShell from "../../components/games/GameShell";
 import usePersistentState from "../../hooks/usePersistentState";
-import { getWordOfTheDay, dictionaries } from "../../utils/wordle";
+import {
+  getWordOfTheDay,
+  dictionaries,
+  buildResultMosaic,
+} from "../../utils/wordle";
 import type { GuessEntry, LetterResult } from "./logic";
 import { evaluateGuess, hardModeViolation } from "./logic";
+import Keyboard from "./components/Keyboard";
+import share from "../../utils/share";
 
 const WordleGame = () => {
   const [hardMode, setHardMode] = usePersistentState<boolean>("wordle:hard", false);
   const wordList = dictionaries.common; // single dictionary for now
   const solution = useMemo(() => getWordOfTheDay("common"), []);
 
-  const [guesses, setGuesses] = useState<GuessEntry[]>([]);
+  type GuessWithReveal = GuessEntry & { revealed: number };
+  const [guesses, setGuesses] = useState<GuessWithReveal[]>([]);
   const [guess, setGuess] = useState("");
   const [message, setMessage] = useState("");
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const revealRow = (row: number) => {
+    for (let i = 0; i < 5; i += 1) {
+      setTimeout(() => {
+        setGuesses((g) => {
+          const copy = [...g];
+          const entry = copy[row];
+          if (entry) entry.revealed = i + 1;
+          return copy;
+        });
+      }, i * 300);
+    }
+  };
+
+  const handleSubmit = () => {
     const upper = guess.toUpperCase();
     if (upper.length !== 5) return;
 
@@ -35,7 +54,8 @@ const WordleGame = () => {
     }
 
     const result = evaluateGuess(upper, solution);
-    setGuesses([...guesses, { guess: upper, result }]);
+    setGuesses([...guesses, { guess: upper, result, revealed: 0 }]);
+    revealRow(guesses.length);
     setGuess("");
     setMessage("");
   };
@@ -43,7 +63,8 @@ const WordleGame = () => {
   const renderCell = (row: number, col: number) => {
     const entry = guesses[row];
     const letter = entry ? entry.guess[col] : "";
-    const res: LetterResult | undefined = entry?.result[col];
+    const revealed = entry ? entry.revealed > col : false;
+    const res: LetterResult | undefined = revealed ? entry?.result[col] : undefined;
     const color =
       res === "correct"
         ? "bg-green-600"
@@ -55,12 +76,57 @@ const WordleGame = () => {
     return (
       <div
         key={col}
-        className={`w-10 h-10 border border-gray-700 flex items-center justify-center text-xl font-bold ${color}`}
+        className={`w-10 h-10 border border-gray-700 flex items-center justify-center text-xl font-bold transition-transform transition-colors duration-300 ${color}`}
+        style={{
+          transform: revealed ? "rotateX(0deg)" : "rotateX(90deg)",
+          transitionDelay: `${col * 300}ms`,
+        }}
       >
         {letter}
       </div>
     );
   };
+
+  const letterHints = useMemo(() => {
+    const map: Record<string, LetterResult> = {};
+    const priority: Record<LetterResult, number> = {
+      absent: 0,
+      present: 1,
+      correct: 2,
+    };
+    guesses.forEach(({ guess: g, result }) => {
+      for (let i = 0; i < g.length; i += 1) {
+        const ch = g[i];
+        const res = result[i];
+        if (!map[ch] || priority[res] > priority[map[ch]]) {
+          map[ch] = res;
+        }
+      }
+    });
+    return map;
+  }, [guesses]);
+
+  const handleKey = (key: string) => {
+    if (key === "ENTER") {
+      handleSubmit();
+    } else if (key === "BACK") {
+      setGuess((g) => g.slice(0, -1));
+    } else if (/^[A-Z]$/.test(key) && guess.length < 5) {
+      setGuess((g) => (g + key).toUpperCase());
+    }
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const key = e.key.toUpperCase();
+      if (key === "ENTER" || key === "BACKSPACE") {
+        e.preventDefault();
+      }
+      handleKey(key === "BACKSPACE" ? "BACK" : key);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
 
   const settings = (
     <label className="flex items-center space-x-2">
@@ -73,9 +139,27 @@ const WordleGame = () => {
     </label>
   );
 
+  const isSolved = guesses.some((g) => g.guess === solution);
+  const isGameOver = isSolved || guesses.length === 6;
+
+  const shareResult = async () => {
+    const mosaic = buildResultMosaic(guesses.map((g) => g.result));
+    const text = `Wordle ${guesses.length}/6\n${mosaic}`;
+    if (!(await share(text))) {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+
   return (
     <GameShell settings={settings}>
       <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 space-y-4 overflow-y-auto">
+        <div className="w-full bg-gray-800 text-center py-1 text-sm">
+          Daily Mode
+        </div>
         <h1 className="text-xl font-bold">Wordle</h1>
 
         <div className="grid grid-rows-6 gap-1" role="grid" aria-label="Wordle board">
@@ -86,21 +170,41 @@ const WordleGame = () => {
           ))}
         </div>
 
-        <form onSubmit={handleSubmit} className="flex space-x-2">
+        <Keyboard onKey={handleKey} letterHints={letterHints} />
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
           <input
             type="text"
             maxLength={5}
             value={guess}
             onChange={(e) => setGuess(e.target.value.toUpperCase())}
-            className="w-32 p-2 text-black text-center uppercase"
+            className="sr-only"
             placeholder="Guess"
           />
-          <button type="submit" className="px-4 py-2 bg-gray-700 rounded">
-            Enter
-          </button>
         </form>
 
         {message && <div className="text-sm text-red-400">{message}</div>}
+
+        {isGameOver && (
+          <div className="p-4 bg-gray-800 rounded text-center space-y-2">
+            <div className="font-semibold">Result</div>
+            <pre className="text-sm leading-4">
+              {buildResultMosaic(guesses.map((g) => g.result))}
+            </pre>
+            <button
+              type="button"
+              onClick={shareResult}
+              className="px-4 py-2 bg-gray-700 rounded"
+            >
+              Share
+            </button>
+          </div>
+        )}
       </div>
     </GameShell>
   );


### PR DESCRIPTION
## Summary
- add flip animation with staggered color reveals
- space on-screen keyboard with 6px gutters and mobile-friendly height
- show daily mode banner and shareable result card

## Testing
- `npm test __tests__/wordle.test.tsx` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7c49b388328bb94d8b4de45922b