### PR TITLE
feat: add timeline chips and copy controls

### DIFF
--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -54,11 +54,16 @@ const PopularModules: React.FC = () => {
         l.message.toLowerCase().includes(logFilter.toLowerCase())
       )
     : [];
-
   const copyLogs = () => {
     const text = filteredLog.map((l) => l.message).join('\n');
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
       navigator.clipboard.writeText(text);
+    }
+  };
+
+  const copyCommand = () => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(commandPreview);
     }
   };
 
@@ -93,6 +98,85 @@ const PopularModules: React.FC = () => {
     success: 'text-green-400',
     error: 'text-red-400',
     warning: 'text-yellow-300',
+  };
+
+  const levelIcon: Record<string, JSX.Element> = {
+    info: (
+      <svg
+        className="w-6 h-6 text-blue-300"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+        />
+      </svg>
+    ),
+    success: (
+      <svg
+        className="w-6 h-6 text-green-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 13l4 4L19 7"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"
+        />
+      </svg>
+    ),
+    warning: (
+      <svg
+        className="w-6 h-6 text-yellow-300"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 8v4m0 4h.01M4.93 19h14.14c1.2 0 1.94-1.3 1.34-2.33L13.34 4.67c-.6-1.04-2.08-1.04-2.68 0L3.59 16.67c-.6 1.03-.15 2.33 1.34 2.33z"
+        />
+      </svg>
+    ),
+    error: (
+      <svg
+        className="w-6 h-6 text-red-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 2a10 10 0 100 20 10 10 0 000-20z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 9l-6 6m0-6l6 6"
+        />
+      </svg>
+    ),
   };
 
   return (
@@ -182,12 +266,21 @@ const PopularModules: React.FC = () => {
               </label>
             ))}
           </form>
-          <pre
-            data-testid="command-preview"
-            className="bg-black text-green-400 p-2 overflow-auto"
-          >
-            {commandPreview}
-          </pre>
+          <div className="flex items-start gap-2">
+            <pre
+              data-testid="command-preview"
+              className="flex-1 bg-black text-green-400 p-2 overflow-auto font-mono"
+            >
+              {commandPreview}
+            </pre>
+            <button
+              type="button"
+              onClick={copyCommand}
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              Copy
+            </button>
+          </div>
           <div className="space-y-1">
             <label className="block text-sm">
               Filter logs
@@ -206,16 +299,20 @@ const PopularModules: React.FC = () => {
             >
               Copy Logs
             </button>
-            <pre className="bg-black p-2 overflow-auto" role="log">
+            <ol className="border-l-2 border-gray-700 pl-4 space-y-2" role="log">
               {filteredLog.map((line, idx) => (
-                <React.Fragment key={idx}>
-                  <span className={levelClass[line.level] || levelClass.info}>
+                <li key={idx} className="flex items-center gap-2">
+                  {levelIcon[line.level] || levelIcon.info}
+                  <span
+                    className={`px-2 py-1 rounded-full bg-gray-700 text-sm font-mono ${
+                      levelClass[line.level] || levelClass.info
+                    }`}
+                  >
                     {line.message}
                   </span>
-                  {'\n'}
-                </React.Fragment>
+                </li>
               ))}
-            </pre>
+            </ol>
           </div>
           <table className="min-w-full text-sm">
             <thead>

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -191,12 +191,22 @@ const ModuleWorkspace: React.FC = () => {
                 Run
               </button>
               {result && (
-                <pre
-                  className="bg-black text-green-400 p-2 overflow-auto"
-                  role="log"
-                >
-                  {result}
-                </pre>
+                <div className="flex items-start gap-2">
+                  <pre
+                    className="flex-1 bg-black text-green-400 p-2 overflow-auto font-mono"
+                    role="log"
+                  >
+                    {result}
+                  </pre>
+                  <button
+                    onClick={() =>
+                      navigator.clipboard?.writeText(result)
+                    }
+                    className="px-2 py-1 text-sm rounded bg-gray-700"
+                  >
+                    Copy
+                  </button>
+                </div>
               )}
               {Object.keys(storeData).length > 0 && (
                 <div>

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -7,6 +7,12 @@ export default function PostExploitation() {
   const [selected, setSelected] = useState<ModuleMetadata | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
+  const transcript = `meterpreter > getuid\nServer username: NT AUTHORITY\\SYSTEM\nmeterpreter > keyscan_start\nStarting the keystroke sniffer...\nmeterpreter > run persistence_service\n[*] Creating service accomplished\n`;
+
+  const copyTranscript = () => {
+    navigator.clipboard?.writeText(transcript);
+  };
+
   const allTags = Array.from(new Set(modules.flatMap((m) => m.tags))).sort();
 
   const toggleTag = (tag: string) => {
@@ -95,15 +101,17 @@ export default function PostExploitation() {
             <p>Select a module to view details.</p>
           )}
           <h3>Example Transcript</h3>
-          <pre className="overflow-x-auto rounded bg-black p-3 text-green-400">
-{`meterpreter > getuid
-Server username: NT AUTHORITY\\SYSTEM
-meterpreter > keyscan_start
-Starting the keystroke sniffer...
-meterpreter > run persistence_service
-[*] Creating service accomplished
-`}
-          </pre>
+          <div className="flex items-start gap-2">
+            <pre className="flex-1 overflow-x-auto rounded bg-black p-3 text-green-400 font-mono">
+              {transcript}
+            </pre>
+            <button
+              onClick={copyTranscript}
+              className="px-2 py-1 text-sm rounded bg-gray-700"
+            >
+              Copy
+            </button>
+          </div>
         </aside>
       </main>
     </>


### PR DESCRIPTION
## Summary
- show module logs as timeline chips with 24px glyph icons
- add monospaced output panes with copy buttons across pages

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: multiple test suites including wireshark.test.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b21949e83483289b225f6bef0c38f0