### PR TITLE
fix(nonogram): handle Uint8ClampedArray in PNG importer

### DIFF
--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -51,16 +51,21 @@ export async function parseMonochromePng(
 }
 
 // Convert raw RGBA data into grid/clues
-const dataToPuzzle = (data: Uint8Array, width: number, height: number) => {
+type ByteArray = Uint8Array | Uint8ClampedArray;
+const dataToPuzzle = (data: ByteArray, width: number, height: number) => {
+  const bytes =
+    data instanceof Uint8ClampedArray
+      ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      : data;
   const grid: Grid = [];
   for (let y = 0; y < height; y++) {
     const row: number[] = [];
     for (let x = 0; x < width; x++) {
       const idx = (y * width + x) * 4;
-      const r = data[idx];
-      const g = data[idx + 1];
-      const b = data[idx + 2];
-      const a = data[idx + 3];
+      const r = bytes[idx];
+      const g = bytes[idx + 1];
+      const b = bytes[idx + 2];
+      const a = bytes[idx + 3];
       // treat non-transparent dark pixels as filled
       const val = a > 127 && (r + g + b) / 3 < 128 ? 1 : 0;
       row.push(val);


### PR DESCRIPTION
## Summary
- normalize Uint8ClampedArray to Uint8Array in nonogram PNG importer

## Testing
- `yarn tsc` *(fails: pages/_app.tsx(...): error TS18046: 'registration.periodicSync' is of type 'unknown' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b2acbad6f48328ab8e2bbb0401487b