### PR TITLE
feat(trash): handle name conflicts on restore

### DIFF
--- a/__tests__/trashState.test.ts
+++ b/__tests__/trashState.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import useTrashState, { TrashItem } from '../apps/trash/state';
+
+describe('useTrashState restoreFromHistory', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('renames on conflict when confirmed', () => {
+    const { result } = renderHook(() => useTrashState());
+    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
+    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
+
+    act(() => {
+      result.current.setItems([existing]);
+      result.current.pushHistory(fromHistory);
+    });
+
+    const confirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const prompt = jest
+      .spyOn(window, 'prompt')
+      .mockReturnValue('App (1)');
+
+    act(() => {
+      result.current.restoreFromHistory(0);
+    });
+
+    expect(result.current.items).toEqual([
+      existing,
+      { ...fromHistory, title: 'App (1)' },
+    ]);
+
+    confirm.mockRestore();
+    prompt.mockRestore();
+  });
+
+  test('replaces on confirm', () => {
+    const { result } = renderHook(() => useTrashState());
+    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
+    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
+
+    act(() => {
+      result.current.setItems([existing]);
+      result.current.pushHistory(fromHistory);
+    });
+
+    const confirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    act(() => {
+      result.current.restoreFromHistory(0);
+    });
+
+    expect(result.current.items).toEqual([{ ...fromHistory }]);
+
+    confirm.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- prompt to rename or replace when restoring items with duplicate titles
- add tests covering rename and replace behavior on history restore

## Testing
- `yarn lint apps/trash/state.ts __tests__/trashState.test.ts` (fails: ESLint couldn't find configuration file)
- `yarn test` (fails: 10 failed, 2 skipped, 99 passed, 109 total)
- `yarn test __tests__/trashState.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b204d97c608328a3a82e4b53d28bc3