### PR TITLE
feat: add flexible code block component

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,3 +522,26 @@ The calculator supports a subset of math.js expressions with the following featu
 
 Invalid syntax is highlighted in the calculator input, selecting the character where parsing failed.
 
+
+## CodeBlock Component
+
+The `CodeBlock` component automatically detects languages using `highlight.js` but accepts a `language` prop for manual override. Lines can be emphasized via the `highlight` prop, and multiple files can be displayed within tabs:
+
+```jsx
+<CodeBlock
+  files=[
+    {
+      name: "server.js",
+      code: "console.log('hi')\nconst x = 1",
+      language: "javascript",
+      highlight: [2]
+    },
+    {
+      name: "README.md",
+      code: "# Hello"
+    }
+  ]
+/>
+```
+
+The active tab's code is highlighted and line numbers supplied in `highlight` receive a subtle background for quick focus.

--- a/__tests__/CodeBlock.test.tsx
+++ b/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import CodeBlock from "../components/CodeBlock";
+
+jest.mock("highlight.js", () => ({
+  highlight: jest.fn((code: string) => ({ value: code })),
+  highlightAuto: jest.fn((code: string) => ({ value: code })),
+}));
+
+const hljs = require("highlight.js");
+
+test("uses manual language override", () => {
+  render(<CodeBlock code="console.log('hi')" language="javascript" />);
+  expect(hljs.highlight).toHaveBeenCalledWith("console.log('hi')", {
+    language: "javascript",
+  });
+});
+
+test("auto-detects language", () => {
+  render(<CodeBlock code="console.log('hi')" />);
+  expect(hljs.highlightAuto).toHaveBeenCalledWith("console.log('hi')");
+});
+
+test("highlights specified lines", () => {
+  const { container } = render(
+    <CodeBlock code={`a\nb\nc`} highlight={[2]} />
+  );
+  const lines = container.querySelectorAll("pre > div");
+  expect(lines[1].className).toMatch("bg-yellow-800/40");
+});
+
+test("renders tabs for multiple files", () => {
+  render(
+    <CodeBlock
+      files={[
+        { name: "a.txt", code: "one" },
+        { name: "b.txt", code: "two" },
+      ]}
+    />
+  );
+  // initial file
+  expect(screen.getByText("one")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("tab", { name: "b.txt" }));
+  expect(screen.getByText("two")).toBeInTheDocument();
+});

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import hljs from "highlight.js";
+import "highlight.js/styles/github-dark.css";
+import Tabs from "./Tabs";
+
+interface CodeFile {
+  name: string;
+  code: string;
+  language?: string;
+  highlight?: number[];
+}
+
+interface CodeBlockProps {
+  code?: string;
+  language?: string;
+  highlight?: number[];
+  files?: CodeFile[];
+}
+
+function renderHighlighted(
+  code: string,
+  language?: string,
+  highlight: number[] = []
+) {
+  const result = language
+    ? hljs.highlight(code, { language }).value
+    : hljs.highlightAuto(code).value;
+
+  const lines = result.split(/\r?\n/);
+  return (
+    <pre className="bg-gray-900 text-gray-100 text-sm rounded overflow-auto">
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          className={`px-4 py-0.5 whitespace-pre ${
+            highlight.includes(i + 1) ? "bg-yellow-800/40" : ""
+          }`}
+          dangerouslySetInnerHTML={{ __html: line || "&nbsp;" }}
+        />
+      ))}
+    </pre>
+  );
+}
+
+export default function CodeBlock({
+  code = "",
+  language,
+  highlight = [],
+  files,
+}: CodeBlockProps) {
+  const [active, setActive] = useState(files ? files[0].name : "");
+
+  if (files && files.length > 0) {
+    const activeFile = files.find((f) => f.name === active) || files[0];
+    const tabs = files.map((f) => ({ id: f.name, label: f.name }));
+    return (
+      <div>
+        <Tabs tabs={tabs} active={activeFile.name} onChange={setActive} />
+        {renderHighlighted(
+          activeFile.code,
+          activeFile.language || language,
+          activeFile.highlight || highlight
+        )}
+      </div>
+    );
+  }
+
+  return renderHighlighted(code, language, highlight);
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
     "hash-wasm": "^4.12.0",
+    "highlight.js": "^11.11.1",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,6 +6083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"highlight.js@npm:^11.11.1":
+  version: 11.11.1
+  resolution: "highlight.js@npm:11.11.1"
+  checksum: 10c0/40f53ac19dac079891fcefd5bd8a21cf2e8931fd47da5bd1dca73b7e4375c1defed0636fc39120c639b9c44119b7d110f7f0c15aa899557a5a1c8910f3c0144c
+  languageName: node
+  linkType: hard
+
 "hoopy@npm:^0.1.4":
   version: 0.1.4
   resolution: "hoopy@npm:0.1.4"
@@ -10893,6 +10900,7 @@ __metadata:
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
     hash-wasm: "npm:^4.12.0"
+    highlight.js: "npm:^11.11.1"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
     html2canvas: "npm:^1.4.1"


### PR DESCRIPTION
## Summary
- add CodeBlock component with auto language detection and overrides
- support line highlighting and tabbed multi-file examples
- document CodeBlock usage in README

## Testing
- `yarn lint` *(fails: Component definition is missing display name, Do not mutate state directly, etc.)*
- `yarn test __tests__/CodeBlock.test.tsx`
- `yarn test` *(fails: __tests__/kismet.test.tsx: Unable to find element with role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d0cac8c83288fcab6cbe47d8add