### PR TITLE
Add Vercel flags rewrite

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,6 +80,14 @@ module.exports = withBundleAnalyzer({
     deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/vercel/flags',
+        destination: '/api/flags',
+      },
+    ];
+  },
   ...(isStaticExport
     ? {}
     : {


### PR DESCRIPTION
## Summary
- expose `.well-known/vercel/flags` via a rewrite to `/api/flags`

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: unable to find button "load sample")*

------
https://chatgpt.com/codex/tasks/task_e_68b2bf7167908328ae4c13deac3fa470