### PR TITLE
Enhance design tokens and illustration guidelines

### DIFF
--- a/docs/illustration-style-guide.md
+++ b/docs/illustration-style-guide.md
@@ -1,0 +1,21 @@
+# Illustration Style Guide
+
+This guide defines visual rules for illustrations and icons so that all assets feel cohesive.
+
+## Color palette
+Use the color tokens defined in `styles/tokens.css`:
+
+- Backgrounds: `--color-bg`
+- Text: `--color-text`
+- Accent: `--color-ub-orange`
+
+Limit palettes to these tokens and their accessible variants to maintain a unified look.
+
+## Line work
+- Apply stroke weights using the design tokens `--stroke-thin`, `--stroke-medium`, and `--stroke-thick`.
+- Corners should use radius tokens like `--radius-sm`, `--radius-md`, and `--radius-lg`.
+
+## Icon and text sizing
+Icons scale with text. Use the icon size tokens (`--icon-xs` … `--icon-xl`) that map directly to text sizes (`--text-xs` … `--text-xl`).
+
+Following these guidelines keeps illustrations, icons, and typography aligned across the project.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -34,11 +34,30 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
+  /* Typography scale */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.25rem;
+  --text-xl: 1.5rem;
+
+  /* Icon sizes mapped to typography */
+  --icon-xs: var(--text-xs);
+  --icon-sm: var(--text-sm);
+  --icon-md: var(--text-md);
+  --icon-lg: var(--text-lg);
+  --icon-xl: var(--text-xl);
+
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;
   --radius-lg: 8px;
   --radius-round: 9999px;
+
+  /* Stroke weights */
+  --stroke-thin: 1px;
+  --stroke-medium: 2px;
+  --stroke-thick: 3px;
 
   /* Motion durations */
   --motion-fast: 150ms;


### PR DESCRIPTION
## Summary
- map icon sizes to text sizes in design tokens
- add stroke weight tokens and document corner radii
- document illustration style guide with color and sizing rules

## Testing
- `yarn test` *(fails: KismetApp › steps through sample capture frames)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d259fb483288b08133390d49b72