### PR TITLE
docs: add speed insights notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ To send text or links directly into the Sticky Notes app:
 
 ---
 
+## Speed Insights
+
+- Enable Speed Insights in the Vercel project dashboard.
+- `<SpeedInsights />` is rendered in [`pages/_app.jsx`](./pages/_app.jsx) alongside `<Analytics />`.
+- Validate collection by requesting `/_vercel/speed-insights/script.js` from a deployed build.
+- No metrics are collected in development mode; ad blockers or network filters can block the script.
+
+See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/quickstart) and [troubleshooting guide](https://vercel.com/docs/speed-insights/troubleshooting) for more information.
+
+---
+
 ## Tech Stack
 
 - **Next.js 15** (app uses `/pages` routing) + **TypeScript** in parts


### PR DESCRIPTION
## Summary
- document how to enable and verify Vercel Speed Insights

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: metasploit, kismet and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b2243505648328bb55e06f68b5d8cd