### PR TITLE
Add performance budgets and Speed Insights scripts

### DIFF
--- a/docs/perf-budget.md
+++ b/docs/perf-budget.md
@@ -1,0 +1,12 @@
+# Performance Budgets
+
+Define critical performance budgets for key routes. Metrics are in milliseconds unless noted.
+
+| Route | LCP (ms) | FID (ms) | CLS |
+|-------|---------|---------|-----|
+| / | 2500 | 100 | 0.1 |
+| /about | 2500 | 100 | 0.1 |
+| /games | 3000 | 100 | 0.1 |
+| /scanner | 3000 | 100 | 0.1 |
+
+Budgets serve as thresholds for automated alerts.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "build:sw": "node scripts/generate-sw.mjs",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "ANALYZE=true yarn build",
+    "speed:activate": "node scripts/speed-insights.mjs",
+    "perf:check": "node scripts/check-perf-budgets.mjs"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/check-perf-budgets.mjs
+++ b/scripts/check-perf-budgets.mjs
@@ -1,0 +1,45 @@
+import fs from 'fs';
+
+const { SLACK_WEBHOOK_URL, VERCEL_TOKEN, VERCEL_PROJECT_ID } = process.env;
+
+if (!VERCEL_TOKEN || !VERCEL_PROJECT_ID) {
+  console.error('Missing VERCEL_TOKEN or VERCEL_PROJECT_ID');
+  process.exit(1);
+}
+
+function parseBudgets() {
+  const md = fs.readFileSync(new URL('../docs/perf-budget.md', import.meta.url), 'utf8');
+  const lines = md.split('\n').filter(l => l.startsWith('|'));
+  const data = lines.slice(2); // skip header and separator
+  return data.map(line => {
+    const [ , route, lcp, fid, cls ] = line.split('|').map(s => s.trim());
+    return { route, lcp: Number(lcp), fid: Number(fid), cls: Number(cls) };
+  });
+}
+
+async function getMetrics(route) {
+  const url = `https://api.vercel.com/v1/speed-insights/${VERCEL_PROJECT_ID}?path=${encodeURIComponent(route)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${VERCEL_TOKEN}` } });
+  if (!res.ok) throw new Error(`Failed metrics for ${route}: ${res.status}`);
+  return res.json();
+}
+
+async function notify(route, metric, value, budget) {
+  if (!SLACK_WEBHOOK_URL) return;
+  const text = `:rotating_light: ${route} ${metric} ${value} exceeds budget ${budget}`;
+  await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+}
+
+(async () => {
+  const budgets = parseBudgets();
+  for (const { route, lcp, fid, cls } of budgets) {
+    const metrics = await getMetrics(route);
+    if (metrics.lcp > lcp) await notify(route, 'LCP', metrics.lcp, lcp);
+    if (metrics.fid > fid) await notify(route, 'FID', metrics.fid, fid);
+    if (metrics.cls > cls) await notify(route, 'CLS', metrics.cls, cls);
+  }
+})();

--- a/scripts/speed-insights.mjs
+++ b/scripts/speed-insights.mjs
@@ -1,0 +1,41 @@
+const { VERCEL_TOKEN, VERCEL_PROJECT_ID, DEPLOYMENT_ID, ANNOTATION_MESSAGE = 'Major deploy' } = process.env;
+
+if (!VERCEL_TOKEN || !VERCEL_PROJECT_ID) {
+  console.error('Missing VERCEL_TOKEN or VERCEL_PROJECT_ID');
+  process.exit(1);
+}
+
+const headers = {
+  Authorization: `Bearer ${VERCEL_TOKEN}`,
+  'Content-Type': 'application/json'
+};
+
+async function activateSpeedInsights() {
+  const res = await fetch(`https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ speedInsights: { enabled: true } })
+  });
+  if (!res.ok) {
+    throw new Error(`Enable Speed Insights failed: ${res.status} ${res.statusText}`);
+  }
+  console.log('Speed Insights activated');
+}
+
+async function annotateDeploy(message) {
+  if (!DEPLOYMENT_ID) return;
+  const res = await fetch(`https://api.vercel.com/v2/deployments/${DEPLOYMENT_ID}/annotations`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ message })
+  });
+  if (!res.ok) {
+    throw new Error(`Annotation failed: ${res.status} ${res.statusText}`);
+  }
+  console.log('Deployment annotated');
+}
+
+(async () => {
+  await activateSpeedInsights();
+  await annotateDeploy(ANNOTATION_MESSAGE);
+})();


### PR DESCRIPTION
## Summary
- document performance budgets per route
- script to enable Vercel Speed Insights and annotate deploys
- Slack alert script for routes exceeding perf budgets

## Testing
- `yarn lint` *(fails: terminated after extended runtime)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b72f34f2748328b627b1bc2443974b