### PR TITLE
Add case study page template with side rail navigation

### DIFF
--- a/data/case-studies/example-project.json
+++ b/data/case-studies/example-project.json
@@ -1,0 +1,27 @@
+{
+  "slug": "example-project",
+  "title": "Example Project",
+  "role": "Lead Developer",
+  "timeframe": "Jan 2024 - Mar 2024",
+  "outcomes": ["Improved performance by 30%", "Reduced costs"],
+  "cta": { "label": "View Project", "href": "https://example.com" },
+  "facts": [
+    { "label": "Team", "value": "5 engineers" },
+    { "label": "Platform", "value": "Web" }
+  ],
+  "problem": {
+    "content": "We needed to modernize an aging system to support new business goals.",
+    "callouts": [
+      { "type": "info", "text": "Legacy technology slowed development." }
+    ]
+  },
+  "approach": {
+    "content": "We adopted a modular architecture and incremental migration strategy."
+  },
+  "results": {
+    "content": "Deployment frequency increased and performance improved."
+  },
+  "lessons": {
+    "content": "Start migrations early and communicate often."
+  }
+}

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks the section id currently intersecting the viewport.
+ * Useful for updating navigation state based on scroll position.
+ */
+export default function useIntersectionObserver(ids: string[]) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const elements = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => Boolean(el));
+
+    if (elements.length === 0) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setActiveId(ids[0] ?? null);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: '-50% 0px -50% 0px' },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [ids]);
+
+  return activeId;
+}

--- a/pages/case-studies/[slug].tsx
+++ b/pages/case-studies/[slug].tsx
@@ -1,0 +1,161 @@
+import fs from 'fs';
+import path from 'path';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import useIntersectionObserver from '../../hooks/useIntersectionObserver';
+import { useMemo } from 'react';
+
+interface Callout {
+  type?: 'info' | 'warning' | 'success';
+  text: string;
+}
+
+interface Section {
+  content: string;
+  callouts?: Callout[];
+}
+
+interface CaseStudy {
+  slug: string;
+  title: string;
+  role: string;
+  timeframe: string;
+  outcomes: string[];
+  cta: { label: string; href: string };
+  facts?: { label: string; value: string }[];
+  problem: Section;
+  approach: Section;
+  results: Section;
+  lessons: Section;
+}
+
+const CalloutBlock = ({ type = 'info', children }: { type?: Callout['type']; children: React.ReactNode }) => {
+  const style = {
+    info: 'border-blue-500 bg-blue-50 text-blue-800',
+    warning: 'border-yellow-500 bg-yellow-50 text-yellow-800',
+    success: 'border-green-500 bg-green-50 text-green-800',
+  }[type];
+  return <div className={`my-4 border-l-4 p-4 ${style}`}>{children}</div>;
+};
+
+export default function CaseStudyPage({ caseStudy }: { caseStudy: CaseStudy }) {
+  const sectionIds = useMemo(() => ['problem', 'approach', 'results', 'lessons'], []);
+  const activeId = useIntersectionObserver(sectionIds);
+
+  return (
+    <div className="max-w-7xl mx-auto flex">
+      <aside className="hidden lg:block w-64 mr-8">
+        <div className="sticky top-24 space-y-8">
+          <div>
+            <h3 className="text-sm font-semibold mb-2">Quick Facts</h3>
+            <dl className="text-sm space-y-1">
+              <div>
+                <dt className="font-medium">Role</dt>
+                <dd>{caseStudy.role}</dd>
+              </div>
+              <div>
+                <dt className="font-medium">Timeframe</dt>
+                <dd>{caseStudy.timeframe}</dd>
+              </div>
+              {caseStudy.facts?.map((fact) => (
+                <div key={fact.label}>
+                  <dt className="font-medium">{fact.label}</dt>
+                  <dd>{fact.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+          <nav>
+            <h3 className="text-sm font-semibold mb-2">Jump to</h3>
+            <ul className="space-y-1 text-sm">
+              {sectionIds.map((id) => (
+                <li key={id}>
+                  <a
+                    href={`#${id}`}
+                    className={
+                      activeId === id
+                        ? 'text-[var(--color-primary)] font-semibold'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }
+                  >
+                    {id.charAt(0).toUpperCase() + id.slice(1)}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </aside>
+      <main className="flex-1">
+        <header className="py-12" id="hero">
+          <h1 className="text-4xl font-bold mb-4">{caseStudy.title}</h1>
+          <p className="mb-1"><strong>Role:</strong> {caseStudy.role}</p>
+          <p className="mb-4"><strong>Timeframe:</strong> {caseStudy.timeframe}</p>
+          <ul className="list-disc ml-6 mb-6">
+            {caseStudy.outcomes.map((o) => (
+              <li key={o}>{o}</li>
+            ))}
+          </ul>
+          <a
+            href={caseStudy.cta.href}
+            className="inline-block px-6 py-3 bg-[var(--color-primary)] text-white rounded"
+          >
+            {caseStudy.cta.label}
+          </a>
+        </header>
+        <section id="problem" className="py-8">
+          <h2 className="text-2xl font-semibold mb-4">Problem</h2>
+          <p>{caseStudy.problem.content}</p>
+          {caseStudy.problem.callouts?.map((c, i) => (
+            <CalloutBlock key={i} type={c.type}>
+              {c.text}
+            </CalloutBlock>
+          ))}
+        </section>
+        <section id="approach" className="py-8">
+          <h2 className="text-2xl font-semibold mb-4">Approach</h2>
+          <p>{caseStudy.approach.content}</p>
+          {caseStudy.approach.callouts?.map((c, i) => (
+            <CalloutBlock key={i} type={c.type}>
+              {c.text}
+            </CalloutBlock>
+          ))}
+        </section>
+        <section id="results" className="py-8">
+          <h2 className="text-2xl font-semibold mb-4">Results</h2>
+          <p>{caseStudy.results.content}</p>
+          {caseStudy.results.callouts?.map((c, i) => (
+            <CalloutBlock key={i} type={c.type}>
+              {c.text}
+            </CalloutBlock>
+          ))}
+        </section>
+        <section id="lessons" className="py-8">
+          <h2 className="text-2xl font-semibold mb-4">Lessons</h2>
+          <p>{caseStudy.lessons.content}</p>
+          {caseStudy.lessons.callouts?.map((c, i) => (
+            <CalloutBlock key={i} type={c.type}>
+              {c.text}
+            </CalloutBlock>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const dir = path.join(process.cwd(), 'data', 'case-studies');
+  const files = fs.readdirSync(dir);
+  const paths = files.map((file) => ({ params: { slug: file.replace(/\.json$/, '') } }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = params?.slug as string;
+  const file = fs.readFileSync(
+    path.join(process.cwd(), 'data', 'case-studies', `${slug}.json`),
+    'utf-8',
+  );
+  const caseStudy = JSON.parse(file);
+  return { props: { caseStudy } };
+};


### PR DESCRIPTION
## Summary
- add dynamic case study page with hero, structured sections, callouts, and side rail quick facts
- implement `useIntersectionObserver` hook to track active section for jump links
- provide example case study data

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test` *(fails: Unable to find button in kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d00b1ec8328bb3f19bd7b0a655d