### PR TITLE
Add Supabase env vars to validation schemas

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -13,10 +13,14 @@ const publicEnvSchema = z.object({
   NEXT_PUBLIC_UI_EXPERIMENTS: z.string().optional(),
   NEXT_PUBLIC_GHIDRA_WASM: z.string().optional(),
   NEXT_PUBLIC_GHIDRA_URL: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
 });
 
 const serverEnvSchema = publicEnvSchema.extend({
   RECAPTCHA_SECRET: z.string(),
+  SUPABASE_URL: z.string().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 function validatePublicEnv(env) {

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -13,10 +13,14 @@ const publicEnvSchema = z.object({
   NEXT_PUBLIC_UI_EXPERIMENTS: z.string().optional(),
   NEXT_PUBLIC_GHIDRA_WASM: z.string().optional(),
   NEXT_PUBLIC_GHIDRA_URL: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
 });
 
 const serverEnvSchema = publicEnvSchema.extend({
   RECAPTCHA_SECRET: z.string(),
+  SUPABASE_URL: z.string().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 export function validatePublicEnv(env: NodeJS.ProcessEnv) {


### PR DESCRIPTION
## Summary
- allow Supabase public keys in environment validation
- extend server env validation with optional Supabase service keys while keeping reCAPTCHA secret required

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: 9 errors, 49 warnings)*
- `yarn test` *(fails: mimikatz, battleship-net, snake.config, frogger.config, others)*


------
https://chatgpt.com/codex/tasks/task_e_68b23252891c8328a935a8d5cd1fb329