### PR TITLE
feat(openvas): visualize task run history

### DIFF
--- a/components/apps/openvas/task-history.json
+++ b/components/apps/openvas/task-history.json
@@ -1,0 +1,8 @@
+[
+  { "time": "08:00", "status": "Queued" },
+  { "time": "08:05", "status": "Running" },
+  { "time": "08:45", "status": "Completed" },
+  { "time": "09:00", "status": "Queued" },
+  { "time": "09:05", "status": "Running" },
+  { "time": "09:30", "status": "Completed" }
+]

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import FeedStatusCard from './feed-status-card';
+import TaskRunChart from './task-run-chart';
 
 const TaskOverview = () => {
   const tasks = [
@@ -13,7 +14,9 @@ const TaskOverview = () => {
       <FeedStatusCard />
       <div className="p-4 bg-gray-800 rounded">
         <h3 className="text-md font-bold mb-2">Demo Task Overview</h3>
-        <ul className="text-sm space-y-1">
+        <h4 className="text-sm font-bold mb-1">Run History</h4>
+        <TaskRunChart />
+        <ul className="text-sm space-y-1 mt-2">
           {tasks.map((t) => (
             <li key={t.name} className="flex justify-between">
               <span>{t.name}</span>
@@ -21,7 +24,9 @@ const TaskOverview = () => {
             </li>
           ))}
         </ul>
-        <p className="text-xs text-gray-400 mt-2">All task data is canned for demonstration purposes.</p>
+        <p className="text-xs text-gray-400 mt-2">
+          All task data is canned for demonstration purposes.
+        </p>
       </div>
     </div>
   );

--- a/components/apps/openvas/task-run-chart.js
+++ b/components/apps/openvas/task-run-chart.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import history from './task-history.json';
+
+const statuses = ['Queued', 'Running', 'Completed'];
+const colors = {
+  Queued: 'fill-blue-500',
+  Running: 'fill-yellow-500',
+  Completed: 'fill-green-500',
+};
+
+const TaskRunChart = () => {
+  const height = 40;
+  const width = history.length * 20 + 20;
+  const points = history
+    .map((d, i) => {
+      const x = i * 20 + 10;
+      const y =
+        height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height + 10}`}
+      className="w-full h-24 mb-2"
+      role="img"
+      aria-label="Task runs and status changes over time"
+    >
+      {statuses.map((s, idx) => {
+        const y = height - (idx / (statuses.length - 1)) * height;
+        return (
+          <g key={s}>
+            <line
+              x1="0"
+              y1={y}
+              x2={width}
+              y2={y}
+              className="stroke-gray-600"
+              strokeWidth="0.5"
+            />
+            <text
+              x="0"
+              y={y - 1}
+              className="fill-white text-[8px]"
+            >
+              {s}
+            </text>
+          </g>
+        );
+      })}
+      <polyline points={points} fill="none" stroke="white" strokeWidth="1" />
+      {history.map((d, i) => {
+        const x = i * 20 + 10;
+        const y =
+          height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
+        return <circle key={d.time} cx={x} cy={y} r="2" className={colors[d.status]} />;
+      })}
+    </svg>
+  );
+};
+
+export default TaskRunChart;


### PR DESCRIPTION
## Summary
- Add sample task run history data and chart component
- Show task run timeline within OpenVAS TaskOverview

## Testing
- `yarn test` *(fails: __tests__/beef.test.tsx, __tests__/niktoPage.test.tsx, __tests__/calculator/parser.test.ts, __tests__/game2048.test.ts, __tests__/mimikatz.test.ts, __tests__/snake.config.test.ts, __tests__/frogger.config.test.ts, __tests__/metasploit.test.tsx, __tests__/kismet.test.tsx)*
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f67e15548328b10463f4cf81620f