### PR TITLE
refactor ghidra import to named capstone export

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,15 +3,15 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import { Capstone, Const, loadCapstone } from 'capstone-wasm';
+import { capstone } from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
 async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
-  await loadCapstone();
-  return { Capstone, Const };
+  await capstone.loadCapstone();
+  return capstone;
 }
 
 // Disassembly data is now loaded from pre-generated JSON


### PR DESCRIPTION
## Summary
- refactor ghidra app to use `capstone` named export from `capstone-wasm`
- adjust loading to call `capstone.loadCapstone`

## Testing
- `yarn lint` (fails: 45 problems, 7 errors)
- `yarn build` (fails: Module not found: Can't resolve 'flags')


------
https://chatgpt.com/codex/tasks/task_e_68b3456d13e4832896938cd16c64379c