### PR TITLE
test: add speed insights spec

### DIFF
--- a/playwright/speed-insights.spec.ts
+++ b/playwright/speed-insights.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.skip(
+  process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true',
+  'Speed Insights script is disabled during static export',
+);
+
+test('Speed Insights script is injected in production', async ({ page }) => {
+  await page.goto('/');
+  const script = page.locator('script[src*="/_vercel/speed-insights/script.js"]');
+  await expect(script).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
- add Playwright spec to ensure Vercel Speed Insights script injection
- skip the test during static export builds

## Testing
- `NEXT_PUBLIC_STATIC_EXPORT=true npx playwright test playwright/speed-insights.spec.ts --workers=1`
- `npx eslint -c .eslintrc.cjs playwright/speed-insights.spec.ts` *(fails: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b22433ca3c83288b23e1198381973a