### PR TITLE
feat(reaver): add AP list and progress visualization

### DIFF
--- a/apps/reaver/components/APList.tsx
+++ b/apps/reaver/components/APList.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+
+export interface AccessPoint {
+  ssid: string;
+  bssid: string;
+  wps: 'enabled' | 'locked' | 'disabled';
+}
+
+const CheckCircle = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
+    <path
+      fillRule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const XCircle = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
+    <path
+      fillRule="evenodd"
+      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-11.707a1 1 0 00-1.414-1.414L10 8.586 7.707 6.293a1 1 0 10-1.414 1.414L8.586 10l-2.293 2.293a1 1 0 101.414 1.414L10 11.414l2.293 2.293a1 1 0 001.414-1.414L11.414 10l2.293-2.293z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const LockClosed = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
+    <path
+      fillRule="evenodd"
+      d="M5 8a5 5 0 1110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2V8zm8-1a3 3 0 10-6 0v1h6V7z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const statusIcon = (status: AccessPoint['wps']) => {
+  switch (status) {
+    case 'enabled':
+      return (
+        <span className="text-green-400" aria-label="WPS enabled">
+          <CheckCircle className="w-5 h-5" />
+        </span>
+      );
+    case 'locked':
+      return (
+        <span className="text-yellow-400" aria-label="WPS locked">
+          <LockClosed className="w-5 h-5" />
+        </span>
+      );
+    case 'disabled':
+    default:
+      return (
+        <span className="text-red-400" aria-label="WPS disabled">
+          <XCircle className="w-5 h-5" />
+        </span>
+      );
+  }
+};
+
+const APList: React.FC = () => {
+  const [aps, setAps] = useState<AccessPoint[]>([]);
+
+  useEffect(() => {
+    fetch('/demo-data/reaver/aps.json')
+      .then((r) => r.json())
+      .then(setAps)
+      .catch(() => setAps([]));
+  }, []);
+
+  return (
+    <table className="w-full text-sm mb-4">
+      <thead>
+        <tr className="text-left">
+          <th className="pb-2">SSID</th>
+          <th className="pb-2">BSSID</th>
+          <th className="pb-2">WPS</th>
+        </tr>
+      </thead>
+      <tbody>
+        {aps.map((ap) => (
+          <tr key={ap.bssid} className="odd:bg-gray-800">
+            <td className="py-1 px-2">{ap.ssid}</td>
+            <td className="py-1 px-2 font-mono">{ap.bssid}</td>
+            <td className="py-1 px-2">{statusIcon(ap.wps)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default APList;

--- a/apps/reaver/components/ProgressDonut.tsx
+++ b/apps/reaver/components/ProgressDonut.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+interface ProgressDonutProps {
+  value: number;
+  total: number;
+}
+
+const ProgressDonut: React.FC<ProgressDonutProps> = ({ value, total }) => {
+  const pct = Math.min(100, (value / total) * 100);
+  const radius = 45;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (pct / 100) * circumference;
+
+  return (
+    <svg viewBox="0 0 100 100" className="w-24 h-24" aria-label="Attack progress">
+      <circle
+        className="text-gray-700"
+        strokeWidth="10"
+        stroke="currentColor"
+        fill="transparent"
+        r={radius}
+        cx="50"
+        cy="50"
+      />
+      <circle
+        className="text-green-500"
+        strokeWidth="10"
+        strokeLinecap="round"
+        stroke="currentColor"
+        fill="transparent"
+        r={radius}
+        cx="50"
+        cy="50"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+      />
+      <text
+        x="50"
+        y="55"
+        textAnchor="middle"
+        className="fill-white text-sm"
+      >
+        {Math.round(pct)}%
+      </text>
+    </svg>
+  );
+};
+
+export default ProgressDonut;

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -7,6 +7,8 @@ import RouterProfiles, {
   ROUTER_PROFILES,
   RouterProfile,
 } from './components/RouterProfiles';
+import APList from './components/APList';
+import ProgressDonut from './components/ProgressDonut';
 
 interface RouterMeta {
   model: string;
@@ -37,6 +39,7 @@ const stages = [
 ];
 
 const TOTAL_PINS = 11000; // example PIN space for demonstration
+const FOUND_PIN = '12345670';
 
 const formatTime = (seconds: number) => {
   const hrs = Math.floor(seconds / 3600);
@@ -59,6 +62,8 @@ const ReaverPanel: React.FC = () => {
   const intervalRef = useRef<NodeJS.Timeout>();
   const burstRef = useRef(0); // attempts since last lock
   const lockRef = useRef(0); // lockout seconds remaining
+  const [logs, setLogs] = useState<string[]>([]);
+  const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetch('/demo-data/reaver/routers.json')
@@ -86,13 +91,19 @@ const ReaverPanel: React.FC = () => {
           if (profile.lockDuration > 0) {
             lockRef.current = profile.lockDuration;
             setLockRemaining(lockRef.current);
+            setLogs((l) => [...l, `WPS locked for ${profile.lockDuration}s`]);
           }
+        }
+
+        if (next % 1000 === 0) {
+          setLogs((l) => [...l, `Tried ${next} PINs`]);
         }
 
         if (next >= TOTAL_PINS) {
           clearInterval(intervalRef.current!);
           setRunning(false);
           setStageIdx(stages.length);
+          setLogs((l) => [...l, `PIN found: ${FOUND_PIN}`]);
           return TOTAL_PINS;
         }
         return next;
@@ -115,12 +126,14 @@ const ReaverPanel: React.FC = () => {
     setLockRemaining(0);
     setStageIdx(0);
     setRunning(true);
+    setLogs(['Attack started']);
   };
 
   const stop = () => {
     setRunning(false);
     clearInterval(intervalRef.current!);
     setStageIdx(-1);
+    setLogs((l) => [...l, 'Attack stopped']);
   };
 
   useEffect(() => {
@@ -130,6 +143,20 @@ const ReaverPanel: React.FC = () => {
       return () => clearTimeout(timer);
     }
   }, [running, stageIdx]);
+
+  useEffect(() => {
+    if (stageIdx >= 0 && stageIdx < stages.length) {
+      setLogs((l) => [...l, `Stage: ${stages[stageIdx].title}`]);
+    }
+    if (stageIdx === stages.length) {
+      setLogs((l) => [...l, 'Attack complete']);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stageIdx]);
+
+  useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+  }, [logs]);
 
   const stageStatus = (i: number) => {
     if (i < stageIdx) return 'completed';
@@ -145,6 +172,11 @@ const ReaverPanel: React.FC = () => {
       <p className="text-sm text-yellow-300 mb-4">
         Educational simulation. No real Wi-Fi traffic is generated.
       </p>
+
+      <div className="mb-6">
+        <h2 className="text-lg mb-2">Access Points</h2>
+        <APList />
+      </div>
 
       <div className="mb-6">
         <h2 className="text-lg mb-2">Attack Stages</h2>
@@ -180,25 +212,28 @@ const ReaverPanel: React.FC = () => {
       <div className="mb-6">
         <h2 className="text-lg mb-2">PIN Brute-force Simulator</h2>
         <RouterProfiles onChange={setProfile} />
-        <div className="flex items-center gap-2 mb-2">
-          <label htmlFor="rate" className="text-sm">
-            Attempts/sec
-          </label>
-          <input
-            id="rate"
-            type="number"
-            min="1"
-            value={rate}
-            onChange={(e) => setRate(Number(e.target.value) || 1)}
-            className="w-20 p-1 bg-gray-800 rounded text-white"
-          />
-          <button
-            type="button"
-            onClick={running ? stop : start}
-            className="px-2 py-1 bg-green-700 rounded disabled:opacity-50"
-          >
-            {running ? 'Stop' : 'Start'}
-          </button>
+        <div className="flex items-center gap-4 mb-4 flex-wrap">
+          <div className="flex items-center gap-2">
+            <label htmlFor="rate" className="text-sm">
+              Attempts/sec
+            </label>
+            <input
+              id="rate"
+              type="number"
+              min="1"
+              value={rate}
+              onChange={(e) => setRate(Number(e.target.value) || 1)}
+              className="w-20 p-1 bg-gray-800 rounded text-white"
+            />
+            <button
+              type="button"
+              onClick={running ? stop : start}
+              className="px-2 py-1 bg-green-700 rounded disabled:opacity-50"
+            >
+              {running ? 'Stop' : 'Start'}
+            </button>
+          </div>
+          <ProgressDonut value={attempts} total={TOTAL_PINS} />
         </div>
         <div className="text-sm mb-1">
           Attempts: {attempts} / {TOTAL_PINS}
@@ -214,9 +249,32 @@ const ReaverPanel: React.FC = () => {
             WPS locked. Resuming in {lockRemaining}s
           </div>
         )}
-        <div className="text-sm">
+        <div className="text-sm mb-2">
           Est. time remaining: {formatTime(timeRemaining)}
         </div>
+        <div
+          ref={logRef}
+          className="h-32 bg-gray-800 rounded p-2 overflow-y-auto text-xs font-mono mb-4"
+        >
+          {logs.map((log, i) => (
+            <div key={i}>{log}</div>
+          ))}
+        </div>
+        {stageIdx === stages.length && (
+          <div className="mt-4 p-4 bg-gray-800 rounded">
+            <h3 className="text-lg mb-2">Attack Summary</h3>
+            <p className="mb-2">
+              WPS PIN: <code className="text-green-400">{FOUND_PIN}</code>
+            </p>
+            <button
+              type="button"
+              onClick={() => navigator.clipboard.writeText(FOUND_PIN)}
+              className="px-2 py-1 bg-blue-600 rounded"
+            >
+              Copy PIN
+            </button>
+          </div>
+        )}
       </div>
 
       <div>

--- a/public/demo-data/reaver/aps.json
+++ b/public/demo-data/reaver/aps.json
@@ -1,0 +1,17 @@
+[
+  {
+    "ssid": "CafeWiFi",
+    "bssid": "00:11:22:33:44:55",
+    "wps": "enabled"
+  },
+  {
+    "ssid": "HomeSecure",
+    "bssid": "66:77:88:99:AA:BB",
+    "wps": "locked"
+  },
+  {
+    "ssid": "Guest",
+    "bssid": "CC:DD:EE:FF:00:11",
+    "wps": "disabled"
+  }
+]


### PR DESCRIPTION
## Summary
- list nearby access points with color-coded WPS status icons
- show attack progress donut, scrolling logs, and copyable result summary

## Testing
- `yarn test apps/reaver --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b1d8d79fcc8328b1f1e18cf646bc49