### PR TITLE
fix: add vercel flags package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.1",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/flags": "^3.1.1",
     "@vercel/speed-insights": "^1.2.0",
     "@vercel/toolbar": "^0.1.38",
     "@xterm/addon-fit": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,6 +2760,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/flags@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@vercel/flags@npm:3.1.1"
+  dependencies:
+    "@edge-runtime/cookies": "npm:^5.0.2"
+    jose: "npm:^5.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.7.0
+    "@sveltejs/kit": "*"
+    next: "*"
+    react: "*"
+    react-dom: "*"
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/220a695fd3f2bdfe7250e5879e32f93ec791afe30a385260f81535d4c4af25c40601a1e40acdcd54ee3a1cbf19cfcf20fccd9c543ace41e2efb6a05fc417d7a7
+  languageName: node
+  linkType: hard
+
 "@vercel/microfrontends@npm:1.3.0":
   version: 1.3.0
   resolution: "@vercel/microfrontends@npm:1.3.0"
@@ -10908,6 +10935,7 @@ __metadata:
     "@types/web-bluetooth": "npm:^0.0.21"
     "@types/wicg-file-system-access": "npm:^2023.10.6"
     "@vercel/analytics": "npm:^1.5.0"
+    "@vercel/flags": "npm:^3.1.1"
     "@vercel/speed-insights": "npm:^1.2.0"
     "@vercel/toolbar": "npm:^0.1.38"
     "@xterm/addon-fit": "npm:^0.10.0"


### PR DESCRIPTION
## Summary
- add `@vercel/flags` dependency to resolve feature flag imports

## Testing
- `node -e "require('@vercel/flags/next'); console.log('loaded');"`
- `node -e "require('@vercel/flags/react'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_68b345661a64832897977a508fcd11ea