### PR TITLE
Fix yarn patch resolution entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,8 +133,8 @@
     "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
     "webpack": "^5.92.0",
-    "next": "patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch",
-    "@napi-rs/canvas": "patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
+    "next@npm:^15.0.0": "patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch",
+    "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
   "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
## Summary
- ensure yarn patch resolutions specify ranges for `next` and `@napi-rs/canvas`

## Testing
- `yarn install --immutable`
- `yarn lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9da54448328aab9eafe9f098fa2