### PR TITLE
Defer PWA install prompt to user action

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -22,9 +22,12 @@ describe('InstallButton', () => {
       window.dispatchEvent(event);
     });
 
+    // The install prompt shouldn't trigger automatically.
+    expect(prompt).not.toHaveBeenCalled();
+
     const button = await screen.findByText(/install/i);
     await userEvent.click(button);
-    expect(prompt).toHaveBeenCalled();
+    expect(prompt).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       resolveChoice({ outcome: 'accepted', platform: 'test' });

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -8,26 +8,28 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 const InstallButton: React.FC = () => {
-  const [prompt, setPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  // Store the install prompt event so it can be triggered later by a user action.
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
     const handler = (e: BeforeInstallPromptEvent) => {
       e.preventDefault();
-      setPrompt(e);
+      setDeferredPrompt(e);
     };
     (window as any).addEventListener('beforeinstallprompt', handler);
     return () => (window as any).removeEventListener('beforeinstallprompt', handler);
   }, []);
 
   const handleInstall = async () => {
-    if (!prompt) return;
-    await prompt.prompt();
-    await prompt.userChoice;
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
     trackEvent('cta_click', { location: 'install_button' });
-    setPrompt(null);
+    // Reset the stored event to avoid prompting multiple times.
+    setDeferredPrompt(null);
   };
 
-  if (!prompt) return null;
+  if (!deferredPrompt) return null;
 
   return (
     <button


### PR DESCRIPTION
## Summary
- store `beforeinstallprompt` event for later use and reset after prompting
- add test ensuring the install prompt only fires when clicking the Install button

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b8dfa9464c8328b772f1ece2bf18da