### PR TITLE
chore: ensure gamepad build preserves directory structure

### DIFF
--- a/tsconfig.gamepad.json
+++ b/tsconfig.gamepad.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "./dist",
+    "rootDir": ".",
     "allowJs": false,
     "tsBuildInfoFile": "./dist/tsconfig.gamepad.tsbuildinfo"
 


### PR DESCRIPTION
## Summary
- set `rootDir` in `tsconfig.gamepad.json` so `gamepad.ts` builds into `dist/utils`

## Testing
- `yarn prebuild`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b34cdde6b083288c93c650254cd397