### PR TITLE
feat: add tag filter and search for metasploit modules

### DIFF
--- a/__tests__/metasploitPage.test.tsx
+++ b/__tests__/metasploitPage.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MetasploitPage from '../apps/metasploit';
+
+describe('Metasploit page module filtering', () => {
+  it('filters modules by search and shows tags', () => {
+    render(<MetasploitPage />);
+
+    // expand tree to reveal a known module
+    fireEvent.click(screen.getAllByText('auxiliary')[0]);
+    fireEvent.click(screen.getAllByText('admin')[0]);
+    fireEvent.click(screen.getAllByText('2wire')[0]);
+    expect(screen.getByText('xslt_password_reset')).toBeInTheDocument();
+
+    // search hides the module
+    fireEvent.change(screen.getAllByPlaceholderText('Search modules')[0], {
+      target: { value: 'nonexistent-module' },
+    });
+    expect(screen.queryByText('xslt_password_reset')).toBeNull();
+
+    // tag buttons are rendered
+    expect(screen.getByRole('button', { name: 'admin' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tag buttons and text search to Metasploit module tree
- include test covering module filtering by tag and search

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: 54 problems, 10 errors)*
- `yarn test` *(fails: multiple failing tests)*
- `yarn test __tests__/metasploitPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b204eac73c8328afcc1ee65a6ba94b