### PR TITLE
Remove legacy Vercel secret references

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,5 @@
   "functions": {
     "api/**/*.js": { "runtime": "nodejs20.x" },
     "api/**/*.ts": { "runtime": "nodejs20.x" }
-  },
-  "env": {
-    "FLAGS_SECRET": "@flags_secret"
-
-  },
-  "env": {
-    "ADMIN_READ_KEY": "@admin-read-key"
   }
 }


### PR DESCRIPTION
## Summary
- drop obsolete `env` keys from `vercel.json`

## Testing
- `yarn lint` *(fails: ESLint couldn't find an eslint.config file)*
- `yarn test` *(fails: various failing tests, e.g. installButton.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e5f2d1c83289f12777ee6cfbff4