### PR TITLE
Fix QR scanner cleanup to use stable video reference

### DIFF
--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -16,6 +16,7 @@ const QRScanner: React.FC = () => {
 
   useEffect(() => {
     let active = true;
+    const video = videoRef.current;
     const start = async () => {
       if (!navigator.mediaDevices?.getUserMedia) {
         setError('Camera API not supported');
@@ -77,7 +78,7 @@ const QRScanner: React.FC = () => {
       active = false;
       controlsRef.current?.stop?.();
       streamRef.current?.getTracks().forEach((t) => t.stop());
-      if (videoRef.current) videoRef.current.srcObject = null;
+      if (video) video.srcObject = null;
       trackRef.current = null;
     };
   }, [facing]);


### PR DESCRIPTION
## Summary
- store the video element in a local constant within the QR scanner effect
- ensure cleanup uses stored element when stopping stream

## Testing
- `yarn lint components/apps/qr/index.tsx` *(fails: ESLint couldn't find an eslint.config.* file)*
- `yarn test` *(fails: multiple test suites including terminal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b23ccb1d488328b1be5016011bf902