### PR TITLE
chore: generate route specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "build:sw": "node scripts/generate-sw.mjs",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "ANALYZE=true yarn build",
+    "generate:specs": "node scripts/generate-route-specs.mjs",
+    "test:generated": "yarn generate:specs && npx playwright test tests/generated",
+    "check:routes": "yarn generate:specs && git diff --exit-code tests/generated"
   },
   "engines": {
     "node": "20.x"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'yarn dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+  },
+});

--- a/scripts/generate-route-specs.mjs
+++ b/scripts/generate-route-specs.mjs
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path from 'path';
+
+const pagesDir = path.join(process.cwd(), 'pages');
+const outDir = path.join(process.cwd(), 'tests', 'generated');
+
+const skipDirNames = new Set(['api', 'admin']); // skip entire directories
+const skipRoutes = new Set(['/profile']); // individual routes to skip
+
+/** Recursively collect Next.js routes from the pages directory */
+function collectRoutes(dir, baseRoute = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const routes = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('_')) continue; // skip _app, _document, etc.
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (skipDirNames.has(entry.name)) continue;
+      routes.push(...collectRoutes(fullPath, baseRoute + '/' + entry.name));
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name);
+      if (!['.js', '.jsx', '.ts', '.tsx'].includes(ext)) continue;
+
+      let routeName = entry.name.slice(0, -ext.length);
+      let route = baseRoute + '/' + routeName;
+      if (routeName === 'index') {
+        route = baseRoute || '/';
+      }
+      if (route.includes('[')) continue; // skip dynamic routes
+      if (skipRoutes.has(route)) continue; // skip auth routes
+
+      routes.push(route);
+    }
+  }
+
+  return routes;
+}
+
+function routeToFile(route) {
+  if (route === '/') return 'index.spec.ts';
+  return route.slice(1).replace(/\//g, '_') + '.spec.ts';
+}
+
+function generateSpec(route) {
+  return `import { test, expect } from '@playwright/test';
+
+test('navigate to ${route}', async ({ page }) => {
+  await page.goto('${route}');
+  await expect(page.getByRole('heading')).toBeVisible();
+});\n`;
+}
+
+function main() {
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const routes = collectRoutes(pagesDir).sort();
+  for (const route of routes) {
+    const file = routeToFile(route);
+    const filePath = path.join(outDir, file);
+    fs.writeFileSync(filePath, generateSpec(route));
+  }
+}
+
+main();

--- a/tests/generated/apps.spec.ts
+++ b/tests/generated/apps.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps', async ({ page }) => {
+  await page.goto('/apps');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_2048.spec.ts
+++ b/tests/generated/apps_2048.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/2048', async ({ page }) => {
+  await page.goto('/apps/2048');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_ascii-art.spec.ts
+++ b/tests/generated/apps_ascii-art.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/ascii-art', async ({ page }) => {
+  await page.goto('/apps/ascii-art');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_autopsy.spec.ts
+++ b/tests/generated/apps_autopsy.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/autopsy', async ({ page }) => {
+  await page.goto('/apps/autopsy');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_beef.spec.ts
+++ b/tests/generated/apps_beef.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/beef', async ({ page }) => {
+  await page.goto('/apps/beef');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_blackjack.spec.ts
+++ b/tests/generated/apps_blackjack.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/blackjack', async ({ page }) => {
+  await page.goto('/apps/blackjack');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_calculator.spec.ts
+++ b/tests/generated/apps_calculator.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/calculator', async ({ page }) => {
+  await page.goto('/apps/calculator');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_checkers.spec.ts
+++ b/tests/generated/apps_checkers.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/checkers', async ({ page }) => {
+  await page.goto('/apps/checkers');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_connect-four.spec.ts
+++ b/tests/generated/apps_connect-four.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/connect-four', async ({ page }) => {
+  await page.goto('/apps/connect-four');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_contact.spec.ts
+++ b/tests/generated/apps_contact.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/contact', async ({ page }) => {
+  await page.goto('/apps/contact');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_converter.spec.ts
+++ b/tests/generated/apps_converter.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/converter', async ({ page }) => {
+  await page.goto('/apps/converter');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_figlet.spec.ts
+++ b/tests/generated/apps_figlet.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/figlet', async ({ page }) => {
+  await page.goto('/apps/figlet');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_http.spec.ts
+++ b/tests/generated/apps_http.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/http', async ({ page }) => {
+  await page.goto('/apps/http');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_input-lab.spec.ts
+++ b/tests/generated/apps_input-lab.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/input-lab', async ({ page }) => {
+  await page.goto('/apps/input-lab');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_john.spec.ts
+++ b/tests/generated/apps_john.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/john', async ({ page }) => {
+  await page.goto('/apps/john');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_kismet.spec.ts
+++ b/tests/generated/apps_kismet.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/kismet', async ({ page }) => {
+  await page.goto('/apps/kismet');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_metasploit-post.spec.ts
+++ b/tests/generated/apps_metasploit-post.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/metasploit-post', async ({ page }) => {
+  await page.goto('/apps/metasploit-post');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_metasploit.spec.ts
+++ b/tests/generated/apps_metasploit.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/metasploit', async ({ page }) => {
+  await page.goto('/apps/metasploit');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_mimikatz_offline.spec.ts
+++ b/tests/generated/apps_mimikatz_offline.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/mimikatz/offline', async ({ page }) => {
+  await page.goto('/apps/mimikatz/offline');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_minesweeper.spec.ts
+++ b/tests/generated/apps_minesweeper.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/minesweeper', async ({ page }) => {
+  await page.goto('/apps/minesweeper');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_nmap-nse.spec.ts
+++ b/tests/generated/apps_nmap-nse.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/nmap-nse', async ({ page }) => {
+  await page.goto('/apps/nmap-nse');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_password_generator.spec.ts
+++ b/tests/generated/apps_password_generator.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/password_generator', async ({ page }) => {
+  await page.goto('/apps/password_generator');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_phaser_matter.spec.ts
+++ b/tests/generated/apps_phaser_matter.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/phaser_matter', async ({ page }) => {
+  await page.goto('/apps/phaser_matter');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_pinball.spec.ts
+++ b/tests/generated/apps_pinball.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/pinball', async ({ page }) => {
+  await page.goto('/apps/pinball');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_project-gallery.spec.ts
+++ b/tests/generated/apps_project-gallery.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/project-gallery', async ({ page }) => {
+  await page.goto('/apps/project-gallery');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_qr.spec.ts
+++ b/tests/generated/apps_qr.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/qr', async ({ page }) => {
+  await page.goto('/apps/qr');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_settings.spec.ts
+++ b/tests/generated/apps_settings.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/settings', async ({ page }) => {
+  await page.goto('/apps/settings');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_simon.spec.ts
+++ b/tests/generated/apps_simon.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/simon', async ({ page }) => {
+  await page.goto('/apps/simon');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_sokoban.spec.ts
+++ b/tests/generated/apps_sokoban.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/sokoban', async ({ page }) => {
+  await page.goto('/apps/sokoban');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_solitaire.spec.ts
+++ b/tests/generated/apps_solitaire.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/solitaire', async ({ page }) => {
+  await page.goto('/apps/solitaire');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_spotify.spec.ts
+++ b/tests/generated/apps_spotify.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/spotify', async ({ page }) => {
+  await page.goto('/apps/spotify');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_ssh.spec.ts
+++ b/tests/generated/apps_ssh.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/ssh', async ({ page }) => {
+  await page.goto('/apps/ssh');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_sticky_notes.spec.ts
+++ b/tests/generated/apps_sticky_notes.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/sticky_notes', async ({ page }) => {
+  await page.goto('/apps/sticky_notes');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_timer_stopwatch.spec.ts
+++ b/tests/generated/apps_timer_stopwatch.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/timer_stopwatch', async ({ page }) => {
+  await page.goto('/apps/timer_stopwatch');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_tower-defense.spec.ts
+++ b/tests/generated/apps_tower-defense.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/tower-defense', async ({ page }) => {
+  await page.goto('/apps/tower-defense');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_volatility.spec.ts
+++ b/tests/generated/apps_volatility.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/volatility', async ({ page }) => {
+  await page.goto('/apps/volatility');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_vscode.spec.ts
+++ b/tests/generated/apps_vscode.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/vscode', async ({ page }) => {
+  await page.goto('/apps/vscode');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_weather.spec.ts
+++ b/tests/generated/apps_weather.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/weather', async ({ page }) => {
+  await page.goto('/apps/weather');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_weather_widget.spec.ts
+++ b/tests/generated/apps_weather_widget.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/weather_widget', async ({ page }) => {
+  await page.goto('/apps/weather_widget');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_wireshark.spec.ts
+++ b/tests/generated/apps_wireshark.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/wireshark', async ({ page }) => {
+  await page.goto('/apps/wireshark');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_word_search.spec.ts
+++ b/tests/generated/apps_word_search.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/word_search', async ({ page }) => {
+  await page.goto('/apps/word_search');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/apps_x.spec.ts
+++ b/tests/generated/apps_x.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /apps/x', async ({ page }) => {
+  await page.goto('/apps/x');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/daily-quote.spec.ts
+++ b/tests/generated/daily-quote.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /daily-quote', async ({ page }) => {
+  await page.goto('/daily-quote');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/dummy-form.spec.ts
+++ b/tests/generated/dummy-form.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /dummy-form', async ({ page }) => {
+  await page.goto('/dummy-form');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/games_blackjack.spec.ts
+++ b/tests/generated/games_blackjack.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /games/blackjack', async ({ page }) => {
+  await page.goto('/games/blackjack');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/games_blackjack_trainer.spec.ts
+++ b/tests/generated/games_blackjack_trainer.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /games/blackjack/trainer', async ({ page }) => {
+  await page.goto('/games/blackjack/trainer');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/games_breakout_editor.spec.ts
+++ b/tests/generated/games_breakout_editor.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /games/breakout/editor', async ({ page }) => {
+  await page.goto('/games/breakout/editor');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/hook-flow.spec.ts
+++ b/tests/generated/hook-flow.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /hook-flow', async ({ page }) => {
+  await page.goto('/hook-flow');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/hydra-preview.spec.ts
+++ b/tests/generated/hydra-preview.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /hydra-preview', async ({ page }) => {
+  await page.goto('/hydra-preview');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/index.spec.ts
+++ b/tests/generated/index.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/input-hub.spec.ts
+++ b/tests/generated/input-hub.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /input-hub', async ({ page }) => {
+  await page.goto('/input-hub');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/keyboard-reference.spec.ts
+++ b/tests/generated/keyboard-reference.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /keyboard-reference', async ({ page }) => {
+  await page.goto('/keyboard-reference');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/module-workspace.spec.ts
+++ b/tests/generated/module-workspace.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /module-workspace', async ({ page }) => {
+  await page.goto('/module-workspace');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/nessus-dashboard.spec.ts
+++ b/tests/generated/nessus-dashboard.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /nessus-dashboard', async ({ page }) => {
+  await page.goto('/nessus-dashboard');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/nessus-report.spec.ts
+++ b/tests/generated/nessus-report.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /nessus-report', async ({ page }) => {
+  await page.goto('/nessus-report');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/network-topology.spec.ts
+++ b/tests/generated/network-topology.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /network-topology', async ({ page }) => {
+  await page.goto('/network-topology');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/nikto-report.spec.ts
+++ b/tests/generated/nikto-report.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /nikto-report', async ({ page }) => {
+  await page.goto('/nikto-report');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/notes.spec.ts
+++ b/tests/generated/notes.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /notes', async ({ page }) => {
+  await page.goto('/notes');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/popular-modules.spec.ts
+++ b/tests/generated/popular-modules.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /popular-modules', async ({ page }) => {
+  await page.goto('/popular-modules');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/post_exploitation.spec.ts
+++ b/tests/generated/post_exploitation.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /post_exploitation', async ({ page }) => {
+  await page.goto('/post_exploitation');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/qr.spec.ts
+++ b/tests/generated/qr.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /qr', async ({ page }) => {
+  await page.goto('/qr');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/qr_vcard.spec.ts
+++ b/tests/generated/qr_vcard.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /qr/vcard', async ({ page }) => {
+  await page.goto('/qr/vcard');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/recon_graph.spec.ts
+++ b/tests/generated/recon_graph.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /recon/graph', async ({ page }) => {
+  await page.goto('/recon/graph');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/security-education.spec.ts
+++ b/tests/generated/security-education.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /security-education', async ({ page }) => {
+  await page.goto('/security-education');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/sekurlsa_logonpasswords.spec.ts
+++ b/tests/generated/sekurlsa_logonpasswords.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /sekurlsa_logonpasswords', async ({ page }) => {
+  await page.goto('/sekurlsa_logonpasswords');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/share-target.spec.ts
+++ b/tests/generated/share-target.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /share-target', async ({ page }) => {
+  await page.goto('/share-target');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/spoofing.spec.ts
+++ b/tests/generated/spoofing.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /spoofing', async ({ page }) => {
+  await page.goto('/spoofing');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/ui_settings_theme.spec.ts
+++ b/tests/generated/ui_settings_theme.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /ui/settings/theme', async ({ page }) => {
+  await page.goto('/ui/settings/theme');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/video-gallery.spec.ts
+++ b/tests/generated/video-gallery.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /video-gallery', async ({ page }) => {
+  await page.goto('/video-gallery');
+  await expect(page.getByRole('heading')).toBeVisible();
+});

--- a/tests/generated/wps-attack.spec.ts
+++ b/tests/generated/wps-attack.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /wps-attack', async ({ page }) => {
+  await page.goto('/wps-attack');
+  await expect(page.getByRole('heading')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- crawl Next.js `pages/` and generate Playwright specs with role locators
- add headless Playwright config with dev server
- provide scripts for regenerating and verifying route specs

## Testing
- `yarn test:generated` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f6229448328898246f06bda0e90