### PR TITLE
feat: add theme variables for dark and neon

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -33,6 +33,31 @@ describe('theme persistence and unlocking', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 
+  test('updates CSS variables without reload', () => {
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root { --color-bg: white; }
+      html[data-theme='dark'] { --color-bg: black; }
+      html[data-theme='neon'] { --color-bg: red; }
+    `;
+    document.head.appendChild(style);
+
+    setTheme('default');
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
+    ).toBe('white');
+
+    setTheme('dark');
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
+    ).toBe('black');
+
+    setTheme('neon');
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
+    ).toBe('red');
+  });
+
   test('defaults to system preference when no stored theme', () => {
     // simulate dark mode preference
     // @ts-ignore

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,3 +17,48 @@
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
 }
+
+/* Dark theme */
+html[data-theme='dark'] {
+  --color-bg: #000000;
+  --color-text: #e5e5e5;
+  --color-primary: #1e88e5;
+  --color-secondary: #121212;
+  --color-accent: #bb86fc;
+  --color-muted: #1f1f1f;
+  --color-surface: #121212;
+  --color-inverse: #ffffff;
+  --color-border: #333333;
+  --color-terminal: #00ff00;
+  --color-dark: #0a0a0a;
+}
+
+/* Neon theme */
+html[data-theme='neon'] {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-primary: #39ff14;
+  --color-secondary: #1a1a1a;
+  --color-accent: #ff00ff;
+  --color-muted: #222222;
+  --color-surface: #111111;
+  --color-inverse: #ffffff;
+  --color-border: #333333;
+  --color-terminal: #39ff14;
+  --color-dark: #000000;
+}
+
+/* Matrix theme */
+html[data-theme='matrix'] {
+  --color-bg: #000000;
+  --color-text: #00ff00;
+  --color-primary: #00ff00;
+  --color-secondary: #001100;
+  --color-accent: #00ff00;
+  --color-muted: #003300;
+  --color-surface: #001100;
+  --color-inverse: #ffffff;
+  --color-border: #003300;
+  --color-terminal: #00ff00;
+  --color-dark: #000000;
+}


### PR DESCRIPTION
## Summary
- define CSS variable overrides for dark, neon, and matrix themes
- test CSS variable updates when themes switch

## Testing
- `yarn lint __tests__/themePersistence.test.ts` *(fails: many existing errors)*
- `yarn test __tests__/themePersistence.test.ts`
- `yarn typecheck` *(fails: Property 'gameState' does not exist on type 'LevelScene')*

------
https://chatgpt.com/codex/tasks/task_e_68b9326733f08328b9a9075474cc900c