### PR TITLE
chore: move ws to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "three": "^0.179.1",
     "turndown": "^7.2.1",
     "workbox-window": "^7.3.0",
-    "ws": "^8.18.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -120,7 +119,8 @@
     "playwright-core": "^1.55.0",
     "typescript": "^5.9.2",
     "wait-on": "^8.0.4",
-    "workbox-build": "^7.3.0"
+    "workbox-build": "^7.3.0",
+    "ws": "^8.18.0"
   },
   "resolutions": {
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- move ws from dependencies to devDependencies

## Testing
- `yarn install`
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, calculator/parser, mimikatz, volatilityPluginBrowser, kismet, snake.config, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2137bf81c832888064ee77c75e4d4