### PR TITLE
Conditionally export static build in Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -85,7 +85,7 @@ function configureWebpack(config, { isServer }) {
 }
 
 module.exports = withBundleAnalyzer({
-  output: 'export',
+  ...(isStaticExport && { output: 'export' }),
   webpack: configureWebpack,
 
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI


### PR DESCRIPTION
## Summary
- gate `next.config.js`'s `output: 'export'` behind `NEXT_PUBLIC_STATIC_EXPORT`

## Testing
- `yarn eslint -f json next.config.js`
- `yarn build` *(fails: Module not found: Can't resolve 'flags/next')*


------
https://chatgpt.com/codex/tasks/task_e_68b33b246dc48328a59a904843f0bc71