### PR TITLE
Use Node 20 runtime in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,15 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "pages/api/**/*.js": {
+    "pages/api/**/*.{js,ts}": {
+      "runtime": "nodejs20.x",
       "memory": 1024,
-      "maxDuration": 30,
-      "runtime": "nodejs20.x"
+      "maxDuration": 30
+    },
+    "app/api/**/route.{js,ts}": {
+      "runtime": "nodejs20.x",
+      "memory": 1024,
+      "maxDuration": 30
     }
   }
 }


### PR DESCRIPTION
## Summary
- specify Node.js 20 runtime for API and app route functions in `vercel.json`

## Testing
- `npm test` *(fails: AboutApp accessibility, KismetApp)*
- `npm run lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b57cb020832887cb8110cabe8a2d