### PR TITLE
Configure Vercel build settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,7 @@
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
     "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
-  }
+  },
+  "installCommand": "corepack enable && yarn set version 4.9.2 && yarn install --immutable",
+  "buildCommand": "yarn build"
 }


### PR DESCRIPTION
## Summary
- specify custom install command for Yarn 4 and immutable installs
- explicitly set Vercel build command to `yarn build`

## Testing
- `yarn lint` *(fails: Component definition is missing display name and other warnings)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b8c96f9f148328a80c5ca7f0d7448d