### PR TITLE
fix: allow network detail in kismet callback

### DIFF
--- a/components/apps/kismet/index.js
+++ b/components/apps/kismet/index.js
@@ -321,6 +321,17 @@ const DeviceDrawer = ({ network, onClose }) => (
   </div>
 );
 
+/**
+ * @typedef {Object} DiscoveredNetwork
+ * @property {string} ssid
+ * @property {string} bssid
+ * @property {number} discoveredAt
+ */
+
+/**
+ * Kismet application component.
+ * @param {{ onNetworkDiscovered?: (net: DiscoveredNetwork) => void }} props
+ */
 const KismetApp = ({ onNetworkDiscovered = () => {} }) => {
   const [networks, setNetworks] = useState([]);
   const [playing, setPlaying] = useState(false);


### PR DESCRIPTION
## Summary
- document callback to expose network details when Kismet finds a new network

## Testing
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, NiktoPage, installButton, mimikatz, kismet test, Metasploit app, others)*
- `yarn build` *(fails: apps/pinball type error)*


------
https://chatgpt.com/codex/tasks/task_e_68b2677f90b4832894d14529a85232dc