### PR TITLE
Adjust pipe gap difficulty and add best-run replay

### DIFF
--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react';
-import InputRemap from './Games/common/input-remap/InputRemap';
-import useInputMapping from './Games/common/input-remap/useInputMapping';
+import React, { useEffect, useRef } from "react";
+import InputRemap from "./Games/common/input-remap/InputRemap";
+import useInputMapping from "./Games/common/input-remap/useInputMapping";
 
 interface HelpOverlayProps {
   gameId: string;
@@ -14,154 +14,155 @@ interface Instruction {
 }
 
 export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
-  '2048': {
-    objective: 'Reach the 2048 tile by merging numbers.',
-    controls: 'Use the arrow keys to slide and combine tiles.',
+  "2048": {
+    objective: "Reach the 2048 tile by merging numbers.",
+    controls: "Use the arrow keys to slide and combine tiles.",
     actions: {
-      up: 'ArrowUp',
-      down: 'ArrowDown',
-      left: 'ArrowLeft',
-      right: 'ArrowRight',
+      up: "ArrowUp",
+      down: "ArrowDown",
+      left: "ArrowLeft",
+      right: "ArrowRight",
     },
   },
   asteroids: {
-    objective: 'Destroy asteroids without crashing your ship.',
-    controls: 'Arrow keys to rotate and thrust, space to fire.',
+    objective: "Destroy asteroids without crashing your ship.",
+    controls: "Arrow keys to rotate and thrust, space to fire.",
     actions: {
-      left: 'ArrowLeft',
-      right: 'ArrowRight',
-      thrust: 'ArrowUp',
-      fire: ' ',
-      hyperspace: 'h',
+      left: "ArrowLeft",
+      right: "ArrowRight",
+      thrust: "ArrowUp",
+      fire: " ",
+      hyperspace: "h",
     },
   },
   battleship: {
-    objective: 'Sink all enemy ships before they sink yours.',
-    controls: 'Click cells to place ships and fire shots.',
+    objective: "Sink all enemy ships before they sink yours.",
+    controls: "Click cells to place ships and fire shots.",
   },
   blackjack: {
-    objective: 'Get as close to 21 as possible without busting.',
-    controls: 'Use on-screen buttons to hit or stand.',
+    objective: "Get as close to 21 as possible without busting.",
+    controls: "Use on-screen buttons to hit or stand.",
   },
   breakout: {
-    objective: 'Clear all bricks with the ball.',
-    controls: 'Move the paddle with the arrow keys.',
+    objective: "Clear all bricks with the ball.",
+    controls: "Move the paddle with the arrow keys.",
   },
-  'car-racer': {
-    objective: 'Avoid other cars and stay on the road.',
-    controls: 'Arrow keys steer, space for brake if available.',
+  "car-racer": {
+    objective: "Avoid other cars and stay on the road.",
+    controls: "Arrow keys steer, space for brake if available.",
   },
   checkers: {
-    objective: 'Capture all opponent pieces or block their moves.',
-    controls: 'Click a piece then a destination square.',
+    objective: "Capture all opponent pieces or block their moves.",
+    controls: "Click a piece then a destination square.",
   },
   chess: {
-    objective: 'Checkmate the opposing king.',
-    controls: 'Click or drag pieces to legal squares.',
+    objective: "Checkmate the opposing king.",
+    controls: "Click or drag pieces to legal squares.",
   },
-  'connect-four': {
-    objective: 'Get four of your discs in a row.',
-    controls: 'Left/Right select column, Space drops, or click a column.',
+  "connect-four": {
+    objective: "Get four of your discs in a row.",
+    controls: "Left/Right select column, Space drops, or click a column.",
   },
   frogger: {
-    objective: 'Cross the road and river to reach the goal.',
-    controls: 'Use the arrow keys to move the frog.',
+    objective: "Cross the road and river to reach the goal.",
+    controls: "Use the arrow keys to move the frog.",
   },
   hangman: {
-    objective: 'Guess the word before the hangman is complete.',
-    controls: 'Type letters or use the on-screen keyboard.',
+    objective: "Guess the word before the hangman is complete.",
+    controls: "Type letters or use the on-screen keyboard.",
   },
   memory: {
-    objective: 'Match all pairs of cards.',
-    controls: 'Click two cards to reveal and match.',
+    objective: "Match all pairs of cards.",
+    controls: "Click two cards to reveal and match.",
   },
   minesweeper: {
-    objective: 'Clear the board without hitting mines.',
-    controls: 'Left-click to reveal, right-click to flag.',
+    objective: "Clear the board without hitting mines.",
+    controls: "Left-click to reveal, right-click to flag.",
   },
   pacman: {
-    objective: 'Eat all pellets while avoiding ghosts.',
-    controls: 'Use the arrow keys to move.',
+    objective: "Eat all pellets while avoiding ghosts.",
+    controls: "Use the arrow keys to move.",
   },
   platformer: {
-    objective: 'Reach the end of the level.',
-    controls: 'Arrow keys move, up to jump.',
+    objective: "Reach the end of the level.",
+    controls: "Arrow keys move, up to jump.",
   },
   pong: {
-    objective: 'Hit the ball past your opponent.',
-    controls: 'Use arrow keys or W/S to move the paddle.',
+    objective: "Hit the ball past your opponent.",
+    controls: "Use arrow keys or W/S to move the paddle.",
   },
   reversi: {
-    objective: 'Control the most discs on the board.',
-    controls: 'Click a square to place a disc and flip others.',
+    objective: "Control the most discs on the board.",
+    controls: "Click a square to place a disc and flip others.",
   },
   simon: {
-    objective: 'Repeat the sequence of lights and sounds.',
-    controls: 'Click the colored pads in order.',
+    objective: "Repeat the sequence of lights and sounds.",
+    controls: "Click the colored pads in order.",
   },
   snake: {
-    objective: 'Grow by eating food and avoid collisions.',
-    controls: 'Arrow keys to move, space to pause.',
+    objective: "Grow by eating food and avoid collisions.",
+    controls: "Arrow keys to move, space to pause.",
   },
   sokoban: {
-    objective: 'Push all boxes onto target squares.',
+    objective: "Push all boxes onto target squares.",
     controls:
-      'Use arrow keys to move and push boxes. U/Z/Backspace to undo, Y to redo, R to reset.',
+      "Use arrow keys to move and push boxes. U/Z/Backspace to undo, Y to redo, R to reset.",
   },
   solitaire: {
-    objective: 'Move all cards to the foundation piles.',
-    controls: 'Click and drag cards to new positions.',
+    objective: "Move all cards to the foundation piles.",
+    controls: "Click and drag cards to new positions.",
   },
   tictactoe: {
-    objective: 'Place three marks in a row to win.',
-    controls: 'Click a square to place your mark.',
+    objective: "Place three marks in a row to win.",
+    controls: "Click a square to place your mark.",
   },
   tetris: {
-    objective: 'Clear lines by completing horizontal rows.',
-    controls: 'Arrow keys move, up rotates, space drops.',
+    objective: "Clear lines by completing horizontal rows.",
+    controls: "Arrow keys move, up rotates, space drops.",
   },
-  'tower-defense': {
-    objective: 'Stop enemies before they reach the end.',
-    controls: 'Use Edit Map to draw paths, then click to place and upgrade towers.',
+  "tower-defense": {
+    objective: "Stop enemies before they reach the end.",
+    controls:
+      "Use Edit Map to draw paths, then click to place and upgrade towers.",
   },
-  'word-search': {
-    objective: 'Find all listed words in the grid.',
-    controls: 'Click or swipe across letters to select words.',
+  "word-search": {
+    objective: "Find all listed words in the grid.",
+    controls: "Click or swipe across letters to select words.",
   },
   wordle: {
-    objective: 'Guess the hidden word in six tries.',
-    controls: 'Type letters and press Enter to submit.',
+    objective: "Guess the hidden word in six tries.",
+    controls: "Type letters and press Enter to submit.",
   },
   nonogram: {
-    objective: 'Fill cells according to row and column clues.',
-    controls: 'Left-click to fill, right-click to mark empty.',
+    objective: "Fill cells according to row and column clues.",
+    controls: "Left-click to fill, right-click to mark empty.",
   },
-  'space-invaders': {
-    objective: 'Defeat the alien waves.',
-    controls: 'Arrow keys move, space to shoot.',
+  "space-invaders": {
+    objective: "Defeat the alien waves.",
+    controls: "Arrow keys move, space to shoot.",
   },
   sudoku: {
-    objective: 'Fill the grid so each row, column, and box has 1-9.',
+    objective: "Fill the grid so each row, column, and box has 1-9.",
     controls:
-      'Click a cell then type a number. Toggle Notes or hold Shift for pencil marks. Conflicts highlight automatically. Choose a difficulty and use Hint for human strategies.',
+      "Click a cell then type a number. Toggle Notes or hold Shift for pencil marks. Conflicts highlight automatically. Choose a difficulty and use Hint for human strategies.",
   },
-  'flappy-bird': {
+  "flappy-bird": {
     objective:
-      'Fly through gaps between pipes. Practice gates, slow-motion, easy mode, and skins available.',
+      "Fly through gaps between pipes. Practice gates, slow-motion, easy mode, and skins available.",
     controls:
-      'Space/click to flap. P: practice, G: easy gravity, M: reduced motion, O: pipe skin, H: hitbox preview.',
+      "Space/click to flap. P: practice, G: easy gravity, M: reduced motion, O: pipe skin, H: hitbox preview, R: replay, Shift+R: best run.",
   },
-  'candy-crush': {
-    objective: 'Match three candies to clear them.',
-    controls: 'Swap adjacent candies by dragging or clicking.',
+  "candy-crush": {
+    objective: "Match three candies to clear them.",
+    controls: "Swap adjacent candies by dragging or clicking.",
   },
   gomoku: {
-    objective: 'Get five stones in a row.',
-    controls: 'Click a grid intersection to place a stone.',
+    objective: "Get five stones in a row.",
+    controls: "Click a grid intersection to place a stone.",
   },
   pinball: {
-    objective: 'Score points by hitting targets.',
-    controls: 'Left/right arrows control flippers, space to launch.',
+    objective: "Score points by hitting targets.",
+    controls: "Left/right arrows control flippers, space to launch.",
   },
 };
 
@@ -178,11 +179,11 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
     const selectors =
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
     const focusables = Array.from(
-      overlayRef.current.querySelectorAll<HTMLElement>(selectors)
+      overlayRef.current.querySelectorAll<HTMLElement>(selectors),
     );
     focusables[0]?.focus();
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Tab' && focusables.length > 0) {
+      if (e.key === "Tab" && focusables.length > 0) {
         const first = focusables[0];
         const last = focusables[focusables.length - 1];
         if (e.shiftKey) {
@@ -194,15 +195,15 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
           e.preventDefault();
           first.focus();
         }
-      } else if (e.key === 'Escape') {
+      } else if (e.key === "Escape") {
         e.preventDefault();
         onClose();
       }
     };
     const node = overlayRef.current;
-    node.addEventListener('keydown', handleKey);
+    node.addEventListener("keydown", handleKey);
     return () => {
-      node.removeEventListener('keydown', handleKey);
+      node.removeEventListener("keydown", handleKey);
       prevFocus.current?.focus();
     };
   }, [onClose]);
@@ -217,14 +218,16 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
     >
       <div className="max-w-md p-4 bg-gray-800 rounded shadow-lg">
         <h2 className="text-xl font-bold mb-2">{gameId} Help</h2>
-        <p className="mb-2"><strong>Objective:</strong> {info.objective}</p>
+        <p className="mb-2">
+          <strong>Objective:</strong> {info.objective}
+        </p>
         {info.actions ? (
           <>
             <p>
-              <strong>Controls:</strong>{' '}
+              <strong>Controls:</strong>{" "}
               {Object.entries(mapping)
                 .map(([a, k]) => `${a}: ${k}`)
-                .join(', ')}
+                .join(", ")}
             </p>
             <div className="mt-2">
               <InputRemap

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
-import useCanvasResize from '../../hooks/useCanvasResize';
+import React, { useEffect, useRef, useState } from "react";
+import useCanvasResize from "../../hooks/useCanvasResize";
 import {
   BIRD_SKINS,
   BIRD_ASSETS,
   PIPE_SKINS,
-} from '../../apps/games/flappy-bird/skins';
+} from "../../apps/games/flappy-bird/skins";
 
 const WIDTH = 400;
 const HEIGHT = 300;
@@ -27,9 +27,9 @@ const FlappyBird = () => {
 
   useEffect(() => {
     try {
-      setSkin(parseInt(localStorage.getItem('flappy-bird-skin') || '0', 10));
+      setSkin(parseInt(localStorage.getItem("flappy-bird-skin") || "0", 10));
       setPipeSkinIndex(
-        parseInt(localStorage.getItem('flappy-pipe-skin') || '0', 10),
+        parseInt(localStorage.getItem("flappy-pipe-skin") || "0", 10),
       );
     } catch {
       /* ignore */
@@ -49,26 +49,26 @@ const FlappyBird = () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
     const width = WIDTH;
     const height = HEIGHT;
     let reduceMotion =
-      localStorage.getItem('flappy-reduced-motion') === '1' ||
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      localStorage.getItem("flappy-reduced-motion") === "1" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     // mode flags
-    let practiceMode = localStorage.getItem('flappy-practice') === '1';
+    let practiceMode = localStorage.getItem("flappy-practice") === "1";
 
     // gravity variants
     const GRAVITY_VARIANTS = [
-      { name: 'Easy', value: 0.2 },
-      { name: 'Normal', value: 0.4 },
-      { name: 'Hard', value: 0.6 },
+      { name: "Easy", value: 0.2 },
+      { name: "Normal", value: 0.4 },
+      { name: "Hard", value: 0.6 },
     ];
     let gravityVariant = parseInt(
-      localStorage.getItem('flappy-gravity-variant') || '1',
+      localStorage.getItem("flappy-gravity-variant") || "1",
       10,
     );
     if (gravityVariant < 0 || gravityVariant >= GRAVITY_VARIANTS.length)
@@ -81,7 +81,7 @@ const FlappyBird = () => {
     let pipeSkin = pipeSkinIndex;
 
     // hitbox preview
-    let showHitbox = localStorage.getItem('flappy-hitbox') === '1';
+    let showHitbox = localStorage.getItem("flappy-hitbox") === "1";
 
     // physics constants
     let bird = { x: 50, y: height / 2, vy: 0 };
@@ -91,6 +91,7 @@ const FlappyBird = () => {
     const pipeWidth = 40;
     const baseGap = 80;
     const practiceGap = 120;
+    const minGap = 60;
     let gap = practiceMode ? practiceGap : baseGap;
     let pipeInterval = 100;
     const pipeSpeed = 2;
@@ -105,7 +106,7 @@ const FlappyBird = () => {
     let crashTimer = 0;
     let birdAngle = 0;
     let loopId = 0;
-    let highHz = localStorage.getItem('flappy-120hz') === '1';
+    let highHz = localStorage.getItem("flappy-120hz") === "1";
     let fps = highHz ? 120 : 60;
 
     // sky, clouds, and wind
@@ -121,7 +122,7 @@ const FlappyBird = () => {
 
     function mixColor(c1, c2, t) {
       return `rgb(${Math.round(c1[0] + (c2[0] - c1[0]) * t)},${Math.round(
-        c1[1] + (c2[1] - c1[1]) * t
+        c1[1] + (c2[1] - c1[1]) * t,
       )},${Math.round(c1[2] + (c2[2] - c1[2]) * t)})`;
     }
 
@@ -140,14 +141,20 @@ const FlappyBird = () => {
     }
 
     function initHills() {
-      hillsBack = Array.from({ length: 2 }, (_, i) => ({ x: i * width, speed: 0.3 }));
-      hillsFront = Array.from({ length: 2 }, (_, i) => ({ x: i * width, speed: 0.6 }));
+      hillsBack = Array.from({ length: 2 }, (_, i) => ({
+        x: i * width,
+        speed: 0.3,
+      }));
+      hillsFront = Array.from({ length: 2 }, (_, i) => ({
+        x: i * width,
+        speed: 0.6,
+      }));
     }
 
     function drawHills() {
-      ctx.fillStyle = '#228B22';
+      ctx.fillStyle = "#228B22";
       for (const h of hillsBack) ctx.fillRect(h.x, height - 30, width, 30);
-      ctx.fillStyle = '#006400';
+      ctx.fillStyle = "#006400";
       for (const h of hillsFront) ctx.fillRect(h.x, height - 15, width, 15);
     }
 
@@ -165,11 +172,27 @@ const FlappyBird = () => {
 
     function drawCloud(c) {
       ctx.save();
-      ctx.fillStyle = 'white';
+      ctx.fillStyle = "white";
       ctx.beginPath();
       ctx.ellipse(c.x, c.y, 20 * c.scale, 12 * c.scale, 0, 0, Math.PI * 2);
-      ctx.ellipse(c.x + 15 * c.scale, c.y + 2 * c.scale, 20 * c.scale, 12 * c.scale, 0, 0, Math.PI * 2);
-      ctx.ellipse(c.x - 15 * c.scale, c.y + 2 * c.scale, 20 * c.scale, 12 * c.scale, 0, 0, Math.PI * 2);
+      ctx.ellipse(
+        c.x + 15 * c.scale,
+        c.y + 2 * c.scale,
+        20 * c.scale,
+        12 * c.scale,
+        0,
+        0,
+        Math.PI * 2,
+      );
+      ctx.ellipse(
+        c.x - 15 * c.scale,
+        c.y + 2 * c.scale,
+        20 * c.scale,
+        12 * c.scale,
+        0,
+        0,
+        Math.PI * 2,
+      );
       ctx.fill();
       ctx.restore();
     }
@@ -203,7 +226,7 @@ const FlappyBird = () => {
 
     function drawBackground() {
       if (reduceMotion) {
-        ctx.fillStyle = '#87CEEB';
+        ctx.fillStyle = "#87CEEB";
         ctx.fillRect(0, 0, width, height);
         skyProgress = 0;
         return;
@@ -226,7 +249,7 @@ const FlappyBird = () => {
     function drawFoliage() {
       if (reduceMotion) return;
       ctx.save();
-      ctx.strokeStyle = 'green';
+      ctx.strokeStyle = "green";
       ctx.lineWidth = 3;
       for (const f of foliage) {
         const sway = gust * 0.5 + Math.sin((frame + f.x) / 20) * 0.2;
@@ -258,47 +281,47 @@ const FlappyBird = () => {
     }
 
     // medals
-      const medalThresholds = [
-        { name: 'bronze', distance: 10 },
-        { name: 'silver', distance: 20 },
-        { name: 'gold', distance: 30 },
-      ];
-      let medals = {};
-      try {
-        medals = JSON.parse(localStorage.getItem('flappy-medals') || '{}');
-      } catch {
-        medals = {};
-      }
+    const medalThresholds = [
+      { name: "bronze", distance: 10 },
+      { name: "silver", distance: 20 },
+      { name: "gold", distance: 30 },
+    ];
+    let medals = {};
+    try {
+      medals = JSON.parse(localStorage.getItem("flappy-medals") || "{}");
+    } catch {
+      medals = {};
+    }
 
-      // records per gravity variant
-      let records = {};
-      try {
-        records = JSON.parse(localStorage.getItem('flappy-records') || '{}');
-      } catch {
-        records = {};
+    // records per gravity variant
+    let records = {};
+    try {
+      records = JSON.parse(localStorage.getItem("flappy-records") || "{}");
+    } catch {
+      records = {};
+    }
+    let best = 0;
+    let ghostRun = null;
+    function loadRecord() {
+      const key = GRAVITY_VARIANTS[gravityVariant].name;
+      const rec = records[key];
+      best = rec ? rec.score : 0;
+      ghostRun = rec ? rec.run : null;
+      bestRef.current = best;
+    }
+    loadRecord();
+    function getMedal(dist) {
+      let m = null;
+      for (const { name, distance } of medalThresholds) {
+        if (dist >= distance) m = name;
       }
-      let best = 0;
-      let ghostRun = null;
-      function loadRecord() {
-        const key = GRAVITY_VARIANTS[gravityVariant].name;
-        const rec = records[key];
-        best = rec ? rec.score : 0;
-        ghostRun = rec ? rec.run : null;
-        bestRef.current = best;
-      }
-      loadRecord();
-      function getMedal(dist) {
-        let m = null;
-        for (const { name, distance } of medalThresholds) {
-          if (dist >= distance) m = name;
-        }
       return m;
     }
     function saveMedal(dist) {
       const medal = getMedal(dist);
       if (medal) {
         medals[dist] = medal;
-        localStorage.setItem('flappy-medals', JSON.stringify(medals));
+        localStorage.setItem("flappy-medals", JSON.stringify(medals));
       }
     }
 
@@ -349,7 +372,7 @@ const FlappyBird = () => {
       reset(newSeed);
       addPipe();
       startLoop();
-      if (liveRef.current) liveRef.current.textContent = 'Score: 0';
+      if (liveRef.current) liveRef.current.textContent = "Score: 0";
     }
 
     function flap(record = true) {
@@ -372,10 +395,10 @@ const FlappyBird = () => {
         ctx.fillRect(pipe.x, 0, pipeWidth, pipe.top);
         ctx.fillRect(pipe.x, pipe.bottom, pipeWidth, height - pipe.bottom);
         // bevel
-        ctx.fillStyle = 'rgba(255,255,255,0.2)';
+        ctx.fillStyle = "rgba(255,255,255,0.2)";
         ctx.fillRect(pipe.x, 0, 4, pipe.top);
         ctx.fillRect(pipe.x, pipe.bottom, 4, height - pipe.bottom);
-        ctx.fillStyle = 'rgba(0,0,0,0.3)';
+        ctx.fillStyle = "rgba(0,0,0,0.3)";
         ctx.fillRect(pipe.x + pipeWidth - 4, 0, 4, pipe.top);
         ctx.fillRect(
           pipe.x + pipeWidth - 4,
@@ -387,7 +410,7 @@ const FlappyBird = () => {
         ctx.fillRect(pipe.x, pipe.bottom, pipeWidth, 2);
         ctx.fillStyle = pipeColor;
         if (showHitbox) {
-          ctx.strokeStyle = 'red';
+          ctx.strokeStyle = "red";
           ctx.strokeRect(pipe.x, 0, pipeWidth, pipe.top);
           ctx.strokeRect(pipe.x, pipe.bottom, pipeWidth, height - pipe.bottom);
         }
@@ -398,7 +421,7 @@ const FlappyBird = () => {
       if (ghostRun && ghostFrame < ghostRun.pos.length) {
         ctx.save();
         ctx.globalAlpha = 0.3;
-        ctx.fillStyle = 'gray';
+        ctx.fillStyle = "gray";
         ctx.beginPath();
         ctx.arc(bird.x, ghostRun.pos[ghostFrame], 10, 0, Math.PI * 2);
         ctx.fill();
@@ -413,23 +436,23 @@ const FlappyBird = () => {
       if (img && img.complete) {
         ctx.drawImage(img, -10, -10, 20, 20);
       } else {
-        ctx.fillStyle = 'yellow';
+        ctx.fillStyle = "yellow";
         ctx.beginPath();
         ctx.arc(0, 0, 10, 0, Math.PI * 2);
         ctx.fill();
       }
       if (showHitbox) {
-        ctx.strokeStyle = 'red';
+        ctx.strokeStyle = "red";
         ctx.strokeRect(-10, -10, 20, 20);
       }
       ctx.restore();
 
       // HUD
-      ctx.fillStyle = 'rgba(0,0,0,0.5)';
+      ctx.fillStyle = "rgba(0,0,0,0.5)";
       ctx.fillRect(5, 5, 160, 140);
-      ctx.fillStyle = '#fff';
-      ctx.font = '16px sans-serif';
-      ctx.textAlign = 'left';
+      ctx.fillStyle = "#fff";
+      ctx.font = "16px sans-serif";
+      ctx.textAlign = "left";
       let hudY = 20;
       const hudLine = (text) => {
         ctx.fillText(text, 10, hudY);
@@ -440,22 +463,29 @@ const FlappyBird = () => {
       hudLine(`Seed: ${seed}`);
       const medal = getMedal(score);
       if (medal) hudLine(`Medal: ${medal}`);
-      if (practiceMode) hudLine('Practice');
+      if (practiceMode) hudLine("Practice");
       hudLine(`Gravity: ${GRAVITY_VARIANTS[gravityVariant].name}`);
-      if (reduceMotion) hudLine('Reduced Motion');
-      if (showHitbox) hudLine('Hitbox');
+      if (reduceMotion) hudLine("Reduced Motion");
+      if (showHitbox) hudLine("Hitbox");
 
       if (!running) {
-        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillStyle = "rgba(0,0,0,0.5)";
         ctx.fillRect(0, 0, width, height);
-        ctx.fillStyle = 'white';
-        ctx.textAlign = 'center';
-        ctx.font = '24px sans-serif';
-        ctx.fillText('Game Over', width / 2, height / 2);
-        ctx.font = '16px sans-serif';
-        ctx.fillText('Press Space or Click to restart', width / 2, height / 2 + 30);
-        if (lastRun) ctx.fillText('Press R to replay', width / 2, height / 2 + 50);
-        ctx.textAlign = 'left';
+        ctx.fillStyle = "white";
+        ctx.textAlign = "center";
+        ctx.font = "24px sans-serif";
+        ctx.fillText("Game Over", width / 2, height / 2);
+        ctx.font = "16px sans-serif";
+        ctx.fillText(
+          "Press Space or Click to restart",
+          width / 2,
+          height / 2 + 30,
+        );
+        if (lastRun)
+          ctx.fillText("Press R to replay", width / 2, height / 2 + 50);
+        if (ghostRun)
+          ctx.fillText("Press Shift+R for best", width / 2, height / 2 + 70);
+        ctx.textAlign = "left";
       }
     }
 
@@ -483,9 +513,13 @@ const FlappyBird = () => {
               bestRef.current = best;
               records[GRAVITY_VARIANTS[gravityVariant].name] = {
                 score: best,
-                run: { pos: runPositions.slice() },
+                run: {
+                  pos: runPositions.slice(),
+                  flaps: flapFrames.slice(),
+                  seed,
+                },
               };
-              localStorage.setItem('flappy-records', JSON.stringify(records));
+              localStorage.setItem("flappy-records", JSON.stringify(records));
               ghostRun = records[GRAVITY_VARIANTS[gravityVariant].name].run;
             }
             lastRun = { seed, flaps: flapFrames };
@@ -505,12 +539,19 @@ const FlappyBird = () => {
       updateHills();
 
       if (frame >= nextPipeFrame) {
+        gap = practiceMode
+          ? practiceGap
+          : Math.max(minGap, baseGap - Math.floor(score / 5) * 2);
         addPipe();
         pipeInterval = Math.max(60, 100 - Math.floor(score / 5) * 5);
         nextPipeFrame = frame + pipeInterval;
       }
 
-      if (isReplaying && replayIndex < replayFlaps.length && frame === replayFlaps[replayIndex]) {
+      if (
+        isReplaying &&
+        replayIndex < replayFlaps.length &&
+        frame === replayFlaps[replayIndex]
+      ) {
         flap(false);
         replayIndex += 1;
       }
@@ -581,79 +622,86 @@ const FlappyBird = () => {
 
     function handleKey(e) {
       if (pausedRef.current) {
-        if (e.code === 'Escape' || e.code === 'Space') {
+        if (e.code === "Escape" || e.code === "Space") {
           pausedRef.current = false;
           setPaused(false);
         }
         return;
       }
 
-      if (e.code === 'Escape' && running) {
+      if (e.code === "Escape" && running) {
         pausedRef.current = true;
         setPaused(true);
         return;
       }
 
-      if (e.code === 'Space') {
+      if (e.code === "Space") {
         e.preventDefault();
         if (running) {
           flap();
         } else {
           startGame();
         }
-      } else if (e.code === 'KeyR' && !running) {
-        if (lastRun) {
+      } else if (e.code === "KeyR" && !running) {
+        if (e.shiftKey) {
+          if (ghostRun && ghostRun.seed !== undefined && ghostRun.flaps) {
+            isReplaying = true;
+            replayFlaps = ghostRun.flaps || [];
+            replayIndex = 0;
+            startGame(ghostRun.seed);
+          }
+        } else if (lastRun) {
           isReplaying = true;
           replayFlaps = lastRun.flaps;
           replayIndex = 0;
           startGame(lastRun.seed);
         }
-      } else if (e.code === 'KeyF') {
+      } else if (e.code === "KeyF") {
         highHz = !highHz;
-        localStorage.setItem('flappy-120hz', highHz ? '1' : '0');
+        localStorage.setItem("flappy-120hz", highHz ? "1" : "0");
         if (running) startLoop();
-      } else if (e.code === 'KeyM') {
+      } else if (e.code === "KeyM") {
         reduceMotion = !reduceMotion;
-        localStorage.setItem('flappy-reduced-motion', reduceMotion ? '1' : '0');
+        localStorage.setItem("flappy-reduced-motion", reduceMotion ? "1" : "0");
         if (liveRef.current)
-          liveRef.current.textContent = `Reduced motion ${reduceMotion ? 'on' : 'off'}`;
-      } else if (e.code === 'KeyP') {
+          liveRef.current.textContent = `Reduced motion ${reduceMotion ? "on" : "off"}`;
+      } else if (e.code === "KeyP") {
         practiceMode = !practiceMode;
-        localStorage.setItem('flappy-practice', practiceMode ? '1' : '0');
+        localStorage.setItem("flappy-practice", practiceMode ? "1" : "0");
         if (liveRef.current)
-          liveRef.current.textContent = practiceMode ? 'Practice mode on' : 'Practice mode off';
+          liveRef.current.textContent = practiceMode
+            ? "Practice mode on"
+            : "Practice mode off";
         startGame();
-      } else if (e.code === 'KeyG' && !running) {
+      } else if (e.code === "KeyG" && !running) {
         gravityVariant = (gravityVariant + 1) % GRAVITY_VARIANTS.length;
-        localStorage.setItem('flappy-gravity-variant', String(gravityVariant));
+        localStorage.setItem("flappy-gravity-variant", String(gravityVariant));
         loadRecord();
         if (liveRef.current)
           liveRef.current.textContent = `Gravity: ${GRAVITY_VARIANTS[gravityVariant].name}`;
-      } else if (e.code === 'KeyX' && !running) {
+      } else if (e.code === "KeyX" && !running) {
         const key = GRAVITY_VARIANTS[gravityVariant].name;
         delete records[key];
-        localStorage.setItem('flappy-records', JSON.stringify(records));
+        localStorage.setItem("flappy-records", JSON.stringify(records));
         loadRecord();
-        if (liveRef.current) liveRef.current.textContent = 'Record reset';
-      } else if (e.code === 'KeyB') {
+        if (liveRef.current) liveRef.current.textContent = "Record reset";
+      } else if (e.code === "KeyB") {
         birdSkin = (birdSkin + 1) % birdSkins.length;
         setSkin(birdSkin);
-        localStorage.setItem('flappy-bird-skin', String(birdSkin));
+        localStorage.setItem("flappy-bird-skin", String(birdSkin));
         if (liveRef.current)
           liveRef.current.textContent = `Bird skin ${birdSkin + 1}`;
-      } else if (e.code === 'KeyO') {
+      } else if (e.code === "KeyO") {
         pipeSkin = (pipeSkin + 1) % pipeSkins.length;
         setPipeSkinIndex(pipeSkin);
-        localStorage.setItem('flappy-pipe-skin', String(pipeSkin));
+        localStorage.setItem("flappy-pipe-skin", String(pipeSkin));
         if (liveRef.current)
           liveRef.current.textContent = `Pipe skin ${pipeSkin + 1}`;
-      } else if (e.code === 'KeyH') {
+      } else if (e.code === "KeyH") {
         showHitbox = !showHitbox;
-        localStorage.setItem('flappy-hitbox', showHitbox ? '1' : '0');
+        localStorage.setItem("flappy-hitbox", showHitbox ? "1" : "0");
         if (liveRef.current)
-          liveRef.current.textContent = showHitbox
-            ? 'Hitbox on'
-            : 'Hitbox off';
+          liveRef.current.textContent = showHitbox ? "Hitbox on" : "Hitbox off";
       }
     }
 
@@ -668,16 +716,16 @@ const FlappyBird = () => {
       }
     }
 
-    window.addEventListener('keydown', handleKey, { passive: false });
-    canvas.addEventListener('mousedown', handlePointer);
-    canvas.addEventListener('touchstart', handlePointer, { passive: true });
+    window.addEventListener("keydown", handleKey, { passive: false });
+    canvas.addEventListener("mousedown", handlePointer);
+    canvas.addEventListener("touchstart", handlePointer, { passive: true });
 
     startGame();
 
     return () => {
-      window.removeEventListener('keydown', handleKey);
-      canvas.removeEventListener('mousedown', handlePointer);
-      canvas.removeEventListener('touchstart', handlePointer);
+      window.removeEventListener("keydown", handleKey);
+      canvas.removeEventListener("mousedown", handlePointer);
+      canvas.removeEventListener("touchstart", handlePointer);
       stopLoop();
     };
   }, [canvasRef, started]);
@@ -718,8 +766,8 @@ const FlappyBird = () => {
             className="px-6 py-3 w-32 bg-gray-700 hover:bg-gray-600 rounded"
             onClick={() => {
               try {
-                localStorage.setItem('flappy-bird-skin', String(skin));
-                localStorage.setItem('flappy-pipe-skin', String(pipeSkinIndex));
+                localStorage.setItem("flappy-bird-skin", String(skin));
+                localStorage.setItem("flappy-pipe-skin", String(pipeSkinIndex));
               } catch {
                 /* ignore */
               }


### PR DESCRIPTION
## Summary
- Shrink pipe gaps as score increases to raise difficulty
- Store seed/flaps for best run and replay it with Shift+R
- Update help overlay to document replay and best-run controls

## Testing
- `npm test` *(fails: __tests__/beef.test.tsx, __tests__/niktoPage.test.tsx, __tests__/game2048.test.ts, __tests__/mimikatz.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f657992483288e07a3d490dc71e3