### PR TITLE
feat: add network request opt-in

### DIFF
--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -7,6 +7,7 @@ import React, {
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../hooks/usePersistentState';
 import ReportTemplates from './components/ReportTemplates';
+import { useSettings } from '../../../hooks/useSettings';
 
 const CytoscapeComponent = dynamic(
   async () => {
@@ -133,6 +134,7 @@ const createWorkspace = (index) => ({
 });
 
 const ReconNG = () => {
+  const { allowNetwork } = useSettings();
   const [selectedModule, setSelectedModule] = useState(modules[0]);
   const [target, setTarget] = useState('');
   const [output, setOutput] = useState('');
@@ -151,21 +153,20 @@ const ReconNG = () => {
   const currentWorkspace = workspaces[activeWs];
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const originalFetch = window.fetch.bind(window);
-      window.fetch = (input, init) => {
-        const url = typeof input === 'string' ? input : input.url;
-        if (/^https?:/i.test(url) && !url.startsWith(window.location.origin) && !url.startsWith('/')) {
-          return Promise.reject(new Error('Outbound requests blocked'));
-        }
-        return originalFetch(input, init);
-      };
-      return () => {
-        window.fetch = originalFetch;
-      };
-    }
-    return undefined;
-  }, []);
+    if (typeof window === 'undefined') return undefined;
+    if (allowNetwork) return undefined;
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (/^https?:/i.test(url) && !url.startsWith(window.location.origin) && !url.startsWith('/')) {
+        return Promise.reject(new Error('Outbound requests blocked'));
+      }
+      return originalFetch(input, init);
+    };
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, [allowNetwork]);
 
   useEffect(() => {
     fetch('/reconng-marketplace.json')

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork } = useSettings();
     const [theme, setThemeState] = useState(getTheme());
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -138,6 +138,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     High Contrast
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={allowNetwork}
+                        onChange={(e) => setAllowNetwork(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Allow Network Requests
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
+import { useSettings } from '../../hooks/useSettings';
 
 export default function Status() {
+  const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(
     typeof navigator !== "undefined" ? navigator.onLine : true
   );
@@ -38,7 +40,10 @@ export default function Status() {
 
   return (
     <div className="flex justify-center items-center">
-      <span className="mx-1.5" title={online ? 'Online' : 'Offline'}>
+      <span
+        className="mx-1.5 relative"
+        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+      >
         <Image
           width={16}
           height={16}
@@ -47,6 +52,9 @@ export default function Status() {
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />
+        {!allowNetwork && (
+          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+        )}
       </span>
       <span className="mx-1.5">
         <Image

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -10,6 +10,7 @@ const DEFAULT_SETTINGS = {
   highContrast: false,
   largeHitAreas: false,
   pongSpin: true,
+  allowNetwork: false,
 };
 
 export async function getAccent() {
@@ -94,6 +95,16 @@ export async function setPongSpin(value) {
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
+export async function getAllowNetwork() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
+  return window.localStorage.getItem('allow-network') === 'true';
+}
+
+export async function setAllowNetwork(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -106,10 +117,21 @@ export async function resetSettings() {
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
+  window.localStorage.removeItem('allow-network');
 }
 
 export async function exportSettings() {
-  const [accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin] = await Promise.all([
+  const [
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    allowNetwork,
+  ] = await Promise.all([
     getAccent(),
     getWallpaper(),
     getDensity(),
@@ -118,9 +140,21 @@ export async function exportSettings() {
     getHighContrast(),
     getLargeHitAreas(),
     getPongSpin(),
+    getAllowNetwork(),
   ]);
   const theme = getTheme();
-  return JSON.stringify({ accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme });
+  return JSON.stringify({
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    allowNetwork,
+    theme,
+  });
 }
 
 export async function importSettings(json) {
@@ -132,7 +166,18 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const { accent, wallpaper, density, reducedMotion, fontScale, highContrast, largeHitAreas, pongSpin, theme } = settings;
+  const {
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    allowNetwork,
+    theme,
+  } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
@@ -141,6 +186,7 @@ export async function importSettings(json) {
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
+  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add persistent allowNetwork setting
- show network badge indicator when requests disabled
- provide settings toggle and global fetch guard

## Testing
- `npx eslint components/apps/reconng/index.js components/apps/settings.js components/util-components/status.js hooks/useSettings.tsx utils/settingsStore.js` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test --findRelatedTests hooks/useSettings.tsx components/util-components/status.js components/apps/settings.js utils/settingsStore.js components/apps/reconng/index.js` *(fails: unrelated suites such as Game2048 and snake.config)*
- `yarn test __tests__/reconng.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1f6796f808328a3ca2f0e163f7cd1