### PR TITLE
fix: prevent bundling server-only modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,13 @@ module.exports = withBundleAnalyzer({
       ...(config.experiments || {}),
       asyncWebAssembly: true,
     };
+    // Prevent bundling of server-only modules in the browser
+    config.resolve = config.resolve || {};
+    config.resolve.fallback = {
+      ...(config.resolve.fallback || {}),
+      module: false,
+      async_hooks: false,
+    };
     if (process.env.NODE_ENV === 'production') {
       config.optimization = {
         ...(config.optimization || {}),
@@ -93,11 +100,6 @@ module.exports = withBundleAnalyzer({
     ],
     deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
-  },
-  webpack: (config) => {
-    config.experiments = config.experiments || {};
-    config.experiments.asyncWebAssembly = true;
-    return config;
   },
   ...(isStaticExport
     ? {}


### PR DESCRIPTION
## Summary
- avoid bundling Node-only modules by providing webpack fallbacks

## Testing
- `yarn build` (fails: Type error: Argument of type 'typeof import("/workspace/kali-linux-portfolio/app-flags")' is not assignable to parameter of type 'Record<string, readonly unknown[] | KeyedFlagDefinitionType>'.)

------
https://chatgpt.com/codex/tasks/task_e_68b32bd0576c8328826e316ad3de8e2a