### PR TITLE
feat(pong): add rally counter and AI difficulty

### DIFF
--- a/components/apps/GameSettingsContext.tsx
+++ b/components/apps/GameSettingsContext.tsx
@@ -1,9 +1,11 @@
 import React, { createContext, useContext } from 'react';
 import usePersistedState from '../../hooks/usePersistedState';
 
+type Difficulty = 'easy' | 'normal' | 'hard';
+
 interface Settings {
-  difficulty: string;
-  setDifficulty: (d: string) => void;
+  difficulty: Difficulty;
+  setDifficulty: (d: Difficulty) => void;
   assists: boolean;
   setAssists: (v: boolean) => void;
   colorBlind: boolean;
@@ -17,7 +19,7 @@ interface Settings {
 const SettingsContext = createContext<Settings | undefined>(undefined);
 
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [difficulty, setDifficulty] = usePersistedState('settings:difficulty', 'normal');
+  const [difficulty, setDifficulty] = usePersistedState<Difficulty>('settings:difficulty', 'normal');
   const [assists, setAssists] = usePersistedState('settings:assists', true);
   const [colorBlind, setColorBlind] = usePersistedState('settings:colorBlind', false);
   const [highContrast, setHighContrast] = usePersistedState('settings:highContrast', false);

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -680,6 +680,7 @@ const PongInner = () => {
               : `Player: ${scores.player} | Opponent: ${scores.opponent}`}
           </div>
           <div className="mt-1">Games: {match.player} | {match.opponent}</div>
+          <div className="mt-1">Rally: {rally}</div>
           {matchWinner && (
             <div className="mt-1 text-lg">Winner: {matchWinner}</div>
           )}


### PR DESCRIPTION
## Summary
- show current rally count across all Pong modes
- formalize AI difficulty levels and persist selection

## Testing
- `npm test` *(fails: game2048.test.tsx, beef.test.tsx, niktoPage.test.tsx, calculator/parser.test.ts, battleship-net.test.ts)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f66b3db48328ae715e2ad63ce81a