### PR TITLE
refactor(todoist): remove JSX wrapper from displayTodoist

### DIFF
--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -961,7 +961,5 @@ export default function Todoist() {
   );
 }
 
-export const displayTodoist = () => {
-  return <Todoist />;
-};
+export const displayTodoist = () => React.createElement(Todoist);
 


### PR DESCRIPTION
## Summary
- refactor `displayTodoist` to use `React.createElement` instead of JSX

## Testing
- `yarn lint components/apps/todoist.js` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e896f008328aaf77c795aa2a09b