### PR TITLE
Add Playwright smoke tests for app routes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: /.*\.spec\.ts/,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  },
+});

--- a/tests/apps.smoke.spec.ts
+++ b/tests/apps.smoke.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const appDir = path.join(process.cwd(), 'pages', 'apps');
+
+function getRoutes(dir: string, prefix = ''): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const routes: string[] = [];
+  for (const entry of entries) {
+    if (entry.isFile() && /\.(jsx?|tsx?)$/.test(entry.name)) {
+      const rel = path.join(prefix, entry.name).replace(/\\/g, '/');
+      routes.push('/apps/' + rel.replace(/\.(jsx?|tsx?)$/, ''));
+    } else if (entry.isDirectory()) {
+      routes.push(...getRoutes(path.join(dir, entry.name), path.join(prefix, entry.name)));
+    }
+  }
+  return routes;
+}
+
+const routes = getRoutes(appDir)
+  .filter((r) => r !== '/apps/index')
+  .map((r) => r.replace(/\/index$/, ''));
+
+for (const route of routes) {
+  test(`loads ${route}`, async ({ page }) => {
+    await page.goto('/apps');
+    await page.locator(`a[href="${route}"]`).click();
+    await expect(page.locator('main')).toBeVisible();
+  });
+}


### PR DESCRIPTION
## Summary
- configure Playwright to look in `tests` and use local dev server
- add smoke tests that visit each `/apps/*` link from the apps index and check for a visible `main`

## Testing
- `yarn playwright test` *(fails: page.goto net::ERR_ABORTED; maybe frame was detached?)*

------
https://chatgpt.com/codex/tasks/task_e_68b907c246708328998e54a1aeb03dd8