### PR TITLE
Fix typed array handling in Nonogram PNG import

### DIFF
--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -51,11 +51,13 @@ export async function parseMonochromePng(
 }
 
 // Convert raw RGBA data into grid/clues
-const dataToPuzzle = (
-  data: Uint8Array | Uint8ClampedArray,
-  width: number,
-  height: number
-) => {
+type ByteArray = Uint8Array | Uint8ClampedArray;
+const dataToPuzzle = (data: ByteArray, width: number, height: number) => {
+  // normalize (zero-copy) so indexing works the same for both cases
+  const bytes =
+    data instanceof Uint8ClampedArray
+      ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      : data;
 
   const grid: Grid = [];
   for (let y = 0; y < height; y++) {


### PR DESCRIPTION
## Summary
- Accept both Uint8Array and Uint8ClampedArray when parsing PNGs for the Nonogram game
- Normalize canvas ImageData to a standard Uint8Array without copying

## Testing
- `yarn tsc -p tsconfig.json` *(fails: pages/_app.tsx(39,23): error TS18046: 'registration.periodicSync' is of type 'unknown', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aed51ffc8328a684f0f7cc098c8d