### PR TITLE
fix: clean yarn resolutions for patched deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,8 +133,12 @@
     "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
     "webpack": "^5.92.0",
-    "next@npm:^15.0.0": "patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch",
-    "@napi-rs/canvas@npm:^0.1.74": "patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
+    "next@npm:^15.0.0": "15.5.2",
+    "@napi-rs/canvas@npm:^0.1.74": "0.1.77"
+  },
+  "patches": {
+    "next@npm:15.5.2": "./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch",
+    "@napi-rs/canvas@npm:0.1.77": "./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,45 +1435,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@patch:@napi-rs/canvas@npm:0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::locator=unnippillil%40workspace%3A.":
-  version: 0.1.77
-  resolution: "@napi-rs/canvas@patch:@napi-rs/canvas@npm%3A0.1.77#./.yarn/patches/@napi-rs-canvas-npm-0.1.77-27723c2ab5.patch::version=0.1.77&hash=93d5cb&locator=unnippillil%40workspace%3A."
-  dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.77"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.77"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.77"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.77"
-  dependenciesMeta:
-    "@napi-rs/canvas-android-arm64":
-      optional: true
-    "@napi-rs/canvas-darwin-arm64":
-      optional: true
-    "@napi-rs/canvas-darwin-x64":
-      optional: true
-    "@napi-rs/canvas-linux-arm-gnueabihf":
-      optional: true
-    "@napi-rs/canvas-linux-arm64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-arm64-musl":
-      optional: true
-    "@napi-rs/canvas-linux-riscv64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-x64-gnu":
-      optional: true
-    "@napi-rs/canvas-linux-x64-musl":
-      optional: true
-    "@napi-rs/canvas-win32-x64-msvc":
-      optional: true
-  checksum: 10c0/32cd0d4b772e341a6f8fa61e4f8bae29e47d978584cab41800aa304863d4555924fe525508d47be8d96300c713327056bab3e48c0f743850775f43c08667cd28
-  languageName: node
-  linkType: hard
-
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -8165,65 +8126,6 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: 10c0/3bed56bcca1f0fe07908fa075229f7f2662b4870974570f9e5a944758db9960868704ea4253f05c79507381b2e0014e8b621d7934408e26a0df8cbb3621986d8
-  languageName: node
-  linkType: hard
-
-"next@patch:next@npm:15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch::locator=unnippillil%40workspace%3A.":
-  version: 15.5.2
-  resolution: "next@patch:next@npm%3A15.5.2#./.yarn/patches/next-npm-15.5.2-fix-module-issuer.patch::version=15.5.2&hash=0b67c1&locator=unnippillil%40workspace%3A."
-  dependencies:
-    "@next/env": "npm:15.5.2"
-    "@next/swc-darwin-arm64": "npm:15.5.2"
-    "@next/swc-darwin-x64": "npm:15.5.2"
-    "@next/swc-linux-arm64-gnu": "npm:15.5.2"
-    "@next/swc-linux-arm64-musl": "npm:15.5.2"
-    "@next/swc-linux-x64-gnu": "npm:15.5.2"
-    "@next/swc-linux-x64-musl": "npm:15.5.2"
-    "@next/swc-win32-arm64-msvc": "npm:15.5.2"
-    "@next/swc-win32-x64-msvc": "npm:15.5.2"
-    "@swc/helpers": "npm:0.5.15"
-    caniuse-lite: "npm:^1.0.30001579"
-    postcss: "npm:8.4.31"
-    sharp: "npm:^0.34.3"
-    styled-jsx: "npm:5.1.6"
-  peerDependencies:
-    "@opentelemetry/api": ^1.1.0
-    "@playwright/test": ^1.51.1
-    babel-plugin-react-compiler: "*"
-    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-    sass: ^1.3.0
-  dependenciesMeta:
-    "@next/swc-darwin-arm64":
-      optional: true
-    "@next/swc-darwin-x64":
-      optional: true
-    "@next/swc-linux-arm64-gnu":
-      optional: true
-    "@next/swc-linux-arm64-musl":
-      optional: true
-    "@next/swc-linux-x64-gnu":
-      optional: true
-    "@next/swc-linux-x64-musl":
-      optional: true
-    "@next/swc-win32-arm64-msvc":
-      optional: true
-    "@next/swc-win32-x64-msvc":
-      optional: true
-    sharp:
-      optional: true
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    "@playwright/test":
-      optional: true
-    babel-plugin-react-compiler:
-      optional: true
-    sass:
-      optional: true
-  bin:
-    next: dist/bin/next
-  checksum: 10c0/023215b0a2614ff2f25e7ab2dfa25267c1b742867bfc160e66a55f374b0af30891c1f93c69d340dddff766a91a3a3e763b444eaa890f1182a6813a5e834408d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace patch protocol in `resolutions` with plain versions
- declare patch files via new `patches` field to avoid invalid URL warnings

## Testing
- `yarn eslint package.json`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e3f4d02483288edb08c5e0b41fbe