### PR TITLE
Fix OPFS directory iteration typing

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -119,7 +119,7 @@ export default function useOPFS(): OPFSHook {
       if (!dir) return [];
       const files: FileSystemFileHandle[] = [];
       try {
-        for await (const entry of dir.values()) {
+        for await (const entry of (dir as any).values()) {
           if (entry.kind === 'file') files.push(entry as FileSystemFileHandle);
         }
       } catch {}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -180,7 +180,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     if (!fetchRef.current) fetchRef.current = window.fetch.bind(window);
     if (!allowNetwork) {
       window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = typeof input === 'string' ? input : input.url;
+        const url =
+          typeof input === 'string'
+            ? input
+            : 'url' in input
+              ? input.url
+              : input.href;
         if (
           /^https?:/i.test(url) &&
           !url.startsWith(window.location.origin) &&


### PR DESCRIPTION
## Summary
- cast OPFS directory handle iteration to any to avoid missing `values` type
- guard custom fetch wrapper against URL objects lacking `url` property

## Testing
- `yarn build` *(fails: Binding element 'Component' implicitly has an 'any' type in pages/_app.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b44a505883288b7ee83960ba9136