### PR TITLE
refactor: noop PWA config and safe SW registration

### DIFF
--- a/lib/safe-service-worker.ts
+++ b/lib/safe-service-worker.ts
@@ -1,0 +1,48 @@
+/**
+ * Register the generated service worker only when it exists on the server.
+ *
+ * A HEAD request is made first to avoid errors when the service worker file is
+ * missing (for example during static exports where no SW is produced).
+ */
+export async function safeRegisterSW() {
+  // Service workers are only enabled in production and in browsers that support them
+  if (process.env.NODE_ENV !== 'production' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  try {
+    const swUrl = '/sw.js';
+
+    // Ensure the service worker file exists before attempting registration
+    const headResp = await fetch(swUrl, { method: 'HEAD' });
+    if (!headResp.ok) return;
+
+    const registration = await navigator.serviceWorker.register(swUrl);
+
+    // Expose a manual refresh helper used elsewhere in the app
+    // to trigger an update check for the service worker
+    (window as any).manualRefresh = () => registration.update();
+
+    if ('periodicSync' in registration) {
+      try {
+        const status = await navigator.permissions.query({
+          name: 'periodic-background-sync' as PermissionName,
+        });
+        if (status.state === 'granted') {
+          await registration.periodicSync.register('content-sync', {
+            minInterval: 24 * 60 * 60 * 1000,
+          });
+        } else {
+          registration.update();
+        }
+      } catch {
+        registration.update();
+      }
+    } else {
+      registration.update();
+    }
+  } catch (err) {
+    console.error('Service worker setup failed', err);
+  }
+}
+

--- a/next.config.js
+++ b/next.config.js
@@ -61,10 +61,9 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
-const withPWA = require('@ducanh2912/next-pwa').default({
-  dest: 'public',
-  disable: process.env.NODE_ENV === 'development',
-});
+// Replace PWA plugin with a noop wrapper so the existing configuration remains
+// intact without generating a service worker during the build.
+const withPWA = (cfg) => cfg;
 
 const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 const isProd = process.env.NODE_ENV === 'production';

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import { safeRegisterSW } from '../lib/safe-service-worker';
 
 function MyApp(props) {
   const { Component, pageProps } = props;
@@ -28,40 +29,7 @@ function MyApp(props) {
       console.error('Analytics initialization failed', err);
     });
 
-    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-      // Register PWA service worker generated via @ducanh2912/next-pwa
-      const register = async () => {
-        try {
-          const registration = await navigator.serviceWorker.register('/sw.js');
-
-          window.manualRefresh = () => registration.update();
-
-          if ('periodicSync' in registration) {
-            try {
-              const status = await navigator.permissions.query({
-                name: 'periodic-background-sync',
-              });
-              if (status.state === 'granted') {
-                await registration.periodicSync.register('content-sync', {
-                  minInterval: 24 * 60 * 60 * 1000,
-                });
-              } else {
-                registration.update();
-              }
-            } catch {
-              registration.update();
-            }
-          } else {
-            registration.update();
-          }
-        } catch (err) {
-          console.error('Service worker registration failed', err);
-        }
-      };
-      register().catch((err) => {
-        console.error('Service worker setup failed', err);
-      });
-    }
+    safeRegisterSW();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- replace `next-pwa` plugin with a noop wrapper in `next.config.js`
- add `safeRegisterSW` helper that checks for the service worker before registering
- use `safeRegisterSW` in `_app.jsx`

## Testing
- `yarn lint` *(fails: Unused eslint-disable directive and other lint errors)*
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7dda0008328a6bd2ed16ffaf949