### PR TITLE
Refactor flags endpoint to explicit handler

### DIFF
--- a/pages/api/flags/index.ts
+++ b/pages/api/flags/index.ts
@@ -1,7 +1,18 @@
-import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getProviderData, verifyAccess, version } from 'flags/next';
 import * as flags from '../../../app-flags';
 
-// Minimal, typed, and includes access verification internally
-export default createFlagsDiscoveryEndpoint(() =>
-  getProviderData(flags as Record<string, any>),
-);
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const access = await verifyAccess(req.headers.authorization);
+  if (!access) {
+    res.status(401).json(null);
+    return;
+  }
+
+  const providerData = getProviderData(flags as Record<string, any>);
+  res.setHeader('x-flags-sdk-version', version);
+  res.status(200).json(providerData);
+}


### PR DESCRIPTION
## Summary
- replace createFlagsDiscoveryEndpoint with direct async handler
- verify authorization and return provider data with SDK version header

## Testing
- `yarn eslint pages/api/flags/index.ts`
- `yarn test pages/api/flags/index.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b31e89a6d08328b910987199e2f32c