### PR TITLE
fix: include defaults in useInputMapping dependencies

### DIFF
--- a/components/apps/Games/common/input-remap/useInputMapping.js
+++ b/components/apps/Games/common/input-remap/useInputMapping.js
@@ -46,7 +46,7 @@ export default function useInputMapping(gameId, defaults = {}) {
     return () => {
       active = false;
     };
-  }, [gameId]);
+  }, [gameId, defaults]);
 
   const setKey = (action, key) => {
     let conflict = null;


### PR DESCRIPTION
## Summary
- update useInputMapping hook to include defaults in effect dependencies

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn eslint components/apps/Games/common/input-remap/useInputMapping.js`


------
https://chatgpt.com/codex/tasks/task_e_68b23cc2c78c8328a543d9aa1fafe550