### PR TITLE
Fix Autopsy component prop typing

### DIFF
--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -334,7 +334,7 @@ function Timeline({ events, onSelect }) {
   );
 }
 
-function Autopsy({ initialArtifacts = null }) {
+function Autopsy({ initialArtifacts } = {}) {
   const [caseName, setCaseName] = useState('');
   const [currentCase, setCurrentCase] = useState(null);
   const [analysis, setAnalysis] = useState('');


### PR DESCRIPTION
## Summary
- Allow Autopsy app to accept artifact arrays by adjusting component's initialArtifacts param

## Testing
- `yarn test` *(fails: WiresharkApp, BeEF, Terminal component, NiktoPage, calculator parser, installButton)*
- `yarn build` *(fails: Cannot find name 'BluetoothDevice')*

------
https://chatgpt.com/codex/tasks/task_e_68b2545d02288328b259bfbe1afbf47c