### PR TITLE
Enable WebAssembly config and preserve export names in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -63,9 +63,18 @@ const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
 module.exports = withBundleAnalyzer({
   output: 'export',
-  // Enable WebAssembly loading
-  webpack: (config) => {
-    config.experiments = { ...config.experiments, asyncWebAssembly: true };
+  // Enable WebAssembly loading and avoid JSON destructuring bug
+  webpack: (config, { isServer }) => {
+    config.experiments = {
+      ...(config.experiments || {}),
+      asyncWebAssembly: true,
+    };
+    if (process.env.NODE_ENV === 'production') {
+      config.optimization = {
+        ...(config.optimization || {}),
+        mangleExports: false,
+      };
+    }
     return config;
   },
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI


### PR DESCRIPTION
## Summary
- configure webpack to enable async WebAssembly
- disable export mangling in production to avoid JSON destructuring bug

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: volatilityApp.test.tsx, kismet.test.tsx)*
- `yarn build` *(fails: Module '"flags"' has no exported member 'verifyAccess')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d5b47c388328ac5a2d79629fd65b