### PR TITLE
refactor: replace any placeholders with concrete types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -21,7 +21,12 @@ export type GamepadEventMap = {
 type Listener<T> = (event: T) => void;
 
 class GamepadManager {
-  private listeners: Record<string, Set<Listener<any>>> = {};
+  private listeners: { [K in keyof GamepadEventMap]: Set<Listener<GamepadEventMap[K]>> } = {
+    connected: new Set(),
+    disconnected: new Set(),
+    button: new Set(),
+    axis: new Set(),
+  };
   private prevButtons = new Map<number, number[]>();
   private prevAxes = new Map<number, number[]>();
   private raf: number | null = null;
@@ -41,15 +46,15 @@ class GamepadManager {
   }
 
   on<K extends keyof GamepadEventMap>(type: K, fn: Listener<GamepadEventMap[K]>) {
-    (this.listeners[type as string] ??= new Set()).add(fn as Listener<any>);
+    this.listeners[type].add(fn);
   }
 
   off<K extends keyof GamepadEventMap>(type: K, fn: Listener<GamepadEventMap[K]>) {
-    this.listeners[type as string]?.delete(fn as Listener<any>);
+    this.listeners[type].delete(fn);
   }
 
   private emit<K extends keyof GamepadEventMap>(type: K, event: GamepadEventMap[K]) {
-    this.listeners[type as string]?.forEach((fn) => (fn as Listener<GamepadEventMap[K]>)(event));
+    this.listeners[type].forEach((fn) => fn(event));
   }
 
   start() {


### PR DESCRIPTION
## Summary
- define minimal Web Serial interfaces and use them in Serial Terminal app
- model WebUSB structures to eliminate `any` in USB app
- tighten Gamepad listener typings and predefine listener sets
- enforce case-sensitive file names via TypeScript config

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce9b48c08328a1d470341035a147