### PR TITLE
feat: add page transition animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "framer-motion": "^11",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,6 @@
 import { useEffect } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useRouter } from 'next/router';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -16,7 +18,8 @@ import PipPortalProvider from '../components/common/PipPortal';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
-
+  const router = useRouter();
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
     const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
@@ -128,7 +131,21 @@ function MyApp(props) {
     <SettingsProvider>
       <PipPortalProvider>
         <div aria-live="polite" id="live-region" />
-        <Component {...pageProps} />
+        {shouldReduceMotion ? (
+          <Component {...pageProps} />
+        ) : (
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={router.asPath}
+              initial={{ opacity: 0, x: 16 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -16 }}
+              transition={{ duration: 0.15 }}
+            >
+              <Component {...pageProps} />
+            </motion.div>
+          </AnimatePresence>
+        )}
         <ShortcutOverlay />
         <Analytics
           beforeSend={(e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,6 +5715,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^11":
+  version: 11.18.2
+  resolution: "framer-motion@npm:11.18.2"
+  dependencies:
+    motion-dom: "npm:^11.18.1"
+    motion-utils: "npm:^11.18.1"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/41b1ef1b4e54ea13adaf01d61812a8783d2352f74641c91b50519775704bc6274db6b6863ff494a1f705fa6c6ed8f4df3497292327c906d53ea0129cef3ec361
+  languageName: node
+  linkType: hard
+
 "fresh@npm:^0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
@@ -8012,6 +8034,22 @@ __metadata:
   version: 0.52.2
   resolution: "monaco-editor@npm:0.52.2"
   checksum: 10c0/5a92da64f1e2ab375c0ce99364137f794d057c97bed10ecc65a08d6e6846804b8ecbd377eacf01e498f7dfbe1b21e8be64f728256681448f0484df90e767b435
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^11.18.1":
+  version: 11.18.1
+  resolution: "motion-dom@npm:11.18.1"
+  dependencies:
+    motion-utils: "npm:^11.18.1"
+  checksum: 10c0/98378bdf9d77870829cdf3624c5eff02e48cfa820dfc74450364d7421884700048d60e277bfbf477df33270fbae4c1980e5914586f5b6dff28d4921fdca8ac47
+  languageName: node
+  linkType: hard
+
+"motion-utils@npm:^11.18.1":
+  version: 11.18.1
+  resolution: "motion-utils@npm:11.18.1"
+  checksum: 10c0/dac083bdeb6e433a277ac4362211b0fdce59ff09d6f7897f0f49d1e3561209c6481f676876daf99a33485054bc7e4b1d1b8d1de16f7b1e5c6f117fe76358ca00
   languageName: node
   linkType: hard
 
@@ -10892,6 +10930,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    framer-motion: "npm:^11"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add framer-motion dependency
- wrap page content with AnimatePresence and motion.div for quick crossfade/slide transitions
- respect prefers-reduced-motion and avoid animating critical overlays

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: __tests__/kismet.test.tsx `steps through sample capture frames`)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d2762d88328a11e3d46a2c83653