### PR TITLE
fix: remove test-exclude patch causing yarn install failure

### DIFF
--- a/.yarn/patches/test-exclude-npm-7.0.1-e6cf81110b.patch
+++ b/.yarn/patches/test-exclude-npm-7.0.1-e6cf81110b.patch
@@ -1,9 +1,0 @@
-diff --git a/README.md b/README.md
-index 190783dc15c79c65c0d8886e2a7d4094b5fb2f8f..59b86b5ef0061e01f4eb79e3f8db72b2d049605e 100644
---- a/README.md
-+++ b/README.md
-@@ -94,3 +94,4 @@ The maintainers of `test-exclude` and thousands of other packages are working wi
- [babel-plugin-istanbul]: https://github.com/istanbuljs/babel-plugin-istanbul
- [@istanbuljs/schema]: https://github.com/istanbuljs/schema
- [@istanbuljs/schema/default-excludes.js]: https://github.com/istanbuljs/schema/blob/master/default-exclude.js
-+

--- a/package.json
+++ b/package.json
@@ -127,22 +127,18 @@
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
     "magic-string": "patch:magic-string@npm:0.30.10#./.yarn/patches/magic-string-0.30.10.patch",
-
     "node-mocks-http": "1.17.2",
     "pa11y": "^9.0.0",
     "playwright-core": "^1.55.0",
-    "test-exclude": "patch:test-exclude@npm:7.0.1#./.yarn/patches/test-exclude-npm-7.0.1-e6cf81110b.patch",
+    "test-exclude": "^7.0.1",
     "typescript": "^5.6",
     "wait-on": "^8.0.4",
     "webpack": "^5.92.0",
     "ws": "^8.18.0"
   },
   "resolutions": {
-
     "magic-string": "^0.30.10",
     "source-map": "^0.7.6",
-
-    "test-exclude": "^7.0.1",
     "webpack": "^5.92.0",
     "workbox-build@npm:7.1.1": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
     "workbox-build@npm:7.1.0": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,7 +2313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -7791,6 +7791,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.1.4":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10c0/65676153e2b0c9095100fe7f25a778bf45608eeb32c6048cf307f579649bcc30353277b3b898a3792602c65764e5baa4f643714dfbdfd64ea271d210c7a425fe
+  languageName: node
+  linkType: hard
+
 "glob@npm:^9.3.5":
   version: 9.3.5
   resolution: "glob@npm:9.3.5"
@@ -8126,6 +8140,23 @@ __metadata:
   version: 1.4.2
   resolution: "index-array-by@npm:1.4.2"
   checksum: 10c0/70cfb089148678236c620f471f75b3bec85da65f24cd44ea601c1eae8f6e0da5e1899cee08ed3a276bea1943b6f910fe6fa388276bca4667c6738bb44eae08cb
+  languageName: node
+  linkType: hard
+
+"inflight@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "inflight@npm:1.0.6"
+  dependencies:
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
+  checksum: 10c0/7faca22584600a9dc5b9fca2cd5feb7135ac8c935449837b315676b4c90aa4f391ec4f42240178244b5a34e8bede1948627fda392ca3191522fc46b34e985ab2
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
@@ -9664,13 +9695,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:0.30.10":
-  version: 0.30.10
-  resolution: "magic-string@npm:0.30.10"
-
+"magic-string@npm:^0.30.10":
+  version: 0.30.18
+  resolution: "magic-string@npm:0.30.18"
   dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.4.15"
-  checksum: 10c0/aa9ca17eae571a19bce92c8221193b6f93ee8511abb10f085e55ffd398db8e4c089a208d9eac559deee96a08b7b24d636ea4ab92f09c6cf42a7d1af51f7fd62b
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/80fba01e13ce1f5c474a0498a5aa462fa158eb56567310747089a0033e432d83a2021ee2c109ac116010cd9dcf90a5231d89fbe3858165f73c00a50a74dbefcd
   languageName: node
   linkType: hard
 
@@ -9867,7 +9897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -10445,7 +10475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -10709,6 +10739,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-is-absolute@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "path-is-absolute@npm:1.0.1"
+  checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
   languageName: node
   linkType: hard
 
@@ -13239,6 +13276,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+    glob: "npm:^7.1.4"
+    minimatch: "npm:^3.0.4"
+  checksum: 10c0/019d33d81adff3f9f1bfcff18125fb2d3c65564f437d9be539270ee74b994986abb8260c7c2ce90e8f30162178b09dbbce33c6389273afac4f36069c48521f57
+  languageName: node
+  linkType: hard
+
 "test-exclude@npm:^7.0.1":
   version: 7.0.1
   resolution: "test-exclude@npm:7.0.1"
@@ -13862,7 +13910,6 @@ __metadata:
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "patch:magic-string@npm:0.30.10#./.yarn/patches/magic-string-0.30.10.patch"
-
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"
@@ -13895,7 +13942,7 @@ __metadata:
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"
     tailwindcss: "npm:^3.2.4"
-    test-exclude: "patch:test-exclude@npm:7.0.1#./.yarn/patches/test-exclude-npm-7.0.1-e6cf81110b.patch"
+    test-exclude: "npm:^7.0.1"
     three: "npm:^0.179.1"
     turndown: "npm:^7.2.1"
     typescript: "npm:^5.6"


### PR DESCRIPTION
## Summary
- replace `test-exclude` patch with normal dependency and drop obsolete patch file
- update lockfile accordingly

## Testing
- `yarn install`
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test')*


------
https://chatgpt.com/codex/tasks/task_e_68b91e017768832894ebe1c0a5bb38ba