### PR TITLE
refactor: type _app props

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,7 +21,8 @@ declare global {
   }
 }
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp(props: AppProps) {
+  const { Component, pageProps } = props;
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
     if (trackingId) {


### PR DESCRIPTION
## Summary
- refactor MyApp to accept typed AppProps and destructure props internally

## Testing
- `yarn build` (fails: Module '"flags"' has no exported member 'verifyAccess')
- `yarn test` (fails: Unable to find button with name /load sample/i)

------
https://chatgpt.com/codex/tasks/task_e_68b2c7c7c4a08328897ec26a25f4912d