### PR TITLE
Handle missing status bar in lock and shutdown flows

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -30,4 +30,25 @@ describe('Ubuntu component', () => {
     expect(bootScreen).toHaveClass('invisible');
     expect(screen.getByTestId('desktop')).toBeInTheDocument();
   });
+
+  it('handles lockScreen when status bar is missing', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(c) => (instance = c)} />);
+    expect(instance).not.toBeNull();
+    act(() => {
+      instance!.lockScreen();
+      jest.advanceTimersByTime(100);
+    });
+    expect(instance!.state.screen_locked).toBe(true);
+  });
+
+  it('handles shutDown when status bar is missing', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(c) => (instance = c)} />);
+    expect(instance).not.toBeNull();
+    act(() => {
+      instance!.shutDown();
+    });
+    expect(instance!.state.shutDownScreen).toBe(true);
+  });
 });

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -63,7 +63,9 @@ export default class Ubuntu extends Component {
 			action: `Set Screen to Locked`
 		});
 
-		document.getElementById('status-bar').blur();
+                const statusBar = document.getElementById('status-bar');
+                // Consider using a React ref if the status bar element lives within this component tree
+                statusBar?.blur();
 		setTimeout(() => {
 			this.setState({ screen_locked: true });
 		}, 100); // waiting for all windows to close (transition-duration)
@@ -93,7 +95,9 @@ export default class Ubuntu extends Component {
 			action: `Switched off the Ubuntu`
 		});
 
-		document.getElementById('status-bar').blur();
+                const statusBar = document.getElementById('status-bar');
+                // Consider using a React ref if the status bar element lives within this component tree
+                statusBar?.blur();
 		this.setState({ shutDownScreen: true });
 		localStorage.setItem('shut-down', true);
 	};


### PR DESCRIPTION
## Summary
- Safely blur status bar using optional chaining
- Document potential ref usage for status bar
- Add tests covering lockScreen and shutDown without status bar

## Testing
- `yarn test __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b907b9d8888328945f253a1a085ed6