### PR TITLE
fix postcss patch path and suppress yarn warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,4 +7,6 @@ logFilters:
     level: discard
   - pattern: "inflight@1.0.6: This module is not supported"
     level: discard
+  - pattern: "source-map@0.8.0-beta.0: The work that was done in this beta branch won't be included in future versions"
+    level: discard
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "pdfjs-dist": "^5.4.54",
     "phaser": "3.70.0",
     "pngjs": "^7.0.0",
-    "postcss": "patch:postcss@npm%3A8.5.6#~/.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch",
+    "postcss": "patch:postcss@npm:8.5.6#./.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch",
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11022,9 +11022,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@patch:postcss@npm%3A8.5.6#~/.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch":
+"postcss@patch:postcss@npm:8.5.6#./.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch::locator=unnippillil%40workspace%3A.":
   version: 8.5.6
-  resolution: "postcss@patch:postcss@npm%3A8.5.6#~/.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch::version=8.5.6&hash=fa4b34"
+  resolution: "postcss@patch:postcss@npm%3A8.5.6#./.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch::version=8.5.6&hash=fa4b34&locator=unnippillil%40workspace%3A."
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
@@ -13962,7 +13962,7 @@ __metadata:
     phaser: "npm:3.70.0"
     playwright-core: "npm:^1.55.0"
     pngjs: "npm:^7.0.0"
-    postcss: "patch:postcss@npm%3A8.5.6#~/.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch"
+    postcss: "patch:postcss@npm:8.5.6#./.yarn/patches/postcss-npm-8.5.6-e7f126c6f3.patch"
     prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     qrcode: "npm:^1.5.4"


### PR DESCRIPTION
## Summary
- use repository local patch for PostCSS instead of missing home directory patch
- discard noisy source-map warning in Yarn config

## Testing
- `yarn install`
- `yarn lint` *(fails: Unexpected global 'window')*
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test')*


------
https://chatgpt.com/codex/tasks/task_e_68b91036a9848328b7995cee51cc9e12