### PR TITLE
feat: add module cards and tree view

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image';
+import { ModuleMetadata } from '../modules/metadata';
+
+interface ModuleCardProps {
+  module: ModuleMetadata;
+  onSelect: (module: ModuleMetadata) => void;
+  selected: boolean;
+}
+
+export default function ModuleCard({ module, onSelect, selected }: ModuleCardProps) {
+  return (
+    <button
+      onClick={() => onSelect(module)}
+      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+        selected ? 'bg-gray-100' : ''
+      }`}
+    >
+      <div className="flex-1 pr-2 font-mono">
+        <h3 className="font-bold">{module.name}</h3>
+        <p className="text-sm">{module.description}</p>
+      </div>
+      <div className="flex flex-col gap-2 items-center">
+        <Image
+          src="/themes/Yaru/status/about.svg"
+          alt="Details"
+          width={24}
+          height={24}
+        />
+        <Image
+          src="/themes/Yaru/status/download.svg"
+          alt="Run"
+          width={24}
+          height={24}
+        />
+      </div>
+    </button>
+  );
+}

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -55,21 +55,29 @@ const buildTree = (catalog) => {
   return root;
 };
 
-const Tree = ({ data, onSelect }) => (
-  <ul className="pl-4">
+const Tree = ({ data, onSelect, depth = 0 }) => (
+  <ul className="pl-0 list-none">
     {Object.entries(data).map(([name, node]) => (
-      <TreeNode key={name} name={name} node={node} onSelect={onSelect} />
+      <TreeNode
+        key={name}
+        name={name}
+        node={node}
+        onSelect={onSelect}
+        depth={depth}
+      />
     ))}
   </ul>
 );
 
-const TreeNode = ({ name, node, onSelect }) => {
+const TreeNode = ({ name, node, onSelect, depth }) => {
+  const indent = depth * 6;
   if (node.module) {
     return (
       <li>
         <button
           onClick={() => onSelect(node.module)}
-          className="text-left hover:underline focus:outline-none"
+          className="text-left hover:underline focus:outline-none h-8 flex items-center w-full"
+          style={{ paddingLeft: indent }}
         >
           {name}
         </button>
@@ -79,8 +87,13 @@ const TreeNode = ({ name, node, onSelect }) => {
   return (
     <li>
       <details>
-        <summary className="cursor-pointer">{name}</summary>
-        <Tree data={node.children} onSelect={onSelect} />
+        <summary
+          className="cursor-pointer h-8 flex items-center"
+          style={{ paddingLeft: indent }}
+        >
+          {name}
+        </summary>
+        <Tree data={node.children} onSelect={onSelect} depth={depth + 1} />
       </details>
     </li>
   );

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -19,6 +20,13 @@ export default class Navbar extends Component {
                                                 'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '
                                         }
                                 >
+                                        <Image
+                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
+                                                alt="Decompiler"
+                                                width={16}
+                                                height={16}
+                                                className="inline mr-1"
+                                        />
                                         Activities
                                 </div>
                                 <div

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
+import ModuleCard from '../components/ModuleCard';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
@@ -60,20 +61,17 @@ export default function PostExploitation() {
               </label>
             ))}
           </div>
-          <ul className="divide-y rounded border">
+          <ul className="grid gap-4 list-none p-0">
             {filtered.map((m) => (
               <li key={m.name}>
-                <button
-                  onClick={() => setSelected(m)}
-                  className={`w-full p-2 text-left hover:bg-gray-50 ${
-                    selected?.name === m.name ? 'bg-gray-100' : ''
-                  }`}
-                >
-                  {m.name}
-                </button>
+                <ModuleCard
+                  module={m}
+                  onSelect={setSelected}
+                  selected={selected?.name === m.name}
+                />
               </li>
             ))}
-            {filtered.length === 0 && <li className="p-2">No modules match your search.</li>}
+            {filtered.length === 0 && <li>No modules match your search.</li>}
           </ul>
         </section>
         <aside className="prose">

--- a/public/themes/Yaru/status/decompiler-symbolic.svg
+++ b/public/themes/Yaru/status/decompiler-symbolic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1">
+  <rect x="1" y="3" width="4" height="10" />
+  <path d="M6 8h8" />
+  <path d="M11 5l3 3-3 3" />
+</svg>


### PR DESCRIPTION
## Summary
- add monospace module cards with 24px action icons
- style module tree view rows at 32px with 6px indent
- show symbolic decompiler glyph in desktop header

## Testing
- `npx eslint components/ModuleCard.tsx components/apps/msf-post/index.js components/screen/navbar.js pages/post_exploitation.tsx`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b2194006708328bf6019f3930a8395