### PR TITLE
Add notes page with server-side Supabase query

### DIFF
--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,0 +1,36 @@
+import type { GetServerSideProps } from 'next';
+import { getAnonSupabaseServer } from '../lib/supabase.server';
+
+interface NotesPageProps {
+  notes: unknown[] | null;
+  error?: string;
+}
+
+export const getServerSideProps: GetServerSideProps<NotesPageProps> = async () => {
+  const supabase = getAnonSupabaseServer();
+  const { data, error } = await supabase.from('notes').select();
+
+  if (error) {
+    return {
+      props: {
+        notes: null,
+        error: error.message,
+      },
+    };
+  }
+
+  return {
+    props: {
+      notes: data ?? null,
+    },
+  };
+};
+
+export default function NotesPage({ notes, error }: NotesPageProps) {
+  if (error) {
+    return <pre>{JSON.stringify({ error }, null, 2)}</pre>;
+  }
+
+  return <pre>{JSON.stringify(notes, null, 2)}</pre>;
+}
+


### PR DESCRIPTION
## Summary
- add `pages/notes.tsx` that fetches notes using a Supabase server client on each request
- handle query errors and render results as formatted JSON

## Testing
- `yarn test` *(fails: beef, terminal, niktoPage, mimikatz, kismet, frogger.config, metasploit)*

------
https://chatgpt.com/codex/tasks/task_e_68b232549ac88328b424bac9a065cb7e