### PR TITLE
feat: add server-side analytics tracker

### DIFF
--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -1,0 +1,13 @@
+import { track } from '@vercel/analytics/server';
+
+export async function trackServerEvent(
+  name: string,
+  props?: Record<string, string | number | boolean>,
+  opts?: { flags?: string[] },
+) {
+  try {
+    await track(name, props, opts);
+  } catch (err) {
+    console.error(err);
+  }
+}


### PR DESCRIPTION
## Summary
- add `trackServerEvent` helper for Vercel analytics with error handling

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint lib/analytics-server.ts`
- `yarn lint lib/analytics-server.ts` *(fails: ESLint couldn't find config; later running with ESLINT_USE_FLAT_CONFIG=false shows repo-wide errors)*
- `yarn test` *(fails: 10 failed, 2 skipped, 119 passed, 129 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d036d048328a5343fa00cacde57