### PR TITLE
fix: pin @napi-rs/canvas patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "magic-string": "^0.30.10",
     "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
-    "@napi-rs/canvas": "patch:@napi-rs/canvas@npm:^0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
+    "@napi-rs/canvas": "patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,90 +1317,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-android-arm64@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.78"
+"@napi-rs/canvas-android-arm64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.77"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-arm64@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.78"
+"@napi-rs/canvas-darwin-arm64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.77"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-x64@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.78"
+"@napi-rs/canvas-darwin-x64@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.77"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.78"
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.77"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.78"
+"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.77"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-musl@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.78"
+"@napi-rs/canvas-linux-arm64-musl@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.77"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.78"
+"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.77"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-gnu@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.78"
+"@napi-rs/canvas-linux-x64-gnu@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.77"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-musl@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.78"
+"@napi-rs/canvas-linux-x64-musl@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.77"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-x64-msvc@npm:0.1.78":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.78"
+"@napi-rs/canvas-win32-x64-msvc@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.77"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@npm:^0.1.77":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas@npm:0.1.78"
+"@napi-rs/canvas@npm:0.1.77":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas@npm:0.1.77"
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.78"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.78"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.78"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.78"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.78"
+    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -1422,24 +1422,24 @@ __metadata:
       optional: true
     "@napi-rs/canvas-win32-x64-msvc":
       optional: true
-  checksum: 10c0/7a98cc5b962b723c02c1e0220d2f937fd108188ecc575a32552915a8ae57c29f00f210adb28144ec110352931146cc71389601128807279b6a621cc0e5f4d0a5
+  checksum: 10c0/f7a1b33e86e53c210db873a6b5b9be9961d9a57b4e1c4e61c2667ed3cb166dec334b4f14d548c8790d9ffc79cf49b9762340f3b3d3f7fc991e9c8cc0a5f8654d
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@patch:@napi-rs/canvas@npm:^0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::locator=unnippillil%40workspace%3A.":
-  version: 0.1.78
-  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.78#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.78&hash=93d5cb&locator=unnippillil%40workspace%3A."
+"@napi-rs/canvas@patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::locator=unnippillil%40workspace%3A.":
+  version: 0.1.77
+  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.77&hash=93d5cb&locator=unnippillil%40workspace%3A."
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.78"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.78"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.78"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.78"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.78"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.78"
+    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
+    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
+    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -1461,7 +1461,7 @@ __metadata:
       optional: true
     "@napi-rs/canvas-win32-x64-msvc":
       optional: true
-  checksum: 10c0/47c54eab09d66e133e1faf9a230048606ad636d86bd0b238104eb9dbd6f628891656218c65a74d920de801c94cd4fe32ff416207926468fe39551b0d23ffe47b
+  checksum: 10c0/32cd0d4b772e341a6f8fa61e4f8bae29e47d978584cab41800aa304863d4555924fe525508d47be8d96300c713327056bab3e48c0f743850775f43c08667cd28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- pin `@napi-rs/canvas` resolution to exact `0.1.77` so patch is applied

## Testing
- `yarn install`
- `yarn lint` *(fails: 8 errors, 38 warnings)*
- `yarn test` *(fails: __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a8f85938832886ca0d277658f39c