### PR TITLE
fix: rename Hangman hint handler to avoid hook lint error

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -196,7 +196,7 @@ const Hangman = () => {
     return () => mq.removeEventListener('change', update);
   }, []);
 
-  const useHint = useCallback(() => {
+  const handleHint = useCallback(() => {
     if (paused || hintCoins <= 0) return;
     const remaining = word
       .split('')
@@ -319,11 +319,11 @@ const Hangman = () => {
       const k = e.key.toLowerCase();
       if (k === 'r') reset();
       else if (k === 'p') togglePause();
-      else if (k === 'h') useHint();
+      else if (k === 'h') handleHint();
       else if (k === 's') toggleSound();
       else if (/^[a-z]$/.test(k) && letters.includes(k)) handleGuess(k);
     },
-    [reset, togglePause, useHint, toggleSound, handleGuess, letters],
+    [reset, togglePause, handleHint, toggleSound, handleGuess, letters],
   );
 
   useEffect(() => {
@@ -498,7 +498,7 @@ const Hangman = () => {
           ))}
         </select>
         <button
-          onClick={useHint}
+          onClick={handleHint}
           disabled={hintCoins <= 0 || paused}
           className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs shadow" 
         >


### PR DESCRIPTION
## Summary
- rename `useHint` to `handleHint` in Hangman component
- update all references to avoid React hook naming warning

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/hangman.js --max-warnings=0`
- `npx jest __tests__/hangman.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b23cc63ee88328ba1ec7117ea5e712