### PR TITLE
Add floating scroll navigation controls

### DIFF
--- a/components/ui/ScrollControls.tsx
+++ b/components/ui/ScrollControls.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+
+const selectors = 'main section[id], main h2[id], main h3[id]';
+
+export default function ScrollControls() {
+  const [show, setShow] = useState(false);
+  const [next, setNext] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const update = () => {
+      const scrollY = window.scrollY || document.documentElement.scrollTop;
+      setShow(scrollY > window.innerHeight);
+
+      const sections = Array.from(
+        document.querySelectorAll<HTMLElement>(selectors)
+      );
+      let candidate: HTMLElement | null = null;
+      for (const el of sections) {
+        const top = el.getBoundingClientRect().top + window.scrollY;
+        if (top > scrollY + 1) {
+          candidate = el;
+          break;
+        }
+      }
+      if (candidate) candidate.setAttribute('tabindex', '-1');
+      setNext(candidate);
+    };
+
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    return () => window.removeEventListener('scroll', update);
+  }, []);
+
+  const focusAfterScroll = (el: HTMLElement) => {
+    const handle = () => {
+      el.focus({ preventScroll: true });
+      window.removeEventListener('scrollend', handle);
+    };
+    if ('onscrollend' in window) {
+      window.addEventListener('scrollend', handle, { once: true });
+    } else {
+      setTimeout(handle, 500);
+    }
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    const main = document.querySelector('main');
+    if (main instanceof HTMLElement) {
+      main.setAttribute('tabindex', '-1');
+      focusAfterScroll(main);
+    }
+  };
+
+  const scrollToNext = () => {
+    if (!next) return;
+    next.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    focusAfterScroll(next);
+  };
+
+  if (!show) return null;
+
+  return (
+    <div
+      className="fixed flex flex-col gap-2 z-50"
+      style={{
+        right: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
+      }}
+    >
+      <button
+        onClick={scrollToTop}
+        aria-label="Back to top"
+        className="rounded bg-gray-900/80 p-2 text-white shadow"
+      >
+        ↑
+      </button>
+      {next && (
+        <button
+          onClick={scrollToNext}
+          aria-label="Next section"
+          className="rounded bg-gray-900/80 p-2 text-white shadow"
+        >
+          ↓
+        </button>
+      )}
+    </div>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import ScrollControls from '../components/ui/ScrollControls';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
@@ -130,6 +131,7 @@ function MyApp(props) {
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
         <ShortcutOverlay />
+        <ScrollControls />
         <Analytics
           beforeSend={(e) => {
             if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add edge-aware floating controls for back-to-top and next-section navigation
- enable smooth scrolling with focus handoff for effortless long-page navigation

## Testing
- `yarn lint` *(fails: process interrupted)*
- `yarn test` *(fails: __tests__/kismet.test.tsx cannot find "Load Sample" button)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d21700083289863c0e27aec5ba3