### PR TITLE
chore: remove magic-string patch

### DIFF
--- a/.yarn/patches/magic-string-npm-0.30.18-561c76e200.patch
+++ b/.yarn/patches/magic-string-npm-0.30.18-561c76e200.patch
@@ -1,9 +1,0 @@
-diff --git a/README.md b/README.md
-index b2e9f9a19f7d78fbc5748da52486fabd86f21a81..381de15e3c9c15842965583288ee8570b8bcff10 100644
---- a/README.md
-+++ b/README.md
-@@ -322,3 +322,4 @@ bundle.addSource(source);
- ## License
- 
- MIT
-+

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "phaser": "3.70.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.6",
-
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
@@ -126,7 +125,7 @@
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
-    "magic-string": "patch:magic-string@npm:0.30.18#./.yarn/patches/magic-string-npm-0.30.18-561c76e200.patch",
+    "magic-string": "0.30.18",
     "node-mocks-http": "1.17.2",
     "pa11y": "^9.0.0",
     "playwright-core": "^1.55.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10994,7 +10994,6 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.4.47, postcss@npm:^8.5.6":
-
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -13893,7 +13892,7 @@ __metadata:
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
-    magic-string: "patch:magic-string@npm:0.30.18#./.yarn/patches/magic-string-npm-0.30.18-561c76e200.patch"
+    magic-string: "npm:0.30.18"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"
@@ -13906,7 +13905,6 @@ __metadata:
     playwright-core: "npm:^1.55.0"
     pngjs: "npm:^7.0.0"
     postcss: "npm:^8.5.6"
-
     prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     qrcode: "npm:^1.5.4"


### PR DESCRIPTION
## Summary
- replace magic-string patch with standard 0.30.18 dependency
- remove magic-string patch file and update yarn.lock

## Testing
- `yarn install`
- `yarn test` *(fails: Playwright Test needs to be invoked separately)*
- `yarn playwright test` *(did not complete; 16 tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68b91acccca88328b9124e449f8d2356