### PR TITLE
Add browser fallbacks to webpack configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -71,11 +71,18 @@ module.exports = withBundleAnalyzer({
     };
     // Prevent bundling of server-only modules in the browser
     config.resolve = config.resolve || {};
-    config.resolve.fallback = {
-      ...(config.resolve.fallback || {}),
-      module: false,
-      async_hooks: false,
-    };
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...(config.resolve.fallback || {}),
+        module: false,
+        async_hooks: false,
+        fs: false,
+        path: false,
+        net: false,
+        tls: false,
+        child_process: false,
+      };
+    }
     if (process.env.NODE_ENV === 'production') {
       config.optimization = {
         ...(config.optimization || {}),


### PR DESCRIPTION
## Summary
- prevent browser build from bundling Node-specific modules by adding fallbacks in webpack config
- ensure webpack function receives `isServer` from Next.js

## Testing
- `yarn test` *(fails: Unable to find accessible element with role "button" and name `/load sample/i` in __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b32db68664832898c9611c6caac221