### PR TITLE
feat: add language detection and demo term page

### DIFF
--- a/components/terms/LanguageChip.tsx
+++ b/components/terms/LanguageChip.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/src/lib/i18n/detect';
+
+interface Props {
+  current: string;
+  onChange: (lang: string) => void;
+}
+
+/**
+ * Small language switcher chip. Shows supported languages and allows
+ * switching back to the default locale.
+ */
+const LanguageChip: React.FC<Props> = ({ current, onChange }) => {
+  return (
+    <div className="flex items-center space-x-1">
+      {SUPPORTED_LOCALES.map((l) => (
+        <button
+          key={l}
+          onClick={() => onChange(l)}
+          className={`px-2 py-1 text-xs rounded-full border ${
+            current === l ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-200'
+          }`}
+        >
+          {l.toUpperCase()}
+        </button>
+      ))}
+      {current !== DEFAULT_LOCALE && (
+        <button
+          onClick={() => onChange(DEFAULT_LOCALE)}
+          className="px-2 py-1 text-xs rounded-full bg-gray-500 text-white"
+        >
+          RESET
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default LanguageChip;

--- a/pages/terms/example.tsx
+++ b/pages/terms/example.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import LanguageChip from '@/components/terms/LanguageChip';
+import { detectLanguage, DEFAULT_LOCALE } from '@/src/lib/i18n/detect';
+
+// Demo term data with synonyms/aliases translated while the definition
+// stays in the default locale.
+const TERM = {
+  term: 'phishing',
+  definition: 'A fraudulent attempt to obtain sensitive information.',
+  synonyms: {
+    en: ['phishing', 'spear phishing'],
+    es: ['suplantación de identidad', 'phishing dirigido'],
+    fr: ['hameçonnage', 'hameçonnage ciblé'],
+  },
+};
+
+export default function ExampleTermPage() {
+  const [lang, setLang] = useState(detectLanguage());
+  const synonyms = TERM.synonyms[lang as keyof typeof TERM.synonyms] || TERM.synonyms[DEFAULT_LOCALE];
+
+  return (
+    <div className="p-4 space-y-4">
+      <LanguageChip current={lang} onChange={setLang} />
+      <h1 className="text-2xl font-bold">{TERM.term}</h1>
+      {/* Definition intentionally remains untranslated */}
+      <p>{TERM.definition}</p>
+      <div>
+        <h2 className="font-semibold">Synonyms</h2>
+        <ul className="list-disc list-inside">
+          {synonyms.map((s) => (
+            <li key={s}>{s}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/i18n/detect.ts
+++ b/src/lib/i18n/detect.ts
@@ -1,0 +1,32 @@
+export const DEFAULT_LOCALE = 'en';
+export const SUPPORTED_LOCALES = ['en', 'es', 'fr'];
+
+/**
+ * Detect the preferred language for the current user.
+ * - In the browser, uses `navigator.languages` / `navigator.language`.
+ * - On the server, an optional Accept-Language header string can be passed.
+ * Falls back to `DEFAULT_LOCALE` when nothing matches.
+ */
+export function detectLanguage(acceptLanguage?: string): string {
+  // Browser context
+  if (typeof navigator !== 'undefined') {
+    const langs = (navigator.languages && navigator.languages.length
+      ? navigator.languages
+      : [navigator.language]) as string[];
+    for (const lang of langs) {
+      const base = lang.toLowerCase().split('-')[0];
+      if (SUPPORTED_LOCALES.includes(base)) return base;
+    }
+  }
+
+  // Server context - parse Accept-Language
+  if (acceptLanguage) {
+    const parts = acceptLanguage.split(',');
+    for (const part of parts) {
+      const base = part.trim().toLowerCase().split(';')[0].split('-')[0];
+      if (SUPPORTED_LOCALES.includes(base)) return base;
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}


### PR DESCRIPTION
## Summary
- add utility to detect user language from browser or headers
- introduce language switcher chip component
- demonstrate term page with dynamic synonyms and static definition

## Testing
- `yarn test` *(fails: IntersectionObserver is not defined, KismetApp missing button)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f4d15488328b9035aec035d84fa