### PR TITLE
fix tower stats lookup type to compile

### DIFF
--- a/apps/games/tower-defense/index.ts
+++ b/apps/games/tower-defense/index.ts
@@ -121,7 +121,7 @@ export const clearSpriteCache = () => {
 };
 
 // ---- tower stats and upgrades ----
-export const TOWER_TYPES = {
+export const TOWER_TYPES: Record<string, { range: number; damage: number }[]> = {
   single: [
     { range: 1, damage: 1 },
     { range: 2, damage: 2 },
@@ -129,7 +129,10 @@ export const TOWER_TYPES = {
   ],
 };
 
-export const getTowerDPS = (type: string, level: number) => {
+export const getTowerDPS = (
+  type: keyof typeof TOWER_TYPES,
+  level: number
+) => {
   const stats = TOWER_TYPES[type]?.[level - 1];
   if (!stats) return 0;
   return stats.damage; // 1 shot per second


### PR DESCRIPTION
## Summary
- allow dynamic lookup of tower type stats
- type-safe getTowerDPS inputs

## Testing
- `yarn test` (fails: ReferenceError: handlePresetSelect is not defined)
- `CI=1 yarn build` (fails: Could not find a declaration file for module 'diff')

------
https://chatgpt.com/codex/tasks/task_e_68b25fd7c97c8328aa31445be6a98e24