### PR TITLE
Refactor notes page to client component

### DIFF
--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,36 +1,37 @@
-import type { GetServerSideProps } from 'next';
-import { getAnonSupabaseServer } from '../lib/supabase';
+'use client';
 
-interface NotesPageProps {
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+interface NotesPageState {
   notes: unknown[] | null;
   error?: string;
 }
 
-export const getServerSideProps: GetServerSideProps<NotesPageProps> = async () => {
-  const supabase = getAnonSupabaseServer();
-  const { data, error } = await supabase.from('notes').select();
+export default function NotesPage() {
+  const [state, setState] = useState<NotesPageState>({ notes: null });
 
-  if (error) {
-    return {
-      props: {
-        notes: null,
-        error: error.message,
-      },
-    };
+  useEffect(() => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    supabase
+      .from('notes')
+      .select()
+      .then(({ data, error }) => {
+        if (error) {
+          setState({ notes: null, error: error.message });
+        } else {
+          setState({ notes: data ?? null });
+        }
+      });
+  }, []);
+
+  if (state.error) {
+    return <pre>{JSON.stringify({ error: state.error }, null, 2)}</pre>;
   }
 
-  return {
-    props: {
-      notes: data ?? null,
-    },
-  };
-};
-
-export default function NotesPage({ notes, error }: NotesPageProps) {
-  if (error) {
-    return <pre>{JSON.stringify({ error }, null, 2)}</pre>;
-  }
-
-  return <pre>{JSON.stringify(notes, null, 2)}</pre>;
+  return <pre>{JSON.stringify(state.notes, null, 2)}</pre>;
 }
 


### PR DESCRIPTION
## Summary
- Convert notes page to a client-side component
- Fetch notes from Supabase on mount and display results

## Testing
- `yarn export` *(fails: Type error in apps/pinball/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b276290c9c83288aa7eb2f7c7afecb