### PR TITLE
feat: add TowerType alias

### DIFF
--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { Tower, getTowerDPS } from '..';
+import { Tower, getTowerDPS, TowerType } from '..';
 
 interface DpsChartsProps {
   towers: (Tower & { type?: string })[];
@@ -16,9 +16,9 @@ const DpsCharts = ({ towers }: DpsChartsProps) => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const dpsMap: Record<string, number> = {};
+    const dpsMap: Partial<Record<TowerType, number>> = {};
     towers.forEach((t) => {
-      const type = (t as any).type || 'single';
+      const type = ((t as any).type || 'single') as TowerType;
       dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
     });
 

--- a/apps/games/tower-defense/index.ts
+++ b/apps/games/tower-defense/index.ts
@@ -127,9 +127,11 @@ export const TOWER_TYPES = {
     { range: 2, damage: 2 },
     { range: 3, damage: 3 },
   ],
-};
+} as const;
 
-export const getTowerDPS = (type: string, level: number) => {
+export type TowerType = keyof typeof TOWER_TYPES;
+
+export const getTowerDPS = (type: TowerType, level: number) => {
   const stats = TOWER_TYPES[type]?.[level - 1];
   if (!stats) return 0;
   return stats.damage; // 1 shot per second


### PR DESCRIPTION
## Summary
- export TowerType alias from tower defense module
- type getTowerDPS with TowerType
- apply TowerType in DpsCharts for type-safe DPS mapping

## Testing
- `yarn test __tests__/tower-defense.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2615b7de08328aa05cbda9ab52692