### PR TITLE
feat(pinball): add hud and visual effects

### DIFF
--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Engine, Render, World, Bodies, Body, Runner } from 'matter-js';
+import { Engine, Render, World, Bodies, Body, Runner, Events } from 'matter-js';
 import { useTiltSensor } from './tilt';
 
 const themes: Record<string, { bg: string; flipper: string }> = {
@@ -16,10 +16,16 @@ export default function Pinball() {
   const leftFlipperRef = useRef<Body>();
   const rightFlipperRef = useRef<Body>();
   const ballRef = useRef<Body>();
+  const sparksRef = useRef<{ x: number; y: number; life: number }[]>([]);
+  const laneGlowRef = useRef<{ left: boolean; right: boolean }>({
+    left: false,
+    right: false,
+  });
   const [theme, setTheme] = useState<keyof typeof themes>('classic');
   const [power, setPower] = useState(1);
   const [bounce, setBounce] = useState(0.5);
   const [tilt, setTilt] = useState(false);
+  const [score, setScore] = useState(0);
   const nudgesRef = useRef<number[]>([]);
 
   const handleTilt = useCallback(() => {
@@ -48,7 +54,10 @@ export default function Pinball() {
     });
     engineRef.current = engine;
 
-    const ball = Bodies.circle(200, 100, 12, { restitution: 0.9 });
+    const ball = Bodies.circle(200, 100, 12, {
+      restitution: 0.9,
+      render: { visible: false },
+    });
     ballRef.current = ball;
     const walls = [
       Bodies.rectangle(200, 0, 400, 40, { isStatic: true }),
@@ -70,10 +79,86 @@ export default function Pinball() {
     });
     leftFlipperRef.current = leftFlipper;
     rightFlipperRef.current = rightFlipper;
-    World.add(engine.world, [ball, ...walls, leftFlipper, rightFlipper]);
+    const leftLane = Bodies.rectangle(80, 80, 40, 10, {
+      isStatic: true,
+      isSensor: true,
+    });
+    const rightLane = Bodies.rectangle(320, 80, 40, 10, {
+      isStatic: true,
+      isSensor: true,
+    });
+    World.add(engine.world, [ball, ...walls, leftFlipper, rightFlipper, leftLane, rightLane]);
     Render.run(render);
     const runner = Runner.create();
     Runner.run(runner, engine);
+
+    Events.on(engine, 'collisionStart', (evt) => {
+      evt.pairs.forEach((pair) => {
+        const bodies = [pair.bodyA, pair.bodyB];
+        if (bodies.includes(ball) && bodies.includes(leftFlipper)) {
+          const { x, y } = pair.collision.supports[0];
+          sparksRef.current.push({ x, y, life: 1 });
+        }
+        if (bodies.includes(ball) && bodies.includes(rightFlipper)) {
+          const { x, y } = pair.collision.supports[0];
+          sparksRef.current.push({ x, y, life: 1 });
+        }
+        if (bodies.includes(ball) && bodies.includes(leftLane)) {
+          laneGlowRef.current.left = true;
+          setScore((s) => s + 100);
+          setTimeout(() => (laneGlowRef.current.left = false), 500);
+        }
+        if (bodies.includes(ball) && bodies.includes(rightLane)) {
+          laneGlowRef.current.right = true;
+          setScore((s) => s + 100);
+          setTimeout(() => (laneGlowRef.current.right = false), 500);
+        }
+      });
+    });
+
+    Events.on(render, 'afterRender', () => {
+      const ctx = render.context;
+      const ball = ballRef.current!;
+      const { x, y } = ball.position;
+      const radius = 12;
+      const gradient = ctx.createRadialGradient(x - 4, y - 4, radius / 4, x, y, radius);
+      gradient.addColorStop(0, '#fff');
+      gradient.addColorStop(1, '#999');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      [
+        { lane: leftLane, glow: laneGlowRef.current.left },
+        { lane: rightLane, glow: laneGlowRef.current.right },
+      ].forEach(({ lane, glow }) => {
+        const { x: lx, y: ly } = lane.position;
+        ctx.save();
+        if (glow) {
+          ctx.shadowColor = '#ffff00';
+          ctx.shadowBlur = 20;
+          ctx.fillStyle = '#ff0';
+        } else {
+          ctx.fillStyle = '#555';
+        }
+        ctx.fillRect(lx - 20, ly - 5, 40, 10);
+        ctx.restore();
+      });
+
+      sparksRef.current = sparksRef.current.filter((s) => {
+        const r = 8 * s.life;
+        const g = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, r);
+        g.addColorStop(0, 'rgba(255,255,200,0.8)');
+        g.addColorStop(1, 'rgba(255,200,0,0)');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, Math.PI * 2);
+        ctx.fill();
+        s.life -= 0.05;
+        return s.life > 0;
+      });
+    });
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (tilt) return;
@@ -166,9 +251,24 @@ export default function Pinball() {
           </select>
         </label>
       </div>
-      {tilt && <div className="text-red-500 font-bold">TILT!</div>}
-      <canvas ref={canvasRef} width={400} height={600} className="border" />
-      <p className="text-xs">Left/Right arrows to flip, N to nudge.</p>
+      <div className="relative">
+        <canvas ref={canvasRef} width={400} height={600} className="border" />
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 text-white font-mono text-xl">
+          {score.toString().padStart(6, '0')}
+        </div>
+        {!tilt && (
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-white text-xs opacity-75">
+            Press N to nudge
+          </div>
+        )}
+        {tilt && (
+          <div className="absolute inset-0 flex items-center justify-center bg-red-700/80">
+            <div className="text-white font-bold text-4xl px-6 py-3 border-4 border-white rounded">
+              TILT
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- draw pinball with highlight shader and spark effect on flipper contact
- track points with monospace HUD and glowing lane indicators
- overlay nudge hint and styled tilt banner

## Testing
- `yarn test __tests__/pinballTilt.test.ts`
- `npx eslint apps/pinball/index.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `npx tsc --noEmit apps/pinball/index.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e7ca601483289895c68db504e616