### PR TITLE
feat: add smoke test routes and error logging

### DIFF
--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -1,6 +1,5 @@
 import { chromium, firefox, webkit } from 'playwright';
 import fs from 'fs';
-import path from 'path';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
@@ -11,12 +10,50 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
     { name: 'webkit', type: webkit },
   ];
 
-  const pagesDir = path.join(process.cwd(), 'pages', 'apps');
-  const files = fs.readdirSync(pagesDir, { withFileTypes: true })
-    .filter((d) => d.isFile() && /\.(jsx?|tsx?)$/.test(d.name))
-    .map((d) => d.name);
-
-  const routes = files.map((file) => `/apps/${file.replace(/\.(jsx?|tsx?)$/, '')}`);
+  // Add new app routes here to include them in smoke tests
+  const routes = [
+    '/apps/2048',
+    '/apps/ascii-art',
+    '/apps/autopsy',
+    '/apps/beef',
+    '/apps/blackjack',
+    '/apps/calculator',
+    '/apps/checkers',
+    '/apps/connect-four',
+    '/apps/contact',
+    '/apps/converter',
+    '/apps/figlet',
+    '/apps/http',
+    '/apps',
+    '/apps/input-lab',
+    '/apps/john',
+    '/apps/kismet',
+    '/apps/metasploit-post',
+    '/apps/metasploit',
+    '/apps/minesweeper',
+    '/apps/nmap-nse',
+    '/apps/password_generator',
+    '/apps/phaser_matter',
+    '/apps/pinball',
+    '/apps/project-gallery',
+    '/apps/qr',
+    '/apps/settings',
+    '/apps/simon',
+    '/apps/sokoban',
+    '/apps/solitaire',
+    '/apps/spotify',
+    '/apps/ssh',
+    '/apps/sticky_notes',
+    '/apps/timer_stopwatch',
+    '/apps/tower-defense',
+    '/apps/volatility',
+    '/apps/vscode',
+    '/apps/weather',
+    '/apps/weather_widget',
+    '/apps/wireshark',
+    '/apps/word_search',
+    '/apps/x',
+  ];
 
   let hadError = false;
   const results = [];
@@ -28,10 +65,14 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
     for (const route of routes) {
       const page = await context.newPage();
       const consoleErrors = [];
+      const pageErrors = [];
       page.on('console', (msg) => {
         if (msg.type() === 'error') {
           consoleErrors.push(msg.text());
         }
+      });
+      page.on('pageerror', (err) => {
+        pageErrors.push(err.message);
       });
       console.log(`[${name}] Visiting ${route}`);
       let error = '';
@@ -39,8 +80,8 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
         const response = await page.goto(`${BASE_URL}${route}`);
         if (!response || !response.ok()) {
           error = `HTTP ${response ? response.status() : 'no response'}`;
-        } else if (consoleErrors.length > 0) {
-          error = consoleErrors.join('\n');
+        } else if (consoleErrors.length > 0 || pageErrors.length > 0) {
+          error = [...pageErrors, ...consoleErrors].join('\n');
         }
       } catch (err) {
         error = err.message;


### PR DESCRIPTION
## Summary
- hard-code app routes for smoke testing
- capture page errors alongside console errors during smoke tests

## Testing
- `yarn smoke` *(fails: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000/apps/2048)*

------
https://chatgpt.com/codex/tasks/task_e_68b92e2bc220832885375b7a3338710a