### PR TITLE
refactor: initialize playerRef with null

### DIFF
--- a/apps/youtube/components/ClipMaker.tsx
+++ b/apps/youtube/components/ClipMaker.tsx
@@ -15,7 +15,7 @@ function extractVideoId(input: string): string {
 }
 
 export default function ClipMaker() {
-  const playerRef = useRef<any>();
+  const playerRef = useRef<any | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [videoId, setVideoId] = useState('');
   const [start, setStart] = useState<number | null>(null);


### PR DESCRIPTION
## Summary
- type YouTube ClipMaker playerRef with nullable initial value to prevent undefined refs

## Testing
- `yarn lint apps/youtube/components/ClipMaker.tsx` *(fails: 8 errors, 37 warnings)*
- `yarn test ClipMaker --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b27eb2c1f88328b8ecffd2d60ff985