### PR TITLE
Bundle capstone WASM locally for Ghidra app

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -86,7 +86,7 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await import('https://unpkg.com/capstone-wasm@1.0.3/dist/index.mjs');
+    const mod = await import('capstone-wasm');
     await mod.loadCapstone();
     capstoneRef.current = mod;
     return mod;

--- a/next.config.js
+++ b/next.config.js
@@ -88,6 +88,13 @@ module.exports = withBundleAnalyzer({
       },
     ];
   },
+  webpack(config) {
+    config.experiments = {
+      ...(config.experiments || {}),
+      asyncWebAssembly: true,
+    };
+    return config;
+  },
   ...(isStaticExport
     ? {}
     : {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
+    "capstone-wasm": "1.0.3",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
     "cron-parser": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,6 +3765,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"capstone-wasm@npm:1.0.3":
+  version: 1.0.3
+  resolution: "capstone-wasm@npm:1.0.3"
+  checksum: 10c0/0fc4ef46db73ee77a58f8138b64ac9e5320b880ba6c250d24f95644b9092b88822643cade698ca1c9d56c313de22e6cebcb940117dac727a8f5b3044ccab7056
+  languageName: node
+  linkType: hard
+
 "centra@npm:^2.7.0":
   version: 2.7.0
   resolution: "centra@npm:2.7.0"
@@ -10841,6 +10848,7 @@ __metadata:
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
+    capstone-wasm: "npm:1.0.3"
     chess.js: "npm:^1.0.0"
     chrono-node: "npm:^2.8.4"
     cron-parser: "npm:^5.3.0"


### PR DESCRIPTION
## Summary
- add capstone-wasm as dependency
- load capstone locally instead of from unpkg CDN
- enable async WebAssembly in Next.js build

## Testing
- `node -e "import('capstone-wasm').then(m=>m.loadCapstone().then(()=>console.log('loaded')))"`
- `yarn test` (failed: Unable to find an accessible element with the role "button" and name `/load sample/i`)
- `yarn lint` (failed: 8 errors, 38 warnings)
- `yarn build` (failed: Module '"flags"' has no exported member 'verifyAccess')


------
https://chatgpt.com/codex/tasks/task_e_68b2d16222bc8328b80010788f487cbf