### PR TITLE
Include precision helper in UnitConverter dependencies

### DIFF
--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -69,7 +69,7 @@ const UnitConverter = () => {
       setRightVal(rounded.toString());
       setError('');
     },
-    [category, fromUnit, toUnit, precision, sigFig],
+    [category, fromUnit, toUnit, precision, sigFig, applyPrecision],
   );
 
   const convertRightToLeft = useCallback(
@@ -90,7 +90,7 @@ const UnitConverter = () => {
       setLeftVal(rounded.toString());
       setError('');
     },
-    [category, fromUnit, toUnit, precision, sigFig],
+    [category, fromUnit, toUnit, precision, sigFig, applyPrecision],
   );
 
   const handleLeftChange = (e) => {


### PR DESCRIPTION
## Summary
- Ensure UnitConverter uses updated precision by including `applyPrecision` in conversion callback dependencies

## Testing
- `yarn test __tests__/converter.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b23cc379a88328ad77b2862a43122d