### PR TITLE
chore: guard indexeddb usage on client

### DIFF
--- a/components/apps/Games/common/save/index.ts
+++ b/components/apps/Games/common/save/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef } from 'react';
 import { createStore, get, set, del, keys } from 'idb-keyval';
 import useOPFS from '../../../../../hooks/useOPFS';

--- a/components/apps/chrome/bookmarks.ts
+++ b/components/apps/chrome/bookmarks.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { get, set } from 'idb-keyval';
 
 export interface Bookmark {
@@ -9,14 +11,18 @@ const BOOKMARKS_KEY = 'chrome-bookmarks';
 const FAVICON_PREFIX = 'chrome-favicon:';
 
 export const getBookmarks = async (): Promise<Bookmark[]> =>
-  (await get<Bookmark[]>(BOOKMARKS_KEY)) || [];
+  (typeof window === 'undefined'
+    ? []
+    : (await get<Bookmark[]>(BOOKMARKS_KEY)) || []);
 
 export const saveBookmarks = async (bookmarks: Bookmark[]): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await set(BOOKMARKS_KEY, bookmarks);
 };
 
 export const addBookmark = async (bookmark: Bookmark): Promise<void> => {
   const bookmarks = await getBookmarks();
+  if (typeof window === 'undefined') return;
   if (!bookmarks.some((b) => b.url === bookmark.url)) {
     bookmarks.push(bookmark);
     await saveBookmarks(bookmarks);
@@ -25,6 +31,7 @@ export const addBookmark = async (bookmark: Bookmark): Promise<void> => {
 
 export const removeBookmark = async (url: string): Promise<void> => {
   const bookmarks = await getBookmarks();
+  if (typeof window === 'undefined') return;
   await saveBookmarks(bookmarks.filter((b) => b.url !== url));
 };
 
@@ -45,8 +52,11 @@ export const importBookmarks = async (json: string): Promise<void> => {
 };
 
 export const getCachedFavicon = async (origin: string): Promise<string | undefined> =>
-  (await get<string>(FAVICON_PREFIX + origin)) || undefined;
+  typeof window === 'undefined'
+    ? undefined
+    : (await get<string>(FAVICON_PREFIX + origin)) || undefined;
 
 export const cacheFavicon = async (origin: string, dataUrl: string): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await set(FAVICON_PREFIX + origin, dataUrl);
 };

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 
@@ -60,6 +62,10 @@ const STORE_NAME = 'recent';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME, { autoIncrement: true });
@@ -72,6 +78,7 @@ function openDB() {
 async function getRecentDirs() {
   try {
     const db = await openDB();
+    if (!db) return [];
     return await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
@@ -87,6 +94,7 @@ async function getRecentDirs() {
 async function addRecentDir(handle) {
   try {
     const db = await openDB();
+    if (!db) return;
     const entry = { name: handle.name, handle };
     await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');

--- a/components/apps/phaser-template.js
+++ b/components/apps/phaser-template.js
@@ -1,3 +1,5 @@
+"use client";
+
 import Phaser from 'phaser';
 import { Howl } from 'howler';
 
@@ -7,6 +9,10 @@ const STORE_NAME = 'scores';
 
 function openDB() {
   return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore(STORE_NAME);
@@ -19,6 +25,7 @@ function openDB() {
 async function getHighscore() {
   try {
     const db = await openDB();
+    if (!db) return 0;
     return await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
@@ -34,6 +41,7 @@ async function getHighscore() {
 async function setHighscore(score) {
   try {
     const db = await openDB();
+    if (!db) return;
     await new Promise((resolve) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       tx.objectStore(STORE_NAME).put(score, 'highscore');

--- a/utils/dailySeed.ts
+++ b/utils/dailySeed.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { getSeed, setSeed } from './idb';
 
 function today(): string {

--- a/utils/idb.ts
+++ b/utils/idb.ts
@@ -1,3 +1,5 @@
+"use client";
+
 const DB_NAME = 'kali-games';
 const VERSION = 1;
 const STORE_SEEDS = 'seeds';

--- a/utils/safeIdb.ts
+++ b/utils/safeIdb.ts
@@ -1,4 +1,6 @@
-import { openDB, type IDBPDatabase, type OpenDBCallbacks } from 'idb';
+"use client";
+
+import type { IDBPDatabase, OpenDBCallbacks } from 'idb';
 import { hasIDB } from './env';
 
 export function makeIdb<DBTypes extends unknown>(
@@ -7,5 +9,5 @@ export function makeIdb<DBTypes extends unknown>(
   options?: OpenDBCallbacks<DBTypes>
 ): Promise<IDBPDatabase<DBTypes>> | null {
   if (!hasIDB) return null;
-  return openDB<DBTypes>(name, version, options);
+  return import('idb').then(({ openDB }) => openDB<DBTypes>(name, version, options));
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { get, set, update } from 'idb-keyval';
 
 const PROGRESS_KEY = 'progress';
@@ -9,27 +11,37 @@ export type Keybinds = Record<string, string>;
 export type Replay = { id: string; data: unknown };
 
 export const getProgress = async (): Promise<ProgressData> =>
-  (await get<ProgressData>(PROGRESS_KEY)) || {};
+  (typeof window === 'undefined'
+    ? {}
+    : (await get<ProgressData>(PROGRESS_KEY)) || {});
 
 export const setProgress = async (progress: ProgressData): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await set(PROGRESS_KEY, progress);
 };
 
 export const getKeybinds = async (): Promise<Keybinds> =>
-  (await get<Keybinds>(KEYBINDS_KEY)) || {};
+  (typeof window === 'undefined'
+    ? {}
+    : (await get<Keybinds>(KEYBINDS_KEY)) || {});
 
 export const setKeybinds = async (keybinds: Keybinds): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await set(KEYBINDS_KEY, keybinds);
 };
 
 export const getReplays = async (): Promise<Replay[]> =>
-  (await get<Replay[]>(REPLAYS_KEY)) || [];
+  (typeof window === 'undefined'
+    ? []
+    : (await get<Replay[]>(REPLAYS_KEY)) || []);
 
 export const saveReplay = async (replay: Replay): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await update<Replay[]>(REPLAYS_KEY, (replays = []) => [...replays, replay]);
 };
 
 export const clearReplays = async (): Promise<void> => {
+  if (typeof window === 'undefined') return;
   await set(REPLAYS_KEY, []);
 };
 


### PR DESCRIPTION
## Summary
- mark IndexedDB helpers as client-only and guard against server use
- add feature detection for file explorer and phaser template
- wrap bookmark and storage utilities in window checks

## Testing
- `yarn smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b929868e348328a498bce973052e36