### PR TITLE
Fix ARP diagram node refs for type safety

### DIFF
--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
 
 interface NodeData {
@@ -17,6 +17,7 @@ const initialNodes: Record<string, NodeData> = {
 
 export default function ArpDiagram() {
   const [nodes, setNodes] = useState<Record<string, NodeData>>(initialNodes);
+  const nodeRefs = useRef<Record<string, React.RefObject<HTMLDivElement>>>({});
 
   const handleDrag = (key: string) => (_: DraggableEvent, data: DraggableData) => {
     setNodes((n) => ({ ...n, [key]: { ...n[key], x: data.x, y: data.y } }));
@@ -35,19 +36,28 @@ export default function ArpDiagram() {
         <path d={getLine('attacker', 'victim')} stroke="#f87171" strokeWidth={2} />
         <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
       </svg>
-      {Object.entries(nodes).map(([key, node]) => (
-        <Draggable
-          key={key}
-          grid={[6, 6]}
-          bounds="parent"
-          position={{ x: node.x, y: node.y }}
-          onDrag={handleDrag(key)}
-        >
-          <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
-            {node.label}
-          </div>
-        </Draggable>
-      ))}
+      {Object.entries(nodes).map(([key, node]) => {
+        const ref =
+          nodeRefs.current[key] ??
+          (nodeRefs.current[key] = React.createRef<HTMLDivElement>());
+        return (
+          <Draggable
+            key={key}
+            nodeRef={ref}
+            grid={[6, 6]}
+            bounds="parent"
+            position={{ x: node.x, y: node.y }}
+            onDrag={handleDrag(key)}
+          >
+            <div
+              ref={ref}
+              className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]"
+            >
+              {node.label}
+            </div>
+          </Draggable>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Use typed refs for draggable ARP nodes
- Attach refs to Draggable components to avoid type mismatch

## Testing
- `node_modules/.bin/eslint apps/ettercap/components/ArpDiagram.tsx`
- `yarn build` *(fails: Cannot find module '@ducanh2912/next-pwa')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f3291d7c83288e67f201b6fbab1a