### PR TITLE
fix flag import path in contact API route

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { randomBytes } from 'crypto';
 import trackServerEvent from '@/lib/analytics-server';
-import { reportValue, beta } from 'flags';
+import { reportValue, beta } from '@/flags';
 import { contactSchema } from '../../utils/contactSchema';
 import { validateServerEnv } from '../../lib/validate';
 import { getServiceSupabase } from '../../lib/supabase';


### PR DESCRIPTION
## Summary
- fix flag import path in contact API route

## Testing
- `yarn lint` (fails: 6 errors, 35 warnings)
- `yarn build` (fails: Type error in apps/autopsy/index.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b247cde73c8328b84c6845e38f00f3