### PR TITLE
Specify runtime version for Vercel functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "api/**/*.js": { "runtime": "nodejs20.x" },
-    "api/**/*.ts": { "runtime": "nodejs20.x" }
+    "api/**/*.js": { "runtime": "@vercel/node@5.3.17" },
+    "api/**/*.ts": { "runtime": "@vercel/node@5.3.17" }
   },
   "env": {
     "FLAGS_SECRET": "@flags_secret",


### PR DESCRIPTION
## Summary
- specify explicit `@vercel/node@5.3.17` runtime for all API functions to satisfy Vercel's runtime version requirement

## Testing
- `yarn install`
- `yarn test` *(fails: `wireshark.test.tsx`, `beef.test.tsx`, `terminal.test.tsx`, `niktoPage.test.tsx`, `installButton.test.tsx`, `mimikatz.test.ts`, `daily2048Seed.test.tsx`, `metasploit.test.tsx`, `kismet.test.tsx`, `aboutAccessibility.test.tsx`, `chess.perft.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2415d1c288328860ad11f7317f70b