### PR TITLE
Handle terminal key events via custom handler

### DIFF
--- a/components/apps/archive/Terminal/index.tsx
+++ b/components/apps/archive/Terminal/index.tsx
@@ -375,60 +375,68 @@ const TerminalPaneInner = (
             domEvent.preventDefault();
           }
         });
-      })();
-    }, []);
-          if (navigator.clipboard) {
-            navigator.clipboard.readText().then((text) => {
-              term.write(text);
-              commandRef.current += text;
-              renderHint();
-            });
-          }
-          return;
-        }
-        if (domEvent.ctrlKey && (domEvent.key === '+' || domEvent.key === '=')) {
-          domEvent.preventDefault();
-          fontSizeRef.current += 1;
-          term.options.fontSize = fontSizeRef.current;
-          fitAddon.fit();
-          return;
-        }
-        if (domEvent.ctrlKey && domEvent.key === '-') {
-          domEvent.preventDefault();
-          fontSizeRef.current = Math.max(8, fontSizeRef.current - 1);
-          term.options.fontSize = fontSizeRef.current;
-          fitAddon.fit();
-          return;
-        }
-        if (domEvent.ctrlKey && domEvent.key === 'r') {
-          domEvent.preventDefault();
-          if (!revSearchRef.current.active) {
-            searchIdxRef.current = historyRef.current.length;
-            setRevSearch({ active: true, query: '', match: '' });
-          } else {
-            updateSearch(revSearchRef.current.query, true);
-          }
-          return;
-        }
-        if (domEvent.key === 'Tab') {
-          domEvent.preventDefault();
-          handleTab();
-        } else if (domEvent.key === 'ArrowLeft') {
-          domEvent.preventDefault();
-          handleSuggestionNav('left');
-        } else if (domEvent.key === 'ArrowRight') {
-          domEvent.preventDefault();
-          handleSuggestionNav('right');
-        } else if (domEvent.key === 'ArrowUp') {
-          domEvent.preventDefault();
-          handleHistoryNav('up');
-        } else if (domEvent.key === 'ArrowDown') {
-          domEvent.preventDefault();
-          handleHistoryNav('down');
-        }
-      });
 
-      term.onData((data: string) => {
+        term.attachCustomKeyEventHandler((domEvent: KeyboardEvent) => {
+          if (domEvent.ctrlKey && domEvent.shiftKey && domEvent.key === 'V') {
+            domEvent.preventDefault();
+            if (navigator.clipboard) {
+              navigator.clipboard.readText().then((text) => {
+                term.write(text);
+                commandRef.current += text;
+                renderHint();
+              });
+            }
+            return false;
+          }
+          if (domEvent.ctrlKey && (domEvent.key === '+' || domEvent.key === '=')) {
+            domEvent.preventDefault();
+            fontSizeRef.current += 1;
+            term.options.fontSize = fontSizeRef.current;
+            fitAddon.fit();
+            return false;
+          }
+          if (domEvent.ctrlKey && domEvent.key === '-') {
+            domEvent.preventDefault();
+            fontSizeRef.current = Math.max(8, fontSizeRef.current - 1);
+            term.options.fontSize = fontSizeRef.current;
+            fitAddon.fit();
+            return false;
+          }
+          if (domEvent.ctrlKey && domEvent.key === 'r') {
+            domEvent.preventDefault();
+            if (!revSearchRef.current.active) {
+              searchIdxRef.current = historyRef.current.length;
+              setRevSearch({ active: true, query: '', match: '' });
+            } else {
+              updateSearch(revSearchRef.current.query, true);
+            }
+            return false;
+          }
+          if (domEvent.key === 'Tab') {
+            domEvent.preventDefault();
+            handleTab();
+            return false;
+          } else if (domEvent.key === 'ArrowLeft') {
+            domEvent.preventDefault();
+            handleSuggestionNav('left');
+            return false;
+          } else if (domEvent.key === 'ArrowRight') {
+            domEvent.preventDefault();
+            handleSuggestionNav('right');
+            return false;
+          } else if (domEvent.key === 'ArrowUp') {
+            domEvent.preventDefault();
+            handleHistoryNav('up');
+            return false;
+          } else if (domEvent.key === 'ArrowDown') {
+            domEvent.preventDefault();
+            handleHistoryNav('down');
+            return false;
+          }
+          return true;
+        });
+
+        term.onData((data: string) => {
         if (revSearchRef.current.active) {
           if (data === '\r') {
             term.write('\x1b[2K\r');


### PR DESCRIPTION
## Summary
- Attach `attachCustomKeyEventHandler` within Terminal's effect
- Move key-handling logic into the custom handler and return booleans

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: unable to find an accessible element with role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d16214b08328b74d7e7e7bc18fc9