### PR TITLE
refactor: type Autopsy app without ComponentType cast

### DIFF
--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -6,11 +6,11 @@ import events from './events.json';
 import KeywordTester from './components/KeywordTester';
 import type { Artifact } from './types';
 
-// The upstream Autopsy component accepts only an optional list of initial artifacts.
-// Casting it to a narrower prop type avoids TypeScript errors from unsupported props.
-const AutopsyApp = AutopsyAppComponent as React.ComponentType<{
+interface AutopsyProps {
   initialArtifacts?: Artifact[];
-}>;
+}
+
+const AutopsyApp: React.FC<AutopsyProps> = AutopsyAppComponent;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling


### PR DESCRIPTION
## Summary
- define explicit props interface for Autopsy app
- remove React.ComponentType cast

## Testing
- `yarn eslint apps/autopsy/index.tsx pages/apps/autopsy.tsx components/apps/autopsy/index.js`
- `yarn test --passWithNoTests apps/autopsy/index.tsx`
- `yarn tsc --noEmit` *(fails: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Record<DictName, string[]>')*

------
https://chatgpt.com/codex/tasks/task_e_68b24eebd03c83289a818dd948726ce3