### PR TITLE
chore: update vercel runtime to node20

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "api/**/*": {
+      "runtime": "nodejs20.x"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- unify Vercel function targets under `api/**/*`
- switch API runtime to Node.js 20 and drop legacy `@vercel/node`

## Testing
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test' and excluded from Jest test runs)*

------
https://chatgpt.com/codex/tasks/task_e_68b928f98b408328b3a19aeceae1dfc6