### PR TITLE
refactor: update capstone-wasm integration in ghidra app

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,16 +3,15 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import capstone from 'capstone-wasm';
+import { Capstone, Const, loadCapstone } from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
-async function loadCapstone() {
+async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
-  await capstone.loadCapstone();
-  return capstone;
-
+  await loadCapstone();
+  return { Capstone, Const };
 }
 
 // Disassembly data is now loaded from pre-generated JSON
@@ -94,7 +93,7 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await loadCapstone();
+    const mod = await loadCapstoneModule();
     capstoneRef.current = mod;
     return mod;
   }, []);


### PR DESCRIPTION
## Summary
- use named imports from capstone-wasm and new load helper
- cache module via ensureCapstone with new loadCapstoneModule

## Testing
- `npx eslint components/apps/ghidra/index.js`
- `yarn test components/apps/ghidra` *(fails: No tests found, exiting with code 1)*
- `yarn build` *(fails: Cannot find name 'FlagValuesEmitter')*


------
https://chatgpt.com/codex/tasks/task_e_68b3400d55408328b1f88b8f0a51c246