### PR TITLE
Add service health polling chip

### DIFF
--- a/__tests__/healthChip.test.tsx
+++ b/__tests__/healthChip.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import HealthChip from "../components/util-components/health-chip";
+
+describe("HealthChip", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("updates chip on service state changes", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "ok", impactedFeatures: [] }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "down", impactedFeatures: ["API"] }),
+      } as any);
+
+    render(<HealthChip />);
+
+    expect(await screen.findByText("OK")).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(await screen.findByText("Down")).toBeInTheDocument();
+    expect(screen.getByText("Down")).toHaveAttribute("title", "API");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/components/util-components/health-chip.tsx
+++ b/components/util-components/health-chip.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+
+type HealthResponse = {
+  status: "ok" | "degraded" | "down";
+  impactedFeatures?: string[];
+};
+
+const STATUS_STYLES: Record<HealthResponse["status"], string> = {
+  ok: "bg-green-500 text-white",
+  degraded: "bg-yellow-500 text-black",
+  down: "bg-red-600 text-white",
+};
+
+const STATUS_LABELS: Record<HealthResponse["status"], string> = {
+  ok: "OK",
+  degraded: "Degraded",
+  down: "Down",
+};
+
+export default function HealthChip() {
+  const [status, setStatus] = useState<HealthResponse["status"]>("ok");
+  const [features, setFeatures] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchHealth = async () => {
+      try {
+        const res = await fetch("/api/health", { cache: "no-store" });
+        const data: HealthResponse = await res.json();
+        if (!cancelled) {
+          setStatus(data.status);
+          setFeatures(data.impactedFeatures || []);
+        }
+      } catch {
+        if (!cancelled) {
+          setStatus("down");
+          setFeatures([]);
+        }
+      }
+    };
+
+    fetchHealth();
+    const id = setInterval(fetchHealth, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  const title =
+    features.length > 0 ? features.join(", ") : "All systems operational";
+
+  return (
+    <span
+      className={`mx-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_STYLES[status]}`}
+      title={title}
+    >
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,22 +1,23 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
+import Image from "next/image";
 import SmallArrow from "./small_arrow";
-import { useSettings } from '../../hooks/useSettings';
+import { useSettings } from "../../hooks/useSettings";
+import HealthChip from "./health-chip";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(
-    typeof navigator !== "undefined" ? navigator.onLine : true
+    typeof navigator !== "undefined" ? navigator.onLine : true,
   );
 
   useEffect(() => {
     const pingServer = async () => {
       if (!window?.location) return;
       try {
-        const url = new URL('/favicon.ico', window.location.href).toString();
-        await fetch(url, { method: 'HEAD', cache: 'no-store' });
+        const url = new URL("/favicon.ico", window.location.href).toString();
+        await fetch(url, { method: "HEAD", cache: "no-store" });
         setOnline(true);
       } catch (e) {
         setOnline(false);
@@ -32,24 +33,35 @@ export default function Status() {
     };
 
     updateStatus();
-    window.addEventListener('online', updateStatus);
-    window.addEventListener('offline', updateStatus);
+    window.addEventListener("online", updateStatus);
+    window.addEventListener("offline", updateStatus);
     return () => {
-      window.removeEventListener('online', updateStatus);
-      window.removeEventListener('offline', updateStatus);
+      window.removeEventListener("online", updateStatus);
+      window.removeEventListener("offline", updateStatus);
     };
   }, []);
 
   return (
     <div className="flex justify-center items-center">
+      <HealthChip />
       <span
         className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+        title={
+          online
+            ? allowNetwork
+              ? "Online"
+              : "Online (requests blocked)"
+            : "Offline"
+        }
       >
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={
+            online
+              ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+              : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"
+          }
           alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"

--- a/pages/api/health.js
+++ b/pages/api/health.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ status: "ok", impactedFeatures: [] });
+}


### PR DESCRIPTION
## Summary
- poll `/api/health` every 5s and display OK/Degraded/Down chip with impacted features tooltip
- surface health chip in status bar
- cover health chip with integration test

## Testing
- `npx eslint components/util-components/health-chip.tsx components/util-components/status.js pages/api/health.js __tests__/healthChip.test.tsx`
- `yarn test __tests__/healthChip.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b72f397db88328808176a31e70ab06