### PR TITLE
mark client-only widgets and lazy-load heavy modules

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 import Phaser from 'phaser';
 import { GameState } from './gameLogic';

--- a/components/PipPortal.tsx
+++ b/components/PipPortal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/components/SpriteStripPreview.tsx
+++ b/components/SpriteStripPreview.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { importSpriteStrip } from '../utils/spriteStrip';
 

--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, {
   useRef,
   useEffect,

--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef } from 'react';
 import { publish } from '../../../../../utils/pubsub';
 import { hasOffscreenCanvas } from '../../../../../utils/feature';

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 import type { PDFDocumentProxy } from 'pdfjs-dist';

--- a/components/common/PipPortal.tsx
+++ b/components/common/PipPortal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,5 +1,12 @@
+"use client";
+
 import React, { Component } from 'react';
-import BackgroundImage from '../util-components/background-image';
+import dynamic from 'next/dynamic';
+
+const BackgroundImage = dynamic(
+    () => import('../util-components/background-image'),
+    { ssr: false }
+);
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 import useDailyQuote from '../../hooks/useDailyQuote';


### PR DESCRIPTION
## Summary
- mark PdfViewer and various game helpers as client components
- lazy-load BackgroundImage to avoid SSR for canvas-heavy background analysis
- annotate PipPortal and Autopsy widgets with use client for browser APIs

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and other pre-existing errors)*
- `yarn test __tests__/pdfviewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b92e2737ac8328a18141a017d166b8