### PR TITLE
feat: improve converter layout

### DIFF
--- a/apps/converter/index.tsx
+++ b/apps/converter/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import copyToClipboard from '../../utils/clipboard';
 
 type Rates = Record<string, number>;
 const initialRates = {
@@ -10,6 +11,34 @@ const initialRates = {
 };
 type Domain = keyof typeof initialRates;
 const categories = Object.keys(initialRates) as Domain[];
+const icons: Record<Domain, string> = {
+  currency: '💱',
+  length: '📏',
+  weight: '⚖️',
+};
+
+const formatPreview = (val: string) => {
+  const n = parseFloat(val);
+  if (isNaN(n)) return '';
+  return n.toLocaleString();
+};
+
+function CopyButton({ value }: { value: string }) {
+  return (
+    <div className="relative group">
+      <button
+        onClick={() => value && copyToClipboard(value)}
+        className="w-6 h-6 flex items-center justify-center bg-gray-700 rounded"
+        aria-label="Copy value"
+      >
+        📋
+      </button>
+      <span className="pointer-events-none absolute -top-6 left-1/2 -translate-x-1/2 rounded bg-black px-1 py-0.5 text-xs opacity-0 transition-opacity delay-100 group-hover:opacity-100 group-focus-within:opacity-100">
+        Copy
+      </span>
+    </div>
+  );
+}
 
 export default function Converter() {
   const [active, setActive] = useState<Domain>('currency');
@@ -121,28 +150,34 @@ export default function Converter() {
           <button
             key={c}
             onClick={() => setActive(c)}
-            className={`px-3 py-1 text-sm ${
+            className={`px-3 py-1 flex items-center gap-1 text-sm ${
               c === active ? 'bg-white text-black' : 'bg-gray-700'
             }`}
           >
+            <span className="text-2xl">{icons[c]}</span>
             {c}
           </button>
         ))}
       </div>
       <div className="space-y-4">
-        <div className="flex flex-col sm:flex-row items-center gap-2">
-          <div className="flex flex-col sm:flex-row gap-2 flex-1">
-            <input
-              type="number"
-              className={`text-black p-1 rounded flex-1 ${
-                focused === 'from' ? 'text-2xl' : 'text-base'
-              }`}
-              value={fromValue}
-              onFocus={() => setFocused('from')}
-              onBlur={() => setFocused(null)}
-              onChange={(e) => convertFrom(e.target.value)}
-              aria-label="from value"
-            />
+        <div className="flex flex-col sm:flex-row items-center gap-[6px]">
+          <div className="flex flex-col sm:flex-row gap-[6px] flex-1">
+            <div className="flex flex-col flex-1">
+              <input
+                type="number"
+                className={`text-black p-1 rounded flex-1 font-mono ${
+                  focused === 'from' ? 'text-2xl' : 'text-base'
+                }`}
+                value={fromValue}
+                onFocus={() => setFocused('from')}
+                onBlur={() => setFocused(null)}
+                onChange={(e) => convertFrom(e.target.value)}
+                aria-label="from value"
+              />
+              <span className="h-4 text-xs text-gray-400 font-mono">
+                {formatPreview(fromValue)}
+              </span>
+            </div>
             <select
               className="text-black p-1 rounded"
               value={fromUnit}
@@ -157,6 +192,7 @@ export default function Converter() {
                 </option>
               ))}
             </select>
+            <CopyButton value={formatPreview(fromValue) || fromValue} />
           </div>
           <button
             className="p-2 bg-gray-700 rounded-full"
@@ -165,18 +201,23 @@ export default function Converter() {
           >
             ↔
           </button>
-          <div className="flex flex-col sm:flex-row gap-2 flex-1">
-            <input
-              type="number"
-              className={`text-black p-1 rounded flex-1 ${
-                focused === 'to' ? 'text-2xl' : 'text-base'
-              }`}
-              value={toValue}
-              onFocus={() => setFocused('to')}
-              onBlur={() => setFocused(null)}
-              onChange={(e) => convertTo(e.target.value)}
-              aria-label="to value"
-            />
+          <div className="flex flex-col sm:flex-row gap-[6px] flex-1">
+            <div className="flex flex-col flex-1">
+              <input
+                type="number"
+                className={`text-black p-1 rounded flex-1 font-mono ${
+                  focused === 'to' ? 'text-2xl' : 'text-base'
+                }`}
+                value={toValue}
+                onFocus={() => setFocused('to')}
+                onBlur={() => setFocused(null)}
+                onChange={(e) => convertTo(e.target.value)}
+                aria-label="to value"
+              />
+              <span className="h-4 text-xs text-gray-400 font-mono">
+                {formatPreview(toValue)}
+              </span>
+            </div>
             <select
               className="text-black p-1 rounded"
               value={toUnit}
@@ -191,6 +232,7 @@ export default function Converter() {
                 </option>
               ))}
             </select>
+            <CopyButton value={formatPreview(toValue) || toValue} />
           </div>
         </div>
         {history.length > 0 && (
@@ -201,16 +243,9 @@ export default function Converter() {
                 className="flex items-center justify-between bg-gray-800 px-2 py-1 rounded"
               >
                 <span>{`${h.fromValue} ${h.fromUnit} = ${h.toValue} ${h.toUnit}`}</span>
-                <button
-                  className="ml-2 px-2 py-0.5 bg-gray-700 rounded text-sm"
-                  onClick={() =>
-                    navigator.clipboard.writeText(
-                      `${h.fromValue} ${h.fromUnit} = ${h.toValue} ${h.toUnit}`,
-                    )
-                  }
-                >
-                  Copy
-                </button>
+                <CopyButton
+                  value={`${h.fromValue} ${h.fromUnit} = ${h.toValue} ${h.toUnit}`}
+                />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add mode tabs with icons
- mirror panels with gutters and monospace numeric formatting
- add copy buttons with tooltip delay

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/converter/index.tsx`
- `yarn test apps/converter/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b219388b9c83289045e77ad66cc342