### PR TITLE
fix vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "functions": {
     "api/**/*": {
       "runtime": "nodejs22.x"


### PR DESCRIPTION
## Summary
- declare version 2 in `vercel.json` so function runtime config validates

## Testing
- `yarn lint vercel.json` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, niktoPage.test.tsx, calculator/parser.test.ts, volatilityPluginBrowser.test.tsx, mimikatz.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b2262edc4c8328aace9de047acca57