### PR TITLE
Persist mock sessions

### DIFF
--- a/apps/metasploit/components/TargetEmulator.test.tsx
+++ b/apps/metasploit/components/TargetEmulator.test.tsx
@@ -4,6 +4,10 @@ import TargetEmulator from './TargetEmulator';
 import modules from '../../../components/apps/metasploit/modules.json';
 
 describe('TargetEmulator', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('shows deterministic output and resets', () => {
     render(<TargetEmulator />);
     const select = screen.getByLabelText(/select module/i);
@@ -14,5 +18,23 @@ describe('TargetEmulator', () => {
     fireEvent.change(select, { target: { value: modules[0].name } });
     const second = screen.getByTestId('session-output').textContent;
     expect(first).toBe(second);
+  });
+
+  it('persists sessions and allows reopening them', () => {
+    const { unmount } = render(<TargetEmulator />);
+    const select = screen.getByLabelText(/select module/i);
+    fireEvent.change(select, { target: { value: modules[0].name } });
+    const output = screen.getByTestId('session-output').textContent;
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    fireEvent.change(screen.getByLabelText(/reopen session/i), {
+      target: { value: modules[0].name },
+    });
+    expect(screen.getByTestId('session-output').textContent).toBe(output);
+    unmount();
+    render(<TargetEmulator />);
+    fireEvent.change(screen.getByLabelText(/reopen session/i), {
+      target: { value: modules[0].name },
+    });
+    expect(screen.getByTestId('session-output').textContent).toBe(output);
   });
 });

--- a/apps/metasploit/components/TargetEmulator.tsx
+++ b/apps/metasploit/components/TargetEmulator.tsx
@@ -3,15 +3,25 @@
 import React, { useState } from 'react';
 import seedrandom from 'seedrandom';
 import modules from '../../../components/apps/metasploit/modules.json';
+import usePersistentState from '../../../hooks/usePersistentState';
 
 interface ModuleInfo {
   name: string;
   description?: string;
 }
 
+interface SavedSession {
+  name: string;
+  output: string;
+}
+
 const TargetEmulator: React.FC = () => {
   const [selected, setSelected] = useState<ModuleInfo | null>(null);
   const [output, setOutput] = useState('Select a module to run.');
+  const [sessions, setSessions] = usePersistentState<SavedSession[]>(
+    'metasploit-sessions',
+    [],
+  );
 
   const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const mod = modules.find((m: ModuleInfo) => m.name === e.target.value) || null;
@@ -28,7 +38,12 @@ const TargetEmulator: React.FC = () => {
         `msf6 exploit(${mod.name}) > run`,
         `[*] Session ${sessionId} opened`
       ];
-      setOutput(lines.join('\n'));
+      const text = lines.join('\n');
+      setOutput(text);
+      setSessions((prev) => [
+        ...prev.filter((s) => s.name !== mod.name),
+        { name: mod.name, output: text },
+      ]);
     } else {
       setOutput('Select a module to run.');
     }
@@ -37,6 +52,13 @@ const TargetEmulator: React.FC = () => {
   const reset = () => {
     setSelected(null);
     setOutput('Select a module to run.');
+  };
+
+  const reopen = (name: string) => {
+    const sess = sessions.find((s) => s.name === name);
+    const mod = modules.find((m: ModuleInfo) => m.name === name) || null;
+    setSelected(mod);
+    setOutput(sess ? sess.output : 'Select a module to run.');
   };
 
   return (
@@ -63,6 +85,21 @@ const TargetEmulator: React.FC = () => {
         >
           Reset
         </button>
+        {sessions.length > 0 && (
+          <select
+            aria-label="Reopen session"
+            onChange={(e) => reopen(e.target.value)}
+            className="border p-1"
+            defaultValue=""
+          >
+            <option value="">Reopen session</option>
+            {sessions.map((s) => (
+              <option key={s.name} value={s.name}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
       <pre
         data-testid="session-output"


### PR DESCRIPTION
## Summary
- persist target emulator sessions using local storage
- allow reopening previous mock sessions from a dropdown
- add tests ensuring sessions persist across resets and reloads

## Testing
- `npm test` *(fails: BeEF app, NiktoPage, calculator parser, and other suites)*
- `npm test -- apps/metasploit/components/TargetEmulator.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b204eb4f3c832880b3522a404b6a17