### PR TITLE
chore: add setSaveData dependency

### DIFF
--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -800,7 +800,7 @@ const Asteroids = () => {
 
     requestRef.current = requestAnimationFrame(update);
     return cleanup;
-  }, [controlsRef, dpr, restartKey, saveReady, selectingLevel, startLevelNum]);
+  }, [controlsRef, dpr, restartKey, saveReady, selectingLevel, startLevelNum, setSaveData]);
   const togglePause = () => {
     pausedRef.current = !pausedRef.current;
     setPaused(pausedRef.current);


### PR DESCRIPTION
## Summary
- fix missing dependency warning in asteroids app by including `setSaveData` in effect deps

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cc120a883288f42d20569173779