### PR TITLE
feat(vscode): add themed sidebar layout

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,11 +1,39 @@
 'use client';
 
 import ExternalFrame from '../../components/ExternalFrame';
+import { kaliTheme } from '../../styles/themes/kali';
+import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
 export default function VsCode() {
   return (
-    <div className="h-full w-full flex max-w-full">
-      <ExternalFrame src="https://vscode.dev/" title="VsCode" />
+    <div
+      className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
+      style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
+    >
+      <aside
+        className="flex flex-col items-center gap-2 p-1"
+        style={{ width: SIDEBAR_WIDTH, backgroundColor: kaliTheme.sidebar }}
+      >
+        <div
+          className="rounded"
+          style={{
+            width: ICON_SIZE,
+            height: ICON_SIZE,
+            backgroundColor: kaliTheme.accent,
+          }}
+        />
+        <div
+          className="rounded"
+          style={{
+            width: ICON_SIZE,
+            height: ICON_SIZE,
+            backgroundColor: kaliTheme.accent,
+          }}
+        />
+      </aside>
+      <div className="flex-1">
+        <ExternalFrame src="https://vscode.dev/" title="VsCode" />
+      </div>
     </div>
   );
 }

--- a/apps/vscode/utils/index.ts
+++ b/apps/vscode/utils/index.ts
@@ -1,0 +1,5 @@
+export const SIDEBAR_WIDTH = 24;
+export const ICON_SIZE = 24;
+
+export type { Task } from './taskRunner';
+export { loadTasks, runTask } from './taskRunner';

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -1,0 +1,8 @@
+export const kaliTheme = {
+  background: 'var(--color-bg)',
+  text: 'var(--color-text)',
+  accent: 'var(--color-primary)',
+  sidebar: 'var(--color-secondary)',
+};
+
+export type KaliTheme = typeof kaliTheme;


### PR DESCRIPTION
## Summary
- add Kali theme variable module
- expose 24px sidebar/icon constants
- apply theme constants and responsive layout to VSCode app

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint apps/vscode/index.tsx apps/vscode/utils/index.ts styles/themes/kali.ts` *(fails: Component definition is missing display name, and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f06a8d2483288468228e4f0c8002