### PR TITLE
feat: enhance plugin browser and Nessus report

### DIFF
--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -31,25 +31,43 @@ const PluginBrowser = () => {
       <p className="text-xs text-yellow-400">
         Plugin data is provided for educational use only.
       </p>
-      <select
-        className="bg-gray-800 text-xs p-1 rounded"
-        value={category}
-        onChange={(e) => setCategory(e.target.value)}
-      >
-        {categories.map((c) => (
-          <option key={c} value={c}>
-            {c}
-          </option>
-        ))}
-      </select>
+      <div className="flex items-center gap-2">
+        <svg
+          className="w-6 h-6 text-gray-400"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M3 4h18l-7 8v6l-4 2v-8z" />
+        </svg>
+        <select
+          className="bg-gray-800 text-xs p-1 rounded"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
       {filtered.map((p) => (
         <div
           key={p.name}
           className="bg-gray-800 p-3 rounded cursor-pointer"
           onClick={() => setSelected(p)}
         >
-          <h3 className="font-semibold text-sm">{p.name}</h3>
-          <p className="text-[10px] text-gray-400">{p.category}</p>
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-sm">{p.name}</h3>
+            <span className="ml-2 px-2 py-0.5 rounded-full bg-gray-700 text-[10px]">
+              {p.category}
+            </span>
+          </div>
           {p.minVersion && p.minVersion !== VOLATILITY_VERSION && (
             <p className="text-[10px] text-red-400">
               Requires Volatility {p.minVersion}

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -133,7 +133,14 @@ const NessusReport: React.FC = () => {
 
   return (
     <div className="p-4 bg-gray-900 text-white min-h-screen">
-      <h1 className="text-2xl mb-4">Sample Nessus Report</h1>
+      <div className="flex items-center mb-4">
+        <img
+          src="/themes/Yaru/apps/nessus.svg"
+          alt="Nessus badge"
+          className="w-12 h-12 mr-2"
+        />
+        <h1 className="text-2xl">Sample Nessus Report</h1>
+      </div>
       <div className="flex items-center space-x-2 mb-4 flex-wrap">
         <label htmlFor="report-file" className="text-sm">
           Import report
@@ -211,26 +218,27 @@ const NessusReport: React.FC = () => {
       </svg>
       <table className="w-full mb-4 text-sm">
         <thead>
-          <tr className="text-left border-b border-gray-700">
-            <th className="py-1" scope="col">ID</th>
-            <th className="py-1" scope="col">Finding</th>
-            <th className="py-1" scope="col">CVSS</th>
-            <th className="py-1" scope="col">Severity</th>
-            <th className="py-1" scope="col">Host</th>
-            <th className="py-1" scope="col">Plugin Family</th>
+          <tr className="text-left border-b border-gray-700 h-9">
+            <th className="px-2" scope="col">ID</th>
+            <th className="px-2" scope="col">Finding</th>
+            <th className="px-2" scope="col">CVSS</th>
+            <th className="px-2" scope="col">Severity</th>
+            <th className="px-2" scope="col">Host</th>
+            <th className="px-2" scope="col">Plugin Family</th>
           </tr>
         </thead>
         <tbody>
           {filtered.map((f) => (
             <tr
               key={f.id}
-              className="border-b border-gray-800 cursor-pointer hover:bg-gray-800"
+              className="border-b border-gray-800 cursor-pointer hover:bg-gray-800 h-9"
+              style={{ borderLeft: `4px solid ${severityColors[f.severity]}` }}
               onClick={() => setSelected(f)}
             >
-              <td className="py-1">{f.id}</td>
-              <td className="py-1">{f.name}</td>
-              <td className="py-1">{f.cvss}</td>
-              <td className="py-1">
+              <td className="px-2">{f.id}</td>
+              <td className="px-2">{f.name}</td>
+              <td className="px-2">{f.cvss}</td>
+              <td className="px-2">
                 <span
                   className="px-2 py-0.5 rounded-full text-xs text-white"
                   style={{ backgroundColor: severityColors[f.severity] }}
@@ -238,8 +246,8 @@ const NessusReport: React.FC = () => {
                   {f.severity}
                 </span>
               </td>
-              <td className="py-1">{f.host}</td>
-              <td className="py-1">{f.pluginFamily}</td>
+              <td className="px-2">{f.host}</td>
+              <td className="px-2">{f.pluginFamily}</td>
             </tr>
           ))}
         </tbody>

--- a/public/demo-data/volatility/plugins.json
+++ b/public/demo-data/volatility/plugins.json
@@ -1,11 +1,19 @@
 [
   {
+    "name": "pslist",
+    "category": "Processes",
+    "description": "Lists running processes with details.",
+    "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pslist.html",
+    "minVersion": "3.0",
+    "output": "System (4)\\nsmss.exe (248)"
+  },
+  {
     "name": "pstree",
     "category": "Processes",
     "description": "Displays hierarchical parent-child relationships of running processes.",
     "doc": "https://volatility3.readthedocs.io/en/latest/plugins/windows/pstree.html",
     "minVersion": "3.0",
-    "output": "System (4)\n└─ smss.exe (248)\n   └─ csrss.exe (612)  # child process"
+    "output": "System (4)\\n└─ smss.exe (248)\\n   └─ csrss.exe (612)  # child process"
   },
   {
     "name": "dlllist",


### PR DESCRIPTION
## Summary
- add filter icon and category badges to Volatility plugin browser
- style Nessus report findings table with severity bars and fixed row height
- include Nessus badge in report header

## Testing
- `yarn test __tests__/volatilityPluginBrowser.test.tsx __tests__/nessus-report.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b2193ca4d483289b596aff8654984b