### PR TITLE
chore: remove unused twitter embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
     "react-onclickoutside": "^6.12.2",
-    "react-twitter-embed": "^4.0.4",
 
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10516,18 +10516,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-twitter-embed@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "react-twitter-embed@npm:4.0.4"
-  dependencies:
-    scriptjs: "npm:^2.5.9"
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/5c5395a8421fd67752f4eae993b682175a3757e73c338f1d0ec56cf413206ae01c9197d39dfee41d0726f4740703a9a9fdce4ac66d1529dbecf0967f7953be39
-  languageName: node
-  linkType: hard
-
 "react@npm:^19.1.1":
   version: 19.1.1
   resolution: "react@npm:19.1.1"
@@ -12329,7 +12317,6 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
     react-onclickoutside: "npm:^6.12.2"
-    react-twitter-embed: "npm:^4.0.4"
 
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"


### PR DESCRIPTION
## Summary
- drop unused `react-twitter-embed` dependency that required missing `scriptjs`

## Testing
- `yarn test __tests__/wireshark.test.tsx` *(fails: handlePresetSelect is not defined)*
- `yarn test __tests__/terminal.test.tsx` *(fails: expected tab count 2, received 0)*
- `yarn test __tests__/niktoPage.test.tsx` *(fails: unable to find `/admin` in DOM)*


------
https://chatgpt.com/codex/tasks/task_e_68b256bbbfe48328a97e70cb3fdd354c