### PR TITLE
chore: streamline yarn ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,8 @@
 .yarn/*
 !.yarn/releases
 !.yarn/plugins
-!.yarn/plugins.yml
 !.yarn/sdks
 !.yarn/versions
-!.yarn/patches
 /.pnp
 .pnp.cjs
 .pnp.loader.mjs


### PR DESCRIPTION
## Summary
- ignore entire `.yarn` folder except releases, plugins, sdks, and versions
- drop outdated exceptions for `plugins.yml` and `patches`

## Testing
- `npm test` *(fails: Playwright Test needs to be invoked via 'npx playwright test')*

------
https://chatgpt.com/codex/tasks/task_e_68b91b581de88328b5dffee91fac48d0