### PR TITLE
fix: include rule in checkers setup effect

### DIFF
--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -138,7 +138,7 @@ const Checkers = () => {
         );
       }
     }
-  }, []);
+  }, [rule]);
 
   useEffect(() => {
     const state = {


### PR DESCRIPTION
## Summary
- include `rule` in the dependency array of Checkers setup effect

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cc2cb708328bd0ee2a213e33a9c