### PR TITLE
fix: set valid Vercel runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "api/**/*.js": { "runtime": "nodejs22.x" },
-    "api/**/*.ts": { "runtime": "nodejs22.x" }
+    "api/**/*.js": { "runtime": "nodejs20.x" },
+    "api/**/*.ts": { "runtime": "nodejs20.x" }
   },
   "env": {
     "FLAGS_SECRET": "@flags_secret"


### PR DESCRIPTION
## Summary
- use `nodejs20.x` as Vercel function runtime

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config file)*
- `yarn test` *(fails: Unable to find an element with the text: 1 / ReferenceError: handlePresetSelect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b227e48f5483289d489dc3e95cf121