### PR TITLE
Add jsconfig for @ path alias support

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  }
+}


### PR DESCRIPTION
## Summary
- add jsconfig.json to expose `@/` path alias for JavaScript files

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68b366896a088328a7eafd51a6980e95