### PR TITLE
chore: validate dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile | tee yarn-install.log
+      - run: node scripts/validate-deps.mjs yarn-install.log
       - run: yarn lint
       - run: yarn build

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn-install.log
 
 # local env files
 .env

--- a/scripts/validate-deps.mjs
+++ b/scripts/validate-deps.mjs
@@ -1,0 +1,23 @@
+import {readFileSync} from 'node:fs';
+import {execSync} from 'node:child_process';
+
+const logFile = process.argv[2] || 'yarn-install.log';
+const banned = ['glob@7', 'inflight@1.0.6', 'source-map@0.8.0-beta.0'];
+
+const log = readFileSync(logFile, 'utf8');
+for (const pattern of banned) {
+  if (log.includes(pattern)) {
+    console.error(`Forbidden dependency found in install log: ${pattern}`);
+    process.exit(1);
+  }
+}
+
+const whyOutput = execSync('yarn why glob && yarn why inflight && yarn why source-map', {encoding: 'utf8'});
+for (const pattern of banned) {
+  if (whyOutput.includes(pattern)) {
+    console.error(`Forbidden dependency found via yarn why: ${pattern}`);
+    process.exit(1);
+  }
+}
+
+console.log('Dependency check passed');


### PR DESCRIPTION
## Summary
- check `yarn install` logs for banned dependency versions
- verify dependency versions with `yarn why` during CI

## Testing
- `yarn install --frozen-lockfile`
- `node scripts/validate-deps.mjs yarn-install.log`
- `yarn lint` *(fails: 40 problems, 6 errors, 34 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68b25907b0e08328a6929d536776196c