### PR TITLE
fix capstone import and update flag values component

### DIFF
--- a/app-flags.ts
+++ b/app-flags.ts
@@ -1,6 +1,10 @@
-export async function beta(): Promise<boolean> {
-  return false;
-}
+import { flag } from '@vercel/flags/next';
+
+export const beta = flag<boolean>({
+  key: 'beta',
+  decide: async () => false,
+  description: 'beta flag',
+});
 
 export function reportValue(_name: string, _value: unknown): void {
   // no-op

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,17 +3,10 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import capstone from 'capstone-wasm';
+import { Capstone, Const, loadCapstone } from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
-
-async function loadCapstone() {
-  if (typeof window === 'undefined') return null;
-  await capstone.loadCapstone();
-  return capstone;
-
-}
 
 // Disassembly data is now loaded from pre-generated JSON
 
@@ -94,9 +87,10 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await loadCapstone();
-    capstoneRef.current = mod;
-    return mod;
+    if (typeof window === 'undefined') return null;
+    await loadCapstone();
+    capstoneRef.current = { Capstone, Const };
+    return capstoneRef.current;
   }, []);
 
   useEffect(() => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import { FlagValues } from '@vercel/flags/react';
 
 declare global {
   interface Window {
@@ -129,7 +130,7 @@ function MyApp(props: AppProps) {
   }, []);
   return (
     <SettingsProvider>
-      <FlagValuesEmitter />
+      <FlagValues values={{}} />
       <PipPortalProvider>
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />

--- a/pages/api/vercel/flags.ts
+++ b/pages/api/vercel/flags.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { verifyAccess, type ApiData } from '@vercel/flags';
 import { getProviderData } from '@vercel/flags/next';
-import * as appFlags from '../../../app-flags';
+import { beta } from '../../../app-flags';
 
 export const config = { runtime: 'edge' };
 
@@ -12,6 +12,6 @@ export default async function handler(request: NextRequest) {
     return NextResponse.json(null, { status: 401 });
   }
 
-  const data = (await getProviderData(appFlags)) as ApiData;
+  const data = (await getProviderData({ beta })) as ApiData;
   return NextResponse.json(data);
 }


### PR DESCRIPTION
## Summary
- use named `capstone-wasm` exports and load helper for Ghidra fallback
- swap deprecated `FlagValuesEmitter` for `FlagValues`
- define `beta` flag via `@vercel/flags` helper and expose it in API route

## Testing
- `yarn tsc --noEmit`
- `yarn build` *(fails: `indexedDB is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68b340037eb0832897dfa2921021a3ab