### PR TITLE
Revert homepage and style tokens to baseline

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,19 +1,14 @@
 import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
-import BetaBadge from '../components/BetaBadge';
 
 /**
  * @returns {JSX.Element}
  */
 const App = () => (
   <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
     <Meta />
     <Ubuntu />
-    <BetaBadge />
     <InstallButton />
   </>
 );

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,19 +1,10 @@
 @import './globals.css';
 
-html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
-}
-
 body{
     font-family: var(--font-family-base);
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
-}
-
-button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
-    min-width: var(--hit-area);
-    min-height: var(--hit-area);
 }
 
 a:focus-visible,
@@ -25,15 +16,15 @@ button:focus-visible {
 /* Top NavBar styling */
 
 .top-arrow-up {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-muted);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid var(--color-muted);
 }
 
 .arrow-custom {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-text);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid var(--color-text);
 }
 
 .animateShow {
@@ -80,30 +71,30 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* Window's styling */
 .arrow-custom-up {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-text);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-down {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-start: 5px solid var(--color-text);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-left {
-    border-block-end: 5px solid transparent;
-    border-block-start: 5px solid transparent;
-    border-inline-end: 5px solid var(--color-text);
+    border-bottom: 5px solid transparent;
+    border-top: 5px solid transparent;
+    border-right: 5px solid var(--color-text);
     width: 0;
 }
 
 .arrow-custom-right {
-    border-block-start: 5px solid transparent;
-    border-block-end: 5px solid transparent;
-    border-inline-start: 5px solid var(--color-text);
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid var(--color-text);
     width: 0;
 }
 
@@ -154,10 +145,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     }
 }
 
-.windowMainScreen {
-    container-type: inline-size;
-}
-
 .windowMainScreen::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
     background-color: transparent;
@@ -197,19 +184,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .xterm .xterm-cursor {
     animation: cursor-pulse 1s steps(2) infinite;
-}
-
-/* High contrast handling for precipitation text */
-.precip-text {
-    color: #0ea5e9;
-}
-
-@media (prefers-contrast: more), (forced-colors: active) {
-    .precip-text {
-        color: #000;
-        background-color: #fff;
-        padding-inline: 2px;
-    }
 }
 
 @keyframes cursor-pulse {
@@ -342,7 +316,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     justify-content: center;
     border: 2px solid var(--color-inverse);
     position: absolute;
-    inset-inline-start: 0;
+    left: 0;
     transition: transform 0.3s;
 }
 
@@ -385,23 +359,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     100% { transform: translateX(0); }
 }
 
-/* Context Menu & Panels */
-.context-menu-bg,
-.windowMainScreen {
-    background-color: rgba(43, 43, 43, 0.85); /* Fallback for unsupported browsers */
-}
-
-@supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
-    .context-menu-bg,
-    .windowMainScreen {
-        -webkit-backdrop-filter: blur(10px);
-        backdrop-filter: blur(10px);
-        background-color: rgba(43, 43, 43, 0.4);
-    }
+/* Context Menu */
+.context-menu-bg {
+    background-color: rgb(43, 43, 43);
 }
 
 .emoji-list>li {
-    padding-inline-start: 10px;
+    padding-left: 10px;
 }
 
 .list-pc {
@@ -513,12 +477,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     display: inline-block;
 }
 
-/* Highlight currently selected cells in word search */
-.selection {
-    /* amber tone for colorblind-safe contrast */
-    background-color: #fbbf24;
-}
-
 /* Ensure monospace layout for app outputs */
 textarea,
 pre {
@@ -531,13 +489,4 @@ button:focus-visible,
 textarea:focus-visible {
     outline: 2px solid #3B82F6;
     outline-offset: 2px;
-}
-
-/* Enable scroll snapping for gallery containers */
-.gallery-container {
-    scroll-snap-type: x mandatory;
-}
-
-.gallery-container > * {
-    scroll-snap-align: start;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -47,9 +47,6 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
-  --font-multiplier: 1;
-  /* Minimum interactive target size */
-  --hit-area: 32px;
 }
 
 /* High contrast theme */
@@ -68,11 +65,6 @@
 /* Dyslexia-friendly fonts */
 .dyslexia {
   --font-family-base: 'OpenDyslexic', 'Comic Sans MS', Arial, sans-serif;
-}
-
-/* Larger hit areas */
-.large-hit-area {
-  --hit-area: 48px;
 }
 
 /* Reduced motion */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,8 @@
 module.exports = {
   mode: 'jit',
-  content: [
-    './pages/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
-    './apps/**/*.{js,ts,jsx,tsx}',
-    './hooks/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      screens: {
-        '3xl': '1920px',
-      },
       colors: {
         'ub-grey': 'var(--color-ub-grey)',
         'ub-warm-grey': 'var(--color-ub-warm-grey)',
@@ -53,18 +45,6 @@ module.exports = {
       },
       zIndex: {
         '-10': '-10',
-      },
-      width: {
-        'app-icon': '64px',
-        'app-icon-lg': '96px',
-        'tray-icon': '16px',
-        'tray-icon-lg': '32px',
-      },
-      height: {
-        'app-icon': '64px',
-        'app-icon-lg': '96px',
-        'tray-icon': '16px',
-        'tray-icon-lg': '32px',
       },
       keyframes: {
         glow: {


### PR DESCRIPTION
## Summary
- restore homepage to earlier version without BetaBadge or skip link
- reset design tokens, index styles, and Tailwind config to commit `cba8492d`

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: Unable to find button "load sample" in kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a72fdc4c832881ee35071100b294