### PR TITLE
Fix vercel runtime configuration for Node.js 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:sw": "node scripts/generate-sw.mjs"
   },
   "engines": {
-    "node": "22.x"
+    "node": "20.x"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*": {
-      "runtime": "nodejs22.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use supported `nodejs20.x` runtime in vercel.json
- align package.json engines to Node.js 20.x

## Testing
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2292b9d4c8328b7fcb23ad4bf6102