### PR TITLE
Fix nonogram hint system import

### DIFF
--- a/games/nonogram/components/HintSystem.tsx
+++ b/games/nonogram/components/HintSystem.tsx
@@ -1,17 +1,15 @@
 'use client';
 
 import React, { useState } from 'react';
-import {
-  Clue,
-  Grid,
-  createHintSystem,
-  findForcedCellsInLine,
-} from '../../../apps/games/nonogram/logic';
+import type { Clue, Grid } from '../../../apps/games/nonogram/logic';
+import { findForcedCellsInLine } from '../../../apps/games/nonogram/logic';
+import { createHintSystem } from '../../../apps/games/nonogram/hints';
 
 interface HintSystemProps {
   rows: Clue[];
   cols: Clue[];
   grid: Grid;
+  solution: Grid;
   maxHints?: number;
   /**
    * Optional callback when a hint is produced. Can be used by the parent
@@ -59,6 +57,7 @@ const HintSystem: React.FC<HintSystemProps> = ({
   rows,
   cols,
   grid,
+  solution,
   maxHints = 3,
   onHint,
 }) => {
@@ -67,7 +66,7 @@ const HintSystem: React.FC<HintSystemProps> = ({
   const [assist, setAssist] = useState(false);
 
   const handleHint = () => {
-    const hint = system.useHint(rows, cols, grid);
+    const hint = system.useHint(grid, solution);
     if (!hint) return;
     onHint?.(hint);
     setSteps((prev) => [


### PR DESCRIPTION
## Summary
- Correct `HintSystem` imports to use the dedicated `hints` module
- Require solution grid in hint system and adjust hint usage accordingly

## Testing
- `yarn build` *(fails: Argument of type 'ImageDataArray' is not assignable to parameter of type 'Uint8Array<ArrayBufferLike>' in games/nonogram/components/PngImport.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a7e81b9c83288bdf45edee180c96