### PR TITLE
feat(nmap): add radar icon and collapsible output

### DIFF
--- a/public/themes/Yaru/apps/radar-symbolic.svg
+++ b/public/themes/Yaru/apps/radar-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="2" fill="none"/>
+  <line x1="8" y1="8" x2="14" y2="8" stroke="currentColor" stroke-width="2"/>
+  <line x1="8" y1="8" x2="8" y2="2" stroke="currentColor" stroke-width="2"/>
+  <circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- add radar icon header to nmap demo
- filter and search scripts in grid layout
- toggleable output sections with severity strip

## Testing
- `yarn test __tests__/wireshark.test.tsx` *(fails: Syntax Error in FilterHelper.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b219431b1883289f98513e05db3492