### PR TITLE
Add sprite strip import utility and preview component

### DIFF
--- a/__tests__/spriteStrip.test.tsx
+++ b/__tests__/spriteStrip.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { act } from 'react';
+import SpriteStripPreview from '../components/SpriteStripPreview';
+import { importSpriteStrip, clearSpriteStripCache } from '../utils/spriteStrip';
+
+jest.useFakeTimers();
+
+describe('sprite strip utilities', () => {
+  test('imports strips with caching', () => {
+    clearSpriteStripCache();
+    const img1 = importSpriteStrip('foo.png');
+    const img2 = importSpriteStrip('foo.png');
+    expect(img1).toBe(img2);
+  });
+
+  test('preview advances frames', () => {
+    const { getByTestId } = render(
+      <SpriteStripPreview src="foo.png" frameWidth={10} frameHeight={10} frames={3} fps={10} />,
+    );
+    const el = getByTestId('sprite-strip-preview');
+    expect(el).toBeTruthy();
+    expect(el).toHaveStyle('background-position: 0px 0px');
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(el).toHaveStyle('background-position: -10px 0px');
+  });
+});

--- a/components/SpriteStripPreview.tsx
+++ b/components/SpriteStripPreview.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { importSpriteStrip } from '../utils/spriteStrip';
+
+interface SpriteStripPreviewProps {
+  /** path to the sprite strip image */
+  src: string;
+  /** width of a single frame in pixels */
+  frameWidth: number;
+  /** height of a single frame in pixels */
+  frameHeight: number;
+  /** total number of frames in the strip */
+  frames: number;
+  /** frames per second for animation */
+  fps?: number;
+}
+
+/**
+ * Renders a sprite strip and cycles through the frames for preview purposes.
+ */
+const SpriteStripPreview: React.FC<SpriteStripPreviewProps> = ({
+  src,
+  frameWidth,
+  frameHeight,
+  frames,
+  fps = 12,
+}) => {
+  const [frame, setFrame] = useState(0);
+
+  // Preload and cache the sprite strip
+  useEffect(() => {
+    importSpriteStrip(src);
+  }, [src]);
+
+  // Cycle through frames
+  useEffect(() => {
+    const id = window.setInterval(
+      () => setFrame((f) => (f + 1) % frames),
+      1000 / fps,
+    );
+    return () => window.clearInterval(id);
+  }, [frames, fps]);
+
+  const style: React.CSSProperties = {
+    width: frameWidth,
+    height: frameHeight,
+    backgroundImage: `url(${src})`,
+    backgroundPosition: `-${frame * frameWidth}px 0px`,
+    backgroundRepeat: 'no-repeat',
+    imageRendering: 'pixelated',
+  };
+
+  return <div style={style} data-testid="sprite-strip-preview" />;
+};
+
+export default SpriteStripPreview;

--- a/utils/spriteStrip.ts
+++ b/utils/spriteStrip.ts
@@ -1,0 +1,22 @@
+const stripCache: Record<string, HTMLImageElement> = {};
+
+/**
+ * Imports a sprite strip image and caches it for reuse.
+ * @param src image source path
+ * @returns the loaded HTMLImageElement
+ */
+export const importSpriteStrip = (src: string): HTMLImageElement => {
+  if (!stripCache[src]) {
+    const img = new Image();
+    img.src = src;
+    stripCache[src] = img;
+  }
+  return stripCache[src];
+};
+
+/**
+ * Clears the sprite strip cache. Useful for testing.
+ */
+export const clearSpriteStripCache = () => {
+  Object.keys(stripCache).forEach((k) => delete stripCache[k]);
+};


### PR DESCRIPTION
## Summary
- add utility to import sprite strips with caching
- add `SpriteStripPreview` component to cycle through frames
- cover sprite strip loading and animation with tests

## Testing
- `yarn test __tests__/tower-defense.test.ts __tests__/spriteStrip.test.tsx`
- `./node_modules/.bin/eslint --config .eslintrc.cjs components/SpriteStripPreview.tsx utils/spriteStrip.ts __tests__/spriteStrip.test.tsx` *(fails: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b204bee9e48328864da449fb37eb6c