### PR TITLE
Handle missing env validation gracefully

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
+const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -82,6 +84,12 @@ function configureWebpack(config, { isServer }) {
     };
   }
   return config;
+}
+
+try {
+  validateEnv?.(process.env);
+} catch {
+  console.warn('Missing env vars; running without validation');
 }
 
 module.exports = withBundleAnalyzer({


### PR DESCRIPTION
## Summary
- import server env validator in `next.config.js`
- warn and skip when required env vars are missing

## Testing
- `yarn test __tests__/aboutAccessibility.test.tsx __tests__/kismet.test.tsx` *(fails: IntersectionObserver is not defined; unable to find button)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e6741088328b901fa24af83dd56