### PR TITLE
Use typed dictionary names for Wordle

### DIFF
--- a/games/wordle/index.tsx
+++ b/games/wordle/index.tsx
@@ -7,6 +7,7 @@ import {
   getWordOfTheDay,
   dictionaries,
   buildResultMosaic,
+  type DictName,
 } from "../../utils/wordle";
 import type { GuessEntry, LetterResult } from "./logic";
 import { evaluateGuess, hardModeViolation } from "./logic";
@@ -18,7 +19,7 @@ const WordleGame = () => {
     "wordle:hard",
     false
   );
-  const [dictName, setDictName] = usePersistentState<string>(
+  const [dictName, setDictName] = usePersistentState<DictName>(
     "wordle:dict",
     "common"
   );
@@ -160,7 +161,7 @@ const WordleGame = () => {
         <select
           className="text-black"
           value={dictName}
-          onChange={(e) => setDictName(e.target.value)}
+          onChange={(e) => setDictName(e.target.value as DictName)}
         >
           {Object.keys(dictionaries).map((name) => (
             <option key={name} value={name}>

--- a/utils/wordle.ts
+++ b/utils/wordle.ts
@@ -4,7 +4,9 @@ import animalWords from '../components/apps/wordle_words_animals.json';
 import fruitWords from '../components/apps/wordle_words_fruits.json';
 import { getDailySeed } from './dailyChallenge';
 
-type DictName = 'common' | 'alt' | 'animals' | 'fruits';
+// Names of the supported word lists. Exported so callers can use the specific
+// union type instead of falling back to plain strings.
+export type DictName = 'common' | 'alt' | 'animals' | 'fruits';
 
 const dictionaries: Record<DictName, string[]> = {
   common: commonWords as string[],


### PR DESCRIPTION
## Summary
- export DictName from wordle utilities
- use DictName for persistent dictionary selection in Wordle game

## Testing
- `npx eslint utils/wordle.ts games/wordle/index.tsx`
- `yarn test` *(fails: Unable to find button "load sample" in KismetApp)*
- `yarn build` *(fails: Cannot find name 'bytes' in games/nonogram/components/PngImport.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2af9eb93c8328bc5f170d66aab378