### PR TITLE
chore: remove unused patch file

### DIFF
--- a/.yarn/patches/magic-string-0.30.10.patch
+++ b/.yarn/patches/magic-string-0.30.10.patch
@@ -1,9 +1,0 @@
-diff --git a/README.md b/README.md
---- a/README.md
-+++ b/README.md
-@@ -322,3 +322,4 @@ bundle.addSource(source);
- ## License
- 
- MIT
-+
-


### PR DESCRIPTION
## Summary
- clean up unused magic-string patch

## Testing
- `yarn lint` (fails: Unexpected global 'window')
- `yarn test` (fails: Playwright Test needs to be invoked via yarn playwright test)


------
https://chatgpt.com/codex/tasks/task_e_68b928f8befc83289c5fc7f10b4985e5