### PR TITLE
feat: add Figure component with attribution

### DIFF
--- a/__tests__/Figure.test.tsx
+++ b/__tests__/Figure.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Figure from '../components/Figure';
+
+test('renders caption, credit, license and learn more link', () => {
+  render(
+    <Figure
+      src="/test.png"
+      alt="test"
+      caption="A test image"
+      credit="Screenshot by Example"
+      license={{ name: 'CC BY', url: 'https://example.com/license' }}
+      learnMoreUrl="https://example.com/source"
+    />
+  );
+
+  expect(screen.getByText('A test image')).toBeInTheDocument();
+  expect(screen.getByText(/Screenshot by Example/)).toBeInTheDocument();
+  const licenseLink = screen.getByRole('link', { name: 'CC BY' });
+  expect(licenseLink).toHaveAttribute('href', 'https://example.com/license');
+  expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+    'href',
+    'https://example.com/source'
+  );
+});

--- a/components/Figure.tsx
+++ b/components/Figure.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+interface LicenseInfo {
+  name: string;
+  url?: string;
+}
+
+interface FigureProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  credit?: string;
+  license?: LicenseInfo;
+  learnMoreUrl?: string;
+  className?: string;
+}
+
+/**
+ * Renders an image with optional caption, credit line and license metadata.
+ * Use for screenshots or photos that require attribution.
+ */
+const Figure: React.FC<FigureProps> = ({
+  src,
+  alt,
+  caption,
+  credit,
+  license,
+  learnMoreUrl,
+  className = "",
+}) => {
+  return (
+    <figure className={className}>
+      <img src={src} alt={alt} />
+      {(caption || credit || license || learnMoreUrl) && (
+        <figcaption className="mt-2 text-sm text-center">
+          {caption && <span>{caption}</span>}
+          {(credit || license) && (
+            <span className="block text-gray-500">
+              {credit}
+              {credit && license ? " / " : ""}
+              {license && (
+                license.url ? (
+                  <a
+                    href={license.url}
+                    rel="license noopener noreferrer"
+                    target="_blank"
+                  >
+                    {license.name}
+                  </a>
+                ) : (
+                  license.name
+                )
+              )}
+            </span>
+          )}
+          {learnMoreUrl && (
+            <span className="block">
+              <a
+                href={learnMoreUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more
+              </a>
+            </span>
+          )}
+        </figcaption>
+      )}
+    </figure>
+  );
+};
+
+export default Figure;
+

--- a/docs/image-attribution.md
+++ b/docs/image-attribution.md
@@ -1,0 +1,29 @@
+# Image attribution guidelines
+
+Use the `Figure` component for screenshots and photos to keep visual content informative and correctly attributed.
+
+## Credit line patterns
+
+- **Screenshots:** `Screenshot of <software/tool> by <source> (<license>)`
+- **Photos:** `Photo by <photographer> via <source> (<license>)`
+
+Include an optional "Learn more" link when additional context or the original source should be referenced.
+
+Each figure should provide:
+
+- Descriptive alt text
+- A caption if helpful
+- Credit and license information
+
+Example:
+
+```tsx
+<Figure
+  src="/img/example.png"
+  alt="Example output"
+  caption="Example output from the tool"
+  credit="Screenshot by Offensive Security"
+  license={{ name: "CC BY 4.0", url: "https://creativecommons.org/licenses/by/4.0/" }}
+  learnMoreUrl="https://example.com/source"
+/>
+```


### PR DESCRIPTION
## Summary
- add Figure component with caption, credit and license link support
- document patterns for screenshot and photo credits with optional source link

## Testing
- `npx eslint components/Figure.tsx __tests__/Figure.test.tsx`
- `yarn test __tests__/Figure.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b48d21e1d88328a9373983524902be