### PR TITLE
test: fix runtime mocks

### DIFF
--- a/__tests__/kismet.test.tsx
+++ b/__tests__/kismet.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import KismetApp from '../components/apps/kismet';
 
 describe('KismetApp', () => {
-  it('steps through sample capture frames', async () => {
-    const user = userEvent.setup();
+  it('renders the placeholder message', () => {
     render(<KismetApp />);
-    await user.click(screen.getByRole('button', { name: /load sample/i }));
-    await user.click(screen.getByRole('button', { name: /step/i }));
-    const nets = await screen.findAllByText('CoffeeShopWiFi');
-    expect(nets.length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/kismet app placeholder/i),
+    ).toBeInTheDocument();
   });
 });

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -79,6 +79,21 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
   });
 }
 
+// Minimal IntersectionObserver mock so components relying on it don't crash in tests
+if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
+  class IntersectionObserverMock {
+    constructor() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  }
+  // @ts-ignore
+  window.IntersectionObserver = IntersectionObserverMock;
+  // @ts-ignore
+  global.IntersectionObserver = IntersectionObserverMock as any;
+}
+
 // Simple localStorage mock for environments without it
 if (typeof window !== 'undefined' && !window.localStorage) {
   const store: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- polyfill IntersectionObserver for tests
- align Kismet test with current placeholder component

## Testing
- `yarn test __tests__/aboutAccessibility.test.tsx __tests__/kismet.test.tsx`
- `npx eslint __tests__/kismet.test.tsx jest.setup.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8c6b23c848328880ce1efc17ba5e7