### PR TITLE
chore: enable corepack preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "ANALYZE=true yarn build",
+    "preinstall": "corepack enable"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- enable Corepack during installs via preinstall script

## Testing
- `yarn test tests/apps.smoke.spec.ts` *(fails: Playwright Test needs to be invoked via 'yarn playwright test')*
- `yarn lint` *(fails: Unexpected global 'window')*

------
https://chatgpt.com/codex/tasks/task_e_68b91b58b8308328bfbdfcc2d550a001