### PR TITLE
fix(chat): handle missing chat id

### DIFF
--- a/__tests__/chatManager.test.ts
+++ b/__tests__/chatManager.test.ts
@@ -1,7 +1,7 @@
 import { getChatId } from '../src/chat/chatManager';
 
 describe('getChatId', () => {
-  it('throws when chat is undefined', () => {
-    expect(() => getChatId(undefined as any)).toThrow('chat is required');
+  it('returns undefined when chat is missing', () => {
+    expect(getChatId(undefined as any)).toBeUndefined();
   });
 });

--- a/src/chat/chatManager.ts
+++ b/src/chat/chatManager.ts
@@ -2,9 +2,6 @@ export interface Chat {
   id: string;
 }
 
-export function getChatId(chat?: Chat) {
-  if (!chat) {
-    throw new Error('chat is required');
-  }
-  return chat.id;
+export function getChatId(chat?: Chat): string | undefined {
+  return chat?.id;
 }


### PR DESCRIPTION
## Summary
- handle undefined chat parameter before accessing id
- test getChatId returns undefined when chat is missing

## Testing
- `yarn test`
- `yarn test __tests__/chatManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8d71b3b748328b15ded82589f32a9