### PR TITLE
feat(radare2): support byte patch export

### DIFF
--- a/__tests__/radare2PatchUtils.test.js
+++ b/__tests__/radare2PatchUtils.test.js
@@ -1,0 +1,13 @@
+import { stagePatch, applyPatches, exportPatches } from '../components/apps/radare2/patchUtils';
+
+describe('radare2 patch utilities', () => {
+  test('stages and applies patches', () => {
+    const base = ['00', '01', '02'];
+    let patches = [];
+    patches = stagePatch(base, patches, 1, 'ff');
+    expect(patches).toEqual([{ offset: 1, original: '01', value: 'ff' }]);
+    const bytes = applyPatches(base, patches);
+    expect(bytes).toEqual(['00', 'ff', '02']);
+    expect(exportPatches(patches)).toEqual([{ offset: 1, original: '01', value: 'ff' }]);
+  });
+});

--- a/components/apps/radare2/patchUtils.js
+++ b/components/apps/radare2/patchUtils.js
@@ -1,0 +1,23 @@
+export const stagePatch = (base, patches, offset, value) => {
+  const original = base[offset];
+  const next = patches.filter((p) => p.offset !== offset);
+  const norm = typeof value === 'string' ? value.trim().slice(0, 2).toLowerCase() : '';
+  if (
+    typeof original !== 'undefined' &&
+    /^[0-9a-f]{2}$/i.test(norm) &&
+    original.toLowerCase() !== norm
+  ) {
+    next.push({ offset, original, value: norm });
+  }
+  return next;
+};
+
+export const applyPatches = (base, patches) => {
+  const out = [...base];
+  patches.forEach(({ offset, value }) => {
+    if (offset >= 0 && offset < out.length) out[offset] = value;
+  });
+  return out;
+};
+
+export const exportPatches = (patches) => patches;


### PR DESCRIPTION
## Summary
- allow HexEditor to stage byte patches and export them as JSON
- process patch operations in hex worker using reusable utilities
- add unit tests for new patch utilities

## Testing
- `yarn test` *(fails: beef, niktoPage, calculator parser, game2048, mimikatz, kismet, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f690b4988328b133ae0e2f3f2a10