### PR TITLE
chore: add diff typings

### DIFF
--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -7,6 +7,7 @@ import { Tower, getTowerDPS, TowerType } from '..';
 interface DpsChartsProps {
   towers: (Tower & { type?: TowerType })[];
 
+}
 
 const DpsCharts = ({ towers }: DpsChartsProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-github-calendar": "^4.5.9",
     "react-leaflet": "^5.0.0",
     "react-onclickoutside": "^6.12.2",
-
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
     "sharp": "^0.34.3",
@@ -101,6 +100,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/canvas-confetti": "^1",
+    "@types/diff": "^8.0.0",
     "@types/figlet": "^1",
     "@types/howler": "^2",
     "@types/jest": "30.0.0",

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'diff' {
+  export interface Change {
+    added?: boolean;
+    removed?: boolean;
+    value: string;
+    count?: number;
+  }
+  export function diffLines(oldStr: string, newStr: string): Change[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,6 +3150,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/diff@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/diff@npm:8.0.0"
+  dependencies:
+    diff: "npm:*"
+  checksum: 10c0/c6e3376abeac8bc77b33252afc239a3cfc2729ecf59abcf00fa0f0eca8c505fd3a375a99a64afecdbb97fbec77b9a6aa8a8918f4d53fd5b45638d609343717cc
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:0.0.39":
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
@@ -5644,6 +5653,13 @@ __metadata:
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
   checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
+  languageName: node
+  linkType: hard
+
+"diff@npm:*":
+  version: 8.0.2
+  resolution: "diff@npm:8.0.2"
+  checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
   languageName: node
   linkType: hard
 
@@ -12244,6 +12260,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/canvas-confetti": "npm:^1"
+    "@types/diff": "npm:^8.0.0"
     "@types/figlet": "npm:^1"
     "@types/howler": "npm:^2"
     "@types/jest": "npm:30.0.0"
@@ -12317,7 +12334,6 @@ __metadata:
     react-github-calendar: "npm:^4.5.9"
     react-leaflet: "npm:^5.0.0"
     react-onclickoutside: "npm:^6.12.2"
-
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
     sharp: "npm:^0.34.3"


### PR DESCRIPTION
## Summary
- install @types/diff and declare diff module
- fix missing interface closure in tower-defense chart

## Testing
- `yarn tsc --noEmit` *(fails: 79 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b263099a3c832888ad84234292bef4