### PR TITLE
Fix ESLint warnings

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -336,7 +336,6 @@ const AsciiArtApp = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-4">
             {samples.map((s, i) => (
               <pre
-                // eslint-disable-next-line react/no-array-index-key
                 key={i}
                 onMouseEnter={() => copy(s)}
                 className="p-2 whitespace-pre cursor-pointer bg-black hover:bg-gray-800 font-mono leading-none"

--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -8,7 +8,6 @@ const escapeHtml = (str: string = '') =>
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    // eslint-disable-next-line no-useless-escape
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 

--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -1,5 +1,4 @@
 /* eslint-env browser */
-/* eslint-disable no-top-level-window/no-top-level-window-or-document */
 const historyKey = 'clipboardHistory';
 let history = JSON.parse(localStorage.getItem(historyKey)) || [];
 

--- a/apps/figlet/worker.ts
+++ b/apps/figlet/worker.ts
@@ -48,14 +48,12 @@ function init() {
   for (const { name } of fonts) {
     const preview = figlet.textSync('Figlet', { font: name as figlet.Fonts });
     const mono = isMonospace(name);
-    // eslint-disable-next-line no-restricted-globals
     self.postMessage({ type: 'font', font: name, preview, mono });
   }
 }
 
 init();
 
-// eslint-disable-next-line no-restricted-globals
 self.onmessage = (e: MessageEvent<any>) => {
   if (e.data?.type === 'load') {
     const { name, data } = e.data as { name: string; data: string };
@@ -63,7 +61,6 @@ self.onmessage = (e: MessageEvent<any>) => {
       figlet.parseFont(name, data);
       const preview = figlet.textSync('Figlet', { font: name as figlet.Fonts });
       const mono = isMonospace(name);
-      // eslint-disable-next-line no-restricted-globals
       self.postMessage({ type: 'font', font: name, preview, mono });
     } catch {
       /* ignore bad font */
@@ -87,6 +84,5 @@ self.onmessage = (e: MessageEvent<any>) => {
     width,
     horizontalLayout: layout as figlet.KerningMethods,
   });
-  // eslint-disable-next-line no-restricted-globals
   self.postMessage({ type: 'render', output: rendered });
 };

--- a/apps/games/battleship/ai.ts
+++ b/apps/games/battleship/ai.ts
@@ -222,7 +222,7 @@ export class RandomAI {
   }
 }
 
-export default {
+const battleshipAI = {
   BOARD_SIZE,
   SHIPS,
   MonteCarloAI,
@@ -230,3 +230,5 @@ export default {
   RandomAI,
   randomizePlacement,
 };
+
+export default battleshipAI;

--- a/apps/games/nonogram/hints.ts
+++ b/apps/games/nonogram/hints.ts
@@ -37,4 +37,5 @@ export const createHintSystem = (maxHints: number) => {
   };
 };
 
-export default { revealRandomCell, createHintSystem };
+const hintsApi = { revealRandomCell, createHintSystem };
+export default hintsApi;

--- a/apps/games/nonogram/logic.ts
+++ b/apps/games/nonogram/logic.ts
@@ -149,7 +149,7 @@ export const autoFill = (grid: Grid, rows: Clue[], cols: Clue[]): Grid => {
   return g;
 };
 
-export default {
+const logicApi = {
   lineToClues,
   generateLinePatterns,
   getPossibleLineSolutions,
@@ -160,3 +160,5 @@ export default {
   toggleCross,
   autoFill,
 };
+
+export default logicApi;

--- a/apps/games/nonogram/packs.ts
+++ b/apps/games/nonogram/packs.ts
@@ -61,4 +61,5 @@ export const loadPackFromJSON = (raw: string): PuzzlePack => {
   return { name: data.name, puzzles };
 };
 
-export default { parsePack, loadPack, loadPackFromJSON };
+const packsApi = { parsePack, loadPack, loadPackFromJSON };
+export default packsApi;

--- a/apps/games/nonogram/progress.ts
+++ b/apps/games/nonogram/progress.ts
@@ -24,4 +24,5 @@ export const loadProgress = (name: string): PuzzleState | null => {
   }
 };
 
-export default { saveProgress, loadProgress };
+const progressApi = { saveProgress, loadProgress };
+export default progressApi;

--- a/apps/games/rng.ts
+++ b/apps/games/rng.ts
@@ -16,4 +16,5 @@ export const deserialize = (state: string) => {
   rng = seedrandom('', { state: JSON.parse(state) });
 };
 
-export default { random, reset, serialize, deserialize };
+const rngApi = { random, reset, serialize, deserialize };
+export default rngApi;

--- a/apps/games/sudoku/index.ts
+++ b/apps/games/sudoku/index.ts
@@ -148,4 +148,5 @@ export const isValidPlacement = (
   }
 };
 
-export default { generateSudoku, getCandidates, isValidPlacement, isValid };
+const sudokuApi = { generateSudoku, getCandidates, isValidPlacement, isValid };
+export default sudokuApi;

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -149,7 +149,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
 
       create() {
         const data = this.cache.json.get('level');
-        this.state = new GameState(data.spawn);
+        this.gameState = new GameState(data.spawn);
 
         // Parallax background layers
         data.parallaxLayers?.forEach((l: any) => {
@@ -227,10 +227,10 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
             if (body.label === 'checkpoint') {
               const cp = this.checkpointFlags.find((c) => c.body === body);
               if (cp) cp.flag.setFillStyle(0x00ff00);
-              this.state.setCheckpoint({ x: body.position.x, y: body.position.y });
+              this.gameState.setCheckpoint({ x: body.position.x, y: body.position.y });
             }
             if (body.label === 'hazard') {
-              const s = this.state.getRespawnPoint();
+              const s = this.gameState.getRespawnPoint();
               this.player.setPosition(s.x, s.y);
               this.player.setVelocity(0, 0);
             }
@@ -240,7 +240,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
                 const [coin] = this.coins.splice(idx, 1);
                 coin.sprite.destroy();
                 this.matter.world.remove(body);
-                const count = this.state.addCoin();
+                const count = this.gameState.addCoin();
                 this.coinText.setText(`Coins: ${count}`);
               }
             }
@@ -306,7 +306,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
         }
 
         const data = this.cache.json.get('level');
-        const pos = this.state.respawnIfOutOfBounds({ x: this.player.x, y: this.player.y }, data.bounds.fallY);
+        const pos = this.gameState.respawnIfOutOfBounds({ x: this.player.x, y: this.player.y }, data.bounds.fallY);
         if (pos !== this.player) {
           this.player.setPosition(pos.x, pos.y);
           this.player.setVelocity(0, 0);

--- a/apps/solitaire/index.tsx
+++ b/apps/solitaire/index.tsx
@@ -47,7 +47,6 @@ const Solitaire = () => {
     <div key={key} className="min-w-[60px] rounded border p-1">
       {pile.map((card, idx) => (
         <div
-          // eslint-disable-next-line react/no-array-index-key
           key={idx}
           className={card.faceDown ? 'text-gray-400' : ''}
         >

--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -1,8 +1,16 @@
 import { isBrowser } from '../../utils/env';
 import { makeIdb } from '../../utils/safeIdb';
 
-const notesContainer = isBrowser ? document.getElementById('notes') : null;
-const addNoteBtn = isBrowser ? document.getElementById('add-note') : null;
+let notesContainer = null;
+let addNoteBtn = null;
+
+function initDom() {
+  if (!isBrowser) return;
+  notesContainer = document.getElementById('notes');
+  addNoteBtn = document.getElementById('add-note');
+}
+
+initDom();
 
 const DB_NAME = 'stickyNotes';
 const STORE_NAME = 'notes';

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -29,7 +29,6 @@ export default function YouTubePlayer({ videoId }) {
 
     const createPlayer = () => {
       if (!containerRef.current) return;
-      // eslint-disable-next-line no-undef
       playerRef.current = new YT.Player(containerRef.current, {
         videoId,
         host: 'https://www.youtube-nocookie.com',

--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -5,7 +5,6 @@ const escapeHtml = (str = '') =>
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    // eslint-disable-next-line no-useless-escape
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -8,7 +8,6 @@ const escapeFilename = (str = '') =>
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    // eslint-disable-next-line no-useless-escape
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 

--- a/components/apps/autopsy/jsonWorker.js
+++ b/components/apps/autopsy/jsonWorker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 self.onmessage = (e) => {
   try {
     const data = JSON.parse(e.data);

--- a/components/apps/autopsy/timelineWorker.js
+++ b/components/apps/autopsy/timelineWorker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 self.onmessage = (e) => {
   const { events = [] } = e.data || {};
   const sorted = events.slice().sort(

--- a/components/apps/fps-game.js
+++ b/components/apps/fps-game.js
@@ -10,9 +10,10 @@ const FPSGame = () => {
   useEffect(() => {
     let handlePointerLockChange;
     let handleMouseMove;
+    const canvas = canvasRef.current;
     (async () => {
       const THREE = await import('three');
-      const canvas = canvasRef.current;
+      if (!canvas) return;
       const renderer = new THREE.WebGLRenderer({ canvas });
       renderer.setSize(canvas.clientWidth, canvas.clientHeight);
       rendererRef.current = renderer;
@@ -55,9 +56,9 @@ const FPSGame = () => {
 
     return () => {
       document.removeEventListener('pointerlockchange', handlePointerLockChange);
-      const canvas = canvasRef.current;
-      if (canvas && handleMouseMove)
+      if (canvas && handleMouseMove) {
         canvas.removeEventListener('mousemove', handleMouseMove);
+      }
     };
   }, []);
 

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -28,10 +28,8 @@ const profileTabs = [
 const notify = (title, body) => {
   if (typeof window === 'undefined') return;
   if ('Notification' in window && Notification.permission === 'granted') {
-    // eslint-disable-next-line no-new
     new Notification(title, { body });
   } else {
-    // eslint-disable-next-line no-alert
     alert(`${title}: ${body}`);
   }
 };

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -223,7 +223,6 @@ const ResourceMonitor = () => {
       </div>
       {stressWindows.current.map((_, i) => (
         <div
-          // eslint-disable-next-line react/no-array-index-key
           key={i}
           ref={(el) => {
             stressEls.current[i] = el;

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -528,7 +528,6 @@ const Simon = () => {
           <div className="mb-1">Leaderboard</div>
           <ol className="list-decimal list-inside">
             {scores.map((score, i) => (
-              // eslint-disable-next-line react/no-array-index-key
               <li key={i}>{score}</li>
             ))}
           </ol>


### PR DESCRIPTION
## Summary
- remove unused eslint-disable comments in components and apps
- refactor FPS game effect and sticky notes DOM init
- convert various default exports to named constants to satisfy lint rules

## Testing
- `npx eslint components/apps/autopsy/timelineWorker.js components/apps/fps-game.js components/apps/openvas/index.js components/apps/resource_monitor.js components/apps/simon.js components/YouTubePlayer.js components/apps/autopsy/KeywordSearchPanel.js components/apps/autopsy/index.js components/apps/autopsy/jsonWorker.js apps/games/rng.ts apps/games/sudoku/index.ts apps/phaser_matter/index.tsx apps/solitaire/index.tsx apps/sticky_notes/main.js apps/ascii-art/index.tsx apps/autopsy/components/KeywordTester.tsx apps/clipboard_manager/main.js apps/figlet/worker.ts apps/games/battleship/ai.ts apps/games/nonogram/hints.ts apps/games/nonogram/logic.ts apps/games/nonogram/packs.ts apps/games/nonogram/progress.ts`
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test')*

------
https://chatgpt.com/codex/tasks/task_e_68b92ad251dc8328a1764b73f2d9d5cd