### PR TITLE
Fix capstone-wasm import in Ghidra app

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,15 +3,15 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import { capstone } from 'capstone-wasm';
+import { Capstone, Const, loadCapstone } from 'capstone-wasm';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
 async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
-  await capstone.loadCapstone();
-  return capstone;
+  await loadCapstone();
+  return { Capstone, Const };
 }
 
 // Disassembly data is now loaded from pre-generated JSON


### PR DESCRIPTION
## Summary
- load capstone-wasm using its exported `loadCapstone` function and expose `Capstone`/`Const`

## Testing
- `npm test` *(fails: KismetApp › steps through sample capture frames)*
- `npx jest __tests__/kismet.test.tsx` *(fails: unable to find button `load sample`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3491338f8832882b53985d2557fab