### PR TITLE
fix(vercel): specify runtime version for serverless functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
-    "api/**/*.js": { "runtime": "@vercel/node@5.3.17" },
-    "api/**/*.ts": { "runtime": "@vercel/node@5.3.17" }
+    "pages/api/**/*.js": { "runtime": "@vercel/node@5.3.17" },
+    "pages/api/**/*.ts": { "runtime": "@vercel/node@5.3.17" }
   },
   "env": {
     "ADMIN_READ_KEY": "@admin-read-key"


### PR DESCRIPTION
## Summary
- ensure Vercel functions under `pages/api` pin to `@vercel/node@5.3.17`

## Testing
- `yarn test` *(fails: WiresharkApp › persists filter expressions via localStorage, BeEF app › updates hook list when refresh is clicked, Terminal component › supports tab management shortcuts, NiktoPage › builds command preview and shows fix suggestion, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b246804e5c8328b728d51fd95225ab