### PR TITLE
fix: include missing dependencies in pong

### DIFF
--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -126,7 +126,7 @@ const PongInner = () => {
       canvas.removeEventListener('touchend', endTouch);
       canvas.removeEventListener('touchcancel', endTouch);
     };
-  }, []);
+  }, [canvasRef]);
 
   useEffect(() => {
     if (mode !== 'online' || !channelRef.current) return undefined;
@@ -590,7 +590,7 @@ const PongInner = () => {
         motionQuery.removeListener(handleMotionChange);
       }
     };
-    }, [difficulty, mode, connected, matchWinner, controls, canvasRef, playSound]);
+    }, [difficulty, mode, connected, matchWinner, controls, canvasRef, playSound, pongSpin]);
 
   const reset = useCallback(() => {
     if (resetRef.current) resetRef.current();


### PR DESCRIPTION
## Summary
- ensure touch event handler effect re-runs when `canvasRef` changes
- rerun game loop setup when `pongSpin` changes

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/pong.js`
- `npx jest __tests__/leaderboardAntiCheat.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b23cca63848328a7f76d294908cfde