### PR TITLE
fix: remove outdated vercel config version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "version": 2,
   "functions": {
     "api/**/*.js": { "runtime": "nodejs20.x" },
     "api/**/*.ts": { "runtime": "nodejs20.x" }


### PR DESCRIPTION
## Summary
- remove deprecated `version` field from Vercel config to allow Node.js 20 runtime

## Testing
- `yarn test` *(fails: handlePresetSelect is not defined, and other failures)*
- `yarn lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b240b0eed8832895762fd911dec2a4