### PR TITLE
refactor: initialize workerRef with null

### DIFF
--- a/apps/x/components/ThreadComposer.tsx
+++ b/apps/x/components/ThreadComposer.tsx
@@ -37,7 +37,7 @@ export default function ThreadComposer() {
     [],
   );
   const previewRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const workerRef = useRef<Worker>();
+  const workerRef = useRef<Worker | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
## Summary
- initialize web worker reference with explicit null

## Testing
- `yarn test --passWithNoTests apps/x/components/ThreadComposer.tsx`
- `yarn lint apps/x/components/ThreadComposer.tsx` *(fails: react/display-name and other errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b27eb0b8008328aa3bb276fbe650e4