### PR TITLE
feat: add tower range tree and damage ticks

### DIFF
--- a/apps/games/tower-defense/components/RangeUpgradeTree.tsx
+++ b/apps/games/tower-defense/components/RangeUpgradeTree.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { TOWER_TYPES, Tower } from '..';
+
+interface RangeUpgradeTreeProps {
+  tower: Tower;
+}
+
+const RangeUpgradeTree = ({ tower }: RangeUpgradeTreeProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const w = canvas.width;
+    const h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+
+    const levels = TOWER_TYPES.single.map((t) => t.range);
+    const maxRange = Math.max(...levels, 1);
+
+    levels.forEach((range, idx) => {
+      ctx.strokeStyle = idx + 1 <= tower.level ? '#ffff00' : '#555555';
+      const radius = (range / maxRange) * (w / 2 - 5);
+      ctx.beginPath();
+      ctx.arc(w / 2, h / 2, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    });
+  }, [tower]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={80}
+      height={80}
+      className="bg-ub-dark-grey"
+      role="img"
+      aria-label="Range upgrade tree"
+    />
+  );
+};
+
+export default RangeUpgradeTree;

--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import GameLayout from "../../components/apps/GameLayout";
 import DpsCharts from "../games/tower-defense/components/DpsCharts";
+import RangeUpgradeTree from "../games/tower-defense/components/RangeUpgradeTree";
 import {
   ENEMY_TYPES,
   Tower,
@@ -46,6 +47,7 @@ const TowerDefense = () => {
       life: number;
     }[]
   >([]);
+  const damageTicksRef = useRef<{ x: number; y: number; life: number }[]>([]);
 
   const togglePath = (x: number, y: number) => {
     const key = `${x},${y}`;
@@ -145,6 +147,18 @@ const TowerDefense = () => {
       );
       ctx.fill();
     });
+    damageTicksRef.current.forEach((t) => {
+      ctx.strokeStyle = `rgba(255,0,0,${t.life})`;
+      ctx.beginPath();
+      ctx.arc(
+        t.x * CELL_SIZE + CELL_SIZE / 2,
+        t.y * CELL_SIZE + CELL_SIZE / 2,
+        (CELL_SIZE / 2) * (1 - t.life),
+        0,
+        Math.PI * 2,
+      );
+      ctx.stroke();
+    });
     damageNumbersRef.current.forEach((d) => {
       ctx.fillStyle = `rgba(255,255,255,${d.life})`;
       ctx.font = "12px sans-serif";
@@ -234,6 +248,11 @@ const TowerDefense = () => {
               value: t.damage,
               life: 1,
             });
+            damageTicksRef.current.push({
+              x: enemy.x,
+              y: enemy.y,
+              life: 1,
+            });
             (t as any).cool = 1;
           }
         }
@@ -245,6 +264,10 @@ const TowerDefense = () => {
       damageNumbersRef.current = damageNumbersRef.current.filter(
         (d) => d.life > 0,
       );
+      damageTicksRef.current.forEach((t) => {
+        t.life -= dt * 2;
+      });
+      damageTicksRef.current = damageTicksRef.current.filter((t) => t.life > 0);
       if (
         enemiesSpawnedRef.current >= waveRef.current * 5 &&
         enemiesRef.current.length === 0
@@ -318,7 +341,8 @@ const TowerDefense = () => {
             onMouseLeave={handleCanvasLeave}
           />
           {selected !== null && (
-            <div className="ml-2 flex flex-col space-y-1">
+            <div className="ml-2 flex flex-col space-y-1 items-center">
+              <RangeUpgradeTree tower={towers[selected]} />
               <button
                 className="bg-gray-700 text-xs px-2 py-1 rounded"
                 onClick={() => upgrade("range")}


### PR DESCRIPTION
## Summary
- visualize range upgrade path for towers
- render red rings for damage ticks

## Testing
- `npm test` (fails: game2048, beef, niktoPage, calculator parser, mimikatz, kismet, snake.config, frogger.config, metasploit)
- `npm run lint` (fails: ESLint couldn't find eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68b1f662b12c8328b57f130e3100ef2d