### PR TITLE
fix: stabilize client-only data

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -184,7 +184,7 @@ export function Settings() {
                 {
                     wallpapers.map((name, index) => (
                         <div
-                            key={index}
+                            key={name}
                             role="button"
                             aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
                             aria-pressed={name === wallpaper}

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -7,21 +7,19 @@ export default class Clock extends Component {
         this.day_list = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         this.state = {
             hour_12: true,
-            current_time: new Date()
+            current_time: null
         };
     }
 
     componentDidMount() {
+        const update = () => this.setState({ current_time: new Date() });
+        update();
         if (typeof window !== 'undefined' && typeof Worker === 'function') {
             this.worker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
-            this.worker.onmessage = () => {
-                this.setState({ current_time: new Date() });
-            };
+            this.worker.onmessage = update;
             this.worker.postMessage({ action: 'start', interval: 10 * 1000 });
         } else {
-            this.update_time = setInterval(() => {
-                this.setState({ current_time: new Date() });
-            }, 10 * 1000);
+            this.update_time = setInterval(update, 10 * 1000);
         }
     }
 
@@ -35,6 +33,7 @@ export default class Clock extends Component {
 
     render() {
         const { current_time } = this.state;
+        if (!current_time) return <span suppressHydrationWarning></span>;
 
         let day = this.day_list[current_time.getDay()];
         let hour = current_time.getHours();
@@ -57,6 +56,6 @@ export default class Clock extends Component {
             display_time = day + " " + month + " " + date;
         }
         else display_time = day + " " + month + " " + date + " " + hour + ":" + minute + " " + meridiem;
-        return <span>{display_time}</span>;
+        return <span suppressHydrationWarning>{display_time}</span>;
     }
 }

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -7,9 +7,7 @@ const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
-  const [online, setOnline] = useState(
-    typeof navigator !== "undefined" ? navigator.onLine : true
-  );
+  const [online, setOnline] = useState(true);
 
   useEffect(() => {
     const pingServer = async () => {


### PR DESCRIPTION
## Summary
- avoid server/client time mismatch in Clock by rendering after mount
- derive network status in effect with consistent initial markup
- use wallpaper name as stable React key

## Testing
- `yarn lint` *(fails: 92 errors, 39 warnings)*
- `yarn test` *(fails: 1 failed, 4 skipped, 109 passed, 110 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b9296bd0b08328be99fabef39bca73