### PR TITLE
Remove missing FLAGS_SECRET secret reference

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,6 @@
     "api/**/*.ts": { "runtime": "nodejs20.x" }
   },
   "env": {
-    "FLAGS_SECRET": "@flags_secret",
     "ADMIN_READ_KEY": "@admin-read-key"
   }
 }


### PR DESCRIPTION
## Summary
- remove `FLAGS_SECRET` environment variable from `vercel.json` since the secret isn't defined

## Testing
- `yarn test` *(fails: ReferenceError: handlePresetSelect is not defined, SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68b2441033fc832894f5df1db13ade8e