### PR TITLE
feat: toggle dark class with theme

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -3,19 +3,34 @@ import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
 describe('theme persistence and unlocking', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    document.documentElement.dataset.theme = '';
+    document.documentElement.className = '';
   });
 
-  test('theme persists across sessions', () => {
+  test('theme persists across sessions and updates DOM', () => {
     setTheme('dark');
     expect(getTheme()).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
     // simulate reload by reading from localStorage again
     expect(window.localStorage.getItem('app:theme')).toBe('dark');
+
+    setTheme('default');
+    expect(document.documentElement.dataset.theme).toBe('default');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
     expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
     expect(unlocked).not.toContain('matrix');
+  });
+
+  test('dark class applied for neon and matrix themes', () => {
+    setTheme('neon');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    setTheme('matrix');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
   test('defaults to system preference when no stored theme', () => {

--- a/public/theme.js
+++ b/public/theme.js
@@ -5,5 +5,7 @@
     var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     var theme = stored || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
+    var darkThemes = ['dark', 'neon', 'matrix'];
+    document.documentElement.classList.toggle('dark', darkThemes.indexOf(theme) !== -1);
   } catch (e) {}
 })();

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -8,6 +8,11 @@ export const THEME_UNLOCKS: Record<string, number> = {
   matrix: 1000,
 };
 
+const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
+
+export const isDarkTheme = (theme: string): boolean =>
+  DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
+
 export const getTheme = (): string => {
   if (typeof window === 'undefined') return 'default';
   try {
@@ -27,6 +32,7 @@ export const setTheme = (theme: string): void => {
   try {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- toggle `.dark` root class when changing theme
- ensure dark-like themes (`dark`, `neon`, `matrix`) get dark styles before hydration
- test DOM updates and dark class behavior for dark themes

## Testing
- `yarn test __tests__/themePersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b93172e8f4832898d235e697fee6e0