### PR TITLE
refine radare2 interface

### DIFF
--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 
 interface Block {
   addr: string;
@@ -14,8 +14,8 @@ interface GraphViewProps {
 }
 
 const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
+  () => import("react-force-graph").then((mod) => mod.ForceGraph2D),
+  { ssr: false },
 );
 
 const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
@@ -23,31 +23,31 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
   const [center, setCenter] = useState({ x: 0, y: 0 });
   const [selected, setSelected] = useState<Block | null>(null);
   const [colors, setColors] = useState({
-    bg: '#000',
-    surface: '#374151',
-    text: '#fff',
-    accent: '#fbbf24',
-    border: '#4b5563',
+    bg: "#000",
+    surface: "#374151",
+    text: "#fff",
+    accent: "#fbbf24",
+    border: "#4b5563",
   });
 
   const graphData = useMemo(() => {
     const nodes = blocks.map((b) => ({ id: b.addr }));
     const links: { source: string; target: string }[] = [];
     blocks.forEach((b) =>
-      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e }))
+      (b.edges || []).forEach((e) => links.push({ source: b.addr, target: e })),
     );
     return { nodes, links };
   }, [blocks]);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
     const style = getComputedStyle(document.documentElement);
     setColors({
-      bg: style.getPropertyValue('--r2-bg').trim() || '#000',
-      surface: style.getPropertyValue('--r2-surface').trim() || '#374151',
-      text: style.getPropertyValue('--r2-text').trim() || '#fff',
-      accent: style.getPropertyValue('--r2-accent').trim() || '#fbbf24',
-      border: style.getPropertyValue('--r2-border').trim() || '#4b5563',
+      bg: style.getPropertyValue("--r2-bg").trim() || "#000",
+      surface: style.getPropertyValue("--r2-surface").trim() || "#374151",
+      text: style.getPropertyValue("--r2-text").trim() || "#fff",
+      accent: style.getPropertyValue("--r2-accent").trim() || "#fbbf24",
+      border: style.getPropertyValue("--r2-border").trim() || "#4b5563",
     });
   }, [theme]);
 
@@ -89,7 +89,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
     y: number,
     w: number,
     h: number,
