### PR TITLE
fix: type for wordle dictionaries

### DIFF
--- a/games/wordle/index.tsx
+++ b/games/wordle/index.tsx
@@ -7,6 +7,7 @@ import {
   getWordOfTheDay,
   dictionaries,
   buildResultMosaic,
+  DictName,
 } from "../../utils/wordle";
 import type { GuessEntry, LetterResult } from "./logic";
 import { evaluateGuess, hardModeViolation } from "./logic";
@@ -18,7 +19,7 @@ const WordleGame = () => {
     "wordle:hard",
     false
   );
-  const [dictName, setDictName] = usePersistentState<string>(
+  const [dictName, setDictName] = usePersistentState<DictName>(
     "wordle:dict",
     "common"
   );
@@ -160,9 +161,9 @@ const WordleGame = () => {
         <select
           className="text-black"
           value={dictName}
-          onChange={(e) => setDictName(e.target.value)}
+          onChange={(e) => setDictName(e.target.value as DictName)}
         >
-          {Object.keys(dictionaries).map((name) => (
+          {(Object.keys(dictionaries) as DictName[]).map((name) => (
             <option key={name} value={name}>
               {name.charAt(0).toUpperCase() + name.slice(1)}
             </option>

--- a/utils/wordle.ts
+++ b/utils/wordle.ts
@@ -4,7 +4,7 @@ import animalWords from '../components/apps/wordle_words_animals.json';
 import fruitWords from '../components/apps/wordle_words_fruits.json';
 import { getDailySeed } from './dailyChallenge';
 
-type DictName = 'common' | 'alt' | 'animals' | 'fruits';
+export type DictName = 'common' | 'alt' | 'animals' | 'fruits';
 
 const dictionaries: Record<DictName, string[]> = {
   common: commonWords as string[],


### PR DESCRIPTION
## Summary
- export `DictName` type from wordle utilities and use it in the game
- cast dictionary selection to `DictName` in Wordle UI

## Testing
- `npx eslint games/wordle/index.tsx utils/wordle.ts`
- `yarn test --passWithNoTests games/wordle/index.tsx`
- `yarn build` *(fails: Property 'values' does not exist on type 'FileSystemDirectoryHandle' in hooks/useOPFS.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b0e1d52483288b384d70c2088c2c