### PR TITLE
fix: iterate OPFS directory entries

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -119,8 +119,14 @@ export default function useOPFS(): OPFSHook {
       if (!dir) return [];
       const files: FileSystemFileHandle[] = [];
       try {
-        for await (const entry of dir.values()) {
-          if (entry.kind === 'file') files.push(entry as FileSystemFileHandle);
+        for await (
+          const [, handle] of (
+            dir as any as {
+              entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+            }
+          ).entries()
+        ) {
+          if (handle.kind === 'file') files.push(handle as FileSystemFileHandle);
         }
       } catch {}
       return files;


### PR DESCRIPTION
## Summary
- iterate OPFS directories using entries() instead of values()
- cast directory handle to access entries method

## Testing
- `yarn lint hooks/useOPFS.ts` *(fails: 46 problems in repo)*
- `yarn eslint hooks/useOPFS.ts`
- `yarn test hooks/useOPFS` *(fails: no tests found)*
- `yarn build` *(fails: Property 'url' does not exist on type 'Request | URL')*


------
https://chatgpt.com/codex/tasks/task_e_68b2b7dd6fec8328b8330cf465aea438