### PR TITLE
chore: self-host Ubuntu font

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,6 @@ These external domains are whitelisted in the default CSP. Update this list when
 
 | Domain | Purpose |
 | --- | --- |
-| `fonts.googleapis.com` | Stylesheets for Google Fonts |
-| `fonts.gstatic.com` | Font files for Google Fonts |
 | `platform.twitter.com` | Twitter widgets and scripts |
 | `syndication.twitter.com` | Twitter embed scripts |
 | `cdn.syndication.twimg.com` | Twitter asset CDN |

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -50,17 +50,6 @@ export default function Meta() {
             <link rel="canonical" href="https://unnippillil.com/" />
             <link rel="icon" href="images/logos/fevicon.svg" />
             <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <link
-                rel="preload"
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                as="style"
-                crossOrigin="anonymous"
-            />
-            <link
-                href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-                rel="stylesheet"
-
-            />
             <script
                 type="application/ld+json"
                 nonce={nonce}

--- a/next.config.js
+++ b/next.config.js
@@ -14,12 +14,12 @@ const ContentSecurityPolicy = [
   "object-src 'none'",
   // Allow external images and data URIs for badges/icons
   "img-src 'self' https: data:",
-  // Permit Google Fonts
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  // Explicitly allow external stylesheets and inline styles
-  "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  // Allow loading fonts from Google
-  "font-src 'self' https://fonts.gstatic.com",
+  // Permit external stylesheets and inline styles
+  "style-src 'self' 'unsafe-inline'",
+  // Explicitly allow external style elements and inline styles
+  "style-src-elem 'self' 'unsafe-inline'",
+  // Allow loading fonts from this origin
+  "font-src 'self'",
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,12 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import { Ubuntu } from 'next/font/google';
+
+export const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+});
 
 function MyApp(props) {
   const { Component, pageProps } = props;

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,6 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import Script from 'next/script';
 import crypto from 'node:crypto';
+import { ubuntu } from './_app';
 
 class MyDocument extends Document {
   /**
@@ -22,7 +23,7 @@ class MyDocument extends Document {
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html lang="en" data-csp-nonce={nonce} className={ubuntu.className}>
         <Head>
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />


### PR DESCRIPTION
## Summary
- remove external Google Fonts links from meta tags
- apply self-hosted Ubuntu font via next/font and update CSP
- document updated CSP without Google Fonts domains

## Testing
- `yarn lint` *(fails: Component definition missing display name, etc.)*
- `yarn test __tests__/solitaireEngine.test.ts`
- `rg -n "fonts.googleapis.com" -l`

------
https://chatgpt.com/codex/tasks/task_e_68b8dfa60c988328b9f5ef40ef41b2c9