### PR TITLE
chore: patch chart.js to drop pnpm engine

### DIFF
--- a/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch
+++ b/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 7cb3b7e36c9049414bfbe645eb7a33a9d90d1a54..1971ddcdf9866e579975fe21b77482a2b63363da 100644
+--- a/package.json
++++ b/package.json
+@@ -122,9 +122,7 @@
+     "typescript": "^4.7.4",
+     "yargs": "^17.5.1"
+   },
+-  "engines": {
+-    "pnpm": ">=8"
+-  },
++  "engines": {},
+   "packageManager": "pnpm@8.13.0",
+   "pnpm": {
+     "overrides": {

--- a/package.json
+++ b/package.json
@@ -25,13 +25,8 @@
     "@emailjs/browser": "^3.10.0",
     "@monaco-editor/react": "^4.7.0",
     "@mozilla/readability": "^0.6.0",
-
-    "@supabase/supabase-js": "^2",
-
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.1",
-
-
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "@vercel/toolbar": "^0.1.38",
@@ -44,7 +39,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
-    "chart.js": "^4.5.0",
+    "chart.js": "patch:chart.js@npm%3A4.5.0#~/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
     "cron-parser": "^5.3.0",
@@ -55,7 +50,6 @@
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
     "flags": "3",
-
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,8 +2783,6 @@ __metadata:
   linkType: hard
 
 "@supabase/supabase-js@npm:^2.56.1":
-
-
   version: 2.56.1
   resolution: "@supabase/supabase-js@npm:2.56.1"
   dependencies:
@@ -6681,9 +6679,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flags@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "flags@npm:4.0.1"
+"flags@npm:3":
+  version: 3.2.0
+  resolution: "flags@npm:3.2.0"
   dependencies:
     "@edge-runtime/cookies": "npm:^5.0.2"
     jose: "npm:^5.2.1"
@@ -6704,10 +6702,9 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/e5382e988d35c22e731f2b31737f332f689401adbadb5a46d960f0fc342c94de9c384fb954ebcf78eadb14e5e644928c686d5b6893828e8b1225979cb377eed9
+  checksum: 10c0/73747877d700b93192a2d7524220d01047db5bc74836bd9e88a6bb740d86b97e4620af7a86f8ede78e3bad6ecbf6e3af0ed4233b2bd2c351a42b3cc9be995456
   languageName: node
   linkType: hard
-
 
 "flat-cache@npm:^4.0.0":
   version: 4.0.1
@@ -12280,12 +12277,8 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@mozilla/readability": "npm:^0.6.0"
     "@playwright/test": "npm:^1.55.0"
-
-    "@supabase/supabase-js": "npm:^2"
-
     "@supabase/ssr": "npm:^0.7.0"
     "@supabase/supabase-js": "npm:^2.56.1"
-
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.6.4"
     "@testing-library/react": "npm:^16.3.0"
@@ -12331,7 +12324,6 @@ __metadata:
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
     flags: "npm:3"
-
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- patch chart.js to remove pnpm engine requirement

## Testing
- `yarn test` (fails: installButton.test.tsx, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b239563094832898890fcd3614d2e4