### PR TITLE
feat: add structured logging with correlation ids

### DIFF
--- a/__tests__/adminMessages.test.ts
+++ b/__tests__/adminMessages.test.ts
@@ -1,0 +1,29 @@
+import { createMocks } from 'node-mocks-http';
+
+describe('admin messages api', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc';
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.ADMIN_READ_KEY;
+  });
+
+  it('logs unauthorized access', async () => {
+    process.env.ADMIN_READ_KEY = 'secret';
+    const { req, res } = createMocks({ method: 'GET', headers: {} });
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const { default: handler } = await import('../pages/api/admin/messages');
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(401);
+    expect(spy).toHaveBeenCalled();
+    const log = JSON.parse(spy.mock.calls[0][0]);
+    expect(log.message).toMatch(/unauthorized/);
+    spy.mockRestore();
+  });
+});

--- a/__tests__/chatManager.test.ts
+++ b/__tests__/chatManager.test.ts
@@ -1,7 +1,15 @@
 import { getChatId } from '../src/chat/chatManager';
+import { createLogger } from '../lib/logger';
 
 describe('getChatId', () => {
-  it('throws when chat is undefined', () => {
-    expect(() => getChatId(undefined as any)).toThrow('chat is required');
+  it('throws and logs when chat is undefined', () => {
+    const logger = createLogger('test');
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    expect(() => getChatId(undefined as any, logger)).toThrow('chat is required');
+    expect(spy).toHaveBeenCalled();
+    const log = JSON.parse((spy.mock.calls[0] as any)[0]);
+    expect(log.level).toBe('error');
+    expect(log.message).toBe('chat is required');
+    spy.mockRestore();
   });
 });

--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -3,16 +3,17 @@
 import React, { useCallback } from 'react';
 import KismetApp from '../../components/apps/kismet';
 import DeauthWalkthrough from './components/DeauthWalkthrough';
+import { createLogger } from '../../lib/logger';
 
 const KismetPage: React.FC = () => {
   const handleNetworkDiscovered = useCallback(
     (net?: { ssid: string; bssid: string; discoveredAt: number }) => {
       if (!net) return;
-      console.log(
-        `Network ${net.ssid || net.bssid} discovered at ${new Date(
-          net.discoveredAt,
-        ).toLocaleTimeString()}`,
-      );
+      const logger = createLogger();
+      logger.info('network discovered', {
+        ssid: net.ssid || net.bssid,
+        time: new Date(net.discoveredAt).toISOString(),
+      });
     },
     [],
   );

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'crypto';
+
+const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'key']);
+
+export interface Logger {
+  info(message: string, meta?: Record<string, any>): void;
+  warn(message: string, meta?: Record<string, any>): void;
+  error(message: string, meta?: Record<string, any>): void;
+  debug(message: string, meta?: Record<string, any>): void;
+}
+
+class ConsoleLogger implements Logger {
+  constructor(private correlationId: string) {}
+
+  private log(level: string, message: string, meta: Record<string, any> = {}) {
+    const safeMeta: Record<string, any> = {};
+    for (const [key, value] of Object.entries(meta)) {
+      if (!SENSITIVE_KEYS.has(key.toLowerCase())) {
+        safeMeta[key] = value;
+      }
+    }
+    const entry = {
+      level,
+      message,
+      correlationId: this.correlationId,
+      ...safeMeta,
+    };
+    console.log(JSON.stringify(entry));
+  }
+
+  info(message: string, meta?: Record<string, any>) {
+    this.log('info', message, meta);
+  }
+  warn(message: string, meta?: Record<string, any>) {
+    this.log('warn', message, meta);
+  }
+  error(message: string, meta?: Record<string, any>) {
+    this.log('error', message, meta);
+  }
+  debug(message: string, meta?: Record<string, any>) {
+    this.log('debug', message, meta);
+  }
+}
+
+export function createLogger(correlationId: string = randomUUID()): Logger {
+  return new ConsoleLogger(correlationId);
+}

--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -1,16 +1,20 @@
 import { serviceClient } from '../../../lib/service-client';
+import { createLogger } from '../../../lib/logger';
 
 export default async function handler(
   req,
   res
 ) {
+  const logger = createLogger(req.headers['x-correlation-id']);
   if (req.method !== 'GET') {
+    logger.warn('method not allowed', { method: req.method });
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
 
   const key = req.headers['x-admin-key'];
   if (key !== process.env.ADMIN_READ_KEY) {
+    logger.warn('unauthorized admin access attempt');
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
@@ -22,10 +26,13 @@ export default async function handler(
       .order('created_at', { ascending: false })
       .limit(100);
     if (error) {
+      logger.error('error fetching messages', { err: error.message });
       throw error;
     }
+    logger.info('admin messages retrieved', { count: data.length });
     res.status(200).json({ messages: data });
   } catch (err) {
+    logger.error('failed to load admin messages', { err: err.message });
     res.status(500).json({ error: err.message });
   }
 }

--- a/src/chat/chatManager.ts
+++ b/src/chat/chatManager.ts
@@ -1,10 +1,14 @@
+import { createLogger, Logger } from '../../lib/logger';
+
 export interface Chat {
   id: string;
 }
 
-export function getChatId(chat?: Chat) {
+export function getChatId(chat?: Chat, logger: Logger = createLogger()) {
   if (!chat) {
+    logger.error('chat is required');
     throw new Error('chat is required');
   }
+  logger.info('chat id retrieved', { chatId: chat.id });
   return chat.id;
 }


### PR DESCRIPTION
## Summary
- introduce JSON-based logger with correlation ID support
- use structured logging in chat manager, admin message API, and Kismet network discovery
- add unit tests verifying error and unauthorized logs

## Testing
- `./node_modules/.bin/jest __tests__/chatManager.test.ts __tests__/adminMessages.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8d733b0b083288a2f1274693b74c0