### PR TITLE
Add print stylesheet and PDF export button

### DIFF
--- a/components/DownloadPdfButton.jsx
+++ b/components/DownloadPdfButton.jsx
@@ -1,0 +1,11 @@
+export default function DownloadPdfButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      className="no-print fixed top-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
+    >
+      Download as PDF
+    </button>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import DownloadPdfButton from '../components/DownloadPdfButton';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
@@ -127,6 +128,10 @@ function MyApp(props) {
   return (
     <SettingsProvider>
       <PipPortalProvider>
+        <header className="print-header">
+          Kali Linux Portfolio
+        </header>
+        <DownloadPdfButton />
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
         <ShortcutOverlay />

--- a/styles/print.css
+++ b/styles/print.css
@@ -1,15 +1,67 @@
+/* Hide print header during screen view */
+.print-header {
+  display: none;
+}
+
 @media print {
   @page {
     margin: 1in;
+    size: A4;
+    @top-center {
+      content: element(page-header);
+    }
   }
+
   body {
     background: white;
     color: black;
+    font-size: 12pt;
+    line-height: 1.5;
+    -webkit-print-color-adjust: exact;
   }
+
+  h1 {
+    font-size: 24pt;
+  }
+
+  h2 {
+    font-size: 18pt;
+  }
+
+  h3 {
+    font-size: 14pt;
+  }
+
+  h4 {
+    font-size: 12pt;
+  }
+
+  h5 {
+    font-size: 10pt;
+  }
+
+  h6 {
+    font-size: 9pt;
+  }
+
+  .print-header {
+    display: block;
+    text-align: center;
+    font-size: 16pt;
+    font-weight: 700;
+    position: running(page-header);
+  }
+
   .no-print {
     display: none !important;
   }
+
+  .page-break {
+    break-after: page;
+  }
+
+  .avoid-break,
   .timeline-item {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 }


### PR DESCRIPTION
## Summary
- add comprehensive print stylesheet with margins, typography scale, and repeated headers
- render persistent print header and 'Download as PDF' button
- include utility classes for page breaking in print media

## Testing
- `npm test` *(fails: Unable to find element by role "button" and name `/load sample/i` in __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d06f4a08328b51f00e9454630de