### PR TITLE
Add global ErrorBoundary component

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    // You can log the error to an error reporting service
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 text-center">
+          <h1 className="text-xl font-bold">Something went wrong.</h1>
+          <p>Please refresh the page or try again.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import ErrorBoundary from '../components/core/ErrorBoundary';
 import { Ubuntu } from 'next/font/google';
 
 const ubuntu = Ubuntu({
@@ -139,25 +140,27 @@ function MyApp(props) {
   }, []);
 
   return (
-    <div className={ubuntu.className}>
-      <SettingsProvider>
-        <PipPortalProvider>
-          <div aria-live="polite" id="live-region" />
-          <Component {...pageProps} />
-          <ShortcutOverlay />
-          <Analytics
-            beforeSend={(e) => {
-              if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-              const evt = e;
-              if (evt.metadata?.email) delete evt.metadata.email;
-              return e;
-            }}
-          />
+    <ErrorBoundary>
+      <div className={ubuntu.className}>
+        <SettingsProvider>
+          <PipPortalProvider>
+            <div aria-live="polite" id="live-region" />
+            <Component {...pageProps} />
+            <ShortcutOverlay />
+            <Analytics
+              beforeSend={(e) => {
+                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                const evt = e;
+                if (evt.metadata?.email) delete evt.metadata.email;
+                return e;
+              }}
+            />
 
-          {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-        </PipPortalProvider>
-      </SettingsProvider>
-    </div>
+            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+          </PipPortalProvider>
+        </SettingsProvider>
+      </div>
+    </ErrorBoundary>
 
   );
 }


### PR DESCRIPTION
## Summary
- add ErrorBoundary class to handle rendering errors
- wrap app in ErrorBoundary to show recovery message

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test` *(fails: process terminated; numerous test suites passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b907c1c6f4832881efdaa8b1001b62