### PR TITLE
docs: update Node.js version to 20.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Always test inside controlled labs and obtain written permission before performi
 ## Quick Start
 
 ### Requirements
-- **Node.js 22.x** (repo includes `.nvmrc`; run `nvm use`)
+- **Node.js 20.x** (repo includes `.nvmrc`; run `nvm use`)
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
 ### Install & Run (Dev)
 ```bash
-nvm install  # installs Node 22 from .nvmrc if needed
+nvm install  # installs Node 20 from .nvmrc if needed
 nvm use
 yarn install
 yarn dev
@@ -241,7 +241,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 ### Static export (GitHub Pages)
 Workflow: `.github/workflows/gh-deploy.yml`:
  - Installs Node, runs `yarn export`, adds `.nojekyll`, and deploys `./out` → `gh-pages` branch.
- - Uses **Node 22.x** to match `package.json`.
+ - Uses **Node 20.x** to match `package.json`.
 - Required env variables (GitHub Secrets):
   - `NEXT_PUBLIC_TRACKING_ID`
   - `NEXT_PUBLIC_SERVICE_ID`
@@ -455,7 +455,7 @@ play/pause and track controls include keyboard hotkeys.
 
 ## Production Hardening Checklist
 
-- [x] **Pin Node to 22.x** across runtime and CI.
+- [x] **Pin Node to 20.x** across runtime and CI.
 - [ ] **Tighten CSP** (`connect-src`, `frame-src`, remove `http:` and `'unsafe-inline'`).
 - [ ] **Set env vars** in the hosting platform; rotate EmailJS keys regularly.
 - [ ] **Disable/flag API demo routes** for production or protect behind feature flags.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "analyze": "ANALYZE=true yarn build"
   },
   "engines": {
-    "node": "22.x"
+    "node": "20.x"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",


### PR DESCRIPTION
## Summary
- pin Node.js engine to 20.x
- update documentation to reference Node.js 20

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: unable to find "load sample" button in `kismet.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3668181308328bded8ccd0cfac078