### PR TITLE
Allow TLS key log uploads and display plaintext

### DIFF
--- a/__tests__/wireshark.test.tsx
+++ b/__tests__/wireshark.test.tsx
@@ -75,7 +75,7 @@ describe('WiresharkApp', () => {
     expect(screen.queryByText('tcp packet')).not.toBeInTheDocument();
   });
 
-  it('reveals decrypted column when TLS keys uploaded', async () => {
+  it('reveals plaintext column when TLS keys uploaded', async () => {
     const packets = [
       {
         timestamp: '1',
@@ -83,19 +83,19 @@ describe('WiresharkApp', () => {
         dest: '2.2.2.2',
         protocol: 6,
         info: 'foo',
-        decrypted: 'secret',
+        plaintext: 'secret',
       },
     ];
     const user = userEvent.setup();
     render(<WiresharkApp initialPackets={packets} />);
 
-    expect(screen.queryByText(/decrypted/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/plaintext/i)).not.toBeInTheDocument();
 
     const file = new File(['dummy'], 'key.log', { type: 'text/plain' });
     const upload = screen.getByLabelText(/tls key file/i);
     fireEvent.change(upload, { target: { files: [file] } });
 
-    expect(await screen.findByText(/decrypted/i)).toBeInTheDocument();
+    expect(await screen.findByText(/plaintext/i)).toBeInTheDocument();
     expect(screen.getByText('secret')).toBeInTheDocument();
   });
 

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -293,7 +293,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
         </button>
         <input
           type="file"
-          accept=".keys,.txt"
+          accept=".keys,.txt,.log"
           onChange={handleTLSKeyUpload}
           aria-label="TLS key file"
           className="px-2 py-1 bg-gray-800 rounded text-white"
@@ -399,7 +399,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
                   <th className="px-2 py-1 text-left">Protocol</th>
                   <th className="px-2 py-1 text-left">Info</th>
                   {hasTlsKeys && (
-                    <th className="px-2 py-1 text-left">Decrypted</th>
+                    <th className="px-2 py-1 text-left">Plaintext</th>
                   )}
                 </tr>
               </thead>
@@ -423,9 +423,9 @@ const WiresharkApp = ({ initialPackets = [] }) => {
                       <td className="px-2 py-1 whitespace-nowrap">{protocolName(p.protocol)}</td>
                       <td className="px-2 py-1">{p.info}</td>
                       {hasTlsKeys && (
-                        <td className="px-2 py-1">{p.decrypted}</td>
+                        <td className="px-2 py-1">{p.plaintext || p.decrypted}</td>
                       )}
-                    </tr>
+                </tr>
                   );
                 })}
               </tbody>

--- a/components/apps/wireshark/utils.js
+++ b/components/apps/wireshark/utils.js
@@ -49,7 +49,7 @@ export const matchesDisplayFilter = (packet, filter) => {
     packet.dest.toLowerCase().includes(f) ||
     protocolName(packet.protocol).toLowerCase().includes(f) ||
     (packet.info || '').toLowerCase().includes(f) ||
-    (packet.decrypted || '').toLowerCase().includes(f)
+    (packet.plaintext || packet.decrypted || '').toLowerCase().includes(f)
   );
 };
 


### PR DESCRIPTION
## Summary
- accept `.log` TLS key log files
- show `Plaintext` column and value when TLS keys are provided
- allow filter expressions to match decrypted plaintext

## Testing
- `npm test __tests__/wireshark.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b204e01f0c8328b2abe7ef95af04a0