### PR TITLE
chore: guard browser APIs in client modules

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 
@@ -60,6 +62,10 @@ const STORE_NAME = 'recent';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME, { autoIncrement: true });
@@ -72,6 +78,7 @@ function openDB() {
 async function getRecentDirs() {
   try {
     const db = await openDB();
+    if (!db) return [];
     return await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
@@ -87,6 +94,7 @@ async function getRecentDirs() {
 async function addRecentDir(handle) {
   try {
     const db = await openDB();
+    if (!db) return;
     const entry = { name: handle.name, handle };
     await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');

--- a/components/apps/phaser-template.js
+++ b/components/apps/phaser-template.js
@@ -7,6 +7,10 @@ const STORE_NAME = 'scores';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME);
@@ -19,6 +23,7 @@ function openDB() {
 async function getHighscore() {
   try {
     const db = await openDB();
+    if (!db) return 0;
     return await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
@@ -34,6 +39,7 @@ async function getHighscore() {
 async function setHighscore(score) {
   try {
     const db = await openDB();
+    if (!db) return;
     await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       tx.objectStore(STORE_NAME).put(score, 'highscore');


### PR DESCRIPTION
## Summary
- prevent server-side execution of phaser template by guarding `indexedDB` access
- mark file explorer as client-only and gate `indexedDB` access

## Testing
- `yarn test` *(fails: Playwright Test needs to be invoked via `yarn playwright test`)*
- `npx eslint components/apps/file-explorer.js components/apps/phaser-template.js`


------
https://chatgpt.com/codex/tasks/task_e_68b929668884832890d43e40a78d06ac