### PR TITLE
fix(chat): handle missing chat id

### DIFF
--- a/__tests__/chatManager.test.ts
+++ b/__tests__/chatManager.test.ts
@@ -1,0 +1,7 @@
+import { getChatId } from '../src/chat/chatManager';
+
+describe('getChatId', () => {
+  it('throws when chat is undefined', () => {
+    expect(() => getChatId(undefined as any)).toThrow('chat is required');
+  });
+});

--- a/src/chat/chatManager.ts
+++ b/src/chat/chatManager.ts
@@ -1,0 +1,10 @@
+export interface Chat {
+  id: string;
+}
+
+export function getChatId(chat?: Chat) {
+  if (!chat) {
+    throw new Error('chat is required');
+  }
+  return chat.id;
+}


### PR DESCRIPTION
## Summary
- add chatManager with guard against undefined chat ids
- test chatManager to ensure it throws when chat is undefined

## Testing
- `yarn test __tests__/chatManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce9c86b483288915f144f59f2a04