### PR TITLE
feat: support saving scan policies

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -22,6 +22,7 @@ describe('OpenVASApp', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+    localStorage.clear();
   });
 
   it('includes group and profile in scan request', async () => {
@@ -80,6 +81,19 @@ describe('OpenVASApp', () => {
     render(<OpenVASApp />);
     expect(screen.getByText('Policy Settings')).toBeInTheDocument();
     expect(screen.getByText('PCI DSS')).toBeInTheDocument();
+  });
+
+  it('allows saving and loading a custom policy', () => {
+    render(<OpenVASApp />);
+    fireEvent.change(screen.getByLabelText('Policy Name'), {
+      target: { value: 'Custom Policy' },
+    });
+    fireEvent.click(screen.getByText('Save Policy'));
+    fireEvent.change(screen.getByLabelText('Policy Name'), {
+      target: { value: 'Modified' },
+    });
+    fireEvent.click(screen.getByText('Load Policy'));
+    expect(screen.getByLabelText('Policy Name')).toHaveValue('Custom Policy');
   });
 
   it('opens issue detail panel with remediation info', () => {

--- a/components/apps/openvas/policy-settings.js
+++ b/components/apps/openvas/policy-settings.js
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 const PolicySettings = ({ policy }) => {
-  const config =
-    policy || {
-      name: 'Full and Fast',
-      portList: 'OpenVAS Default',
-      maxHosts: '10 concurrent hosts',
-      qod: '70% minimum',
-    };
+  const defaultConfig = {
+    name: 'Full and Fast',
+    portList: 'OpenVAS Default',
+    maxHosts: '10 concurrent hosts',
+    qod: '70% minimum',
+  };
+  const [config, setConfig] = useState(policy || defaultConfig);
+
+  const handleChange = (field) => (e) =>
+    setConfig({ ...config, [field]: e.target.value });
+
+  const savePolicy = () => {
+    if (typeof window !== 'undefined')
+      localStorage.setItem('openvasPolicy', JSON.stringify(config));
+  };
+
+  const loadPolicy = () => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('openvasPolicy');
+      if (stored) setConfig(JSON.parse(stored));
+    }
+  };
+
   return (
     <div className="p-4 bg-gray-800 rounded mb-4">
       <h3 className="text-md font-bold mb-2">Policy Settings</h3>
@@ -25,6 +41,60 @@ const PolicySettings = ({ policy }) => {
           <span className="font-semibold">QoD:</span> {config.qod}
         </li>
       </ul>
+      <form className="mt-2 space-y-2">
+        <label className="block text-xs">
+          Policy Name
+          <input
+            aria-label="Policy Name"
+            className="w-full p-1 rounded text-black"
+            value={config.name}
+            onChange={handleChange('name')}
+          />
+        </label>
+        <label className="block text-xs">
+          Port List
+          <input
+            aria-label="Port List"
+            className="w-full p-1 rounded text-black"
+            value={config.portList}
+            onChange={handleChange('portList')}
+          />
+        </label>
+        <label className="block text-xs">
+          Max Hosts
+          <input
+            aria-label="Max Hosts"
+            className="w-full p-1 rounded text-black"
+            value={config.maxHosts}
+            onChange={handleChange('maxHosts')}
+          />
+        </label>
+        <label className="block text-xs">
+          QoD
+          <input
+            aria-label="QoD"
+            className="w-full p-1 rounded text-black"
+            value={config.qod}
+            onChange={handleChange('qod')}
+          />
+        </label>
+      </form>
+      <div className="flex gap-2 mt-2 text-xs">
+        <button
+          type="button"
+          onClick={savePolicy}
+          className="px-2 py-1 bg-blue-600 rounded"
+        >
+          Save Policy
+        </button>
+        <button
+          type="button"
+          onClick={loadPolicy}
+          className="px-2 py-1 bg-green-600 rounded"
+        >
+          Load Policy
+        </button>
+      </div>
       <p className="text-xs text-gray-400 mt-2">
         Sample configuration shown for demo purposes.
       </p>


### PR DESCRIPTION
## Summary
- allow creating editable scan policies and persist them in localStorage
- add Save/Load buttons for policies
- cover saving/loading with tests

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `yarn test` *(fails: __tests__/niktoPage.test.tsx, __tests__/beef.test.tsx, __tests__/calculator/parser.test.ts and others)*
- `yarn test __tests__/openvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1f67f911483289c634612d21aae1a