### PR TITLE
Specify node runtime per API route

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -9,6 +9,8 @@ const RATE_LIMIT_MAX = 5;
 
 export const rateLimit = new Map<string, { count: number; start: number }>();
 
+export const runtime = 'nodejs';
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     validateServerEnv(process.env);

--- a/pages/api/figlet/fonts.ts
+++ b/pages/api/figlet/fonts.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
   let fonts: { name: string; data: string }[] = [];

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -7,6 +7,8 @@ import path from 'path';
 const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (
     process.env.FEATURE_TOOL_APIS !== 'enabled' ||

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -6,6 +6,8 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/metasploit.js
+++ b/pages/api/metasploit.js
@@ -1,5 +1,7 @@
 import modules from '../../components/apps/metasploit/modules.json';
 
+export const runtime = 'nodejs';
+
 export default function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,5 +1,7 @@
 import modules from '../../components/apps/mimikatz/modules.json';
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/nse/update.ts
+++ b/pages/api/nse/update.ts
@@ -6,6 +6,8 @@ interface VersionInfo {
   sha: string;
 }
 
+export const runtime = 'nodejs';
+
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   try {
     const versionPath = path.join(process.cwd(), 'public', 'demo-data', 'nmap', 'script-db-version.json');

--- a/pages/api/pacman/leaderboard.ts
+++ b/pages/api/pacman/leaderboard.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 interface Entry {
   name: string;
   score: number;

--- a/pages/api/plugins/[name].ts
+++ b/pages/api/plugins/[name].ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { name } = req.query;
   const filename = Array.isArray(name) ? name.join('/') : name;

--- a/pages/api/plugins/index.ts
+++ b/pages/api/plugins/index.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(_req: NextApiRequest, res: NextApiResponse) {
   const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');
   try {

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -6,6 +6,8 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+export const runtime = 'nodejs';
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });

--- a/pages/api/wallpapers.ts
+++ b/pages/api/wallpapers.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
+export const runtime = 'nodejs';
+
 export default function handler(req: NextApiRequest, res: NextApiResponse<string[]>) {
   const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "version": 2,
-  "functions": {
-    "api/**/*.js": { "runtime": "nodejs22.x" },
-    "api/**/*.ts": { "runtime": "nodejs22.x" }
-
-  }
-}


### PR DESCRIPTION
## Summary
- declare `runtime = 'nodejs'` for API routes that depend on Node APIs
- remove `vercel.json` runtime override

## Testing
- `yarn test` *(fails: wireshark.test.tsx, beef.test.tsx, terminal.test.tsx, niktoPage.test.tsx, mimikatz.test.ts, battleship-net.test.ts, kismet.test.tsx, metasploit.test.tsx, frogger.config.test.ts, calculator/parser.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ce3d77483288d79eb8aaf201a00