### PR TITLE
feat: enhance terminal toolbar and tab UX

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -10,7 +10,13 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       ref={ref}
       data-testid="xterm-container"
       className={`text-white ${className}`}
-      style={{ background: 'var(--kali-bg)', fontFamily: 'monospace', ...style }}
+      style={{
+        background: 'var(--kali-bg)',
+        fontFamily: 'monospace',
+        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
+        lineHeight: 1.4,
+        ...style,
+      }}
       {...props}
     />
   ),

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
 
+function middleEllipsis(text: string, max = 30) {
+  if (text.length <= max) return text;
+  const half = Math.floor((max - 1) / 2);
+  return `${text.slice(0, half)}…${text.slice(text.length - half)}`;
+}
+
 export interface TabDefinition {
   id: string;
   title: string;
@@ -166,7 +172,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         {tabs.map((t, i) => (
           <div
             key={t.id}
-            className={`flex items-center px-2 py-1 cursor-pointer select-none ${
+            className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
               t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
             }`}
             draggable
@@ -175,12 +181,10 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             onDrop={handleDrop(i)}
             onClick={() => setActive(t.id)}
           >
-            <span className="mr-2 truncate" style={{ maxWidth: 150 }}>
-              {t.title}
-            </span>
+            <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
             {t.closable !== false && tabs.length > 1 && (
               <button
-                className="ml-1"
+                className="p-0.5"
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);


### PR DESCRIPTION
## Summary
- add terminal toolbar with copy, paste and settings icons
- preview ANSI colors and `ls --color` output before applying settings
- use middle-ellipsis tab titles and GNOME-aligned close buttons

## Testing
- `yarn lint apps/terminal/index.tsx components/ui/TabbedWindow.tsx apps/terminal/components/Terminal.tsx` (fails: ESLint couldn't find config)
- `yarn test apps/terminal --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit` (fails: existing type errors)

------
https://chatgpt.com/codex/tasks/task_e_68b21926d46c8328857ff6ee333d6279