### PR TITLE
fix: support configurable overlay root

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -285,15 +285,15 @@ describe('Window keyboard dragging', () => {
 });
 
 describe('Window overlay inert behaviour', () => {
-  it('sets and removes inert on #root restoring focus', () => {
+  it('sets and removes inert on default __next root restoring focus', () => {
     const ref = React.createRef<Window>();
     const root = document.createElement('div');
-    root.id = 'root';
+    root.id = '__next';
     document.body.appendChild(root);
 
-      const opener = document.createElement('button');
-      document.body.appendChild(opener);
-      opener.focus();
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
 
     render(
       <Window
@@ -322,5 +322,49 @@ describe('Window overlay inert behaviour', () => {
 
     expect(root).not.toHaveAttribute('inert');
 
+    document.body.removeChild(root);
+    document.body.removeChild(opener);
+  });
+
+  it('respects overlayRoot prop when provided', () => {
+    const ref = React.createRef<Window>();
+    const root = document.createElement('div');
+    root.id = 'custom-root';
+    document.body.appendChild(root);
+
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+        overlayRoot="custom-root"
+      />,
+      { container: root }
+    );
+
+    act(() => {
+      ref.current!.activateOverlay();
+    });
+
+    expect(root).toHaveAttribute('inert');
+
+    act(() => {
+      ref.current!.closeWindow();
+    });
+
+    expect(root).not.toHaveAttribute('inert');
+
+    document.body.removeChild(root);
+    document.body.removeChild(opener);
   });
 });

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -139,8 +139,18 @@ export class Window extends Component {
         shrink();
     }
 
+    getOverlayRoot = () => {
+        if (this.props.overlayRoot) {
+            if (typeof this.props.overlayRoot === 'string') {
+                return document.getElementById(this.props.overlayRoot);
+            }
+            return this.props.overlayRoot;
+        }
+        return document.getElementById('__next');
+    }
+
     activateOverlay = () => {
-        const root = document.getElementById('root');
+        const root = this.getOverlayRoot();
         if (root) {
             root.setAttribute('inert', '');
         }
@@ -148,7 +158,7 @@ export class Window extends Component {
     }
 
     deactivateOverlay = () => {
-        const root = document.getElementById('root');
+        const root = this.getOverlayRoot();
         if (root) {
             root.removeAttribute('inert');
         }


### PR DESCRIPTION
## Summary
- resolve overlay root from `props.overlayRoot` or Next.js `__next`
- test inert behaviour on default and custom roots

## Testing
- `npm test __tests__/window.test.tsx`
- `npx eslint components/base/window.js __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b93077a4788328abae56ff2d33ebe3