### PR TITLE
Add route abort guard to app

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import UseRouteAbortGuard from '../components/UseRouteAbortGuard';
 import { Ubuntu } from 'next/font/google';
 
 const ubuntu = Ubuntu({
@@ -143,6 +144,7 @@ function MyApp(props) {
       <SettingsProvider>
         <PipPortalProvider>
           <div aria-live="polite" id="live-region" />
+          <UseRouteAbortGuard />
           <Component {...pageProps} />
           <ShortcutOverlay />
           <Analytics


### PR DESCRIPTION
## Summary
- import `UseRouteAbortGuard` into `_app.jsx`
- render the guard so route changes abort pending requests

## Testing
- `CI=true npm test __tests__/blackjack.test.ts`
- `npm run build` *(fails: Module not found: Can't resolve 'react-dom/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b907b96c1483288f6437c1bd938d30