### PR TITLE
refactor theme management

### DIFF
--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,32 +1,24 @@
 import { useEffect, useState } from 'react';
-
-const THEME_KEY = 'app-theme';
+import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
 
 export const useTheme = () => {
-  const [theme, setThemeState] = useState<'light' | 'dark'>('dark');
+  const [theme, setThemeState] = useState<string>(() => getTheme());
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const stored = window.localStorage.getItem(THEME_KEY);
-    let initial: 'light' | 'dark' = 'light';
-    if (stored === 'light' || stored === 'dark') {
-      initial = stored;
-    } else {
-      const prefersDark = window.matchMedia?.(
-        '(prefers-color-scheme: dark)'
-      ).matches;
-      initial = prefersDark ? 'dark' : 'light';
-    }
-    setThemeState(initial);
-    document.documentElement.classList.toggle('dark', initial === 'dark');
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === THEME_KEY) {
+        const next = getTheme();
+        setThemeState(next);
+        applyTheme(next);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, []);
 
-  const setTheme = (next: 'light' | 'dark') => {
+  const setTheme = (next: string) => {
     setThemeState(next);
-    if (typeof window !== 'undefined') {
-      document.documentElement.classList.toggle('dark', next === 'dark');
-      window.localStorage.setItem(THEME_KEY, next);
-    }
+    applyTheme(next);
   };
 
   return { theme, setTheme };

--- a/public/theme.js
+++ b/public/theme.js
@@ -6,6 +6,6 @@
     var theme = stored || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
     var darkThemes = ['dark', 'neon', 'matrix'];
-    document.documentElement.classList.toggle('dark', darkThemes.indexOf(theme) !== -1);
+    document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
   } catch (e) {}
 })();


### PR DESCRIPTION
## Summary
- centralize theme handling with shared utilities
- sync theme hook with storage and DOM via shared `THEME_KEY`
- align theme bootstrap script with shared key and dark-class logic

## Testing
- `npm test hooks/useTheme.ts utils/theme.ts -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b93266639c832883d87180e1304fd3