### PR TITLE
fix(hashcat): align benchmark output test

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -21,7 +21,10 @@ describe('HashcatApp', () => {
     const { getByText, getByTestId } = render(<HashcatApp />);
     fireEvent.click(getByText('Run Benchmark'));
     await waitFor(() => {
-      expect(getByTestId('benchmark-output').textContent).toMatch(/GPU0/);
+      // The benchmark now reports full hashcat-style output (e.g. "GPU0: 4500 MH/s")
+      // instead of merely containing the device label. Verify the numeric speed and
+      // units to ensure the component renders the complete result.
+      expect(getByTestId('benchmark-output').textContent).toMatch(/GPU0: \d+ MH\/s/);
     });
   });
 


### PR DESCRIPTION
## Summary
- update benchmark test to match full GPU0 speed format

## Testing
- `yarn test __tests__/hashcat.test.tsx`
- `yarn eslint __tests__/hashcat.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce98994c83289fa2df69bf02b6a8