### PR TITLE
chore: remove unused diff types

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/canvas-confetti": "^1",
-    "@types/diff": "^8.0.0",
     "@types/figlet": "^1",
     "@types/howler": "^2",
     "@types/jest": "30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,15 +2881,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/diff@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@types/diff@npm:8.0.0"
-  dependencies:
-    diff: "npm:*"
-  checksum: 10c0/c6e3376abeac8bc77b33252afc239a3cfc2729ecf59abcf00fa0f0eca8c505fd3a375a99a64afecdbb97fbec77b9a6aa8a8918f4d53fd5b45638d609343717cc
-  languageName: node
-  linkType: hard
-
 "@types/estree@npm:0.0.39":
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
@@ -5266,13 +5257,6 @@ __metadata:
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
   checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
-  languageName: node
-  linkType: hard
-
-"diff@npm:*":
-  version: 8.0.2
-  resolution: "diff@npm:8.0.2"
-  checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
   languageName: node
   linkType: hard
 
@@ -11671,7 +11655,6 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/canvas-confetti": "npm:^1"
-    "@types/diff": "npm:^8.0.0"
     "@types/figlet": "npm:^1"
     "@types/howler": "npm:^2"
     "@types/jest": "npm:30.0.0"


### PR DESCRIPTION
## Summary
- remove `@types/diff` from dev dependencies
- prune lockfile

## Testing
- `yarn lint` *(fails: ESLint has 12 errors)*
- `yarn test` *(fails: wireshark, beef, niktoPage suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b2137cc7b48328af5ac7991de03080