### PR TITLE
style chrome fullpage app toolbar icons

### DIFF
--- a/apps/chrome/components/FullPageCapture.tsx
+++ b/apps/chrome/components/FullPageCapture.tsx
@@ -54,22 +54,50 @@ export default function FullPageCapture() {
 
   return (
     <div className="p-4 space-y-4">
-      <div className="space-x-2">
+      <div className="flex space-x-2">
         <button
           type="button"
           onClick={() => capture('png')}
           disabled={processing}
-          className="px-3 py-1 rounded bg-blue-600 text-white"
+          className="p-2 rounded bg-blue-600 text-white"
         >
-          Download PNG
+          <svg
+            viewBox="0 0 24 24"
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 5v8m0 0l3-3m-3 3l-3-3M5 19h14"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="sr-only">Download PNG</span>
         </button>
         <button
           type="button"
           onClick={() => capture('pdf')}
           disabled={processing}
-          className="px-3 py-1 rounded bg-green-600 text-white"
+          className="p-2 rounded bg-green-600 text-white"
         >
-          Download PDF
+          <svg
+            viewBox="0 0 24 24"
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 5v8m0 0l3-3m-3 3l-3-3M5 19h14"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="sr-only">Download PDF</span>
         </button>
       </div>
       <div ref={canvasContainer} />

--- a/apps/chrome/components/ReadingMode.tsx
+++ b/apps/chrome/components/ReadingMode.tsx
@@ -43,19 +43,50 @@ const ReadingMode = () => {
 
   return (
     <div className="p-4 h-full overflow-auto">
-      <div className="mb-4 space-x-2">
+      <div className="mb-4 flex space-x-2">
         <button
-          className="border px-2 py-1 rounded"
+          className="p-2 border rounded"
           onClick={() => setMode(mode === 'live' ? 'snapshot' : 'live')}
         >
-          {mode === 'live' ? 'Show Saved' : 'Show Live'}
+          <svg
+            viewBox="0 0 24 24"
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+          <span className="sr-only">
+            {mode === 'live' ? 'Show Saved' : 'Show Live'}
+          </span>
         </button>
         <button
-          className="border px-2 py-1 rounded"
+          className="p-2 border rounded"
           onClick={saveSnapshot}
           disabled={!content}
         >
-          Save snapshot
+          <svg
+            viewBox="0 0 24 24"
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 5v8m0 0l3-3m-3 3l-3-3M5 19h14"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="sr-only">Save snapshot</span>
         </button>
       </div>
       <article dangerouslySetInnerHTML={{ __html: displayed }} />

--- a/apps/chrome/index.tsx
+++ b/apps/chrome/index.tsx
@@ -2,5 +2,11 @@
 import FullPageCapture from './components/FullPageCapture';
 
 export default function ChromeFullPageCapture() {
-  return <FullPageCapture />;
+  return (
+    <div
+      className="w-full h-full md:w-[1024px] md:h-[768px] bg-[var(--kali-bg)] text-[var(--kali-fg)] font-[system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif]"
+    >
+      <FullPageCapture />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Apply Kali color variables and system font stack to Chrome full-page capture app
- Adjust toolbar icons to 16px with p-2 padding for consistency
- Add responsive 1024×768 sizing in the Chrome app container

## Testing
- `npm test` *(fails: game2048, beef, kismet, mimikatz tests)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f063a540832891bdaae5044045c1