### PR TITLE
feat(settings): add grid layout and toggles

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -11,6 +11,8 @@ import {
 } from "../../utils/settingsStore";
 import { getTheme, setTheme } from "../../utils/theme";
 import KeymapOverlay from "./components/KeymapOverlay";
+import Tabs from "../../components/Tabs";
+import ToggleSwitch from "../../components/ToggleSwitch";
 
 export default function Settings() {
   const {
@@ -101,22 +103,7 @@ export default function Settings() {
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
       <div className="flex justify-center border-b border-gray-900">
-        <div role="tablist" className="flex">
-          {tabs.map((t) => (
-            <button
-              key={t.id}
-              role="tab"
-              aria-selected={activeTab === t.id}
-              tabIndex={activeTab === t.id ? 0 : -1}
-              onClick={() => setActiveTab(t.id)}
-              className={`px-4 py-2 focus:outline-none ${
-                activeTab === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
-              }`}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
+        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
       </div>
       {activeTab === "appearance" && (
         <>
@@ -172,7 +159,7 @@ export default function Settings() {
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
           </div>
-          <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
             {wallpapers.map((name) => (
               <div
                 key={name}
@@ -229,27 +216,21 @@ export default function Settings() {
               <option value="compact">Compact</option>
             </select>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={reducedMotion}
-                onChange={(e) => setReducedMotion(e.target.checked)}
-                className="mr-2"
-              />
-              Reduced Motion
-            </label>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
+            <ToggleSwitch
+              checked={reducedMotion}
+              onChange={setReducedMotion}
+              ariaLabel="Reduced Motion"
+            />
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={highContrast}
-                onChange={(e) => setHighContrast(e.target.checked)}
-                className="mr-2"
-              />
-              High Contrast
-            </label>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">High Contrast:</span>
+            <ToggleSwitch
+              checked={highContrast}
+              onChange={setHighContrast}
+              ariaLabel="High Contrast"
+            />
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+import React from "react";
+
+type Tab<T extends string> = {
+  id: T;
+  label: string;
+};
+
+interface TabsProps<T extends string> {
+  tabs: readonly Tab<T>[];
+  active: T;
+  onChange: (id: T) => void;
+  className?: string;
+}
+
+export default function Tabs<T extends string>({
+  tabs,
+  active,
+  onChange,
+  className = "",
+}: TabsProps<T>) {
+  return (
+    <div role="tablist" className={`flex ${className}`.trim()}>
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          role="tab"
+          aria-selected={active === t.id}
+          tabIndex={active === t.id ? 0 : -1}
+          onClick={() => onChange(t.id)}
+          className={`px-4 py-2 focus:outline-none ${
+            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React from "react";
+
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export default function ToggleSwitch({
+  checked,
+  onChange,
+  className = "",
+  ariaLabel,
+}: ToggleSwitchProps) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+        checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
+      } ${className}`.trim()}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
+          checked ? "translate-x-5" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce reusable Tabs component for settings navigation
- style toggle switches with theme colors and fixed height
- display wallpapers in responsive two-column grid

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test __tests__/game2048.test.tsx` *(fails: 4 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f0789a488328ac5a8a4e5288037c