### PR TITLE
Use local patch path for @napi-rs/canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,8 +133,7 @@
     "magic-string": "^0.30.10",
     "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
-    "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
+    "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
   "packageManager": "yarn@4.9.2"
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2354,9 +2354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch":
+"@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::locator=unnippillil%40workspace%3A.":
   version: 0.1.77
-  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#~/.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.77&hash=93d5cb"
+  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.77&hash=93d5cb&locator=unnippillil%40workspace%3A."
   dependencies:
     "@napi-rs/canvas-android-arm64": "npm:0.1.77"
     "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"


### PR DESCRIPTION
## Summary
- reference @napi-rs/canvas patch from repo's `.yarn/patches`
- update lockfile after reinstall

## Testing
- `yarn install`


------
https://chatgpt.com/codex/tasks/task_e_68b247d43d108328b52e6f9d435410f7