### PR TITLE
fix: use timeout type for YouTube hovercard

### DIFF
--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -35,7 +35,7 @@ async function trimVideoCache() {
 function ChannelHovercard({ id, name }: { id: string; name: string }) {
   const [show, setShow] = useState(false);
   const [info, setInfo] = useState<any>(null);
-  const timer = useRef<NodeJS.Timeout>();
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchInfo = useCallback(async () => {
     if (info) return;


### PR DESCRIPTION
## Summary
- use browser-friendly timeout type for YouTube ChannelHovercard timer

## Testing
- `yarn lint components/apps/youtube/index.tsx` *(fails: Component definition is missing display name, etc.)*
- `yarn test components/apps/youtube/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b27eae17408328b4cbcf6a207a77db