### PR TITLE
refactor: reuse hashcat regex for john

### DIFF
--- a/__tests__/john-utils.test.ts
+++ b/__tests__/john-utils.test.ts
@@ -1,0 +1,17 @@
+import { identifyHashType } from '../components/apps/john/utils';
+
+describe('identifyHashType', () => {
+  it('detects common hash types', () => {
+    expect(identifyHashType('d41d8cd98f00b204e9800998ecf8427e')).toBe('MD5');
+    expect(
+      identifyHashType('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+    ).toBe('SHA1');
+    expect(
+      identifyHashType(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      )
+    ).toBe('SHA256');
+    expect(identifyHashType('$2y$10$' + 'a'.repeat(53))).toBe('bcrypt');
+    expect(identifyHashType('notahash')).toBe('Unknown');
+  });
+});

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import progressInfo from './progress.json';
 
-const hashTypes = [
+export const hashTypes = [
   {
     id: '0',
     name: 'MD5',

--- a/components/apps/john/utils.js
+++ b/components/apps/john/utils.js
@@ -1,3 +1,5 @@
+import { detectHashType, hashTypes } from '../hashcat';
+
 export const parseRules = (text) =>
   text
     .split(/\r?\n/)
@@ -18,10 +20,9 @@ export const distributeTasks = (hashes, endpoints) => {
 };
 
 export const identifyHashType = (hash) => {
-  if (/^[a-fA-F0-9]{32}$/.test(hash)) return 'MD5';
-  if (/^[a-fA-F0-9]{40}$/.test(hash)) return 'SHA1';
-  if (/^[a-fA-F0-9]{64}$/.test(hash)) return 'SHA256';
-  return 'Unknown';
+  const id = detectHashType(hash);
+  const match = hashTypes.find((t) => t.id === id);
+  return match && match.regex.test(hash) ? match.name : 'Unknown';
 };
 
 export const generateIncrementalCandidates = (


### PR DESCRIPTION
## Summary
- export hashcat hash regex table for reuse
- use detectHashType in John's utilities for hash detection
- test hash identification across MD5, SHA1, SHA256, bcrypt, and unknown strings

## Testing
- `yarn test __tests__/john-utils.test.ts`
- `yarn test` *(fails: be**f.test.tsx*, *niktoPage.test.tsx*, *calculator/parser.test.ts*, *game2048.test.ts*, *mimikatz.test.ts*, *kismet.test.tsx*, *snake.config.test.ts*, *metasploit.test.tsx*)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f68aaad8832887f82d963f4a3dad