### PR TITLE
Track contact form analytics

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -1,50 +1,50 @@
-'use client';
+"use client";
 
-import React, { useEffect, useState } from 'react';
-import FormError from '../../components/ui/FormError';
-import Toast from '../../components/ui/Toast';
-import { processContactForm } from '../../components/apps/contact';
-import { copyToClipboard } from '../../utils/clipboard';
-import { openMailto } from '../../utils/mailto';
+import React, { useEffect, useState } from "react";
+import FormError from "../../components/ui/FormError";
+import Toast from "../../components/ui/Toast";
+import { processContactForm } from "../../components/apps/contact";
+import { copyToClipboard } from "../../utils/clipboard";
+import { openMailto } from "../../utils/mailto";
+import trackEvent from "@/lib/analytics-client";
 
-const DRAFT_KEY = 'contact-draft';
-const EMAIL = 'alex.unnippillil@hotmail.com';
+const DRAFT_KEY = "contact-draft";
+const EMAIL = "alex.unnippillil@hotmail.com";
 
 const getRecaptchaToken = (siteKey: string): Promise<string> =>
   new Promise((resolve) => {
     const g: any = (window as any).grecaptcha;
-    if (!g || !siteKey) return resolve('');
+    if (!g || !siteKey) return resolve("");
     g.ready(() => {
-      g
-        .execute(siteKey, { action: 'submit' })
+      g.execute(siteKey, { action: "submit" })
         .then((token: string) => resolve(token))
-        .catch(() => resolve(''));
+        .catch(() => resolve(""));
     });
   });
 
 const ContactApp: React.FC = () => {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [message, setMessage] = useState('');
-  const [honeypot, setHoneypot] = useState('');
-  const [error, setError] = useState('');
-  const [toast, setToast] = useState('');
-  const [csrfToken, setCsrfToken] = useState('');
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [honeypot, setHoneypot] = useState("");
+  const [error, setError] = useState("");
+  const [toast, setToast] = useState("");
+  const [csrfToken, setCsrfToken] = useState("");
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
     if (saved) {
       try {
         const draft = JSON.parse(saved);
-        setName(draft.name || '');
-        setEmail(draft.email || '');
-        setMessage(draft.message || '');
+        setName(draft.name || "");
+        setEmail(draft.email || "");
+        setMessage(draft.message || "");
       } catch {
         /* ignore */
       }
     }
     const meta = document.querySelector('meta[name="csrf-token"]');
-    setCsrfToken(meta?.getAttribute('content') || '');
+    setCsrfToken(meta?.getAttribute("content") || "");
   }, []);
 
   useEffect(() => {
@@ -54,27 +54,35 @@ const ContactApp: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
+    setError("");
+    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || "";
     const recaptchaToken = await getRecaptchaToken(siteKey);
-    const result = await processContactForm({
-      name,
-      email,
-      message,
-      honeypot,
-      csrfToken,
-      recaptchaToken,
-    });
-    if (result.success) {
-      setToast('Message sent');
-      setName('');
-      setEmail('');
-      setMessage('');
-      setHoneypot('');
-      localStorage.removeItem(DRAFT_KEY);
-    } else {
-      setError(result.error || 'Submission failed');
-      setToast('Failed to send');
+    try {
+      const result = await processContactForm({
+        name,
+        email,
+        message,
+        honeypot,
+        csrfToken,
+        recaptchaToken,
+      });
+      if (result.success) {
+        setToast("Message sent");
+        setName("");
+        setEmail("");
+        setMessage("");
+        setHoneypot("");
+        localStorage.removeItem(DRAFT_KEY);
+        trackEvent("contact_submit", { method: "form" });
+      } else {
+        setError(result.error || "Submission failed");
+        setToast("Failed to send");
+        trackEvent("contact_submit_error", { method: "form" });
+      }
+    } catch {
+      setError("Submission failed");
+      setToast("Failed to send");
+      trackEvent("contact_submit_error", { method: "form" });
     }
   };
 
@@ -82,7 +90,7 @@ const ContactApp: React.FC = () => {
     <div className="min-h-screen bg-gray-900 text-white p-4">
       <h1 className="mb-4 text-2xl">Contact</h1>
       <p className="mb-4 text-sm">
-        Prefer email?{' '}
+        Prefer email?{" "}
         <button
           type="button"
           onClick={() => copyToClipboard(EMAIL)}
@@ -201,10 +209,9 @@ const ContactApp: React.FC = () => {
           Send
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </div>
   );
 };
 
 export default ContactApp;
-

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -1,0 +1,13 @@
+export const trackEvent = async (
+  name: string,
+  properties?: Record<string, string | number | boolean | null>,
+): Promise<void> => {
+  try {
+    const { track } = await import("@vercel/analytics");
+    track(name, properties);
+  } catch {
+    // ignore analytics errors
+  }
+};
+
+export default trackEvent;


### PR DESCRIPTION
## Summary
- import a reusable `trackEvent` helper and send analytics on contact form submission
- emit analytics for failed submissions as well

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint apps/contact/index.tsx lib/analytics-client.ts -f json`
- `yarn test` *(fails: battleship-net.test.ts, beef.test.tsx, terminal.test.tsx, niktoPage.test.tsx, mimikatz.test.ts, kismet.test.tsx, metasploit.test.tsx, frogger.config.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d056d9883288be7a591eb26ef03