### PR TITLE
feat: add plugin score heatmap

### DIFF
--- a/components/apps/nessus/PluginScoreHeatmap.js
+++ b/components/apps/nessus/PluginScoreHeatmap.js
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+
+const PluginScoreHeatmap = ({ findings = [] }) => {
+  const data = useMemo(() => {
+    const map = new Map();
+    findings.forEach((f) => {
+      if (typeof f.cvss !== 'number') return;
+      const current = map.get(f.name) || { name: f.name, total: 0, count: 0 };
+      current.total += f.cvss;
+      current.count += 1;
+      map.set(f.name, current);
+    });
+    const aggregated = Array.from(map.values()).map(({ name, total, count }) => ({
+      name,
+      avg: total / count,
+    }));
+    aggregated.sort((a, b) => b.avg - a.avg);
+    return aggregated;
+  }, [findings]);
+
+  if (data.length === 0) {
+    return <div className="text-sm text-gray-400">No plugin scores available.</div>;
+  }
+
+  return (
+    <div className="my-4">
+      <h3 className="text-lg mb-2">Plugin Score Heatmap</h3>
+      <ul className="space-y-1">
+        {data.map(({ name, avg }) => {
+          const hue = (1 - avg / 10) * 120;
+          return (
+            <li key={name} className="flex items-center">
+              <span className="w-48 truncate mr-2 text-sm">{name}</span>
+              <div
+                className="flex-1 h-4"
+                role="img"
+                aria-label={`${name} average score ${avg.toFixed(1)}`}
+                style={{
+                  backgroundColor: `hsl(${hue}, 70%, 50%)`,
+                  width: `${(avg / 10) * 100}%`,
+                }}
+              />
+              <span className="ml-2 text-sm">{avg.toFixed(1)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default PluginScoreHeatmap;

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import HostBubbleChart from './HostBubbleChart';
 import PluginFeedViewer from './PluginFeedViewer';
 import ScanComparison from './ScanComparison';
+import PluginScoreHeatmap from './PluginScoreHeatmap';
 import FormError from '../../ui/FormError';
 
 // helpers for persistent storage of jobs and false positives
@@ -280,6 +281,7 @@ const Nessus = () => {
       <HostBubbleChart hosts={hostData} />
       <PluginFeedViewer />
       <ScanComparison />
+      <PluginScoreHeatmap findings={findings} />
       {error && <FormError className="mb-2">{error}</FormError>}
       <form onSubmit={addJob} className="mb-4 space-x-2">
         <input


### PR DESCRIPTION
## Summary
- add PluginScoreHeatmap to aggregate CVSS scores and color-code bars
- display heatmap in Nessus app

## Testing
- `yarn test` (fails: snake.config.test, frogger.config.test, niktoPage.test, beef.test, game2048.test, kismet.test, mimikatz.test)
- `yarn lint` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68b1f68e478c8328a71290cb2568076f