### PR TITLE
Use structuredClone for Sokoban undo snapshots

### DIFF
--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -5,6 +5,11 @@ import levelPack from './sokoban_levels.json';
 
 const TILE = 32;
 
+// Provide a lightweight structuredClone polyfill for browsers that lack support
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = (val) => JSON.parse(JSON.stringify(val));
+}
+
 const parseLevel = (level) => {
   const board = level.map((r) => r.split(''));
   let player = { x: 0, y: 0 };
@@ -166,7 +171,7 @@ const move = ({ x, y }) => {
   if (paused) return;
   const res = attemptMove(stateRef.current, x, y);
   if (!res) return;
-  undoRef.current.push(JSON.parse(JSON.stringify(stateRef.current)));
+  undoRef.current.push(structuredClone(stateRef.current));
   const newState = {
     board: res.board,
     player: res.player,


### PR DESCRIPTION
## Summary
- use `structuredClone` for Sokoban undo snapshots
- add lightweight `structuredClone` polyfill for older browsers

## Testing
- `CI=true yarn test`
- `npx eslint components/apps/sokoban.js`
- `yarn dev` *(fails: no browser available to verify gameplay)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d09524b4832888eb10b0fac55ceb