### PR TITLE
chore: disable npm workspace warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+workspaces=false


### PR DESCRIPTION
## Summary
- disable npm workspaces to avoid warning in public repo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e19c29cc8328888126e583c8b233