### PR TITLE
Refactor Ghidra Capstone initialization

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,16 +3,15 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import capstone from 'capstone-wasm';
+import { Capstone, Const, loadCapstone as initCapstone } from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
-async function loadCapstone() {
+async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
-  await capstone.loadCapstone();
-  return capstone;
-
+  await initCapstone();
+  return { Capstone, Const };
 }
 
 // Disassembly data is now loaded from pre-generated JSON
@@ -94,7 +93,7 @@ export default function GhidraApp() {
   // S1: Detect GHIDRA web support and fall back to Capstone
   const ensureCapstone = useCallback(async () => {
     if (capstoneRef.current) return capstoneRef.current;
-    const mod = await loadCapstone();
+    const mod = await loadCapstoneModule();
     capstoneRef.current = mod;
     return mod;
   }, []);


### PR DESCRIPTION
## Summary
- switch to named `capstone-wasm` imports and initialize via `loadCapstoneModule`
- update `ensureCapstone` to cache `{ Capstone, Const }`

## Testing
- `npx eslint components/apps/ghidra/index.js`
- `yarn build` *(fails: process did not complete within allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68b340a6817883289780f827952ea578