### PR TITLE
chore: specify node runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*": {
-      "runtime": "nodejs22.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- set vercel functions runtime to Node.js 20 in string form

## Testing
- `npx vercel build --yes` *(fails: The specified token is not valid; ENETUNREACH)*
- `yarn test` *(fails: BeEF app, Terminal component, NiktoPage, mimikatz API, calculator parser)*

------
https://chatgpt.com/codex/tasks/task_e_68b228c866e48328bf2d1bb46d5c8a07