### PR TITLE
ci: run lint before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn lint
-      - run: yarn build
+      - name: Lint
+        run: yarn lint
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary
- run lint before building in CI

## Testing
- `timeout 100s yarn lint` *(fails: 45 problems including 7 errors and 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3527894e8832895e0220471b1f810