### PR TITLE
Add FlagValuesEmitter for encrypted feature flags

### DIFF
--- a/components/FlagValuesEmitter.tsx
+++ b/components/FlagValuesEmitter.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react';
+import { encryptFlagValues, FlagValues } from 'flags/react';
+import { beta } from '../flags';
+
+async function FlagValuesLoader() {
+  const values = { beta: await beta() };
+  return <FlagValues values={await encryptFlagValues(values)} />;
+}
+
+export default function FlagValuesEmitter() {
+  return (
+    <Suspense fallback={null}>
+      {/* Suspense will handle the async flag loading */}
+      <FlagValuesLoader />
+    </Suspense>
+  );
+}
+

--- a/flags.ts
+++ b/flags.ts
@@ -1,0 +1,3 @@
+export async function beta() {
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "flags": "^4.0.1",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import FlagValuesEmitter from '../components/FlagValuesEmitter';
 
 /**
  * @param {import('next/app').AppProps} props
@@ -128,6 +129,7 @@ function MyApp({ Component, pageProps }) {
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
         <ShortcutOverlay />
+        <FlagValuesEmitter />
         <Analytics />
         {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
       </PipPortalProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@edge-runtime/cookies@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@edge-runtime/cookies@npm:5.0.2"
+  checksum: 10c0/4db80e80403c7086f1d269afdf8956c035d88b173c70ca9e912d58683b58c300a1df922dee74bb44f964f1fab7e446f8ed8d32fc9715a7c322671e03405a682a
+  languageName: node
+  linkType: hard
+
 "@emailjs/browser@npm:^3.10.0":
   version: 3.12.1
   resolution: "@emailjs/browser@npm:3.12.1"
@@ -6265,6 +6272,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flags@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "flags@npm:4.0.1"
+  dependencies:
+    "@edge-runtime/cookies": "npm:^5.0.2"
+    jose: "npm:^5.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.7.0
+    "@sveltejs/kit": "*"
+    next: "*"
+    react: "*"
+    react-dom: "*"
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/e5382e988d35c22e731f2b31737f332f689401adbadb5a46d960f0fc342c94de9c384fb954ebcf78eadb14e5e644928c686d5b6893828e8b1225979cb377eed9
+  languageName: node
+  linkType: hard
+
 "flat-cache@npm:^4.0.0":
   version: 4.0.1
   resolution: "flat-cache@npm:4.0.1"
@@ -7917,6 +7951,13 @@ __metadata:
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
   checksum: 10c0/9262aef1da3f1bec5b03caf50c46368899fe03b8ff26cbe3d53af4584dd1049079fc97230bbf1500b6149db7cc765b9ee45f0deb24bb6fc3fa06229d7148c17f
+  languageName: node
+  linkType: hard
+
+"jose@npm:^5.2.1":
+  version: 5.10.0
+  resolution: "jose@npm:5.10.0"
+  checksum: 10c0/e20d9fc58d7e402f2e5f04e824b8897d5579aae60e64cb88ebdea1395311c24537bf4892f7de413fab1acf11e922797fb1b42269bc8fc65089a3749265ccb7b0
   languageName: node
   linkType: hard
 
@@ -11562,11 +11603,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
   version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=74658d"
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
+  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
   languageName: node
   linkType: hard
 
@@ -11713,6 +11754,7 @@ __metadata:
     fake-indexeddb: "npm:^6.1.0"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    flags: "npm:^4.0.1"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add FlagValuesEmitter component that encrypts beta flag values
- emit encrypted flag values in `_app.jsx`
- install `flags` dependency

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test __tests__/beef.test.tsx` *(fails: unable to find element "1" and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d099ee48328ad216d3b0910c186