### PR TITLE
feat(nessus): add dashboard, cards and filters

### DIFF
--- a/apps/nessus/components/FiltersDrawer.tsx
+++ b/apps/nessus/components/FiltersDrawer.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import { Severity, severities } from '../types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  severityFilters: Record<Severity, boolean>;
+  toggleSeverity: (sev: Severity) => void;
+  tags: string[];
+  tagFilters: string[];
+  toggleTag: (tag: string) => void;
+}
+
+export default function FiltersDrawer({
+  open,
+  onClose,
+  severityFilters,
+  toggleSeverity,
+  tags,
+  tagFilters,
+  toggleTag,
+}: Props) {
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      onClick={onClose}
+    >
+      <div
+        className={`absolute right-0 top-0 h-full w-64 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg mb-4">Filters</h3>
+        <div className="mb-6">
+          <h4 className="font-semibold mb-2">Severity</h4>
+          {severities.map((sev) => (
+            <label key={sev} className="flex items-center gap-2 mb-1">
+              <input
+                type="checkbox"
+                checked={severityFilters[sev]}
+                onChange={() => toggleSeverity(sev)}
+              />
+              {sev}
+            </label>
+          ))}
+        </div>
+        <div>
+          <h4 className="font-semibold mb-2">Tags</h4>
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={`px-2 py-1 rounded-full border text-sm ${tagFilters.includes(tag) ? 'bg-blue-600 border-blue-600' : 'bg-gray-800 border-gray-700'}`}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/nessus/components/FindingCard.tsx
+++ b/apps/nessus/components/FindingCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { Plugin, Severity } from '../types';
+
+const colors: Record<Severity, string> = {
+  Critical: 'border-red-600',
+  High: 'border-orange-500',
+  Medium: 'border-yellow-500',
+  Low: 'border-green-500',
+  Info: 'border-gray-500',
+};
+
+interface Props {
+  plugin: Plugin;
+}
+
+export default function FindingCard({ plugin }: Props) {
+  return (
+    <div className={`border-l-4 ${colors[plugin.severity]} bg-gray-800 p-3 rounded`}>
+      <div className="flex justify-between items-center mb-1">
+        <span className="font-mono">{plugin.id}</span>
+        <span className="text-sm">{plugin.severity}</span>
+      </div>
+      <div className="font-semibold">{plugin.name}</div>
+      <div className="flex gap-2 mt-2 flex-wrap text-xs">
+        {plugin.cwe?.map((cwe) => (
+          <span key={cwe} className="px-2 py-1 bg-gray-700 rounded">
+            CWE-{cwe}
+          </span>
+        ))}
+        {plugin.cve?.map((cve) => (
+          <span key={cve} className="px-2 py-1 bg-gray-700 rounded">
+            CVE-{cve}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/nessus/components/SummaryDashboard.tsx
+++ b/apps/nessus/components/SummaryDashboard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import { Severity, severities } from '../types';
+
+const colors: Record<Severity, string> = {
+  Critical: 'bg-red-700',
+  High: 'bg-orange-600',
+  Medium: 'bg-yellow-600',
+  Low: 'bg-green-600',
+  Info: 'bg-gray-600',
+};
+
+interface Props {
+  summary: Record<Severity, number>;
+  trend: number[];
+}
+
+export default function SummaryDashboard({ summary, trend }: Props) {
+  const max = Math.max(1, ...trend);
+  const width = 100;
+  const height = 24;
+  const step = trend.length > 1 ? width / (trend.length - 1) : width;
+  const d = trend
+    .map((v, i) => {
+      const x = i * step;
+      const y = height - (v / max) * height;
+      return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-5 gap-2">
+        {severities.map((sev) => (
+          <div key={sev} className={`p-2 rounded ${colors[sev]}`}>
+            <div className="text-xs">{sev}</div>
+            <div className="text-lg font-bold">{summary[sev]}</div>
+          </div>
+        ))}
+      </div>
+      {trend.length > 0 && (
+        <svg width={width} height={height} className="bg-gray-800 rounded">
+          <path d={d} fill="none" stroke="#3b82f6" strokeWidth={2} />
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/apps/nessus/types.ts
+++ b/apps/nessus/types.ts
@@ -1,0 +1,20 @@
+export const severities = ['Critical', 'High', 'Medium', 'Low', 'Info'] as const;
+export type Severity = (typeof severities)[number];
+
+export interface Plugin {
+  id: number;
+  name: string;
+  severity: Severity;
+  cwe?: string[];
+  cve?: string[];
+  tags?: string[];
+}
+
+export interface Finding {
+  plugin: number;
+  severity: Severity;
+}
+
+export interface Scan {
+  findings: Finding[];
+}

--- a/public/demo-data/nessus/plugins.json
+++ b/public/demo-data/nessus/plugins.json
@@ -1,7 +1,7 @@
 [
-  {"id": 1001, "name": "SSL Certificate Expiry", "severity": "High"},
-  {"id": 1002, "name": "Weak SSH Ciphers", "severity": "Medium"},
-  {"id": 1003, "name": "Default Credentials", "severity": "Critical"},
-  {"id": 1004, "name": "Outdated Web Server", "severity": "Low"},
-  {"id": 1005, "name": "Informational Banner", "severity": "Info"}
+  {"id": 1001, "name": "SSL Certificate Expiry", "severity": "High", "cwe": ["295"], "cve": ["2024-0001"], "tags": ["ssl", "certificate"]},
+  {"id": 1002, "name": "Weak SSH Ciphers", "severity": "Medium", "cwe": ["327"], "cve": ["2023-0002"], "tags": ["ssh", "crypto"]},
+  {"id": 1003, "name": "Default Credentials", "severity": "Critical", "cwe": ["1392"], "tags": ["auth"]},
+  {"id": 1004, "name": "Outdated Web Server", "severity": "Low", "cwe": ["200"], "cve": ["2022-0004"], "tags": ["web", "server"]},
+  {"id": 1005, "name": "Informational Banner", "severity": "Info", "tags": ["info"]}
 ]


### PR DESCRIPTION
## Summary
- add summary dashboard with risk tiles and trend sparkline
- show CWE/CVE badges on finding cards
- include drawer with severity and tag filters

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/nessus/index.tsx apps/nessus/components/FindingCard.tsx apps/nessus/components/FiltersDrawer.tsx apps/nessus/components/SummaryDashboard.tsx`
- `yarn test apps/nessus` *(fails: No tests found, exit code 1)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d8db49808328ac7d70f94dab4b76