### PR TITLE
fix: correct capstone import

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,7 +3,7 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import capstone from 'capstone-wasm';
+import * as capstone from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';


### PR DESCRIPTION
## Summary
- replace default import of `capstone-wasm` with a namespace import in Ghidra app

## Testing
- `npx eslint components/apps/ghidra/index.js`
- `yarn test components/apps/ghidra --passWithNoTests`
- `yarn build` *(fails: Cannot find name 'FlagValuesEmitter')*

------
https://chatgpt.com/codex/tasks/task_e_68b33f5108c48328a2cf62d111da64f7