### PR TITLE
fix: pin vercel runtime plugin

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }
 }


### PR DESCRIPTION
## Summary
- pin Node.js serverless runtime to a specific @vercel/node version to satisfy Vercel build requirements

## Testing
- `npx eslint vercel.json`
- `yarn test __tests__/contact.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b92f8154548328810f2730a901381b