### PR TITLE
fix: declare gameState property

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -129,7 +129,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
 
     class LevelScene extends Phaser.Scene {
       player!: Phaser.Physics.Matter.Image;
-      state!: GameState;
+      gameState!: GameState;
       lastGrounded = 0;
       coyoteTime = 100; // ms
       jumpBufferTimer = 0;


### PR DESCRIPTION
## Summary
- define `gameState` field in Phaser Matter LevelScene so TypeScript build succeeds

## Testing
- `yarn test apps/phaser_matter --passWithNoTests`
- `yarn typecheck`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68b93262f8a48328826ad383d7701971