### PR TITLE
fix: allow react-dom client resolution

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -89,7 +89,7 @@ function configureWebpack(config, { isServer }) {
   };
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
-    'react-dom': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
+    'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
   };
   if (isProd) {
     config.optimization = {


### PR DESCRIPTION
## Summary
- fix webpack alias for React DOM to avoid interfering with `react-dom/client`

## Testing
- `yarn build`
- `yarn lint` *(fails: 15 errors)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b90d2d5e0083288194351db9a6dfe9