### PR TITLE
feat: enhance reaver ui

### DIFF
--- a/apps/reaver/components/APList.tsx
+++ b/apps/reaver/components/APList.tsx
@@ -6,21 +6,11 @@ export interface AccessPoint {
   wps: 'enabled' | 'locked' | 'disabled';
 }
 
-const CheckCircle = (props: React.SVGProps<SVGSVGElement>) => (
+const LockOpen = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
     <path
       fillRule="evenodd"
-      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-      clipRule="evenodd"
-    />
-  </svg>
-);
-
-const XCircle = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
-    <path
-      fillRule="evenodd"
-      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-11.707a1 1 0 00-1.414-1.414L10 8.586 7.707 6.293a1 1 0 10-1.414 1.414L8.586 10l-2.293 2.293a1 1 0 101.414 1.414L10 11.414l2.293 2.293a1 1 0 001.414-1.414L11.414 10l2.293-2.293z"
+      d="M10 2a4 4 0 00-4 4v2a2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V9a2 2 0 00-2-2h-5V6a2 2 0 114 0h2a4 4 0 00-4-4h-2z"
       clipRule="evenodd"
     />
   </svg>
@@ -30,7 +20,7 @@ const LockClosed = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
     <path
       fillRule="evenodd"
-      d="M5 8a5 5 0 1110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2V8zm8-1a3 3 0 10-6 0v1h6V7z"
+      d="M5 8a5 5 0 1110 0v2a2 2 0 012 2v7a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2V8zm8-2a3 3 0 00-6 0v2h6V6z"
       clipRule="evenodd"
     />
   </svg>
@@ -40,22 +30,16 @@ const statusIcon = (status: AccessPoint['wps']) => {
   switch (status) {
     case 'enabled':
       return (
-        <span className="text-green-400" aria-label="WPS enabled">
-          <CheckCircle className="w-5 h-5" />
-        </span>
+        <LockOpen className="w-6 h-6 text-green-400" aria-label="WPS enabled" />
       );
     case 'locked':
       return (
-        <span className="text-yellow-400" aria-label="WPS locked">
-          <LockClosed className="w-5 h-5" />
-        </span>
+        <LockClosed className="w-6 h-6 text-yellow-400" aria-label="WPS locked" />
       );
     case 'disabled':
     default:
       return (
-        <span className="text-red-400" aria-label="WPS disabled">
-          <XCircle className="w-5 h-5" />
-        </span>
+        <LockClosed className="w-6 h-6 text-red-400" aria-label="WPS disabled" />
       );
   }
 };
@@ -71,24 +55,20 @@ const APList: React.FC = () => {
   }, []);
 
   return (
-    <table className="w-full text-sm mb-4">
-      <thead>
-        <tr className="text-left">
-          <th className="pb-2">SSID</th>
-          <th className="pb-2">BSSID</th>
-          <th className="pb-2">WPS</th>
-        </tr>
-      </thead>
-      <tbody>
-        {aps.map((ap) => (
-          <tr key={ap.bssid} className="odd:bg-gray-800">
-            <td className="py-1 px-2">{ap.ssid}</td>
-            <td className="py-1 px-2 font-mono">{ap.bssid}</td>
-            <td className="py-1 px-2">{statusIcon(ap.wps)}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+      {aps.map((ap) => (
+        <div
+          key={ap.bssid}
+          className="flex items-center justify-between bg-gray-800 rounded p-3"
+        >
+          <div>
+            <div className="font-semibold">{ap.ssid}</div>
+            <div className="text-xs font-mono text-gray-400">{ap.bssid}</div>
+          </div>
+          {statusIcon(ap.wps)}
+        </div>
+      ))}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- show WPS status in AP cards with lock icons
- style reaver logs with severity strips and mono font
- add icon-based start/stop controls

## Testing
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, niktoPage.test.tsx, volatilityPluginBrowser.test.tsx, mimikatz.test.ts, kismet.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b2193bf8c883288df03ee47dcad2dc