### PR TITLE
Refine profile selection and memory views

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -36,10 +36,7 @@ describe('OpenVASApp', () => {
       screen.getByPlaceholderText('Group (e.g. Servers)'),
       { target: { value: 'servers' } }
     );
-    fireEvent.change(
-      screen.getByLabelText('Scan profile'),
-      { target: { value: 'HIPAA' } }
-    );
+    fireEvent.click(screen.getByRole('tab', { name: 'HIPAA' }));
     fireEvent.click(screen.getByText('Scan'));
     await waitFor(() => expect(fetch).toHaveBeenCalled());
     expect(fetch).toHaveBeenCalledWith(

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -6,6 +6,24 @@ import hipaaProfile from './templates/hipaa.json';
 
 const templates = { PCI: pciProfile, HIPAA: hipaaProfile };
 
+const CardIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+    <rect x="2" y="5" width="20" height="14" rx="2" />
+    <rect x="4" y="8" width="16" height="2" />
+  </svg>
+);
+
+const HealthIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M11 2h2v8h8v2h-8v8h-2v-8H3v-2h8z" />
+  </svg>
+);
+
+const profileTabs = [
+  { id: 'PCI', label: 'PCI', icon: <CardIcon /> },
+  { id: 'HIPAA', label: 'HIPAA', icon: <HealthIcon /> },
+];
+
 // Simple helper for notifications that falls back to alert()
 const notify = (title, body) => {
   if (typeof window === 'undefined') return;
@@ -368,18 +386,23 @@ const OpenVASApp = () => {
           value={group}
           onChange={(e) => setGroup(e.target.value)}
         />
-        <select
-          aria-label="Scan profile"
-          className="flex-1 p-2 rounded text-black"
-          value={profile}
-          onChange={(e) => setProfile(e.target.value)}
-        >
-          {Object.keys(templates).map((name) => (
-            <option key={name} value={name}>
-              {name}
-            </option>
+        <div className="flex items-center space-x-2" role="tablist" aria-label="Scan profile">
+          {profileTabs.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              role="tab"
+              aria-selected={profile === p.id}
+              aria-label={p.label}
+              onClick={() => setProfile(p.id)}
+              className={`w-6 h-6 flex items-center justify-center rounded ${
+                profile === p.id ? 'bg-gray-700' : 'bg-gray-600'
+              }`}
+            >
+              {p.icon}
+            </button>
           ))}
-        </select>
+        </div>
         <button
           type="button"
           onClick={() => runScan()}
@@ -602,17 +625,22 @@ const OpenVASApp = () => {
         {announce}
       </div>
       {output && (
-        <pre className="bg-black text-green-400 p-2 rounded whitespace-pre-wrap">
-          {output}
-        </pre>
+        <div className="bg-black text-white text-xs font-mono rounded overflow-auto">
+          {output.split('\n').map((line, i) => (
+            <div key={i} className={`px-2 ${i % 2 ? 'bg-gray-900' : 'bg-gray-800'}`}>
+              {line || '\u00A0'}
+            </div>
+          ))}
+        </div>
       )}
       {summaryUrl && (
         <a
           href={summaryUrl}
           download="openvas-summary.md"
-          className="inline-block mt-2 px-4 py-2 bg-blue-600 rounded"
+          aria-label="Download summary"
+          className="inline-flex items-center mt-2 p-2 bg-blue-600 rounded"
         >
-          Download Summary
+          <img src="/themes/Yaru/status/download.svg" alt="" className="w-4 h-4" />
         </a>
       )}
       <footer className="mt-4 text-xs text-gray-400">

--- a/components/apps/volatility/MemoryHeatmap.js
+++ b/components/apps/volatility/MemoryHeatmap.js
@@ -6,12 +6,6 @@ const categories = {
   socket: 'Sockets',
 };
 
-const colors = {
-  process: '#ef4444', // red-500
-  dll: '#3b82f6', // blue-500
-  socket: '#10b981', // green-500
-};
-
 // Use darker shades for chips to ensure sufficient contrast on white text
 const chipColors = {
   process: 'bg-red-700',
@@ -56,9 +50,10 @@ const MemoryHeatmap = ({ data }) => {
         if (x + cell.width < 0 || y + cell.height < 0 || x > canvas.width || y > canvas.height) {
           return;
         }
-        ctx.fillStyle = colors[cell.type];
+        const gap = 6;
+        ctx.fillStyle = '#ffffff';
         ctx.globalAlpha = cell.value;
-        ctx.fillRect(x, y, cell.width, cell.height);
+        ctx.fillRect(x + gap / 2, y + gap / 2, cell.width - gap, cell.height - gap);
       });
       ctx.globalAlpha = 1;
       if (!prefersReducedMotion.current) {

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -67,9 +67,13 @@ const PluginBrowser = () => {
         </div>
       ))}
       {selected && (
-        <pre className="text-xs bg-black p-3 rounded overflow-auto">
-          {selected.output}
-        </pre>
+        <div className="text-xs bg-black rounded overflow-auto">
+          {selected.output.split('\n').map((line, i) => (
+            <div key={i} className={`px-2 ${i % 2 ? 'bg-gray-900' : 'bg-gray-800'}`}>
+              {line || '\u00A0'}
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -281,9 +281,13 @@ const VolatilityApp = () => {
         )}
       </div>
       {output && (
-        <pre className="h-32 overflow-auto p-4 bg-black text-green-400 whitespace-pre-wrap">
-          {output}
-        </pre>
+        <div className="h-32 overflow-auto bg-black text-white text-xs font-mono rounded">
+          {output.split('\n').map((line, i) => (
+            <div key={i} className={`px-2 ${i % 2 ? 'bg-gray-900' : 'bg-gray-800'}`}>
+              {line || '\u00A0'}
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace OpenVAS scan profile dropdown with 24px icon tabs
- Render analysis outputs in monospaced zebra rows and add symbolic download icon
- Shade memory heatmap bands with 6px gaps and unify plugin output styling

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: multiple suites such as wireshark, beef, niktoPage, mimikatz, volatilityPluginBrowser, kismet, snake.config, frogger.config)*
- `yarn test __tests__/openvas.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b2194761088328aa1ad16e00b33785