### PR TITLE
feat: enable class-based dark mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   mode: 'jit',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- enable Tailwind's `dark` class support by setting `darkMode` to `'class'`

## Testing
- `CI=1 yarn test __tests__/calc.test.ts`
- `npx eslint tailwind.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68b93265938c8328afd52bc663edfc31