### PR TITLE
Add markdown rendering with anchors and TOC

### DIFF
--- a/__tests__/markdown.test.ts
+++ b/__tests__/markdown.test.ts
@@ -1,0 +1,27 @@
+import { renderMarkdown } from '../lib/markdown';
+
+jest.mock('marked', () => {
+  const markedFn = (md: string, opts: any) => {
+    const renderer = opts.renderer;
+    const slugger = { slug: (str: string) => str.toLowerCase().replace(/\s+/g, '-') };
+    return md.replace(/^## (.+)$/gm, (_: string, title: string) =>
+      renderer.heading(title, 2, title, slugger),
+    );
+  };
+  markedFn.Renderer = class {
+    heading(text: string) {
+      return `<h2>${text}</h2>`;
+    }
+  };
+  return { marked: markedFn };
+});
+
+describe('renderMarkdown', () => {
+  it('generates anchors and toc entries', async () => {
+    const md = '# Title\n\n## Section One\nContent';
+    const { html, toc } = await renderMarkdown(md);
+    expect(toc).toEqual([{ id: 'section-one', text: 'Section One', level: 2 }]);
+    expect(html).toContain('id="section-one"');
+    expect(html).toContain('href="#section-one"');
+  });
+});

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,18 @@
+export interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export async function renderMarkdown(md: string): Promise<{ html: string; toc: TocItem[] }> {
+  const { marked } = await import('marked');
+  const toc: TocItem[] = [];
+  const renderer = new marked.Renderer();
+  renderer.heading = (text, level, raw, slugger) => {
+    const id = slugger.slug(raw);
+    toc.push({ id, text: raw, level });
+    return `<h${level} id="${id}" class="group"><span>${text}</span><a href="#${id}" class="ml-2 opacity-0 group-hover:opacity-100 inline-block">🔗</a></h${level}>`;
+  };
+  const html = marked(md, { renderer });
+  return { html, toc };
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
+    "marked": "^16.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
     "monaco-editor": "^0.52.2",

--- a/pages/docs/[slug].tsx
+++ b/pages/docs/[slug].tsx
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { useEffect, useState } from 'react';
+import { renderMarkdown, TocItem } from '../../lib/markdown';
+
+interface DocProps {
+  html: string;
+  toc: TocItem[];
+}
+
+export default function DocPage({ html, toc }: DocProps) {
+  const [showTop, setShowTop] = useState(false);
+  useEffect(() => {
+    const first = document.querySelector('h2');
+    const handler = () => {
+      if (!first) return;
+      setShowTop(window.scrollY > (first as HTMLElement).offsetTop);
+    };
+    window.addEventListener('scroll', handler);
+    handler();
+    return () => window.removeEventListener('scroll', handler);
+  }, []);
+  return (
+    <div className="prose mx-auto p-4">
+      <a id="top" />
+      {toc.length > 2 && (
+        <nav className="mb-4">
+          <strong>Table of Contents</strong>
+          <ul>
+            {toc.map((t) => (
+              <li key={t.id} style={{ marginLeft: (t.level - 2) * 16 }}>
+                <a href={`#${t.id}`}>{t.text}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+      {showTop && (
+        <button
+          className="fixed bottom-4 right-4 px-3 py-2 bg-gray-800 text-white rounded"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        >
+          Back to top
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const dir = path.join(process.cwd(), 'docs');
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
+  return {
+    paths: files.map((f) => ({ params: { slug: f.replace(/\.md$/, '') } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<DocProps> = async ({ params }) => {
+  const slug = params?.slug as string;
+  const file = fs.readFileSync(path.join(process.cwd(), 'docs', `${slug}.md`), 'utf8');
+  const { html, toc } = await renderMarkdown(file);
+  return { props: { html, toc } };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7744,6 +7744,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:^16.2.1":
+  version: 16.2.1
+  resolution: "marked@npm:16.2.1"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/0f4a259c8a7884a14830f06b4b44c0e5fab27924102f2713606e0627c8473d130ab9070900a40c18b0e8d39ba2f31194ce6931999ba4c7bd3b6240f6cfe9cbb3
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -10903,6 +10912,7 @@ __metadata:
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
+    marked: "npm:^16.2.1"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"


### PR DESCRIPTION
## Summary
- parse Markdown and inject heading anchors with link icons
- render docs with table of contents and back-to-top control
- cover markdown rendering with unit test

## Testing
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: KismetApp steps through sample capture frames)*
- `yarn test __tests__/markdown.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b48d0c3a2c8328822cd2ce9725463f