### PR TITLE
docs: note Workbox glob warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Serverful deployments run the built Next.js server so all API routes are availab
 ```bash
 yarn build && yarn start
 ```
+> **Note:** Workbox's build tooling uses `glob@7`, which pulls the deprecated [`inflight`](https://www.npmjs.com/package/inflight) module. Security scanners may surface advisories such as [GHSA-ww39-953v-wcq6](https://github.com/advisories/GHSA-ww39-953v-wcq6) and [GHSA-cj88-88mr-972w](https://github.com/advisories/GHSA-cj88-88mr-972w); these warnings stem from transient build-time dependencies and are considered safe here.
 After the server starts, exercise an API route to confirm server-side functionality:
 ```bash
 curl -X POST http://localhost:3000/api/dummy


### PR DESCRIPTION
## Summary
- document that Workbox's build chain pulls deprecated glob@7/inflight with advisories

## Testing
- `npx eslint README.md` *(fails: Parsing error: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b2138293908328b9726d55962cc2d8