### PR TITLE
Initialize fetchRef with null

### DIFF
--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -90,7 +90,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
-  const fetchRef = useRef<typeof fetch>();
+  const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- initialize fetchRef with a null default value and explicit fetch type union

## Testing
- `yarn test` *(fails: handlePresetSelect is not defined, etc.)*
- `yarn lint` *(fails: 45 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ead477483289e3a29285969ca5c