### PR TITLE
Use named trackEvent import and fix type errors

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -6,7 +6,7 @@ import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
-import trackEvent from "@/lib/analytics-client";
+import { trackEvent } from "@/lib/analytics-client";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";

--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -34,7 +34,9 @@ function isMonospace(name: string) {
   const chars = 'ABCDE';
   let width: number | undefined;
   for (const ch of chars) {
-    const glyph = strip(figlet.textSync(ch, { font: name }).split('\n'));
+    const glyph = strip(
+      figlet.textSync(ch, { font: name as figlet.Fonts }).split('\n'),
+    );
     const w = glyph.reduce((m, line) => Math.max(m, line.length), 0);
     if (width === undefined) width = w;
     else if (w !== width) return false;
@@ -44,7 +46,7 @@ function isMonospace(name: string) {
 
 function init() {
   for (const { name } of fonts) {
-    const preview = figlet.textSync('Figlet', { font: name });
+    const preview = figlet.textSync('Figlet', { font: name as figlet.Fonts });
     const mono = isMonospace(name);
     // eslint-disable-next-line no-restricted-globals
     self.postMessage({ type: 'font', font: name, preview, mono });
@@ -59,7 +61,7 @@ self.onmessage = (e: MessageEvent<any>) => {
     const { name, data } = e.data as { name: string; data: string };
     try {
       figlet.parseFont(name, data);
-      const preview = figlet.textSync('Figlet', { font: name });
+      const preview = figlet.textSync('Figlet', { font: name as figlet.Fonts });
       const mono = isMonospace(name);
       // eslint-disable-next-line no-restricted-globals
       self.postMessage({ type: 'font', font: name, preview, mono });
@@ -81,9 +83,9 @@ self.onmessage = (e: MessageEvent<any>) => {
     .map((line) => line.trim())
     .join('\n');
   const rendered = figlet.textSync(normalized, {
-    font,
+    font: font as figlet.Fonts,
     width,
-    horizontalLayout: layout,
+    horizontalLayout: layout as figlet.KerningMethods,
   });
   // eslint-disable-next-line no-restricted-globals
   self.postMessage({ type: 'render', output: rendered });

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,6 +4,7 @@ export type EventName =
   | 'cta_click'
   | 'signup_submit'
   | 'contact_submit'
+  | 'contact_submit_error'
   | 'outbound_link_click'
   | 'download_click';
 


### PR DESCRIPTION
## Summary
- switch contact app to named `trackEvent` import
- declare `contact_submit_error` analytics event
- cast figlet worker options to figlet types to satisfy TypeScript

## Testing
- `yarn build` *(fails: Element implicitly has an 'any' type in apps/games/tower-defense/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bc1980883288bd9713e3ba0c8ba