### PR TITLE
Specify Vercel config version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
     "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
-
   }
 }


### PR DESCRIPTION
## Summary
- declare the config version in `vercel.json`
- ensure Node.js 20 functions resolve without runtime version errors

## Testing
- `yarn test` *(fails: 2 failing test suites, aboutAccessibility.test.tsx and kismet.test.tsx)*
- `yarn lint` *(timed out; interrupted after long runtime)*
- `npx eslint vercel.json`


------
https://chatgpt.com/codex/tasks/task_e_68b8c7a9c5c8832889d7a8f2ad0f68d9