### PR TITLE
style: refine wireshark ui

### DIFF
--- a/components/apps/wireshark/DecodeTree.js
+++ b/components/apps/wireshark/DecodeTree.js
@@ -4,7 +4,7 @@ import React from 'react';
 const DecodeTree = ({ data }) => {
   if (!data || typeof data !== 'object') return null;
   return (
-    <ul className="pl-4 list-disc">
+    <ul className="pl-[6px] border-l border-gray-700">
       {Object.entries(data).map(([key, value]) => (
         <li key={key} className="mb-1">
           <span className="font-semibold">{key}:</span>{' '}

--- a/components/apps/wireshark/colorDefs.js
+++ b/components/apps/wireshark/colorDefs.js
@@ -1,6 +1,6 @@
 export const colorDefinitions = [
-  { name: 'Red', className: 'text-red-500' },
-  { name: 'Blue', className: 'text-blue-500' },
-  { name: 'Green', className: 'text-green-500' },
-  { name: 'Yellow', className: 'text-yellow-500' },
+  { name: 'Red', className: 'border-red-500' },
+  { name: 'Blue', className: 'border-blue-500' },
+  { name: 'Green', className: 'border-green-500' },
+  { name: 'Yellow', className: 'border-yellow-500' },
 ];

--- a/components/apps/wireshark/utils.js
+++ b/components/apps/wireshark/utils.js
@@ -58,5 +58,7 @@ export const getRowColor = (packet, rules) => {
   const rule = rules.find((r) => matchesDisplayFilter(packet, r.expression));
   if (!rule) return '';
   const key = rule.color ? rule.color.toLowerCase() : '';
-  return colorMap[key] || rule.color || '';
+  if (colorMap[key]) return colorMap[key];
+  if (rule.color) return `border-[${rule.color}]`;
+  return '';
 };


### PR DESCRIPTION
## Summary
- add device menu and symbolic toolbar icons
- show rule colors as left border strips and standardize packet row height
- improve packet detail tree with monospace font and small indent guides

## Testing
- `npm test` *(fails: wireshark, beef, niktoPage, calculator parser, volatility plugin browser, mimikatz)*

------
https://chatgpt.com/codex/tasks/task_e_68b21934e3ec8328a45eae2a0906ba0a