### PR TITLE
feat: add structured data for spoofing term

### DIFF
--- a/__tests__/spoofingStructuredData.test.tsx
+++ b/__tests__/spoofingStructuredData.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { spoofingJsonLd } from '../pages/spoofing';
+
+describe('Spoofing structured data', () => {
+  it('exports DefinedTerm and BreadcrumbList JSON-LD', () => {
+    const [term, breadcrumb] = spoofingJsonLd;
+    expect(term['@type']).toBe('DefinedTerm');
+    expect(breadcrumb['@type']).toBe('BreadcrumbList');
+  });
+});

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import Head from 'next/head';
 import Meta from '../components/SEO/Meta';
+import { buildBreadcrumbList, buildDefinedTerm } from '../src/lib/seo/jsonld';
 
 interface TileProps {
   title: string;
@@ -58,19 +60,42 @@ const DnsDiagram = () => (
   </svg>
 );
 
-const SpoofingOverview = () => (
-  <>
-    <Meta />
-    <main className="p-4 grid gap-4 md:grid-cols-2 bg-ub-cool-grey min-h-screen">
-      <ToolTile title="arpspoof" link="https://manpages.debian.org/unstable/dsniff/arpspoof.8.en.html">
-        <ArpDiagram />
-      </ToolTile>
-      <ToolTile title="dnsspoof" link="https://manpages.debian.org/unstable/dsniff/dnsspoof.8.en.html">
-        <DnsDiagram />
-      </ToolTile>
-    </main>
-  </>
-);
+const baseUrl = 'https://example.com';
+export const spoofingJsonLd = [
+  buildDefinedTerm({
+    name: 'Spoofing',
+    description: 'Spoofing describes techniques used to impersonate another system or user.',
+    url: `${baseUrl}/spoofing`,
+  }),
+  buildBreadcrumbList([
+    { name: 'Home', url: baseUrl },
+    { name: 'Spoofing', url: `${baseUrl}/spoofing` },
+  ]),
+];
+
+const SpoofingOverview = () => {
+  return (
+    <>
+      <Meta />
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(spoofingJsonLd),
+          }}
+        />
+      </Head>
+      <main className="p-4 grid gap-4 md:grid-cols-2 bg-ub-cool-grey min-h-screen">
+        <ToolTile title="arpspoof" link="https://manpages.debian.org/unstable/dsniff/arpspoof.8.en.html">
+          <ArpDiagram />
+        </ToolTile>
+        <ToolTile title="dnsspoof" link="https://manpages.debian.org/unstable/dsniff/dnsspoof.8.en.html">
+          <DnsDiagram />
+        </ToolTile>
+      </main>
+    </>
+  );
+};
 
 export default SpoofingOverview;
 

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,0 +1,35 @@
+export interface DefinedTermInput {
+  name: string;
+  description?: string;
+  url: string;
+  inDefinedTermSet?: string;
+}
+
+export function buildDefinedTerm({ name, description, url, inDefinedTermSet }: DefinedTermInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name,
+    description,
+    url,
+    inDefinedTermSet,
+  };
+}
+
+export interface BreadcrumbInput {
+  name: string;
+  url: string;
+}
+
+export function buildBreadcrumbList(items: BreadcrumbInput[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add JSON-LD helpers for DefinedTerm and BreadcrumbList
- embed structured data into Spoofing term page
- test that spoofing page exposes Rich Result data

## Testing
- `node_modules/.bin/eslint src/lib/seo/jsonld.ts pages/spoofing.tsx __tests__/spoofingStructuredData.test.tsx`
- `yarn test __tests__/spoofingStructuredData.test.tsx`
- `curl -s -X POST -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" --data-urlencode "html=$(cat /tmp/spoofing.html)" https://validator.schema.org/validate | tail -c 200`


------
https://chatgpt.com/codex/tasks/task_e_68b72f40a4e08328afd56d06e56e2391