-    r: number
+    r: number,
   ) => {
     ctx.beginPath();
     ctx.moveTo(x + r, y);
@@ -107,7 +107,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
   const nodeCanvasObject = (
     node: any,
     ctx: CanvasRenderingContext2D,
-    globalScale: number
+    globalScale: number,
   ) => {
     const label = node.id;
     const fontSize = 12 / globalScale;
@@ -124,9 +124,9 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
     roundRect(ctx, x, y, width, height, 6);
     ctx.fill();
     ctx.stroke();
-    ctx.fillStyle = isSelected ? '#000' : colors.text;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
+    ctx.fillStyle = isSelected ? "#000" : colors.text;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
     ctx.fillText(label, node.x, node.y);
   };
 
@@ -134,7 +134,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
     node: any,
     color: string,
     ctx: CanvasRenderingContext2D,
-    globalScale: number
+    globalScale: number,
   ) => {
     const label = node.id;
     const fontSize = 12 / globalScale;
@@ -157,7 +157,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
   const linkColor = (link: any) => {
     if (
       selected &&
-      typeof link.source !== 'string' &&
+      typeof link.source !== "string" &&
       link.source.id === selected.addr
     ) {
       return colors.accent;
@@ -168,7 +168,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
   const linkWidth = (link: any) => {
     if (
       selected &&
-      typeof link.source !== 'string' &&
+      typeof link.source !== "string" &&
       link.source.id === selected.addr
     ) {
       return 2;
@@ -182,49 +182,67 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
         <button
           onClick={zoomIn}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           +
         </button>
         <button
           onClick={zoomOut}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           -
         </button>
         <button
           onClick={() => pan(0, -20)}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           ↑
         </button>
         <button
           onClick={() => pan(0, 20)}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           ↓
         </button>
         <button
           onClick={() => pan(-20, 0)}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           ←
         </button>
         <button
           onClick={() => pan(20, 0)}
           className="px-2 py-1 rounded"
-          style={{ backgroundColor: 'var(--r2-surface)', border: '1px solid var(--r2-border)' }}
+          style={{
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
+          }}
         >
           →
         </button>
       </div>
       <div
         className="h-64 rounded"
-        style={{ backgroundColor: 'var(--r2-surface)' }}
+        style={{ backgroundColor: "var(--r2-surface)" }}
       >
         <ForceGraph2D
           ref={fgRef}
@@ -232,6 +250,9 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
           backgroundColor={colors.surface}
           linkColor={linkColor}
           linkWidth={linkWidth}
+          linkDirectionalArrowLength={4}
+          linkDirectionalArrowRelPos={1}
+          linkDirectionalArrowColor={linkColor}
           nodeCanvasObject={nodeCanvasObject}
           nodePointerAreaPaint={nodePointerAreaPaint}
           onNodeClick={handleNodeClick}
@@ -241,14 +262,12 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
         <div
           className="mt-2 p-2 rounded text-sm"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
           <div>Block: {selected.addr}</div>
-          <div>
-            Outgoing edges: {selected.edges?.join(', ') || 'None'}
-          </div>
+          <div>Outgoing edges: {selected.edges?.join(", ") || "None"}</div>
         </div>
       )}
     </div>
@@ -256,4 +275,3 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
 };
 
 export default GraphView;
-

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -1,26 +1,31 @@
-import React, { useEffect, useRef, useState } from 'react';
-import HexEditor from './HexEditor';
+import React, { useEffect, useRef, useState } from "react";
+import HexEditor from "./HexEditor";
 import {
   loadNotes,
   saveNotes,
   loadBookmarks,
   saveBookmarks,
   extractStrings,
-} from './utils';
-import GraphView from '../../../apps/radare2/components/GraphView';
-import GuideOverlay from './GuideOverlay';
-import { useTheme } from '../../../hooks/useTheme';
-import './theme.css';
+} from "./utils";
+import GraphView from "../../../apps/radare2/components/GraphView";
+import GuideOverlay from "./GuideOverlay";
+import { useTheme } from "../../../hooks/useTheme";
+import "./theme.css";
 
 const Radare2 = ({ initialData = {} }) => {
-  const { file = 'demo', hex = '', disasm = [], xrefs = {}, blocks = [] } =
-    initialData;
-  const [mode, setMode] = useState('code');
-  const [seekAddr, setSeekAddr] = useState('');
-  const [findTerm, setFindTerm] = useState('');
+  const {
+    file = "demo",
+    hex = "",
+    disasm = [],
+    xrefs = {},
+    blocks = [],
+  } = initialData;
+  const [mode, setMode] = useState("code");
+  const [seekAddr, setSeekAddr] = useState("");
+  const [findTerm, setFindTerm] = useState("");
   const [currentAddr, setCurrentAddr] = useState(null);
   const [notes, setNotes] = useState([]);
-  const [noteText, setNoteText] = useState('');
+  const [noteText, setNoteText] = useState("");
   const [bookmarks, setBookmarks] = useState([]);
   const [showGuide, setShowGuide] = useState(false);
   const [strings, setStrings] = useState([]);
@@ -28,16 +33,18 @@ const Radare2 = ({ initialData = {} }) => {
   const { theme, setTheme } = useTheme();
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       setNotes(loadNotes(file));
       setBookmarks(loadBookmarks(file));
-
     }
   }, [file]);
 
   useEffect(() => {
     try {
-      if (typeof window !== 'undefined' && !localStorage.getItem('r2HelpDismissed')) {
+      if (
+        typeof window !== "undefined" &&
+        !localStorage.getItem("r2HelpDismissed")
+      ) {
         setShowGuide(true);
       }
     } catch {
@@ -46,18 +53,18 @@ const Radare2 = ({ initialData = {} }) => {
   }, []);
 
   useEffect(() => {
-    const base = disasm[0]?.addr || '0x0';
+    const base = disasm[0]?.addr || "0x0";
     setStrings(extractStrings(hex, base));
   }, [hex, disasm]);
 
   const scrollToAddr = (addr) => {
     const idx = disasm.findIndex(
-      (l) => l.addr.toLowerCase() === addr.toLowerCase()
+      (l) => l.addr.toLowerCase() === addr.toLowerCase(),
     );
     if (idx >= 0) {
       setCurrentAddr(disasm[idx].addr);
       const el = document.getElementById(`asm-${idx}`);
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   };
 
@@ -70,12 +77,12 @@ const Radare2 = ({ initialData = {} }) => {
     const idx = disasm.findIndex(
       (l) =>
         l.text.toLowerCase().includes(findTerm.toLowerCase()) ||
-        l.addr.toLowerCase() === findTerm.toLowerCase()
+        l.addr.toLowerCase() === findTerm.toLowerCase(),
     );
     if (idx >= 0) {
       setCurrentAddr(disasm[idx].addr);
       const el = document.getElementById(`asm-${idx}`);
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   };
 
@@ -84,7 +91,7 @@ const Radare2 = ({ initialData = {} }) => {
     const next = [...notes, { addr: currentAddr, text: noteText.trim() }];
     setNotes(next);
     saveNotes(file, next);
-    setNoteText('');
+    setNoteText("");
   };
 
   const toggleBookmark = (addr) => {
@@ -98,29 +105,34 @@ const Radare2 = ({ initialData = {} }) => {
   return (
     <div
       className={`h-full w-full p-4 overflow-auto ${
-        theme === 'dark' ? 'r2-dark' : 'r2-light'
+        theme === "dark" ? "r2-dark" : "r2-light"
       }`}
-      style={{ backgroundColor: 'var(--r2-bg)', color: 'var(--r2-text)' }}
+      style={{ backgroundColor: "var(--r2-bg)", color: "var(--r2-text)" }}
     >
       {showGuide && <GuideOverlay onClose={() => setShowGuide(false)} />}
-      <div className="flex gap-2 mb-2 flex-wrap">
+      <div className="flex gap-2 mb-2 flex-wrap items-center">
+        <img
+          src="/themes/Yaru/apps/radare2.svg"
+          alt="Radare2 badge"
+          className="w-12 h-12"
+        />
         <input
           value={seekAddr}
           onChange={(e) => setSeekAddr(e.target.value)}
           placeholder="seek 0x..."
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            color: 'var(--r2-text)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            color: "var(--r2-text)",
+            border: "1px solid var(--r2-border)",
           }}
         />
         <button
           onClick={handleSeek}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
           Seek
@@ -131,67 +143,71 @@ const Radare2 = ({ initialData = {} }) => {
           placeholder="find"
           className="px-2 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            color: 'var(--r2-text)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            color: "var(--r2-text)",
+            border: "1px solid var(--r2-border)",
           }}
         />
         <button
           onClick={handleFind}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
           Find
         </button>
         <button
-          onClick={() => setMode((m) => (m === 'code' ? 'graph' : 'code'))}
+          onClick={() => setMode((m) => (m === "code" ? "graph" : "code"))}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
-          {mode === 'code' ? 'Graph' : 'Code'}
+          {mode === "code" ? "Graph" : "Code"}
         </button>
         <button
           onClick={() => setShowGuide(true)}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
           Help
         </button>
         <button
-          onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
           className="px-3 py-1 rounded"
           style={{
-            backgroundColor: 'var(--r2-surface)',
-            border: '1px solid var(--r2-border)',
+            backgroundColor: "var(--r2-surface)",
+            border: "1px solid var(--r2-border)",
           }}
         >
-          {theme === 'dark' ? 'Light' : 'Dark'}
+          {theme === "dark" ? "Light" : "Dark"}
         </button>
       </div>
 
-      {mode === 'graph' ? (
+      {mode === "graph" ? (
         <GraphView blocks={blocks} theme={theme} />
       ) : (
         <div className="grid md:grid-cols-2 gap-4">
           <HexEditor hex={hex} theme={theme} />
           <div
             ref={disasmRef}
-            className="overflow-auto rounded p-2 max-h-64"
+            className="overflow-auto rounded max-h-64 p-1.5 font-mono"
             style={{
-              backgroundColor: 'var(--r2-surface)',
-              border: '1px solid var(--r2-border)',
+              backgroundColor: "var(--r2-surface)",
+              border: "1px solid var(--r2-border)",
+              backgroundImage:
+                "repeating-linear-gradient(to right, transparent, transparent calc(8ch - 1px), var(--r2-border) calc(8ch - 1px), var(--r2-border) 8ch)",
+              backgroundOrigin: "content-box",
+              backgroundClip: "content-box",
             }}
           >
-            <ul className="font-mono text-sm">
+            <ul className="text-sm">
               {disasm.map((line, idx) => (
                 <li
                   key={line.addr}
@@ -199,9 +215,11 @@ const Radare2 = ({ initialData = {} }) => {
                   className="cursor-pointer"
                   style={{
                     backgroundColor:
-                      currentAddr === line.addr ? 'var(--r2-accent)' : 'transparent',
+                      currentAddr === line.addr
+                        ? "var(--r2-accent)"
+                        : "transparent",
                     color:
-                      currentAddr === line.addr ? '#000' : 'var(--r2-text)',
+                      currentAddr === line.addr ? "#000" : "var(--r2-text)",
                   }}
                   onClick={() => setCurrentAddr(line.addr)}
                 >
@@ -212,7 +230,7 @@ const Radare2 = ({ initialData = {} }) => {
                     }}
                     className="mr-1"
                   >
-                    {bookmarks.includes(line.addr) ? '★' : '☆'}
+                    {bookmarks.includes(line.addr) ? "★" : "☆"}
                   </button>
                   {line.addr}: {line.text}
                 </li>
@@ -228,13 +246,16 @@ const Radare2 = ({ initialData = {} }) => {
           <ul
             className="rounded p-2"
             style={{
-              backgroundColor: 'var(--r2-surface)',
-              border: '1px solid var(--r2-border)',
+              backgroundColor: "var(--r2-surface)",
+              border: "1px solid var(--r2-border)",
             }}
           >
             {strings.map((s) => (
               <li key={s.addr}>
-                <button onClick={() => scrollToAddr(s.addr)} className="underline">
+                <button
+                  onClick={() => scrollToAddr(s.addr)}
+                  className="underline"
+                >
                   {s.addr}: {s.text}
                 </button>
               </li>
@@ -247,7 +268,7 @@ const Radare2 = ({ initialData = {} }) => {
         <div className="mt-4">
           <h2 className="text-lg">Xrefs for {currentAddr}</h2>
           <p className="mb-2">
-            {(xrefs[currentAddr] || []).join(', ') || 'None'}
+            {(xrefs[currentAddr] || []).join(", ") || "None"}
           </p>
           <textarea
             value={noteText}
@@ -255,17 +276,17 @@ const Radare2 = ({ initialData = {} }) => {
             placeholder="Add note"
             className="w-full p-2 rounded"
             style={{
-              backgroundColor: 'var(--r2-surface)',
-              color: 'var(--r2-text)',
-              border: '1px solid var(--r2-border)',
+              backgroundColor: "var(--r2-surface)",
+              color: "var(--r2-text)",
+              border: "1px solid var(--r2-border)",
             }}
           />
           <button
             onClick={handleAddNote}
             className="mt-2 px-3 py-1 rounded"
             style={{
-              backgroundColor: 'var(--r2-surface)',
-              border: '1px solid var(--r2-border)',
+              backgroundColor: "var(--r2-surface)",
+              border: "1px solid var(--r2-border)",
             }}
           >
             Save Note
@@ -279,8 +300,8 @@ const Radare2 = ({ initialData = {} }) => {
           <ul
             className="rounded p-2"
             style={{
-              backgroundColor: 'var(--r2-surface)',
-              border: '1px solid var(--r2-border)',
+              backgroundColor: "var(--r2-surface)",
+              border: "1px solid var(--r2-border)",
             }}
           >
             {notes.map((n, i) => (


### PR DESCRIPTION
## Summary
- add arrowheads to radare2 graph edges
- style disassembly panel with monospace column guides and 6px padding
- show radare2 48px badge in tool header

## Testing
- `npm test` (fails: wireshark.test.tsx, beef.test.tsx, niktoPage.test.tsx, volatilityPluginBrowser.test.tsx, mimikatz.test.ts, calculator/parser.test.ts, volatilityPluginBrowser.test.tsx, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b2194590588328a3d2307ccda1ec38