### PR TITLE
Add global error boundary with client reporting

### DIFF
--- a/app/api/log-client-error/route.ts
+++ b/app/api/log-client-error/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  console.error('Client error:', body);
+  return NextResponse.json({ ok: true });
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,10 +1,12 @@
+
 'use client';
 
 import { useEffect } from 'react';
+import { reportClientError } from '../lib/client-error-reporter';
 
-export default function Error({ error }: { error: Error }) {
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   useEffect(() => {
-    console.error(error);
+    reportClientError(error, error.stack);
   }, [error]);
 
   return (
@@ -12,10 +14,10 @@ export default function Error({ error }: { error: Error }) {
       <h2 className="text-xl font-semibold">Something went wrong!</h2>
       <button
         type="button"
-        onClick={() => window.location.reload()}
+        onClick={() => reset()}
         className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
       >
-        Reload
+        Try again
       </button>
     </div>
   );

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { reportClientError } from '../lib/client-error-reporter';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    reportClientError(error, error.stack);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+          <h2 className="text-xl font-semibold">Something went wrong!</h2>
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/lib/client-error-reporter.ts
+++ b/lib/client-error-reporter.ts
@@ -1,0 +1,32 @@
+export interface ClientErrorPayload {
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  url: string;
+  segment: string;
+}
+
+export async function reportClientError(error: Error, componentStack?: string) {
+  const payload: ClientErrorPayload = {
+    message: error.message,
+    stack: error.stack,
+    componentStack,
+    url: typeof window !== 'undefined' ? window.location.href : '',
+    segment: typeof window !== 'undefined' ? window.location.pathname : '',
+  };
+
+  if (process.env.NODE_ENV === 'development') {
+    console.error('[ClientError]', payload);
+    return;
+  }
+
+  try {
+    await fetch('/api/log-client-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error('Failed to report client error', err);
+  }
+}

--- a/pages/apps/weather.jsx
+++ b/pages/apps/weather.jsx
@@ -1,9 +1,16 @@
 import dynamic from 'next/dynamic';
 
-const WeatherApp = dynamic(() => import('../../apps/weather'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const WeatherApp = dynamic(
+  () =>
+    import('../../apps/weather').catch((err) => {
+      console.error('Failed to load Weather app', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  }
+);
 
 export default WeatherApp;
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,10 +2,28 @@ import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
 
-const Ubuntu = dynamic(() => import('../components/ubuntu'), { ssr: false });
-const InstallButton = dynamic(() => import('../components/InstallButton'), {
-  ssr: false,
-});
+const Ubuntu = dynamic(
+  () =>
+    import('../components/ubuntu').catch((err) => {
+      console.error('Failed to load Ubuntu component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading Ubuntu...</p>,
+  }
+);
+const InstallButton = dynamic(
+  () =>
+    import('../components/InstallButton').catch((err) => {
+      console.error('Failed to load InstallButton component', err);
+      throw err;
+    }),
+  {
+    ssr: false,
+    loading: () => <p>Loading install options...</p>,
+  }
+);
 
 /**
  * @returns {JSX.Element}

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -5,10 +5,15 @@ import { logEvent } from './analytics';
 export const createDynamicApp = (id, title) =>
   dynamic(
     () =>
-      import(/* webpackPrefetch: true */ `../components/apps/${id}`).then((mod) => {
-        logEvent({ category: 'Application', action: `Loaded ${title}` });
-        return mod.default;
-      }),
+      import(/* webpackPrefetch: true */ `../components/apps/${id}`)
+        .then((mod) => {
+          logEvent({ category: 'Application', action: `Loaded ${title}` });
+          return mod.default;
+        })
+        .catch((err) => {
+          console.error(`Failed to load ${title}`, err);
+          throw err;
+        }),
     {
       ssr: false,
       loading: () => (


### PR DESCRIPTION
## Summary
- add client-side error reporter and API logger
- wire global and route-level error boundaries to report errors
- ensure dynamic imports log and show fallback UIs

## Testing
- `yarn lint` *(fails: Unexpected global 'window')*
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test')*

------
https://chatgpt.com/codex/tasks/task_e_68b92970e57483288d8144997593e95f