### PR TITLE
fix: add tower type for tower-defense DPS lookup

### DIFF
--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { Tower, getTowerDPS } from '..';
+import { Tower, getTowerDPS, TowerType } from '..';
 
 interface DpsChartsProps {
-  towers: (Tower & { type?: string })[];
+  towers: Tower[];
 }
 
 const DpsCharts = ({ towers }: DpsChartsProps) => {
@@ -18,7 +18,7 @@ const DpsCharts = ({ towers }: DpsChartsProps) => {
 
     const dpsMap: Record<string, number> = {};
     towers.forEach((t) => {
-      const type = (t as any).type || 'single';
+      const type: TowerType = t.type || 'single';
       dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
     });
 

--- a/apps/games/tower-defense/index.ts
+++ b/apps/games/tower-defense/index.ts
@@ -127,9 +127,11 @@ export const TOWER_TYPES = {
     { range: 2, damage: 2 },
     { range: 3, damage: 3 },
   ],
-};
+} as const;
 
-export const getTowerDPS = (type: string, level: number) => {
+export type TowerType = keyof typeof TOWER_TYPES;
+
+export const getTowerDPS = (type: TowerType, level: number) => {
   const stats = TOWER_TYPES[type]?.[level - 1];
   if (!stats) return 0;
   return stats.damage; // 1 shot per second
@@ -146,6 +148,7 @@ export type Tower = {
   range: number;
   damage: number;
   level: number;
+  type?: TowerType;
 };
 
 export const upgradeTower = (tower: Tower, path: 'range' | 'damage') => {


### PR DESCRIPTION
## Summary
- define explicit TowerType keys for tower stats and DPS calculation
- use TowerType when aggregating tower DPS in charts

## Testing
- `yarn test` *(fails: wireshark, beef, terminal, calculator parser, mimikatz, kismet, battleship-net, niktoPage, Metasploit app, aboutAccessibility, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b26000c6fc832899efc69f00601918