### PR TITLE
Add testimonial components and pages

### DIFF
--- a/components/testimonials/TestimonialCard.tsx
+++ b/components/testimonials/TestimonialCard.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Testimonial } from '@/data/testimonials';
+
+interface Props {
+  testimonial: Testimonial;
+}
+
+export default function TestimonialCard({ testimonial }: Props) {
+  return (
+    <Link
+      href={`/testimonials/${testimonial.id}`}
+      className="block border rounded-lg p-4 hover:bg-gray-50 focus:outline-none"
+    >
+      <div className="flex items-center gap-4">
+        <Image
+          src={testimonial.avatar}
+          alt={`${testimonial.name} avatar`}
+          width={64}
+          height={64}
+          className="rounded-full"
+        />
+        <div>
+          <p className="font-semibold">{testimonial.name}</p>
+          <p className="text-sm text-gray-600">{testimonial.role}</p>
+          <span className="mt-1 inline-block rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700">
+            {testimonial.relationship}
+          </span>
+        </div>
+      </div>
+      <p className="mt-3 text-sm text-gray-700">{testimonial.snippet}</p>
+      {testimonial.source && (
+        <p className="mt-3 text-xs text-blue-600 underline">Source verified</p>
+      )}
+    </Link>
+  );
+}

--- a/data/testimonials.ts
+++ b/data/testimonials.ts
@@ -1,0 +1,45 @@
+export interface Testimonial {
+  id: string;
+  name: string;
+  role: string;
+  relationship: string;
+  avatar: string;
+  snippet: string;
+  content: string;
+  pullQuote: string;
+  source?: {
+    url: string;
+    label: string;
+  };
+}
+
+export const testimonials: Testimonial[] = [
+  {
+    id: 'jane-doe',
+    name: 'Jane Doe',
+    role: 'CTO, ACME Corp',
+    relationship: 'Former Manager',
+    avatar: 'https://avatars.githubusercontent.com/u/583231?v=4',
+    snippet: 'Kali consistently delivered high-quality security insights.',
+    content:
+      'Kali consistently delivered high-quality security insights and took initiative to strengthen our infrastructure. Their blend of curiosity and accountability made them a pivotal team member during critical projects.',
+    pullQuote:
+      '“Kali’s blend of curiosity and accountability strengthened our infrastructure.”',
+    source: {
+      url: 'https://www.linkedin.com/in/janedoe',
+      label: 'LinkedIn',
+    },
+  },
+  {
+    id: 'john-smith',
+    name: 'John Smith',
+    role: 'Security Researcher, Example Labs',
+    relationship: 'Conference Peer',
+    avatar: 'https://avatars.githubusercontent.com/u/9919?v=4',
+    snippet: 'I met Kali at DEF CON where their demo stood out.',
+    content:
+      'I met Kali at DEF CON where their demo stood out for clarity and impact. They made complex exploit chains understandable for newcomers and veterans alike.',
+    pullQuote:
+      '“Their DEF CON demo made complex exploit chains understandable.”',
+  },
+];

--- a/pages/testimonials/[id].tsx
+++ b/pages/testimonials/[id].tsx
@@ -1,0 +1,62 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { testimonials, Testimonial } from '@/data/testimonials';
+
+interface Props {
+  testimonial: Testimonial;
+}
+
+export default function TestimonialDetail({ testimonial }: Props) {
+  return (
+    <main className="min-h-screen bg-gray-100 p-4">
+      <Link href="/testimonials" className="text-sm text-blue-600">
+        &larr; Back
+      </Link>
+      <div className="mt-4 flex items-center gap-4">
+        <Image
+          src={testimonial.avatar}
+          alt={`${testimonial.name} avatar`}
+          width={80}
+          height={80}
+          className="rounded-full"
+        />
+        <div>
+          <h2 className="text-xl font-semibold">{testimonial.name}</h2>
+          <p className="text-sm text-gray-600">{testimonial.role}</p>
+          <span className="mt-1 inline-block rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700">
+            {testimonial.relationship}
+          </span>
+        </div>
+      </div>
+      <blockquote className="mt-6 border-l-4 border-blue-500 pl-4 italic text-lg">
+        {testimonial.pullQuote}
+      </blockquote>
+      <p className="mt-4 whitespace-pre-line">{testimonial.content}</p>
+      {testimonial.source && (
+        <p className="mt-6 text-sm">
+          Source:{' '}
+          <a
+            href={testimonial.source.url}
+            className="text-blue-600 underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {testimonial.source.label}
+          </a>
+        </p>
+      )}
+    </main>
+  );
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: testimonials.map((t) => ({ params: { id: t.id } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }: { params: { id: string } }) {
+  const testimonial = testimonials.find((t) => t.id === params.id);
+  return { props: { testimonial } };
+}

--- a/pages/testimonials/index.tsx
+++ b/pages/testimonials/index.tsx
@@ -1,0 +1,15 @@
+import TestimonialCard from '@/components/testimonials/TestimonialCard';
+import { testimonials } from '@/data/testimonials';
+
+export default function TestimonialsPage() {
+  return (
+    <main className="min-h-screen bg-gray-100 p-4">
+      <h1 className="mb-4 text-2xl">Testimonials</h1>
+      <div className="grid gap-4">
+        {testimonials.map((t) => (
+          <TestimonialCard key={t.id} testimonial={t} />
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce testimonial dataset for reusable social proof content
- add card component showing avatar, role, and relationship
- create testimonial pages with long-form view, pull quotes, and optional source link

## Testing
- `yarn lint` (fails: 7 errors, 38 warnings)
- `yarn test` (fails: __tests__/kismet.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b48d09faf0832889db4bbfb002d4a1