### PR TITLE
feat: add daily quote card with export

### DIFF
--- a/pages/daily-quote.tsx
+++ b/pages/daily-quote.tsx
@@ -1,0 +1,64 @@
+import { useRef } from 'react';
+import useDailyQuote from '../hooks/useDailyQuote';
+import { toPng } from 'html-to-image';
+import share, { canShare } from '../utils/share';
+
+export default function DailyQuote() {
+  const quote = useDailyQuote();
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const exportCard = () => {
+    const node = cardRef.current;
+    if (!node || !quote) return;
+    toPng(node)
+      .then((dataUrl) => {
+        const link = document.createElement('a');
+        link.download = 'daily-quote.png';
+        link.href = dataUrl;
+        link.click();
+      })
+      .catch(() => {/* ignore */});
+  };
+
+  const shareQuote = () => {
+    if (!quote) return;
+    const text = `"${quote.content}" — ${quote.author}`;
+    share(text);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+      <div
+        ref={cardRef}
+        className="p-6 rounded text-center bg-gradient-to-br from-[var(--color-primary)]/30 to-[var(--color-secondary)]/30 text-white"
+      >
+        {quote ? (
+          <>
+            <p className="text-3xl sm:text-4xl mb-4">&ldquo;{quote.content}&rdquo;</p>
+            <p className="text-sm text-white/80">— {quote.author}</p>
+          </>
+        ) : (
+          <p>Loading...</p>
+        )}
+      </div>
+      <div className="flex gap-2 mt-4">
+        <button
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          onClick={exportCard}
+          disabled={!quote}
+        >
+          Export Card
+        </button>
+        {canShare() && (
+          <button
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            onClick={shareQuote}
+            disabled={!quote}
+          >
+            Share
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add /daily-quote page that displays daily quote and allows export/share

## Testing
- `npm test` *(fails: beef, calculator parser, game2048, kismet, niktoPage, snake.config, frogger.config, metasploit, mimikatz, etc.)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b204ba1068832888134127bdc2c124