### PR TITLE
feat: add app error boundary

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({ error }: { error: Error }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-4">
+      <h2 className="text-xl font-semibold">Something went wrong!</h2>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+      >
+        Reload
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add client-side error boundary with reload action for app router

## Testing
- `yarn lint` (fails: 7 errors, 38 warnings)
- `yarn test __tests__/blackjack.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7e6e5e08328a49a7d96ad7162a7