### PR TITLE
style: terminal output and warning banner

### DIFF
--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import TerminalOutput from './TerminalOutput';
 
 interface BuilderProps {
   doc: string;
@@ -12,14 +13,6 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
   };
 
   const command = build(params);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-    } catch {
-      /* ignore */
-    }
-  };
 
   return (
     <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
@@ -42,13 +35,8 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
           className="border p-1 text-black w-full"
         />
       </label>
-      <div className="flex items-center mt-2">
-        <pre className="flex-1 bg-black text-white p-1 overflow-auto" aria-label="command output">
-          {command}
-        </pre>
-        <button type="button" onClick={copy} className="ml-2 px-2 py-1 bg-ub-green text-black">
-          Copy
-        </button>
+      <div className="mt-2">
+        <TerminalOutput text={command} ariaLabel="command output" />
       </div>
     </form>
   );

--- a/components/NetworkAttackStepper.tsx
+++ b/components/NetworkAttackStepper.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import WarningBanner from './WarningBanner';
 
 interface Step {
   title: string;
@@ -111,9 +112,7 @@ const NetworkAttackStepper: React.FC = () => {
         <div className="bg-green-100 border-l-4 border-green-500 p-2">
           <strong>Mitigation:</strong> {current.mitigation}
         </div>
-        <div className="bg-yellow-100 border-l-4 border-yellow-500 p-2">
-          <strong>Warning:</strong> {current.warning}
-        </div>
+        <WarningBanner>{current.warning}</WarningBanner>
       </div>
       <div className="mt-4 flex justify-between">
         <button

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface TerminalOutputProps {
+  text: string;
+  ariaLabel?: string;
+}
+
+export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps) {
+  const lines = text.split('\n');
+  const copyLine = async (line: string) => {
+    try {
+      await navigator.clipboard.writeText(line);
+    } catch {
+      // ignore
+    }
+  };
+  return (
+    <div
+      className="bg-black text-green-400 font-mono text-xs p-2 rounded"
+      aria-label={ariaLabel}
+    >
+      {lines.map((line, idx) => (
+        <div key={idx} className="flex items-start">
+          <span className="flex-1 whitespace-pre-wrap">{line}</span>
+          <button
+            className="ml-2 text-gray-400 hover:text-white"
+            onClick={() => copyLine(line)}
+            aria-label="copy line"
+          >
+            📋
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/WarningBanner.tsx
+++ b/components/WarningBanner.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface WarningBannerProps {
+  children: React.ReactNode;
+}
+
+export default function WarningBanner({ children }: WarningBannerProps) {
+  return (
+    <div className="flex items-center bg-amber-100 text-amber-900 p-2" role="alert">
+      <span className="mr-2" role="img" aria-label="warning">
+        ⚠️
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
+import TerminalOutput from '../../TerminalOutput';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 const parseLines = (text) =>
@@ -385,9 +386,10 @@ const Dsniff = () => {
               Copy sample command
             </button>
           </div>
-          <pre className="text-xs bg-ub-dark p-2 flex-1 overflow-auto" aria-label="sample command output">
-            {`${sampleCommand}\n${sampleOutput}`}
-          </pre>
+          <TerminalOutput
+            text={`${sampleCommand}\n${sampleOutput}`}
+            ariaLabel="sample command output"
+          />
         </div>
       </div>
       <div className="mb-4" data-testid="pcap-demo">

--- a/components/apps/mimikatz/index.js
+++ b/components/apps/mimikatz/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import WarningBanner from "../../WarningBanner";
 
 // Demo output for each tab
 const demoOutput = {
@@ -25,10 +26,15 @@ const tabs = [
 
 // Masks tokens and hashes unless unmasked by user
 const maskSensitive = (line, show) => {
-  if (show) return line;
-  return line.replace(
-    /(Token|NTLM hash|Kerberos Ticket|Ticket cache):\s*\S+/gi,
-    (match, p1) => `${p1}: ********`,
+  const match = line.match(
+    /(Token|NTLM hash|Kerberos Ticket|Ticket cache):\s*(\S+)/i,
+  );
+  if (!match) return line;
+  const [, label, value] = match;
+  return (
+    <>
+      {label}: <span className="p-[6px]">{show ? value : "********"}</span>
+    </>
   );
 };
 
@@ -56,9 +62,9 @@ const MimikatzApp = () => {
 
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white">
-      <div className="bg-yellow-600 text-black text-center text-sm py-1">
-        Warning: demo only. No real credentials are used.
-      </div>
+      <WarningBanner>
+        Demo only. No real credentials are used.
+      </WarningBanner>
       <div className="flex border-b border-gray-700">
         {tabs.map((t) => (
           <button


### PR DESCRIPTION
## Summary
- style command outputs with terminal-look and per-line copy buttons
- add reusable amber warning banner component with alert icon
- wrap sensitive token values with 6px padding for clarity

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: Assign object to a variable before exporting as module default, 62 problems)*
- `yarn test` *(fails: wireshark, beef, nikto, volatility plugin browser, mimikatz, and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b219412c348328afd2f72fc3de181a