### PR TITLE
Remove obsolete Tailwind JIT mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  mode: 'jit',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- drop `mode: 'jit'` from Tailwind config now that JIT mode is default

## Testing
- `yarn build` *(fails: apps/pinball/index.tsx type error)*
- `yarn test` *(fails: handlePresetSelect is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2762a90d48328a51beaa019ee2ef3