### PR TITLE
Add custom 404 and 500 pages with support details

### DIFF
--- a/__tests__/errorPages.test.tsx
+++ b/__tests__/errorPages.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NotFound from '../pages/404';
+import ServerError from '../pages/500';
+
+describe('error pages', () => {
+  it('404 page provides navigation and details', () => {
+    render(<NotFound />);
+    expect(screen.getByRole('heading', { name: /Page not found/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Home/i })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /Projects/i })).toHaveAttribute('href', '/apps/project-gallery');
+    expect(screen.getByRole('link', { name: /Contact/i })).toHaveAttribute('href', '/apps/contact');
+    expect(screen.getByText(/Error ID:/)).toBeInTheDocument();
+  });
+
+  it('500 page provides navigation and details', () => {
+    render(<ServerError />);
+    expect(screen.getByRole('heading', { name: /Something went wrong/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Home/i })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /Projects/i })).toHaveAttribute('href', '/apps/project-gallery');
+    expect(screen.getByRole('link', { name: /Contact/i })).toHaveAttribute('href', '/apps/contact');
+    expect(screen.getByText(/Error ID:/)).toBeInTheDocument();
+  });
+});

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+const NotFound = () => {
+  const [errorId, setErrorId] = useState('');
+  const [timestamp, setTimestamp] = useState('');
+
+  useEffect(() => {
+    setErrorId(Math.random().toString(36).slice(2, 10));
+    setTimestamp(new Date().toLocaleString());
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center space-y-6">
+      <Image src="/images/errors/404.svg" alt="Not found" width={150} height={150} />
+      <h1 className="text-4xl font-bold">Page not found</h1>
+      <p className="text-gray-600">The page you&apos;re looking for doesn&apos;t exist.</p>
+      <nav className="space-x-4">
+        <Link href="/" className="text-blue-500 underline">Home</Link>
+        <Link href="/apps/project-gallery" className="text-blue-500 underline">Projects</Link>
+        <Link href="/apps/contact" className="text-blue-500 underline">Contact</Link>
+      </nav>
+      <p className="text-sm text-gray-500">Error ID: {errorId} • {timestamp}</p>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+const ServerError = () => {
+  const [errorId, setErrorId] = useState('');
+  const [timestamp, setTimestamp] = useState('');
+
+  useEffect(() => {
+    setErrorId(Math.random().toString(36).slice(2, 10));
+    setTimestamp(new Date().toLocaleString());
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center space-y-6">
+      <Image src="/images/errors/500.svg" alt="Server error" width={150} height={150} />
+      <h1 className="text-4xl font-bold">Something went wrong</h1>
+      <p className="text-gray-600">We&apos;re working to fix the problem.</p>
+      <nav className="space-x-4">
+        <Link href="/" className="text-blue-500 underline">Home</Link>
+        <Link href="/apps/project-gallery" className="text-blue-500 underline">Projects</Link>
+        <Link href="/apps/contact" className="text-blue-500 underline">Contact</Link>
+      </nav>
+      <p className="text-sm text-gray-500">Error ID: {errorId} • {timestamp}</p>
+    </div>
+  );
+};
+
+export default ServerError;

--- a/public/images/errors/404.svg
+++ b/public/images/errors/404.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 8c-8 0-14 6-14 14v26l4-4 4 4 4-4 4 4 4-4 4 4V22c0-8-6-14-14-14z" stroke="#94a3b8" stroke-width="2" fill="none"/>
+  <circle cx="26" cy="26" r="2" fill="#94a3b8"/>
+  <circle cx="38" cy="26" r="2" fill="#94a3b8"/>
+</svg>

--- a/public/images/errors/500.svg
+++ b/public/images/errors/500.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="30" stroke="#94a3b8" stroke-width="2"/>
+  <line x1="32" y1="18" x2="32" y2="38" stroke="#94a3b8" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="46" r="2" fill="#94a3b8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add friendly 404 and 500 error pages with navigation shortcuts
- include simple illustrations and runtime error identifiers
- test that error pages guide users back to home, projects, and contact

## Testing
- `yarn eslint pages/404.tsx pages/500.tsx __tests__/errorPages.test.tsx`
- `yarn test __tests__/errorPages.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b48d1cc50c83288d95aabf993b57c9