### PR TITLE
test: add module metadata characterization and refactor for lookup

### DIFF
--- a/__tests__/metadata.test.ts
+++ b/__tests__/metadata.test.ts
@@ -1,0 +1,61 @@
+import modules from '../modules/metadata';
+
+describe('modules metadata', () => {
+  it('matches the current module metadata', () => {
+    expect(modules).toEqual([
+      {
+        name: 'getsystem',
+        description: 'Attempt to elevate your privilege to that of local system.',
+        tags: ['privilege', 'elevation'],
+        options: [
+          {
+            name: 'SESSION',
+            required: true,
+            description: 'The session to run this module on.',
+          },
+        ],
+      },
+      {
+        name: 'keyscan_start',
+        description: 'Start capturing keystrokes.',
+        tags: ['keylogging'],
+        options: [
+          {
+            name: 'SESSION',
+            required: true,
+            description: 'The session to run this module on.',
+          },
+        ],
+      },
+      {
+        name: 'persistence_service',
+        description: 'Achieve persistence by installing a service.',
+        tags: ['persistence', 'service'],
+        options: [
+          {
+            name: 'SESSION',
+            required: true,
+            description: 'The session to run this module on.',
+          },
+          {
+            name: 'RPORT',
+            required: false,
+            description: 'Remote port used for callback.',
+          },
+        ],
+      },
+      {
+        name: 'hashdump',
+        description: 'Dump password hashes from the SAM database.',
+        tags: ['credentials', 'dump'],
+        options: [
+          {
+            name: 'SESSION',
+            required: true,
+            description: 'The session to run this module on.',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -11,8 +11,8 @@ export interface ModuleMetadata {
   options: ModuleOption[];
 }
 
-const modules: ModuleMetadata[] = [
-  {
+const MODULES: Record<string, ModuleMetadata> = {
+  getsystem: {
     name: 'getsystem',
     description: 'Attempt to elevate your privilege to that of local system.',
     tags: ['privilege', 'elevation'],
@@ -24,7 +24,7 @@ const modules: ModuleMetadata[] = [
       },
     ],
   },
-  {
+  keyscan_start: {
     name: 'keyscan_start',
     description: 'Start capturing keystrokes.',
     tags: ['keylogging'],
@@ -36,7 +36,7 @@ const modules: ModuleMetadata[] = [
       },
     ],
   },
-  {
+  persistence_service: {
     name: 'persistence_service',
     description: 'Achieve persistence by installing a service.',
     tags: ['persistence', 'service'],
@@ -53,7 +53,7 @@ const modules: ModuleMetadata[] = [
       },
     ],
   },
-  {
+  hashdump: {
     name: 'hashdump',
     description: 'Dump password hashes from the SAM database.',
     tags: ['credentials', 'dump'],
@@ -65,6 +65,11 @@ const modules: ModuleMetadata[] = [
       },
     ],
   },
-];
+};
+
+export const getModuleMetadata = (name: string): ModuleMetadata | undefined =>
+  MODULES[name];
+
+const modules: ModuleMetadata[] = Object.values(MODULES);
 
 export default modules;


### PR DESCRIPTION
## Summary
- add tests capturing current module metadata
- refactor metadata module to use a lookup map and expose getter

## Testing
- `yarn test __tests__/metadata.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b8d7382a208328bf637f10b5d2ef52