### PR TITLE
refactor: type GameShell component

### DIFF
--- a/components/games/GameShell.tsx
+++ b/components/games/GameShell.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, ReactNode } from 'react';
 import useOrientationGuard from '../../hooks/useOrientationGuard';
 import useGameInput from '../../hooks/useGameInput';
 import usePersistentState from '../usePersistentState';
+
+interface GameShellProps {
+  children: ReactNode;
+  controls?: ReactNode;
+  settings?: ReactNode;
+  onPause?: () => void;
+  onResume?: () => void;
+}
 
 /**
  * Generic shell for browser games. Exposes slots for the game content,
@@ -16,7 +24,7 @@ export default function GameShell({
   settings = null,
   onPause = () => {},
   onResume = () => {},
-}) {
+}: GameShellProps) {
   useOrientationGuard();
 
   const [paused, setPaused] = useState(false);
@@ -34,10 +42,10 @@ export default function GameShell({
     onResume();
   }, [onResume]);
 
-  const toggleSettings = () => setShowSettings((s) => !s);
-  const toggleMute = () => setMuted((m) => !m);
+  const toggleSettings = () => setShowSettings((s: boolean) => !s);
+  const toggleMute = () => setMuted((m: boolean) => !m);
 
-  const handleInput = ({ action, type }) => {
+  const handleInput = ({ action, type }: { action: string; type: string }) => {
     if (action === 'pause' && type === 'keydown') {
       paused ? resume() : pause();
     }

--- a/games/memory/index.tsx
+++ b/games/memory/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from 'react';
-import GameShell from '../../components/games/GameShell.jsx';
+import GameShell from '../../components/games/GameShell';
 import SizeSelector from './components/SizeSelector';
 import { generateBoard } from './utils';
 import {


### PR DESCRIPTION
## Summary
- convert GameShell to TypeScript with typed props
- update memory game to use new GameShell import

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*
- `yarn build` *(fails: Property 'clientWidth' does not exist on type 'HTMLCanvasElement | null')*

------
https://chatgpt.com/codex/tasks/task_e_68b2a00b32fc832886cc2c15bac7ab42