### PR TITLE
feat: enforce script performance budgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "build:sw": "node scripts/generate-sw.mjs",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "ANALYZE=true yarn build",
+    "check:pr-scripts": "node scripts/check-pr-scripts.mjs"
   },
   "engines": {
     "node": "20.x"

--- a/perf-budget.config.json
+++ b/perf-budget.config.json
@@ -1,0 +1,4 @@
+{
+  "maxScriptBytes": 150000,
+  "psiUrl": "https://pagespeed.web.dev/analysis/https://unnippillil.com/"
+}

--- a/scripts/check-pr-scripts.mjs
+++ b/scripts/check-pr-scripts.mjs
@@ -1,0 +1,88 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const configPath = path.resolve('perf-budget.config.json');
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+function getChangedFiles() {
+  const base = process.env.GITHUB_BASE_REF || 'main';
+  let ref = base;
+  try {
+    execSync(`git rev-parse --verify origin/${base}`, { stdio: 'ignore' });
+    ref = `origin/${base}`;
+  } catch {
+    try {
+      execSync(`git rev-parse --verify ${base}`, { stdio: 'ignore' });
+      ref = base;
+    } catch {
+      ref = 'HEAD~1';
+    }
+  }
+  const diff = execSync(`git diff --name-only ${ref}...HEAD`).toString().trim();
+  return diff ? diff.split('\n') : [];
+}
+
+function isScriptFile(file) {
+  return ['.js', '.mjs', '.ts', '.tsx', '.jsx'].includes(path.extname(file));
+}
+
+const blockingRegex = /<script(?![^>]*(?:async|defer))[^>]*>/i;
+
+const changed = getChangedFiles();
+const oversized = [];
+const blocking = [];
+
+for (const file of changed) {
+  if (!fs.existsSync(file) || !isScriptFile(file)) continue;
+  const size = fs.statSync(file).size;
+  if (size > config.maxScriptBytes) {
+    oversized.push({ file, size });
+  }
+  const content = fs.readFileSync(file, 'utf8');
+  if (blockingRegex.test(content)) {
+    blocking.push(file);
+  }
+}
+
+if (oversized.length || blocking.length) {
+  let body = '### Performance budget report\n';
+  if (oversized.length) {
+    body += `\n**Scripts exceeding ${config.maxScriptBytes} bytes**\n`;
+    for (const o of oversized) {
+      body += `- ${o.file} (${o.size} bytes)\n`;
+    }
+  }
+  if (blocking.length) {
+    body += '\n**Render-blocking script tags found**\n';
+    for (const b of blocking) {
+      body += `- ${b}\n`;
+    }
+  }
+  if (config.psiUrl) {
+    body += `\n[Speed Insights evidence](${config.psiUrl})`;
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const pr = process.env.PR_NUMBER;
+  if (token && repo && pr) {
+    fetch(`https://api.github.com/repos/${repo}/issues/${pr}/comments`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ body })
+    }).catch(err => {
+      console.error('Failed to post comment', err);
+    });
+  } else {
+    console.log(body);
+  }
+  process.exit(1);
+} else {
+  console.log('No script budget issues found');
+}


### PR DESCRIPTION
## Summary
- add perf budget config with max script size and PSI link
- add check-pr-scripts script to flag oversized or render-blocking JS and comment with Speed Insights evidence
- expose script via yarn `check:pr-scripts`

## Testing
- `node scripts/check-pr-scripts.mjs`
- `yarn test` *(fails: aboutAccessibility.test.tsx, kismet.test.tsx)*
- `yarn lint` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f6daf308328bf58e1dc775136c4