### PR TITLE
feat: migrate flags discovery to app router

### DIFF
--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,8 @@
+import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
+import { type ProviderData } from 'flags';
+import * as appFlags from '../../../../app-flags';
+
+export const GET = createFlagsDiscoveryEndpoint(async () => {
+  const providerData: ProviderData = getProviderData(appFlags);
+  return providerData;
+});

--- a/next.config.js
+++ b/next.config.js
@@ -99,14 +99,6 @@ module.exports = withBundleAnalyzer({
     config.experiments.asyncWebAssembly = true;
     return config;
   },
-  async rewrites() {
-    return [
-      {
-        source: '/.well-known/vercel/flags',
-        destination: '/api/flags',
-      },
-    ];
-  },
   ...(isStaticExport
     ? {}
     : {

--- a/pages/api/flags/index.ts
+++ b/pages/api/flags/index.ts
@@ -1,7 +1,0 @@
-import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
-import * as flags from '../../../app-flags';
-
-// Minimal, typed, and includes access verification internally
-export default createFlagsDiscoveryEndpoint(() =>
-  getProviderData(flags as Record<string, any>),
-);


### PR DESCRIPTION
## Summary
- add App Router `/.well-known/vercel/flags` endpoint backed by `flags` provider
- remove legacy Pages API route and rewrite

## Testing
- `yarn lint` (fails: 7 errors, 38 warnings)
- `yarn test` (fails: __tests__/kismet.test.tsx)`

------
https://chatgpt.com/codex/tasks/task_e_68b31e8d279883289bdda2f5912bd5c4