### PR TITLE
Use local capstone-wasm and enable WASM

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -86,7 +86,7 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await import('https://unpkg.com/capstone-wasm@1.0.3/dist/index.mjs');
+    const mod = await import('capstone-wasm');
     await mod.loadCapstone();
     capstoneRef.current = mod;
     return mod;

--- a/next.config.js
+++ b/next.config.js
@@ -63,6 +63,11 @@ const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
 module.exports = withBundleAnalyzer({
   output: 'export',
+  // Enable WebAssembly loading
+  webpack: (config) => {
+    config.experiments = { ...config.experiments, asyncWebAssembly: true };
+    return config;
+  },
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
   eslint: {
     ignoreDuringBuilds: true,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
+    "capstone-wasm": "1.0.3",
     "chess.js": "^1.0.0",
     "chrono-node": "^2.8.4",
     "cron-parser": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,6 +3765,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"capstone-wasm@npm:1.0.3":
+  version: 1.0.3
+  resolution: "capstone-wasm@npm:1.0.3"
+  checksum: 10c0/0fc4ef46db73ee77a58f8138b64ac9e5320b880ba6c250d24f95644b9092b88822643cade698ca1c9d56c313de22e6cebcb940117dac727a8f5b3044ccab7056
+  languageName: node
+  linkType: hard
+
 "centra@npm:^2.7.0":
   version: 2.7.0
   resolution: "centra@npm:2.7.0"
@@ -10841,6 +10848,7 @@ __metadata:
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
+    capstone-wasm: "npm:1.0.3"
     chess.js: "npm:^1.0.0"
     chrono-node: "npm:^2.8.4"
     cron-parser: "npm:^5.3.0"


### PR DESCRIPTION
## Summary
- add capstone-wasm dependency and load it locally
- configure Next.js webpack to allow WebAssembly

## Testing
- `yarn eslint components/apps/ghidra/index.js next.config.js`
- `yarn test --passWithNoTests components/apps/ghidra/index.js`
- `yarn build` *(fails: Module '"flags"' has no exported member 'verifyAccess')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d16c52d883289b102d373eaa9eb5