### PR TITLE
refactor(reaver): type interval ref properly

### DIFF
--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -75,7 +75,7 @@ const ReaverPanel: React.FC = () => {
   const [running, setRunning] = useState(false);
   const [lockRemaining, setLockRemaining] = useState(0);
   const [stageIdx, setStageIdx] = useState(-1);
-  const intervalRef = useRef<NodeJS.Timeout>();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const burstRef = useRef(0); // attempts since last lock
   const lockRef = useRef(0); // lockout seconds remaining
   const [logs, setLogs] = useState<LogEntry[]>([]);


### PR DESCRIPTION
## Summary
- type `intervalRef` using `ReturnType<typeof setInterval>`

## Testing
- `yarn exec eslint apps/reaver/index.tsx`
- `yarn test apps/reaver/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b27eb424dc8328a8c381d7457a4b7e