### PR TITLE
feat: enforce safe locale placeholders

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,27 @@
+# Internationalization
+
+Locale files live under `locales/` and contain translations in JSON format. A placeholder checker validates these files to prevent runtime issues and unsafe interpolation.
+
+## Placeholder rules
+
+- Use named placeholders wrapped in double curly braces, e.g. `{{user}}`.
+- Positional placeholders such as `%s` or numeric tokens like `{{0}}` are rejected.
+- Empty placeholders (`{{}}`) and mismatched braces are also reported.
+- `%{name}` and placeholders with extra spaces (`{{ name }}`) are automatically converted to the safe `{{name}}` form when the checker runs with `--fix`.
+
+## Running the checker
+
+The validation runs as part of the standard lint script:
+
+```bash
+yarn lint
+```
+
+It can also be executed independently or with autofix:
+
+```bash
+yarn lint:locales        # validate locale files
+yarn lint:locales --fix  # apply safe placeholder fixes
+```
+
+Any reported issues cause the command to exit with a non-zero status, blocking CI.

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build && yarn build:sw",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "node scripts/check-locales.mjs && eslint --max-warnings=0 .",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "build:sw": "node scripts/generate-sw.mjs",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "ANALYZE=true yarn build",
+    "lint:locales": "node scripts/check-locales.mjs"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/check-locales.mjs
+++ b/scripts/check-locales.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const localesDir = path.resolve(process.cwd(), 'locales');
+const fix = process.argv.includes('--fix');
+
+if (!fs.existsSync(localesDir)) {
+  // No locales directory, nothing to do
+  process.exit(0);
+}
+
+const localeFiles = fs.readdirSync(localesDir).filter(f => f.endsWith('.json'));
+let hasError = false;
+
+for (const file of localeFiles) {
+  const filePath = path.join(localesDir, file);
+  const raw = fs.readFileSync(filePath, 'utf8');
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    console.error(`${filePath}: invalid JSON`);
+    hasError = true;
+    continue;
+  }
+
+  let fileModified = false;
+
+  function walk(obj, pathArr = []) {
+    for (const [key, val] of Object.entries(obj)) {
+      const currentPath = [...pathArr, key];
+      if (typeof val === 'string') {
+        const original = val;
+        let str = val;
+        // Autofix for named params: %{name} -> {{name}}
+        str = str.replace(/%\{(\w+)\}/g, (_, p1) => {
+          fileModified = true;
+          return `{{${p1}}}`;
+        });
+        // Autofix for spaces inside placeholders: {{ name }} -> {{name}}
+        str = str.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, p1) => {
+          const fixed = `{{${p1}}}`;
+          if (match !== fixed) fileModified = true;
+          return fixed;
+        });
+        if (fix && str !== original) {
+          obj[key] = str;
+        }
+        const open = (str.match(/\{\{/g) || []).length;
+        const close = (str.match(/\}\}/g) || []).length;
+        const unsafe =
+          /%[sd]/.test(str) ||
+          /\{\{\s*\d+\s*\}\}/.test(str) ||
+          /\{\{\s*\}\}/.test(str) ||
+          open !== close;
+        if (unsafe) {
+          hasError = true;
+          console.error(`${filePath}:${currentPath.join('.')} => "${original}"`);
+        }
+      } else if (val && typeof val === 'object') {
+        walk(val, currentPath);
+      }
+    }
+  }
+
+  walk(data);
+
+  if (fix && fileModified) {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+  }
+}
+
+if (hasError) {
+  console.error('Locale placeholder check failed.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to validate locale placeholders and support autofix
- hook placeholder checker into lint script
- document placeholder rules in docs/i18n.md

## Testing
- `yarn lint` (fails: ✖ 45 problems (7 errors, 38 warnings))
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b72f6301148328a061685520b2d1f8