### PR TITLE
feat: add Sokoban level text import and solver preview

### DIFF
--- a/__tests__/sokoban.test.ts
+++ b/__tests__/sokoban.test.ts
@@ -6,6 +6,7 @@ import {
   redo,
   isSolved,
   findHint,
+  findSolution,
   wouldDeadlock,
   findMinPushes,
 } from '../apps/sokoban/engine';
@@ -55,6 +56,12 @@ describe('sokoban engine', () => {
     const state = loadLevel(defaultLevels[0]);
     const hint = findHint(state);
     expect(hint).toBe('ArrowRight');
+  });
+
+  test('solver returns full solution path', () => {
+    const state = loadLevel(defaultLevels[0]);
+    const sol = findSolution(state);
+    expect(sol).toEqual(['ArrowRight']);
   });
 
   test('minimal pushes computed', () => {


### PR DESCRIPTION
## Summary
- allow Sokoban level packs to be pasted as text
- add solver function returning full path and preview overlay in Sokoban UI
- cover solver path with a new test

## Testing
- `yarn test __tests__/sokoban.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1f667c9f88328b1b2f133ebc3326f