### PR TITLE
refactor: dynamically import capstone

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,16 +3,15 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import capstone from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
 async function loadCapstone() {
   if (typeof window === 'undefined') return null;
+  const capstone = await import('capstone-wasm');
   await capstone.loadCapstone();
   return capstone;
-
 }
 
 // Disassembly data is now loaded from pre-generated JSON


### PR DESCRIPTION
## Summary
- load Capstone WASM module dynamically within `loadCapstone`
- remove unused top-level Capstone import

## Testing
- `npx eslint components/apps/ghidra/index.js`
- `yarn lint components/apps/ghidra/index.js` *(fails: 7 errors, 38 warnings)*
- `npx jest __tests__/kismet.test.tsx` *(fails: Unable to find button)*

------
https://chatgpt.com/codex/tasks/task_e_68b32c838c3483289e3d6f32c533ce48