### PR TITLE
Add responsive project card thumbnails and filter chips

### DIFF
--- a/apps/project-gallery/components/FilterChip.tsx
+++ b/apps/project-gallery/components/FilterChip.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  icon: ReactNode;
+}
+
+export default function FilterChip({ label, active, onClick, icon }: FilterChipProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1 px-3 py-1 rounded-full border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 ${
+        active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'
+      }`}
+    >
+      {icon}
+      <span className="text-sm">{label}</span>
+    </button>
+  );
+}

--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -3,6 +3,80 @@
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
+import FilterChip from '../components/FilterChip';
+
+const TagIcon = () => (
+  <svg
+    className="w-6 h-6"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6Z" />
+  </svg>
+);
+
+const StackIcon = () => (
+  <svg
+    className="w-6 h-6"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M6 6.878V6a2.25 2.25 0 0 1 2.25-2.25h7.5A2.25 2.25 0 0 1 18 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 0 0 4.5 9v.878m13.5-3A2.25 2.25 0 0 1 19.5 9v.878m0 0a2.246 2.246 0 0 0-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0 1 21 12v6a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18v-6c0-.98.626-1.813 1.5-2.122"
+    />
+  </svg>
+);
+
+const CalendarIcon = () => (
+  <svg
+    className="w-6 h-6"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+    />
+  </svg>
+);
+
+const TypeIcon = () => (
+  <svg
+    className="w-6 h-6"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.25 7.125C2.25 6.504 2.754 6 3.375 6h6c.621 0 1.125.504 1.125 1.125v3.75c0 .621-.504 1.125-1.125 1.125h-6a1.125 1.125 0 0 1-1.125-1.125v-3.75ZM14.25 8.625c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v8.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 0 1-1.125-1.125v-8.25ZM3.75 16.125c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 0 1-1.125-1.125v-2.25Z"
+    />
+  </svg>
+);
 
 interface Project {
   id: number;
@@ -81,57 +155,54 @@ export default function ProjectGalleryPage() {
     [projects, tech, year, type, tags]
   );
 
-  const pillClass = (active: boolean) =>
-    `px-3 py-1 rounded-full border ${active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'}`;
-
   return (
     <div className="p-4 space-y-4 text-black">
       <div className="flex flex-wrap gap-2">
         {tagList.map((t) => (
-          <button
+          <FilterChip
             key={t}
+            label={t}
+            active={tags.includes(t)}
             onClick={() =>
               setTags(tags.includes(t) ? tags.filter((tag) => tag !== t) : [...tags, t])
             }
-            className={pillClass(tags.includes(t))}
-          >
-            {t}
-          </button>
+            icon={<TagIcon />}
+          />
         ))}
       </div>
       <div className="flex flex-wrap gap-2">
         {stacks.map((s) => (
-          <button
+          <FilterChip
             key={s}
+            label={s}
+            active={tech.includes(s)}
             onClick={() =>
               setTech(tech.includes(s) ? tech.filter((t) => t !== s) : [...tech, s])
             }
-            className={pillClass(tech.includes(s))}
-          >
-            {s}
-          </button>
+            icon={<StackIcon />}
+          />
         ))}
       </div>
       <div className="flex flex-wrap gap-2">
         {years.map((y) => (
-          <button
+          <FilterChip
             key={y}
+            label={String(y)}
+            active={year === String(y)}
             onClick={() => setYear(year === String(y) ? '' : String(y))}
-            className={pillClass(year === String(y))}
-          >
-            {y}
-          </button>
+            icon={<CalendarIcon />}
+          />
         ))}
       </div>
       <div className="flex flex-wrap gap-2">
         {types.map((t) => (
-          <button
+          <FilterChip
             key={t}
+            label={t}
+            active={type === t}
             onClick={() => setType(type === t ? '' : t)}
-            className={pillClass(type === t)}
-          >
-            {t}
-          </button>
+            icon={<TypeIcon />}
+          />
         ))}
       </div>
       <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
@@ -142,9 +213,11 @@ export default function ProjectGalleryPage() {
             className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
             aria-label={`${p.title}: ${p.description}`}
           >
-            <img src={p.thumbnail} alt={p.title} className="w-full h-40 object-cover" />
+            <div className="w-full aspect-video overflow-hidden">
+              <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
+            </div>
             <div className="p-2 flex-1">
-              <h3 className="font-semibold">{p.title}</h3>
+              <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>
               <p className="text-sm">{p.description}</p>
             </div>
             <div className="absolute inset-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity bg-black/60 text-white flex flex-col">
@@ -156,9 +229,7 @@ export default function ProjectGalleryPage() {
                 ))}
               </div>
               <div className="mt-auto p-2 text-right">
-                <button className="bg-blue-600 text-white px-2 py-1 rounded">
-                  Quick view
-                </button>
+                <button className="bg-blue-600 text-white px-4 h-10 rounded">Launch</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- keep project cards’ thumbnails at a fixed aspect ratio with clamped 16 px titles
- add reusable filter chip component with 24 px icons and 2 px focus rings
- show a 40 px tall "Launch" button on card hover

## Testing
- `yarn lint` *(fails: ESLint config missing)*
- `yarn test` *(fails: wireshark, beef, niktoPage and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b2193422b48328ba34b5a48f0c5585