### PR TITLE
Use Webpack 5 moduleGraph issuer API in Next error loader

### DIFF
--- a/node_modules/next/dist/build/webpack/loaders/error-loader.js
+++ b/node_modules/next/dist/build/webpack/loaders/error-loader.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "default", {
+    enumerable: true,
+    get: function() {
+        return _default;
+    }
+});
+const _picocolors = require("../../../lib/picocolors");
+const _path = /*#__PURE__*/ _interop_require_default(require("path"));
+function _interop_require_default(obj) {
+    return obj && obj.__esModule ? obj : {
+        default: obj
+    };
+}
+const ErrorLoader = function() {
+    var _this__compiler;
+    // @ts-ignore exists
+    const options = this.getOptions() || {};
+    const { reason = 'An unknown error has occurred' } = options;
+    // @ts-expect-error
+    const resource =
+        this._module
+            ? this._compilation.moduleGraph.getIssuer(this._module)?.resource ?? null
+            : null;
+    const context = this.rootContext ?? ((_this__compiler = this._compiler) == null ? void 0 : _this__compiler.context);
+    const issuer = resource ? context ? _path.default.relative(context, resource) : resource : null;
+    const err = Object.defineProperty(new Error(reason + (issuer ? `\nLocation: ${(0, _picocolors.cyan)(issuer)}` : '')), "__NEXT_ERROR_CODE", {
+        value: "E339",
+        enumerable: false,
+        configurable: true
+    });
+    this.emitError(err);
+};
+const _default = ErrorLoader;
+
+//# sourceMappingURL=error-loader.js.map

--- a/node_modules/next/dist/esm/build/webpack/loaders/error-loader.js
+++ b/node_modules/next/dist/esm/build/webpack/loaders/error-loader.js
@@ -1,0 +1,24 @@
+import { cyan } from '../../../lib/picocolors';
+import path from 'path';
+const ErrorLoader = function() {
+    var _this__compiler;
+    // @ts-ignore exists
+    const options = this.getOptions() || {};
+    const { reason = 'An unknown error has occurred' } = options;
+    // @ts-expect-error
+    const resource =
+        this._module
+            ? this._compilation.moduleGraph.getIssuer(this._module)?.resource ?? null
+            : null;
+    const context = this.rootContext ?? ((_this__compiler = this._compiler) == null ? void 0 : _this__compiler.context);
+    const issuer = resource ? context ? path.relative(context, resource) : resource : null;
+    const err = Object.defineProperty(new Error(reason + (issuer ? `\nLocation: ${cyan(issuer)}` : '')), "__NEXT_ERROR_CODE", {
+        value: "E339",
+        enumerable: false,
+        configurable: true
+    });
+    this.emitError(err);
+};
+export default ErrorLoader;
+
+//# sourceMappingURL=error-loader.js.map


### PR DESCRIPTION
## Summary
- access module issuers via `compilation.moduleGraph.getIssuer` per Webpack 5
- mirror change in both CJS and ESM builds of Next's error-loader

## Testing
- `yarn build` *(fails: Global CSS cannot be imported from files other than your Custom <App> and Final loader didn't return a Buffer or String, but no DEP_WEBPACK_MODULE_ISSUER warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d2c09d148328aa9ee54e1166d220