### PR TITLE
fix: enable serverless api routes on vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -85,7 +85,7 @@ function configureWebpack(config, { isServer }) {
 }
 
 module.exports = withBundleAnalyzer({
-  output: 'export',
+  ...(isStaticExport ? { output: 'export' } : {}),
   webpack: configureWebpack,
 
   // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "pages/api/**/*.ts": { "memory": 1024, "maxDuration": 30 },
-    "pages/api/**/*.js": { "memory": 1024, "maxDuration": 30 }
+    "pages/api/**/*.{ts,js}": { "memory": 1024, "maxDuration": 30 }
   }
 }


### PR DESCRIPTION
## Summary
- conditionally set Next.js static export to allow API routes
- match both TS and JS API handlers in Vercel functions configuration

## Testing
- `yarn install`
- `yarn test --runInBand` *(failed: process terminated after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b33a9c912083288423874483dc8660