### PR TITLE
fix: escape apostrophe in radare2 guide overlay

### DIFF
--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -76,7 +76,7 @@ export default function GuideOverlay({ onClose }) {
             checked={dontShow}
             onChange={(e) => setDontShow(e.target.checked)}
           />
-          <span>Don't show again</span>
+          <span>Don&apos;t show again</span>
         </label>
         <div className="mt-4 flex justify-between">
           <a


### PR DESCRIPTION
## Summary
- escape apostrophe in radare2 GuideOverlay message

## Testing
- `yarn lint components/apps/radare2/GuideOverlay.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e88d8748328b4f883b929e11f7c