### PR TITLE
feat(openvas): enable severity drill-down in chart

### DIFF
--- a/components/apps/openvas/chart-data.json
+++ b/components/apps/openvas/chart-data.json
@@ -1,6 +1,0 @@
-{
-  "low": 4,
-  "medium": 3,
-  "high": 2,
-  "critical": 1
-}


### PR DESCRIPTION
## Summary
- make severity chart bars clickable to filter findings by level
- derive chart data from current findings and highlight selected severity

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn test` *(fails: e.g., battleship-net.test.ts, kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f67ed4d48328b43fb2cd0da546b6