### PR TITLE
docs: add centralized brand guidelines and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,3 +522,7 @@ The calculator supports a subset of math.js expressions with the following featu
 
 Invalid syntax is highlighted in the calculator input, selecting the character where parsing failed.
 
+
+## Brand Guidelines
+
+See [docs/brand-guidelines.md](docs/brand-guidelines.md) for color tokens, typography, icon usage examples, downloadable assets, and do/don't guidance.

--- a/docs/brand-guidelines.md
+++ b/docs/brand-guidelines.md
@@ -1,0 +1,52 @@
+# Brand Guidelines
+
+Centralized instructions for applying project branding.
+
+## Color Tokens
+
+Use the following CSS variables defined in `styles/tokens.css` for consistent theming:
+
+| Token | Variable | Example |
+| --- | --- | --- |
+| `ub-grey` | `--color-ub-grey` | `#0f1317` |
+| `ub-orange` | `--color-ub-orange` | `#1793d1` |
+| `ubt-blue` | `--color-ubt-blue` | `#62A0EA` |
+| `ubt-green` | `--color-ubt-green` | `#73D216` |
+
+## Typography
+
+The primary typeface is Ubuntu:
+
+```html
+<p class="font-ubuntu text-ub-grey">Sample text</p>
+```
+
+## Icon Usage
+
+Reference icons with the `img` element and Tailwind sizing utilities:
+
+```html
+<img src="/brand/logo-v1.svg" alt="Project logo" class="w-8 h-8" />
+```
+
+## Do & Don't
+
+![Do: use the supplied logo without changes](../public/brand/logo-v1.svg)
+
+![Don't: recolor or distort the logo](../public/brand/logo-dont.svg)
+
+## Downloadable Assets
+
+All brand assets live in `/public/brand`. Versioning metadata is provided in `assets.json`:
+
+```json
+{
+  "version": "1.0.0",
+  "assets": [
+    { "name": "logo", "file": "logo-v1.svg", "version": "1.0.0" },
+    { "name": "logo-misuse-example", "file": "logo-dont.svg", "version": "1.0.0" }
+  ]
+}
+```
+
+Use this single location to keep branding consistent across projects.

--- a/public/brand/assets.json
+++ b/public/brand/assets.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "assets": [
+    { "name": "logo", "file": "logo-v1.svg", "version": "1.0.0" },
+    { "name": "logo-misuse-example", "file": "logo-dont.svg", "version": "1.0.0" }
+  ]
+}

--- a/public/brand/logo-dont.svg
+++ b/public/brand/logo-dont.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#73D216"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#000000" font-family="Ubuntu" transform="scale(1.2,0.8)">UB</text>
+</svg>

--- a/public/brand/logo-v1.svg
+++ b/public/brand/logo-v1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#1793d1"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#ffffff" font-family="Ubuntu">UB</text>
+</svg>


### PR DESCRIPTION
## Summary
- document color tokens, typography, icon usage, and logo dos/don'ts
- publish downloadable brand assets with version metadata
- link brand guidelines from README

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test __tests__/kismet.test.tsx` *(fails: Unable to find an accessible element with role "button" and name /load sample/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d19f8cc8328a6344e14d136f430