### PR TITLE
Remove missing Vercel secret reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ keyboard focus so bundles are warmed before launch. When adding a new app, expor
 | `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |
 | `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | ReCAPTCHA site key used on the client. |
 | `RECAPTCHA_SECRET` | ReCAPTCHA secret key for server-side verification. |
-| `ADMIN_READ_KEY` | Secret key required by admin message APIs. |
+| `ADMIN_READ_KEY` | Secret key required by admin message APIs. Configure this directly as an environment variable (e.g., in the Vercel dashboard). |
 | `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
 | `NEXT_PUBLIC_STATIC_EXPORT` | Set to `'true'` during `yarn export` to disable server APIs. |
 | `FEATURE_TOOL_APIS` | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow. |
@@ -264,7 +264,7 @@ Workflow: `.github/workflows/gh-deploy.yml`:
   - `NEXT_PUBLIC_UI_EXPERIMENTS`
   - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
   - `RECAPTCHA_SECRET`
-  - `ADMIN_READ_KEY`
+  - `ADMIN_READ_KEY` (set manually in Vercel or your host)
 - Build command: `yarn build`
 - Output: Next.js (serverless by default on Vercel).
 - If you keep API routes, Vercel deploys them as serverless functions. For a static build, disable API routes or feature-flag those apps.

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,5 @@
   "functions": {
     "pages/api/**/*.js": { "runtime": "@vercel/node@5.3.17" },
     "pages/api/**/*.ts": { "runtime": "@vercel/node@5.3.17" }
-  },
-  "env": {
-    "ADMIN_READ_KEY": "@admin-read-key"
   }
 }


### PR DESCRIPTION
## Summary
- drop `ADMIN_READ_KEY` secret reference from `vercel.json` so deployments don't fail when the secret isn't configured
- document that `ADMIN_READ_KEY` must be set manually in the deployment environment

## Testing
- `yarn lint` *(fails: 6 errors, 35 warnings)*
- `yarn test` *(fails: multiple test suites, e.g. wireshark, beef, terminal, niktoPage, installButton, mimikatz, kismet, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b248295c20832885f227d1716b8478