### PR TITLE
Add TypeScript types for diff module

### DIFF
--- a/types/diff.d.ts
+++ b/types/diff.d.ts
@@ -1,0 +1,9 @@
+declare module 'diff' {
+  export interface Change {
+    value: string;
+    added?: boolean;
+    removed?: boolean;
+    count?: number;
+  }
+  export function diffLines(oldStr: string, newStr: string): Change[];
+}


### PR DESCRIPTION
## Summary
- add minimal `diff` type declarations to satisfy TypeScript in HTML Rewriter app

## Testing
- `npx tsc --noEmit` *(fails: 79 errors in 39 files unrelated to diff)*
- `yarn test apps/html-rewriter --passWithNoTests`
- `yarn lint apps/html-rewriter/index.tsx` *(fails: 6 errors, 34 warnings in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68b262754bf48328bdf4731f7e5512e8