### PR TITLE
chore(ci): use yarn immutable cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --immutable --immutable-cache
       - run: yarn lint
       - run: yarn build


### PR DESCRIPTION
## Summary
- use Yarn 4 immutable cache install in CI workflow

## Testing
- `yarn lint` *(fails: import/no-anonymous-default-export, etc.)*
- `yarn test` *(fails: handlePresetSelect is not defined, etc.)*
- `yarn test --runTestsByPath __tests__/wireshark.test.tsx` *(fails: handlePresetSelect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b27685e2f88328ac13a94c51859354