### PR TITLE
Initialize gamepad listeners to prevent crashes

### DIFF
--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -21,7 +21,12 @@ export type GamepadEventMap = {
 type Listener<T> = (event: T) => void;
 
 class GamepadManager {
-  private listeners: Record<string, Set<Listener<any>>> = {};
+  private listeners: Record<keyof GamepadEventMap, Set<Listener<any>>> = {
+    connected: new Set(),
+    disconnected: new Set(),
+    button: new Set(),
+    axis: new Set(),
+  };
   private prevState = new Map<number, { buttons: number[]; axes: number[] }>();
 
   private raf: number | null = null;


### PR DESCRIPTION
## Summary
- initialize listener sets in GamepadManager so events register correctly

## Testing
- `yarn test __tests__/gamepad.test.ts`
- `yarn lint` *(fails: Unused eslint-disable directive & import/no-anonymous-default-export warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9fa612883288021c261cff9fcae