### PR TITLE
feat: persist plugin run and export results

### DIFF
--- a/__tests__/pluginManager.test.tsx
+++ b/__tests__/pluginManager.test.tsx
@@ -26,4 +26,26 @@ describe('PluginManager', () => {
     );
     expect(button.textContent).toBe('Installed');
   });
+
+  test('persists last plugin run and exports CSV', async () => {
+    const { unmount } = render(<PluginManager />);
+    const installBtn = await screen.findByText('Install');
+    fireEvent.click(installBtn);
+    await waitFor(() =>
+      expect(localStorage.getItem('installedPlugins')).toContain('demo')
+    );
+    const runBtn = await screen.findByText('Run');
+    fireEvent.click(runBtn);
+    await waitFor(() =>
+      expect(localStorage.getItem('lastPluginRun')).toContain('demo')
+    );
+    unmount();
+    (global as any).URL.createObjectURL = jest.fn();
+    (global as any).URL.revokeObjectURL = jest.fn();
+    render(<PluginManager />);
+    expect(await screen.findByText(/Last Run: demo/)).toBeInTheDocument();
+    const exportBtn = screen.getByText('Export CSV');
+    fireEvent.click(exportBtn);
+    expect((global as any).URL.createObjectURL).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- store the last plugin run in localStorage and show run results
- add ability to export plugin run results to CSV
- test persistence and CSV export

## Testing
- `yarn test __tests__/pluginManager.test.tsx`
- `yarn lint components/apps/plugin-manager/index.tsx __tests__/pluginManager.test.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f68e054c8328a9aef8d94f25620f