### PR TITLE
fix: initialize worker ref with null

### DIFF
--- a/apps/x/components/ThreadComposer.tsx
+++ b/apps/x/components/ThreadComposer.tsx
@@ -37,7 +37,7 @@ export default function ThreadComposer() {
     [],
   );
   const previewRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const workerRef = useRef<Worker>();
+  const workerRef = useRef<Worker | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
## Summary
- initialize ThreadComposer's worker ref with null to avoid undefined

## Testing
- `yarn lint apps/x/components/ThreadComposer.tsx` *(fails: 45 problems (8 errors, 37 warnings))*
- `npx eslint apps/x/components/ThreadComposer.tsx`
- `yarn test apps/x/components/ThreadComposer.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b284f870b48328a4e1d75dc300776d