### PR TITLE
chore: remove react-twitter-embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^4.2.1",
     "react-onclickoutside": "^6.12.2",
-    "react-twitter-embed": "^4.0.4",
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
     "sharp": "^0.34.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10539,18 +10539,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-twitter-embed@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "react-twitter-embed@npm:4.0.4"
-  dependencies:
-    scriptjs: "npm:^2.5.9"
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/5c5395a8421fd67752f4eae993b682175a3757e73c338f1d0ec56cf413206ae01c9197d39dfee41d0726f4740703a9a9fdce4ac66d1529dbecf0967f7953be39
-  languageName: node
-  linkType: hard
-
 "react@npm:^19.1.1":
   version: 19.1.1
   resolution: "react@npm:19.1.1"
@@ -10934,13 +10922,6 @@ __metadata:
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
   checksum: 10c0/5b8d5bfddaae3513410eda54f2268e98a376a429931921a81b5c3a2873aab7ca4d775a8caac5498f8cbc7d0daeab947cf923dbd8e215d61671f9f4e392d34356
-  languageName: node
-  linkType: hard
-
-"scriptjs@npm:^2.5.9":
-  version: 2.5.9
-  resolution: "scriptjs@npm:2.5.9"
-  checksum: 10c0/7b81adefb3ce7761a9b13f4cc22c6c77418a3f6a828bf400c9184ea3801c3fc2c352c4966382cece4a60cc843e0d1a1087bcf96b9a81a1bb6de7ddc60fd80811
   languageName: node
   linkType: hard
 
@@ -12361,7 +12342,6 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^4.2.1"
     react-onclickoutside: "npm:^6.12.2"
-    react-twitter-embed: "npm:^4.0.4"
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
     sharp: "npm:^0.34.3"


### PR DESCRIPTION
## Summary
- remove unused `react-twitter-embed` package

## Testing
- `yarn lint` *(fails: import/no-anonymous-default-export, unused eslint-disable, etc.)*
- `yarn test` *(fails: WiresharkApp localStorage persistence, BeEF app, Terminal component, NiktoPage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b250df8fe08328a16d18b2332f424d