### PR TITLE
Add CTA components and sticky action bar

### DIFF
--- a/components/CTAButton.tsx
+++ b/components/CTAButton.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { trackEvent } from '@/lib/analytics-client';
+
+interface Props {
+  location?: string;
+}
+
+const VARIANTS = ['Install Now', 'Get Started'];
+
+const CTAButton: React.FC<Props> = ({ location = 'default' }) => {
+  const [label, setLabel] = useState(VARIANTS[0]);
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview') {
+      setLabel(Math.random() < 0.5 ? VARIANTS[0] : VARIANTS[1]);
+    }
+  }, []);
+
+  const handleClick = () => {
+    trackEvent('cta_click', { location });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="bg-ubt-blue text-white px-4 py-2 rounded shadow focus:outline-none focus:ring-2 focus:ring-white"
+    >
+      {label}
+    </button>
+  );
+};
+
+export default CTAButton;

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import modulesData from '../data/module-index.json';
 import versionInfo from '../data/module-version.json';
+import CTAButton from './CTAButton';
 
 interface Module {
   id: string;
@@ -352,6 +353,9 @@ const PopularModules: React.FC = () => {
       ) : (
         <p>Select a module to view logs and results.</p>
       )}
+      <div className="flex justify-center mt-8">
+        <CTAButton location="popular-modules-end" />
+      </div>
     </div>
   );
 };

--- a/components/StickyActionBar.tsx
+++ b/components/StickyActionBar.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import CTAButton from './CTAButton';
+
+const StickyActionBar: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const isLong = document.body.scrollHeight > window.innerHeight * 1.5;
+      if (!isLong) {
+        setVisible(false);
+        return;
+      }
+      setVisible(window.scrollY > 300);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-ubt-blue/90 p-3 flex justify-center z-50">
+      <CTAButton location="sticky-bar" />
+    </div>
+  );
+};
+
+export default StickyActionBar;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import StickyActionBar from '../components/StickyActionBar';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
@@ -129,6 +130,7 @@ function MyApp(props) {
       <PipPortalProvider>
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
+        <StickyActionBar />
         <ShortcutOverlay />
         <Analytics
           beforeSend={(e) => {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,6 +2,7 @@ import Ubuntu from '../components/ubuntu';
 import Meta from '../components/SEO/Meta';
 import InstallButton from '../components/InstallButton';
 import BetaBadge from '../components/BetaBadge';
+import CTAButton from '../components/CTAButton';
 
 /**
  * @returns {JSX.Element}
@@ -12,6 +13,9 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
+    <div className="absolute top-4 left-1/2 -translate-x-1/2 z-50">
+      <CTAButton location="hero" />
+    </div>
     <Ubuntu />
     <BetaBadge />
     <InstallButton />


### PR DESCRIPTION
## Summary
- add reusable CTA button with preview-only A/B text
- show CTA in hero and at end of popular modules
- add sticky action bar that surfaces CTA on long pages

## Testing
- `yarn test` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i` in __tests__/kismet.test.tsx)*
- `yarn lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d15513c83289df982c32c4d584d