### PR TITLE
Allow Vercel Live feedback script through CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
+| `vercel.live` | Vercel Live feedback script |
 | `https://*` / `http://*` / `ws://*` / `wss://*` | Wide dev allowance for external resources; tighten for production |
 
 **Notes for prod hardening**

--- a/next.config.js
+++ b/next.config.js
@@ -21,7 +21,7 @@ const ContentSecurityPolicy = [
   // Restrict fonts to same origin
   "font-src 'self'",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://vercel.live",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content


### PR DESCRIPTION
## Summary
- allow `https://vercel.live` scripts by expanding Content Security Policy
- document `vercel.live` in CSP external domain list

## Testing
- `yarn lint` *(fails: Unexpected global 'window' and other existing warnings)*
- `yarn test` *(fails: Playwright Test needs to be invoked separately)*

------
https://chatgpt.com/codex/tasks/task_e_68b92638b89483288721d6ae7e9ad4cb