### PR TITLE
Fix module not found errors in flags.ts

### DIFF
--- a/app-flags.ts
+++ b/app-flags.ts
@@ -1,4 +1,4 @@
-import { flag } from '@vercel/flags/next';
+import { flag } from 'flags/next';
 
 
 // Example feature flag used by pages/api/vercel/flags.ts

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
-import { FlagValues } from '@vercel/flags/react';
+import { FlagValues } from 'flags/react';
 
 declare global {
   interface Window {

--- a/pages/api/vercel/flags.ts
+++ b/pages/api/vercel/flags.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { verifyAccess, type ApiData, version } from 'flags';
+import { verifyAccess, type ApiData } from 'flags';
 import { getProviderData } from 'flags/next';
-import { beta } from '../../../app-flags';
+import * as appFlags from '../../../app-flags';
 
 export const config = { runtime: 'edge' };
 
@@ -11,7 +11,7 @@ export default async function handler(request: NextRequest) {
   if (!authorized) {
     return NextResponse.json(null, { status: 401 });
   }
-  const data = (await getProviderData(appFlags as any)) as ApiData;
+  const data = (await getProviderData(appFlags)) as ApiData;
   return NextResponse.json(data);
 
 }


### PR DESCRIPTION
## Summary
- switch feature flag imports to `flags` package
- wire API route to provide app flag definitions

## Testing
- `yarn test` *(fails: Unable to find button "load sample" in KismetApp)*

------
https://chatgpt.com/codex/tasks/task_e_68b346008b00832888888e142fdde4e3