### PR TITLE
fix: stop crash when opening applications

### DIFF
--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
 
 interface NodeData {
@@ -17,6 +17,7 @@ const initialNodes: Record<string, NodeData> = {
 
 export default function ArpDiagram() {
   const [nodes, setNodes] = useState<Record<string, NodeData>>(initialNodes);
+  const nodeRefs = useRef<Record<string, React.RefObject<HTMLDivElement>>>({});
 
   const handleDrag = (key: string) => (_: DraggableEvent, data: DraggableData) => {
     setNodes((n) => ({ ...n, [key]: { ...n[key], x: data.x, y: data.y } }));
@@ -35,19 +36,22 @@ export default function ArpDiagram() {
         <path d={getLine('attacker', 'victim')} stroke="#f87171" strokeWidth={2} />
         <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
       </svg>
-      {Object.entries(nodes).map(([key, node]) => (
+      {Object.entries(nodes).map(([key, node]) => {
+        const ref = nodeRefs.current[key] ?? (nodeRefs.current[key] = React.createRef<HTMLDivElement>());
+        return (
         <Draggable
           key={key}
           grid={[6, 6]}
           bounds="parent"
           position={{ x: node.x, y: node.y }}
           onDrag={handleDrag(key)}
+          nodeRef={ref}
         >
-          <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
+          <div ref={ref} className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
             {node.label}
           </div>
         </Draggable>
-      ))}
+      )})}
     </div>
   );
 }

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Draggable from 'react-draggable';
 import {
   MonteCarloAI,
@@ -96,6 +96,7 @@ const Battleship = () => {
     false,
   );
   const [dragHint, setDragHint] = useState(null);
+  const shipRefs = useRef([]);
 
   const tryPlace = (shipId, x, y, dir) => {
     const ship = ships.find((s) => s.id === shipId);
@@ -451,7 +452,10 @@ const Battleship = () => {
           <div className="flex space-x-4">
             <div className="relative border border-ub-dark-grey" style={{width:BOARD_SIZE*CELL,height:BOARD_SIZE*CELL}}>
               {renderBoard(playerBoard)}
-                {ships.map((ship,i)=>(
+                {ships.map((ship,i)=>{
+                  if(!shipRefs.current[i]) shipRefs.current[i] = React.createRef();
+                  const ref = shipRefs.current[i];
+                  return (
                   <Draggable
                     key={ship.id}
                     grid={[CELL,CELL]}
@@ -460,14 +464,15 @@ const Battleship = () => {
                     onDrag={(e,data)=>handleDrag(i,e,data)}
                     onStop={(e,data)=>handleDragStop(i,e,data)}
                     disabled={phase!=='placement'}
+                    nodeRef={ref}
                   >
                     <div
+                      ref={ref}
                       className="absolute bg-blue-700 opacity-80"
                       style={{width:(ship.dir===0?ship.len:1)*CELL,height:(ship.dir===1?ship.len:1)*CELL}}
                       onDoubleClick={()=>rotateShip(ship.id)}
                     />
-                  </Draggable>
-                ))}
+                  </Draggable>)})}
             </div>
             <div className="flex flex-col space-y-2">
               <button className="px-2 py-1 bg-gray-700" onClick={randomize}>Randomize</button>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
@@ -32,6 +32,7 @@ export class Window extends Component {
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
         this._menuOpener = null;
+        this.nodeRef = createRef();
     }
 
     componentDidMount() {
@@ -484,8 +485,10 @@ export class Window extends Component {
                     allowAnyClick={false}
                     defaultPosition={{ x: this.startX, y: this.startY }}
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
+                    nodeRef={this.nodeRef}
                 >
                     <div
+                        ref={this.nodeRef}
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
                         className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}


### PR DESCRIPTION
## Summary
- avoid ReactDOM.findDOMNode by using nodeRef for Draggable windows and components
- update Battleship and ARP diagram draggables to use node refs

## Testing
- `yarn lint components/base/window.js components/apps/battleship.js apps/ettercap/components/ArpDiagram.tsx` *(fails: 45 problems (7 errors, 38 warnings))*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e74c995483289657547bcd84bafd