### PR TITLE
fix minesweeper cursor dependency

### DIFF
--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -361,7 +361,7 @@ const Minesweeper = () => {
     };
     draw();
     return () => cancelAnimationFrame(frame);
-  }, [board, status, paused, flags, showRisk]);
+  }, [board, status, paused, flags, showRisk, cursor.x, cursor.y, cursorVisible]);
 
   useEffect(() => {
     if (!useQuestionMarks && board) {


### PR DESCRIPTION
## Summary
- update minesweeper canvas render effect to react to cursor position and visibility

## Testing
- `yarn test` *(fails: Unable to find an element and other test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cc7f68483289227005d4bc964fe