### PR TITLE
feat(theme): add neon and matrix palettes

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,3 +17,66 @@
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
 }
+
+/* Dark theme overrides */
+:root[data-theme='dark'] {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-primary: #1793d1;
+  --color-secondary: #0a0a0a;
+  --color-accent: #1793d1;
+  --color-muted: #111111;
+  --color-surface: #0a0a0a;
+  --color-inverse: #000000;
+  --color-border: #333333;
+  --color-terminal: #00ff00;
+  --color-dark: #050505;
+  --color-ub-grey: #000000;
+  --color-ub-cool-grey: #0a0a0a;
+  --color-ubt-grey: #ffffff;
+  --color-ubt-cool-grey: #cccccc;
+  --color-ub-orange: #1793d1;
+  --color-ub-border-orange: #1793d1;
+}
+
+/* Neon theme overrides */
+:root[data-theme='neon'] {
+  --color-bg: #000000;
+  --color-text: #f8f8ff;
+  --color-primary: #ff00ff;
+  --color-secondary: #00ffff;
+  --color-accent: #ff00ff;
+  --color-muted: #111111;
+  --color-surface: #0a0a0a;
+  --color-inverse: #000000;
+  --color-border: #ff00ff;
+  --color-terminal: #39ff14;
+  --color-dark: #000000;
+  --color-ub-grey: #000000;
+  --color-ub-cool-grey: #0a0a0a;
+  --color-ubt-grey: #f8f8ff;
+  --color-ubt-cool-grey: #ff00ff;
+  --color-ub-orange: #ff00ff;
+  --color-ub-border-orange: #ff00ff;
+}
+
+/* Matrix theme overrides */
+:root[data-theme='matrix'] {
+  --color-bg: #000000;
+  --color-text: #00ff00;
+  --color-primary: #00ff00;
+  --color-secondary: #003300;
+  --color-accent: #00ff00;
+  --color-muted: #001a00;
+  --color-surface: #000d00;
+  --color-inverse: #000000;
+  --color-border: #00ff00;
+  --color-terminal: #00ff00;
+  --color-dark: #000000;
+  --color-ub-grey: #000000;
+  --color-ub-cool-grey: #001100;
+  --color-ubt-grey: #00ff00;
+  --color-ubt-cool-grey: #00cc00;
+  --color-ub-orange: #00ff00;
+  --color-ub-border-orange: #00ff00;
+}


### PR DESCRIPTION
## Summary
- add `neon`, `matrix`, and explicit `dark` theme palettes using CSS data attributes

## Testing
- `yarn test __tests__/themePersistence.test.ts`
- `yarn lint styles/globals.css` *(fails: Component definition is missing display name, Unexpected global 'window', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b93176726883289fd1342c48e514d1