### PR TITLE
feat(resource-monitor): add standardized charts

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -8,6 +8,7 @@ import {
   FetchEntry,
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
+import RequestChart from './RequestChart';
 
 const HISTORY_KEY = 'network-insights-history';
 
@@ -31,9 +32,9 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white">
+    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
       <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded">
+      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
         {active.map((f) => (
           <li key={f.id} className="p-1">
@@ -50,12 +51,12 @@ export default function NetworkInsights() {
         <h2 className="font-bold">History</h2>
         <button
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 bg-ub-dark-grey rounded"
+          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded">
+      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
         {history.map((f) => (
           <li key={f.id} className="p-1">
@@ -71,6 +72,12 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
+      <div className="mt-2 flex justify-center">
+        <RequestChart
+          data={history.map((h) => h.duration ?? 0)}
+          label="Request duration (ms)"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/resource-monitor/components/RequestChart.tsx
+++ b/apps/resource-monitor/components/RequestChart.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+
+interface RequestChartProps {
+  data: number[];
+  label: string;
+}
+
+export default function RequestChart({ data, label }: RequestChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const width = canvas.width;
+    const height = canvas.height;
+
+    ctx.clearRect(0, 0, width, height);
+
+    // draw panel background
+    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--kali-panel');
+    ctx.fillRect(0, 0, width, height);
+
+    // gridlines
+    ctx.strokeStyle = 'rgba(255,255,255,0.1)';
+    ctx.lineWidth = 1;
+    for (let i = 1; i < 5; i++) {
+      const y = (height / 5) * i;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+
+    if (data.length > 0) {
+      const maxVal = Math.max(...data);
+      ctx.strokeStyle = '#00ff00';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      data.forEach((v, i) => {
+        const x = (i / (data.length - 1 || 1)) * width;
+        const y = height - (v / maxVal) * height;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    }
+
+    // legend
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '10px sans-serif';
+    ctx.fillText(label, 4, 12);
+  }, [data, label]);
+
+  return (
+    <div className="w-full max-w-[300px] h-[150px]" style={{ background: 'var(--kali-panel)' }}>
+      <canvas ref={canvasRef} width={300} height={150} className="w-full h-full" />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- use Kali theme variables for resource monitor backgrounds
- add request duration chart with legend and gridlines
- standardize chart container to 300x150 with responsive width

## Testing
- `yarn lint apps/resource-monitor/components/NetworkInsights.tsx apps/resource-monitor/components/RequestChart.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test --passWithNoTests apps/resource-monitor/components/NetworkInsights.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1f07c2ec083289eb82c8a5fff0bef