### PR TITLE
Handle Uint8ClampedArray in nonogram PNG import

### DIFF
--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -51,7 +51,11 @@ export async function parseMonochromePng(
 }
 
 // Convert raw RGBA data into grid/clues
-const dataToPuzzle = (data: Uint8Array, width: number, height: number) => {
+const dataToPuzzle = (
+  data: Uint8Array | Uint8ClampedArray,
+  width: number,
+  height: number
+) => {
   const grid: Grid = [];
   for (let y = 0; y < height; y++) {
     const row: number[] = [];

--- a/types/pngjs.d.ts
+++ b/types/pngjs.d.ts
@@ -1,0 +1,3 @@
+declare module "pngjs" {
+  export const PNG: any;
+}


### PR DESCRIPTION
## Summary
- allow parsing ImageData by accepting Uint8ClampedArray for puzzle generation
- add module declaration for `pngjs` to satisfy TypeScript in Next.js build

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*
- `yarn build` *(fails: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Record<DictName, string[]>' in games/wordle/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ac4bbf108328868cb06dff46d9a5