### PR TITLE
feat: add app router flags endpoint

### DIFF
--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,8 @@
+import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
+import { type ProviderData } from 'flags';
+import * as appFlags from '../../../../app-flags';
+
+export const GET = createFlagsDiscoveryEndpoint(async () => {
+  const providerData: ProviderData = getProviderData(appFlags);
+  return providerData;
+});

--- a/next.config.js
+++ b/next.config.js
@@ -99,14 +99,6 @@ module.exports = withBundleAnalyzer({
     config.experiments.asyncWebAssembly = true;
     return config;
   },
-  async rewrites() {
-    return [
-      {
-        source: '/.well-known/vercel/flags',
-        destination: '/api/flags',
-      },
-    ];
-  },
   ...(isStaticExport
     ? {}
     : {

--- a/pages/api/flags/index.ts
+++ b/pages/api/flags/index.ts
@@ -1,7 +1,0 @@
-import { getProviderData, createFlagsDiscoveryEndpoint } from 'flags/next';
-import * as flags from '../../../app-flags';
-
-// Minimal, typed, and includes access verification internally
-export default createFlagsDiscoveryEndpoint(() =>
-  getProviderData(flags as Record<string, any>),
-);


### PR DESCRIPTION
## Summary
- add App Router discovery endpoint under `/.well-known/vercel/flags`
- remove legacy pages API handler and rewrite

## Testing
- `yarn lint` (fails: react/display-name etc.)
- `yarn test` (fails: KismetApp sample load)


------
https://chatgpt.com/codex/tasks/task_e_68b3218b01388328a4b40bb4b8097d17