### PR TITLE
feat: add QR generator forms with download options

### DIFF
--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,12 +1,33 @@
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
+import Tabs from '../../components/Tabs';
 import FormError from '../../components/ui/FormError';
 import { clearScans, loadScans, saveScans } from '../../utils/qrStorage';
 
+const tabs = [
+  { id: 'text', label: 'Text' },
+  { id: 'url', label: 'URL' },
+  { id: 'wifi', label: 'Wi-Fi' },
+  { id: 'vcard', label: 'vCard' },
+] as const;
+
+type TabId = (typeof tabs)[number]['id'];
+
 const QRPage: React.FC = () => {
+  const [active, setActive] = useState<TabId>('text');
   const [text, setText] = useState('');
-  const [qrUrl, setQrUrl] = useState('');
+  const [url, setUrl] = useState('');
+  const [ssid, setSsid] = useState('');
+  const [wifiPassword, setWifiPassword] = useState('');
+  const [wifiType, setWifiType] = useState('WPA');
+  const [vName, setVName] = useState('');
+  const [vOrg, setVOrg] = useState('');
+  const [vPhone, setVPhone] = useState('');
+  const [vEmail, setVEmail] = useState('');
+  const [qrPng, setQrPng] = useState('');
+  const [qrSvg, setQrSvg] = useState('');
+  const [fileName, setFileName] = useState('qr');
   const [scanResult, setScanResult] = useState('');
   const [batch, setBatch] = useState<string[]>([]);
   const [error, setError] = useState('');
@@ -15,13 +36,78 @@ const QRPage: React.FC = () => {
 
   const generateQr = async (e: React.FormEvent) => {
     e.preventDefault();
+    let data = '';
+    let name = 'qr';
+    switch (active) {
+      case 'text':
+        data = text;
+        name = 'text';
+        break;
+      case 'url':
+        data = url;
+        name = 'url';
+        break;
+      case 'wifi':
+        data = `WIFI:T:${wifiType};S:${ssid};P:${wifiPassword};;`;
+        name = 'wifi';
+        break;
+      case 'vcard': {
+        const parts = vName.trim().split(' ');
+        const first = parts.shift() || '';
+        const last = parts.pop() || '';
+        const middle = parts.join(' ');
+        const lines = [
+          'BEGIN:VCARD',
+          'VERSION:3.0',
+          `N:${last};${first};${middle};;`,
+          `FN:${vName}`,
+        ];
+        if (vOrg) lines.push(`ORG:${vOrg}`);
+        if (vPhone) lines.push(`TEL;TYPE=CELL:${vPhone}`);
+        if (vEmail) lines.push(`EMAIL:${vEmail}`);
+        lines.push('END:VCARD');
+        data = lines.join('\n');
+        name = 'vcard';
+        break;
+      }
+    }
+    if (!data) {
+      setError('Please fill in required fields');
+      setQrPng('');
+      setQrSvg('');
+      return;
+    }
     try {
-      const url = await QRCode.toDataURL(text);
-      setQrUrl(url);
+      const png = await QRCode.toDataURL(data);
+      const svg = await QRCode.toString(data, { type: 'svg' });
+      setQrPng(png);
+      setQrSvg(svg);
+      setFileName(name);
       setError('');
     } catch {
       setError('Failed to generate QR code');
+      setQrPng('');
+      setQrSvg('');
     }
+  };
+
+  const downloadPng = () => {
+    if (!qrPng) return;
+    const a = document.createElement('a');
+    a.href = qrPng;
+    a.download = `${fileName}.png`;
+    a.click();
+  };
+
+  const downloadSvg = () => {
+    if (!qrSvg) return;
+    const blob = new Blob([qrSvg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${fileName}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   useEffect(() => {
@@ -100,28 +186,160 @@ const QRPage: React.FC = () => {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-4">
-      <form onSubmit={generateQr} className="w-full max-w-md">
-        <label className="mb-2 block text-sm font-medium" htmlFor="qr-text">
-          Text to encode
-        </label>
-        <input
-          id="qr-text"
-          type="text"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          className="mb-4 w-full rounded border p-2"
+      <div className="w-full max-w-md">
+        <Tabs
+          tabs={tabs}
+          active={active}
+          onChange={setActive}
+          className="mb-4 justify-center"
         />
-        <button
-          type="submit"
-          className="w-full rounded bg-blue-600 p-2 text-white"
-        >
-          Generate QR
-        </button>
-      </form>
-      {error && <FormError className="mt-0">{error}</FormError>}
-      {qrUrl && (
-        <img src={qrUrl} alt="Generated QR code" className="h-48 w-48" />
-      )}
+        {active === 'text' && (
+          <form onSubmit={generateQr} className="space-y-2">
+            <label className="block text-sm" htmlFor="qr-text">
+              Text
+            </label>
+            <input
+              id="qr-text"
+              type="text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              className="w-full rounded border p-2"
+            />
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 p-2 text-white"
+            >
+              Generate
+            </button>
+          </form>
+        )}
+        {active === 'url' && (
+          <form onSubmit={generateQr} className="space-y-2">
+            <label className="block text-sm" htmlFor="qr-url">
+              URL
+            </label>
+            <input
+              id="qr-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              className="w-full rounded border p-2"
+            />
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 p-2 text-white"
+            >
+              Generate
+            </button>
+          </form>
+        )}
+        {active === 'wifi' && (
+          <form onSubmit={generateQr} className="space-y-2">
+            <label className="block text-sm">
+              SSID
+              <input
+                type="text"
+                value={ssid}
+                onChange={(e) => setSsid(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <label className="block text-sm">
+              Password
+              <input
+                type="text"
+                value={wifiPassword}
+                onChange={(e) => setWifiPassword(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <label className="block text-sm">
+              Encryption
+              <select
+                value={wifiType}
+                onChange={(e) => setWifiType(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              >
+                <option value="WPA">WPA/WPA2</option>
+                <option value="WEP">WEP</option>
+                <option value="nopass">None</option>
+              </select>
+            </label>
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 p-2 text-white"
+            >
+              Generate
+            </button>
+          </form>
+        )}
+        {active === 'vcard' && (
+          <form onSubmit={generateQr} className="space-y-2">
+            <label className="block text-sm">
+              Full Name
+              <input
+                type="text"
+                value={vName}
+                onChange={(e) => setVName(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <label className="block text-sm">
+              Organization
+              <input
+                type="text"
+                value={vOrg}
+                onChange={(e) => setVOrg(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <label className="block text-sm">
+              Phone
+              <input
+                type="tel"
+                value={vPhone}
+                onChange={(e) => setVPhone(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <label className="block text-sm">
+              Email
+              <input
+                type="email"
+                value={vEmail}
+                onChange={(e) => setVEmail(e.target.value)}
+                className="mt-1 w-full rounded border p-2"
+              />
+            </label>
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 p-2 text-white"
+            >
+              Generate
+            </button>
+          </form>
+        )}
+        {error && <FormError className="mt-2">{error}</FormError>}
+        {qrPng && (
+          <div className="mt-4 flex flex-col items-center gap-2">
+            <img src={qrPng} alt="Generated QR code" className="h-48 w-48" />
+            <div className="flex gap-2">
+              <button
+                onClick={downloadPng}
+                className="rounded bg-blue-600 p-2 text-white"
+              >
+                Download PNG
+              </button>
+              <button
+                onClick={downloadSvg}
+                className="rounded bg-green-600 p-2 text-white"
+              >
+                Download SVG
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
       <div className="w-full max-w-md">
         <video ref={videoRef} className="h-48 w-full rounded border" />
         {scanResult && (

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -7,7 +7,8 @@ const VCardPage: React.FC = () => {
   const [phone, setPhone] = useState('');
   const [email, setEmail] = useState('');
   const [vcard, setVcard] = useState('');
-  const [qr, setQr] = useState('');
+  const [png, setPng] = useState('');
+  const [svg, setSvg] = useState('');
 
   useEffect(() => {
     if (!name && !org && !phone && !email) {
@@ -33,20 +34,35 @@ const VCardPage: React.FC = () => {
 
   useEffect(() => {
     if (!vcard) {
-      setQr('');
+      setPng('');
+      setSvg('');
       return;
     }
     QRCode.toDataURL(vcard, { margin: 1 })
-      .then(setQr)
-      .catch(() => setQr(''));
+      .then(setPng)
+      .catch(() => setPng(''));
+    QRCode.toString(vcard, { type: 'svg', margin: 1 })
+      .then(setSvg)
+      .catch(() => setSvg(''));
   }, [vcard]);
 
   const downloadPng = () => {
-    if (!qr) return;
+    if (!png) return;
     const link = document.createElement('a');
-    link.href = qr;
+    link.href = png;
     link.download = 'vcard.png';
     link.click();
+  };
+
+  const downloadSvg = () => {
+    if (!svg) return;
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'vcard.svg';
+    link.click();
+    URL.revokeObjectURL(url);
   };
 
   return (
@@ -92,14 +108,23 @@ const VCardPage: React.FC = () => {
       {vcard && (
         <div className="flex flex-col items-center gap-2">
           <pre className="whitespace-pre-wrap break-all text-xs">{vcard}</pre>
-          {qr && <img src={qr} alt="vCard QR" className="h-48 w-48" />}
-          <button
-            type="button"
-            onClick={downloadPng}
-            className="rounded bg-blue-600 p-2 text-white"
-          >
-            Download
-          </button>
+          {png && <img src={png} alt="vCard QR" className="h-48 w-48" />}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={downloadPng}
+              className="rounded bg-blue-600 p-2 text-white"
+            >
+              Download PNG
+            </button>
+            <button
+              type="button"
+              onClick={downloadSvg}
+              className="rounded bg-green-600 p-2 text-white"
+            >
+              Download SVG
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add tabbed QR code generator with Text, URL, Wi-Fi, and vCard forms
- enable downloading generated codes as PNG or SVG
- extend vCard generator with SVG export option

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: failing suites such as beef, game2048, niktoPage, kismet, mimikatz, frogger.config, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b204cd16a0832888878ac039ab1c7c