### PR TITLE
chore: extend CSP for new script sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `cdn.syndication.twimg.com` | Twitter asset CDN |
 | `*.twitter.com` | Additional Twitter content |
 | `*.x.com` | X (Twitter) domain equivalents |
-| `*.google.com` | Google services used by demos |
+| `*.google.com` | Google services used by demos (e.g., reCAPTCHA) |
+| `cdn.jsdelivr.net` | Math.js library |
+| `cdnjs.cloudflare.com` | PDF.js worker |
 | `stackblitz.com` | StackBlitz IDE embeds |
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,7 @@ const ContentSecurityPolicy = [
   // Allow loading fonts from Google
   "font-src 'self' https://fonts.gstatic.com",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com",
+  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content


### PR DESCRIPTION
## Summary
- include Google reCAPTCHA, jsDelivr and cdnjs in CSP `script-src`
- document new CSP domains

## Testing
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, niktoPage.test.tsx, volatilityPluginBrowser.test.tsx, mimikatz.test.ts, kismet.test.tsx, frogger.config.test.ts, metasploit app tests, etc.)*
- `yarn build` *(fails: lint errors and parsing error in components/apps/todoist.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b2243257c48328913d1e2be4fa8a05