### PR TITLE
Include skin color in car-racer effect deps

### DIFF
--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -411,7 +411,7 @@ const CarRacer = () => {
       cancelAnimationFrame(req);
       if (worker) worker.terminate();
     };
-  }, [canvasRef, highScore, playBeep]);
+  }, [canvasRef, highScore, playBeep, currentSkin.color]);
 
   const saveGhostRun = (score) => {
     if (ghostRunRef.current.length > 1 && score >= ghostBestScoreRef.current) {


### PR DESCRIPTION
## Summary
- ensure car-racer animation effect reruns when the car skin color changes by adding `currentSkin.color` to useEffect deps

## Testing
- `yarn test` *(fails: missing handlePresetSelect, failing tests)*
- `yarn test __tests__/carRacer.test.ts`
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cc1efd083289269d0a783c7f2b9