### PR TITLE
chore: target Node 20 runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:sw": "node scripts/generate-sw.mjs"
   },
   "engines": {
-    "node": "22.x"
+    "node": "20.x"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
@@ -129,5 +129,4 @@
     "test-exclude": "^7.0.1"
   },
   "packageManager": "yarn@4.9.2"
-
 }


### PR DESCRIPTION
## Summary
- target Node 20 runtime for Vercel deployment

## Testing
- `yarn test` *(fails: BeEF app, Terminal component, calculator parser, mimikatz api, kismet app, snake/frogger config, etc.)*
- `vercel build` *(fails: missing project settings and network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b228cf9e1483289fbf09d421d6c1dd