### PR TITLE
feat(chess): add opening book for initial moves

### DIFF
--- a/__tests__/chess.openingBook.test.ts
+++ b/__tests__/chess.openingBook.test.ts
@@ -1,0 +1,15 @@
+import { suggestMoves } from "../games/chess/engine/wasmEngine";
+
+describe("opening book", () => {
+  test("starting position uses book moves", () => {
+    const fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    const moves = suggestMoves(fen, 2, 4);
+    expect(moves.map((m) => m.san)).toEqual(["e4", "d4", "c4", "Nf3"]);
+  });
+
+  test("after 1.e4 uses book responses", () => {
+    const fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+    const moves = suggestMoves(fen, 2, 4);
+    expect(moves.map((m) => m.san)).toEqual(["c5", "e5", "e6", "c6"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add hard-coded opening book for common early chess positions
- return book moves before running minimax
- cover opening book in tests

## Testing
- `npx eslint -c .eslintrc.cjs games/chess/engine/wasmEngine.ts __tests__/chess.openingBook.test.ts` (warn: File ignored because no matching configuration was supplied)
- `npx jest --runTestsByPath __tests__/chess.openingBook.test.ts __tests__/chess.perft.test.ts`
- `npx jest __tests__/chess.perft.test.ts --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_68b1f66a66d483289caeb2cd8a277ead