### PR TITLE
feat: enhance metasploit ui

### DIFF
--- a/components/apps/metasploit/ConsolePane.tsx
+++ b/components/apps/metasploit/ConsolePane.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface ConsolePaneProps {
+  output: string;
+}
+
+const ConsolePane: React.FC<ConsolePaneProps> = ({ output }) => {
+  const lines = output.split('\n');
+  const copyLine = (line: string) => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(line);
+    }
+  };
+  return (
+    <div className="flex-grow bg-black text-green-400 font-mono overflow-auto">
+      {lines.map((line, idx) => (
+        <div key={idx} className="group relative flex items-center h-9 px-2">
+          <span className="flex-grow">{line || '\u00A0'}</span>
+          <button
+            type="button"
+            aria-label="Copy line"
+            onClick={() => copyLine(line)}
+            className="absolute right-2 opacity-0 group-hover:opacity-100 text-xs px-1 rounded bg-gray-700 text-white"
+          >
+            Copy
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ConsolePane;


### PR DESCRIPTION
## Summary
- display Metasploit modules in two-column grid with icons and severity chips
- add copy-enabled console pane using monospace rows
- introduce session sidebar with themed accent and spacing

## Testing
- `yarn lint` *(fails: ESLint couldn't find config file)*
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, niktoPage.test.tsx, mimikatz.test.ts, volatilityPluginBrowser.test.tsx, kismet.test.tsx, snake.config.test.ts, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b21933129c832882f202b1172a5a78