### PR TITLE
fix: import missing Add-to-Home-Screen initializer

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import { initA2HS } from '@/src/pwa/a2hs';
 
 import { Ubuntu } from 'next/font/google';
 


### PR DESCRIPTION
## Summary
- import Add-to-Home-Screen initializer so the app no longer crashes with `initA2HS` ReferenceError

## Testing
- `yarn test __tests__/installButton.test.tsx`
- `yarn eslint pages/_app.jsx` *(warn: File ignored because no matching configuration was supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b34a20883289d55e8ce1e64ef84