### PR TITLE
Replace react-onclickoutside with internal hook

### DIFF
--- a/hooks/useClickOutside.ts
+++ b/hooks/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+/**
+ * useClickOutside triggers the handler when a user clicks outside the referenced element.
+ */
+export default function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  handler: (event: MouseEvent | TouchEvent) => void,
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      const el = ref.current;
+      if (!el || el.contains(event.target as Node)) return;
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "react-ga4": "^2.1.0",
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
-    "react-onclickoutside": "^6.12.2",
-
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
     "sharp": "^0.34.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10506,16 +10506,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-onclickoutside@npm:^6.12.2":
-  version: 6.13.2
-  resolution: "react-onclickoutside@npm:6.13.2"
-  peerDependencies:
-    react: ^15.5.x || ^16.x || ^17.x || ^18.x
-    react-dom: ^15.5.x || ^16.x || ^17.x || ^18.x
-  checksum: 10c0/fafe6fd036729d7e8f6b5d59046aa0dbc7b547269e167f3c7ab3fa30508ce768133ad46654014449bc1a697d1473bad78a1b869071bd81256c89f225c7c4f2ed
-  languageName: node
-  linkType: hard
-
 "react@npm:^19.1.1":
   version: 19.1.1
   resolution: "react@npm:19.1.1"
@@ -12316,8 +12306,6 @@ __metadata:
     react-ga4: "npm:^2.1.0"
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
-    react-onclickoutside: "npm:^6.12.2"
-
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
     sharp: "npm:^0.34.3"


### PR DESCRIPTION
## Summary
- remove unused `react-onclickoutside` dependency
- add reusable `useClickOutside` hook for components

## Testing
- `yarn install`
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, NiktoPage, InstallButton, mimikatz api)*

------
https://chatgpt.com/codex/tasks/task_e_68b25d759dd883288efead2e5616a51c