### PR TITLE
feat: improve typography readability

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './typography.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,0 +1,51 @@
+/* Typography settings */
+:root {
+  /* Modular scale ratio and steps */
+  --ratio: 1.25;
+  --step-0: 1rem;
+  --step-1: calc(var(--step-0) * var(--ratio));
+  --step-2: calc(var(--step-1) * var(--ratio));
+  --step-3: calc(var(--step-2) * var(--ratio));
+  --step-4: calc(var(--step-3) * var(--ratio));
+  /* Comfortable reading measure */
+  --max-line-length: 65ch;
+}
+
+/* Fluid heading sizes */
+h1 {
+  font-size: clamp(var(--step-3), 5vw, var(--step-4));
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: clamp(var(--step-2), 4vw, var(--step-3));
+  line-height: 1.2;
+}
+
+h3 {
+  font-size: clamp(var(--step-1), 3vw, var(--step-2));
+  line-height: 1.3;
+}
+
+h4 {
+  font-size: clamp(var(--step-0), 2.5vw, var(--step-1));
+  line-height: 1.4;
+}
+
+/* Text blocks */
+p {
+  max-inline-size: var(--max-line-length);
+  margin-block: var(--space-4);
+  hanging-punctuation: first;
+}
+
+ul,
+ol {
+  margin-block: var(--space-4);
+  padding-inline-start: var(--space-5);
+}
+
+li {
+  margin-block: var(--space-2);
+  hanging-punctuation: first;
+}


### PR DESCRIPTION
## Summary
- add modular scale and measure tokens
- implement fluid heading sizes with `clamp`
- refine paragraph and list spacing for better long-form readability

## Testing
- `npx eslint styles/index.css styles/typography.css`
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d102dc4832888d77ff943e0c7ab