### PR TITLE
Fix terminal handler and capstone WASM loading

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -7,6 +7,16 @@ import ImportAnnotate from './ImportAnnotate';
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
+const CAPSTONE_URL =
+  process.env.NEXT_PUBLIC_GHIDRA_WASM ??
+  'https://unpkg.com/capstone-wasm@1.0.3/dist/index.mjs';
+
+async function loadCapstone() {
+  if (typeof window === 'undefined') return null;
+  const mod = await import(/* webpackIgnore: true */ CAPSTONE_URL);
+  return mod.default ?? mod;
+}
+
 // Disassembly data is now loaded from pre-generated JSON
 
 // S6: Interactive control flow graph with accessible labelling
@@ -86,7 +96,8 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await import('https://unpkg.com/capstone-wasm@1.0.3/dist/index.mjs');
+    const mod = await loadCapstone();
+    if (!mod) return null;
     await mod.loadCapstone();
     capstoneRef.current = mod;
     return mod;

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import MemoryHeatmap from './MemoryHeatmap';
 import PluginBrowser from './PluginBrowser';
 import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthrough';
-import memoryDemo from '../../../public/demo-data/volatility/memory.json';
+import memoryFixture from '../../../public/demo-data/volatility/memory.json';
 
 // pull demo data for various volatility plugins from the memory fixture
 const {
@@ -11,7 +11,7 @@ const {
   netscan = [],
   malfind = [],
   yarascan = [],
-} = memoryDemo;
+} = memoryFixture;
 
 const heuristicColors = {
   informational: 'bg-blue-600',


### PR DESCRIPTION
## Summary
- rewrite Terminal onKey handler to keep returns inside the function and support font size/history shortcuts
- load capstone-wasm via runtime dynamic import so webpack ignores the remote ESM
- clean up Volatility fixture destructuring

## Testing
- `nvm use 22`
- `yarn install`
- `yarn build` *(fails: Module '"flags"' has no exported member 'verifyAccess')*


------
https://chatgpt.com/codex/tasks/task_e_68b2d205bf4c832886428bc396caad87