### PR TITLE
Remove fake-indexeddb import from app and restrict to tests

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import 'fake-indexeddb/auto';
 import 'tailwindcss/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';


### PR DESCRIPTION
## Summary
- Remove fake-indexeddb polyfill from `_app.jsx`
- Keep IndexedDB polyfill in `jest.setup.ts` for tests

## Testing
- `yarn test __tests__/saveSlots.test.ts`
- `yarn build` *(fails: Global CSS cannot be imported from files other than your Custom <App>)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d090dd5483288b8ee0d1eb79f669