### PR TITLE
Pin Vercel function runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }
 }


### PR DESCRIPTION
## Summary
- specify `@vercel/node@5.3.20` runtime in vercel.json to resolve Function Runtimes version errors

## Testing
- `yarn test __tests__/calc.test.ts`
- ⚠️ `yarn test` (hangs after completing tests)


------
https://chatgpt.com/codex/tasks/task_e_68b8cbe388e88328b699ca610af7cecf