### PR TITLE
Guard IndexedDB access for server builds

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -60,6 +60,10 @@ const STORE_NAME = 'recent';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('indexedDB is not available'));
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME, { autoIncrement: true });

--- a/components/apps/phaser-template.js
+++ b/components/apps/phaser-template.js
@@ -7,6 +7,10 @@ const STORE_NAME = 'scores';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('indexedDB is not available'));
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME);

--- a/utils/idb.ts
+++ b/utils/idb.ts
@@ -5,6 +5,10 @@ const STORE_REPLAYS = 'replays';
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('indexedDB is not available'));
+      return;
+    }
     const req = indexedDB.open(DB_NAME, VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;


### PR DESCRIPTION
## Summary
- avoid server-side `indexedDB` errors by checking availability before opening
- update file explorer and phaser template modules to guard IndexedDB usage

## Testing
- `yarn lint utils/idb.ts components/apps/file-explorer.js components/apps/phaser-template.js` *(fails: 45 problems (7 errors, 38 warnings))*
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*
- `yarn build` *(fails: Module not found: Can't resolve 'flags')*

------
https://chatgpt.com/codex/tasks/task_e_68b342e33cf08328943f38953a3a9f93