### PR TITLE
feat: add accessibility quick settings

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState.js';
-import { useEffect } from 'react';
+import { useEffect, ChangeEvent } from 'react';
 
 interface Props {
   open: boolean;
@@ -12,6 +12,10 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [textSize, setTextSize] = usePersistentState('qs-text-size', 'medium');
+  const [spacing, setSpacing] = usePersistentState('qs-spacing', 'normal');
+  const [contrast, setContrast] = usePersistentState('qs-contrast', false);
+  const [dyslexic, setDyslexic] = usePersistentState('qs-dyslexic-font', false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +24,24 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('text-size-small', 'text-size-medium', 'text-size-large');
+    root.classList.add(`text-size-${textSize}`);
+  }, [textSize]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('spacing-relaxed', spacing === 'relaxed');
+  }, [spacing]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('high-contrast', contrast);
+  }, [contrast]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dyslexia-font', dyslexic);
+  }, [dyslexic]);
 
   return (
     <div
@@ -43,6 +65,35 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Text size</span>
+        <select
+          value={textSize}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => setTextSize(e.target.value)}
+        >
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </select>
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Spacing</span>
+        <select
+          value={spacing}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => setSpacing(e.target.value)}
+        >
+          <option value="normal">Normal</option>
+          <option value="relaxed">Relaxed</option>
+        </select>
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>High contrast</span>
+        <input type="checkbox" checked={contrast} onChange={() => setContrast(!contrast)} />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Dyslexia font</span>
+        <input type="checkbox" checked={dyslexic} onChange={() => setDyslexic(!dyslexic)} />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import url('https://fonts.cdnfonts.com/css/open-dyslexic');
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
@@ -16,4 +17,30 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
+}
+
+html.text-size-small {
+  font-size: 14px;
+}
+
+html.text-size-medium {
+  font-size: 16px;
+}
+
+html.text-size-large {
+  font-size: 20px;
+}
+
+html.spacing-relaxed body {
+  line-height: 1.75;
+  letter-spacing: 0.05em;
+}
+
+html.high-contrast {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+}
+
+html.dyslexia-font {
+  font-family: 'OpenDyslexic', system-ui, sans-serif;
 }


### PR DESCRIPTION
## Summary
- add quick settings controls for text size, spacing, high contrast, and dyslexia-friendly font
- store accessibility preferences in localStorage and apply them globally
- define CSS classes for font scale, spacing, contrast, and dyslexia font

## Testing
- `yarn lint components/ui/QuickSettings.tsx styles/globals.css` *(fails: 7 errors, 39 warnings)*
- `yarn test` *(fails: kismet.test.tsx no button named "load sample")*

------
https://chatgpt.com/codex/tasks/task_e_68b48d22855c83288c0c0590b866f5b3