### PR TITLE
fix: add explicit types for MyApp

### DIFF
--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -13,6 +13,7 @@ declare global {
     documentPictureInPicture?: {
       requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
     };
+    manualRefresh?: () => void;
   }
 }
 


### PR DESCRIPTION
## Summary
- type Next.js custom App with AppProps
- add window.manualRefresh definition and related helper types

## Testing
- `npx eslint pages/_app.tsx`
- `yarn lint` *(fails: 8 errors, 38 warnings)*
- `yarn test` *(fails: KismetApp sample capture test)*
- `yarn build` *(fails: createFlagsEndpoint missing from flags/next)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b9d35a8c8328aa2183331ac9ce82