### PR TITLE
feat: generate module HTML report

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint --max-warnings=0 .",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
+    "module-report": "node scripts/generate-module-report.mjs",
     "build:sw": "node scripts/generate-sw.mjs"
   },
   "engines": {

--- a/public/module-report.html
+++ b/public/module-report.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Module Report</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+    h2 { margin-top: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Module Report</h1>
+  
+  <section>
+    <h2>Port Scanner</h2>
+    <p>Scans for open network ports</p>
+    <h3>Logs</h3>
+    <ul>
+      <li>[info] Starting port scan...</li><li>[success] Found open port 22 on 192.168.0.1</li><li>[info] Scan complete.</li>
+    </ul>
+    <h3>Results</h3>
+    <ul>
+      <li>192.168.0.1: Ports 22,80 open</li><li>192.168.0.2: No open ports</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Brute Force</h2>
+    <p>Attempts common passwords</p>
+    <h3>Logs</h3>
+    <ul>
+      <li>[info] Starting brute force...</li><li>[warning] Tried 100 passwords</li><li>[error] No valid credentials found.</li>
+    </ul>
+    <h3>Results</h3>
+    <ul>
+      <li>admin@example.com: Login failed</li><li>root@example.com: Login failed</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Vuln Check</h2>
+    <p>Checks for known CVEs</p>
+    <h3>Logs</h3>
+    <ul>
+      <li>[info] Checking for vulnerabilities...</li><li>[success] CVE-2024-1234 found on host1</li><li>[info] Check complete.</li>
+    </ul>
+    <h3>Results</h3>
+    <ul>
+      <li>host1: CVE-2024-1234</li><li>host2: No issues</li>
+    </ul>
+  </section>
+</body>
+</html>

--- a/scripts/generate-module-report.mjs
+++ b/scripts/generate-module-report.mjs
@@ -1,0 +1,66 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function escapeHtml(str = '') {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function render(mods) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Module Report</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+    h2 { margin-top: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Module Report</h1>
+  ${mods
+    .map(
+      (m) => `
+  <section>
+    <h2>${escapeHtml(m.name)}</h2>
+    <p>${escapeHtml(m.description)}</p>
+    <h3>Logs</h3>
+    <ul>
+      ${m.log
+        .map((l) => `<li>[${escapeHtml(l.level)}] ${escapeHtml(l.message)}</li>`)
+        .join('')}
+    </ul>
+    <h3>Results</h3>
+    <ul>
+      ${m.results
+        .map((r) => `<li>${escapeHtml(r.target)}: ${escapeHtml(r.status)}</li>`)
+        .join('')}
+    </ul>
+  </section>`
+    )
+    .join('')}
+</body>
+</html>`;
+}
+
+async function build() {
+  const modulesPath = path.join(__dirname, '..', 'data', 'module-index.json');
+  const outputPath = path.join(__dirname, '..', 'public', 'module-report.html');
+  const raw = await fs.readFile(modulesPath, 'utf8');
+  const mods = JSON.parse(raw);
+  const html = render(mods);
+  await fs.writeFile(outputPath, html, 'utf8');
+  console.log(`Module report written to ${outputPath}`);
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to convert `data/module-index.json` into a static HTML report
- document modules by exporting prebuilt `public/module-report.html`

## Testing
- `node scripts/generate-module-report.mjs`
- `yarn test` *(fails: beef.test.tsx, niktoPage.test.tsx, battleship-net.test.ts, kismet.test.tsx, snake.config.test.ts, mimikatz.test.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f688126c83288200d0527ecab78f