### PR TITLE
feat(calc): add user formulas with validation

### DIFF
--- a/__tests__/calculator.formulas.test.ts
+++ b/__tests__/calculator.formulas.test.ts
@@ -1,0 +1,14 @@
+import { validateFormula } from '../apps/calculator/formulas';
+
+global.math = require('mathjs');
+
+describe('formula validation', () => {
+  test('accepts valid expressions', () => {
+    expect(validateFormula('2+2')).toBe(true);
+  });
+
+  test('rejects invalid expressions', () => {
+    expect(validateFormula('2++2')).toBe(false);
+  });
+});
+

--- a/apps/calculator/components/FormulaEditor.tsx
+++ b/apps/calculator/components/FormulaEditor.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useFormulas, validateFormula, Formula } from '../formulas';
+
+export default function FormulaEditor() {
+  const [formulas, setFormulas] = useFormulas();
+  const [name, setName] = useState('');
+  const [expr, setExpr] = useState('');
+  const [error, setError] = useState('');
+
+  const save = () => {
+    if (!name.trim() || !expr.trim()) {
+      setError('Name and expression required');
+      return;
+    }
+    if (!validateFormula(expr)) {
+      setError('Invalid formula');
+      return;
+    }
+    setFormulas([...formulas, { name: name.trim(), expr }]);
+    setName('');
+    setExpr('');
+    setError('');
+  };
+
+  const insert = (f: Formula) => {
+    const display = document.getElementById('display') as HTMLInputElement | null;
+    if (display) {
+      const start = display.selectionStart ?? display.value.length;
+      const end = display.selectionEnd ?? display.value.length;
+      display.value = display.value.slice(0, start) + f.expr + display.value.slice(end);
+      const pos = start + f.expr.length;
+      display.selectionStart = display.selectionEnd = pos;
+      display.focus();
+    }
+  };
+
+  return (
+    <div id="formulas" className="formulas hidden">
+      <div className="space-y-1">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          className="h-8 w-full"
+        />
+        <input
+          value={expr}
+          onChange={(e) => setExpr(e.target.value)}
+          placeholder="Expression"
+          className="h-8 w-full"
+        />
+        <button onClick={save} className="btn h-8 w-full">
+          Save
+        </button>
+        {error && <div className="text-red-500">{error}</div>}
+      </div>
+      <ul>
+        {formulas.map((f, i) => (
+          <li key={i}>
+            <button onClick={() => insert(f)}>{f.name}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/calculator/formulas.ts
+++ b/apps/calculator/formulas.ts
@@ -1,0 +1,29 @@
+import usePersistentState from '../../hooks/usePersistentState';
+import { evaluate } from './main';
+
+export interface Formula {
+  name: string;
+  expr: string;
+}
+
+export const FORMULAS_KEY = 'calc-formulas';
+
+export function useFormulas() {
+  return usePersistentState<Formula[]>(
+    FORMULAS_KEY,
+    () => [],
+    (v): v is Formula[] =>
+      Array.isArray(v) &&
+      v.every((f) => typeof f?.name === 'string' && typeof f?.expr === 'string'),
+  );
+}
+
+export function validateFormula(expr: string): boolean {
+  try {
+    evaluate(expr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -4,6 +4,7 @@ import usePersistentState from '../../hooks/usePersistentState';
 import ModeSwitcher from './components/ModeSwitcher';
 import './styles.css';
 import MemorySlots from './components/MemorySlots';
+import FormulaEditor from './components/FormulaEditor';
 
 export default function Calculator() {
   const HISTORY_LIMIT = 10;
@@ -56,6 +57,8 @@ export default function Calculator() {
       const buttons = document.querySelectorAll<HTMLButtonElement>('.btn');
       const historyToggle = document.getElementById('toggle-history');
       const historyEl = document.getElementById('history');
+      const formulasToggle = document.getElementById('toggle-formulas');
+      const formulasEl = document.getElementById('formulas');
       const baseSelect = document.getElementById('base-select') as HTMLSelectElement | null;
 
       const insertAtCursor = (text: string) => {
@@ -166,6 +169,10 @@ export default function Calculator() {
         historyEl?.classList.toggle('hidden');
       });
 
+      formulasToggle?.addEventListener('click', () => {
+        formulasEl?.classList.toggle('hidden');
+      });
+
       baseSelect?.addEventListener('change', () => {
         setBase(parseInt(baseSelect.value, 10));
       });
@@ -189,6 +196,7 @@ export default function Calculator() {
       <button id="toggle-scientific" className="toggle h-12" aria-pressed="false" aria-label="toggle scientific mode">Scientific</button>
       <button id="toggle-programmer" className="toggle h-12" aria-pressed="false" aria-label="toggle programmer mode">Programmer</button>
       <button id="toggle-history" className="toggle h-12" aria-pressed="false" aria-label="toggle history">History</button>
+      <button id="toggle-formulas" className="toggle h-12" aria-pressed="false" aria-label="toggle formulas">Formulas</button>
       <div className="memory-grid grid grid-cols-3 !gap-1" aria-label="memory functions">
         <button className={btnCls} data-action="mplus" aria-label="add to memory">M+</button>
         <button className={btnCls} data-action="mminus" aria-label="subtract from memory">M&minus;</button>
@@ -212,8 +220,8 @@ export default function Calculator() {
         <button className={btnCls} data-value="." data-key="." aria-label="decimal point">.</button>
         <button className={btnCls} data-action="equals" data-key="= Enter" aria-label="equals">=</button>
         <button className={btnCls} data-value="+" data-key="+" aria-label="add">+</button>
-        <button className={`${btnCls} span-two w-full`} data-action="clear" data-key="Escape c" aria-label="clear">C</button>
-        <button className={`${btnCls} span-two w-full`} data-action="backspace" data-key="Backspace" aria-label="backspace">⌫</button>
+      <button className={`${btnCls} span-two w-full`} data-action="clear" data-key="Escape c" aria-label="clear">C</button>
+      <button className={`${btnCls} span-two w-full`} data-action="backspace" data-key="Backspace" aria-label="backspace">⌫</button>
       </div>
       <div id="scientific" className="scientific hidden grid grid-cols-3 !gap-1" aria-label="scientific functions">
         <button className={btnCls} data-value="sin(" aria-label="sine">sin</button>
@@ -240,6 +248,7 @@ export default function Calculator() {
       <button id="print-tape" className={btnCls} data-action="print" aria-label="print tape">Print</button>
         <div id="paren-indicator" />
       </div>
+      <FormulaEditor />
       <div id="history" className="history hidden" aria-live="polite">
         {history.map(({ expr, result }, i) => (
           <div key={i} className="history-entry">


### PR DESCRIPTION
## Summary
- add persistent formula storage with validation
- provide FormulaEditor UI to create and insert saved formulas
- wire formulas toggle into calculator

## Testing
- `yarn test` *(fails: game2048, niktoPage, beef, calculator parser)*

------
https://chatgpt.com/codex/tasks/task_e_68b204d67f948328a9bbf69d2c3ff023