### PR TITLE
feat: dynamically load analytics

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import 'fake-indexeddb/auto';
@@ -19,10 +18,17 @@ function MyApp(props) {
 
 
   useEffect(() => {
-    const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
-    if (trackingId) {
-      ReactGA.initialize(trackingId);
-    }
+    const initAnalytics = async () => {
+      const trackingId = process.env.NEXT_PUBLIC_TRACKING_ID;
+      if (trackingId) {
+        const { default: ReactGA } = await import('react-ga4');
+        ReactGA.initialize(trackingId);
+      }
+    };
+    initAnalytics().catch((err) => {
+      console.error('Analytics initialization failed', err);
+    });
+
     if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
       const register = async () => {
         try {


### PR DESCRIPTION
## Summary
- dynamically import react-ga4 in analytics effect
- remove static ReactGA import and initialize only when tracking ID exists

## Testing
- `NEXT_PUBLIC_TRACKING_ID='test' yarn test --runTestsByPath __tests__/analytics.test.ts`
- `yarn test --runTestsByPath __tests__/analytics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8d09325788328893eb4bd8eda8c86