### PR TITLE
fix: initialize BroadcastChannel ref for BLE sensor

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -25,7 +25,7 @@ const BleSensor: React.FC = () => {
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [profiles, setProfiles] = useState<SavedProfile[]>([]);
-  const bcRef = useRef<BroadcastChannel>();
+  const bcRef = useRef<BroadcastChannel | null>(null);
 
   const refreshProfiles = async () => setProfiles(await loadProfiles());
 


### PR DESCRIPTION
## Summary
- Initialize BLE sensor broadcast channel ref with `null` to reflect possible absence

## Testing
- `yarn lint components/apps/ble-sensor.tsx` *(fails: react/display-name, parsing errors in unrelated files)*
- `yarn test` *(fails: WiresharkApp, BeEF app, Terminal component, NiktoPage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b284f4e5288328a0f6d96ba4e490e2