### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+registries:
+  npm-registry:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: ${{secrets.NPM_TOKEN}}
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    registries:
+      - npm-registry
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- configure Dependabot to monitor npm packages and GitHub Actions weekly
- include placeholder for private npm registry authentication

## Testing
- `yarn test` *(fails: command not found)*
- `npm test` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(installation in progress, Node not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ce9e4a308328bda7c03c1d810b33