### PR TITLE
chore: update node engine to 22.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "analyze": "ANALYZE=true yarn build"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",


### PR DESCRIPTION
## Summary
- bump Node engine requirement to 22.x

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find accessible element with role button and name /load sample/i)*
- `yarn lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b32cfbc8748328b8524dcfe9530469