### PR TITLE
feat: add copyable html report

### DIFF
--- a/__tests__/ReportExport.test.tsx
+++ b/__tests__/ReportExport.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ReportExport from '../apps/autopsy/components/ReportExport';
+
+describe('ReportExport', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('copies html report to clipboard', async () => {
+    render(
+      <ReportExport
+        caseName="demo"
+        artifacts={[
+          {
+            name: 'file',
+            type: 'txt',
+            description: 'desc',
+            size: 1,
+            plugin: 'p',
+            timestamp: '2023-01-01',
+          },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByText('Copy HTML Report'));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalled()
+    );
+    expect((navigator.clipboard.writeText as jest.Mock).mock.calls[0][0]).toContain('<!DOCTYPE html>');
+  });
+});

--- a/apps/autopsy/components/ReportExport.tsx
+++ b/apps/autopsy/components/ReportExport.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import copyToClipboard from '../../../utils/clipboard';
 
 interface Artifact {
   name: string;
@@ -45,13 +46,25 @@ const ReportExport: React.FC<ReportExportProps> = ({ caseName = 'case', artifact
     URL.revokeObjectURL(url);
   };
 
+  const copyReport = () => {
+    copyToClipboard(htmlReport);
+  };
+
   return (
-    <button
-      onClick={exportReport}
-      className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
-    >
-      Download HTML Report
-    </button>
+    <div className="flex gap-2">
+      <button
+        onClick={copyReport}
+        className="bg-ub-gray px-3 py-1 rounded text-sm text-black"
+      >
+        Copy HTML Report
+      </button>
+      <button
+        onClick={exportReport}
+        className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
+      >
+        Download HTML Report
+      </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow autopsy report exports to be copied or downloaded
- add test covering copy-to-clipboard export

## Testing
- `npm test __tests__/ReportExport.test.tsx`
- `npm test __tests__/beef.test.tsx` *(fails: Unable to find an element with the text: 1)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68b204cf34dc832897defc2b160695d8