### PR TITLE
fix: use modern Vercel runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- use Node.js 20 runtime for Vercel functions

## Testing
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test' and excluded from Jest test runs)*
- `npx -y vercel build` *(fails: No Project Settings found locally)*

------
https://chatgpt.com/codex/tasks/task_e_68b9297b0f348328b85429f7e9f96f10