### PR TITLE
feat: add terminal script argument presets

### DIFF
--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -4,6 +4,11 @@ import { useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import runScript, { ScriptController } from '../utils/scriptRunner';
 
+interface ScriptEntry {
+  code: string;
+  presets?: Record<string, string[]>;
+}
+
 const examplesHref = new URL(
   '../../../scripts/examples/terminal.ts',
   import.meta.url,
@@ -14,28 +19,74 @@ interface ScriptsProps {
 }
 
 const Scripts = ({ runCommand }: ScriptsProps) => {
-  const [scripts, setScripts] = usePersistentState<Record<string, string>>(
-    'terminal-scripts',
-    {},
-  );
+  const [scripts, setScripts] =
+    usePersistentState<Record<string, ScriptEntry | string>>(
+      'terminal-scripts',
+      {},
+    );
   const [name, setName] = useState('');
   const [code, setCode] = useState('');
   const [controller, setController] = useState<ScriptController | null>(null);
+  const [selectedPresets, setSelectedPresets] = useState<Record<string, string>>(
+    {},
+  );
 
   const save = () => {
     const trimmed = name.trim();
     if (!trimmed) return;
-    setScripts({ ...scripts, [trimmed]: code });
+    setScripts({
+      ...scripts,
+      [trimmed]: { code, presets: {} },
+    });
     setName('');
     setCode('');
   };
 
   const run = (n: string) => {
-    const content = scripts[n];
-    if (!content) return;
-    const ctrl = runScript(content, runCommand);
+    const entry = scripts[n];
+    if (!entry) return;
+    const data: ScriptEntry =
+      typeof entry === 'string' ? { code: entry } : entry;
+    const preset = selectedPresets[n];
+    let args: string[] = [];
+    if (preset && data.presets?.[preset]) {
+      args = data.presets[preset];
+    } else {
+      const input = window.prompt('Arguments (space-separated)?') || '';
+      args = input.trim() ? input.trim().split(/\s+/) : [];
+    }
+    const ctrl = runScript(data.code, runCommand, args);
     setController(ctrl);
     ctrl.finished.finally(() => setController(null));
+  };
+
+  const addPreset = (n: string) => {
+    const entry = scripts[n];
+    if (!entry) return;
+    const data: ScriptEntry =
+      typeof entry === 'string' ? { code: entry } : entry;
+    const presetName = window.prompt('Preset name?');
+    if (!presetName) return;
+    const argStr = window.prompt('Arguments (space-separated)?') || '';
+    const args = argStr.trim() ? argStr.trim().split(/\s+/) : [];
+    const updated: ScriptEntry = {
+      ...data,
+      presets: { ...(data.presets || {}), [presetName]: args },
+    };
+    setScripts({ ...scripts, [n]: updated });
+    setSelectedPresets({ ...selectedPresets, [n]: presetName });
+  };
+
+  const removePreset = (n: string, preset: string) => {
+    const entry = scripts[n];
+    if (!entry) return;
+    const data: ScriptEntry =
+      typeof entry === 'string' ? { code: entry } : entry;
+    const presets = { ...(data.presets || {}) };
+    delete presets[preset];
+    const updated: ScriptEntry = { ...data, presets };
+    setScripts({ ...scripts, [n]: updated });
+    setSelectedPresets((p) => ({ ...p, [n]: '' }));
   };
 
   const cancel = () => controller?.cancel();
@@ -44,6 +95,11 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
     const updated = { ...scripts };
     delete updated[n];
     setScripts(updated);
+    setSelectedPresets((p) => {
+      const np = { ...p };
+      delete np[n];
+      return np;
+    });
   };
 
   return (
@@ -58,7 +114,7 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
         >
           View examples
         </a>
-        .
+        . Use <code>$1</code>, <code>$2</code>… in scripts for arguments.
       </p>
       <div className="space-y-1">
         <input
@@ -89,23 +145,57 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
         )}
       </div>
       <ul className="space-y-1">
-        {Object.keys(scripts).map((n) => (
-          <li key={n} className="flex items-center gap-2">
-            <span className="flex-1 truncate">{n}</span>
-            <button
-              onClick={() => run(n)}
-              className="bg-green-600 text-white px-2 py-0.5 rounded"
-            >
-              Run
-            </button>
-            <button
-              onClick={() => remove(n)}
-              className="bg-gray-600 text-white px-2 py-0.5 rounded"
-            >
-              Delete
-            </button>
-          </li>
-        ))}
+        {Object.keys(scripts).map((n) => {
+          const entry = scripts[n];
+          const data: ScriptEntry =
+            typeof entry === 'string' ? { code: entry } : entry;
+          const presets = data.presets || {};
+          return (
+            <li key={n} className="flex items-center gap-2">
+              <span className="flex-1 truncate">{n}</span>
+              <select
+                value={selectedPresets[n] || ''}
+                onChange={(e) =>
+                  setSelectedPresets({ ...selectedPresets, [n]: e.target.value })
+                }
+                className="border px-1 py-0.5"
+              >
+                <option value="">custom</option>
+                {Object.keys(presets).map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={() => run(n)}
+                className="bg-green-600 text-white px-2 py-0.5 rounded"
+              >
+                Run
+              </button>
+              <button
+                onClick={() => addPreset(n)}
+                className="bg-blue-600 text-white px-2 py-0.5 rounded"
+              >
+                Add Preset
+              </button>
+              {selectedPresets[n] && presets[selectedPresets[n]] && (
+                <button
+                  onClick={() => removePreset(n, selectedPresets[n])}
+                  className="bg-yellow-600 text-white px-2 py-0.5 rounded"
+                >
+                  Remove
+                </button>
+              )}
+              <button
+                onClick={() => remove(n)}
+                className="bg-gray-600 text-white px-2 py-0.5 rounded"
+              >
+                Delete
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/terminal/utils/scriptRunner.ts
+++ b/apps/terminal/utils/scriptRunner.ts
@@ -41,6 +41,7 @@ export interface ScriptController {
 export function runScript(
   source: string,
   exec: (command: string) => Promise<any> | any,
+  args: string[] = [],
 ): ScriptController {
   const steps = parseScript(source);
   let aborted = false;
@@ -53,7 +54,11 @@ export function runScript(
       for (const step of steps) {
         if (aborted) break;
         if (step.type === 'command') {
-          await exec(step.command);
+          const command = step.command.replace(/\$(\d+)/g, (_, n) => {
+            const idx = parseInt(n, 10) - 1;
+            return args[idx] ?? '';
+          });
+          await exec(command);
         } else {
           await new Promise<void>((res) => {
             timeout = setTimeout(res, step.ms);


### PR DESCRIPTION
## Summary
- allow terminal scripts to use positional args
- add UI to save and reuse per-script argument presets

## Testing
- `yarn test` *(fails: BeEF app updates hook list, game2048 logic, calculator parser, mimikatz API, kismet, snake.config, frogger.config)*

------
https://chatgpt.com/codex/tasks/task_e_68b204aa3d108328975df010632ec361