### PR TITLE
feat: add docs links to filter presets

### DIFF
--- a/apps/wireshark/components/FilterHelper.tsx
+++ b/apps/wireshark/components/FilterHelper.tsx
@@ -12,6 +12,10 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
     'wireshark:recent-filters',
     []
   );
+  const [applied, setApplied] = usePersistentState<Record<string, boolean>>(
+    'wireshark:applied-presets',
+    {}
+  );
 
   const suggestions = Array.from(
     new Set([...recent, ...presets.map((p) => p.expression)])
@@ -36,31 +40,36 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
     }
   };
 
-  const handlePresetSelect = (
-    e: React.ChangeEvent<HTMLSelectElement>
-  ) => {
-    const val = e.target.value;
-    if (!val) return;
-    onChange(val);
-    setRecent((prev) => [val, ...prev.filter((f) => f !== val)].slice(0, 5));
-    e.target.selectedIndex = 0;
+  const handlePresetClick = (expression: string) => {
+    onChange(expression);
+    setRecent((prev) => [expression, ...prev.filter((f) => f !== expression)].slice(0, 5));
+    setApplied((prev) => ({ ...prev, [expression]: true }));
   };
 
   return (
     <>
-      <select
-        onChange={handlePresetSelect}
-        defaultValue=""
-        aria-label="Preset filters"
-        className="px-2 py-1 bg-gray-800 rounded text-white"
-      >
-        <option value="">Preset filters...</option>
-        {presets.map(({ label, expression }) => (
-          <option key={expression} value={expression}>
-            {label}
-          </option>
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        {presets.map(({ label, expression, docUrl }) => (
+          <div key={expression} className="flex items-center gap-1">
+            <button
+              onClick={() => handlePresetClick(expression)}
+              className="px-2 py-1 bg-gray-800 rounded text-white text-xs"
+              aria-label={`Apply ${label} filter`}
+            >
+              {label}
+              {applied[expression] ? ' ✓' : ''}
+            </button>
+            <a
+              href={docUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 underline text-xs"
+            >
+              docs
+            </a>
+          </div>
         ))}
-      </select>
+      </div>
       <input
         list="display-filter-suggestions"
         value={value}

--- a/filters/presets.ts
+++ b/filters/presets.ts
@@ -1,17 +1,50 @@
 export interface FilterPreset {
   label: string;
   expression: string;
+  docUrl: string;
 }
 
 const presets: FilterPreset[] = [
-  { label: 'TCP', expression: 'tcp' },
-  { label: 'UDP', expression: 'udp' },
-  { label: 'ICMP', expression: 'icmp' },
-  { label: 'HTTP', expression: 'http' },
-  { label: 'HTTP traffic', expression: 'tcp.port == 80' },
-  { label: 'HTTPS traffic', expression: 'tcp.port == 443' },
-  { label: 'DNS queries', expression: 'udp.port == 53' },
-  { label: 'Host 10.0.0.1', expression: 'ip.addr == 10.0.0.1' }
+  {
+    label: 'TCP',
+    expression: 'tcp',
+    docUrl: 'https://www.wireshark.org/docs/dfref/t/tcp.html',
+  },
+  {
+    label: 'UDP',
+    expression: 'udp',
+    docUrl: 'https://www.wireshark.org/docs/dfref/u/udp.html',
+  },
+  {
+    label: 'ICMP',
+    expression: 'icmp',
+    docUrl: 'https://www.wireshark.org/docs/dfref/i/icmp.html',
+  },
+  {
+    label: 'HTTP',
+    expression: 'http',
+    docUrl: 'https://www.wireshark.org/docs/dfref/h/http.html',
+  },
+  {
+    label: 'HTTP traffic',
+    expression: 'tcp.port == 80',
+    docUrl: 'https://www.wireshark.org/docs/dfref/t/tcp.html',
+  },
+  {
+    label: 'HTTPS traffic',
+    expression: 'tcp.port == 443',
+    docUrl: 'https://www.wireshark.org/docs/dfref/t/tcp.html',
+  },
+  {
+    label: 'DNS queries',
+    expression: 'udp.port == 53',
+    docUrl: 'https://www.wireshark.org/docs/dfref/u/udp.html',
+  },
+  {
+    label: 'Host 10.0.0.1',
+    expression: 'ip.addr == 10.0.0.1',
+    docUrl: 'https://www.wireshark.org/docs/dfref/i/ip.html',
+  },
 ];
 
 export default presets;


### PR DESCRIPTION
## Summary
- link Wireshark filter presets to official documentation
- track and persist applied state for each filter preset

## Testing
- `yarn test` *(fails: multiple test suite failures)*
- `yarn lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b204b4549c8328b201c5591da4f2fc