### PR TITLE
Fix Flappy Bird skin dependency

### DIFF
--- a/__tests__/flappyBird.test.tsx
+++ b/__tests__/flappyBird.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FlappyBird from '../components/apps/flappy-bird';
+
+beforeAll(() => {
+  // Minimal ResizeObserver mock for the test environment
+  // @ts-ignore
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('FlappyBird', () => {
+  it('starts the game with default skins', async () => {
+    render(<FlappyBird />);
+    fireEvent.click(screen.getByText('Start'));
+    expect(await screen.findByText('Score: 0')).toBeInTheDocument();
+  });
+
+  it('starts the game with alternate skins', async () => {
+    render(<FlappyBird />);
+    fireEvent.change(screen.getByLabelText('Bird Skin'), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText('Pipe Skin'), { target: { value: '1' } });
+    fireEvent.click(screen.getByText('Start'));
+    expect(await screen.findByText('Score: 0')).toBeInTheDocument();
+  });
+});

--- a/components/apps/flappy-bird.js
+++ b/components/apps/flappy-bird.js
@@ -728,7 +728,7 @@ const FlappyBird = () => {
       canvas.removeEventListener("touchstart", handlePointer);
       stopLoop();
     };
-  }, [canvasRef, started]);
+  }, [canvasRef, started, pipeSkinIndex, skin]);
 
   return (
     <div className="relative w-full h-full">


### PR DESCRIPTION
## Summary
- ensure Flappy Bird's main effect updates when bird or pipe skins change
- add tests to confirm game starts with default and alternate skins

## Testing
- `yarn eslint components/apps/flappy-bird.js __tests__/flappyBird.test.tsx` *(fails: ESLint couldn't find configuration)*
- `yarn test __tests__/flappyBird.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b23cc5c37c8328bd107029f1c8d7d9