### PR TITLE
fix: correct analytics event imports

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -6,7 +6,7 @@ import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
-import trackEvent from "@/lib/analytics-client";
+import { trackEvent } from "@/lib/analytics-client";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,6 +4,7 @@ export type EventName =
   | 'cta_click'
   | 'signup_submit'
   | 'contact_submit'
+  | 'contact_submit_error'
   | 'outbound_link_click'
   | 'download_click';
 


### PR DESCRIPTION
## Summary
- fix analytics event import in contact app
- support contact_submit_error event in analytics client

## Testing
- `yarn build` *(fails: Type error in apps/figlet/worker.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ac185388328a8a47b25fddaa12b