### PR TITLE
fix: allow network discovery callback argument

### DIFF
--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -6,7 +6,8 @@ import DeauthWalkthrough from './components/DeauthWalkthrough';
 
 const KismetPage: React.FC = () => {
   const handleNetworkDiscovered = useCallback(
-    (net: { ssid: string; bssid: string; discoveredAt: number }) => {
+    (net?: { ssid: string; bssid: string; discoveredAt: number }) => {
+      if (!net) return;
       console.log(
         `Network ${net.ssid || net.bssid} discovered at ${new Date(
           net.discoveredAt,


### PR DESCRIPTION
## Summary
- handle optional parameter for Kismet network discovery callback

## Testing
- `yarn test`
- `yarn build` *(fails: Type error in apps/qr/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b29395be648328b08628cf94beaeb6