### PR TITLE
fix: add watch later dependency

### DIFF
--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -414,7 +414,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
           ? w
           : [...w, v],
       ),
-    [],
+    [setWatchLater],
   );
   const shareClip = useCallback(async () => {
     if (!current || loopStart === null || loopEnd === null) return;


### PR DESCRIPTION
## Summary
- include `setWatchLater` in `addWatchLater` callback dependencies for YouTube app

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/youtube/index.tsx __tests__/youtube.test.tsx`
- `npx jest __tests__/youtube.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b23cd006248328bcf3fded3c69f7e0