### PR TITLE
chore: use node20 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Always test inside controlled labs and obtain written permission before performi
 ## Quick Start
 
 ### Requirements
-- **Node.js 22.x** (repo includes `.nvmrc`; run `nvm use`)
+- **Node.js 20.x** (repo includes `.nvmrc`; run `nvm use`)
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
 ### Install & Run (Dev)
 ```bash
-nvm install  # installs Node 22 from .nvmrc if needed
+nvm install  # installs Node 20 from .nvmrc if needed
 nvm use
 yarn install
 yarn dev
@@ -237,7 +237,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 ### Static export (GitHub Pages)
 Workflow: `.github/workflows/gh-deploy.yml`:
 - Installs Node, runs `yarn build && yarn export`, adds `.nojekyll`, and deploys `./out` → `gh-pages` branch.
-- **Action item:** update matrix to **Node 22.x** to match `package.json`.
+- **Action item:** update matrix to **Node 20.x** to match `package.json`.
 - Required env variables (GitHub Secrets):
   - `NEXT_PUBLIC_TRACKING_ID`
   - `NEXT_PUBLIC_SERVICE_ID`
@@ -449,7 +449,7 @@ play/pause and track controls include keyboard hotkeys.
 
 ## Production Hardening Checklist
 
-- [ ] **Pin Node to 22.x** across runtime and CI.
+- [ ] **Pin Node to 20.x** across runtime and CI.
 - [ ] **Tighten CSP** (`connect-src`, `frame-src`, remove `http:` and `'unsafe-inline'`).
 - [ ] **Set env vars** in the hosting platform; rotate EmailJS keys regularly.
 - [ ] **Disable/flag API demo routes** for production or protect behind feature flags.

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "api/**/*.js": { "runtime": "nodejs22.x" },
-    "api/**/*.ts": { "runtime": "nodejs22.x" }
+    "api/**/*.js": { "runtime": "nodejs20.x" },
+    "api/**/*.ts": { "runtime": "nodejs20.x" }
 
   }
 }


### PR DESCRIPTION
## Summary
- set serverless functions to use Node 20 runtime
- update docs to reference Node 20 instead of Node 22

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: e.g., BeEF app tests unable to find expected elements)*

------
https://chatgpt.com/codex/tasks/task_e_68b22cba320c8328b09c97533fabb24a