### PR TITLE
feat: add video notes panel with search

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -20,6 +20,9 @@ export interface OPFSHook {
     name: string,
     dir?: FileSystemDirectoryHandle | null,
   ) => Promise<boolean>;
+  listFiles: (
+    dir?: FileSystemDirectoryHandle | null,
+  ) => Promise<FileSystemFileHandle[]>;
 }
 
 export default function useOPFS(): OPFSHook {
@@ -111,6 +114,20 @@ export default function useOPFS(): OPFSHook {
     [root],
   );
 
-  return { supported, root, getDir, readFile, writeFile, deleteFile };
+  const listFiles = useCallback<OPFSHook['listFiles']>(
+    async (dir: FileSystemDirectoryHandle | null | undefined = root) => {
+      if (!dir) return [];
+      const files: FileSystemFileHandle[] = [];
+      try {
+        for await (const entry of dir.values()) {
+          if (entry.kind === 'file') files.push(entry as FileSystemFileHandle);
+        }
+      } catch {}
+      return files;
+    },
+    [root],
+  );
+
+  return { supported, root, getDir, readFile, writeFile, deleteFile, listFiles };
 }
 


### PR DESCRIPTION
## Summary
- add listFiles helper to OPFS hook
- add side notes panel in YouTubePlayer storing notes per video in OPFS
- enable text search across saved video notes

## Testing
- `yarn test` *(fails: BeEF app, NiktoPage, calculator parser)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6081d988328acab6d417822d65c