### PR TITLE
Fix duplicate handler in Wireshark filter helper

### DIFF
--- a/apps/wireshark/components/FilterHelper.tsx
+++ b/apps/wireshark/components/FilterHelper.tsx
@@ -53,14 +53,6 @@ const FilterHelper: React.FC<FilterHelperProps> = ({ value, onChange }) => {
     setRecent((prev) => [expression, ...prev.filter((f) => f !== expression)].slice(0, 5));
   };
 
-  const handlePresetSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const expression = e.target.value;
-    if (expression) {
-      handlePresetClick(expression);
-    }
-
-  };
-
   const handleSavePreset = () => {
     const expression = value.trim();
     if (!expression) return;


### PR DESCRIPTION
## Summary
- remove duplicated `handlePresetSelect` function in Wireshark filter helper to avoid redeclaration

## Testing
- `yarn eslint apps/wireshark/components/FilterHelper.tsx && echo 'ESLint passed'`
- `yarn test apps/wireshark/components/FilterHelper.tsx` *(fails: No tests found)*
- `yarn build apps/wireshark` *(fails: games/2048/index.tsx Type error)*

------
https://chatgpt.com/codex/tasks/task_e_68b29c7b74a8832897fd233b72efcd4b