### PR TITLE
feat: style terminal container and add GNOME icons

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+export type TerminalContainerProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
+  ({ style, className = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      data-testid="xterm-container"
+      className={`text-white ${className}`}
+      style={{ background: 'var(--kali-bg)', fontFamily: 'monospace', ...style }}
+      {...props}
+    />
+  ),
+);
+
+Terminal.displayName = 'Terminal';
+
+export default Terminal;

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
+import TerminalContainer from './components/Terminal';
 
 export interface TerminalProps {
   openApp?: (id: string) => void;
@@ -197,14 +198,19 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   useEffect(() => {
     let disposed = false;
     (async () => {
-      const [{ Terminal }, { FitAddon }, { SearchAddon }] = await Promise.all([
+      const [{ Terminal: XTerm }, { FitAddon }, { SearchAddon }] = await Promise.all([
         import('@xterm/xterm'),
         import('@xterm/addon-fit'),
         import('@xterm/addon-search'),
       ]);
       await import('@xterm/xterm/css/xterm.css');
       if (disposed) return;
-      const term = new Terminal({ cursorBlink: true, scrollback: 1000 });
+      const term = new XTerm({
+        cursorBlink: true,
+        scrollback: 1000,
+        cols: 80,
+        rows: 24,
+      });
       const fit = new FitAddon();
       const search = new SearchAddon();
       termRef.current = term;
@@ -335,10 +341,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
           </div>
         </div>
       )}
-      <div
-        data-testid="xterm-container"
+      <TerminalContainer
         ref={containerRef}
-        className="h-full w-full bg-black text-white"
+        className="resize overflow-hidden"
+        style={{ width: '80ch', height: '24em' }}
       />
       {overflow.top && (
         <div className="pointer-events-none absolute top-0 left-0 right-0 h-4 bg-gradient-to-b from-black" />

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,0 +1,56 @@
+import Image from 'next/image';
+
+export function CloseIcon() {
+  return (
+    <Image
+      src="/themes/Yaru/window/window-close-symbolic.svg"
+      alt="Close"
+      width={16}
+      height={16}
+    />
+  );
+}
+
+export function MinimizeIcon() {
+  return (
+    <Image
+      src="/themes/Yaru/window/window-minimize-symbolic.svg"
+      alt="Minimize"
+      width={16}
+      height={16}
+    />
+  );
+}
+
+export function MaximizeIcon() {
+  return (
+    <Image
+      src="/themes/Yaru/window/window-maximize-symbolic.svg"
+      alt="Maximize"
+      width={16}
+      height={16}
+    />
+  );
+}
+
+export function RestoreIcon() {
+  return (
+    <Image
+      src="/themes/Yaru/window/window-restore-symbolic.svg"
+      alt="Restore"
+      width={16}
+      height={16}
+    />
+  );
+}
+
+export function PinIcon() {
+  return (
+    <Image
+      src="/themes/Yaru/window/window-pin-symbolic.svg"
+      alt="Pin"
+      width={16}
+      height={16}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- style terminal container with Kali background and monospace font
- default terminal to 80x24 cells and make container resizable
- add GNOME-style 16px toolbar icons

## Testing
- `yarn test` *(fails: game2048, beef, mimikatz, kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f06930d483288e7340d51e27683f