### PR TITLE
Add Autopsy component typings

### DIFF
--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -1,16 +1,10 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import AutopsyAppComponent from '../../components/apps/autopsy';
+import AutopsyApp from '../../components/apps/autopsy';
 import events from './events.json';
 import KeywordTester from './components/KeywordTester';
 import type { Artifact } from './types';
-
-interface AutopsyProps {
-  initialArtifacts?: Artifact[];
-}
-
-const AutopsyApp = AutopsyAppComponent as React.FC<AutopsyProps>;
 
 const AutopsyPage: React.FC = () => {
   // Track which view is active so we can restore UI state when toggling

--- a/components/apps/autopsy/index.d.ts
+++ b/components/apps/autopsy/index.d.ts
@@ -1,0 +1,9 @@
+import type { FC } from 'react';
+import type { Artifact } from '../../../apps/autopsy/types';
+
+export interface AutopsyProps {
+  initialArtifacts?: Artifact[] | null;
+}
+
+declare const AutopsyApp: FC<AutopsyProps>;
+export default AutopsyApp;


### PR DESCRIPTION
## Summary
- add `AutopsyProps` typings for Autopsy component
- rely on new component typings in autopsy app page

## Testing
- `yarn lint apps/autopsy/index.tsx components/apps/autopsy/index.d.ts` *(fails: Component definition is missing display name in existing tests, etc.)*
- `yarn test apps/autopsy --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b2590f5ef88328ba90d61b97604104