### PR TITLE
Rename Hangman hint callback

### DIFF
--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -196,7 +196,7 @@ const Hangman = () => {
     return () => mq.removeEventListener('change', update);
   }, []);
 
-  const handleHint = useCallback(() => {
+  const hint = useCallback(() => {
     if (paused || hintCoins <= 0) return;
     const remaining = word
       .split('')
@@ -319,11 +319,11 @@ const Hangman = () => {
       const k = e.key.toLowerCase();
       if (k === 'r') reset();
       else if (k === 'p') togglePause();
-      else if (k === 'h') handleHint();
+      else if (k === 'h') hint();
       else if (k === 's') toggleSound();
       else if (/^[a-z]$/.test(k) && letters.includes(k)) handleGuess(k);
     },
-    [reset, togglePause, handleHint, toggleSound, handleGuess, letters],
+    [reset, togglePause, hint, toggleSound, handleGuess, letters],
   );
 
   useEffect(() => {
@@ -498,7 +498,7 @@ const Hangman = () => {
           ))}
         </select>
         <button
-          onClick={handleHint}
+          onClick={hint}
           disabled={hintCoins <= 0 || paused}
           className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs shadow" 
         >


### PR DESCRIPTION
## Summary
- rename `handleHint` callback to `hint`
- update key handler and button to invoke `hint`
- adjust key handler `useCallback` dependencies

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint components/apps/hangman.js`
- `yarn test __tests__/hangman.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b240e20d8c832891e00ad74cdb2091