### PR TITLE
feat: mask editor candidate size estimates

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -91,6 +91,13 @@ describe('HashcatApp', () => {
     expect((getByLabelText('Mask') as HTMLInputElement).value).toBe('?d');
   });
 
+  it('estimates candidate space for mask', () => {
+    const { getByLabelText, getByText } = render(<HashcatApp />);
+    fireEvent.change(getByLabelText('Attack Mode:'), { target: { value: '3' } });
+    fireEvent.change(getByLabelText('Mask'), { target: { value: '?d?d' } });
+    expect(getByText(/Candidate space:/).textContent).toContain('100');
+  });
+
   it('previews selected rule set', () => {
     const { getByLabelText } = render(<HashcatApp />);
     fireEvent.change(getByLabelText('Rule Set:'), {

--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import RulesSandbox from './components/RulesSandbox';
+import StatsChart from '../../components/StatsChart';
 
 interface Preset {
   value: string;
@@ -30,6 +31,7 @@ const Hashcat: React.FC = () => {
   const [attackMode, setAttackMode] = useState('0');
   const [mask, setMask] = useState('');
   const appendMask = (token: string) => setMask((m) => m + token);
+  const [maskStats, setMaskStats] = useState({ count: 0, time: 0 });
 
   const [hashInput, setHashInput] = useState('');
   const [showHash, setShowHash] = useState(false);
@@ -116,6 +118,43 @@ const Hashcat: React.FC = () => {
   useEffect(() => () => stopInterval(), []);
 
   const showMask = attackMode === '3' || attackMode === '6' || attackMode === '7';
+
+  const formatTime = (seconds: number) => {
+    if (seconds < 60) return `${seconds.toFixed(2)}s`;
+    const minutes = seconds / 60;
+    if (minutes < 60) return `${minutes.toFixed(2)}m`;
+    const hours = minutes / 60;
+    if (hours < 24) return `${hours.toFixed(2)}h`;
+    const days = hours / 24;
+    return `${days.toFixed(2)}d`;
+  };
+
+  useEffect(() => {
+    if (!mask) {
+      setMaskStats({ count: 0, time: 0 });
+      return;
+    }
+    const sets: Record<string, number> = {
+      '?l': 26,
+      '?u': 26,
+      '?d': 10,
+      '?s': 33,
+      '?a': 95,
+    };
+    let total = 1;
+    for (let i = 0; i < mask.length; i++) {
+      if (mask[i] === '?' && i < mask.length - 1) {
+        const token = mask.slice(i, i + 2);
+        if (sets[token]) {
+          total *= sets[token];
+          i++;
+          continue;
+        }
+      }
+      total *= 1;
+    }
+    setMaskStats({ count: total, time: total / 1_000_000 });
+  }, [mask]);
 
   const SpeedGauge: React.FC<{ speed: number }> = ({ speed }) => {
     const pct = Math.min((speed / 2000) * 100, 100);
@@ -213,6 +252,15 @@ const Hashcat: React.FC = () => {
               </button>
             ))}
           </div>
+          {mask && (
+            <div className="mt-2">
+              <p>Candidate space: {maskStats.count.toLocaleString()}</p>
+              <p className="text-sm">
+                Estimated @1M/s: {formatTime(maskStats.time)}
+              </p>
+              <StatsChart count={maskStats.count} time={maskStats.time} />
+            </div>
+          )}
         </div>
       )}
 

--- a/components/StatsChart.js
+++ b/components/StatsChart.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const StatsChart = ({ count, time }) => {
+  const max = Math.max(count, time, 1);
+  const cH = (count / max) * 80;
+  const tH = (time / max) * 80;
+  return (
+    <svg viewBox="0 0 120 100" className="w-full h-24 mt-2">
+      <rect x="10" y={90 - cH} width="40" height={cH} fill="#10b981" />
+      <rect x="70" y={90 - tH} width="40" height={tH} fill="#3b82f6" />
+      <text x="30" y="95" textAnchor="middle" fontSize="8" fill="white">
+        candidates
+      </text>
+      <text x="90" y="95" textAnchor="middle" fontSize="8" fill="white">
+        seconds
+      </text>
+    </svg>
+  );
+};
+
+export default StatsChart;

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -7,6 +7,7 @@ import {
   parsePotfile,
 } from './utils';
 import FormError from '../../ui/FormError';
+import StatsChart from '../../StatsChart';
 
 // Enhanced John the Ripper interface that supports rule uploads,
 // basic hash analysis and mock distribution of cracking tasks.
@@ -171,24 +172,6 @@ const JohnApp = () => {
     if (hours < 24) return `${hours.toFixed(2)}h`;
     const days = hours / 24;
     return `${days.toFixed(2)}d`;
-  };
-
-  const StatsChart = ({ count, time }) => {
-    const max = Math.max(count, time, 1);
-    const cH = (count / max) * 80;
-    const tH = (time / max) * 80;
-    return (
-      <svg viewBox="0 0 120 100" className="w-full h-24 mt-2">
-        <rect x="10" y={90 - cH} width="40" height={cH} fill="#10b981" />
-        <rect x="70" y={90 - tH} width="40" height={tH} fill="#3b82f6" />
-        <text x="30" y="95" textAnchor="middle" fontSize="8" fill="white">
-          candidates
-        </text>
-        <text x="90" y="95" textAnchor="middle" fontSize="8" fill="white">
-          seconds
-        </text>
-      </svg>
-    );
   };
 
   const handleModeChange = (e) => {


### PR DESCRIPTION
## Summary
- add reusable `StatsChart` bar renderer
- show live candidate counts for mask editor using chart
- test mask candidate size estimation

## Testing
- `yarn test __tests__/hashcat.test.tsx`
- `yarn test __tests__/john-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b204b0f3e08328ab5da0433e5f523a