### PR TITLE
feat(radare2): support OPFS symbol comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ play/pause and track controls include keyboard hotkeys.
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
-- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
+- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file bookmarks, symbol renaming, and OPFS-backed comments.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 
 ---


### PR DESCRIPTION
## Summary
- persist per-address symbols and comments using OPFS
- expose rename button and inline comment display in Radare2
- document OPFS-backed comments and renaming

## Testing
- `yarn test` *(fails: __tests__/game2048.test.ts, __tests__/beef.test.tsx, __tests__/niktoPage.test.tsx, __tests__/calculator/parser.test.ts, __tests__/mimikatz.test.ts)*
- `yarn test __tests__/radare2Guide.test.tsx __tests__/radare2.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b204b7572483288fac4cef88f25ee3