### PR TITLE
chore: remove unused @types/diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/canvas-confetti": "^1",
-    "@types/diff": "^8.0.0",
     "@types/figlet": "^1",
     "@types/howler": "^2",
     "@types/jest": "30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,15 +2141,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/diff@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@types/diff@npm:8.0.0"
-  dependencies:
-    diff: "npm:*"
-  checksum: 10c0/c6e3376abeac8bc77b33252afc239a3cfc2729ecf59abcf00fa0f0eca8c505fd3a375a99a64afecdbb97fbec77b9a6aa8a8918f4d53fd5b45638d609343717cc
-  languageName: node
-  linkType: hard
-
 "@types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
@@ -2933,8 +2924,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0":
+"acorn-walk@npm:^8.0.0":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/76537ac5fb2c37a64560feaf3342023dadc086c46da57da363e64c6148dc21b57d49ace26f949e225063acb6fb441eabffd89f7a3066de5ad37ab3e328927c62
+  languageName: node
+  linkType: hard
 
+"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.15.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -4568,7 +4567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:*, diff@npm:^8":
+"diff@npm:^8":
   version: 8.0.2
   resolution: "diff@npm:8.0.2"
   checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
@@ -10793,7 +10792,6 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/canvas-confetti": "npm:^1"
-    "@types/diff": "npm:^8.0.0"
     "@types/figlet": "npm:^1"
     "@types/howler": "npm:^2"
     "@types/jest": "npm:30.0.0"


### PR DESCRIPTION
## Summary
- remove unused `@types/diff` from dev dependencies
- refresh yarn.lock

## Testing
- `yarn install`
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a0d3a64c8328a74812e5f0c96ba4