### PR TITLE
feat: enhance tower defense visuals and UI

### DIFF
--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
-import GameLayout from '../../components/apps/GameLayout';
-import DpsCharts from '../games/tower-defense/components/DpsCharts';
+import { useEffect, useRef, useState } from "react";
+import GameLayout from "../../components/apps/GameLayout";
+import DpsCharts from "../games/tower-defense/components/DpsCharts";
 import {
   ENEMY_TYPES,
   Tower,
@@ -10,7 +10,7 @@ import {
   Enemy,
   createEnemyPool,
   spawnEnemy,
-} from '../games/tower-defense';
+} from "../games/tower-defense";
 
 const GRID_SIZE = 10;
 const CELL_SIZE = 40;
@@ -28,11 +28,24 @@ const TowerDefense = () => {
   const pathSetRef = useRef<Set<string>>(new Set());
   const [towers, setTowers] = useState<Tower[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
+  const [hovered, setHovered] = useState<number | null>(null);
   const enemiesRef = useRef<EnemyInstance[]>([]);
   const enemyPool = useRef(createEnemyPool(50));
   const lastTime = useRef(0);
   const running = useRef(false);
   const spawnTimer = useRef(0);
+  const waveRef = useRef(1);
+  const waveCountdownRef = useRef<number | null>(null);
+  const [, forceRerender] = useState(0);
+  const enemiesSpawnedRef = useRef(0);
+  const damageNumbersRef = useRef<
+    {
+      x: number;
+      y: number;
+      value: number;
+      life: number;
+    }[]
+  >([]);
 
   const togglePath = (x: number, y: number) => {
     const key = `${x},${y}`;
@@ -65,11 +78,21 @@ const TowerDefense = () => {
     setTowers((ts) => [...ts, { x, y, range: 1, damage: 1, level: 1 }]);
   };
 
+  const handleCanvasMove = (e: React.MouseEvent) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) / CELL_SIZE);
+    const y = Math.floor((e.clientY - rect.top) / CELL_SIZE);
+    const idx = towers.findIndex((t) => t.x === x && t.y === y);
+    setHovered(idx >= 0 ? idx : null);
+  };
+
+  const handleCanvasLeave = () => setHovered(null);
+
   const draw = () => {
-    const ctx = canvasRef.current?.getContext('2d');
+    const ctx = canvasRef.current?.getContext("2d");
     if (!ctx) return;
     ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
-    ctx.strokeStyle = '#555';
+    ctx.strokeStyle = "#555";
     for (let i = 0; i <= GRID_SIZE; i += 1) {
       ctx.beginPath();
       ctx.moveTo(i * CELL_SIZE, 0);
@@ -80,11 +103,13 @@ const TowerDefense = () => {
       ctx.lineTo(CANVAS_SIZE, i * CELL_SIZE);
       ctx.stroke();
     }
-    ctx.fillStyle = '#666';
+    ctx.fillStyle = "rgba(255,255,0,0.2)";
     path.forEach((c) => {
       ctx.fillRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+      ctx.strokeStyle = "yellow";
+      ctx.strokeRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
     });
-    ctx.fillStyle = 'blue';
+    ctx.fillStyle = "blue";
     towers.forEach((t, i) => {
       ctx.beginPath();
       ctx.arc(
@@ -92,23 +117,23 @@ const TowerDefense = () => {
         t.y * CELL_SIZE + CELL_SIZE / 2,
         CELL_SIZE / 3,
         0,
-        Math.PI * 2
+        Math.PI * 2,
       );
       ctx.fill();
-      if (selected === i) {
-        ctx.strokeStyle = 'yellow';
+      if (selected === i || hovered === i) {
+        ctx.strokeStyle = "yellow";
         ctx.beginPath();
         ctx.arc(
           t.x * CELL_SIZE + CELL_SIZE / 2,
           t.y * CELL_SIZE + CELL_SIZE / 2,
           t.range * CELL_SIZE,
           0,
-          Math.PI * 2
+          Math.PI * 2,
         );
         ctx.stroke();
       }
     });
-    ctx.fillStyle = 'red';
+    ctx.fillStyle = "red";
     enemiesRef.current.forEach((en) => {
       ctx.beginPath();
       ctx.arc(
@@ -116,9 +141,18 @@ const TowerDefense = () => {
         en.y * CELL_SIZE + CELL_SIZE / 2,
         CELL_SIZE / 4,
         0,
-        Math.PI * 2
+        Math.PI * 2,
       );
       ctx.fill();
+    });
+    damageNumbersRef.current.forEach((d) => {
+      ctx.fillStyle = `rgba(255,255,255,${d.life})`;
+      ctx.font = "12px sans-serif";
+      ctx.fillText(
+        d.value.toString(),
+        d.x * CELL_SIZE + CELL_SIZE / 2,
+        d.y * CELL_SIZE + CELL_SIZE / 2 - (1 - d.life) * 10,
+      );
     });
   };
 
@@ -146,11 +180,25 @@ const TowerDefense = () => {
   const update = (time: number) => {
     const dt = (time - lastTime.current) / 1000;
     lastTime.current = time;
-    if (running.current) {
+
+    if (waveCountdownRef.current !== null) {
+      waveCountdownRef.current -= dt;
+      forceRerender((n) => n + 1);
+      if (waveCountdownRef.current <= 0) {
+        waveCountdownRef.current = null;
+        running.current = true;
+        spawnTimer.current = 0;
+        enemiesSpawnedRef.current = 0;
+      }
+    } else if (running.current) {
       spawnTimer.current += dt;
-      if (spawnTimer.current > 1) {
+      if (
+        spawnTimer.current > 1 &&
+        enemiesSpawnedRef.current < waveRef.current * 5
+      ) {
         spawnTimer.current = 0;
         spawnEnemyInstance();
+        enemiesSpawnedRef.current += 1;
       }
       enemiesRef.current.forEach((en) => {
         const next = path[en.pathIndex + 1];
@@ -176,15 +224,36 @@ const TowerDefense = () => {
         (t as any).cool = (t as any).cool ? (t as any).cool - dt : 0;
         if ((t as any).cool <= 0) {
           const enemy = enemiesRef.current.find(
-            (e) =>
-              Math.hypot(e.x - t.x, e.y - t.y) <= t.range
+            (e) => Math.hypot(e.x - t.x, e.y - t.y) <= t.range,
           );
           if (enemy) {
             enemy.health -= t.damage;
+            damageNumbersRef.current.push({
+              x: enemy.x,
+              y: enemy.y,
+              value: t.damage,
+              life: 1,
+            });
             (t as any).cool = 1;
           }
         }
       });
+      damageNumbersRef.current.forEach((d) => {
+        d.y -= dt * 0.5;
+        d.life -= dt * 2;
+      });
+      damageNumbersRef.current = damageNumbersRef.current.filter(
+        (d) => d.life > 0,
+      );
+      if (
+        enemiesSpawnedRef.current >= waveRef.current * 5 &&
+        enemiesRef.current.length === 0
+      ) {
+        running.current = false;
+        waveRef.current += 1;
+        waveCountdownRef.current = 5;
+        forceRerender((n) => n + 1);
+      }
     }
     draw();
     requestAnimationFrame(update);
@@ -198,11 +267,13 @@ const TowerDefense = () => {
 
   const start = () => {
     if (!path.length) return;
-    running.current = true;
     setEditing(false);
+    waveRef.current = 1;
+    waveCountdownRef.current = 3;
+    forceRerender((n) => n + 1);
   };
 
-  const upgrade = (type: 'range' | 'damage') => {
+  const upgrade = (type: "range" | "damage") => {
     if (selected === null) return;
     setTowers((ts) => {
       const t = { ...ts[selected] };
@@ -216,44 +287,53 @@ const TowerDefense = () => {
   return (
     <GameLayout gameId="tower-defense">
       <div className="p-2 space-y-2">
+        {waveCountdownRef.current !== null && (
+          <div className="text-center bg-gray-700 text-white py-1 rounded">
+            Wave {waveRef.current} in {Math.ceil(waveCountdownRef.current)}
+          </div>
+        )}
         <div className="space-x-2 mb-2">
           <button
             className="px-2 py-1 bg-gray-700 rounded"
             onClick={() => setEditing((e) => !e)}
           >
-            {editing ? 'Finish Editing' : 'Edit Map'}
+            {editing ? "Finish Editing" : "Edit Map"}
           </button>
           <button
             className="px-2 py-1 bg-gray-700 rounded"
             onClick={start}
-            disabled={running.current}
+            disabled={running.current || waveCountdownRef.current !== null}
           >
             Start
           </button>
+        </div>
+        <div className="flex">
+          <canvas
+            ref={canvasRef}
+            width={CANVAS_SIZE}
+            height={CANVAS_SIZE}
+            className="bg-black"
+            onClick={handleCanvasClick}
+            onMouseMove={handleCanvasMove}
+            onMouseLeave={handleCanvasLeave}
+          />
           {selected !== null && (
-            <>
+            <div className="ml-2 flex flex-col space-y-1">
               <button
-                className="px-2 py-1 bg-gray-700 rounded"
-                onClick={() => upgrade('range')}
+                className="bg-gray-700 text-xs px-2 py-1 rounded"
+                onClick={() => upgrade("range")}
               >
-                Upgrade Range
+                +Range
               </button>
               <button
-                className="px-2 py-1 bg-gray-700 rounded"
-                onClick={() => upgrade('damage')}
+                className="bg-gray-700 text-xs px-2 py-1 rounded"
+                onClick={() => upgrade("damage")}
               >
-                Upgrade Damage
+                +Damage
               </button>
-            </>
+            </div>
           )}
         </div>
-        <canvas
-          ref={canvasRef}
-          width={CANVAS_SIZE}
-          height={CANVAS_SIZE}
-          className="bg-black"
-          onClick={handleCanvasClick}
-        />
         {!editing && <DpsCharts towers={towers} />}
       </div>
     </GameLayout>

--- a/games/tower-defense/index.tsx
+++ b/games/tower-defense/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../apps/tower-defense";


### PR DESCRIPTION
## Summary
- highlight path tiles and show turret range on hover
- add wave banner with countdown and sidebar upgrade controls
- animate fading damage numbers for hits

## Testing
- `yarn test __tests__/tower-defense.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7c2daac8328a27fbf29e133251d