### PR TITLE
Fix volatility fixture usage and add worker test

### DIFF
--- a/__tests__/volatilityApp.test.tsx
+++ b/__tests__/volatilityApp.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import VolatilityApp from '../components/apps/volatility';
+import memoryFixture from '../public/demo-data/volatility/memory.json';
 
 describe('VolatilityApp demo', () => {
   test('renders process tree and modules from fixture', () => {
@@ -17,5 +18,25 @@ describe('VolatilityApp demo', () => {
 
     const heuristic = screen.getByText('suspicious');
     expect(heuristic).toHaveClass('bg-yellow-600');
+  });
+
+  test('sends demo segments to heatmap worker', async () => {
+    const postMessageSpy = jest.fn();
+    // @ts-ignore
+    global.Worker = class {
+      postMessage = postMessageSpy;
+      terminate() {}
+    };
+
+    render(<VolatilityApp />);
+
+    await waitFor(() =>
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        segments: memoryFixture.segments,
+      })
+    );
+
+    // @ts-ignore
+    delete global.Worker;
   });
 });

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -5,11 +5,14 @@ import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthr
 import memoryFixture from '../../../public/demo-data/volatility/memory.json';
 
 // pull demo data for various volatility plugins from the memory fixture
-const pstree = memoryDemo.pstree ?? [];
-const dlllist = memoryDemo.dlllist ?? {};
-const netscan = memoryDemo.netscan ?? [];
-const malfind = memoryDemo.malfind ?? [];
-const yarascan = memoryDemo.yarascan ?? [];
+const pstree = Array.isArray(memoryFixture.pstree) ? memoryFixture.pstree : [];
+const dlllist =
+  memoryFixture.dlllist && typeof memoryFixture.dlllist === 'object'
+    ? memoryFixture.dlllist
+    : {};
+const netscan = Array.isArray(memoryFixture.netscan) ? memoryFixture.netscan : [];
+const malfind = Array.isArray(memoryFixture.malfind) ? memoryFixture.malfind : [];
+const yarascan = Array.isArray(memoryFixture.yarascan) ? memoryFixture.yarascan : [];
 
 
 const heuristicColors = {
@@ -113,7 +116,7 @@ const VolatilityApp = () => {
     if (typeof window !== 'undefined' && typeof Worker === 'function') {
       workerRef.current = new Worker(new URL('./heatmap.worker.js', import.meta.url));
       workerRef.current.onmessage = (e) => setHeatmapData(e.data);
-      workerRef.current.postMessage({ segments: memoryDemo.segments });
+      workerRef.current.postMessage({ segments: memoryFixture.segments });
     }
     return () => workerRef.current?.terminate();
   }, []);
@@ -122,7 +125,7 @@ const VolatilityApp = () => {
     setLoading(true);
     setOutput('');
     try {
-      workerRef.current?.postMessage({ segments: memoryDemo.segments });
+      workerRef.current?.postMessage({ segments: memoryFixture.segments });
       setOutput('Analysis simulated with demo memory plugin output.');
     } catch (err) {
       setOutput('Analysis failed');


### PR DESCRIPTION
## Summary
- switch to property assignments for volatility fixture values
- send heatmap worker demo segments from fixture
- test that demo segments are sent to heatmap worker

## Testing
- `yarn test __tests__/volatilityApp.test.tsx`
- `yarn test` *(fails: KismetApp steps through sample capture frames)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d5b18ae88328a009519670217446