### PR TITLE
fix vercel runtime config schema

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "functions": {
-    "runtime": "nodejs22.x"
+    "api/**/*": {
+      "runtime": "nodejs22.x"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- adjust Vercel config to use a wildcard function pattern and specify Node.js 22 runtime

## Testing
- `yarn lint vercel.json` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test --passWithNoTests` *(fails: multiple test suites including wireshark, beef, niktoPage, volatilityPluginBrowser, mimikatz, snake.config, frogger.config, and kismet)*

------
https://chatgpt.com/codex/tasks/task_e_68b222f184d88328a06c781a891feaa7