### PR TITLE
feat: add asteroids power-up inventory and level select

### DIFF
--- a/__tests__/asteroids-utils.test.ts
+++ b/__tests__/asteroids-utils.test.ts
@@ -8,6 +8,8 @@ import {
   handleBulletAsteroidCollision,
   spawnPowerUp,
   applyPowerUp,
+  addToInventory,
+  useInventory,
   POWER_UPS,
 } from '../components/apps/asteroids-utils';
 
@@ -93,5 +95,21 @@ describe('power-ups', () => {
     expect(lives).toBe(4);
     lives = applyPowerUp({ type: POWER_UPS.RAPID_FIRE }, ship, lives, 50, 40);
     expect(ship.rapidFire).toBe(40);
+  });
+});
+
+describe('inventory', () => {
+  it('stores and uses power-ups', () => {
+    const inv: string[] = [];
+    addToInventory(inv, POWER_UPS.SHIELD);
+    addToInventory(inv, POWER_UPS.EXTRA_LIFE);
+    const ship: any = { shield: 0, rapidFire: 0 };
+    let lives = 3;
+    lives = useInventory(inv, 0, ship, lives, 50, 30);
+    expect(ship.shield).toBe(50);
+    expect(inv).toHaveLength(1);
+    lives = useInventory(inv, 0, ship, lives, 50, 30);
+    expect(lives).toBe(4);
+    expect(inv).toHaveLength(0);
   });
 });

--- a/components/apps/asteroids-utils.js
+++ b/components/apps/asteroids-utils.js
@@ -95,6 +95,24 @@ export function applyPowerUp(powerUp, ship, lives, shieldDuration = 600, rapidFi
   return lives;
 }
 
+// Manage simple inventory of collected power-ups
+export function addToInventory(inv, type) {
+  inv.push(type);
+}
+
+export function useInventory(
+  inv,
+  index,
+  ship,
+  lives,
+  shieldDuration = 600,
+  rapidFireDuration = 600,
+) {
+  if (index < 0 || index >= inv.length) return lives;
+  const type = inv.splice(index, 1)[0];
+  return applyPowerUp({ type }, ship, lives, shieldDuration, rapidFireDuration);
+}
+
 export function updatePowerUps(list) {
   for (let i = list.length - 1; i >= 0; i -= 1) {
     const p = list[i];


### PR DESCRIPTION
## Summary
- add inventory helpers for asteroids power-ups
- allow collecting and activating stored power-ups with HUD icons
- introduce level selection overlay for asteroids game

## Testing
- `yarn test __tests__/asteroids-utils.test.ts`
- `npx eslint components/apps/asteroids.js components/apps/asteroids-utils.js __tests__/asteroids-utils.test.ts` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f674f9c08328ac12fec75c67f31f