### PR TITLE
Include submitScore in pacman effect dependencies

### DIFF
--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -610,7 +610,17 @@ const Pacman = () => {
         }
       }
     });
-  }, [score, availableDirs, levelIndex, isTunnel, prefersReduced, setAnnouncement, ghostSpeeds, gameSpeed]);
+  }, [
+    score,
+    availableDirs,
+    levelIndex,
+    isTunnel,
+    prefersReduced,
+    setAnnouncement,
+    ghostSpeeds,
+    gameSpeed,
+    submitScore,
+  ]);
 
   const stepRef = useRef(step);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add `submitScore` to the dependency list for the Pacman game loop effect to satisfy exhaustive deps rule

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/pacman.js -f json`


------
https://chatgpt.com/codex/tasks/task_e_68b23cc972fc8328a2f5bf73a2caf955