### PR TITLE
feat(pacman): add speed controls and pellet counter

### DIFF
--- a/games/pacman/components/SpeedControls.tsx
+++ b/games/pacman/components/SpeedControls.tsx
@@ -8,9 +8,16 @@ interface GhostSpeeds {
 interface Props {
   ghostSpeeds: GhostSpeeds;
   setGhostSpeeds: React.Dispatch<React.SetStateAction<GhostSpeeds>>;
+  gameSpeed: number;
+  setGameSpeed: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const SpeedControls: React.FC<Props> = ({ ghostSpeeds, setGhostSpeeds }) => {
+const SpeedControls: React.FC<Props> = ({
+  ghostSpeeds,
+  setGhostSpeeds,
+  gameSpeed,
+  setGameSpeed,
+}) => {
   const handleChange = (key: keyof GhostSpeeds) => (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -41,6 +48,18 @@ const SpeedControls: React.FC<Props> = ({ ghostSpeeds, setGhostSpeeds }) => {
           step="0.1"
           value={ghostSpeeds.chase}
           onChange={handleChange('chase')}
+          className="w-32"
+        />
+      </label>
+      <label className="flex flex-col items-center text-sm">
+        <span>Game: {gameSpeed.toFixed(1)}</span>
+        <input
+          type="range"
+          min="0.5"
+          max="2"
+          step="0.1"
+          value={gameSpeed}
+          onChange={(e) => setGameSpeed(parseFloat(e.target.value))}
           className="w-32"
         />
       </label>


### PR DESCRIPTION
## Summary
- add game speed slider and hook it into pacman and ghosts
- track and display remaining pellets

## Testing
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f66ce99c832891c8a2435bad1e47