### PR TITLE
fix tower type indexing

### DIFF
--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { Tower, getTowerDPS } from '..';
+import { Tower, TowerType, getTowerDPS } from '..';
 
 interface DpsChartsProps {
-  towers: (Tower & { type?: string })[];
+  towers: (Tower & { type?: TowerType })[];
 }
 
 const DpsCharts = ({ towers }: DpsChartsProps) => {
@@ -16,13 +16,13 @@ const DpsCharts = ({ towers }: DpsChartsProps) => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const dpsMap: Record<string, number> = {};
+    const dpsMap: Record<TowerType, number> = {} as Record<TowerType, number>;
     towers.forEach((t) => {
-      const type = (t as any).type || 'single';
+      const type: TowerType = t.type || 'single';
       dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
     });
 
-    const entries = Object.entries(dpsMap);
+    const entries = Object.entries(dpsMap) as [TowerType, number][];
     const w = canvas.width;
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);

--- a/apps/games/tower-defense/index.ts
+++ b/apps/games/tower-defense/index.ts
@@ -127,9 +127,11 @@ export const TOWER_TYPES = {
     { range: 2, damage: 2 },
     { range: 3, damage: 3 },
   ],
-};
+} as const;
 
-export const getTowerDPS = (type: string, level: number) => {
+export type TowerType = keyof typeof TOWER_TYPES;
+
+export const getTowerDPS = (type: TowerType, level: number) => {
   const stats = TOWER_TYPES[type]?.[level - 1];
   if (!stats) return 0;
   return stats.damage; // 1 shot per second


### PR DESCRIPTION
## Summary
- tighten tower type typing with `keyof typeof TOWER_TYPES`
- update DPS chart to use new `TowerType`

## Testing
- `yarn test __tests__/tower-defense.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b26108723c8328bca0bd4339cfb6ae