### PR TITLE
fix: use supported Node runtime in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*": {
-      "runtime": "nodejs22.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use Node 20 runtime for Vercel functions

## Testing
- `yarn test` *(fails: ReferenceError, Unable to find element, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b228f20e7c832891a22364f21c4c44