### PR TITLE
fix(pinball): initialize canvas ref with null

### DIFF
--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -11,7 +11,7 @@ const themes: Record<string, { bg: string; flipper: string }> = {
 };
 
 export default function Pinball() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const engineRef = useRef<Engine | null>(null);
   const leftFlipperRef = useRef<Body | null>(null);
   const rightFlipperRef = useRef<Body | null>(null);


### PR DESCRIPTION
## Summary
- type the pinball canvas ref as nullable to satisfy React `useRef` requirements

## Testing
- `yarn tsc -p tsconfig.json --noEmit` *(fails: components/apps/archive/Terminal/index.tsx:390:9 - error TS1005: ',' expected)*
- `yarn test apps/pinball --passWithNoTests` *(fails: Error: Cannot find module '@next/bundle-analyzer')*

------
https://chatgpt.com/codex/tasks/task_e_68b27b5bc49c8328a50e3d9284fffd1c