### PR TITLE
fix vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*": {
-      "runtime": { "name": "nodejs", "version": "22.x" }
+      "runtime": "nodejs22.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- align `vercel.json` with Vercel schema using string runtime value

## Testing
- `yarn test` (fails: Syntax Error in FilterHelper.tsx, missing elements in various tests, API status 501, etc.)
- `yarn lint vercel.json` (fails: ESLint couldn't find eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68b227bbe650832898e81aacdd04bc5c