### PR TITLE
feat: add grouped client logos

### DIFF
--- a/components/ClientLogos/index.tsx
+++ b/components/ClientLogos/index.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from 'react';
+
+interface Logo {
+  src: string;
+  alt: string;
+}
+
+interface LogoGroup {
+  title: string;
+  logos: Logo[];
+}
+
+const logoGroups: LogoGroup[] = [
+  {
+    title: 'Security',
+    logos: [
+      { src: '/images/client-logos/security.svg', alt: 'Security Corp' },
+      { src: '/images/client-logos/devops.svg', alt: 'DevOps Services' }
+    ]
+  },
+  {
+    title: 'Finance',
+    logos: [
+      { src: '/images/client-logos/finance.svg', alt: 'Finance Inc' },
+      { src: '/images/client-logos/analytics.svg', alt: 'Analytics LLC' }
+    ]
+  }
+];
+
+const ClientLogos: React.FC = () => {
+  return (
+    <div className="space-y-8">
+      {logoGroups.map(group => (
+        <section key={group.title}>
+          <h3 className="text-center font-semibold mb-4">{group.title}</h3>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 place-items-center">
+            {group.logos.map(logo => (
+              <img
+                key={logo.alt}
+                src={logo.src}
+                alt={logo.alt}
+                className="h-12 w-auto filter grayscale hover:grayscale-0 transition"
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+};
+
+export default ClientLogos;

--- a/docs/client-logos.md
+++ b/docs/client-logos.md
@@ -1,0 +1,11 @@
+# Client Logo Guidelines
+
+To keep the client logo wall consistent and accessible:
+
+- Provide logos as SVG or high-resolution PNG assets.
+- Logos render in grayscale by default and reveal full color on hover.
+- Maintain each logo's original aspect ratio. Set only the height and allow the width to scale automatically.
+- Avoid stretching or distorting logos; whitespace trimming is acceptable but do not alter shapes.
+- Ensure logos remain legible on small screens; the component limits logos to a 3rem height and uses a responsive grid.
+
+Use the `ClientLogos` component to display grouped logos by industry or project type while honoring these guidelines.

--- a/public/images/client-logos/analytics.svg
+++ b/public/images/client-logos/analytics.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,10 90,90 10,90" fill="#f97316"/>
+</svg>

--- a/public/images/client-logos/devops.svg
+++ b/public/images/client-logos/devops.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="20" y="20" width="60" height="60" fill="#8b5cf6"/>
+</svg>

--- a/public/images/client-logos/finance.svg
+++ b/public/images/client-logos/finance.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path d="M20 80 L50 20 L80 80 Z" fill="#10b981"/>
+</svg>

--- a/public/images/client-logos/security.svg
+++ b/public/images/client-logos/security.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#3b82f6"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `ClientLogos` component with grouped industry logos and monochrome hover effect
- document logo usage guidelines to avoid distortion
- include placeholder SVG assets for sample industries

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: KismetApp cannot find 'load sample' button)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d0ac75083288d53f51e8d5f7818