### PR TITLE
Fix glob resolution for Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
     "magic-string": "0.30.18",
-
     "node-mocks-http": "1.17.2",
     "pa11y": "^9.0.0",
     "playwright-core": "^1.55.0",
@@ -139,13 +138,12 @@
   },
   "resolutions": {
     "magic-string": "0.30.18",
-
     "source-map": "^0.7.6",
     "test-exclude": "7.0.1",
     "webpack": "^5.92.0",
     "workbox-build@npm:7.1.1": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
     "workbox-build@npm:7.1.0": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
-    "glob@^7.1.6": "^9.3.5"
+    "glob@npm:^7.1.6": "npm:glob@^9.3.5"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,7 +7791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^9.3.5":
+"glob@npm:glob@^9.3.5":
   version: 9.3.5
   resolution: "glob@npm:9.3.5"
   dependencies:
@@ -9667,10 +9667,9 @@ __metadata:
 "magic-string@npm:0.30.18":
   version: 0.30.18
   resolution: "magic-string@npm:0.30.18"
-
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
-  checksum: 10c0/aa9ca17eae571a19bce92c8221193b6f93ee8511abb10f085e55ffd398db8e4c089a208d9eac559deee96a08b7b24d636ea4ab92f09c6cf42a7d1af51f7fd62b
+  checksum: 10c0/80fba01e13ce1f5c474a0498a5aa462fa158eb56567310747089a0033e432d83a2021ee2c109ac116010cd9dcf90a5231d89fbe3858165f73c00a50a74dbefcd
   languageName: node
   linkType: hard
 
@@ -13862,7 +13861,6 @@ __metadata:
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "npm:0.30.18"
-
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"


### PR DESCRIPTION
## Summary
- ensure glob dependency overrides resolve to latest v9 release

## Testing
- `yarn install`
- `yarn test` *(fails: Playwright Test needs to be invoked via `yarn playwright test`)*

------
https://chatgpt.com/codex/tasks/task_e_68b921b90f748328b006438982d806ec