### PR TITLE
Escape apostrophe in radare2 guide overlay

### DIFF
--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -76,7 +76,7 @@ export default function GuideOverlay({ onClose }) {
             checked={dontShow}
             onChange={(e) => setDontShow(e.target.checked)}
           />
-          <span>Don't show again</span>
+          <span>Don&apos;t show again</span>
         </label>
         <div className="mt-4 flex justify-between">
           <a


### PR DESCRIPTION
## Summary
- escape apostrophe in Radare2 guide overlay to satisfy lint rule

## Testing
- `npx eslint -c /tmp/eslint.config.js components/apps/radare2/GuideOverlay.js`

------
https://chatgpt.com/codex/tasks/task_e_68b23cccd6908328b1aa5984a0a15ae0