### PR TITLE
Add sitemap footer with contact links and availability info

### DIFF
--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import React from 'react';
+
+const SiteFooter: React.FC = () => {
+  return (
+    <footer className="mt-8 p-4 text-center text-gray-300 bg-gray-900 border-t border-gray-700" aria-label="Footer">
+      <nav aria-label="Sitemap" className="mb-3">
+        <ul className="flex flex-wrap justify-center gap-4">
+          <li>
+            <Link href="/apps" title="Browse desktop apps" aria-label="Browse desktop apps">
+              Apps
+            </Link>
+          </li>
+          <li>
+            <Link href="/games" title="Play classic games" aria-label="Play classic games">
+              Games
+            </Link>
+          </li>
+          <li>
+            <Link href="/profile" title="Read more about me" aria-label="Read more about me">
+              Profile
+            </Link>
+          </li>
+          <li>
+            <Link href="/apps/contact" title="Send a message" aria-label="Send a message">
+              Contact
+            </Link>
+          </li>
+        </ul>
+      </nav>
+      <nav aria-label="Social links" className="mb-3">
+        <ul className="flex justify-center gap-4">
+          <li>
+            <a
+              href="https://github.com/Alex-Unnippillil"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="GitHub profile"
+              aria-label="GitHub profile"
+            >
+              GitHub
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.linkedin.com/in/alexunnippillil"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="LinkedIn profile"
+              aria-label="LinkedIn profile"
+            >
+              LinkedIn
+            </a>
+          </li>
+          <li>
+            <a href="mailto:alex@unnippillil.com" title="Send email" aria-label="Send email">
+              Email
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <p className="mb-2 text-sm">
+        📍 Toronto, Canada (UTC-5) — <span className="italic">available 09:00–17:00 ET</span>
+      </p>
+      <p className="text-xs text-gray-400">
+        Thanks for visiting! Reach out if you have questions or would like to collaborate.
+      </p>
+    </footer>
+  );
+};
+
+export default SiteFooter;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,6 +2,7 @@ import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
 import BetaBadge from '../components/BetaBadge';
+import SiteFooter from '../components/SiteFooter';
 
 /**
  * @returns {JSX.Element}
@@ -15,6 +16,7 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <SiteFooter />
   </>
 );
 


### PR DESCRIPTION
## Summary
- add accessible `SiteFooter` with sitemap for apps, games, profile and contact
- surface social profiles and email with descriptive titles and aria labels
- show location, timezone, and availability hint at page end

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*
- `npx eslint components/SiteFooter.tsx pages/index.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68b48d096198832890d725f7752bc759