### PR TITLE
Memoize fetchStars and fix effect dependencies

### DIFF
--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from './usePersistentState';
 
 const GitHubStars = ({ user, repo }) => {
@@ -7,7 +7,7 @@ const GitHubStars = ({ user, repo }) => {
   const [stars, setStars] = usePersistentState(`gh-stars-${user}/${repo}`, null);
   const [loading, setLoading] = useState(stars === null);
 
-  const fetchStars = async () => {
+  const fetchStars = useCallback(async () => {
     try {
       setLoading(true);
       const res = await fetch(`https://api.github.com/repos/${user}/${repo}`);
@@ -19,7 +19,7 @@ const GitHubStars = ({ user, repo }) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, repo, setStars]);
 
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
@@ -39,7 +39,7 @@ const GitHubStars = ({ user, repo }) => {
     if (stars === null) {
       fetchStars();
     }
-  }, [visible]);
+  }, [visible, stars, fetchStars]);
 
   if (!repo) return null;
 


### PR DESCRIPTION
## Summary
- memoize GitHubStars fetchStars with useCallback
- add stars and fetchStars to visibility effect dependencies

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/GitHubStars.js --max-warnings=0 && echo 'lint ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b23cbeeb208328bd8fff0ebe7ea284