### PR TITLE
refactor: rename useHint hook

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -196,7 +196,7 @@ const Hangman = () => {
     return () => mq.removeEventListener('change', update);
   }, []);
 
-  const useHint = useCallback(() => {
+  const hint = useCallback(() => {
     if (paused || hintCoins <= 0) return;
     const remaining = word
       .split('')
@@ -319,11 +319,11 @@ const Hangman = () => {
       const k = e.key.toLowerCase();
       if (k === 'r') reset();
       else if (k === 'p') togglePause();
-      else if (k === 'h') useHint();
+      else if (k === 'h') hint();
       else if (k === 's') toggleSound();
       else if (/^[a-z]$/.test(k) && letters.includes(k)) handleGuess(k);
     },
-    [reset, togglePause, useHint, toggleSound, handleGuess, letters],
+    [reset, togglePause, hint, toggleSound, handleGuess, letters],
   );
 
   useEffect(() => {
@@ -498,7 +498,7 @@ const Hangman = () => {
           ))}
         </select>
         <button
-          onClick={useHint}
+          onClick={hint}
           disabled={hintCoins <= 0 || paused}
           className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs shadow" 
         >


### PR DESCRIPTION
## Summary
- rename `useHint` to `hint` in Hangman app
- update key handler and button references

## Testing
- `yarn lint components/apps/hangman.js` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e881d1c8328b7835f8416bf1072