### PR TITLE
fix: initialize BroadcastChannel ref with null

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -25,7 +25,7 @@ const BleSensor: React.FC = () => {
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [profiles, setProfiles] = useState<SavedProfile[]>([]);
-  const bcRef = useRef<BroadcastChannel>();
+  const bcRef = useRef<BroadcastChannel | null>(null);
 
   const refreshProfiles = async () => setProfiles(await loadProfiles());
 


### PR DESCRIPTION
## Summary
- initialize `BroadcastChannel` ref with `null` default to avoid undefined

## Testing
- `yarn lint components/apps/ble-sensor.tsx` *(fails: Couldn't find the node_modules state file)*
- `yarn test components/apps/ble-sensor.tsx` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ead4cdc8328a7de02eaa966dbb2