### PR TITLE
feat: enable static export mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
+const isStatic = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -55,12 +57,11 @@ const securityHeaders = [
   },
 ];
 
-const isExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
-
 module.exports = {
-  // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
+  ...(isStatic ? { output: 'export' } : {}),
+  // Enforce ESLint during builds; set ignoreDuringBuilds to true only when a separate lint step runs in CI
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     domains: [


### PR DESCRIPTION
## Summary
- conditionally enable `output: 'export'` when `NEXT_PUBLIC_STATIC_EXPORT` is true
- run ESLint during builds

## Testing
- `nvm use`
- `yarn build` *(fails: Expected 1 arguments, but got 0)*
- `yarn export` *(fails: Expected 1 arguments, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_68b27627f2248328aac97c664b89cb8a