### PR TITLE
chore: remove duplicate jest mapping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,6 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
-    '^@/(.*)$': '<rootDir>/$1',
     '^flags$': '<rootDir>/flags',
   },
   testPathIgnorePatterns: ['<rootDir>/playwright/', '<rootDir>/__tests__/playwright/'],


### PR DESCRIPTION
## Summary
- remove duplicate '@/' alias in Jest configuration

## Testing
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, NiktoPage, KismetApp, calculator parser, install button, mimikatz API and daily2048Seed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2762c3db08328b0a671ddfd831931