### PR TITLE
feat: add browser environment guard

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { isBrowser } from '../utils/isBrowser';
 
 export default function Error({ error }: { error: Error }) {
   useEffect(() => {
@@ -10,13 +11,17 @@ export default function Error({ error }: { error: Error }) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 p-4">
       <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => window.location.reload()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
-        Reload
-      </button>
+      {isBrowser && (
+        <button
+          type="button"
+          onClick={() => {
+            if (isBrowser) globalThis.location.reload();
+          }}
+          className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+        >
+          Reload
+        </button>
+      )}
     </div>
   );
 }

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,4 +1,7 @@
+import { isBrowser } from './isBrowser';
+
 export const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (!isBrowser) return false;
   try {
     if (navigator?.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);

--- a/utils/csp.ts
+++ b/utils/csp.ts
@@ -1,6 +1,8 @@
+import { isBrowser } from './isBrowser';
+
 export function getCspNonce(): string | undefined {
-  if (typeof document !== 'undefined') {
-    return document.documentElement.dataset.cspNonce;
+  if (isBrowser) {
+    return globalThis.document.documentElement.dataset.cspNonce;
   }
   return undefined;
 }

--- a/utils/dailyChallenge.ts
+++ b/utils/dailyChallenge.ts
@@ -4,6 +4,7 @@ import {
   recordScore as baseRecordScore,
 } from '../components/apps/Games/common/leaderboard';
 import { broadcastLeaderboard } from './sync';
+import { isBrowser } from './isBrowser';
 
 const SEED_PREFIX = 'dailySeed:';
 const COMPLETE_PREFIX = 'dailyComplete:';
@@ -22,9 +23,9 @@ export const getDailySeed = (gameId: string, date: Date = new Date()): string =>
   const day = date.toISOString().split('T')[0];
   const key = `${gameId}:${day}`;
   const seed = hash(key);
-  if (typeof window !== 'undefined') {
+  if (isBrowser) {
     try {
-      window.localStorage.setItem(`${SEED_PREFIX}${gameId}`, seed);
+      globalThis.localStorage.setItem(`${SEED_PREFIX}${gameId}`, seed);
     } catch {
       /* ignore storage errors */
     }
@@ -38,12 +39,14 @@ export const hasCompleted = (
   gameId: string,
   date: Date = new Date(),
 ): boolean => {
-  if (typeof window === 'undefined') return false;
+  if (!isBrowser) return false;
   const day = date.toISOString().split('T')[0];
   try {
-    return window.localStorage.getItem(
-      `${COMPLETE_PREFIX}${gameId}:${day}`
-    ) === '1';
+    return (
+      globalThis.localStorage.getItem(
+        `${COMPLETE_PREFIX}${gameId}:${day}`
+      ) === '1'
+    );
   } catch {
     return false;
   }
@@ -57,10 +60,10 @@ export const recordCompletion = (
   limit = 10,
 ): LeaderboardEntry[] => {
   const board = baseRecordScore(gameId, name, score, limit);
-  if (typeof window !== 'undefined') {
+  if (isBrowser) {
     try {
       const day = date.toISOString().split('T')[0];
-      window.localStorage.setItem(
+      globalThis.localStorage.setItem(
         `${COMPLETE_PREFIX}${gameId}:${day}`,
         '1',
       );

--- a/utils/dailySeed.ts
+++ b/utils/dailySeed.ts
@@ -1,4 +1,5 @@
 import { getSeed, setSeed } from './idb';
+import { isBrowser } from './isBrowser';
 
 function today(): string {
   return new Date().toISOString().split('T')[0];
@@ -6,7 +7,11 @@ function today(): string {
 
 export async function getDailySeed(game: string): Promise<string> {
   const date = today();
-  if (typeof window !== 'undefined' && 'serviceWorker' in navigator && navigator.serviceWorker.controller) {
+  if (
+    isBrowser &&
+    'serviceWorker' in navigator &&
+    navigator.serviceWorker.controller
+  ) {
     const channel = new MessageChannel();
     const sw = navigator.serviceWorker.controller;
     return new Promise((resolve) => {

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,3 +1,5 @@
-export const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
-export const hasIDB = typeof indexedDB !== 'undefined';
-export const hasStorage = typeof localStorage !== 'undefined';
+import { isBrowser } from './isBrowser';
+
+export { isBrowser };
+export const hasIDB = typeof globalThis.indexedDB !== 'undefined';
+export const hasStorage = typeof globalThis.localStorage !== 'undefined';

--- a/utils/feature.ts
+++ b/utils/feature.ts
@@ -1,6 +1,9 @@
+import { isBrowser } from './isBrowser';
+
 export const hasOffscreenCanvas = (): boolean =>
-  typeof window !== 'undefined' &&
-  'OffscreenCanvas' in window &&
-  typeof HTMLCanvasElement !== 'undefined' &&
-  typeof HTMLCanvasElement.prototype.transferControlToOffscreen === 'function';
+  isBrowser &&
+  'OffscreenCanvas' in globalThis &&
+  typeof globalThis.HTMLCanvasElement !== 'undefined' &&
+  typeof globalThis.HTMLCanvasElement.prototype.transferControlToOffscreen ===
+    'function';
 

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from './isBrowser';
+
 export interface ButtonEvent {
   gamepad: Gamepad;
   index: number;
@@ -35,11 +37,11 @@ class GamepadManager {
   constructor(deadzone = 0.1) {
     this.deadzone = deadzone;
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('gamepadconnected', (e) =>
+    if (isBrowser) {
+      globalThis.addEventListener('gamepadconnected', (e) =>
         this.emit('connected', (e as GamepadEvent).gamepad)
       );
-      window.addEventListener('gamepaddisconnected', (e) =>
+      globalThis.addEventListener('gamepaddisconnected', (e) =>
         this.emit('disconnected', (e as GamepadEvent).gamepad)
       );
     }
@@ -58,7 +60,7 @@ class GamepadManager {
   }
 
   private poll = () => {
-    const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    const pads = isBrowser && navigator.getGamepads ? navigator.getGamepads() : [];
     for (const pad of pads) {
       if (!pad) continue;
 
@@ -132,7 +134,7 @@ export interface TwinStickState {
  */
 export function pollTwinStick(deadzone = 0.25): TwinStickState {
   const state: TwinStickState = { moveX: 0, moveY: 0, aimX: 0, aimY: 0, fire: false };
-  const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+  const pads = isBrowser && navigator.getGamepads ? navigator.getGamepads() : [];
   for (const pad of pads) {
     if (!pad) continue;
     const [lx, ly, rx, ry] = pad.axes;

--- a/utils/isBrowser.ts
+++ b/utils/isBrowser.ts
@@ -1,0 +1,7 @@
+export const isBrowser =
+  typeof globalThis !== 'undefined' &&
+  typeof globalThis['window'] !== 'undefined' &&
+  typeof globalThis['document'] !== 'undefined' &&
+  typeof globalThis['navigator'] !== 'undefined';
+
+export default isBrowser;

--- a/utils/mailto.ts
+++ b/utils/mailto.ts
@@ -1,14 +1,17 @@
+import { isBrowser } from './isBrowser';
+
 export const openMailto = (
   email: string,
   subject = '',
   body = '',
 ): void => {
+  if (!isBrowser) return;
   const params = new URLSearchParams();
   if (subject) params.set('subject', subject);
   if (body) params.set('body', body);
   const query = params.toString();
   const href = `mailto:${email}${query ? `?${query}` : ''}`;
-  window.location.href = href;
+  globalThis.location.href = href;
 };
 
 export default openMailto;

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from './isBrowser';
+
 const STORAGE_KEY = 'qrScans';
 const LAST_SCAN_KEY = 'qrLastScan';
 const LAST_GEN_KEY = 'qrLastGeneration';
@@ -12,12 +14,12 @@ const getStorage = (): StorageWithDirectory =>
   navigator.storage as StorageWithDirectory;
 
 const hasOpfs =
-  typeof window !== 'undefined' &&
+  isBrowser &&
   'storage' in navigator &&
   Boolean(getStorage().getDirectory);
 
 export const loadScans = async (): Promise<string[]> => {
-  if (typeof window === 'undefined') return [];
+  if (!isBrowser) return [];
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -29,14 +31,14 @@ export const loadScans = async (): Promise<string[]> => {
     }
   }
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    return JSON.parse(globalThis.localStorage.getItem(STORAGE_KEY) || '[]');
   } catch {
     return [];
   }
 };
 
 export const saveScans = async (scans: string[]): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   if (hasOpfs) {
     const root = await getStorage().getDirectory();
     const handle = await root.getFileHandle(FILE_NAME, { create: true });
@@ -45,11 +47,11 @@ export const saveScans = async (scans: string[]): Promise<void> => {
     await writable.close();
     return;
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(scans));
+  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(scans));
 };
 
 export const clearScans = async (): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -59,25 +61,25 @@ export const clearScans = async (): Promise<void> => {
     }
     return;
   }
-  localStorage.removeItem(STORAGE_KEY);
+  globalThis.localStorage.removeItem(STORAGE_KEY);
 };
 
 export const loadLastScan = (): string => {
-  if (typeof window === 'undefined') return '';
-  return localStorage.getItem(LAST_SCAN_KEY) || '';
+  if (!isBrowser) return '';
+  return globalThis.localStorage.getItem(LAST_SCAN_KEY) || '';
 };
 
 export const saveLastScan = (scan: string): void => {
-  if (typeof window === 'undefined') return;
-  localStorage.setItem(LAST_SCAN_KEY, scan);
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem(LAST_SCAN_KEY, scan);
 };
 
 export const loadLastGeneration = (): string => {
-  if (typeof window === 'undefined') return '';
-  return localStorage.getItem(LAST_GEN_KEY) || '';
+  if (!isBrowser) return '';
+  return globalThis.localStorage.getItem(LAST_GEN_KEY) || '';
 };
 
 export const saveLastGeneration = (payload: string): void => {
-  if (typeof window === 'undefined') return;
-  localStorage.setItem(LAST_GEN_KEY, payload);
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem(LAST_GEN_KEY, payload);
 };

--- a/utils/safeStorage.ts
+++ b/utils/safeStorage.ts
@@ -1,3 +1,5 @@
 import { hasStorage } from './env';
 
-export const safeLocalStorage: Storage | undefined = hasStorage ? window.localStorage : undefined;
+export const safeLocalStorage: Storage | undefined = hasStorage
+  ? globalThis.localStorage
+  : undefined;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,5 +1,6 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import { isBrowser } from './isBrowser';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -14,110 +15,110 @@ const DEFAULT_SETTINGS = {
 };
 
 export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  if (!isBrowser) return DEFAULT_SETTINGS.accent;
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   await set('accent', accent);
 }
 
 export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  if (!isBrowser) return DEFAULT_SETTINGS.wallpaper;
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   await set('bg-image', wallpaper);
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  if (!isBrowser) return DEFAULT_SETTINGS.density;
+  return globalThis.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  return window.localStorage.getItem('reduced-motion') === 'true';
+  if (!isBrowser) return DEFAULT_SETTINGS.reducedMotion;
+  return globalThis.localStorage.getItem('reduced-motion') === 'true';
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  if (!isBrowser) return DEFAULT_SETTINGS.fontScale;
+  const stored = globalThis.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  if (!isBrowser) return DEFAULT_SETTINGS.highContrast;
+  return globalThis.localStorage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  if (!isBrowser) return DEFAULT_SETTINGS.largeHitAreas;
+  return globalThis.localStorage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  if (!isBrowser) return DEFAULT_SETTINGS.pongSpin;
+  const val = globalThis.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  if (!isBrowser) return DEFAULT_SETTINGS.allowNetwork;
+  return globalThis.localStorage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  if (!isBrowser) return;
+  globalThis.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
+  globalThis.localStorage.removeItem('density');
+  globalThis.localStorage.removeItem('reduced-motion');
+  globalThis.localStorage.removeItem('font-scale');
+  globalThis.localStorage.removeItem('high-contrast');
+  globalThis.localStorage.removeItem('large-hit-areas');
+  globalThis.localStorage.removeItem('pong-spin');
+  globalThis.localStorage.removeItem('allow-network');
 }
 
 export async function exportSettings() {
@@ -158,7 +159,7 @@ export async function exportSettings() {
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   let settings;
   try {
     settings = typeof json === 'string' ? JSON.parse(json) : json;

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,6 +1,8 @@
+import { isBrowser } from './isBrowser';
+
 // Simple helper around the Web Share API
 export const canShare = () =>
-  typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+  isBrowser && typeof globalThis.navigator.share === 'function';
 
 // Shares the provided text along with optional title and url
 export const share = async (
@@ -10,7 +12,7 @@ export const share = async (
 ): Promise<boolean> => {
   if (!canShare()) return false;
   try {
-    await navigator.share({ text, title, url: url ?? window.location.href });
+    await globalThis.navigator.share({ text, title, url: url ?? globalThis.location.href });
     return true;
   } catch {
     return false;

--- a/utils/sync.ts
+++ b/utils/sync.ts
@@ -1,9 +1,11 @@
+import { isBrowser } from './isBrowser';
+
 type StateMessage = { type: 'state'; state: unknown };
 type LeaderboardMessage = { type: 'leaderboard'; leaderboard: unknown };
 type SyncMessage = StateMessage | LeaderboardMessage;
 
 const channel =
-  typeof window !== 'undefined' && 'BroadcastChannel' in self
+  isBrowser && 'BroadcastChannel' in self
     ? new BroadcastChannel('sync')
     : null;
 
@@ -35,8 +37,10 @@ export const subscribe = (
   return () => channel.removeEventListener('message', listener);
 };
 
-export default {
+const sync = {
   broadcastState,
   broadcastLeaderboard,
   subscribe,
 };
+
+export default sync;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -8,12 +8,14 @@ export const THEME_UNLOCKS: Record<string, number> = {
   matrix: 1000,
 };
 
+import { isBrowser } from './isBrowser';
+
 export const getTheme = (): string => {
-  if (typeof window === 'undefined') return 'default';
+  if (!isBrowser) return 'default';
   try {
-    const stored = window.localStorage.getItem(THEME_KEY);
+    const stored = globalThis.localStorage.getItem(THEME_KEY);
     if (stored) return stored;
-    const prefersDark = window.matchMedia?.(
+    const prefersDark = globalThis.matchMedia?.(
       '(prefers-color-scheme: dark)'
     ).matches;
     return prefersDark ? 'dark' : 'default';
@@ -23,9 +25,9 @@ export const getTheme = (): string => {
 };
 
 export const setTheme = (theme: string): void => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser) return;
   try {
-    window.localStorage.setItem(THEME_KEY, theme);
+    globalThis.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
   } catch {
     /* ignore storage errors */


### PR DESCRIPTION
## Summary
- add `isBrowser` util to centralize browser detection
- guard browser-specific utilities with `isBrowser`
- use globalThis to avoid top-level `window` access and keep lint rule

## Testing
- `npx eslint utils/isBrowser.ts utils/env.ts utils/safeStorage.ts utils/mailto.ts app/error.tsx utils/share.ts utils/theme.ts utils/feature.ts utils/dailySeed.ts utils/gamepad.ts utils/dailyChallenge.ts utils/sync.ts utils/settingsStore.js utils/qrStorage.ts utils/clipboard.ts utils/csp.ts --max-warnings=0`
- `yarn test` *(fails: Playwright Test needs to be invoked separately)*

------
https://chatgpt.com/codex/tasks/task_e_68b928f819d883288011b828aa86dcc8