### PR TITLE
feat: add potfile parsing script with filtering

### DIFF
--- a/__tests__/parsePotfile.test.ts
+++ b/__tests__/parsePotfile.test.ts
@@ -1,0 +1,18 @@
+import { parsePotfile } from '../components/apps/john/utils';
+
+describe('parsePotfile', () => {
+  it('parses lines into hash/password pairs', () => {
+    const text = 'hash1:pass1\nhash2:pass2\ninvalid\n';
+    expect(parsePotfile(text)).toEqual([
+      { hash: 'hash1', password: 'pass1' },
+      { hash: 'hash2', password: 'pass2' },
+    ]);
+  });
+
+  it('allows filtering of parsed entries', () => {
+    const text = 'abc:hello\nxyz:world\n';
+    const entries = parsePotfile(text);
+    const filtered = entries.filter((e) => e.password.includes('hello'));
+    expect(filtered).toEqual([{ hash: 'abc', password: 'hello' }]);
+  });
+});

--- a/john/potfile.mjs
+++ b/john/potfile.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { parsePotfile } from '../components/apps/john/utils.js';
+
+function main() {
+  const [filePath, filter = ''] = process.argv.slice(2);
+  if (!filePath) {
+    console.error('Usage: node john/potfile.mjs <file> [filter]');
+    process.exit(1);
+  }
+  const text = readFileSync(filePath, 'utf8');
+  const entries = parsePotfile(text);
+  const lowered = filter.toLowerCase();
+  const filtered = filter
+    ? entries.filter(
+        (p) =>
+          p.hash.includes(filter) ||
+          p.password.toLowerCase().includes(lowered)
+      )
+    : entries;
+  filtered.forEach((p) => {
+    console.log(`${p.hash}:${p.password}`);
+  });
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] === currentFile) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add `john/potfile.mjs` CLI to parse potfiles and filter entries
- test `parsePotfile` utility for parsing and filtering

## Testing
- `yarn test __tests__/parsePotfile.test.ts`
- `yarn test` *(fails: BeEF app, NiktoPage, calculator parser, game2048)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f682e31083288698aa785abde507