### PR TITLE
feat: tighten csp for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,14 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
-| `https://*` / `http://*` / `ws://*` / `wss://*` | Wide dev allowance for external resources; tighten for production |
+| `example.com` | Sample iframe content |
+| `developer.mozilla.org` | MDN iframe demos |
+| `en.wikipedia.org` | Wikipedia iframe demos |
+
+In development (`NODE_ENV !== 'production'`), `connect-src` and `frame-src` also allow `https://*`, `http://*`, `ws://*`, and `wss://*` for testing and hot module reloading. These wildcards are stripped from production builds.
 
 **Notes for prod hardening**
-- The sample CSP currently **permits wide `connect-src` and `frame-src`** to enable sandboxed iframes (Chrome app) and demos. In production, **tighten** these to the exact domains you embed. Remove `http:` origins; prefer `https:` only.
+- The sample CSP uses wide `connect-src` and `frame-src` during development for sandboxed iframes and demos. Production builds restrict these to the domains above; further tighten if you embed additional hosts.
 - Consider removing `'unsafe-inline'` from `style-src` once all inline styles are eliminated.
 - If deploying on a domain that serves a PDF resume via `<object>`, keep `X-Frame-Options: SAMEORIGIN`. Otherwise you can rely on CSP `frame-ancestors` instead.
 

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,36 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
+const isProd = process.env.NODE_ENV === 'production';
+
+const connectSrc = [
+  "'self'",
+  ...(isProd ? [] : ['https://*', 'http://*', 'ws://*', 'wss://*']),
+  'https://platform.twitter.com',
+  'https://syndication.twitter.com',
+  'https://cdn.syndication.twimg.com',
+  'https://*.twitter.com',
+  'https://*.x.com',
+  'https://*.google.com',
+  'https://stackblitz.com',
+];
+
+const frameSrc = [
+  "'self'",
+  ...(isProd ? [] : ['https://*', 'http://*']),
+  'https://stackblitz.com',
+  'https://*.google.com',
+  'https://platform.twitter.com',
+  'https://syndication.twitter.com',
+  'https://*.twitter.com',
+  'https://*.x.com',
+  'https://www.youtube-nocookie.com',
+  'https://open.spotify.com',
+  'https://example.com',
+  'https://developer.mozilla.org',
+  'https://en.wikipedia.org',
+];
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -21,9 +51,9 @@ const ContentSecurityPolicy = [
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
-  // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  `connect-src ${connectSrc.join(' ')}`,
+  // Allow iframes from specific providers (and any in dev) so the Chrome and StackBlitz apps can load arbitrary content
+  `frame-src ${frameSrc.join(' ')}`,
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",


### PR DESCRIPTION
## Summary
- restrict CSP connect/frame wildcards in production
- document updated CSP allowlist

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` (fails: Component definition is missing display name)
- `yarn test` (fails: BeEF app tests, NiktoPage tests, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b2137e4bd083289011710953055ee9