### PR TITLE
Use SettingsContext for theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ play/pause and track controls include keyboard hotkeys.
 - **`components/base/window.js`** - draggable, focusable window with header controls; integrates with desktop z-index.
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
+- **`hooks/useSettings.tsx`** - global settings context exposing theme, accent, wallpaper and other preferences with persistence.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
 - **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,4 +1,6 @@
-import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { getTheme, getUnlockedThemes } from '../utils/theme';
 
 describe('theme persistence and unlocking', () => {
   beforeEach(() => {
@@ -6,9 +8,12 @@ describe('theme persistence and unlocking', () => {
   });
 
   test('theme persists across sessions', () => {
-    setTheme('dark');
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+    act(() => result.current.setTheme('dark'));
+    expect(result.current.theme).toBe('dark');
     expect(getTheme()).toBe('dark');
-    // simulate reload by reading from localStorage again
     expect(window.localStorage.getItem('app:theme')).toBe('dark');
   });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -9,7 +9,6 @@ import {
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
-import { getTheme, setTheme } from "../../utils/theme";
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
@@ -28,8 +27,9 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    theme,
+    setTheme,
   } = useSettings();
-  const [theme, setThemeState] = useState<string>(getTheme());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
@@ -77,10 +77,7 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
-      if (parsed.theme !== undefined) {
-        setThemeState(parsed.theme);
-        setTheme(parsed.theme);
-      }
+      if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,7 +98,6 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
-    setThemeState("default");
     setTheme("default");
   };
 
@@ -127,10 +123,7 @@ export default function Settings() {
             <label className="mr-2 text-ubt-grey">Theme:</label>
             <select
               value={theme}
-              onChange={(e) => {
-                setThemeState(e.target.value);
-                setTheme(e.target.value);
-              }}
+              onChange={(e) => setTheme(e.target.value)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getTheme, setTheme, getUnlockedThemes } from '../utils/theme';
+import { getUnlockedThemes } from '../utils/theme';
 import { useSettings } from '../hooks/useSettings';
 
 interface Props {
@@ -8,14 +8,8 @@ interface Props {
 
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
-  const [theme, setThemeState] = useState(getTheme());
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent } = useSettings();
-
-  const changeTheme = (t: string) => {
-    setThemeState(t);
-    setTheme(t);
-  };
+  const { accent, setAccent, theme, setTheme } = useSettings();
 
   return (
     <div>
@@ -29,7 +23,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             <select
               aria-label="theme-select"
               value={theme}
-              onChange={(e) => changeTheme(e.target.value)}
+              onChange={(e) => setTheme(e.target.value)}
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,11 +1,9 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
-import { getTheme, setTheme } from '../../utils/theme';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork } = useSettings();
-    const [theme, setThemeState] = useState(getTheme());
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -65,7 +63,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey">Theme:</label>
                 <select
                     value={theme}
-                    onChange={(e) => { setThemeState(e.target.value); setTheme(e.target.value); }}
+                    onChange={(e) => setTheme(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
                     <option value="default">Default</option>
@@ -236,7 +234,6 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
-                        setThemeState('default');
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -261,7 +258,7 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
-                        if (parsed.theme !== undefined) { setThemeState(parsed.theme); setTheme(parsed.theme); }
+                        if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,7 @@ import {
   setAllowNetwork as saveAllowNetwork,
   defaults,
 } from '../utils/settingsStore';
+import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
 // Utility to lighten or darken a hex color by a percentage
@@ -48,6 +49,7 @@ interface SettingsContextValue {
   largeHitAreas: boolean;
   pongSpin: boolean;
   allowNetwork: boolean;
+  theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -57,6 +59,7 @@ interface SettingsContextValue {
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
+  setTheme: (value: string) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -69,6 +72,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
+  theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -78,6 +82,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
   setAllowNetwork: () => {},
+  setTheme: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -90,6 +95,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -103,8 +109,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
+      setTheme(loadTheme());
     })();
   }, []);
+
+  useEffect(() => {
+    saveTheme(theme);
+  }, [theme]);
 
   useEffect(() => {
     const border = shadeColor(accent, -0.2);
@@ -212,6 +223,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         largeHitAreas,
         pongSpin,
         allowNetwork,
+        theme,
         setAccent,
         setWallpaper,
         setDensity,
@@ -221,6 +233,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setLargeHitAreas,
         setPongSpin,
         setAllowNetwork,
+        setTheme,
       }}
     >
       {children}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState.js';
-import { getTheme, setTheme } from '../../../utils/theme';
+import { useSettings } from '../../../hooks/useSettings';
 
 /** Simple Adwaita-like toggle switch */
 function Toggle({
@@ -32,26 +32,12 @@ function Toggle({
 }
 
 export default function ThemeSettings() {
-  // Persist theme selection in localStorage so it survives reloads
-  const [theme, setThemeState] = usePersistentState('app:theme', 'default');
+  const { theme, setTheme } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
 
-  // Initialize and sync theme with user preference or system settings
-  useEffect(() => {
-    const current = getTheme();
-    setThemeState(current);
-    setTheme(current);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Apply theme whenever selection changes
-  useEffect(() => {
-    setTheme(theme);
-  }, [theme]);
-
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    setThemeState(e.target.value);
+    setTheme(e.target.value);
   };
 
   return (


### PR DESCRIPTION
## Summary
- expose `theme` state and setter in `useSettings` with storage persistence
- read and update theme through context in Settings pages and drawer
- adjust tests and docs for context-based theme handling

## Testing
- `yarn test __tests__/themePersistence.test.ts`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b931776cd4832896f90f5d77eea1b0