### PR TITLE
feat: add sections with drag and drop

### DIFF
--- a/components/apps/todoist.worker.js
+++ b/components/apps/todoist.worker.js
@@ -1,19 +1,20 @@
 self.onmessage = (e) => {
   const { type } = e.data || {};
   if (type !== 'move') return;
-  const { groups, from, to, id } = e.data;
-  const newGroups = {
-    ...groups,
-    [from]: [...groups[from]],
-    [to]: [...groups[to]],
-  };
-  const index = newGroups[from].findIndex((t) => t.id === id);
-  if (index > -1) {
-    const [task] = newGroups[from].splice(index, 1);
-    newGroups[to].push(task);
-    self.postMessage({ groups: newGroups, taskTitle: task.title, to });
-  } else {
-    self.postMessage({ groups: newGroups });
+  const { sections, from, to, id } = e.data;
+  const newSections = sections.map((s) => ({ ...s, tasks: [...s.tasks] }));
+  const fromIndex = newSections.findIndex((s) => s.title === from);
+  const toIndex = newSections.findIndex((s) => s.title === to);
+  if (fromIndex > -1 && toIndex > -1) {
+    const tasks = newSections[fromIndex].tasks;
+    const index = tasks.findIndex((t) => t.id === id);
+    if (index > -1) {
+      const [task] = tasks.splice(index, 1);
+      newSections[toIndex].tasks.push(task);
+      self.postMessage({ sections: newSections, taskTitle: task.title, to });
+      return;
+    }
   }
+  self.postMessage({ sections });
 };
 


### PR DESCRIPTION
## Summary
- switch todoist app to sections array and persist to localStorage
- support drag-and-drop moves between sections
- update worker logic to reorder section tasks

## Testing
- `yarn lint` *(fails: ESLint couldn't find config file)*
- `yarn test` *(fails: game2048, beef, mimikatz, kismet tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8f791308328b094b1dfe7fe63fd