### PR TITLE
Add window chrome and status bar to VSCode app

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
+import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
@@ -31,8 +33,73 @@ export default function VsCode() {
           }}
         />
       </aside>
-      <div className="flex-1">
-        <ExternalFrame src="https://vscode.dev/" title="VsCode" />
+      <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
+        <div
+          className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
+          style={{ backgroundColor: kaliTheme.background }}
+        >
+          <button aria-label="Minimize">
+            <MinimizeIcon />
+          </button>
+          <button aria-label="Maximize">
+            <MaximizeIcon />
+          </button>
+          <button aria-label="Close">
+            <CloseIcon />
+          </button>
+        </div>
+        <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
+          <ExternalFrame
+            src="https://vscode.dev/"
+            title="VsCode"
+            className="w-full h-full"
+          />
+          <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
+            <Image
+              src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+              alt="Open Folder"
+              width={64}
+              height={64}
+            />
+            <span className="text-lg">Open Folder</span>
+          </div>
+        </div>
+        <div
+          className="flex items-center gap-2 px-2 py-1 border-t border-black/20"
+          style={{ backgroundColor: kaliTheme.sidebar }}
+        >
+          <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-3 h-3"
+            >
+              <line x1="6" y1="3" x2="6" y2="15" />
+              <circle cx="18" cy="6" r="3" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M18 9a9 9 0 0 1-9 9" />
+            </svg>
+            MAIN
+          </span>
+          <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-3 h-3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            CHECKS
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap VS Code iframe with symbolic window chrome and theme-aware background
- add status bar badges for branch and checks with 12px pill styling
- overlay "Open Folder" callout with 64px grid icon

## Testing
- `npm test` *(fails: Syntax Error in wireshark test and multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b21928168c8328a312931befc1c41a