### PR TITLE
Use Node 20 runtime across Vercel and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn typecheck

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "api/**/*.js": { "runtime": "nodejs22.x" },
-    "api/**/*.ts": { "runtime": "nodejs22.x" }
+    "api/**/*.js": { "runtime": "nodejs20.x" },
+    "api/**/*.ts": { "runtime": "nodejs20.x" }
 
   }
 }


### PR DESCRIPTION
## Summary
- use Node 20 runtime for API routes in Vercel config
- sync CI to Node 20

## Testing
- `npx vercel build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b22e05a0e08328aeccd16d3f139e2a