### PR TITLE
chore: guard browser globals and add typecheck

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,12 @@ export default [
       'no-top-level-window/no-top-level-window-or-document': 'error',
     },
   },
+  {
+    files: ['utils/qrStorage.ts', 'utils/safeStorage.ts', 'utils/sync.ts'],
+    rules: {
+      'no-restricted-globals': ['error', 'window', 'document'],
+    },
+  },
   ...compat.config({
     extends: ['next/core-web-vitals'],
     rules: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint --max-warnings=0 .",
+    "typecheck": "tsc --noEmit",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "noEmit": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "esnext",

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,3 +1,3 @@
-export const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+export { isBrowser } from './isBrowser';
 export const hasIDB = typeof indexedDB !== 'undefined';
 export const hasStorage = typeof localStorage !== 'undefined';

--- a/utils/isBrowser.ts
+++ b/utils/isBrowser.ts
@@ -1,0 +1,1 @@
+export const isBrowser = () => typeof window !== 'undefined';

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from './isBrowser';
+
 const STORAGE_KEY = 'qrScans';
 const LAST_SCAN_KEY = 'qrLastScan';
 const LAST_GEN_KEY = 'qrLastGeneration';
@@ -12,12 +14,10 @@ const getStorage = (): StorageWithDirectory =>
   navigator.storage as StorageWithDirectory;
 
 const hasOpfs =
-  typeof window !== 'undefined' &&
-  'storage' in navigator &&
-  Boolean(getStorage().getDirectory);
+  isBrowser() && 'storage' in navigator && Boolean(getStorage().getDirectory);
 
 export const loadScans = async (): Promise<string[]> => {
-  if (typeof window === 'undefined') return [];
+  if (!isBrowser()) return [];
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -36,7 +36,7 @@ export const loadScans = async (): Promise<string[]> => {
 };
 
 export const saveScans = async (scans: string[]): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
   if (hasOpfs) {
     const root = await getStorage().getDirectory();
     const handle = await root.getFileHandle(FILE_NAME, { create: true });
@@ -49,7 +49,7 @@ export const saveScans = async (scans: string[]): Promise<void> => {
 };
 
 export const clearScans = async (): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -63,21 +63,21 @@ export const clearScans = async (): Promise<void> => {
 };
 
 export const loadLastScan = (): string => {
-  if (typeof window === 'undefined') return '';
+  if (!isBrowser()) return '';
   return localStorage.getItem(LAST_SCAN_KEY) || '';
 };
 
 export const saveLastScan = (scan: string): void => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
   localStorage.setItem(LAST_SCAN_KEY, scan);
 };
 
 export const loadLastGeneration = (): string => {
-  if (typeof window === 'undefined') return '';
+  if (!isBrowser()) return '';
   return localStorage.getItem(LAST_GEN_KEY) || '';
 };
 
 export const saveLastGeneration = (payload: string): void => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
   localStorage.setItem(LAST_GEN_KEY, payload);
 };

--- a/utils/safeStorage.ts
+++ b/utils/safeStorage.ts
@@ -1,3 +1,4 @@
 import { hasStorage } from './env';
 
-export const safeLocalStorage: Storage | undefined = hasStorage ? window.localStorage : undefined;
+export const safeLocalStorage: Storage | undefined =
+  hasStorage ? localStorage : undefined;

--- a/utils/sync.ts
+++ b/utils/sync.ts
@@ -1,11 +1,12 @@
+import { isBrowser } from './isBrowser';
+
 type StateMessage = { type: 'state'; state: unknown };
 type LeaderboardMessage = { type: 'leaderboard'; leaderboard: unknown };
 type SyncMessage = StateMessage | LeaderboardMessage;
 
-const channel =
-  typeof window !== 'undefined' && 'BroadcastChannel' in self
-    ? new BroadcastChannel('sync')
-    : null;
+const channel = isBrowser() && 'BroadcastChannel' in self
+  ? new BroadcastChannel('sync')
+  : null;
 
 export const broadcastState = (state: unknown): void => {
   channel?.postMessage({ type: 'state', state } as StateMessage);


### PR DESCRIPTION
## Summary
- add ESLint rule to block window/document in selected server utils
- add runtime `isBrowser` helper and guard unsafe references
- add `typecheck` script and run tsc with no emit

## Testing
- `yarn lint` *(fails: Unexpected global 'document', 87 errors, 39 warnings)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b92976130c8328b673f68d128af176