### PR TITLE
feat: add safe copy script for gamepad build artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prebuild": "tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build && yarn build:sw",
-    "postbuild": "node -e \"const fs=require('fs');fs.mkdirSync('public/vendor',{recursive:true});fs.copyFileSync('dist/utils/gamepad.js','public/vendor/gamepad.js')\"",
+    "postbuild": "node scripts/safe-copy.mjs",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build && yarn build:sw",
     "test": "jest",

--- a/scripts/safe-copy.mjs
+++ b/scripts/safe-copy.mjs
@@ -1,0 +1,17 @@
+import { access, mkdir, copyFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const src = 'dist/utils/gamepad.js';
+const destDir = 'public/vendor';
+const dest = `${destDir}/gamepad.js`;
+
+try {
+  await access(src, constants.F_OK);
+} catch {
+  console.warn(`Warning: ${src} not found. Skipping copy.`);
+  process.exit(0);
+}
+
+await mkdir(destDir, { recursive: true });
+await copyFile(src, dest);
+console.log(`Copied ${src} to ${dest}`);


### PR DESCRIPTION
## Summary
- add safe-copy script to check for the gamepad build artifact and copy it if present
- run script via postbuild hook

## Testing
- `npx eslint scripts/safe-copy.mjs`
- `npm test` *(fails: manual cancellation after ~58s due to prolonged runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c96fa7c4832893d7c36caebee914