### PR TITLE
Add Leaflet dependency and styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "idb-keyval": "^6.2.1",
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
+    "leaflet": "^1.9",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
     "monaco-editor": "^0.52.2",
@@ -80,7 +81,6 @@
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
     "react-onclickoutside": "^6.12.2",
-
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
     "sharp": "^0.34.3",
@@ -104,6 +104,7 @@
     "@types/figlet": "^1",
     "@types/howler": "^2",
     "@types/jest": "30.0.0",
+    "@types/leaflet": "^1.9.20",
     "@types/matter-js": "0.20.0",
     "@types/node": "^24.2.1",
     "@types/qrcode": "^1.5.5",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
+import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3171,6 +3171,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/geojson@npm:*":
+  version: 7946.0.16
+  resolution: "@types/geojson@npm:7946.0.16"
+  checksum: 10c0/1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c
+  languageName: node
+  linkType: hard
+
 "@types/howler@npm:^2":
   version: 2.2.12
   resolution: "@types/howler@npm:2.2.12"
@@ -3244,6 +3251,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/ff8f54fc49621210291f815fe5b15d809fd7d032941b3180743440bd507ecdf08b9e844625fa346af568c84bf34114eb378dcdc3e921a08ba1e2a08d7e3c809c
+  languageName: node
+  linkType: hard
+
+"@types/leaflet@npm:^1.9.20":
+  version: 1.9.20
+  resolution: "@types/leaflet@npm:1.9.20"
+  dependencies:
+    "@types/geojson": "npm:*"
+  checksum: 10c0/14a32df400c6a371bc7e65ee4467118dc1b977cae002c45f7315ed032fade30bac3b97feac60a08809dd767bd68b17900ae6f947258cc0745412562ad12f2e82
   languageName: node
   linkType: hard
 
@@ -8689,6 +8705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"leaflet@npm:^1.9":
+  version: 1.9.4
+  resolution: "leaflet@npm:1.9.4"
+  checksum: 10c0/f639441dbb7eb9ae3fcd29ffd7d3508f6c6106892441634b0232fafb9ffb1588b05a8244ec7085de2c98b5ed703894df246898477836cfd0ce5b96d4717b5ca1
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -12247,6 +12270,7 @@ __metadata:
     "@types/figlet": "npm:^1"
     "@types/howler": "npm:^2"
     "@types/jest": "npm:30.0.0"
+    "@types/leaflet": "npm:^1.9.20"
     "@types/matter-js": "npm:0.20.0"
     "@types/node": "npm:^24.2.1"
     "@types/qrcode": "npm:^1.5.5"
@@ -12292,6 +12316,7 @@ __metadata:
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
+    leaflet: "npm:^1.9"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"
@@ -12317,7 +12342,6 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
     react-onclickoutside: "npm:^6.12.2"
-
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
     sharp: "npm:^0.34.3"


### PR DESCRIPTION
## Summary
- add Leaflet dependency and type definitions to satisfy React-Leaflet
- import Leaflet CSS in `_app.jsx`

## Testing
- `yarn install --check-cache`
- `yarn lint` (fails: 6 errors, 34 warnings)
- `yarn test` (fails: ReferenceError: handlePresetSelect is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68b25d73b5948328984530148fdda35a