### PR TITLE
chore: silence bare engine warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,4 +7,6 @@ logFilters:
     level: discard
   - pattern: "inflight@1.0.6: This module is not supported"
     level: discard
+  - pattern: "The engine \"bare\" appears to be invalid"
+    level: discard
 


### PR DESCRIPTION
## Summary
- suppress Yarn warnings about invalid `bare` engines used by dependencies

## Testing
- `yarn install`
- `yarn lint` *(fails: 7 errors, 38 warnings)*
- `yarn test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e1926b108328bf717897c31fac41