### PR TITLE
fix: add gameState to level scene

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -129,7 +129,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
 
     class LevelScene extends Phaser.Scene {
       player!: Phaser.Physics.Matter.Image;
-      state!: GameState;
+      gameState!: GameState;
       lastGrounded = 0;
       coyoteTime = 100; // ms
       jumpBufferTimer = 0;


### PR DESCRIPTION
## Summary
- define `gameState` on `LevelScene` so create method assignment compiles

## Testing
- `npx eslint apps/phaser_matter/index.tsx --format json`
- `npx tsc --noEmit --diagnostics`
- `yarn test --passWithNoTests apps/phaser_matter`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b93338f1208328a38bb8a4c9be9da5