### PR TITLE
fix hold key detection

### DIFF
--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -548,17 +548,24 @@ const Tetris = () => {
     lastRotateRef.current = false;
   }, [canHold, getPiece, hold, next]);
 
-  const actionFromKey = useCallback((key) => {
-    const entry = Object.entries(keyBindings).find(([, k]) => k.toLowerCase() === key.toLowerCase());
-    return entry ? entry[0] : null;
-  }, [keyBindings]);
+  const actionFromKey = useCallback(
+    (key, code) => {
+      const entry = Object.entries(keyBindings).find(
+        ([, k]) =>
+          k.toLowerCase() === key.toLowerCase() ||
+          k.toLowerCase() === code.toLowerCase()
+      );
+      return entry ? entry[0] : null;
+    },
+    [keyBindings],
+  );
 
   const togglePause = useCallback(() => setPaused((p) => !p), [setPaused]);
   const toggleSound = useCallback(() => setSound((s) => !s), [setSound]);
 
   const handleKeyDown = useCallback(
     (e) => {
-      const action = actionFromKey(e.key.length === 1 ? e.key : e.code);
+      const action = actionFromKey(e.key, e.code);
       if (!action) return;
       e.preventDefault();
         if (action === 'left' || action === 'right') {
@@ -593,7 +600,7 @@ const Tetris = () => {
 
   const handleKeyUp = useCallback(
     (e) => {
-      const action = actionFromKey(e.key.length === 1 ? e.key : e.code);
+      const action = actionFromKey(e.key, e.code);
       if (!action) return;
         if (action === 'left' || action === 'right') {
           keyHeld.current[action] = false;


### PR DESCRIPTION
## Summary
- ensure Tetris control mapping checks both `event.key` and `event.code` so hold and other non-character keys are recognized
- DAS/ARR sliders remain customizable in settings

## Testing
- `npm test` *(fails: game2048, beef, niktoPage, calculator parser tests)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6639e148328b8ae7166494df36f