### PR TITLE
fix: remove stale postcss patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
   },
   "resolutions": {
     "magic-string": "^0.30.10",
-    "postcss": "^8.5.6",
     "test-exclude": "^7.0.1",
     "webpack": "^5.92.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9778,7 +9778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.9":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.9":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -10690,7 +10690,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.6":
+"postcss@npm:8.4.31":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
+  dependencies:
+    nanoid: "npm:^3.3.6"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.21, postcss@npm:^8.4.47":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -12378,7 +12389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf


### PR DESCRIPTION
## Summary
- remove postcss entry from Yarn resolutions to avoid missing patch
- regenerate lockfile to resolve postcss without custom patch

## Testing
- `yarn install`
- `yarn test` *(fails: process hung, manually terminated after passing tests)*
- `yarn lint` *(fails: 7 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b90f1ccdbc8328abb4d4704e011cd9