### PR TITLE
fix: update vercel function runtime pattern

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "functions": {
-    "pages/api/**/*.js": {
+    "api/**/*.js": {
       "runtime": "nodejs20.x"
     },
-    "pages/api/**/*.ts": {
+    "api/**/*.ts": {
       "runtime": "nodejs20.x"
     }
   }


### PR DESCRIPTION
## Summary
- update vercel function paths to ensure runtime version is respected

## Testing
- `yarn test`
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find button labeled "load sample")*


------
https://chatgpt.com/codex/tasks/task_e_68b31cf8ebf48328817492f8591ffe6b