### PR TITLE
fix: relocate yarn patch to dependency

### DIFF
--- a/.yarn/patches/magic-string-0.30.10.patch
+++ b/.yarn/patches/magic-string-0.30.10.patch
@@ -1,9 +1,0 @@
-diff --git a/README.md b/README.md
---- a/README.md
-+++ b/README.md
-@@ -322,3 +322,4 @@ bundle.addSource(source);
- ## License
- 
- MIT
-+
-

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "typescript": "^5.6",
     "wait-on": "^8.0.4",
     "webpack": "^5.92.0",
+    "workbox-build": "patch:workbox-build@npm:7.1.1#./.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
     "ws": "^8.18.0"
   },
   "resolutions": {
@@ -141,8 +142,7 @@
     "source-map": "^0.7.6",
     "test-exclude": "7.0.1",
     "webpack": "^5.92.0",
-    "workbox-build@npm:7.1.1": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
-    "workbox-build@npm:7.1.0": "patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch",
+    "workbox-build@npm:7.1.0": "npm:workbox-build@7.1.1",
     "glob@npm:^7.1.6": "npm:glob@^9.3.5"
   },
   "packageManager": "yarn@4.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13899,6 +13899,7 @@ __metadata:
     typescript: "npm:^5.6"
     wait-on: "npm:^8.0.4"
     webpack: "npm:^5.92.0"
+    workbox-build: "patch:workbox-build@npm:7.1.1#./.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch"
     ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -14349,7 +14350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-build@npm:7.1.1":
+"workbox-build@npm:7.1.1, workbox-build@npm:workbox-build@7.1.1":
   version: 7.1.1
   resolution: "workbox-build@npm:7.1.1"
   dependencies:
@@ -14394,9 +14395,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-build@patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch":
+"workbox-build@patch:workbox-build@npm:7.1.1#./.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch::locator=unnippillil%40workspace%3A.":
   version: 7.1.1
-  resolution: "workbox-build@patch:workbox-build@npm%3A7.1.1#~/.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch::version=7.1.1&hash=5e1bdc"
+  resolution: "workbox-build@patch:workbox-build@npm%3A7.1.1#./.yarn/patches/workbox-build-npm-7.1.1-a854f3faae.patch::version=7.1.1&hash=5e1bdc&locator=unnippillil%40workspace%3A."
   dependencies:
     "@apideck/better-ajv-errors": "npm:^0.3.1"
     "@babel/core": "npm:^7.24.4"


### PR DESCRIPTION
## Summary
- patch `workbox-build` via direct dependency instead of resolutions
- drop unused `magic-string` patch
- adjust yarn resolutions for `workbox-build`

## Testing
- `yarn install`
- `yarn explain peer-requirements`

------
https://chatgpt.com/codex/tasks/task_e_68b929608368832882265d693ed6fdc2