### PR TITLE
Fix JSX tag mismatch in Todoist component

### DIFF
--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -956,6 +956,7 @@ export default function Todoist() {
                 </div>
               )}
         </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- correct JSX closing tags in Todoist component to resolve parsing error

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/todoist.js`

------
https://chatgpt.com/codex/tasks/task_e_68b23ccecfb88328820b0fddc8731408