### PR TITLE
Add cache headers for static assets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -77,6 +77,24 @@ module.exports = {
   async headers() {
     return [
       {
+        source: '/fonts/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/images/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=604800',
+          },
+        ],
+      },
+      {
         source: '/(.*)',
         headers: securityHeaders,
       },


### PR DESCRIPTION
## Summary
- add cache-control headers for fonts and images in Next.js config

## Testing
- `CI=1 yarn build` (fails: Expected 1 arguments, but got 0 in apps/pinball/index.tsx)
- `yarn start` (fails: Could not find a production build)


------
https://chatgpt.com/codex/tasks/task_e_68b2768cdba48328a6031ea0cab57512