### PR TITLE
docs: add press kit with bios and media usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A desktop-style portfolio built with Next.js and Tailwind that emulates a Kali/Ubuntu UI with windows, a dock, context menus, and a rich catalog of **security-tool simulations**, **utilities**, and **retro games**. This README is tailored for a professional full-stack engineer preparing **production deployment** and ongoing maintenance.
 
 > Repo homepage: https://unnippillil.com/
+> Press kit: [docs/press-kit.md](./docs/press-kit.md)
 
 ---
 

--- a/docs/press-kit.md
+++ b/docs/press-kit.md
@@ -1,0 +1,52 @@
+# Press Kit
+
+This kit provides media-ready bios, images, and talking points for covering the Kali Linux Portfolio project by Alex Unnippillil.
+
+## Bios
+
+### Tagline
+Alex Unnippillil builds playful security-tool simulations and retro games inside a Kali-themed web desktop.
+
+### Short Bio (\~50 words)
+Alex Unnippillil is a full-stack developer and security enthusiast who created the Kali Linux Portfolio—a browser-based desktop that mimics a Kali/Ubuntu interface. The project showcases safe simulations of popular security utilities alongside classic games, blending education and nostalgia.
+
+### Medium Bio (\~100 words)
+Alex Unnippillil is a developer focused on demystifying cybersecurity through approachable software. His Kali Linux Portfolio reimagines the Kali desktop in the browser with draggable windows, a dock, and a catalog of security-tool simulations that are strictly non-operational. The site doubles as an arcade, featuring retro titles and gamepad support. Alex shares his work openly, encouraging learners to explore defensive and offensive concepts in a safe environment while enjoying modern web capabilities such as PWAs and offline caching.
+
+### Long Bio (\~200 words)
+Alex Unnippillil is a full-stack engineer with a passion for making security concepts accessible. Drawing on years of tinkering with penetration-testing distributions, he built the Kali Linux Portfolio to resemble a familiar desktop environment where curious minds can poke around without risk. Each simulated tool— from Nmap to Wireshark—renders canned output and interactive interfaces, guiding visitors through typical workflows while emphasizing legal and ethical boundaries. Beyond security demonstrations, the portfolio hosts a growing library of mini-games, multimedia experiments, and utilities that showcase the flexibility of modern web APIs. Alex aims to bridge the gap between curiosity and capability by delivering technical depth through approachable design, giving educators and newcomers a safe space to learn.
+
+## Headshots & Logos
+
+| Asset | Path | Usage Rules |
+| --- | --- | --- |
+| Headshot (PNG) | `/public/images/logos/bitmoji.png` | May be cropped or resized. Do not alter colors or add filters. Credit “Alex Unnippillil” when used. |
+| Logo (PNG) | `/public/images/logos/logo.png` | Maintain original colors and aspect ratio. Clear space equal to 10% of logo width on all sides. |
+| Logo 1024px (PNG) | `/public/images/logos/logo_1024.png` | For print or high-res displays. Same rules as standard logo. |
+| Logo 1200px (PNG) | `/public/images/logos/logo_1200.png` | For large-format use. Same rules as standard logo. |
+
+## Sample Q&A
+
+**Q:** What is the goal of the Kali Linux Portfolio?
+
+**A:** To offer a safe, educational environment where visitors can explore simulated security tools and enjoy retro games inside a web-based Kali-style desktop.
+
+**Q:** Can the tools execute real attacks?
+
+**A:** No. All tools are client-side simulations that use canned data. They are intended strictly for learning and demonstration.
+
+**Q:** How can others contribute?
+
+**A:** Contributions are welcome via GitHub. Bug reports, feature ideas, and pull requests help grow the catalog of simulations and games.
+
+## Notable Highlights
+
+- 20+ security-tool simulations with interactive UIs.
+- Retro game library with gamepad support.
+- Offline-capable PWA and share-target integration.
+- Accessible design with keyboard navigation and screen-reader labels.
+
+## Attribution & Contact
+
+Assets and bios provided here may be used for editorial coverage without additional permission. For follow-up inquiries, please reference this document before reaching out; all necessary assets and information are provided so articles can be assembled without additional questions.
+


### PR DESCRIPTION
## Summary
- add press kit with multiple bio lengths
- document headshot/logo assets and usage rules
- link README to press-kit resources

## Testing
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with the role "button" and name `/load sample/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d196f2c83288ccd01019608174c