### PR TITLE
docs: note Node 20 pin and engines reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Always test inside controlled labs and obtain written permission before performi
 ## Quick Start
 
 ### Requirements
-- **Node.js 20.x** (repo includes `.nvmrc`; run `nvm use`)
+- **Node.js 20.x** (repo includes `.nvmrc`; run `nvm use`; update `.nvmrc` and `package.json` `engines` if you upgrade)
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
@@ -237,6 +237,7 @@ Workflow: `.github/workflows/gh-deploy.yml`:
 
 ### Vercel deployment
 - Create a Vercel project and connect this repo.
+- In Project Settings, pin **Node.js 20.x** under "Node.js Version" to match `.nvmrc` and `package.json` `engines` (update `engines` if you upgrade Node).
 - Required env variables (Project Settings):
   - `NEXT_PUBLIC_TRACKING_ID`
   - `NEXT_PUBLIC_SERVICE_ID`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This project is built with [Next.js](https://nextjs.org/).
 
 ## Prerequisites
 
-- Node.js 20
+- Node.js 20 (pinned via `.nvmrc` and `package.json` `engines`; update both if you upgrade)
 - yarn or npm
 
 ## Installation


### PR DESCRIPTION
## Summary
- remind contributors to update `.nvmrc` and `package.json` engines when changing Node
- advise pinning Node 20.x in Vercel project settings

## Testing
- `npx eslint README.md docs/getting-started.md` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b213812b3483289514b022a2617b90