### PR TITLE
refactor(reaver): type intervalRef as setInterval return

### DIFF
--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -75,7 +75,7 @@ const ReaverPanel: React.FC = () => {
   const [running, setRunning] = useState(false);
   const [lockRemaining, setLockRemaining] = useState(0);
   const [stageIdx, setStageIdx] = useState(-1);
-  const intervalRef = useRef<NodeJS.Timeout>();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const burstRef = useRef(0); // attempts since last lock
   const lockRef = useRef(0); // lockout seconds remaining
   const [logs, setLogs] = useState<LogEntry[]>([]);


### PR DESCRIPTION
## Summary
- refine Reaver simulator intervalRef type using `ReturnType<typeof setInterval>`

## Testing
- `./node_modules/.bin/eslint apps/reaver/index.tsx && echo 'lint ok'`
- `./node_modules/.bin/jest apps/reaver/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b284fb31348328bd6ec6380b783462