### PR TITLE
Fix OPFS directory iteration typing

### DIFF
--- a/hooks/useOPFS.ts
+++ b/hooks/useOPFS.ts
@@ -119,8 +119,12 @@ export default function useOPFS(): OPFSHook {
       if (!dir) return [];
       const files: FileSystemFileHandle[] = [];
       try {
-        for await (const entry of dir.values()) {
-          if (entry.kind === 'file') files.push(entry as FileSystemFileHandle);
+        const it =
+          (dir as any).values?.() ?? (dir as any).entries?.() ?? [];
+        for await (const entry of it) {
+          const handle = Array.isArray(entry) ? entry[1] : entry;
+          if (handle.kind === 'file')
+            files.push(handle as FileSystemFileHandle);
         }
       } catch {}
       return files;


### PR DESCRIPTION
## Summary
- handle FileSystemDirectoryHandle iteration using optional `values`/`entries` to avoid missing typings

## Testing
- `yarn eslint hooks/useOPFS.ts`
- `yarn test hooks/useOPFS.test.ts --passWithNoTests`
- `yarn build` *(fails: Property 'url' does not exist on type 'Request | URL' in hooks/useSettings.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b8aab3548328ad1478028eaac51a