### PR TITLE
Remove obsolete flags rewrite

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -134,14 +134,6 @@ module.exports = withBundleAnalyzer({
             },
           ];
         },
-        async rewrites() {
-          return [
-            {
-              source: '/.well-known/vercel/flags',
-              destination: '/api/vercel/flags',
-            },
-          ];
-        },
       }),
 });
 


### PR DESCRIPTION
## Summary
- remove unused Vercel flags rewrite from `next.config.js`

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*
- `yarn lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b36688793083288dfc28e19cf202ae