### PR TITLE
Add comfortable reading mode styles

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -9,6 +9,11 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    line-height: var(--line-height-base);
+    letter-spacing: var(--letter-spacing-base);
+    word-spacing: var(--word-spacing-base);
+    text-align: var(--text-align-base);
+    hyphens: var(--hyphenation);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
@@ -540,4 +545,14 @@ textarea:focus-visible {
 
 .gallery-container > * {
     scroll-snap-align: start;
+}
+
+/* Comfortable reading mode styles */
+.reading-mode a {
+    text-decoration: underline;
+}
+
+.reading-mode em,
+.reading-mode i {
+    font-style: normal;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -48,6 +48,11 @@
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
+  --line-height-base: 1.5;
+  --letter-spacing-base: normal;
+  --word-spacing-base: normal;
+  --text-align-base: start;
+  --hyphenation: auto;
   /* Minimum interactive target size */
   --hit-area: 32px;
 }
@@ -68,6 +73,16 @@
 /* Dyslexia-friendly fonts */
 .dyslexia {
   --font-family-base: 'OpenDyslexic', 'Comic Sans MS', Arial, sans-serif;
+}
+
+/* Comfortable reading preset */
+.reading-mode {
+  --font-family-base: 'Merriweather', Georgia, serif;
+  --line-height-base: 1.6;
+  --letter-spacing-base: 0.02em;
+  --word-spacing-base: 0.05em;
+  --text-align-base: start;
+  --hyphenation: manual;
 }
 
 /* Larger hit areas */


### PR DESCRIPTION
## Summary
- add CSS variables and .reading-mode preset for comfortable reading fonts and spacing
- underline links and remove italics in reading mode
- expose base typography variables for easier customization

## Testing
- `yarn lint` *(fails: component definition is missing display name, etc.)*
- `yarn test` *(fails: __tests__/kismet.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d233c0c8328a5d5476d7a52b1d1