### PR TITLE
Remove unsupported runtime from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "functions": {
-    "pages/api/**/*.js": {
-      "runtime": "nodejs20.x"
-    },
-    "pages/api/**/*.ts": {
-      "runtime": "nodejs20.x"
-    }
+    "pages/api/**/*.js": {},
+    "pages/api/**/*.ts": {}
   }
 }


### PR DESCRIPTION
## Summary
- clean up `vercel.json` by removing invalid Node.js runtime entries

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" in kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b31e7c780c8328891df4db4cab0fcb