### PR TITLE
chore: document CI lint requirement in build config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ const securityHeaders = [
 const isExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
 module.exports = {
-  // Temporarily ignore ESLint during builds; CI runs lint separately
+  // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- clarify Next.js config to skip ESLint during builds only when CI runs lint separately

## Testing
- `yarn lint next.config.js` *(fails: ESLint couldn't find an eslint.config.js file)*
- `yarn test next.config.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b240e704c08328ad3f609fc399d2f3