### PR TITLE
feat: compare two projects

### DIFF
--- a/__tests__/projectGallery.test.tsx
+++ b/__tests__/projectGallery.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import ProjectGallery from '../components/apps/project-gallery';
 
 jest.mock('react-ga4', () => ({ event: jest.fn() }));
@@ -74,5 +74,26 @@ describe('ProjectGallery', () => {
     render(<ProjectGallery />);
     await screen.findByText('Beta');
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+  });
+
+  it('compares two projects side-by-side', async () => {
+    render(<ProjectGallery />);
+    await screen.findByText('Alpha');
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select Alpha for comparison' })
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select Beta for comparison' })
+    );
+    const table = await screen.findByRole('table');
+    const tbl = within(table);
+    expect(tbl.getByText('Alpha')).toBeInTheDocument();
+    expect(tbl.getByText('Beta')).toBeInTheDocument();
+    expect(tbl.getByText('Stack')).toBeInTheDocument();
+    expect(tbl.getByText('Highlights')).toBeInTheDocument();
+    expect(tbl.getByText('JS')).toBeInTheDocument();
+    expect(tbl.getByText('TS')).toBeInTheDocument();
+    expect(tbl.getByText('frontend, react')).toBeInTheDocument();
+    expect(tbl.getByText('backend')).toBeInTheDocument();
   });
 });

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -34,6 +34,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   const [type, setType] = useState('');
   const [tags, setTags] = useState<string[]>([]);
   const [ariaMessage, setAriaMessage] = useState('');
+  const [selected, setSelected] = useState<Project[]>([]);
 
   const readFilters = async () => {
     try {
@@ -144,6 +145,15 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
     openApp && openApp('chrome');
   };
 
+  const toggleSelect = (project: Project) => {
+    setSelected((prev) => {
+      const exists = prev.find((p) => p.id === project.id);
+      if (exists) return prev.filter((p) => p.id !== project.id);
+      if (prev.length === 2) return [prev[1], project];
+      return [...prev, project];
+    });
+  };
+
   return (
     <div className="p-4 h-full overflow-auto bg-ub-cool-grey text-white">
       <div className="flex flex-wrap gap-2 mb-4">
@@ -215,6 +225,34 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
           </label>
         ))}
       </div>
+      {selected.length === 2 && (
+        <div className="mb-4 overflow-auto">
+          <table className="w-full text-sm text-left" role="table">
+            <thead>
+              <tr>
+                <th />
+                {selected.map((p) => (
+                  <th key={p.id}>{p.title}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>Stack</th>
+                {selected.map((p) => (
+                  <td key={`${p.id}-stack`}>{p.stack.join(', ')}</td>
+                ))}
+              </tr>
+              <tr>
+                <th>Highlights</th>
+                {selected.map((p) => (
+                  <td key={`${p.id}-tags`}>{p.tags.join(', ')}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
       <div className="columns-1 sm:columns-2 md:columns-3 gap-4">
         {filtered.map((project) => (
           <div
@@ -241,6 +279,15 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
             <div className="p-4 space-y-2">
               <h3 className="text-lg font-semibold">{project.title}</h3>
               <p className="text-sm">{project.description}</p>
+              <button
+                onClick={() => toggleSelect(project)}
+                aria-label={`Select ${project.title} for comparison`}
+                className="bg-gray-700 text-xs px-2 py-1 rounded-full"
+              >
+                {selected.some((p) => p.id === project.id)
+                  ? 'Deselect'
+                  : 'Compare'}
+              </button>
               <div className="flex flex-wrap gap-1">
                 {project.stack.map((s) => (
                   <button


### PR DESCRIPTION
## Summary
- allow selecting up to two projects and toggle them for side-by-side comparison
- display stacks and highlights for chosen projects in a comparison table
- test project comparison workflow

## Testing
- `npm test __tests__/projectGallery.test.tsx`
- `npm test` *(fails: Unable to find text '1' in BeEF app, calculator parser variable test, kismet, mimikatz, game2048, etc.)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68b204e98b78832898fc5d3f06abdb2d