### PR TITLE
chore: skip eslint during build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,10 @@ const securityHeaders = [
 const isExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
 module.exports = {
+  // Temporarily ignore ESLint during builds; CI runs lint separately
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   images: {
     domains: [
       'opengraph.githubassets.com',


### PR DESCRIPTION
## Summary
- ignore ESLint during Next.js builds (temporary; lint runs in CI)

## Testing
- `yarn test` *(fails: metasploit, kismet, installButton, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e8c2264832892495a2993da485c