### PR TITLE
feat: add search intent classifier

### DIFF
--- a/__tests__/intentClassifier.test.ts
+++ b/__tests__/intentClassifier.test.ts
@@ -1,0 +1,41 @@
+import classifySearchIntent from '@/src/lib/search/intentClassifier';
+import trackServerEvent from '@/lib/analytics-server';
+
+jest.mock('@/lib/analytics-server', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve()),
+}));
+
+describe('classifySearchIntent', () => {
+  beforeEach(() => {
+    (trackServerEvent as jest.Mock).mockClear();
+  });
+
+  it('detects compare intent', () => {
+    const query = 'compare apples vs oranges';
+    const intent = classifySearchIntent(query);
+    expect(intent).toBe('compare');
+    expect(trackServerEvent).toHaveBeenCalledWith('search_intent', { query, intent });
+  });
+
+  it('detects example intent', () => {
+    const query = 'example of phishing email';
+    const intent = classifySearchIntent(query);
+    expect(intent).toBe('example');
+    expect(trackServerEvent).toHaveBeenCalledWith('search_intent', { query, intent });
+  });
+
+  it('detects risk intent', () => {
+    const query = 'risk of sql injection';
+    const intent = classifySearchIntent(query);
+    expect(intent).toBe('risk');
+    expect(trackServerEvent).toHaveBeenCalledWith('search_intent', { query, intent });
+  });
+
+  it('defaults to definition intent', () => {
+    const query = 'what is kali linux';
+    const intent = classifySearchIntent(query);
+    expect(intent).toBe('definition');
+    expect(trackServerEvent).toHaveBeenCalledWith('search_intent', { query, intent });
+  });
+});

--- a/src/lib/search/intentClassifier.ts
+++ b/src/lib/search/intentClassifier.ts
@@ -1,0 +1,36 @@
+// Lightweight search intent classifier to keep p90 latency <20ms
+// Patterns are precompiled at module load so the function remains synchronous
+// and edge-friendly.
+import trackServerEvent from '@/lib/analytics-server';
+
+export type SearchIntent = 'definition' | 'compare' | 'example' | 'risk';
+
+// Precompiled regexes for different intents
+const comparePattern = /\b(compare|vs|versus|difference between|differ)\b/i;
+const examplePattern = /\b(example|examples|sample|demo)\b/i;
+const riskPattern = /\b(risk|danger|threat|hazard|impact)\b/i;
+
+/**
+ * Classify a search query into an intent and log it for analytics.
+ * The function is synchronous and uses simple heuristics to ensure
+ * sub-millisecond execution when deployed to the edge.
+ */
+export default function classifySearchIntent(query: string): SearchIntent {
+  const normalized = query.toLowerCase();
+  let intent: SearchIntent;
+
+  if (comparePattern.test(normalized)) {
+    intent = 'compare';
+  } else if (examplePattern.test(normalized)) {
+    intent = 'example';
+  } else if (riskPattern.test(normalized)) {
+    intent = 'risk';
+  } else {
+    intent = 'definition';
+  }
+
+  // Log query and detected intent for analytics. Fire-and-forget to avoid latency.
+  trackServerEvent('search_intent', { query, intent }).catch(() => {});
+
+  return intent;
+}


### PR DESCRIPTION
## Summary
- add synchronous search intent classifier for definition, compare, example, and risk queries
- log classified intent with query for analytics
- test intent detection and analytics logging

## Testing
- `npx eslint src/lib/search/intentClassifier.ts __tests__/intentClassifier.test.ts && echo 'eslint success'`
- `yarn test __tests__/intentClassifier.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b72f48ae608328b57b26db263d0c4b