### PR TITLE
feat(solitaire): support draw modes and auto-complete

### DIFF
--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -7,6 +7,7 @@ import {
   moveTableauToTableau,
   moveWasteToTableau,
   moveToFoundation,
+  autoComplete,
   valueToString,
   GameState,
   Card,
@@ -592,10 +593,22 @@ const Solitaire = () => {
       game.stock.length === 0 &&
       game.tableau.every((p) => p.every((c) => c.faceUp))
     ) {
+      if (prefersReducedMotion) {
+        // When animations are disabled we can instantly finish the game using
+        // the engine's autoComplete helper.
+        setGame((g) => autoComplete(g));
+        return;
+      }
       setAutoCompleting(true);
       autoCompleteNext(game);
     }
-  }, [game, autoCompleteNext, autoCompleting]);
+  }, [
+    game,
+    autoCompleteNext,
+    autoCompleting,
+    prefersReducedMotion,
+    setGame,
+  ]);
   if (variant !== 'klondike') {
     return (
       <div className="h-full w-full bg-green-700 text-white select-none p-2">


### PR DESCRIPTION
## Summary
- handle draw-1 vs draw-3 stock draws and redeals
- add engine auto-complete routine and trigger it when animations are disabled

## Testing
- `npm test __tests__/solitaireEngine.test.ts`
- `npm test __tests__/solitaireLogic.test.ts`
- `npx eslint components/apps/solitaire/engine.ts components/apps/solitaire/index.tsx` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6665ee4832898d379f174ec29a8