### PR TITLE
fix: ensure asteroid canvas and context exist

### DIFF
--- a/games/asteroids/index.tsx
+++ b/games/asteroids/index.tsx
@@ -58,40 +58,6 @@ const AsteroidsGame: React.FC = () => {
       window.removeEventListener("keyup", up);
     };
   }, []);
-
-  // Initialise canvas and start loop
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    function resize() {
-      const { clientWidth, clientHeight } = canvas;
-      canvas.width = clientWidth * DPR;
-      canvas.height = clientHeight * DPR;
-      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
-    }
-    resize();
-    window.addEventListener("resize", resize);
-
-    initGame();
-
-    let id: number;
-    const loop = () => {
-      if (!paused) {
-        update(canvas);
-        draw(ctx, canvas);
-      }
-      id = requestAnimationFrame(loop);
-    };
-    id = requestAnimationFrame(loop);
-    return () => {
-      cancelAnimationFrame(id);
-      window.removeEventListener("resize", resize);
-    };
-    }, [paused, initGame, update, draw]);
-
   const initGame = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -256,6 +222,40 @@ const AsteroidsGame: React.FC = () => {
     },
     [],
   );
+
+  // Initialise canvas and start loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    function resize() {
+      if (!canvas || !ctx) return;
+      const { clientWidth, clientHeight } = canvas;
+      canvas.width = clientWidth * DPR;
+      canvas.height = clientHeight * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    }
+    resize();
+    window.addEventListener("resize", resize);
+
+    initGame();
+
+    let id: number;
+    const loop = () => {
+      if (!paused) {
+        update(canvas);
+        draw(ctx, canvas);
+      }
+      id = requestAnimationFrame(loop);
+    };
+    id = requestAnimationFrame(loop);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener("resize", resize);
+    };
+  }, [paused, initGame, update, draw]);
 
   const resetGame = () => {
     initGame();


### PR DESCRIPTION
## Summary
- guard `resize` against null canvas or context
- move canvas init effect after hooks to avoid use-before-declaration

## Testing
- `npx eslint games/asteroids/index.tsx`
- `yarn test games/asteroids` *(fails: No tests found, exiting with code 1)*
- `yarn build` *(fails: Module '../../../apps/games/nonogram/logic' has no exported member 'createHintSystem')*


------
https://chatgpt.com/codex/tasks/task_e_68b2a348a6c883289c9a3f3d522bc8c5