### PR TITLE
feat(radare2): extract buffer strings

### DIFF
--- a/__tests__/radare2.test.js
+++ b/__tests__/radare2.test.js
@@ -6,6 +6,7 @@ import {
   loadNotes,
   saveBookmarks,
   loadBookmarks,
+  extractStrings,
 } from '../components/apps/radare2/utils';
 
 describe('Radare2 utilities', () => {
@@ -49,5 +50,13 @@ describe('Radare2 utilities', () => {
     saveBookmarks('b.bin', bmB);
     expect(loadBookmarks('a.bin')).toEqual(bmA);
     expect(loadBookmarks('b.bin')).toEqual(bmB);
+  });
+
+  test('extracts ASCII and UTF-16 strings', () => {
+    const hex = '746573740068006900';
+    expect(extractStrings(hex, '0x1000')).toEqual([
+      { addr: '0x1000', text: 'test' },
+      { addr: '0x1005', text: 'hi' },
+    ]);
   });
 });

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -5,6 +5,7 @@ import {
   saveNotes,
   loadBookmarks,
   saveBookmarks,
+  extractStrings,
 } from './utils';
 import GraphView from '../../../apps/radare2/components/GraphView';
 import GuideOverlay from './GuideOverlay';
@@ -22,6 +23,7 @@ const Radare2 = ({ initialData = {} }) => {
   const [noteText, setNoteText] = useState('');
   const [bookmarks, setBookmarks] = useState([]);
   const [showGuide, setShowGuide] = useState(false);
+  const [strings, setStrings] = useState([]);
   const disasmRef = useRef(null);
   const { theme, setTheme } = useTheme();
 
@@ -42,6 +44,11 @@ const Radare2 = ({ initialData = {} }) => {
       /* ignore storage errors */
     }
   }, []);
+
+  useEffect(() => {
+    const base = disasm[0]?.addr || '0x0';
+    setStrings(extractStrings(hex, base));
+  }, [hex, disasm]);
 
   const scrollToAddr = (addr) => {
     const idx = disasm.findIndex(
@@ -212,6 +219,27 @@ const Radare2 = ({ initialData = {} }) => {
               ))}
             </ul>
           </div>
+        </div>
+      )}
+
+      {strings.length > 0 && (
+        <div className="mt-4">
+          <h2 className="text-lg">Strings</h2>
+          <ul
+            className="rounded p-2"
+            style={{
+              backgroundColor: 'var(--r2-surface)',
+              border: '1px solid var(--r2-border)',
+            }}
+          >
+            {strings.map((s) => (
+              <li key={s.addr}>
+                <button onClick={() => scrollToAddr(s.addr)} className="underline">
+                  {s.addr}: {s.text}
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/components/apps/radare2/utils.js
+++ b/components/apps/radare2/utils.js
@@ -47,6 +47,44 @@ export const parseGraph = (analysis) => {
   return { nodes, links };
 };
 
+export const extractStrings = (hex, baseAddr = '0x0') => {
+  const bytes = (hex.match(/.{1,2}/g) || []).map((b) => parseInt(b, 16));
+  const base = parseInt(baseAddr, 16) || 0;
+  const results = [];
+  const isPrintable = (c) => c >= 0x20 && c <= 0x7e;
+  for (let i = 0; i < bytes.length; i++) {
+    if (isPrintable(bytes[i]) && bytes[i + 1] === 0x00) {
+      let j = i;
+      let s = '';
+      while (
+        j + 1 < bytes.length &&
+        isPrintable(bytes[j]) &&
+        bytes[j + 1] === 0x00
+      ) {
+        s += String.fromCharCode(bytes[j]);
+        j += 2;
+      }
+      if (s.length >= 2) {
+        results.push({ addr: '0x' + (base + i).toString(16), text: s });
+        i = j - 1;
+        continue;
+      }
+    }
+    if (isPrintable(bytes[i])) {
+      let j = i;
+      let s = '';
+      while (j < bytes.length && isPrintable(bytes[j])) {
+        s += String.fromCharCode(bytes[j]);
+        j++;
+      }
+      if (s.length >= 4)
+        results.push({ addr: '0x' + (base + i).toString(16), text: s });
+      i = j - 1;
+    }
+  }
+  return results;
+};
+
 const NOTES_PREFIX = 'r2-notes-';
 const BOOKMARK_PREFIX = 'r2-bookmarks-';
 


### PR DESCRIPTION
## Summary
- extract ASCII and UTF-16 strings from hex buffers
- show string list in radare2 viewer and allow navigation to disassembly
- test string extraction utility

## Testing
- `npm test __tests__/radare2.test.js`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b204b7cc1c83288164f162f224200d