### PR TITLE
Implement glossary content graph with pagination and link tests

### DIFF
--- a/__tests__/glossaryLinks.test.tsx
+++ b/__tests__/glossaryLinks.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import TermPage from '@/pages/glossary/[term]';
+import { GLOSSARY } from '@/data/glossary';
+
+const linkTerms = GLOSSARY.map((t) => t.name);
+
+it('renders paginated references with valid links', () => {
+  const { rerender } = render(<TermPage term="root" page={1} />);
+  // first page shows 10 references
+  expect(screen.getAllByRole('listitem').length).toBe(10);
+
+  // verify each link points to a valid term
+  screen.getAllByRole('link').forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    const slug = href.replace('/glossary/', '').split('?')[0];
+    expect(linkTerms).toContain(slug);
+  });
+
+  // navigate to third page and ensure remaining references are rendered
+  rerender(<TermPage term="root" page={3} />);
+  expect(screen.getAllByRole('listitem').length).toBe(6);
+  screen.getAllByRole('link').forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    const slug = href.replace('/glossary/', '').split('?')[0];
+    expect(linkTerms).toContain(slug);
+  });
+});

--- a/data/glossary.ts
+++ b/data/glossary.ts
@@ -1,0 +1,39 @@
+export interface GlossaryEntry {
+  name: string;
+  description: string;
+  links: string[];
+}
+
+export const GLOSSARY: GlossaryEntry[] = [
+  { name: 'root', description: 'Root term', links: [] },
+  { name: 'term1', description: '', links: ['root'] },
+  { name: 'term2', description: '', links: ['root'] },
+  { name: 'term3', description: '', links: ['root'] },
+  { name: 'term4', description: '', links: ['root'] },
+  { name: 'term5', description: '', links: ['root'] },
+  { name: 'term6', description: '', links: ['root'] },
+  { name: 'term7', description: '', links: ['root'] },
+  { name: 'term8', description: '', links: ['root'] },
+  { name: 'term9', description: '', links: ['root'] },
+  { name: 'term10', description: '', links: ['root'] },
+  { name: 'term11', description: '', links: ['root'] },
+  { name: 'term12', description: '', links: ['root'] },
+  { name: 'term13', description: '', links: ['root'] },
+  { name: 'term14', description: '', links: ['root'] },
+  { name: 'term15', description: '', links: ['root'] },
+  { name: 'term16', description: '', links: ['root'] },
+  { name: 'term17', description: '', links: ['root'] },
+  { name: 'term18', description: '', links: ['root'] },
+  { name: 'term19', description: '', links: ['root'] },
+  { name: 'term20', description: '', links: ['root'] },
+  { name: 'term21', description: '', links: ['root'] },
+  { name: 'term22', description: '', links: ['root'] },
+  { name: 'term23', description: '', links: ['root'] },
+  { name: 'term24', description: '', links: ['root'] },
+  { name: 'term25', description: '', links: ['root'] },
+  { name: 'term26', description: '', links: ['root'] },
+];
+
+export function getGlossaryMap(): Record<string, GlossaryEntry> {
+  return Object.fromEntries(GLOSSARY.map((t) => [t.name, t]));
+}

--- a/pages/glossary/[term].tsx
+++ b/pages/glossary/[term].tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import { buildGlossaryGraph } from '@/src/lib/glossary/graph';
+import { GLOSSARY } from '@/data/glossary';
+
+const PAGE_SIZE = 10;
+
+export interface TermPageProps {
+  term: string;
+  page?: number;
+}
+
+/**
+ * Page component for an individual glossary term. Displays other terms that
+ * reference the current one. Results are paginated when the list exceeds
+ * the page size.
+ */
+export default function TermPage({ term, page = 1 }: TermPageProps) {
+  const graph = buildGlossaryGraph(GLOSSARY);
+  const references = graph.references[term] || [];
+  const start = (page - 1) * PAGE_SIZE;
+  const paginated = references.slice(start, start + PAGE_SIZE);
+  const totalPages = Math.ceil(references.length / PAGE_SIZE);
+
+  return (
+    <div>
+      <h1>{term}</h1>
+      <ul>
+        {paginated.map((name) => (
+          <li key={name}>
+            <Link href={`/glossary/${name}`}>{name}</Link>
+          </li>
+        ))}
+      </ul>
+      {totalPages > 1 && (
+        <nav>
+          {Array.from({ length: totalPages }, (_, i) => (
+            <Link key={i} href={`/glossary/${term}?page=${i + 1}`}>
+              {i + 1}
+            </Link>
+          ))}
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/src/lib/glossary/graph.ts
+++ b/src/lib/glossary/graph.ts
@@ -1,0 +1,28 @@
+import type { GlossaryEntry } from '@/data/glossary';
+
+export interface GlossaryGraph {
+  /**
+   * Map of a term to a list of terms that reference it.
+   */
+  references: Record<string, string[]>;
+}
+
+/**
+ * Build a graph of glossary entries, capturing which terms reference others.
+ * @param entries Array of glossary entries.
+ */
+export function buildGlossaryGraph(entries: GlossaryEntry[]): GlossaryGraph {
+  const graph: GlossaryGraph = { references: {} };
+  for (const entry of entries) {
+    for (const link of entry.links) {
+      if (!graph.references[link]) {
+        graph.references[link] = [];
+      }
+      graph.references[link].push(entry.name);
+    }
+    if (!graph.references[entry.name]) {
+      graph.references[entry.name] = [];
+    }
+  }
+  return graph;
+}


### PR DESCRIPTION
## Summary
- add glossary data and graph builder to compute referencing terms
- paginate referencing term list in glossary pages
- test glossary pages render valid links without breaks

## Testing
- `yarn test __tests__/glossaryLinks.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b72f3c15908328ae2df6c151456f93