### PR TITLE
feat: add module key value store

### DIFF
--- a/__tests__/moduleWorkspaceStore.test.tsx
+++ b/__tests__/moduleWorkspaceStore.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ModuleWorkspace from '../pages/module-workspace';
+import { getValue, clearStore } from '../utils/moduleStore';
+
+describe('ModuleWorkspace key-value store', () => {
+  afterEach(() => clearStore());
+
+  it('saves module output to the store', () => {
+    render(<ModuleWorkspace />);
+
+    fireEvent.change(screen.getByPlaceholderText('New workspace'), {
+      target: { value: 'ws1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Port Scanner/i }));
+    fireEvent.change(screen.getByLabelText(/TARGET/), {
+      target: { value: 'host' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    const stored = getValue('port-scan');
+    expect(stored).toBeDefined();
+    expect(stored).toContain('port-scan TARGET=host');
+  });
+});

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
+import { setValue, getAll } from '../utils/moduleStore';
 
 interface ModuleOption {
   name: string;
@@ -57,6 +58,7 @@ const ModuleWorkspace: React.FC = () => {
   const [selected, setSelected] = useState<Module | null>(null);
   const [optionValues, setOptionValues] = useState<Record<string, string>>({});
   const [result, setResult] = useState('');
+  const [storeData, setStoreData] = useState<Record<string, string>>({});
 
   const tags = Array.from(new Set(modules.flatMap((m) => m.tags)));
   const filteredModules = filter
@@ -89,7 +91,10 @@ const ModuleWorkspace: React.FC = () => {
       .map((o) => `${o.name}=${optionValues[o.name] || ''}`)
       .join(' ');
     const cmd = `${selected.id} ${opts}`.trim();
-    setResult(`$ ${cmd}\n${selected.sample}`);
+    const res = `$ ${cmd}\n${selected.sample}`;
+    setResult(res);
+    setValue(selected.id, res);
+    setStoreData(getAll());
   };
 
   return (
@@ -192,6 +197,18 @@ const ModuleWorkspace: React.FC = () => {
                 >
                   {result}
                 </pre>
+              )}
+              {Object.keys(storeData).length > 0 && (
+                <div>
+                  <h3 className="font-semibold">Stored Values</h3>
+                  <ul className="text-xs">
+                    {Object.entries(storeData).map(([k, v]) => (
+                      <li key={k}>
+                        <strong>{k}</strong>: {v}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               )}
             </div>
           )}

--- a/utils/moduleStore.ts
+++ b/utils/moduleStore.ts
@@ -1,0 +1,21 @@
+const store: Record<string, string> = {};
+
+export function setValue(key: string, value: string): void {
+  store[key] = value;
+}
+
+export function getValue(key: string): string | undefined {
+  return store[key];
+}
+
+export function getAll(): Record<string, string> {
+  return { ...store };
+}
+
+export function clearStore(): void {
+  for (const k of Object.keys(store)) {
+    delete store[k];
+  }
+}
+
+export default { setValue, getValue, getAll, clearStore };


### PR DESCRIPTION
## Summary
- add in-memory key-value store for module runs
- surface stored values in module workspace
- test storing module output

## Testing
- `yarn test __tests__/moduleWorkspaceStore.test.tsx`
- `yarn test` *(fails: __tests__/beef.test.tsx, __tests__/calculator/parser.test.ts, __tests__/game2048.test.ts, __tests__/mimikatz.test.ts, __tests__/kismet.test.tsx, __tests__/frogger.config.test.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f688c2e08328abd222264e80137a