### PR TITLE
Export DictName type for Wordle dictionary selection

### DIFF
--- a/games/wordle/index.tsx
+++ b/games/wordle/index.tsx
@@ -8,6 +8,7 @@ import {
   dictionaries,
   buildResultMosaic,
 } from "../../utils/wordle";
+import type { DictName } from "../../utils/wordle";
 import type { GuessEntry, LetterResult } from "./logic";
 import { evaluateGuess, hardModeViolation } from "./logic";
 import Keyboard from "./components/Keyboard";
@@ -18,7 +19,7 @@ const WordleGame = () => {
     "wordle:hard",
     false
   );
-  const [dictName, setDictName] = usePersistentState<string>(
+  const [dictName, setDictName] = usePersistentState<DictName>(
     "wordle:dict",
     "common"
   );
@@ -160,7 +161,7 @@ const WordleGame = () => {
         <select
           className="text-black"
           value={dictName}
-          onChange={(e) => setDictName(e.target.value)}
+          onChange={(e) => setDictName(e.target.value as DictName)}
         >
           {Object.keys(dictionaries).map((name) => (
             <option key={name} value={name}>

--- a/utils/wordle.ts
+++ b/utils/wordle.ts
@@ -4,7 +4,7 @@ import animalWords from '../components/apps/wordle_words_animals.json';
 import fruitWords from '../components/apps/wordle_words_fruits.json';
 import { getDailySeed } from './dailyChallenge';
 
-type DictName = 'common' | 'alt' | 'animals' | 'fruits';
+export type DictName = 'common' | 'alt' | 'animals' | 'fruits';
 
 const dictionaries: Record<DictName, string[]> = {
   common: commonWords as string[],


### PR DESCRIPTION
## Summary
- export the `DictName` type from the Wordle utilities
- use `DictName` with `usePersistentState` for the Wordle dictionary selector

## Testing
- `yarn build` *(fails: Property 'values' does not exist on type 'FileSystemDirectoryHandle')*

------
https://chatgpt.com/codex/tasks/task_e_68b2b0e4df448328b92a92ba88a348c7