### PR TITLE
Use useEffect for lock screen event listeners

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
@@ -6,10 +6,15 @@ export default function LockScreen(props) {
 
     const { wallpaper } = useSettings();
 
-    if (props.isLocked) {
+    useEffect(() => {
+        if (!props.isLocked) return;
         window.addEventListener('click', props.unLockScreen);
         window.addEventListener('keypress', props.unLockScreen);
-    };
+        return () => {
+            window.removeEventListener('click', props.unLockScreen);
+            window.removeEventListener('keypress', props.unLockScreen);
+        };
+    }, [props.isLocked, props.unLockScreen]);
 
     return (
         <div


### PR DESCRIPTION
## Summary
- add `useEffect` to register click and keypress listeners when locked
- clean up event handlers on unlock or unmount

## Testing
- `npx eslint components/screen/lock_screen.js`
- `yarn test __tests__/solitaireEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc6075dc8328b3faac7e5b323db3