### PR TITLE
chore: simplify vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,5 @@
   "functions": {
     "api/**/*.js": { "runtime": "nodejs20.x" },
     "api/**/*.ts": { "runtime": "nodejs20.x" }
-  },
-  "env": {
-    "FLAGS_SECRET": "@flags_secret"
-
-  },
-  "env": {
-    "ADMIN_READ_KEY": "@admin-read-key"
   }
 }


### PR DESCRIPTION
## Summary
- streamline `vercel.json` to only specify Node.js 20 runtimes for API functions

## Testing
- `yarn test` *(fails: bare-fs package missing)*
- `npm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e653aa88328adb4f7933dda937e