### PR TITLE
Update Vercel config and fix module import paths

### DIFF
--- a/apps/wireshark/filters/presets.json
+++ b/apps/wireshark/filters/presets.json
@@ -1,0 +1,6 @@
+[
+  { "label": "HTTP(S)", "expression": "tcp.port == 80 || tcp.port == 443" },
+  { "label": "DNS",    "expression": "udp.port == 53" },
+  { "label": "SSH",    "expression": "tcp.port == 22" },
+  { "label": "TLS",    "expression": "tls" }
+]

--- a/games/tic-tac-toe/components/Tutorial.tsx
+++ b/games/tic-tac-toe/components/Tutorial.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { minimax, checkWinner, createBoard, Player } from '../../../apps/games/tictactoe/engine';
+import { minimax, checkWinner, createBoard, Player } from '../../../apps/games/tictactoe/logic';
 
 type Step = {
   board: (Player | null)[];

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -22,3 +22,28 @@ export function getServiceSupabase() {
     },
   };
 }
+
+export function getAnonSupabaseServer() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error('Supabase environment variables are not set');
+  }
+  return {
+    from(table: string) {
+      return {
+        async select() {
+          const res = await fetch(`${url}/rest/v1/${table}?select=*`, {
+            headers: { apikey: key, Authorization: `Bearer ${key}` },
+          });
+          if (!res.ok) {
+            const error = await res.text();
+            return { data: null, error };
+          }
+          const data = await res.json();
+          return { data, error: null };
+        },
+      };
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prebuild": "tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build && yarn build:sw",
+    "postbuild": "node -e \"const fs=require('fs');fs.mkdirSync('public/vendor',{recursive:true});fs.copyFileSync('dist/utils/gamepad.js','public/vendor/gamepad.js')\"",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build && yarn build:sw",
     "test": "jest",
@@ -39,7 +40,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
-    "chart.js": "patch:chart.js@npm%3A4.5.0#~/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch",
+    "chart.js": "patch:chart.js@npm%3A4.5.0#./.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
     "cron-parser": "^5.3.0",
@@ -132,9 +133,7 @@
   "resolutions": {
     "magic-string": "^0.30.10",
     "postcss": "^8.5.6",
-    "test-exclude": "^7.0.1",
-    "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
+    "test-exclude": "^7.0.1"
   },
   "packageManager": "yarn@4.9.2"
 }
-

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { randomBytes } from 'crypto';
 import trackServerEvent from '@/lib/analytics-server';
-import { reportValue, beta } from 'flags';
+import { reportValue, beta } from '@/flags';
 import { contactSchema } from '../../utils/contactSchema';
 import { validateServerEnv } from '../../lib/validate';
 import { getServiceSupabase } from '../../lib/supabase';

--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps } from 'next';
-import { getAnonSupabaseServer } from '../lib/supabase.server';
+import { getAnonSupabaseServer } from '../lib/supabase';
 
 interface NotesPageProps {
   notes: unknown[] | null;

--- a/public/apps/asteroids/main.js
+++ b/public/apps/asteroids/main.js
@@ -1,4 +1,4 @@
-import { pollTwinStick } from '../../utils/gamepad.ts';
+import { pollTwinStick } from '/vendor/gamepad.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "api/**/*.js": { "runtime": "@vercel/node@5.3.17" },
-    "api/**/*.ts": { "runtime": "@vercel/node@5.3.17" }
-  },
-  "env": {
-    "ADMIN_READ_KEY": "@admin-read-key"
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,90 +2245,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-android-arm64@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.77"
+"@napi-rs/canvas-android-arm64@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.78"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-arm64@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.77"
+"@napi-rs/canvas-darwin-arm64@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.78"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-x64@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.77"
+"@napi-rs/canvas-darwin-x64@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.78"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77"
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.78"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77"
+"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.78"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-musl@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.77"
+"@napi-rs/canvas-linux-arm64-musl@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.78"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77"
+"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.78"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-gnu@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.77"
+"@napi-rs/canvas-linux-x64-gnu@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.78"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-musl@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.77"
+"@napi-rs/canvas-linux-x64-musl@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.78"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-x64-msvc@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.77"
+"@napi-rs/canvas-win32-x64-msvc@npm:0.1.78":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.78"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@npm:0.1.77":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas@npm:0.1.77"
+"@napi-rs/canvas@npm:^0.1.74":
+  version: 0.1.78
+  resolution: "@napi-rs/canvas@npm:0.1.78"
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
+    "@napi-rs/canvas-android-arm64": "npm:0.1.78"
+    "@napi-rs/canvas-darwin-arm64": "npm:0.1.78"
+    "@napi-rs/canvas-darwin-x64": "npm:0.1.78"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.78"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.78"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.78"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.78"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.78"
+    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.78"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.78"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -2350,46 +2350,7 @@ __metadata:
       optional: true
     "@napi-rs/canvas-win32-x64-msvc":
       optional: true
-  checksum: 10c0/f7a1b33e86e53c210db873a6b5b9be9961d9a57b4e1c4e61c2667ed3cb166dec334b4f14d548c8790d9ffc79cf49b9762340f3b3d3f7fc991e9c8cc0a5f8654d
-  languageName: node
-  linkType: hard
-
-"@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.77&hash=93d5cb"
-  dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
-  dependenciesMeta:
-    "@napi-rs/canvas-android-arm64":
-      optional: true
-    "@napi-rs/canvas-darwin-arm64":
-      optional: true
-    "@napi-rs/canvas-darwin-x64":
-      optional: true
-    "@napi-rs/canvas-linux-arm-gnueabihf":
-      optional: true
-    "@napi-rs/canvas-linux-arm64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-arm64-musl":
-      optional: true
-    "@napi-rs/canvas-linux-riscv64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-x64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-x64-musl":
-      optional: true
-    "@napi-rs/canvas-win32-x64-msvc":
-      optional: true
-  checksum: 10c0/32cd0d4b772e341a6f8fa61e4f8bae29e47d978584cab41800aa304863d4555924fe525508d47be8d96300c713327056bab3e48c0f743850775f43c08667cd28
+  checksum: 10c0/7a98cc5b962b723c02c1e0220d2f937fd108188ecc575a32552915a8ae57c29f00f210adb28144ec110352931146cc71389601128807279b6a621cc0e5f4d0a5
   languageName: node
   linkType: hard
 
@@ -4871,9 +4832,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chart.js@patch:chart.js@npm%3A4.5.0#~/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch":
+"chart.js@patch:chart.js@npm%3A4.5.0#./.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch::locator=unnippillil%40workspace%3A.":
   version: 4.5.0
-  resolution: "chart.js@patch:chart.js@npm%3A4.5.0#~/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch::version=4.5.0&hash=8a08b4"
+  resolution: "chart.js@patch:chart.js@npm%3A4.5.0#./.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch::version=4.5.0&hash=8a08b4&locator=unnippillil%40workspace%3A."
   dependencies:
     "@kurkle/color": "npm:^0.3.0"
   checksum: 10c0/b5c73ab44ab5f0c58ee112968ab26814f88c9ee0a76be9526c54edd01e8f689d55c0d2bec3c95f8938a338ea46aaf4ea1e5954f8e8c14d023b09267c0f39927d
@@ -12337,7 +12298,7 @@ __metadata:
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
-    chart.js: "patch:chart.js@npm%3A4.5.0#~/.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch"
+    chart.js: "patch:chart.js@npm%3A4.5.0#./.yarn/patches/chart.js-npm-4.5.0-e95c375db8.patch"
     chess.js: "npm:^1.0.0"
     chrono-node: "npm:^2.8.4"
     cron-parser: "npm:^5.3.0"


### PR DESCRIPTION
## Summary
- simplify Vercel config to v2 schema
- clean package.json patches and ensure gamepad helper is copied after build
- fix several broken imports and add missing Wireshark filter presets

## Testing
- `yarn lint` *(fails: Component definition is missing display name, Do not mutate state directly, `'` can be escaped with `&apos;`)*
- `yarn test` *(fails: ReferenceError: handlePresetSelect is not defined, Unable to find an element with the text: 1, expect(received).toBe(expected))*
- `yarn build` *(fails: Type error: Conversion of type '({ initialArtifacts }: { initialArtifacts?: null | undefined; }) => Element' to type 'ComponentType<{ initialArtifacts: Artifact[]; expandedNodes: string[]; onExpandedNodesChange: (nodes: string[]) => void; }>' may be a mistake)*

------
https://chatgpt.com/codex/tasks/task_e_68b246e07fd48328bc211a05d451fbed