### PR TITLE
fix: declare LevelScene game state

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -129,7 +129,7 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
 
     class LevelScene extends Phaser.Scene {
       player!: Phaser.Physics.Matter.Image;
-      gameState!: GameState;
+      declare gameState: GameState;
       lastGrounded = 0;
       coyoteTime = 100; // ms
       jumpBufferTimer = 0;


### PR DESCRIPTION
## Summary
- declare a `gameState` field on the Phaser `LevelScene` to satisfy TypeScript

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68b93512f7408328b8cbe6655aa9672d