### PR TITLE
feat(trash): add filtering options

### DIFF
--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import useTrashState from './state';
 import HistoryList from './components/HistoryList';
-import type { TrashItem } from './state';
 
 const DEFAULT_ICON = './themes/Yaru/system/folder.png';
 
@@ -17,6 +16,9 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     restoreAllFromHistory,
   } = useTrashState();
   const [selected, setSelected] = useState<number | null>(null);
+  const [search, setSearch] = useState('');
+  const [type, setType] = useState('');
+  const [date, setDate] = useState('');
 
   const notifyChange = () => window.dispatchEvent(new Event('trash-change'));
 
@@ -88,6 +90,32 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     notifyChange();
   }, [restoreAllFromHistory]);
 
+  const types = useMemo(() => {
+    const map = new Map<string, string>();
+    items.forEach(item => {
+      if (!map.has(item.id)) map.set(item.id, item.title);
+    });
+    return Array.from(map.entries());
+  }, [items]);
+
+  const formatDate = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+  const filtered = useMemo(
+    () =>
+      items
+        .map((item, index) => ({ item, index }))
+        .filter(({ item }) =>
+          (!type || item.id === type) &&
+          (!date || formatDate(item.closedAt) === date) &&
+          (search === '' || item.title.toLowerCase().includes(search.toLowerCase())),
+        ),
+    [items, type, date, search],
+  );
+
+  useEffect(() => {
+    setSelected(null);
+  }, [search, type, date]);
+
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
       <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
@@ -125,6 +153,36 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           </button>
         </div>
       </div>
+      <div className="p-2 flex flex-wrap gap-2 bg-ub-cool-grey">
+        <input
+          aria-label="Search"
+          type="search"
+          placeholder="Search..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="px-2 py-1 text-black"
+        />
+        <select
+          aria-label="Type filter"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="px-2 py-1 text-black"
+        >
+          <option value="">All Types</option>
+          {types.map(([id, title]) => (
+            <option key={id} value={id}>
+              {title}
+            </option>
+          ))}
+        </select>
+        <input
+          aria-label="Deletion date"
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="px-2 py-1 text-black"
+        />
+      </div>
       <div className="flex-1 overflow-auto">
         {items.length === 0 ? (
           <div className="flex flex-col items-center justify-center mt-12 space-y-1.5">
@@ -135,14 +193,16 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             />
             <span>Trash is empty</span>
           </div>
+        ) : filtered.length === 0 ? (
+          <div className="p-2">No items match your filters.</div>
         ) : (
           <ul className="p-2 space-y-1.5">
-            {items.map((item, idx) => (
+            {filtered.map(({ item, index }) => (
               <li
                 key={item.closedAt}
                 tabIndex={0}
-                onClick={() => setSelected(idx)}
-                className={`flex items-center p-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
+                onClick={() => setSelected(index)}
+                className={`flex items-center p-1 cursor-pointer ${selected === index ? 'bg-ub-drk-abrgn' : ''}`}
               >
                 <img
                   src={item.icon || DEFAULT_ICON}


### PR DESCRIPTION
## Summary
- add type, date and search filters to trash

## Testing
- `npm test` *(fails: BeEF app, NiktoPage, calculator parser, game2048, mimikatz, kismet, snake config)*

------
https://chatgpt.com/codex/tasks/task_e_68b204dbb9048328a877dc4d6ec4e677