### PR TITLE
chore: configure vercel functions for node 20 runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,15 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": {
+      "runtime": "nodejs20.x",
+      "memory": 1024,
+      "maxDuration": 30
+    },
+    "app/api/**/route.{js,ts}": {
+      "runtime": "nodejs20.x",
+      "memory": 1024,
+      "maxDuration": 30
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure Vercel functions to use Node.js 20 runtime with increased memory and max duration

## Testing
- `yarn test` *(fails: Playwright Test needs to be invoked via 'yarn playwright test' and excluded from Jest test runs)*

------
https://chatgpt.com/codex/tasks/task_e_68b92e24b25c8328b9b60a2db76f78ea