### PR TITLE
feat: add beta badge

### DIFF
--- a/components/BetaBadge.tsx
+++ b/components/BetaBadge.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { beta } from '../lib/flags';
+
+export default function BetaBadge() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await beta();
+        if (!cancelled) setEnabled(result);
+      } catch {
+        if (!cancelled) setEnabled(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!enabled) return null;
+
+  return <span>Beta</span>;
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,3 @@
+export async function beta(): Promise<boolean> {
+  return process.env.NEXT_PUBLIC_BETA === 'true';
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
+import BetaBadge from '../components/BetaBadge';
 
 /**
  * @returns {JSX.Element}
@@ -12,6 +13,7 @@ const App = () => (
     </a>
     <Meta />
     <Ubuntu />
+    <BetaBadge />
     <InstallButton />
   </>
 );


### PR DESCRIPTION
## Summary
- show BetaBadge when beta flag resolves true
- expose beta flag helper
- render BetaBadge on home page

## Testing
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*
- `yarn test` *(fails: multiple tests failing, e.g. wireshark, beef, terminal, nikto, calculator parser, mimikatz, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d08f968832896e55db9440320d1