### PR TITLE
Fix undefined variable in Nonogram PNG parser

### DIFF
--- a/games/nonogram/components/PngImport.tsx
+++ b/games/nonogram/components/PngImport.tsx
@@ -62,10 +62,10 @@ const dataToPuzzle = (
     const row: number[] = [];
     for (let x = 0; x < width; x++) {
       const idx = (y * width + x) * 4;
-      const r = bytes[idx];
-      const g = bytes[idx + 1];
-      const b = bytes[idx + 2];
-      const a = bytes[idx + 3];
+      const r = data[idx];
+      const g = data[idx + 1];
+      const b = data[idx + 2];
+      const a = data[idx + 3];
       // treat non-transparent dark pixels as filled
       const val = a > 127 && (r + g + b) / 3 < 128 ? 1 : 0;
       row.push(val);


### PR DESCRIPTION
## Summary
- fix `dataToPuzzle` to read from the provided RGBA data buffer instead of an undefined `bytes` variable

## Testing
- `yarn test` (fails: __tests__/kismet.test.tsx: Unable to find button with name "load sample")

------
https://chatgpt.com/codex/tasks/task_e_68b2af37ae0083288f84b487615ecbbf