### PR TITLE
Handle missing server config in contact form

### DIFF
--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -24,6 +24,7 @@ const errorMap: Record<string, string> = {
   invalid_input: 'Please check your input and try again.',
   invalid_csrf: 'Security token mismatch. Refresh and retry.',
   invalid_recaptcha: 'Captcha verification failed. Please try again.',
+  server_not_configured: 'Email service unavailable. Use the options above.',
 };
 
 export const processContactForm = async (
@@ -58,6 +59,7 @@ export const processContactForm = async (
       return {
         success: false,
         error: errorMap[body.code as string] || 'Submission failed',
+        code: body.code as string,
       };
     }
     return { success: true };
@@ -246,6 +248,7 @@ const ContactApp: React.FC = () => {
       setError(msg);
       setBanner({ type: 'error', message: msg });
       if (
+        result.code === 'server_not_configured' ||
         result.error?.toLowerCase().includes('captcha') ||
         result.error === 'Submission failed'
       ) {

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -13,7 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     validateServerEnv(process.env);
   } catch {
-    res.status(500).json({ ok: false });
+    res.status(500).json({ ok: false, code: 'server_not_configured' });
     return;
   }
   if (req.method === 'GET') {


### PR DESCRIPTION
## Summary
- return `server_not_configured` error code when contact API env vars missing
- show contact form fallback UI when this error code is received

## Testing
- `npx eslint pages/api/contact.ts components/apps/contact/index.tsx` *(fails: ESLint couldn't find a configuration file)*
- `yarn test __tests__/contact.api.test.ts __tests__/contact.test.tsx __tests__/contactRateLimit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2137d1b508328b7e63a05b99950bc