### PR TITLE
Ignore Playwright tests during Jest runs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,11 @@ const customJestConfig = {
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
     '^@/(.*)$': '<rootDir>/$1',
   },
-  testPathIgnorePatterns: ['<rootDir>/playwright/', '<rootDir>/__tests__/playwright/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/playwright/',
+    '<rootDir>/__tests__/playwright/',
+    '<rootDir>/tests/',
+  ],
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- update Jest configuration to ignore Playwright integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b92e75b1488328aae7254b6ff1eeca