### PR TITLE
Check OffscreenCanvas before worker rendering

### DIFF
--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { publish } from '../../../../../utils/pubsub';
+import { hasOffscreenCanvas } from '../../../../../utils/feature';
 
 interface PerfSample {
   t: number;
@@ -41,11 +42,7 @@ const PerfOverlay: React.FC = () => {
     if (!canvas) return;
 
     // Prefer OffscreenCanvas with a worker when supported
-    if (
-      typeof window !== 'undefined' &&
-      typeof Worker === 'function' &&
-      'OffscreenCanvas' in window
-    ) {
+    if (typeof Worker === 'function' && hasOffscreenCanvas()) {
       const worker = new Worker(new URL('./perf.worker.js', import.meta.url));
       workerRef.current = worker;
       const offscreen = canvas.transferControlToOffscreen();

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import { CAR_SKINS, loadSkinAssets } from '../../apps/games/car-racer/customization';
+import { hasOffscreenCanvas } from '../../utils/feature';
 
 // Canvas dimensions
 const WIDTH = 300;
@@ -149,8 +150,7 @@ const CarRacer = () => {
     const canvas = canvasRef.current;
     if (!canvas || typeof window === 'undefined') return;
 
-    const supportsWorker =
-      typeof Worker === 'function' && 'OffscreenCanvas' in window;
+    const supportsWorker = typeof Worker === 'function' && hasOffscreenCanvas();
     let worker;
     let ctx;
     if (supportsWorker) {

--- a/utils/feature.ts
+++ b/utils/feature.ts
@@ -1,0 +1,6 @@
+export const hasOffscreenCanvas = (): boolean =>
+  typeof window !== 'undefined' &&
+  'OffscreenCanvas' in window &&
+  typeof HTMLCanvasElement !== 'undefined' &&
+  typeof HTMLCanvasElement.prototype.transferControlToOffscreen === 'function';
+


### PR DESCRIPTION
## Summary
- add `hasOffscreenCanvas` utility to detect OffscreenCanvas and transferControlToOffscreen support
- guard PerfOverlay and car-racer worker setup behind `hasOffscreenCanvas`

## Testing
- `yarn test` *(fails: unable to find elements, missing modules, syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b21378d10c8328975517817ee40341