### PR TITLE
feat: add supabase anon server util

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -22,3 +22,30 @@ export function getServiceSupabase() {
     },
   };
 }
+
+export function getAnonSupabaseServer() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error('Supabase environment variables are not set');
+  }
+  return {
+    from(table: string) {
+      return {
+        async select() {
+          const response = await fetch(`${url}/rest/v1/${table}?select=*`, {
+            headers: {
+              apikey: key,
+              Authorization: `Bearer ${key}`,
+            },
+          });
+          if (!response.ok) {
+            return { data: null, error: new Error(await response.text()) };
+          }
+          const data = await response.json();
+          return { data, error: null };
+        },
+      };
+    },
+  };
+}

--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps } from 'next';
-import { getAnonSupabaseServer } from '../lib/supabase.server';
+import { getAnonSupabaseServer } from '../lib/supabase';
 
 interface NotesPageProps {
   notes: unknown[] | null;


### PR DESCRIPTION
## Summary
- support anonymous Supabase calls on the server
- switch notes page to use the new helper

## Testing
- `npx eslint lib/supabase.ts pages/notes.tsx`
- `yarn build` *(fails: Conversion of type '({ initialArtifacts }: { initialArtifacts?: null | undefined; }) => Element' to type 'ComponentType<{ initialArtifacts: Artifact[]; expandedNodes: string[]; onExpandedNodesChange: (nodes: string[]) => void; }>' may be a mistake)*
- `npx ts-node --transpile-only -e "process.env.SUPABASE_URL='https://example.supabase.co';process.env.SUPABASE_ANON_KEY='anon'; const m=require('./lib/supabase'); m.getAnonSupabaseServer().from('notes').select().then(console.log).catch(console.error);"` *(fails: getaddrinfo ENOTFOUND example.supabase.co)*

------
https://chatgpt.com/codex/tasks/task_e_68b247d1644483288127c931d001b65f