### PR TITLE
Add capture cards and log styling enhancements

### DIFF
--- a/apps/wireshark/components/FilterHelper.tsx
+++ b/apps/wireshark/components/FilterHelper.tsx
@@ -84,9 +84,8 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
           <option key={label} value={expression}>
             {label}
           </option>
-
         ))}
-      </div>
+      </select>
       <input
         list="display-filter-suggestions"
         value={value}

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -8,7 +8,7 @@ const parseLines = (text) =>
   text
     .split('\n')
     .filter(Boolean)
-    .map((line) => {
+    .map((line, i) => {
       const parts = line.trim().split(/\s+/);
       let protocol = parts[0] || '';
       let host = parts[1] || '';
@@ -22,6 +22,7 @@ const parseLines = (text) =>
         protocol,
         host,
         details: rest.join(' '),
+        timestamp: new Date(Date.now() + i * 1000).toISOString(),
       };
     });
 
@@ -97,8 +98,11 @@ const LogRow = ({ log, prefersReduced }) => {
   }, [prefersReduced]);
 
   return (
-    <tr ref={rowRef} className="odd:bg-black even:bg-ub-grey">
-      <td className="pr-2 text-green-400">
+    <tr ref={rowRef} className="odd:bg-black even:bg-ub-grey font-mono">
+      <td className="px-2 py-[6px] text-gray-400 bg-gray-900">
+        {log.timestamp}
+      </td>
+      <td className="px-2 py-[6px] text-green-400">
         <abbr
           title={protocolInfo[log.protocol] || log.protocol}
           className="underline decoration-dotted cursor-help"
@@ -107,8 +111,8 @@ const LogRow = ({ log, prefersReduced }) => {
           {log.protocol}
         </abbr>
       </td>
-      <td className="pr-2 text-white">{log.host}</td>
-      <td className="text-green-400">{log.details}</td>
+      <td className="px-2 py-[6px] text-white">{log.host}</td>
+      <td className="px-2 py-[6px] text-green-400">{log.details}</td>
     </tr>
   );
 };
@@ -571,7 +575,7 @@ const Dsniff = () => {
         </div>
       </div>
       <div
-        className="bg-black text-green-400 p-2 h-40 overflow-auto"
+        className="bg-black text-green-400 p-2 h-40 overflow-auto font-mono"
         aria-live="polite"
         role="log"
       >

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import Waterfall from './Waterfall';
 import BurstChart from './BurstChart';
 import { protocolName, getRowColor, matchesDisplayFilter } from './utils';
@@ -123,6 +124,11 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   const pausedRef = useRef(false);
   const prefersReducedMotion = useRef(false);
   const VISIBLE = 100;
+
+  const interfaces = [
+    { name: 'eth0', type: 'wired' },
+    { name: 'wlan0', type: 'wireless' },
+  ];
 
   // Load persisted filter on mount
   useEffect(() => {
@@ -281,6 +287,58 @@ const WiresharkApp = ({ initialPackets = [] }) => {
       {error && (
         <p className="text-red-400 text-xs p-2 bg-gray-900">{error}</p>
       )}
+      <div className="p-2 grid gap-2 md:grid-cols-2 bg-gray-900">
+        {interfaces.map((iface) => (
+          <div
+            key={iface.name}
+            className="flex items-center justify-between bg-gray-800 rounded p-2"
+          >
+            <div className="flex items-center space-x-2">
+              <Image
+                src={
+                  iface.type === 'wired'
+                    ? '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
+                    : '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
+                }
+                alt={iface.type}
+                width={24}
+                height={24}
+              />
+              <span className="text-white">{iface.name}</span>
+            </div>
+            <div className="flex items-center space-x-1">
+              <button
+                onClick={startCapture}
+                aria-label={`start capture on ${iface.name}`}
+                className="p-1"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-6 h-6"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </button>
+              <button
+                onClick={stopCapture}
+                aria-label={`stop capture on ${iface.name}`}
+                className="p-1"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-6 h-6"
+                >
+                  <path d="M6 6h12v12H6z" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
       <div className="p-2 flex space-x-2 bg-gray-900 flex-wrap">
         <button
           onClick={startCapture}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -13,11 +14,12 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-			<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <div className="pl-3 pr-1">
+                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                </div>
                                 <div
-                                        className={
-                                                'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '
-                                        }
+                                        className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
                                 >
                                         Activities
                                 </div>


### PR DESCRIPTION
## Summary
- Display capture cards in Wireshark with interface badges and 24 px play/stop icons
- Style dsniff logs in monospace with padded lines and a contrasting timestamp column
- Show a symbolic network icon in the desktop header for quick visual identity

## Testing
- `npm test __tests__/wireshark.test.tsx` *(fails: ReferenceError handlePresetSelect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b219303a24832898f6fb0a949daf7e