### PR TITLE
Fix webpack Module.issuer deprecation

### DIFF
--- a/.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch
+++ b/.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch
@@ -1,0 +1,25 @@
+diff --git a/dist/build/webpack/loaders/error-loader.js b/dist/build/webpack/loaders/error-loader.js
+index 04812c7ecbebcb38e4315ae25b049858c20f99cb..9ea44e5b7f577f0e0de53c9c39639e57acd61695 100644
+--- a/dist/build/webpack/loaders/error-loader.js
++++ b/dist/build/webpack/loaders/error-loader.js
+@@ -16,12 +16,12 @@ Object.defineProperty(exports, "default", {
+     };
+ }
+ const ErrorLoader = function() {
+-    var _this__module_issuer, _this__module, _this__compiler;
++    var _this__module, _this__compiler, _this__compilation, _this__issuer;
+     // @ts-ignore exists
+     const options = this.getOptions() || {};
+     const { reason = 'An unknown error has occurred' } = options;
+     // @ts-expect-error
+-    const resource = ((_this__module = this._module) == null ? void 0 : (_this__module_issuer = _this__module.issuer) == null ? void 0 : _this__module_issuer.resource) ?? null;
++    const resource = ((_this__module = this._module) == null ? void 0 : (_this__issuer = (_this__compilation = this._compilation) == null ? void 0 : _this__compilation.moduleGraph.getIssuer(_this__module)) == null ? void 0 : _this__issuer.resource) ?? null;
+     const context = this.rootContext ?? ((_this__compiler = this._compiler) == null ? void 0 : _this__compiler.context);
+     const issuer = resource ? context ? _path.default.relative(context, resource) : resource : null;
+     const err = Object.defineProperty(new Error(reason + (issuer ? `\nLocation: ${(0, _picocolors.cyan)(issuer)}` : '')), "__NEXT_ERROR_CODE", {
+@@ -33,4 +33,4 @@ const ErrorLoader = function() {
+ };
+ const _default = ErrorLoader;
+ 
+-//# sourceMappingURL=error-loader.js.map
++//# sourceMappingURL=error-loader.js.map

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
     "webpack": "^5.92.0",
+    "next": "patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch",
     "@napi-rs/canvas": "patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
   "packageManager": "yarn@4.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8109,7 +8109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^15.0.0":
+"next@npm:15.5.2":
   version: 15.5.2
   resolution: "next@npm:15.5.2"
   dependencies:
@@ -8165,6 +8165,65 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: 10c0/3bed56bcca1f0fe07908fa075229f7f2662b4870974570f9e5a944758db9960868704ea4253f05c79507381b2e0014e8b621d7934408e26a0df8cbb3621986d8
+  languageName: node
+  linkType: hard
+
+"next@patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch::locator=unnippillil%40workspace%3A.":
+  version: 15.5.2
+  resolution: "next@patch:next@npm%3A15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch::version=15.5.2&hash=0b67c1&locator=unnippillil%40workspace%3A."
+  dependencies:
+    "@next/env": "npm:15.5.2"
+    "@next/swc-darwin-arm64": "npm:15.5.2"
+    "@next/swc-darwin-x64": "npm:15.5.2"
+    "@next/swc-linux-arm64-gnu": "npm:15.5.2"
+    "@next/swc-linux-arm64-musl": "npm:15.5.2"
+    "@next/swc-linux-x64-gnu": "npm:15.5.2"
+    "@next/swc-linux-x64-musl": "npm:15.5.2"
+    "@next/swc-win32-arm64-msvc": "npm:15.5.2"
+    "@next/swc-win32-x64-msvc": "npm:15.5.2"
+    "@swc/helpers": "npm:0.5.15"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.34.3"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.51.1
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10c0/023215b0a2614ff2f25e7ab2dfa25267c1b742867bfc160e66a55f374b0af30891c1f93c69d340dddff766a91a3a3e763b444eaa890f1182a6813a5e834408d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- patch Next.js error-loader to use the ModuleGraph API instead of the deprecated `module.issuer`
- add yarn resolution to apply the patched loader

## Testing
- `yarn test __tests__/calc.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b8d11a99508328b3a9a2b2db75ebcb