### PR TITLE
Implement custom flags API endpoint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,6 +80,11 @@ module.exports = withBundleAnalyzer({
     deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
+  async rewrites() {
+    return [
+      { source: '/.well-known/vercel/flags', destination: '/api/flags' },
+    ];
+  },
   ...(isStaticExport
     ? {}
     : {

--- a/pages/api/flags/index.ts
+++ b/pages/api/flags/index.ts
@@ -1,6 +1,20 @@
-import { getProviderData, createFlagsEndpoint } from 'flags/next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyAccess, version, type ProviderData } from 'flags';
+import { getProviderData } from 'flags/next';
 import * as appFlags from '../../flags';
 
-export default createFlagsEndpoint(async (req, res) => {
-  res.status(200).json(await getProviderData(appFlags));
-});
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const ok = await verifyAccess(req.headers.authorization as string);
+  if (!ok) {
+    res.status(401).json(null);
+    return;
+  }
+
+  const data: ProviderData = await getProviderData(appFlags);
+  res.setHeader('x-flags-sdk-version', version);
+  res.status(200).json(data);
+}
+


### PR DESCRIPTION
## Summary
- replace deprecated `createFlagsEndpoint` with custom handler that verifies access
- rewrite `/.well-known/vercel/flags` to `/api/flags`

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i` in __tests__/kismet.test.tsx)*
- `yarn build` *(fails: Binding element 'Component' implicitly has an 'any' type in pages/_app.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bec38d2483288e9a6630a108b93a