### PR TITLE
feat(reconng): mask per-module API keys

### DIFF
--- a/__tests__/reconng.test.tsx
+++ b/__tests__/reconng.test.tsx
@@ -29,6 +29,13 @@ describe('ReconNG app', () => {
     });
   });
 
+  it('hides API keys by default', async () => {
+    render(<ReconNG />);
+    await userEvent.click(screen.getByText('Settings'));
+    const input = screen.getByPlaceholderText('DNS Enumeration API Key');
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
   it('loads marketplace modules', async () => {
     render(<ReconNG />);
     await userEvent.click(screen.getByText('Marketplace'));

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -140,6 +140,7 @@ const ReconNG = () => {
   const [view, setView] = useState('run');
   const [marketplace, setMarketplace] = useState([]);
   const [apiKeys, setApiKeys] = usePersistentState('reconng-api-keys', {});
+  const [showApiKeys, setShowApiKeys] = useState({});
   const [workspaces, setWorkspaces] = useState([createWorkspace(0)]);
   const [activeWs, setActiveWs] = useState(0);
   const [ariaMessage, setAriaMessage] = useState('');
@@ -539,13 +540,24 @@ const ReconNG = () => {
           {allModules.map((m) => (
             <div key={m} className="mb-2">
               <label className="block mb-1">{`${m} API Key`}</label>
-              <input
-                type="text"
-                value={apiKeys[m] || ''}
-                onChange={(e) => setApiKeys({ ...apiKeys, [m]: e.target.value })}
-                className="w-full bg-gray-800 px-2 py-1"
-                placeholder={`${m} API Key`}
-              />
+              <div className="flex">
+                <input
+                  type={showApiKeys[m] ? 'text' : 'password'}
+                  value={apiKeys[m] || ''}
+                  onChange={(e) => setApiKeys({ ...apiKeys, [m]: e.target.value })}
+                  className="flex-1 bg-gray-800 px-2 py-1"
+                  placeholder={`${m} API Key`}
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setShowApiKeys({ ...showApiKeys, [m]: !showApiKeys[m] })
+                  }
+                  className="ml-2 px-2 py-1 bg-gray-700"
+                >
+                  {showApiKeys[m] ? 'Hide' : 'Show'}
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/docs/reconng.md
+++ b/docs/reconng.md
@@ -20,7 +20,7 @@ Checking the **Live fetch** box sends a limited request to the schema's `fetchUr
 
 ## Data Storage
 
-- API keys are persisted in `localStorage` under the key `reconng-api-keys`.
+ - Per-module API keys are persisted in `localStorage` under the key `reconng-api-keys` and inputs are masked by default.
 - Workspace graphs and entity sets exist only in memory but can be exported as CSV or JSON.
 - Static marketplace and chain data live in the `public/` directory.
 


### PR DESCRIPTION
## Summary
- hide stored API keys behind password inputs with per-module show toggles
- document per-module API key storage
- test that API key inputs are masked by default

## Testing
- `yarn lint components/apps/reconng/index.js __tests__/reconng.test.tsx` *(fails: ESLint couldn't find config)*
- `yarn test __tests__/reconng.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1f67a54cc832880319710bb5331f1