### PR TITLE
Add protocol log filter with counts

### DIFF
--- a/__tests__/protocolFilter.test.ts
+++ b/__tests__/protocolFilter.test.ts
@@ -1,0 +1,34 @@
+import { filterLogsByProtocol, countProtocols } from '../utils/protocolFilter';
+
+describe('filterLogsByProtocol', () => {
+  const logs = [
+    'HTTP GET /index.html',
+    'HTTPS handshake started',
+    'Arp who-has 10.0.0.1',
+    'ftp transfer complete',
+    'SSH connection established',
+    'Random line',
+    'https second line',
+    'ssh another login',
+  ];
+
+  it('filters logs and counts per protocol', () => {
+    const result = filterLogsByProtocol(logs);
+    expect(result.HTTP.count).toBe(1);
+    expect(result.HTTPS.count).toBe(2);
+    expect(result.ARP.count).toBe(1);
+    expect(result.FTP.count).toBe(1);
+    expect(result.SSH.count).toBe(2);
+
+    expect(result.HTTPS.lines).toEqual([
+      'HTTPS handshake started',
+      'https second line',
+    ]);
+  });
+
+  it('returns counts only', () => {
+    const counts = countProtocols(logs.join('\n'));
+    expect(counts).toEqual({ HTTP: 1, HTTPS: 2, ARP: 1, FTP: 1, SSH: 2 });
+  });
+});
+

--- a/utils/protocolFilter.ts
+++ b/utils/protocolFilter.ts
@@ -1,0 +1,72 @@
+export interface ProtocolResult {
+  lines: string[];
+  count: number;
+}
+
+export interface ProtocolFilterOutput {
+  HTTP: ProtocolResult;
+  HTTPS: ProtocolResult;
+  ARP: ProtocolResult;
+  FTP: ProtocolResult;
+  SSH: ProtocolResult;
+}
+
+const initialResult = (): ProtocolFilterOutput => ({
+  HTTP: { lines: [], count: 0 },
+  HTTPS: { lines: [], count: 0 },
+  ARP: { lines: [], count: 0 },
+  FTP: { lines: [], count: 0 },
+  SSH: { lines: [], count: 0 },
+});
+
+/**
+ * Filters log lines by protocol keywords and returns matched lines with counts.
+ * Matching is case-insensitive and uses word boundaries.
+ */
+export function filterLogsByProtocol(
+  logs: string | string[],
+): ProtocolFilterOutput {
+  const result = initialResult();
+  const lines = Array.isArray(logs) ? logs : logs.split(/\r?\n/);
+
+  const re = {
+    https: /\bhttps\b/i,
+    http: /\bhttp\b/i,
+    arp: /\barp\b/i,
+    ftp: /\bftp\b/i,
+    ssh: /\bssh\b/i,
+  };
+
+  for (const line of lines) {
+    if (re.https.test(line)) {
+      result.HTTPS.lines.push(line);
+      result.HTTPS.count++;
+    } else if (re.http.test(line)) {
+      result.HTTP.lines.push(line);
+      result.HTTP.count++;
+    }
+    if (re.arp.test(line)) {
+      result.ARP.lines.push(line);
+      result.ARP.count++;
+    }
+    if (re.ftp.test(line)) {
+      result.FTP.lines.push(line);
+      result.FTP.count++;
+    }
+    if (re.ssh.test(line)) {
+      result.SSH.lines.push(line);
+      result.SSH.count++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convenience helper that returns just the counts for each protocol.
+ */
+export function countProtocols(logs: string | string[]) {
+  const { HTTP, HTTPS, ARP, FTP, SSH } = filterLogsByProtocol(logs);
+  return { HTTP: HTTP.count, HTTPS: HTTPS.count, ARP: ARP.count, FTP: FTP.count, SSH: SSH.count };
+}
+


### PR DESCRIPTION
## Summary
- add utility to filter log lines for HTTP, HTTPS, ARP, FTP, and SSH and report counts
- test protocol filter and count helper

## Testing
- `yarn test protocolFilter.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1f6867cd88328a7e79c4fcb29222c