### PR TITLE
chore: memoize reversi undo

### DIFF
--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import {
   SIZE,
   DIRECTIONS,
@@ -350,7 +350,7 @@ const Reversi = () => {
     setHistory([]);
   };
 
-  const undo = () => {
+  const undo = useCallback(() => {
     if (!history.length) return;
     const last = history[history.length - 1];
     setBoard(last.board.map((row) => row.slice()));
@@ -360,7 +360,7 @@ const Reversi = () => {
     previewRef.current = null;
     flippingRef.current = [];
     aiThinkingRef.current = false;
-  };
+  }, [history]);
 
   useEffect(() => {
     const handler = (e) => {


### PR DESCRIPTION
## Summary
- wrap Reversi's undo handler in `useCallback` for a stable identity
- ensure keydown listener uses memoized `undo`

## Testing
- `yarn test __tests__/reversi.test.ts`
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23ccd70b48328a713ac3260eff8a9