### PR TITLE
feat: filter findings by severity and path prefix

### DIFF
--- a/__tests__/niktoApp.test.tsx
+++ b/__tests__/niktoApp.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import NiktoApp from '../components/apps/nikto';
 
 describe('NiktoApp', () => {
@@ -13,5 +14,30 @@ describe('NiktoApp', () => {
     fireEvent.drop(zone, { dataTransfer: { files: [file] } });
     expect(await screen.findByText('example.com')).toBeInTheDocument();
     expect(screen.getByText('/admin')).toBeInTheDocument();
+  });
+
+  it('filters entries by severity and path prefix', async () => {
+    const user = userEvent.setup();
+    render(<NiktoApp />);
+    const zone = screen.getByTestId('drop-zone');
+    const file = {
+      name: 'report.txt',
+      text: () =>
+        Promise.resolve(
+          'Host: example.com\n/admin High\n/cgi-bin/test Medium'
+        ),
+    } as any;
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+    await screen.findByText('/admin');
+    await user.type(
+      screen.getByPlaceholderText(/filter path/i),
+      '/cgi'
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/filter severity/i),
+      'Medium'
+    );
+    expect(screen.queryByText('/admin')).not.toBeInTheDocument();
+    expect(screen.getByText('/cgi-bin/test')).toBeInTheDocument();
   });
 });

--- a/__tests__/niktoReport.test.tsx
+++ b/__tests__/niktoReport.test.tsx
@@ -35,7 +35,7 @@ describe('NiktoReport', () => {
     await screen.findByText('/admin');
     expect(screen.getAllByRole('row')).toHaveLength(3);
 
-    await user.type(screen.getByPlaceholderText(/filter by path/i), 'cgi');
+    await user.type(screen.getByPlaceholderText(/filter by path/i), '/cgi');
     expect(screen.queryByText('/admin')).not.toBeInTheDocument();
 
     await user.clear(screen.getByPlaceholderText(/filter by path/i));

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -16,6 +16,7 @@ const NiktoApp = () => {
   const [entries, setEntries] = useState([]);
   const [filterHost, setFilterHost] = useState('');
   const [filterPath, setFilterPath] = useState('');
+  const [filterSeverity, setFilterSeverity] = useState('All');
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -134,9 +135,11 @@ const NiktoApp = () => {
     return entries.filter(
       (e) =>
         e.host.toLowerCase().includes(filterHost.toLowerCase()) &&
-        e.path.toLowerCase().includes(filterPath.toLowerCase())
+        e.path.toLowerCase().startsWith(filterPath.toLowerCase()) &&
+        (filterSeverity === 'All' ||
+          e.severity.toLowerCase() === filterSeverity.toLowerCase())
     );
-  }, [entries, filterHost, filterPath]);
+  }, [entries, filterHost, filterPath, filterSeverity]);
 
   const exportCsv = () => {
     const rows = [
@@ -314,6 +317,20 @@ const NiktoApp = () => {
                 onChange={(e) => setFilterPath(e.target.value)}
                 className="p-1 rounded text-black flex-1"
               />
+              <select
+                aria-label="Filter severity"
+                value={filterSeverity}
+                onChange={(e) => setFilterSeverity(e.target.value)}
+                className="p-1 rounded text-black"
+              >
+                {['All', 'Info', 'Low', 'Medium', 'High', 'Critical'].map(
+                  (s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  )
+                )}
+              </select>
               <button
                 type="button"
                 onClick={exportCsv}

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -32,7 +32,7 @@ const NiktoReport: React.FC = () => {
       findings.filter(
         (f) =>
           (severity === 'All' || f.severity.toLowerCase() === severity.toLowerCase()) &&
-          f.path.toLowerCase().includes(pathFilter.toLowerCase())
+          f.path.toLowerCase().startsWith(pathFilter.toLowerCase())
       ),
     [findings, severity, pathFilter]
   );


### PR DESCRIPTION
## Summary
- allow Nikto parser results to filter by severity and path prefix
- match Nikto report paths using prefix
- test filtering behavior

## Testing
- `npm test __tests__/niktoReport.test.tsx __tests__/niktoApp.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b204cd7f9483289d8e00184fd984a4