### PR TITLE
feat: add custom ESLint rule for top-level window/document

### DIFF
--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -1,4 +1,5 @@
 /* eslint-env browser */
+/* eslint-disable no-top-level-window/no-top-level-window-or-document */
 const historyKey = 'clipboardHistory';
 let history = JSON.parse(localStorage.getItem(historyKey)) || [];
 

--- a/apps/color_picker/main.js
+++ b/apps/color_picker/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-top-level-window/no-top-level-window-or-document */
 const colors = [];
 const input = document.getElementById('color-input');
 const swatches = document.getElementById('swatches');

--- a/eslint-plugin-no-top-level-window/index.js
+++ b/eslint-plugin-no-top-level-window/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-top-level-window-or-document': require('./no-top-level-window-or-document'),
+  },
+};

--- a/eslint-plugin-no-top-level-window/no-top-level-window-or-document.js
+++ b/eslint-plugin-no-top-level-window/no-top-level-window-or-document.js
@@ -1,0 +1,22 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow top-level access to window or document',
+    },
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name !== 'window' && node.name !== 'document') return;
+        const scope = context.sourceCode.getScope(node);
+        if (scope.type === 'global' || scope.type === 'module') {
+          context.report({
+            node,
+            message: `Unexpected global '${node.name}'.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-no-top-level-window/package.json
+++ b/eslint-plugin-no-top-level-window/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-no-top-level-window",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,18 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 
 const compat = new FlatCompat();
 
 export default [
   { ignores: ['components/apps/Chrome/index.tsx'] },
+  {
+    plugins: {
+      'no-top-level-window': noTopLevelWindow,
+    },
+    rules: {
+      'no-top-level-window/no-top-level-window-or-document': 'error',
+    },
+  },
   ...compat.config({
     extends: ['next/core-web-vitals'],
     rules: {


### PR DESCRIPTION
## Summary
- add `eslint-plugin-no-top-level-window` to prevent global `window`/`document`
- enable rule in lint config
- suppress rule for standalone app scripts

## Testing
- `yarn lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68b907c03f8483288f0bbf663bb6248e