### PR TITLE
chore: pin vercel runtime to node 20

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*": {
-      "runtime": "nodejs22.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use Node 20 runtime in Vercel configuration

## Testing
- `yarn test` *(fails: ReferenceError and missing elements)*
- `CI=1 yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npx --yes vercel build --yes` *(fails: The specified token is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68b228ce8d7083288a834c80289fe4a3