### PR TITLE
Add safe-mode example with safety checks

### DIFF
--- a/docs/terms/safe-mode-example.md
+++ b/docs/terms/safe-mode-example.md
@@ -1,0 +1,20 @@
+---
+term: safe-mode-example
+title: Safe Mode Example
+tags:
+  - safe-mode
+safety:
+  reviewed: true
+  red_team_checked: true
+disclaimer: "This example is for educational purposes only. Do not use it to cause harm."
+---
+
+# Safe Mode Example
+
+> **Disclaimer:** This example is provided for educational purposes only. Do not use it for malicious activities.
+
+This sample demonstrates a benign command:
+
+```bash
+echo "Hello from safe mode"
+```

--- a/scripts/red-team-check.mjs
+++ b/scripts/red-team-check.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: node scripts/red-team-check.mjs <file>");
+  process.exit(1);
+}
+
+const content = fs.readFileSync(file, "utf8");
+
+if (!content.includes("safe-mode")) {
+  console.error("File is missing safe-mode tag");
+  process.exit(1);
+}
+
+if (!/educational purposes only/i.test(content)) {
+  console.error("File is missing educational disclaimer");
+  process.exit(1);
+}
+
+const banned = ["rm -rf", "dd if=", "malware", "exploit", "payload"];
+for (const keyword of banned) {
+  if (content.toLowerCase().includes(keyword)) {
+    console.error(`Disallowed keyword detected: ${keyword}`);
+    process.exit(1);
+  }
+}
+
+console.log("Red-team check passed");


### PR DESCRIPTION
## Summary
- add safe-mode example with disclaimers and safety metadata
- introduce a simple red-team check script to validate safe-mode examples

## Testing
- `node scripts/red-team-check.mjs docs/terms/safe-mode-example.md`
- `yarn lint docs/terms/safe-mode-example.md` *(fails: Component definition is missing display name, ...)*
- `yarn test --passWithNoTests` *(fails: AboutApp accessibility › supports roving tabindex for navigation tabs, KismetApp › steps through sample capture frames)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f506dc083289290b7ad06626c46