### PR TITLE
fix: use Node 20 runtime for Vercel functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "api/**/*.js": { "runtime": "nodejs22.x" },
-    "api/**/*.ts": { "runtime": "nodejs22.x" }
+    "api/**/*.js": { "runtime": "nodejs20.x" },
+    "api/**/*.ts": { "runtime": "nodejs20.x" }
 
   }
 }


### PR DESCRIPTION
## Summary
- use Node 20 runtime for all Vercel functions

## Testing
- `yarn test` *(fails: unable to find an element in BeEF app tests; multiple suites failed)*
- `vercel --prod --yes` *(fails: The specified token is not valid. Use `vercel login` to generate a new token.)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ce13f5c8328bfc848d83881f08c