### PR TITLE
Initialize animation ref with null

### DIFF
--- a/games/space-invaders/components/Shield.tsx
+++ b/games/space-invaders/components/Shield.tsx
@@ -19,7 +19,7 @@ interface ShieldProps {
 const Shield: React.FC<ShieldProps> = ({ regenDuration = 3000, maxHp = 6 }) => {
   const [hp, setHp] = useState(maxHp);
   const [progress, setProgress] = useState(0); // 0..1
-  const animRef = useRef<number>();
+  const animRef = useRef<number | null>(null);
 
   // Start a regeneration timer when the shield is destroyed
   useEffect(() => {


### PR DESCRIPTION
## Summary
- explicitly initialize animation frame ref to null in Space Invaders shield

## Testing
- `yarn eslint games/space-invaders/components/Shield.tsx`
- `yarn test` *(fails: handlePresetSelect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b27eb058808328ac5cf2ff4af81694