### PR TITLE
chore: conditionally load bundle analyzer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,9 +55,10 @@ const securityHeaders = [
   },
 ];
 
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYZE === 'true',
-});
+const withBundleAnalyzer =
+  process.env.ANALYZE === 'true'
+    ? require('@next/bundle-analyzer')({ enabled: true })
+    : (config) => config;
 
 module.exports = withBundleAnalyzer({
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI


### PR DESCRIPTION
## Summary
- load @next/bundle-analyzer only when ANALYZE env var is true

## Testing
- `yarn build` *(fails: Parameter 'data' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68b287a47b648328b270b44bce540c5b