### PR TITLE
Add global route abort guard component

### DIFF
--- a/components/UseRouteAbortGuard.tsx
+++ b/components/UseRouteAbortGuard.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+declare global {
+  interface Window {
+    routeAbortController?: AbortController;
+  }
+}
+
+export default function UseRouteAbortGuard() {
+  const router = useRouter();
+
+  useEffect(() => {
+    window.routeAbortController = new AbortController();
+    const handleRouteChange = () => {
+      window.routeAbortController?.abort();
+      window.routeAbortController = new AbortController();
+    };
+    router.events.on('routeChangeStart', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+      window.routeAbortController?.abort();
+      delete window.routeAbortController;
+    };
+  }, [router.events]);
+
+  return null;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import UseRouteAbortGuard from '../components/UseRouteAbortGuard';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
@@ -133,6 +134,7 @@ function MyApp(props) {
   return (
     <SettingsProvider>
       <PipPortalProvider>
+        <UseRouteAbortGuard />
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
         <ShortcutOverlay />


### PR DESCRIPTION
## Summary
- add `UseRouteAbortGuard` component to manage an AbortController per route
- include `UseRouteAbortGuard` in root app layout to cancel requests on navigation

## Testing
- `npx eslint components/UseRouteAbortGuard.tsx pages/_app.jsx` *(warning: File ignored because no matching configuration was supplied)*
- `yarn test __tests__/abortableFetch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7eb05788328a86b3a4ea6ff1220