### PR TITLE
docs: add development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ To send text or links directly into the Sticky Notes app:
 
 ---
 
+## Development
+
+```bash
+nvm use                 # Node 20
+corepack enable
+cp .env.local.example .env.local
+yarn install --immutable --immutable-cache
+yarn dev                # start development server
+# or build and start
+yarn build && yarn start
+```
+
+---
+
 ## Core Commands
 
 - `yarn install` – install project dependencies.


### PR DESCRIPTION
## Summary
- document development environment setup commands

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test` *(fails: handlePresetSelect is not defined, SyntaxError: Unexpected token 'export', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2768f1144832884a30fc1aa9ea550