### PR TITLE
Parse Nessus XML into table with suggestion sidebar

### DIFF
--- a/__tests__/nessusParser.test.ts
+++ b/__tests__/nessusParser.test.ts
@@ -1,0 +1,34 @@
+import { parseNessus } from '../workers/nessus-parser';
+
+describe('nessus parser worker', () => {
+  test('extracts findings with description and solution', () => {
+    const sample = `<?xml version="1.0"?>
+<NessusClientData_v2>
+  <Report name="Sample">
+    <ReportHost name="192.168.0.1">
+      <HostProperties>
+        <tag name="host-ip">192.168.0.1</tag>
+      </HostProperties>
+      <ReportItem pluginID="100" pluginName="Test Vuln">
+        <risk_factor>Low</risk_factor>
+        <description>Some description</description>
+        <solution>Apply patch</solution>
+        <cvss_base_score>4.0</cvss_base_score>
+      </ReportItem>
+    </ReportHost>
+  </Report>
+</NessusClientData_v2>`;
+    const findings = parseNessus(sample);
+    expect(findings).toEqual([
+      {
+        host: '192.168.0.1',
+        id: '100',
+        name: 'Test Vuln',
+        cvss: 4.0,
+        severity: 'Low',
+        description: 'Some description',
+        solution: 'Apply patch',
+      },
+    ]);
+  });
+});

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -53,6 +53,7 @@ const Nessus = () => {
   const [falsePositives, setFalsePositives] = useState([]);
   const [findings, setFindings] = useState([]);
   const [parseError, setParseError] = useState('');
+  const [selected, setSelected] = useState(null);
   const parserWorkerRef = useRef(null);
 
   const hostData = useMemo(
@@ -73,7 +74,7 @@ const Nessus = () => {
     parserWorkerRef.current = new Worker(
       new URL('../../../workers/nessus-parser.ts', import.meta.url)
     );
-    parserWorkerRef.current.onmessage = (e) => {
+      parserWorkerRef.current.onmessage = (e) => {
       const { findings: parsed = [], error: err } = e.data || {};
       if (err) {
         setParseError(err);
@@ -264,7 +265,11 @@ const Nessus = () => {
                 </thead>
                 <tbody>
                   {findings.map((f, i) => (
-                    <tr key={i} className="border-t border-gray-700">
+                    <tr
+                      key={i}
+                      className="border-t border-gray-700 cursor-pointer"
+                      onClick={() => setSelected(f)}
+                    >
                       <td className="p-1">{f.host}</td>
                       <td className="p-1">{f.name}</td>
                       <td className="p-1">{f.cvss}</td>
@@ -352,6 +357,28 @@ const Nessus = () => {
           </li>
         ))}
       </ul>
+      {selected && (
+        <div className="fixed top-0 right-0 w-80 h-full bg-gray-800 p-4 overflow-auto shadow-lg">
+          <button
+            type="button"
+            onClick={() => setSelected(null)}
+            className="mb-2 bg-red-600 px-2 py-1 rounded text-sm"
+          >
+            Close
+          </button>
+          <h3 className="text-xl mb-2">{selected.name}</h3>
+          <p className="text-sm mb-2">
+            <span className="font-bold">Host:</span> {selected.host}
+          </p>
+          <p className="text-sm mb-2">
+            <span className="font-bold">CVSS:</span> {selected.cvss} ({selected.severity})
+          </p>
+          <p className="mb-2 text-sm whitespace-pre-wrap">{selected.description}</p>
+          <p className="text-sm text-green-300">
+            {selected.solution || 'No solution provided.'}
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/workers/nessus-parser.ts
+++ b/workers/nessus-parser.ts
@@ -1,45 +1,52 @@
 import { XMLParser } from 'fast-xml-parser';
 
-interface Finding {
+export interface Finding {
   host: string;
   id: string;
   name: string;
   cvss: number;
   severity: string;
+  description: string;
+  solution: string;
 }
+
+export const parseNessus = (data: string): Finding[] => {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const json = parser.parse(data);
+  const reportHosts = json?.NessusClientData_v2?.Report?.ReportHost;
+  const hosts = Array.isArray(reportHosts) ? reportHosts : [reportHosts];
+  const findings: Finding[] = [];
+  hosts.forEach((host: any) => {
+    if (!host) return;
+    const hostName =
+      host['@_name'] ||
+      host?.HostProperties?.tag?.find(
+        (t: any) => t['@_name'] === 'host-ip'
+      )?.['#text'] ||
+      'unknown';
+    const items = Array.isArray(host.ReportItem)
+      ? host.ReportItem
+      : [host.ReportItem];
+    items.forEach((item: any) => {
+      if (!item) return;
+      const finding: Finding = {
+        host: hostName,
+        id: String(item['@_pluginID'] || ''),
+        name: item['@_pluginName'] || '',
+        cvss: parseFloat(item.cvss3_base_score || item.cvss_base_score || '0'),
+        severity: item.risk_factor || 'Unknown',
+        description: item.description || '',
+        solution: item.solution || '',
+      };
+      findings.push(finding);
+    });
+  });
+  return findings;
+};
 
 self.onmessage = ({ data }: MessageEvent<string>) => {
   try {
-    const parser = new XMLParser({ ignoreAttributes: false });
-    const json = parser.parse(data);
-    const reportHosts = json?.NessusClientData_v2?.Report?.ReportHost;
-    const hosts = Array.isArray(reportHosts) ? reportHosts : [reportHosts];
-    const findings: Finding[] = [];
-    hosts.forEach((host: any) => {
-      if (!host) return;
-      const hostName =
-        host['@_name'] ||
-        host?.HostProperties?.tag?.find(
-          (t: any) => t['@_name'] === 'host-ip'
-        )?.['#text'] ||
-        'unknown';
-      const items = Array.isArray(host.ReportItem)
-        ? host.ReportItem
-        : [host.ReportItem];
-      items.forEach((item: any) => {
-        if (!item) return;
-        const finding: Finding = {
-          host: hostName,
-          id: String(item['@_pluginID'] || ''),
-          name: item['@_pluginName'] || '',
-          cvss: parseFloat(
-            item.cvss3_base_score || item.cvss_base_score || '0'
-          ),
-          severity: item.risk_factor || 'Unknown',
-        };
-        findings.push(finding);
-      });
-    });
+    const findings = parseNessus(data);
     self.postMessage({ findings });
   } catch (err: any) {
     self.postMessage({ error: err?.message || 'Parse failed' });


### PR DESCRIPTION
## Summary
- extend Nessus worker to parse descriptions and solutions from XML reports
- add selectable Nessus findings table with suggestion sidebar
- cover Nessus XML parsing with dedicated unit test

## Testing
- `npm test -- __tests__/nessus.test.ts __tests__/nessus-report.test.tsx __tests__/nessusParser.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b204d06514832885cd3085322a1012