### PR TITLE
Memoize 2048 controls to avoid unnecessary rebinds

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -432,7 +432,7 @@ const Game2048 = () => {
     return () => window.removeEventListener('keydown', esc);
   }, []);
 
-  const reset = () => {
+  const reset = useCallback(() => {
     resetRng(seed || today);
     setBoard(initBoard(hardMode));
     setHistory([]);
@@ -443,13 +443,26 @@ const Game2048 = () => {
     setMergeCells(new Set());
     setScore(0);
     setUndosLeft(UNDO_LIMIT);
-  };
+  }, [
+    hardMode,
+    seed,
+    today,
+    setBoard,
+    setHistory,
+    setMoves,
+    setWon,
+    setLost,
+    setAnimCells,
+    setMergeCells,
+    setScore,
+    setUndosLeft,
+  ]);
 
   const close = () => {
     document.getElementById('close-2048')?.click();
   };
 
-  const undo = () => {
+  const undo = useCallback(() => {
     if (!history.length || undosLeft === 0) return;
     const prev = history[history.length - 1];
     deserializeRng(prev.rng);
@@ -462,7 +475,19 @@ const Game2048 = () => {
     setMergeCells(new Set());
     setHistory((h) => h.slice(0, -1));
     setUndosLeft((u) => u - 1);
-  };
+  }, [
+    history,
+    undosLeft,
+    setBoard,
+    setScore,
+    setMoves,
+    setWon,
+    setLost,
+    setAnimCells,
+    setMergeCells,
+    setHistory,
+    setUndosLeft,
+  ]);
 
   useEffect(() => {
     const handler = (e) => {


### PR DESCRIPTION
## Summary
- wrap 2048 `reset` and `undo` functions with `useCallback`
- only rebind keydown handler when these callbacks change

## Testing
- `ESLINT_USE_FLAT_CONFIG=false yarn lint` *(fails: 56 problems, 9 errors)*
- `yarn test` *(fails: multiple failing suites such as BeEF app and Terminal component)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cc02f6c832892fec670e19df7e6