### PR TITLE
feat(sudoku): add pencil marks and validity feedback

### DIFF
--- a/games/sudoku/components/PencilMarks.tsx
+++ b/games/sudoku/components/PencilMarks.tsx
@@ -1,10 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 export type PencilMarksProps = {
   /**
-   * Initial list of candidate numbers for the cell.
+   * Current list of candidate numbers for the cell.
    */
-  initial?: number[];
+  marks: number[];
+  /**
+   * Notify parent components when the marks change.
+   */
+  onChange: (marks: number[]) => void;
   /**
    * Whether the marks should start hidden.
    */
@@ -16,14 +20,18 @@ export type PencilMarksProps = {
  * candidates for a Sudoku cell. Each number can be toggled individually and
  * the entire set of notes can be shown or hidden per cell.
  */
-const PencilMarks: React.FC<PencilMarksProps> = ({ initial = [], hidden }) => {
-  const [marks, setMarks] = useState<number[]>(initial);
+const PencilMarks: React.FC<PencilMarksProps> = ({
+  marks,
+  onChange,
+  hidden,
+}) => {
   const [visible, setVisible] = useState(!hidden);
 
   const toggleMark = (n: number) => {
-    setMarks((prev) =>
-      prev.includes(n) ? prev.filter((m) => m !== n) : [...prev, n]
-    );
+    const next = marks.includes(n)
+      ? marks.filter((m) => m !== n)
+      : [...marks, n];
+    onChange(next.sort((a, b) => a - b));
   };
 
   const toggleVisibility = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- enable interactive pencil marks in Sudoku cells
- add immediate validity feedback with placement checks and ARIA messages

## Testing
- `npm test` *(fails: game2048, beef, niktoPage, calculator parser, mimikatz, kismet, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f65a816c83288178e20272581fbb