### PR TITLE
fix: guard browser APIs for ssr

### DIFF
--- a/utils/idb.ts
+++ b/utils/idb.ts
@@ -5,6 +5,10 @@ const STORE_REPLAYS = 'replays';
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB not available on server'));
+      return;
+    }
     const req = indexedDB.open(DB_NAME, VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;


### PR DESCRIPTION
## Summary
- avoid IndexedDB access during SSR in ClipboardManager
- lazy-init and guard IndexedDB use in Sticky Notes app
- guard shared IDB helper from server usage

## Testing
- `yarn test` (fails: GamepadManager tests due to undefined listeners)
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b8d7c849b08328b196157922f3edc5