### PR TITLE
feat: update weather visuals

### DIFF
--- a/apps/weather/components/CityDetail.tsx
+++ b/apps/weather/components/CityDetail.tsx
@@ -11,13 +11,17 @@ interface Props {
 export default function CityDetail({ city, onClose }: Props) {
   const [unit, setUnit] = useState<'C' | 'F'>('C');
   const [hourly, setHourly] = useState<number[]>([]);
+  const [precip, setPrecip] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&hourly=temperature_2m&forecast_days=1&timezone=auto`,
+      `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&hourly=temperature_2m,precipitation_probability&forecast_days=1&timezone=auto`,
     )
       .then((res) => res.json())
-      .then((data) => setHourly(data.hourly.temperature_2m as number[]))
+      .then((data) => {
+        setHourly(data.hourly.temperature_2m as number[]);
+        setPrecip(data.hourly.precipitation_probability?.[0] ?? null);
+      })
       .catch(() => {});
   }, [city]);
 
@@ -26,6 +30,14 @@ export default function CityDetail({ city, onClose }: Props) {
   const min = Math.min(...slice);
   const max = Math.max(...slice);
   const range = max - min || 1;
+
+  const step = 6;
+  const height = 100;
+  const points = slice
+    .map(
+      (t, i) => `${i * step},${height - ((t - min) / range) * height}`,
+    )
+    .join(' ');
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4">
@@ -48,15 +60,31 @@ export default function CityDetail({ city, onClose }: Props) {
             °F
           </button>
         </div>
-        <div className="flex items-end h-24 gap-0.5">
-          {slice.map((t, i) => (
-            <div
-              key={i}
-              className="bg-blue-400 w-1"
-              style={{ height: `${((t - min) / range) * 100}%` }}
+        <div className="h-24 relative">
+          <svg
+            viewBox={`0 0 ${step * (slice.length - 1)} ${height}`}
+            className="absolute inset-0 w-full h-full"
+          >
+            <polyline
+              points={points}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1"
             />
-          ))}
+            {slice.map((t, i) => (
+              <circle
+                key={i}
+                cx={i * step}
+                cy={height - ((t - min) / range) * height}
+                r="2"
+                className="fill-blue-400"
+              />
+            ))}
+          </svg>
         </div>
+        {precip !== null && (
+          <div className="mt-4 precip-text">Precipitation: {precip}%</div>
+        )}
       </div>
     </div>
   );

--- a/apps/weather/components/WeatherIcon.tsx
+++ b/apps/weather/components/WeatherIcon.tsx
@@ -5,12 +5,17 @@ interface Props {
   className?: string;
 }
 
-export default function WeatherIcon({ code, className = 'w-6 h-6' }: Props) {
-  // Simple mapping based on weather code groups
+export default function WeatherIcon({ code, className = 'w-16 h-16' }: Props) {
+  const base = className;
+  // Simple mapping based on weather code groups with colored accents
   if (code === 0) {
     // clear sky
     return (
-      <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <svg
+        viewBox="0 0 24 24"
+        className={`${base} text-yellow-400`}
+        fill="currentColor"
+      >
         <circle cx="12" cy="12" r="5" />
         <g stroke="currentColor" strokeWidth="2" fill="none">
           <line x1="12" y1="1" x2="12" y2="4" />
@@ -29,7 +34,11 @@ export default function WeatherIcon({ code, className = 'w-6 h-6' }: Props) {
   if (code >= 51 && code <= 67) {
     // rain
     return (
-      <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <svg
+        viewBox="0 0 24 24"
+        className={`${base} text-blue-400`}
+        fill="currentColor"
+      >
         <path d="M7 17a5 5 0 1 1 10 0H7Z" />
         <path d="M7 17a5 5 0 0 1 10 0H7Z" />
         <g stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round">
@@ -44,7 +53,11 @@ export default function WeatherIcon({ code, className = 'w-6 h-6' }: Props) {
   if (code >= 71 && code <= 86) {
     // snow
     return (
-      <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <svg
+        viewBox="0 0 24 24"
+        className={`${base} text-cyan-200`}
+        fill="currentColor"
+      >
         <path d="M12 2v20M2 12h20" stroke="currentColor" strokeWidth="2" />
         <path d="M5 5l14 14M19 5L5 19" stroke="currentColor" strokeWidth="2" />
       </svg>
@@ -54,7 +67,11 @@ export default function WeatherIcon({ code, className = 'w-6 h-6' }: Props) {
   if (code >= 95) {
     // storm
     return (
-      <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <svg
+        viewBox="0 0 24 24"
+        className={`${base} text-purple-400`}
+        fill="currentColor"
+      >
         <path d="M7 14a5 5 0 1 1 10 0H7Z" />
         <polygon points="13 14 9 21 13 21 11 24 15 17 11 17 13 14" />
       </svg>
@@ -63,7 +80,11 @@ export default function WeatherIcon({ code, className = 'w-6 h-6' }: Props) {
 
   // default: cloudy
   return (
-    <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+    <svg
+      viewBox="0 0 24 24"
+      className={`${base} text-gray-300`}
+      fill="currentColor"
+    >
       <path d="M5 16a7 7 0 0 1 14 0H5Z" />
     </svg>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -199,6 +199,19 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     animation: cursor-pulse 1s steps(2) infinite;
 }
 
+/* High contrast handling for precipitation text */
+.precip-text {
+    color: #0ea5e9;
+}
+
+@media (prefers-contrast: more), (forced-colors: active) {
+    .precip-text {
+        color: #000;
+        background-color: #fff;
+        padding-inline: 2px;
+    }
+}
+
 @keyframes cursor-pulse {
     0% { opacity: 1; }
     50% { opacity: 0.2; }


### PR DESCRIPTION
## Summary
- expand weather icons to 64px with color accents
- render hourly temperatures with thin line chart and 6px spacing
- add high-contrast styling for precipitation text

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: e.g., VolatilityPluginBrowser, mimikatz, battleship-net)*

------
https://chatgpt.com/codex/tasks/task_e_68b21943caec83288dbd1dad7f3d0a99