### PR TITLE
chore: update workbox build to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
     "react-onclickoutside": "^6.12.2",
-
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
     "sharp": "^0.34.3",
@@ -124,7 +123,7 @@
     "playwright-core": "^1.55.0",
     "typescript": "^5.9.2",
     "wait-on": "^8.0.4",
-    "workbox-build": "^7.3.0",
+    "workbox-build": "^7",
     "ws": "^8.18.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12317,7 +12317,6 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
     react-onclickoutside: "npm:^6.12.2"
-
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
     sharp: "npm:^0.34.3"
@@ -12328,7 +12327,7 @@ __metadata:
     turndown: "npm:^7.2.1"
     typescript: "npm:^5.9.2"
     wait-on: "npm:^8.0.4"
-    workbox-build: "npm:^7.3.0"
+    workbox-build: "npm:^7"
     workbox-window: "npm:^7.3.0"
     ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
@@ -12701,7 +12700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-build@npm:^7.3.0":
+"workbox-build@npm:^7":
   version: 7.3.0
   resolution: "workbox-build@npm:7.3.0"
   dependencies:


### PR DESCRIPTION
## Summary
- update workbox-build to the latest v7 range

## Testing
- `yarn test` *(fails: WiresharkApp, BeEF, Terminal component, NiktoPage, calculator parser, InstallButton, mimikatz, KismetApp, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b25c985d588328aa2e779a50354eed