### PR TITLE
feat(weather): add per-tile unit toggle

### DIFF
--- a/apps/weather/components/CityDetail.tsx
+++ b/apps/weather/components/CityDetail.tsx
@@ -5,12 +5,18 @@ import { City } from '../state';
 
 interface Props {
   city: City;
+  unit: 'C' | 'F';
+  onUnitChange: (unit: 'C' | 'F') => void;
   onClose: () => void;
 }
 
-export default function CityDetail({ city, onClose }: Props) {
-  const [unit, setUnit] = useState<'C' | 'F'>('C');
+export default function CityDetail({ city, unit: initialUnit, onUnitChange, onClose }: Props) {
+  const [unit, setUnit] = useState<'C' | 'F'>(initialUnit);
   const [hourly, setHourly] = useState<number[]>([]);
+
+  useEffect(() => {
+    setUnit(initialUnit);
+  }, [initialUnit]);
 
   useEffect(() => {
     fetch(
@@ -37,13 +43,19 @@ export default function CityDetail({ city, onClose }: Props) {
         <div className="flex gap-1.5 mb-4">
           <button
             className={`px-1.5 rounded ${unit === 'C' ? 'bg-blue-600' : 'bg-white/20'}`}
-            onClick={() => setUnit('C')}
+            onClick={() => {
+              setUnit('C');
+              onUnitChange('C');
+            }}
           >
             °C
           </button>
           <button
             className={`px-1.5 rounded ${unit === 'F' ? 'bg-blue-600' : 'bg-white/20'}`}
-            onClick={() => setUnit('F')}
+            onClick={() => {
+              setUnit('F');
+              onUnitChange('F');
+            }}
           >
             °F
           </button>

--- a/apps/weather/components/Forecast.tsx
+++ b/apps/weather/components/Forecast.tsx
@@ -3,7 +3,15 @@
 import WeatherIcon from './WeatherIcon';
 import { ForecastDay } from '../state';
 
-export default function Forecast({ days }: { days: ForecastDay[] }) {
+export default function Forecast({
+  days,
+  unit,
+}: {
+  days: ForecastDay[];
+  unit: 'C' | 'F';
+}) {
+  const convert = (t: number) => (unit === 'C' ? t : t * 1.8 + 32);
+
   return (
     <div className="flex gap-1.5">
       {days.map((d) => (
@@ -12,7 +20,9 @@ export default function Forecast({ days }: { days: ForecastDay[] }) {
           className="flex flex-col items-center p-1.5 bg-white/10 rounded"
         >
           <WeatherIcon code={d.condition} />
-          <div className="text-sm mt-1">{Math.round(d.temp)}°</div>
+          <div className="text-sm mt-1">
+            {Math.round(convert(d.temp))}°{unit}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
 import useWeatherState, { City, ForecastDay } from './state';
 import Forecast from './components/Forecast';
 import CityDetail from './components/CityDetail';
@@ -11,16 +12,50 @@ interface ReadingUpdate {
   time: number;
 }
 
-function CityTile({ city }: { city: City }) {
+function CityTile({
+  city,
+  unit,
+  onUnitChange,
+}: {
+  city: City;
+  unit: 'C' | 'F';
+  onUnitChange: (u: 'C' | 'F') => void;
+}) {
+  const temp = city.lastReading
+    ? Math.round(unit === 'C' ? city.lastReading.temp : city.lastReading.temp * 1.8 + 32)
+    : null;
+
   return (
     <div>
       <div className="font-bold mb-1.5">{city.name}</div>
       {city.lastReading ? (
-        <div className="mb-1.5">{Math.round(city.lastReading.temp)}°C</div>
+        <div className="mb-1.5">
+          {temp}°{unit}
+        </div>
       ) : (
         <div className="opacity-70 mb-1.5">No data</div>
       )}
-      {city.forecast && <Forecast days={city.forecast.slice(0, 5)} />}
+      {city.forecast && <Forecast days={city.forecast.slice(0, 5)} unit={unit} />}
+      <div className="flex gap-1.5 mt-1.5">
+        <button
+          className={`px-1.5 rounded ${unit === 'C' ? 'bg-blue-600' : 'bg-white/20'}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnitChange('C');
+          }}
+        >
+          °C
+        </button>
+        <button
+          className={`px-1.5 rounded ${unit === 'F' ? 'bg-blue-600' : 'bg-white/20'}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnitChange('F');
+          }}
+        >
+          °F
+        </button>
+      </div>
     </div>
   );
 }
@@ -34,6 +69,7 @@ export default function WeatherApp() {
     typeof navigator !== 'undefined' ? !navigator.onLine : false,
   );
   const [selected, setSelected] = useState<City | null>(null);
+  const [globalUnit, setGlobalUnit] = usePersistentState<'C' | 'F'>('weather-unit', 'C');
   const dragSrc = useRef<number | null>(null);
 
   useEffect(() => {
@@ -134,26 +170,71 @@ export default function WeatherApp() {
           Add
         </button>
       </div>
+      <div className="flex gap-1.5 mb-4">
+        <button
+          className={`px-1.5 rounded ${globalUnit === 'C' ? 'bg-blue-600' : 'bg-white/20'}`}
+          onClick={() => setGlobalUnit('C')}
+        >
+          °C
+        </button>
+        <button
+          className={`px-1.5 rounded ${globalUnit === 'F' ? 'bg-blue-600' : 'bg-white/20'}`}
+          onClick={() => setGlobalUnit('F')}
+        >
+          °F
+        </button>
+      </div>
       <div className="grid grid-cols-2 gap-4">
-        {cities.map((city, i) => (
-          <div
-            key={city.id}
-            draggable
-            onDragStart={() => onDragStart(i)}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={() => onDrop(i)}
-            onClick={() => setSelected(city)}
-            className="bg-white/10 p-4 rounded cursor-pointer"
-          >
-            <CityTile city={city} />
-          </div>
-        ))}
+        {cities.map((city, i) => {
+          const unit = city.unit || globalUnit;
+          return (
+            <div
+              key={city.id}
+              draggable
+              onDragStart={() => onDragStart(i)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => onDrop(i)}
+              onClick={() => setSelected(city)}
+              className="bg-white/10 p-4 rounded cursor-pointer"
+            >
+              <CityTile
+                city={city}
+                unit={unit}
+                onUnitChange={(u) => {
+                  setCities((prev) => {
+                    const next = [...prev];
+                    if (!next[i]) return prev;
+                    next[i] = { ...next[i], unit: u };
+                    return next;
+                  });
+                  setSelected((sel) =>
+                    sel && sel.id === city.id ? { ...sel, unit: u } : sel,
+                  );
+                }}
+              />
+            </div>
+          );
+        })}
       </div>
       {offline && (
         <div className="mt-4 text-sm">Offline - showing cached data</div>
       )}
       {selected && (
-        <CityDetail city={selected} onClose={() => setSelected(null)} />
+        <CityDetail
+          city={selected}
+          unit={selected.unit || globalUnit}
+          onUnitChange={(u) => {
+            setCities((prev) => {
+              const idx = prev.findIndex((c) => c.id === selected.id);
+              if (idx === -1) return prev;
+              const next = [...prev];
+              next[idx] = { ...next[idx], unit: u };
+              return next;
+            });
+            setSelected((sel) => (sel ? { ...sel, unit: u } : sel));
+          }}
+          onClose={() => setSelected(null)}
+        />
       )}
     </div>
   );

--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -19,6 +19,7 @@ export interface City {
   name: string;
   lat: number;
   lon: number;
+  unit?: 'C' | 'F';
   lastReading?: WeatherReading;
   forecast?: ForecastDay[];
 }
@@ -37,6 +38,7 @@ const isCity = (v: any): v is City =>
   typeof v.name === 'string' &&
   typeof v.lat === 'number' &&
   typeof v.lon === 'number' &&
+  (v.unit === undefined || v.unit === 'C' || v.unit === 'F') &&
   (v.lastReading === undefined || isWeatherReading(v.lastReading)) &&
   (v.forecast === undefined || isForecastArray(v.forecast));
 


### PR DESCRIPTION
## Summary
- allow individual weather tiles to toggle °C/°F
- add global unit selector for weather app
- persist chosen units per tile

## Testing
- `npx eslint -c .eslintrc.cjs apps/weather/index.tsx apps/weather/components/CityDetail.tsx apps/weather/components/Forecast.tsx apps/weather/state.ts` *(warnings: File ignored because no matching configuration was supplied)*
- `yarn test apps/weather --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f6933dac83288608105e369f4b5a