### PR TITLE
fix: polyfill missing node modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -75,6 +75,14 @@ module.exports = withBundleAnalyzer({
         mangleExports: false,
       };
     }
+    if (!isServer) {
+      config.resolve = config.resolve || {};
+      config.resolve.fallback = {
+        ...(config.resolve.fallback || {}),
+        module: false,
+        async_hooks: false,
+      };
+    }
     return config;
   },
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
@@ -93,11 +101,6 @@ module.exports = withBundleAnalyzer({
     ],
     deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
-  },
-  webpack: (config) => {
-    config.experiments = config.experiments || {};
-    config.experiments.asyncWebAssembly = true;
-    return config;
   },
   ...(isStaticExport
     ? {}


### PR DESCRIPTION
## Summary
- avoid missing Node built-ins by adding webpack fallbacks for `module` and `async_hooks`
- remove duplicate webpack configuration block

## Testing
- `yarn build` *(fails: Argument of type 'typeof import("/workspace/kali-linux-portfolio/app-flags")' is not assignable to parameter of type 'Record<string, readonly unknown[] | KeyedFlagDefinitionType>'*
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b32bc806348328b21e1f6cef4b8685