### PR TITLE
Restrict tower defense type to valid keys

### DIFF
--- a/apps/games/tower-defense/index.ts
+++ b/apps/games/tower-defense/index.ts
@@ -121,7 +121,7 @@ export const clearSpriteCache = () => {
 };
 
 // ---- tower stats and upgrades ----
-export const TOWER_TYPES: Record<string, { range: number; damage: number }[]> = {
+export const TOWER_TYPES = {
   single: [
     { range: 1, damage: 1 },
     { range: 2, damage: 2 },


### PR DESCRIPTION
## Summary
- tighten `TOWER_TYPES` to a const object and export `TowerType` alias
- ensure `getTowerDPS` only accepts defined tower types

## Testing
- `npx eslint apps/games/tower-defense/index.ts`
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, NiktoPage, calculator parser, installButton, mimikatz api, KismetApp, daily seed tests)*
- `yarn test __tests__/tower-defense.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b266f3ebc48328933291da82f0be20