### PR TITLE
Ensure gamepad file is built and copied correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "copy:gamepad": "node -e \"const fs=require('fs');fs.mkdirSync('public/vendor',{recursive:true});fs.copyFileSync('dist/utils/gamepad.js','public/vendor/gamepad.js')\"",
     "dev": "next dev",
-    "build": "next build && yarn build:sw",
-    "postbuild": "node -e \"const fs=require('fs');fs.mkdirSync('public/vendor',{recursive:true});fs.copyFileSync('dist/utils/gamepad.js','public/vendor/gamepad.js')\"",
+    "build": "yarn build:gamepad && next build && yarn build:sw && yarn copy:gamepad",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build && yarn build:sw",
     "test": "jest",

--- a/tsconfig.gamepad.json
+++ b/tsconfig.gamepad.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "./dist",
+    "rootDir": ".",
     "allowJs": false,
     "tsBuildInfoFile": "./dist/tsconfig.gamepad.tsbuildinfo"
 


### PR DESCRIPTION
## Summary
- preserve utils directory when compiling gamepad script
- ensure gamepad helper is generated and copied as part of build

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68b34b7bb8b88328b675e4fdade02781