### PR TITLE
feat: add cron schedule utility

### DIFF
--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -1,0 +1,14 @@
+import { getNextRunTimes } from '../utils/cron';
+
+describe('getNextRunTimes', () => {
+  it('calculates upcoming times for cron expression', () => {
+    const start = new Date('2020-01-01T00:00:00Z');
+    const runs = getNextRunTimes('*/5 * * * *', 3, { currentDate: start });
+    expect(runs.map((d) => d.toISOString())).toEqual([
+      '2020-01-01T00:05:00.000Z',
+      '2020-01-01T00:10:00.000Z',
+      '2020-01-01T00:15:00.000Z',
+    ]);
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chart.js": "^4.5.0",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
+    "cron-parser": "^5.3.0",
     "cytoscape": "^3.33.1",
     "cytoscape-cose-bilkent": "^4.1.0",
     "diff": "^5.1.0",

--- a/scripts/cron-next-run.mjs
+++ b/scripts/cron-next-run.mjs
@@ -1,0 +1,15 @@
+import { CronExpressionParser } from 'cron-parser';
+
+const expression = process.argv[2];
+const count = Number(process.argv[3] ?? 5);
+
+if (!expression) {
+  console.error('Usage: node scripts/cron-next-run.mjs "<cron expression>" [count]');
+  process.exit(1);
+}
+
+const interval = CronExpressionParser.parse(expression);
+for (let i = 0; i < count; i++) {
+  console.log(interval.next().toString());
+}
+

--- a/utils/cron.ts
+++ b/utils/cron.ts
@@ -1,0 +1,21 @@
+import { CronExpressionParser, ParserOptions } from 'cron-parser';
+
+/**
+ * Calculate the next run times for a cron expression.
+ * @param expression - Cron-style expression (e.g. "*\/5 * * * *").
+ * @param count - Number of run times to generate.
+ * @param options - Optional cron-parser options such as currentDate.
+ */
+export function getNextRunTimes(
+  expression: string,
+  count = 5,
+  options: ParserOptions = {},
+): Date[] {
+  const interval = CronExpressionParser.parse(expression, options);
+  const result: Date[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(interval.next().toDate());
+  }
+  return result;
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,6 +4768,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cron-parser@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "cron-parser@npm:5.3.0"
+  dependencies:
+    luxon: "npm:^3.6.1"
+  checksum: 10c0/770d88db93af031ecc0fa7e7fc4f587af32df66eaff985137f86a02fee9af038533788dd36d5bc6ac283392e9db82b55fd4841e7e02098617fc7b73a813c5b7a
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -8357,6 +8366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"luxon@npm:^3.6.1":
+  version: 3.7.1
+  resolution: "luxon@npm:3.7.1"
+  checksum: 10c0/f83bc23a4c09da9111bc2510d2f5346e1ced4938379ebff13e308fece2ea852eb6e8b9ed8053b8d82e0fce05d5dd46e4cd64d8831ca04cfe32c0954b6f087258
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -11683,6 +11699,7 @@ __metadata:
     chart.js: "npm:^4.5.0"
     chess.js: "npm:^1.0.0"
     chrono-node: "npm:^2.8.4"
+    cron-parser: "npm:^5.3.0"
     cytoscape: "npm:^3.33.1"
     cytoscape-cose-bilkent: "npm:^4.1.0"
     diff: "npm:^5.1.0"


### PR DESCRIPTION
## Summary
- add `cron-parser` dependency
- implement `getNextRunTimes` to compute upcoming cron schedule occurrences
- add CLI helper script and unit test

## Testing
- `yarn test __tests__/cron.test.ts`
- `yarn lint utils/cron.ts scripts/cron-next-run.mjs __tests__/cron.test.ts` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b204c27d408328aa37e868d8778d4e