### PR TITLE
refactor: convert api routes to js

### DIFF
--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -1,10 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { serviceClient } from '../../../lib/service-client';
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+/**
+ * Retrieve recent contact messages (admin only).
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
@@ -26,7 +27,7 @@ export default async function handler(
       throw error;
     }
     res.status(200).json({ messages: data });
-  } catch (err: any) {
+  } catch (err) {
     res.status(500).json({ error: err.message });
   }
 }

--- a/pages/api/dummy.js
+++ b/pages/api/dummy.js
@@ -1,0 +1,12 @@
+/**
+ * Simple dummy endpoint for testing.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(req, res) {
+  if (req.method === 'POST') {
+    res.status(200).json({ message: 'Received' });
+  } else {
+    res.status(405).json({ message: 'Method not allowed' });
+  }
+}

--- a/pages/api/dummy.ts
+++ b/pages/api/dummy.ts
@@ -1,9 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'POST') {
-    res.status(200).json({ message: 'Received' });
-  } else {
-    res.status(405).json({ message: 'Method not allowed' });
-  }
-}

--- a/pages/api/figlet/fonts.js
+++ b/pages/api/figlet/fonts.js
@@ -1,10 +1,14 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+/**
+ * Serve figlet fonts bundled with the app.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(req, res) {
   const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
-  let fonts: { name: string; data: string }[] = [];
+  let fonts = [];
   try {
     const files = fs.readdirSync(fontsDir).filter((f) => f.toLowerCase().endsWith('.flf'));
     fonts = files.map((file) => ({

--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -1,26 +1,25 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
-
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
+/**
+ * Submit a leaderboard entry.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     res.status(405).end('Method Not Allowed');
     return;
   }
 
-  const { game, username, score } = req.body as {
-    game?: string;
-    username?: string;
-    score?: number;
-  };
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    res.status(500).json({ error: 'Missing Supabase env' });
+    return;
+  }
+
+  const { game, username, score } = req.body || {};
 
   if (
     typeof game !== 'string' ||
@@ -31,6 +30,7 @@ export default async function handler(
     return;
   }
 
+  const supabase = createClient(url, key);
   const { error } = await supabase
     .from('leaderboard')
     .insert({ game, username: username.slice(0, 50), score });

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -1,24 +1,28 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-);
-
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
+/**
+ * Retrieve top leaderboard scores.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     res.status(405).end('Method Not Allowed');
     return;
   }
 
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    res.status(500).json({ error: 'Missing Supabase env' });
+    return;
+  }
+
   const game = typeof req.query.game === 'string' ? req.query.game : '2048';
   const limit = Number(req.query.limit ?? 10);
 
+  const supabase = createClient(url, key);
   const { data, error } = await supabase
     .from('leaderboard')
     .select('username, score, game')

--- a/pages/api/modules/update.js
+++ b/pages/api/modules/update.js
@@ -1,10 +1,15 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import versionData from '../../../data/module-version.json';
 
 const REMOTE_VERSION_URL =
   'https://raw.githubusercontent.com/unnipillil/kali-linux-portfolio/main/data/module-version.json';
 
-function compareSemver(a: string, b: string): number {
+/**
+ * Compare two semantic version strings.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number} positive if a>b, negative if a<b, 0 if equal
+ */
+function compareSemver(a, b) {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
@@ -14,10 +19,12 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
+/**
+ * Check if the client needs a module version update.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
   const currentParam = req.query.version;
   const current = Array.isArray(currentParam)
     ? currentParam[0]
@@ -29,7 +36,7 @@ export default async function handler(
       headers: { 'User-Agent': 'kali-linux-portfolio' },
     });
     if (response.ok) {
-      const json = (await response.json()) as { version?: string };
+      const json = await response.json();
       if (json.version) {
         latest = json.version;
       }

--- a/pages/api/nse/update.js
+++ b/pages/api/nse/update.js
@@ -1,16 +1,16 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-interface VersionInfo {
-  sha: string;
-}
-
-export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+/**
+ * Check for updates to the Nmap script database.
+ * @param {import('next').NextApiRequest} _req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(_req, res) {
   try {
     const versionPath = path.join(process.cwd(), 'public', 'demo-data', 'nmap', 'script-db-version.json');
     const raw = await readFile(versionPath, 'utf8');
-    const { sha: current } = JSON.parse(raw) as VersionInfo;
+    const { sha: current } = JSON.parse(raw);
 
     const apiUrl = 'https://api.github.com/repos/nmap/nmap/commits?path=scripts/script.db&per_page=1';
     const response = await fetch(apiUrl, {

--- a/pages/api/pacman/leaderboard.js
+++ b/pages/api/pacman/leaderboard.js
@@ -1,27 +1,21 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
-
-interface Entry {
-  name: string;
-  score: number;
-}
 
 const filePath = path.join(process.cwd(), 'data', 'pacman-leaderboard.json');
 const MAX_ENTRIES = 10;
 
-function readBoard(): Entry[] {
+function readBoard() {
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const data = JSON.parse(raw);
-    if (Array.isArray(data)) return data as Entry[];
+    if (Array.isArray(data)) return data;
     return [];
   } catch {
     return [];
   }
 }
 
-function writeBoard(board: Entry[]): void {
+function writeBoard(board) {
   try {
     fs.writeFileSync(filePath, JSON.stringify(board, null, 2));
   } catch {
@@ -29,17 +23,19 @@ function writeBoard(board: Entry[]): void {
   }
 }
 
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Entry[]>,
-) {
+/**
+ * Handle leaderboard retrieval and submission for Pacman game.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(req, res) {
   if (req.method === 'GET') {
     res.status(200).json(readBoard());
     return;
   }
 
   if (req.method === 'POST') {
-    const { name, score } = req.body as Partial<Entry>;
+    const { name, score } = req.body || {};
     if (typeof name !== 'string' || typeof score !== 'number') {
       res.status(400).json(readBoard());
       return;

--- a/pages/api/plugins/[name].js
+++ b/pages/api/plugins/[name].js
@@ -1,8 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+/**
+ * Serve an individual plugin file from the catalog.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(req, res) {
   const { name } = req.query;
   const filename = Array.isArray(name) ? name.join('/') : name;
   const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');

--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -1,8 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+/**
+ * List available plugin catalog entries.
+ * @param {import('next').NextApiRequest} _req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(_req, res) {
   const catalogDir = path.join(process.cwd(), 'plugins', 'catalog');
   try {
     const files = fs.readdirSync(catalogDir);

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -1,10 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import { createClient } from "@supabase/supabase-js";
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
+/**
+ * Record application events in Supabase.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default async function handler(req, res) {
   if (req.method !== "POST") {
     res.status(405).json({ ok: false });
     return;

--- a/pages/api/vercel/flags.js
+++ b/pages/api/vercel/flags.js
@@ -1,18 +1,21 @@
-import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { verifyAccess, type ApiData } from 'flags';
+import { verifyAccess } from 'flags';
 import { getProviderData } from 'flags/next';
 // Feature flag definitions used by the provider
 import * as appFlags from '../../../app-flags';
 
 export const config = { runtime: 'edge' };
 
-export default async function handler(request: NextRequest) {
+/**
+ * Serve feature flag configuration for Vercel's toolbar.
+ * @param {import('next/server').NextRequest} request
+ */
+export default async function handler(request) {
   const authorized = await verifyAccess(request.headers.get('authorization'));
   if (!authorized) {
     return NextResponse.json(null, { status: 401 });
   }
-  const data = (await getProviderData(appFlags)) as ApiData;
+  const data = await getProviderData(appFlags);
   return NextResponse.json(data);
 
 }

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -1,8 +1,12 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse<string[]>) {
+/**
+ * Return available wallpaper filenames.
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+export default function handler(req, res) {
   const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
   try {
     const files = fs


### PR DESCRIPTION
## Summary
- convert Next.js API routes from TypeScript to JavaScript
- remove unused imports and types
- add basic JSDoc comments for clarity

## Testing
- `npx eslint pages/api --max-warnings=0`
- `yarn test` *(fails: Unable to find accessible element in kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3668566d48328b47d71b45f8cc3cf