### PR TITLE
feat(weather): add city group saving and switching

### DIFF
--- a/apps/weather/state.ts
+++ b/apps/weather/state.ts
@@ -23,6 +23,11 @@ export interface City {
   forecast?: ForecastDay[];
 }
 
+export interface CityGroup {
+  name: string;
+  cities: City[];
+}
+
 const isWeatherReading = (v: any): v is WeatherReading =>
   v && typeof v.temp === 'number' && typeof v.condition === 'number' && typeof v.time === 'number';
 
@@ -44,5 +49,22 @@ const isCityArray = (v: unknown): v is City[] => Array.isArray(v) && v.every(isC
 
 export default function useWeatherState() {
   return usePersistentState<City[]>('weather-cities', [], isCityArray);
+}
+
+const isCityGroup = (v: any): v is CityGroup =>
+  v && typeof v.name === 'string' && isCityArray(v.cities);
+
+const isCityGroupArray = (v: unknown): v is CityGroup[] =>
+  Array.isArray(v) && v.every(isCityGroup);
+
+export function useWeatherGroups() {
+  return usePersistentState<CityGroup[]>('weather-city-groups', [], isCityGroupArray);
+}
+
+const isStringOrNull = (v: unknown): v is string | null =>
+  v === null || typeof v === 'string';
+
+export function useCurrentGroup() {
+  return usePersistentState<string | null>('weather-current-group', null, isStringOrNull);
 }
 


### PR DESCRIPTION
## Summary
- allow saving city lists as named groups and switch between them
- persist current group selection

## Testing
- `yarn lint apps/weather/index.tsx apps/weather/state.ts` *(fails: ESLint couldn't find config)*
- `yarn test apps/weather --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b204a677288328a4de7d1e5d643e39