### PR TITLE
chore: configure yarn path and filters

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
+yarnPath: .yarn/releases/yarn-4.4.0.cjs
 nodeLinker: node-modules
 
 logFilters:
@@ -7,4 +8,7 @@ logFilters:
     level: discard
   - pattern: "inflight@1.0.6: This module is not supported"
     level: discard
-
+  - pattern: "The engine \"bare\" appears to be invalid"
+    level: discard
+  - pattern: "Workspaces can only be enabled in private projects."
+    level: discard

--- a/package.json
+++ b/package.json
@@ -134,5 +134,5 @@
     "test-exclude": "^7.0.1",
     "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.4.0"
 }


### PR DESCRIPTION
## Summary
- pin Yarn to `.yarn/releases/yarn-4.4.0.cjs`
- filter additional Yarn log noise for invalid engine and workspace warnings
- align package manager to Yarn 4.4.0

## Testing
- `npx jest` *(fails: WiresharkApp, BeEF app, Terminal component, InstallButton, NiktoPage, Mimikatz API, KismetApp, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2591061cc8328813c0a599a3b8e1c