### PR TITLE
refactor: centralize theme handling across components

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,4 +1,9 @@
-import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import {
+  getTheme,
+  setTheme,
+  getUnlockedThemes,
+  THEME_KEY,
+} from '../utils/theme';
 
 describe('theme persistence and unlocking', () => {
   beforeEach(() => {
@@ -9,7 +14,7 @@ describe('theme persistence and unlocking', () => {
     setTheme('dark');
     expect(getTheme()).toBe('dark');
     // simulate reload by reading from localStorage again
-    expect(window.localStorage.getItem('app:theme')).toBe('dark');
+    expect(window.localStorage.getItem(THEME_KEY)).toBe('dark');
   });
 
   test('themes unlock at score milestones', () => {

--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -10,7 +10,6 @@ import {
 import GraphView from "../../../apps/radare2/components/GraphView";
 import GuideOverlay from "./GuideOverlay";
 import { useTheme } from "../../../hooks/useTheme";
-import styles from "./theme.module.css";
 
 const Radare2 = ({ initialData = {} }) => {
   const {
@@ -30,7 +29,7 @@ const Radare2 = ({ initialData = {} }) => {
   const [showGuide, setShowGuide] = useState(false);
   const [strings, setStrings] = useState([]);
   const disasmRef = useRef(null);
-  const { theme, setTheme } = useTheme();
+  const { theme } = useTheme();
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -104,9 +103,7 @@ const Radare2 = ({ initialData = {} }) => {
 
   return (
     <div
-      className={`h-full w-full p-4 overflow-auto ${
-        theme === "dark" ? styles["r2-dark"] : styles["r2-light"]
-      }`}
+      className="h-full w-full p-4 overflow-auto"
       style={{ backgroundColor: "var(--r2-bg)", color: "var(--r2-text)" }}
     >
       {showGuide && <GuideOverlay onClose={() => setShowGuide(false)} />}
@@ -177,16 +174,6 @@ const Radare2 = ({ initialData = {} }) => {
           }}
         >
           Help
-        </button>
-        <button
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          className="px-3 py-1 rounded"
-          style={{
-            backgroundColor: "var(--r2-surface)",
-            border: "1px solid var(--r2-border)",
-          }}
-        >
-          {theme === "dark" ? "Light" : "Dark"}
         </button>
       </div>
 

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,32 +1,33 @@
 import { useEffect, useState } from 'react';
+import {
+  getTheme,
+  setTheme as storeTheme,
+  THEME_KEY,
+} from '../utils/theme';
 
-const THEME_KEY = 'app-theme';
+export type Theme = 'default' | 'dark' | 'neon' | 'matrix';
 
 export const useTheme = () => {
-  const [theme, setThemeState] = useState<'light' | 'dark'>('dark');
+  const [theme, setThemeState] = useState<Theme>('default');
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const stored = window.localStorage.getItem(THEME_KEY);
-    let initial: 'light' | 'dark' = 'light';
-    if (stored === 'light' || stored === 'dark') {
-      initial = stored;
-    } else {
-      const prefersDark = window.matchMedia?.(
-        '(prefers-color-scheme: dark)'
-      ).matches;
-      initial = prefersDark ? 'dark' : 'light';
-    }
+    const initial = getTheme() as Theme;
     setThemeState(initial);
-    document.documentElement.classList.toggle('dark', initial === 'dark');
+    storeTheme(initial);
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === THEME_KEY && e.newValue) {
+        setThemeState(e.newValue as Theme);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, []);
 
-  const setTheme = (next: 'light' | 'dark') => {
+  const setTheme = (next: Theme) => {
     setThemeState(next);
-    if (typeof window !== 'undefined') {
-      document.documentElement.classList.toggle('dark', next === 'dark');
-      window.localStorage.setItem(THEME_KEY, next);
-    }
+    storeTheme(next);
   };
 
   return { theme, setTheme };


### PR DESCRIPTION
## Summary
- refactor `useTheme` hook to share theme helpers and support all themes
- drop local theme management from Radare2 app
- align theme persistence test with shared THEME_KEY

## Testing
- `npx eslint hooks/useTheme.ts components/apps/radare2/index.js __tests__/themePersistence.test.ts`
- `yarn test __tests__/themePersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9317285d88328a06ae70a451a860a