### PR TITLE
fix autopsy props typing

### DIFF
--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -10,7 +10,7 @@ interface AutopsyProps {
   initialArtifacts?: Artifact[];
 }
 
-const AutopsyApp: React.FC<AutopsyProps> = AutopsyAppComponent;
+const AutopsyApp = AutopsyAppComponent as React.FC<AutopsyProps>;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling


### PR DESCRIPTION
## Summary
- fix type mismatch by casting Autopsy component to expected props

## Testing
- `yarn lint apps/autopsy/index.tsx` *(fails: Component definition is missing display name in projectGallery.test.tsx, etc.)*
- `yarn build` *(fails: Cannot find name 'BluetoothDevice' in apps/bluetooth-tools/components/HidDemo.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2541dedd08328831b3e4b98b07af9