### PR TITLE
Add visual backoff indicator to Hydra Stepper

### DIFF
--- a/__tests__/hydraStepper.test.tsx
+++ b/__tests__/hydraStepper.test.tsx
@@ -21,6 +21,20 @@ describe('Hydra Stepper', () => {
     jest.useRealTimers();
   });
 
+  it('shows backoff indicator', () => {
+    render(
+      <Stepper
+        active
+        totalAttempts={10}
+        backoffThreshold={2}
+        lockoutThreshold={5}
+        runId={1}
+      />
+    );
+    expect(screen.getByTestId('backoff-bar')).toBeInTheDocument();
+    expect(screen.getByText(/Delay: 500ms/)).toBeInTheDocument();
+  });
+
   it('locks out after reaching threshold', () => {
     render(
       <Stepper


### PR DESCRIPTION
## Summary
- enhance Hydra Stepper with delay state and ref to simulate exponential backoff
- show backoff delay with progress bar and text
- cover backoff indicator and lockout behaviour with tests

## Testing
- `node_modules/.bin/jest __tests__/hydraStepper.test.tsx --runInBand --ci`


------
https://chatgpt.com/codex/tasks/task_e_68b204af03a08328b3e32b6eb7e41452