### PR TITLE
fix: output gamepad util to expected path

### DIFF
--- a/tsconfig.gamepad.json
+++ b/tsconfig.gamepad.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": false,
     "allowJs": false,
     "tsBuildInfoFile": "./dist/tsconfig.gamepad.tsbuildinfo"
 


### PR DESCRIPTION
## Summary
- ensure gamepad util compiles to dist/utils

## Testing
- `yarn prebuild`
- `node -e "const fs=require('fs');fs.mkdirSync('public/vendor',{recursive:true});fs.copyFileSync('dist/utils/gamepad.js','public/vendor/gamepad.js');console.log('copy success');"`


------
https://chatgpt.com/codex/tasks/task_e_68b34c3583988328ab50b7a55d541046