### PR TITLE
feat(qr): store last scans and generations

### DIFF
--- a/__tests__/qrLast.test.ts
+++ b/__tests__/qrLast.test.ts
@@ -1,0 +1,22 @@
+import {
+  loadLastGeneration,
+  loadLastScan,
+  saveLastGeneration,
+  saveLastScan,
+} from '../utils/qrStorage';
+
+describe('qr last storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves and loads last scan', () => {
+    saveLastScan('foo');
+    expect(loadLastScan()).toBe('foo');
+  });
+
+  it('saves and loads last generation', () => {
+    saveLastGeneration('bar');
+    expect(loadLastGeneration()).toBe('bar');
+  });
+});

--- a/apps/qr/index.tsx
+++ b/apps/qr/index.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import QRCode from 'qrcode';
 import Presets from './components/Presets';
 import Scan from './components/Scan';
+import {
+  loadLastGeneration,
+  loadLastScan,
+  saveLastGeneration,
+  saveLastScan,
+} from '../../utils/qrStorage';
 
 export default function QR() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -11,6 +17,27 @@ export default function QR() {
   const [mode, setMode] = useState<'generate' | 'scan'>('generate');
   const [size, setSize] = useState(256);
   const [scanResult, setScanResult] = useState('');
+  const [lastGen, setLastGen] = useState('');
+  const [lastScan, setLastScan] = useState('');
+
+  useEffect(() => {
+    setLastGen(loadLastGeneration());
+    setLastScan(loadLastScan());
+  }, []);
+
+  useEffect(() => {
+    if (payload) {
+      saveLastGeneration(payload);
+      setLastGen(payload);
+    }
+  }, [payload]);
+
+  useEffect(() => {
+    if (scanResult) {
+      saveLastScan(scanResult);
+      setLastScan(scanResult);
+    }
+  }, [scanResult]);
 
   const downloadPng = useCallback(async () => {
     if (!payload) return;
@@ -129,12 +156,27 @@ export default function QR() {
         </>
       )}
 
-      {mode === 'scan' && scanResult && (
+      {lastScan && (
         <div className="space-y-2">
-          <p className="break-all text-sm">{scanResult}</p>
+          <p className="text-xs text-gray-300">Last scan</p>
+          <p className="break-all text-sm">{lastScan}</p>
           <button
             type="button"
-            onClick={() => navigator.clipboard?.writeText(scanResult)}
+            onClick={() => navigator.clipboard?.writeText(lastScan)}
+            className="px-2 py-1 bg-blue-600 rounded"
+          >
+            Copy
+          </button>
+        </div>
+      )}
+
+      {lastGen && (
+        <div className="space-y-2">
+          <p className="text-xs text-gray-300">Last generation</p>
+          <p className="break-all text-sm">{lastGen}</p>
+          <button
+            type="button"
+            onClick={() => navigator.clipboard?.writeText(lastGen)}
             className="px-2 py-1 bg-blue-600 rounded"
           >
             Copy

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -1,4 +1,6 @@
 const STORAGE_KEY = 'qrScans';
+const LAST_SCAN_KEY = 'qrLastScan';
+const LAST_GEN_KEY = 'qrLastGeneration';
 const FILE_NAME = 'qr-scans.json';
 
 const hasOpfs =
@@ -50,4 +52,24 @@ export const clearScans = async (): Promise<void> => {
     return;
   }
   localStorage.removeItem(STORAGE_KEY);
+};
+
+export const loadLastScan = (): string => {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem(LAST_SCAN_KEY) || '';
+};
+
+export const saveLastScan = (scan: string): void => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(LAST_SCAN_KEY, scan);
+};
+
+export const loadLastGeneration = (): string => {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem(LAST_GEN_KEY) || '';
+};
+
+export const saveLastGeneration = (payload: string): void => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(LAST_GEN_KEY, payload);
 };


### PR DESCRIPTION
## Summary
- persist last QR scan and generation in localStorage with quick copy buttons
- expose helpers to load/save last entries
- cover new QR storage helpers with unit tests

## Testing
- `npm test` *(fails: __tests__/beef.test.tsx, __tests__/niktoPage.test.tsx, __tests__/calculator/parser.test.ts, __tests__/game2048.test.ts, __tests__/mimikatz.test.ts, __tests__/kismet.test.tsx, __tests__/snake.config.test.ts, and others)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*


------
https://chatgpt.com/codex/tasks/task_e_68b204cadfe08328a5779dfb8f83e11c