### PR TITLE
feat: embed stack repo in vscode app

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -50,7 +50,7 @@ export default function VsCode() {
         </div>
         <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
           <ExternalFrame
-            src="https://vscode.dev/"
+            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
             title="VsCode"
             className="w-full h-full"
           />


### PR DESCRIPTION
## Summary
- load the prebuilt StackBlitz project inside the VS Code utility

## Testing
- `yarn test` (fails: wireshark, beef, terminal, niktoPage, installButton, mimikatz, battleship-net, kismet)
- `npx eslint apps/vscode/index.tsx components/ExternalFrame.js`

------
https://chatgpt.com/codex/tasks/task_e_68b247cb8ed0832891f9bfe85f49e0e5