### PR TITLE
fix: point vercel functions to pages api

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "api/**/*.ts": { "memory": 1024, "maxDuration": 30 }
+    "pages/api/**/*.ts": { "memory": 1024, "maxDuration": 30 },
+    "pages/api/**/*.js": { "memory": 1024, "maxDuration": 30 }
   }
 }


### PR DESCRIPTION
## Summary
- point Vercel `functions` glob to `pages/api` paths so functions are detected

## Testing
- `yarn lint vercel.json` *(fails: 8 errors, 39 warnings)*
- `yarn test __tests__/kismet.test.tsx` *(fails: TestingLibraryElementError in KismetApp)*

------
https://chatgpt.com/codex/tasks/task_e_68b330e5775083289b5121dab674803a