### PR TITLE
feat: add Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@mozilla/readability": "^0.6.0",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
     "@xterm/xterm": "^5.5.0",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -128,6 +129,7 @@ function MyApp({ Component, pageProps }) {
         <Component {...pageProps} />
         <ShortcutOverlay />
         <Analytics />
+        {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
       </PipPortalProvider>
     </SettingsProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3499,6 +3499,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/speed-insights@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@vercel/speed-insights@npm:1.2.0"
+  peerDependencies:
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10c0/2fb4c4a46330949182d6f63691c51310b636fc3cc464bde3c0f24f100b712c3c4ec57a9fedcd6dc3cc75951064b3295b3cb616c80ff7179fbe310cd4314fffaa
+  languageName: node
+  linkType: hard
+
 "@webgpu/types@npm:*":
   version: 0.1.64
   resolution: "@webgpu/types@npm:0.1.64"
@@ -11670,6 +11697,7 @@ __metadata:
     "@types/web-bluetooth": "npm:^0.0.21"
     "@types/wicg-file-system-access": "npm:^2023.10.6"
     "@vercel/analytics": "npm:^1.5.0"
+    "@vercel/speed-insights": "npm:^1.2.0"
     "@xterm/addon-fit": "npm:^0.10.0"
     "@xterm/addon-search": "npm:^0.15.0"
     "@xterm/xterm": "npm:^5.5.0"


### PR DESCRIPTION
## Summary
- integrate Vercel Speed Insights in the Next.js app
- install @vercel/speed-insights dependency

## Testing
- `yarn build` *(fails: React hook and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2243094b08328a4f1181e78fc8823