### PR TITLE
feat: add SkillsMap with legend and proof links

### DIFF
--- a/__tests__/SkillsMap.test.tsx
+++ b/__tests__/SkillsMap.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import SkillsMap, { SkillGroup } from "../components/SkillsMap";
+
+describe("SkillsMap", () => {
+  const groups: SkillGroup[] = [
+    {
+      name: "Languages",
+      skills: [
+        {
+          name: "JavaScript",
+          level: "expert",
+          proof: [{ label: "repo", url: "https://example.com/repo" }],
+        },
+      ],
+    },
+  ];
+
+  it("shows legend and reveals proof links on click", () => {
+    render(<SkillsMap groups={groups} />);
+
+    expect(screen.getByText(/expert/i)).toBeInTheDocument();
+    const skill = screen.getByText("JavaScript");
+    fireEvent.click(skill);
+    expect(screen.getByRole("link", { name: /repo/i })).toBeInTheDocument();
+  });
+});

--- a/components/SkillsMap/index.tsx
+++ b/components/SkillsMap/index.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+export interface ProofLink {
+  label: string;
+  url: string;
+}
+
+export interface Skill {
+  name: string;
+  level: "beginner" | "intermediate" | "expert";
+  proof?: ProofLink[];
+}
+
+export interface SkillGroup {
+  name: string;
+  description?: string;
+  skills: Skill[];
+}
+
+interface SkillsMapProps {
+  groups: SkillGroup[];
+  layout?: "matrix";
+}
+
+const levelColors: Record<Skill["level"], string> = {
+  beginner: "var(--color-ubt-blue)",
+  intermediate: "var(--color-ubt-gedit-orange)",
+  expert: "var(--color-ubt-green)",
+};
+
+export default function SkillsMap({
+  groups,
+  layout = "matrix",
+}: SkillsMapProps) {
+  const [openSkill, setOpenSkill] = useState<string | null>(null);
+
+  if (layout !== "matrix") {
+    console.warn("Only matrix layout is currently implemented.");
+  }
+
+  return (
+    <div>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {groups.map((group) => (
+          <div
+            key={group.name}
+            className="border rounded p-4"
+            title={group.description || group.name}
+          >
+            <h3 className="font-bold mb-2">{group.name}</h3>
+            <ul className="space-y-1">
+              {group.skills.map((skill) => {
+                const color = levelColors[skill.level];
+                const isOpen = openSkill === skill.name;
+                return (
+                  <li key={skill.name}>
+                    <button
+                      onClick={() => setOpenSkill(isOpen ? null : skill.name)}
+                      className="flex items-center gap-2 focus:outline-none underline-offset-2 hover:underline"
+                    >
+                      <span
+                        className="w-3 h-3 rounded-full"
+                        style={{ backgroundColor: color }}
+                        aria-label={`${skill.level} proficiency`}
+                      />
+                      <span className="text-left">{skill.name}</span>
+                    </button>
+                    {isOpen && skill.proof && (
+                      <ul className="ml-5 mt-1 list-disc">
+                        {skill.proof.map((p) => (
+                          <li key={p.url}>
+                            <a
+                              href={p.url}
+                              className="underline text-blue-400"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {p.label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex gap-4" aria-label="Skill proficiency legend">
+        {Object.entries(levelColors).map(([level, color]) => (
+          <div key={level} className="flex items-center gap-1">
+            <span
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span className="text-sm capitalize">{level}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add matrix-based SkillsMap component with group tooltips
- encode skill levels with legend and accessible color tokens
- enable click-to-reveal proof links for each skill

## Testing
- `npx eslint components/SkillsMap/index.tsx __tests__/SkillsMap.test.tsx`
- `yarn test __tests__/SkillsMap.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b48d0626ac832883c3cb83240beb6b