### PR TITLE
Mark DOM-bound components as client and use dynamic imports

### DIFF
--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 interface LoaderProps {

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
 import { showA2HS } from '@/src/pwa/a2hs';

--- a/components/LabMode.tsx
+++ b/components/LabMode.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 interface Props {

--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useMemo, useEffect } from 'react';
 
 interface ViewerProps {

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';

--- a/components/hooks/usePersistentState.js
+++ b/components/hooks/usePersistentState.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 export default function usePersistentState(key, initialValue) {

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';

--- a/components/usePersistentState.js
+++ b/components/usePersistentState.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 // Simple hook to persist state in localStorage

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';

--- a/pages/daily-quote.tsx
+++ b/pages/daily-quote.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRef } from 'react';
 import useDailyQuote from '../hooks/useDailyQuote';
 import { toPng } from 'html-to-image';

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from 'react';
 import FormError from '../components/ui/FormError';
 

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 
 const HookFlow: React.FC = () => {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,7 +1,11 @@
-import Ubuntu from '../components/ubuntu';
+import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
-import InstallButton from '../components/InstallButton';
 import BetaBadge from '../components/BetaBadge';
+
+const Ubuntu = dynamic(() => import('../components/ubuntu'), { ssr: false });
+const InstallButton = dynamic(() => import('../components/InstallButton'), {
+  ssr: false,
+});
 
 /**
  * @returns {JSX.Element}

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { useRouter } from 'next/router';

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useMemo, useState } from 'react';
 import data from '../components/apps/nessus/sample-report.json';
 

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useMemo, useState } from 'react';
 
 interface NiktoFinding {

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 

--- a/pages/share-target.tsx
+++ b/pages/share-target.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 


### PR DESCRIPTION
## Summary
- mark DOM-interacting components and pages with `"use client"`
- load DOM-heavy widgets via `next/dynamic` to keep pages server-rendered

## Testing
- `yarn lint` *(fails: Component definition is missing display name in __tests__/projectGallery.test.tsx, __tests__/ubuntu.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b907bfae2c8328b6269896988f8fbb