### PR TITLE
refactor: refine analytics and storage typings

### DIFF
--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -4,8 +4,9 @@ type EventInput = Parameters<typeof ReactGA.event>[0];
 
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
   try {
-    if (typeof ReactGA?.event === 'function') {
-      (ReactGA.event as any)(...args);
+    const eventFn = ReactGA.event;
+    if (typeof eventFn === 'function') {
+      eventFn(...args);
     }
   } catch {
     // Ignore analytics errors
@@ -13,7 +14,7 @@ const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
 };
 
 export const logEvent = (event: EventInput): void => {
-  safeEvent(event as any);
+  safeEvent(event);
 };
 
 export const logGameStart = (game: string): void => {


### PR DESCRIPTION
## Summary
- refactor analytics utility to call ReactGA.event without `any` casts
- add typed helper for experimental `navigator.storage.getDirectory` and remove `any`
- document TODO for future File System Access API typing

## Testing
- `yarn tsc --noEmit && echo tsc-ok`

------
https://chatgpt.com/codex/tasks/task_e_68b8d719a7d083288423401e20292fd9