### PR TITLE
chore: document provider flag import

### DIFF
--- a/pages/api/vercel/flags.ts
+++ b/pages/api/vercel/flags.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { verifyAccess, type ApiData } from 'flags';
 import { getProviderData } from 'flags/next';
+// Feature flag definitions used by the provider
 import * as appFlags from '../../../app-flags';
 
 export const config = { runtime: 'edge' };


### PR DESCRIPTION
## Summary
- document feature flag definitions import in Vercel flags API handler

## Testing
- `npm test` *(fails: __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b34fff2b108328a132c2f3a7c9ebc5