### PR TITLE
Enable class-based dark mode for Tailwind

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import 'tailwindcss/tailwind.css';
+import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   mode: 'jit',
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- switch Tailwind to class-based dark mode
- load custom Tailwind build instead of package CSS
- prepare Tailwind source file for local build

## Testing
- `npx tailwindcss -c tailwind.config.js -i ./styles/tailwind.css -o /tmp/tailwind.css`
- `node -e <playwright script>`
- `npx eslint tailwind.config.js pages/_app.jsx styles/tailwind.css`


------
https://chatgpt.com/codex/tasks/task_e_68b931736f248328b3c39cd17b0ad7ed