### PR TITLE
Add skeleton loading with friendly network messaging

### DIFF
--- a/components/LoadingSkeleton.tsx
+++ b/components/LoadingSkeleton.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+
+export default function LoadingSkeleton() {
+  const [showMessage, setShowMessage] = useState(false);
+  const [showSpinner, setShowSpinner] = useState(false);
+
+  useEffect(() => {
+    const msg = setTimeout(() => setShowMessage(true), 2000);
+    const spin = setTimeout(() => setShowSpinner(true), 5000);
+    return () => {
+      clearTimeout(msg);
+      clearTimeout(spin);
+    };
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4" role="status" aria-live="polite">
+      <div className="animate-pulse space-y-2">
+        <div className="h-6 bg-gray-200 rounded w-1/2" />
+        <div className="h-4 bg-gray-200 rounded w-full" />
+        <div className="h-4 bg-gray-200 rounded w-5/6" />
+      </div>
+      {showMessage && (
+        <p className="text-sm text-gray-500">
+          Still loading—thanks for your patience.
+        </p>
+      )}
+      {showSpinner && (
+        <div className="flex items-center space-x-2 text-sm text-gray-500">
+          <div className="w-4 h-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          <span>Almost there…</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/apps/2048.jsx
+++ b/pages/apps/2048.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Page2048 = dynamic(() => import('../../apps/2048'), {
+const Page2048 = dynamic(() => import('@/apps/2048'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default Page2048;

--- a/pages/apps/ascii-art.jsx
+++ b/pages/apps/ascii-art.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const AsciiArt = dynamic(() => import('../../apps/ascii-art'), {
+const AsciiArt = dynamic(() => import('@/apps/ascii-art'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default AsciiArt;

--- a/pages/apps/autopsy.jsx
+++ b/pages/apps/autopsy.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Autopsy = dynamic(() => import('../../apps/autopsy'), {
+const Autopsy = dynamic(() => import('@/apps/autopsy'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function AutopsyPage() {

--- a/pages/apps/beef.jsx
+++ b/pages/apps/beef.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Beef = dynamic(() => import('../../apps/beef'), {
+const Beef = dynamic(() => import('@/apps/beef'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function BeefPage() {

--- a/pages/apps/blackjack.jsx
+++ b/pages/apps/blackjack.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Blackjack = dynamic(() => import('../../apps/blackjack'), {
+const Blackjack = dynamic(() => import('@/apps/blackjack'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function BlackjackPage() {

--- a/pages/apps/calculator.jsx
+++ b/pages/apps/calculator.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Calculator = dynamic(() => import('../../apps/calculator'), {
+const Calculator = dynamic(() => import('@/apps/calculator'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function CalculatorPage() {

--- a/pages/apps/checkers.jsx
+++ b/pages/apps/checkers.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Checkers = dynamic(() => import('../../apps/checkers'), {
+const Checkers = dynamic(() => import('@/apps/checkers'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function CheckersPage() {

--- a/pages/apps/connect-four.jsx
+++ b/pages/apps/connect-four.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ConnectFour = dynamic(() => import('../../apps/connect-four'), {
+const ConnectFour = dynamic(() => import('@/apps/connect-four'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default ConnectFour;

--- a/pages/apps/contact.jsx
+++ b/pages/apps/contact.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ContactApp = dynamic(() => import('../../apps/contact'), {
+const ContactApp = dynamic(() => import('@/apps/contact'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function ContactPage() {

--- a/pages/apps/converter.jsx
+++ b/pages/apps/converter.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Converter = dynamic(() => import('../../apps/converter'), {
+const Converter = dynamic(() => import('@/apps/converter'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function ConverterPage() {

--- a/pages/apps/figlet.jsx
+++ b/pages/apps/figlet.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const FigletPage = dynamic(() => import('../../apps/figlet'), {
+const FigletPage = dynamic(() => import('@/apps/figlet'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default FigletPage;

--- a/pages/apps/http.jsx
+++ b/pages/apps/http.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const HTTPPreview = dynamic(() => import('../../apps/http'), {
+const HTTPPreview = dynamic(() => import('@/apps/http'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function HTTPPage() {

--- a/pages/apps/input-lab.jsx
+++ b/pages/apps/input-lab.jsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
+const InputLab = dynamic(() => import('@/apps/input-lab'), { ssr: false });
 
 export default function InputLabPage() {
   return <InputLab />;

--- a/pages/apps/john.jsx
+++ b/pages/apps/john.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const John = dynamic(() => import('../../apps/john'), {
+const John = dynamic(() => import('@/apps/john'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function JohnPage() {

--- a/pages/apps/kismet.jsx
+++ b/pages/apps/kismet.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Kismet = dynamic(() => import('../../apps/kismet'), {
+const Kismet = dynamic(() => import('@/apps/kismet'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function KismetPage() {

--- a/pages/apps/metasploit-post.jsx
+++ b/pages/apps/metasploit-post.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'), {
+const MetasploitPost = dynamic(() => import('@/apps/metasploit-post'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function MetasploitPostPage() {

--- a/pages/apps/metasploit.jsx
+++ b/pages/apps/metasploit.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Metasploit = dynamic(() => import('../../apps/metasploit'), {
+const Metasploit = dynamic(() => import('@/apps/metasploit'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function MetasploitPage() {

--- a/pages/apps/minesweeper.jsx
+++ b/pages/apps/minesweeper.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Minesweeper = dynamic(() => import('../../apps/minesweeper'), {
+const Minesweeper = dynamic(() => import('@/apps/minesweeper'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function MinesweeperPage() {

--- a/pages/apps/nmap-nse.jsx
+++ b/pages/apps/nmap-nse.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
+const NmapNSE = dynamic(() => import('@/apps/nmap-nse'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function NmapNSEPage() {

--- a/pages/apps/password_generator.jsx
+++ b/pages/apps/password_generator.jsx
@@ -1,9 +1,8 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
+const PasswordGenerator = dynamic(() => import('@/apps/password_generator'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function PasswordGeneratorPage() {

--- a/pages/apps/phaser_matter.jsx
+++ b/pages/apps/phaser_matter.jsx
@@ -1,9 +1,8 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
+const PhaserMatter = dynamic(() => import('@/apps/phaser_matter'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function PhaserMatterPage() {

--- a/pages/apps/pinball.jsx
+++ b/pages/apps/pinball.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Pinball = dynamic(() => import('../../apps/pinball'), {
+const Pinball = dynamic(() => import('@/apps/pinball'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default Pinball;

--- a/pages/apps/project-gallery.jsx
+++ b/pages/apps/project-gallery.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'), {
+const ProjectGalleryApp = dynamic(() => import('@/apps/project-gallery/pages'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default ProjectGalleryApp;

--- a/pages/apps/qr.jsx
+++ b/pages/apps/qr.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const QRApp = dynamic(() => import('../../apps/qr'), {
+const QRApp = dynamic(() => import('@/apps/qr'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function QRPage() {

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('@/apps/settings'), { ssr: false });
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/simon.jsx
+++ b/pages/apps/simon.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Simon = dynamic(() => import('../../apps/simon'), {
+const Simon = dynamic(() => import('@/apps/simon'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function SimonPage() {

--- a/pages/apps/sokoban.jsx
+++ b/pages/apps/sokoban.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const Sokoban = dynamic(() => import('../../apps/sokoban'), {
+const Sokoban = dynamic(() => import('@/apps/sokoban'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 const SokobanPage = () => (

--- a/pages/apps/solitaire.jsx
+++ b/pages/apps/solitaire.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const PageSolitaire = dynamic(() => import('../../apps/solitaire'), {
+const PageSolitaire = dynamic(() => import('@/apps/solitaire'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default PageSolitaire;

--- a/pages/apps/spotify.jsx
+++ b/pages/apps/spotify.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SpotifyApp = dynamic(() => import('../../apps/spotify'), {
+const SpotifyApp = dynamic(() => import('@/apps/spotify'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default SpotifyApp;

--- a/pages/apps/ssh.jsx
+++ b/pages/apps/ssh.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SSHPreview = dynamic(() => import('../../apps/ssh'), {
+const SSHPreview = dynamic(() => import('@/apps/ssh'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function SSHPage() {

--- a/pages/apps/sticky_notes.jsx
+++ b/pages/apps/sticky_notes.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
+const StickyNotes = dynamic(() => import('@/apps/sticky_notes'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function StickyNotesPage() {

--- a/pages/apps/timer_stopwatch.jsx
+++ b/pages/apps/timer_stopwatch.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
+const TimerStopwatch = dynamic(() => import('@/apps/timer_stopwatch'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function TimerStopwatchPage() {

--- a/pages/apps/tower-defense.jsx
+++ b/pages/apps/tower-defense.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const TowerDefense = dynamic(() => import('../../apps/tower-defense'), {
+const TowerDefense = dynamic(() => import('@/apps/tower-defense'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default TowerDefense;

--- a/pages/apps/volatility.jsx
+++ b/pages/apps/volatility.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Volatility = dynamic(() => import('../../apps/volatility'), {
+const Volatility = dynamic(() => import('@/apps/volatility'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function VolatilityPage() {

--- a/pages/apps/vscode.jsx
+++ b/pages/apps/vscode.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const VSCode = dynamic(() => import('../../apps/vscode'), {
+const VSCode = dynamic(() => import('@/apps/vscode'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function VSCodePage() {

--- a/pages/apps/weather.jsx
+++ b/pages/apps/weather.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const WeatherApp = dynamic(() => import('../../apps/weather'), {
+const WeatherApp = dynamic(() => import('@/apps/weather'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default WeatherApp;

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
+const WeatherWidget = dynamic(() => import('@/apps/weather_widget'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function WeatherWidgetPage() {

--- a/pages/apps/wireshark.jsx
+++ b/pages/apps/wireshark.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Wireshark = dynamic(() => import('../../apps/wireshark'), {
+const Wireshark = dynamic(() => import('@/apps/wireshark'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default function WiresharkPage() {

--- a/pages/apps/word_search.jsx
+++ b/pages/apps/word_search.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
 const WordSearch = dynamic(
-  () => import('../../apps/word_search'),
-  { ssr: false, loading: () => <p>Loading...</p> },
+  () => import('@/apps/word_search'),
+   loading: () => <p>Loading...</p> },
 );
 
 export default function WordSearchPage() {

--- a/pages/apps/x.jsx
+++ b/pages/apps/x.jsx
@@ -1,8 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const PageX = dynamic(() => import('../../apps/x'), {
+const PageX = dynamic(() => import('@/apps/x'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
 });
 
 export default PageX;

--- a/utils/dynamic.tsx
+++ b/utils/dynamic.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import nextDynamic, { DynamicOptions } from 'next/dynamic';
+import LoadingSkeleton from '@/components/LoadingSkeleton';
+
+export default function dynamic<P = unknown>(
+  loader: Parameters<typeof nextDynamic<P>>[0],
+  options: DynamicOptions<P> = {}
+) {
+  return nextDynamic(loader, {
+    ssr: false,
+    loading: () => <LoadingSkeleton />,
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- implement reusable skeleton loader with friendly delays and minimal spinner fallback
- wrap next/dynamic to default to skeleton loader and update app pages

## Testing
- `yarn test` *(fails: Unable to find element "button" with name /load sample/i in kismet.test.tsx)*
- `yarn lint` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d26e27483289d9dc852385208bd