### PR TITLE
Implement module chain execution

### DIFF
--- a/docs/reconng.md
+++ b/docs/reconng.md
@@ -14,6 +14,10 @@ Modules are defined in `components/apps/reconng/index.js` as schema objects with
 
 Static fixtures in `public/reconng-marketplace.json` and `public/reconng-chain.json` supply marketplace modules and example chains. Module runs default to the schema's `demo` output so the simulation works without network access.
 
+## Module Chains
+
+The Builder view visualizes an example module chain and lets you execute it. Modules run in topological order and pass any discovered artifacts (domains, IPs and entities) to downstream modules. Results are rendered with Cytoscape using the `cose-bilkent` layout.
+
 ## Opt-in Network Requests
 
 Checking the **Live fetch** box sends a limited request to the schema's `fetchUrl`. If the request succeeds, its text replaces the demo output. If it fails, the demo data is shown instead. Remote responses are not stored and the graph remains the example data.


### PR DESCRIPTION
## Summary
- chain Recon-ng modules by passing artifacts downstream
- compute topological order for module chains and run with cytoscape visualization
- document module chain workflow

## Testing
- `npm test` *(fails: Unable to find element text "1" in __tests__/beef.test.tsx, among others)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f67b76588328939c5aff31071521