### PR TITLE
feat(wireshark): add burst visualization

### DIFF
--- a/components/apps/wireshark/BurstChart.js
+++ b/components/apps/wireshark/BurstChart.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const BurstChart = ({ minutes = [] }) => {
+  if (!minutes.length) return null;
+  const max = Math.max(...minutes.map((m) => m.count));
+  const avg = minutes.reduce((sum, m) => sum + m.count, 0) / minutes.length;
+  return (
+    <div
+      className="h-24 bg-black flex items-end overflow-x-auto px-2"
+      role="img"
+      aria-label="Traffic bursts by minute"
+    >
+      {minutes.map((m) => {
+        const height = (m.count / max) * 100;
+        const isBurst = m.count > avg * 2;
+        return (
+          <div
+            key={m.minute}
+            className={`w-4 mx-1 ${isBurst ? 'bg-red-500' : 'bg-gray-500'}`}
+            style={{ height: `${height}%` }}
+            title={`Minute ${m.minute}: ${m.count} packets`}
+            aria-label={`Minute ${m.minute}: ${m.count} packets${isBurst ? ' burst' : ''}`}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default BurstChart;

--- a/components/apps/wireshark/burstWorker.js
+++ b/components/apps/wireshark/burstWorker.js
@@ -1,13 +1,20 @@
 let last = 0;
 let timeline = [];
+const minuteCounts = {};
 self.onmessage = (e) => {
   const pkt = e.data;
   const ts = Number(pkt.timestamp);
   const burstStart = !last || ts - last > 1000;
   timeline = [...timeline, { ...pkt, burstStart }].slice(-500);
+  const minute = ts > 1e12 ? Math.floor(ts / 60000) : Math.floor(ts / 60);
+  minuteCounts[minute] = (minuteCounts[minute] || 0) + 1;
+  const minutes = Object.entries(minuteCounts)
+    .map(([m, count]) => ({ minute: Number(m), count }))
+    .sort((a, b) => a.minute - b.minute);
   if (burstStart) {
     self.postMessage({ type: 'burst', start: ts });
   }
   last = ts;
   self.postMessage({ type: 'timeline', timeline });
+  self.postMessage({ type: 'minutes', minutes });
 };

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Waterfall from './Waterfall';
+import BurstChart from './BurstChart';
 import { protocolName, getRowColor, matchesDisplayFilter } from './utils';
 import DecodeTree from './DecodeTree';
 import FlowGraph from '../../../apps/wireshark/components/FlowGraph';
@@ -112,6 +113,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   const [colorRules, setColorRules] = useState([]);
   const [paused, setPaused] = useState(false);
   const [timeline, setTimeline] = useState([]);
+  const [minuteData, setMinuteData] = useState([]);
   const [viewIndex, setViewIndex] = useState(0);
   const [announcement, setAnnouncement] = useState('');
   const [selectedPacket, setSelectedPacket] = useState(null);
@@ -143,6 +145,9 @@ const WiresharkApp = ({ initialPackets = [] }) => {
         }
         if (e.data.type === 'timeline') {
           setTimeline(e.data.timeline);
+        }
+        if (e.data.type === 'minutes') {
+          setMinuteData(e.data.minutes);
         }
       };
       // seed worker with any bundled packets
@@ -348,6 +353,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           prefersReducedMotion={prefersReducedMotion.current}
         />
       </div>
+      <BurstChart minutes={minuteData} />
       <div className="p-2 flex space-x-2 bg-gray-900 overflow-x-auto">
         <button
           className={`px-2 py-1 rounded border ${


### PR DESCRIPTION
## Summary
- group packets by minute in burst worker and emit minute aggregates
- render minute-level burst chart in Wireshark app
- visualize traffic spikes with color-coded bars

## Testing
- `npx eslint -c .eslintrc.cjs components/apps/wireshark/index.js components/apps/wireshark/burstWorker.js components/apps/wireshark/BurstChart.js` *(fails: config extends not supported)*
- `yarn test __tests__/wireshark.test.tsx`
- `yarn test __tests__/beef.test.tsx` *(fails: Unable to find element '1')*


------
https://chatgpt.com/codex/tasks/task_e_68b1f68584c08328aba6318a1472c03a