### PR TITLE
Add MD5 hashing example and worker support

### DIFF
--- a/__tests__/hash-example.test.ts
+++ b/__tests__/hash-example.test.ts
@@ -1,0 +1,32 @@
+import { createMD5, createSHA1 } from 'hash-wasm';
+
+describe('hash-wasm algorithms', () => {
+  it('computes MD5 and SHA-1 for sample entries', async () => {
+    const samples: Record<string, { md5: string; sha1: string }> = {
+      hello: {
+        md5: '5d41402abc4b2a76b9719d911017c592',
+        sha1: 'aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d',
+      },
+      world: {
+        md5: '7d793037a0760186574b0282f2f435e7',
+        sha1: '7c211433f02071597741e6ff5a8ea34789abbf43',
+      },
+    };
+
+    const md5 = await createMD5();
+    const sha1 = await createSHA1();
+
+    for (const [text, expected] of Object.entries(samples)) {
+      md5.init();
+      md5.update(text);
+      const md5Result = md5.digest('hex');
+
+      sha1.init();
+      sha1.update(text);
+      const sha1Result = sha1.digest('hex');
+
+      expect(md5Result).toBe(expected.md5);
+      expect(sha1Result).toBe(expected.sha1);
+    }
+  });
+});

--- a/components/apps/converter/HashConverter.js
+++ b/components/apps/converter/HashConverter.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 
 const algorithms = [
+  'MD5',
   'SHA-1',
   'SHA-256',
   'SHA-384',

--- a/scripts/examples/hash.ts
+++ b/scripts/examples/hash.ts
@@ -1,0 +1,21 @@
+import { createMD5, createSHA1 } from 'hash-wasm';
+
+export async function hashExample() {
+  const samples = ['hello', 'world'];
+  const md5 = await createMD5();
+  const sha1 = await createSHA1();
+
+  for (const text of samples) {
+    md5.init();
+    md5.update(text);
+    const md5Digest = md5.digest('hex');
+
+    sha1.init();
+    sha1.update(text);
+    const sha1Digest = sha1.digest('hex');
+
+    console.log(`${text}: MD5=${md5Digest} SHA-1=${sha1Digest}`);
+  }
+}
+
+hashExample();

--- a/workers/hash-worker.ts
+++ b/workers/hash-worker.ts
@@ -1,4 +1,5 @@
 import {
+  createMD5,
   createSHA1,
   createSHA256,
   createSHA384,
@@ -9,6 +10,7 @@ import {
 } from 'hash-wasm';
 
 export type Algorithm =
+  | 'MD5'
   | 'SHA-1'
   | 'SHA-256'
   | 'SHA-384'
@@ -47,6 +49,9 @@ self.onmessage = async ({ data }: MessageEvent<HashWorkerRequest>) => {
 
     for (const alg of algorithms) {
       switch (alg) {
+        case 'MD5':
+          hashers[alg] = await createMD5();
+          break;
         case 'SHA-1':
           hashers[alg] = await createSHA1();
           break;
@@ -111,6 +116,9 @@ self.onmessage = async ({ data }: MessageEvent<HashWorkerRequest>) => {
     const hashers: Record<string, any> = {};
     for (const alg of hashAlgs) {
       switch (alg) {
+        case 'MD5':
+          hashers[alg] = await createMD5();
+          break;
         case 'SHA-1':
           hashers[alg] = await createSHA1();
           break;


### PR DESCRIPTION
## Summary
- include MD5 in hash converter algorithms and worker logic
- add example script to log MD5 and SHA-1 for sample strings
- add unit test verifying MD5 and SHA-1 digests

## Testing
- `npm test` *(fails: beef, niktoPage, calculator parser, mimikatz, battleship-net, kismet, snake.config, frogger.config, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b204c80fb48328bc2da44b7559c3df