### PR TITLE
Handle missing dynamic app imports with fallback component

### DIFF
--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -4,16 +4,22 @@ import { logEvent } from './analytics';
 
 export const createDynamicApp = (id, title) =>
   dynamic(
-    () =>
-      import(/* webpackPrefetch: true */ `../components/apps/${id}`)
-        .then((mod) => {
-          logEvent({ category: 'Application', action: `Loaded ${title}` });
-          return mod.default;
-        })
-        .catch((err) => {
-          console.error(`Failed to load ${title}`, err);
-          throw err;
-        }),
+    async () => {
+      try {
+        const mod = await import(
+          /* webpackPrefetch: true */ `../components/apps/${id}`
+        );
+        logEvent({ category: 'Application', action: `Loaded ${title}` });
+        return mod.default;
+      } catch (err) {
+        console.error(`Failed to load ${title}`, err);
+        return () => (
+          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+            {`Unable to load ${title}`}
+          </div>
+        );
+      }
+    },
     {
       ssr: false,
       loading: () => (


### PR DESCRIPTION
## Summary
- guard dynamic app imports with try/catch
- show a fallback UI when an app component fails to load

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*
- `time curl -I http://localhost:3001/apps/volatility`


------
https://chatgpt.com/codex/tasks/task_e_68b935b3ef688328aed9d352916644ec