### PR TITLE
feat(settings): add reset desktop button

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -85,7 +85,14 @@ export default function Settings() {
   };
 
   const handleReset = async () => {
+    if (
+      !window.confirm(
+        "Reset desktop to default settings? This will clear all saved data."
+      )
+    )
+      return;
     await resetSettings();
+    window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);
@@ -202,6 +209,14 @@ export default function Settings() {
               ></div>
             ))}
           </div>
+          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+            <button
+              onClick={handleReset}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Reset Desktop
+            </button>
+          </div>
         </>
       )}
       {activeTab === "accessibility" && (
@@ -275,12 +290,6 @@ export default function Settings() {
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Import Settings
-            </button>
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Reset Desktop
             </button>
           </div>
         </>


### PR DESCRIPTION
## Summary
- add Reset Desktop button to the Appearance tab
- confirm before resetting and clear local storage
- reapply default theme, wallpaper, and accents after reset

## Testing
- `npx eslint -c .eslintrc.cjs apps/settings/index.tsx` *(fails: File ignored because no matching configuration was supplied)*
- `yarn test apps/settings/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1e8f6058c832898abd5f9a682a5c7