### PR TITLE
Initialize SpeedrunTimer raf ref with null

### DIFF
--- a/games/platformer/components/SpeedrunTimer.tsx
+++ b/games/platformer/components/SpeedrunTimer.tsx
@@ -29,7 +29,7 @@ export default function SpeedrunTimer() {
   const [splits, setSplits] = useState<number[]>([]);
   const [bestFinal, setBestFinal] = useState<number | null>(null);
   const [bestSplits, setBestSplits] = useState<number[]>([]);
-  const raf = useRef<number>();
+  const raf = useRef<number | null>(null);
 
   // load best times
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize SpeedrunTimer animation frame ref with `null`

## Testing
- `yarn test` *(fails: handlePresetSelect is not defined, etc.)*
- `npx eslint games/platformer/components/SpeedrunTimer.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b27eaf163883288ec7f32943fdb7e9