### PR TITLE
refactor flags API handler

### DIFF
--- a/pages/api/flags/index.ts
+++ b/pages/api/flags/index.ts
@@ -1,7 +1,20 @@
-import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
-import * as flags from '../../../app-flags';
+import { getProviderData } from 'flags/next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyAccess, version, type ProviderData } from 'flags';
+import * as appFlags from '../../../app-flags';
 
-// Minimal, typed, and includes access verification internally
-export default createFlagsDiscoveryEndpoint(() =>
-  getProviderData(flags as Record<string, any>),
-);
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ProviderData | null>,
+): Promise<void> {
+  const access = await verifyAccess(req.headers.authorization);
+  if (!access) {
+    res.status(401).json(null);
+    return;
+  }
+
+  const data = getProviderData(appFlags as Record<string, unknown>);
+  res.setHeader('x-flags-sdk-version', version);
+  res.status(200).json(data);
+}
+


### PR DESCRIPTION
## Summary
- implement manual flags discovery endpoint with access verification and version header
- use type-only `ProviderData` import from `flags`

## Testing
- `yarn test pages/api/flags/index.ts --passWithNoTests`
- `npx eslint pages/api/flags/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b31e892dd88328a107d5395cd46626