### PR TITLE
feat: add project comparison page

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -3,6 +3,7 @@
     "id": 1,
     "title": "Alpha",
     "description": "Example project Alpha",
+    "goals": "Demonstrate Alpha capabilities",
     "stack": ["JS"],
     "tags": ["frontend", "react"],
     "year": 2021,
@@ -11,12 +12,14 @@
     "repo": "https://example.com/alpha",
     "demo": "https://example.com/alpha-demo",
     "snippet": "console.log('Alpha');",
-    "language": "javascript"
+    "language": "javascript",
+    "results": "Delivered Alpha demo"
   },
   {
     "id": 2,
     "title": "Beta",
     "description": "Example project Beta",
+    "goals": "Illustrate Beta workflow",
     "stack": ["TS"],
     "tags": ["backend"],
     "year": 2022,
@@ -25,6 +28,7 @@
     "repo": "https://example.com/beta",
     "demo": "https://example.com/beta-demo",
     "snippet": "console.log('Beta');",
-    "language": "typescript"
+    "language": "typescript",
+    "results": "Released Beta prototype"
   }
 ]

--- a/pages/projects/compare.tsx
+++ b/pages/projects/compare.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+import projectsData from '../../data/projects.json';
+
+interface Project {
+  id: number;
+  title: string;
+  goals: string;
+  stack: string[];
+  results: string;
+}
+
+export default function CompareProjects() {
+  const router = useRouter();
+  const [selected, setSelected] = useState<number[]>([]);
+
+  // initialize from query string
+  useEffect(() => {
+    if (!router.isReady) return;
+    const { ids } = router.query;
+    if (typeof ids === 'string') {
+      const parsed = ids
+        .split(',')
+        .map((i) => parseInt(i, 10))
+        .filter((n) => !isNaN(n))
+        .slice(0, 3);
+      setSelected(parsed);
+    }
+  }, [router.isReady, router.query]);
+
+  // encode selection in query string
+  useEffect(() => {
+    const query = selected.length ? { ids: selected.join(',') } : {};
+    router.replace({ pathname: router.pathname, query }, undefined, {
+      shallow: true,
+    });
+  }, [router, selected]);
+
+  const toggle = (id: number) => {
+    setSelected((prev) => {
+      if (prev.includes(id)) {
+        return prev.filter((p) => p !== id);
+      }
+      if (prev.length >= 3) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const allProjects = projectsData as Project[];
+  const projects = useMemo(
+    () => allProjects.filter((p) => selected.includes(p.id)),
+    [allProjects, selected],
+  );
+
+  return (
+    <div className="p-4 space-y-4 text-black">
+      <h1 className="text-2xl font-bold">Compare Projects</h1>
+      <p>Select up to three projects to compare.</p>
+      <div className="flex flex-wrap gap-2">
+        {allProjects.map((p) => {
+          const checked = selected.includes(p.id);
+          const disabled = !checked && selected.length >= 3;
+          return (
+            <label key={p.id} className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => toggle(p.id)}
+              />
+              {p.title}
+            </label>
+          );
+        })}
+      </div>
+      {projects.length > 0 && (
+        <div className="overflow-auto">
+          <table className="min-w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="sticky top-0 bg-gray-200 p-2 text-left">Category</th>
+                {projects.map((p) => (
+                  <th
+                    key={p.id}
+                    className="sticky top-0 bg-gray-200 p-2"
+                  >
+                    <a
+                      href={`/projects/${p.id}`}
+                      className="text-blue-600 underline"
+                    >
+                      {p.title}
+                    </a>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th className="sticky left-0 bg-gray-100 p-2 text-left">Goals</th>
+                {projects.map((p) => (
+                  <td key={p.id} className="border p-2 align-top">
+                    {p.goals}
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <th className="sticky left-0 bg-gray-100 p-2 text-left">Stack</th>
+                {projects.map((p) => (
+                  <td key={p.id} className="border p-2 align-top">
+                    {p.stack.join(', ')}
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <th className="sticky left-0 bg-gray-100 p-2 text-left">Results</th>
+                {projects.map((p) => (
+                  <td key={p.id} className="border p-2 align-top">
+                    {p.results}
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/public/projects.json
+++ b/public/projects.json
@@ -3,6 +3,7 @@
     "id": 1,
     "title": "Alpha",
     "description": "Example project Alpha",
+    "goals": "Demonstrate Alpha capabilities",
     "stack": ["JS"],
     "tags": ["frontend", "react"],
     "year": 2021,
@@ -11,12 +12,14 @@
     "repo": "https://example.com/alpha",
     "demo": "https://example.com/alpha-demo",
     "snippet": "console.log('Alpha');",
-    "language": "javascript"
+    "language": "javascript",
+    "results": "Delivered Alpha demo"
   },
   {
     "id": 2,
     "title": "Beta",
     "description": "Example project Beta",
+    "goals": "Illustrate Beta workflow",
     "stack": ["TS"],
     "tags": ["backend"],
     "year": 2022,
@@ -25,6 +28,7 @@
     "repo": "https://example.com/beta",
     "demo": "https://example.com/beta-demo",
     "snippet": "console.log('Beta');",
-    "language": "typescript"
+    "language": "typescript",
+    "results": "Released Beta prototype"
   }
 ]

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -4,6 +4,7 @@ const ASSETS = [
   '/feeds',
   '/about',
   '/projects',
+  '/projects/compare',
   '/projects.json',
   '/apps',
   '/apps/weather',

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -4,6 +4,7 @@ const ASSETS = [
   '/feeds',
   '/about',
   '/projects',
+  '/projects/compare',
   '/projects.json',
   '/apps',
   '/apps/weather',


### PR DESCRIPTION
## Summary
- add interactive project comparison page supporting up to 3 selections
- extend project data with goals and results fields
- cache new page in service worker

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i` in __tests__/kismet.test.tsx)*
- `npx eslint pages/projects/compare.tsx workers/service-worker.js public/workers/service-worker.js data/projects.json public/projects.json`


------
https://chatgpt.com/codex/tasks/task_e_68b48d05dca883288d4605549f7b480f