### PR TITLE
feat(calculator): improve keypad and add tape panel

### DIFF
--- a/apps/calculator/components/Tape.tsx
+++ b/apps/calculator/components/Tape.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+interface TapeProps {
+  entries: { expr: string; result: string }[];
+}
+
+export default function Tape({ entries }: TapeProps) {
+  return (
+    <div className="tape font-mono">
+      {entries.map(({ expr, result }, i) => (
+        <div key={i} className="p-1 odd:bg-black/20 even:bg-black/10">
+          {expr} = {result}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -5,6 +5,7 @@ import ModeSwitcher from './components/ModeSwitcher';
 import './styles.css';
 import MemorySlots from './components/MemorySlots';
 import FormulaEditor from './components/FormulaEditor';
+import Tape from './components/Tape';
 
 export default function Calculator() {
   const HISTORY_LIMIT = 10;
@@ -23,7 +24,7 @@ export default function Calculator() {
   );
 
   const btnCls =
-    'btn h-12 w-12 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white';
+    'btn min-h-12 w-12 transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white';
 
   useEffect(() => {
     let evaluate: any;
@@ -197,33 +198,111 @@ export default function Calculator() {
       <button id="toggle-programmer" className="toggle h-12" aria-pressed="false" aria-label="toggle programmer mode">Programmer</button>
       <button id="toggle-history" className="toggle h-12" aria-pressed="false" aria-label="toggle history">History</button>
       <button id="toggle-formulas" className="toggle h-12" aria-pressed="false" aria-label="toggle formulas">Formulas</button>
-      <div className="memory-grid grid grid-cols-3 !gap-1" aria-label="memory functions">
+      <div className="memory-grid grid grid-cols-3" aria-label="memory functions">
         <button className={btnCls} data-action="mplus" aria-label="add to memory">M+</button>
         <button className={btnCls} data-action="mminus" aria-label="subtract from memory">M&minus;</button>
         <button className={btnCls} data-action="mr" aria-label="recall memory">MR</button>
       </div>
       <MemorySlots />
-      <div className="button-grid grid grid-cols-4 !gap-1" aria-label="calculator keypad">
+      <div className="button-grid grid grid-cols-4 font-mono" aria-label="calculator keypad">
         <button className={btnCls} data-value="7" data-key="7" aria-label="seven">7</button>
         <button className={btnCls} data-value="8" data-key="8" aria-label="eight">8</button>
         <button className={btnCls} data-value="9" data-key="9" aria-label="nine">9</button>
-        <button className={btnCls} data-value="/" data-key="/" aria-label="divide">&divide;</button>
+        <button className={btnCls} data-value="/" data-key="/" aria-label="divide">
+          <svg
+            viewBox="0 0 24 24"
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <circle cx="12" cy="6" r="1.5" fill="currentColor" stroke="none" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <circle cx="12" cy="18" r="1.5" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
         <button className={btnCls} data-value="4" data-key="4" aria-label="four">4</button>
         <button className={btnCls} data-value="5" data-key="5" aria-label="five">5</button>
         <button className={btnCls} data-value="6" data-key="6" aria-label="six">6</button>
-        <button className={btnCls} data-value="*" data-key="*" aria-label="multiply">&times;</button>
+        <button className={btnCls} data-value="*" data-key="*" aria-label="multiply">
+          <svg
+            viewBox="0 0 24 24"
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="18" y1="6" x2="6" y2="18" />
+          </svg>
+        </button>
         <button className={btnCls} data-value="1" data-key="1" aria-label="one">1</button>
         <button className={btnCls} data-value="2" data-key="2" aria-label="two">2</button>
         <button className={btnCls} data-value="3" data-key="3" aria-label="three">3</button>
-        <button className={btnCls} data-value="-" data-key="-" aria-label="subtract">&minus;</button>
+        <button className={btnCls} data-value="-" data-key="-" aria-label="subtract">
+          <svg
+            viewBox="0 0 24 24"
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
         <button className={btnCls} data-value="0" data-key="0" aria-label="zero">0</button>
         <button className={btnCls} data-value="." data-key="." aria-label="decimal point">.</button>
         <button className={btnCls} data-action="equals" data-key="= Enter" aria-label="equals">=</button>
-        <button className={btnCls} data-value="+" data-key="+" aria-label="add">+</button>
-      <button className={`${btnCls} span-two w-full`} data-action="clear" data-key="Escape c" aria-label="clear">C</button>
-      <button className={`${btnCls} span-two w-full`} data-action="backspace" data-key="Backspace" aria-label="backspace">⌫</button>
+        <button className={btnCls} data-value="+" data-key="+" aria-label="add">
+          <svg
+            viewBox="0 0 24 24"
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+      <button className={`${btnCls} span-two w-full`} data-action="clear" data-key="Escape c" aria-label="clear">
+        <svg
+          viewBox="0 0 24 24"
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 6h18" />
+          <path d="M8 6V4h8v2" />
+          <path d="M19 6l-1 14H6L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+        </svg>
+      </button>
+      <button className={`${btnCls} span-two w-full`} data-action="backspace" data-key="Backspace" aria-label="backspace">
+        <svg
+          viewBox="0 0 24 24"
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 19h8a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-8L7 12l5 7z" />
+          <path d="M14 9l3 3-3 3" />
+          <path d="M11 9l-3 3 3 3" />
+        </svg>
+      </button>
       </div>
-      <div id="scientific" className="scientific hidden grid grid-cols-3 !gap-1" aria-label="scientific functions">
+        <div id="scientific" className="scientific hidden grid grid-cols-3 gap-1.5" aria-label="scientific functions">
         <button className={btnCls} data-value="sin(" aria-label="sine">sin</button>
         <button className={btnCls} data-value="cos(" aria-label="cosine">cos</button>
         <button className={btnCls} data-value="tan(" aria-label="tangent">tan</button>
@@ -231,7 +310,7 @@ export default function Calculator() {
         <button className={btnCls} data-value="(" data-key="(" aria-label="left parenthesis">(</button>
         <button className={btnCls} data-value=")" data-key=")" aria-label="right parenthesis">)</button>
       </div>
-      <div id="programmer" className="programmer hidden grid !gap-1" aria-label="programmer functions">
+        <div id="programmer" className="programmer hidden grid gap-1.5" aria-label="programmer functions">
         <select id="base-select" defaultValue="10" className="h-12">
           <option value="2">Bin</option>
           <option value="8">Oct</option>
@@ -256,6 +335,7 @@ export default function Calculator() {
           </div>
         ))}
       </div>
+      <Tape entries={history} />
     </div>
   );
 }

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -48,14 +48,14 @@ body {
 .memory-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
+  gap: 6px;
   margin-bottom: 0.5rem;
 }
 
 .button-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
+  gap: 6px;
 }
 
 @container (max-width: 200px) {
@@ -71,10 +71,13 @@ body {
   border-radius: 4px;
   font-size: 1rem;
   cursor: pointer;
+  min-height: 48px;
+  transition: transform 150ms;
 }
 
 .btn:hover {
   background: #e0e0e0;
+  transform: translateY(-2px);
 }
 
 .btn.active-key {
@@ -87,6 +90,10 @@ body {
 
 .hidden {
   display: none !important;
+}
+
+.button-grid .btn {
+  font-family: monospace;
 }
 
 


### PR DESCRIPTION
## Summary
- style calculator keypad buttons with minimum 48px height, 6px gaps, and monospace numerals
- replace clear/backspace/operators with 24px SVG icons and add hover elevation
- add Tape component for printing log entries with alternating row shading

## Testing
- `npx eslint --config .eslintrc.cjs apps/calculator/index.tsx apps/calculator/components/Tape.tsx` (fails: File ignored because no matching configuration was supplied)
- `yarn test --passWithNoTests` (fails: multiple test suites failed)


------
https://chatgpt.com/codex/tasks/task_e_68b2192628908328aaa0302cc0d488ec