### PR TITLE
refactor: simplify autopsy page

### DIFF
--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -2,15 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import AutopsyAppComponent from '../../components/apps/autopsy';
-import events from './events.json';
 import KeywordTester from './components/KeywordTester';
-import type { Artifact } from './types';
-
-interface AutopsyProps {
-  initialArtifacts?: Artifact[];
-}
-
-const AutopsyApp = AutopsyAppComponent as React.FC<AutopsyProps>;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling
@@ -55,9 +47,7 @@ const AutopsyPage: React.FC = () => {
           Keyword Tester
         </button>
       </div>
-      {view === 'autopsy' && (
-        <AutopsyApp initialArtifacts={events.artifacts as Artifact[]} />
-      )}
+      {view === 'autopsy' && <AutopsyAppComponent />}
       {view === 'keywords' && <KeywordTester />}
     </div>
   );


### PR DESCRIPTION
## Summary
- streamline Autopsy page by removing unused events dependency and initialArtifacts prop
- render Autopsy component directly without extra wrapper

## Testing
- `npx jest apps/autopsy/index.tsx --passWithNoTests`
- `npx next build` *(fails: Module '@/lib/analytics-client' has no default export in apps/contact/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b257197c74832880fc39cb9c74ac79