### PR TITLE
feat: add CSP middleware with nonce

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+function nonce() {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  return Buffer.from(arr).toString('base64');
+}
+
+export function middleware(req: NextRequest) {
+  const n = nonce();
+  const csp = [
+    "default-src 'self'",
+    "img-src 'self' https: data:",
+    "style-src 'self' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    `script-src 'self' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
+    "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+    "frame-ancestors 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'"
+  ].join('; ');
+
+  const res = NextResponse.next();
+  res.headers.set('x-csp-nonce', n);
+  res.headers.set('Content-Security-Policy', csp);
+  return res;
+}

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,22 +1,13 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
-import Script from 'next/script';
-import crypto from 'node:crypto';
 
 class MyDocument extends Document {
   /**
    * @param {import('next/document').DocumentContext} ctx
    */
   static async getInitialProps(ctx) {
-    const nonce = crypto.randomBytes(16).toString('base64');
-    const initialProps = await Document.getInitialProps(ctx);
-    const csp = ctx.res?.getHeader('Content-Security-Policy');
-    if (csp) {
-      ctx.res.setHeader(
-        'Content-Security-Policy',
-        csp.toString().replace(/__CSP_NONCE__/g, nonce),
-      );
-    }
-    return { ...initialProps, nonce };
+    const initial = await Document.getInitialProps(ctx);
+    const nonce = ctx?.res?.getHeader?.('x-csp-nonce');
+    return { ...initial, nonce };
   }
 
   render() {
@@ -27,12 +18,7 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <Script
-            src="/theme.js"
-            strategy="afterInteractive"
-            nonce={nonce}
-            // Apply theme once the page is interactive to avoid blocking initial paint
-          />
+          <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Summary
- add middleware to issue CSP headers with a nonce
- read and apply CSP nonce in custom document

## Testing
- `yarn lint pages/_document.jsx middleware.ts` *(fails: many pre-existing errors)*
- `yarn test` *(fails: Playwright tests must run separately)*

------
https://chatgpt.com/codex/tasks/task_e_68b92e26d4d883288e3d86835c2649c8