### PR TITLE
Style contact form inputs and toast

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -100,42 +100,90 @@ const ContactApp: React.FC = () => {
       </p>
       <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
         <div>
-          <label htmlFor="contact-name" className="mb-1 block text-sm">
+          <label htmlFor="contact-name" className="mb-[6px] block text-sm">
             Name
           </label>
-          <input
-            id="contact-name"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
+          <div className="relative">
+            <input
+              id="contact-name"
+              className="h-11 w-full rounded border border-gray-700 bg-gray-800 pl-10 pr-3 text-white"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25v-1.5A4.5 4.5 0 0 1 9 14.25h6a4.5 4.5 0 0 1 4.5 4.5v1.5"
+              />
+            </svg>
+          </div>
         </div>
         <div>
-          <label htmlFor="contact-email" className="mb-1 block text-sm">
+          <label htmlFor="contact-email" className="mb-[6px] block text-sm">
             Email
           </label>
-          <input
-            id="contact-email"
-            type="email"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
+          <div className="relative">
+            <input
+              id="contact-email"
+              type="email"
+              className="h-11 w-full rounded border border-gray-700 bg-gray-800 pl-10 pr-3 text-white"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15A2.25 2.25 0 0 1 2.25 17.25V6.75A2.25 2.25 0 0 1 4.5 4.5h15a2.25 2.25 0 0 1 2.25 2.25ZM3 6l9 6 9-6"
+              />
+            </svg>
+          </div>
         </div>
         <div>
-          <label htmlFor="contact-message" className="mb-1 block text-sm">
+          <label htmlFor="contact-message" className="mb-[6px] block text-sm">
             Message
           </label>
-          <textarea
-            id="contact-message"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            rows={4}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            required
-          />
+          <div className="relative">
+            <textarea
+              id="contact-message"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 pl-10 text-white"
+              rows={4}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              required
+            />
+            <svg
+              className="pointer-events-none absolute left-3 top-3 h-6 w-6 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286a2.25 2.25 0 0 1-1.98 2.193c-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.1 2.1 0 0 1-.825-.242M3.75 7.5c0-1.621 1.152-3.026 2.76-3.235A48.455 48.455 0 0 1 12 3c2.115 0 4.198.137 6.24.402 1.608.209 2.76 1.614 2.76 3.235v6.226c0 1.621-1.152 3.026-2.76 3.235-.577.075-1.157.14-1.74.194V21L12.345 16.845"
+              />
+            </svg>
+          </div>
         </div>
         <input
           type="text"
@@ -148,7 +196,7 @@ const ContactApp: React.FC = () => {
         {error && <FormError>{error}</FormError>}
         <button
           type="submit"
-          className="rounded bg-blue-600 px-4 py-2"
+          className="flex h-12 w-full items-center justify-center rounded bg-blue-600 px-4 sm:w-auto"
         >
           Send
         </button>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="alert"
       aria-live="assertive"
-      className={`fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-80 text-white px-4 py-2 rounded shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : 'translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (


### PR DESCRIPTION
## Summary
- Adjust contact form labels and inputs for consistent sizing and add symbolic field icons
- Style submit button for mobile width and show GNOME-style toast

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test` *(fails: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21937a94483288cee88b3e5e376a9