### PR TITLE
Handle missing daily puzzles gracefully

### DIFF
--- a/__tests__/dailyPuzzle.test.ts
+++ b/__tests__/dailyPuzzle.test.ts
@@ -5,14 +5,19 @@ describe("getDailyPuzzle", () => {
 
   test("returns same puzzle for same day", () => {
     const date = new Date("2024-01-01");
-    const a = getDailyPuzzle("test", puzzles, date);
-    const b = getDailyPuzzle("test", puzzles, date);
+    const a = getDailyPuzzle("test", puzzles, date)!;
+    const b = getDailyPuzzle("test", puzzles, date)!;
     expect(a).toBe(b);
   });
 
   test("returns different puzzles on different days", () => {
-    const a = getDailyPuzzle("test", puzzles, new Date("2024-01-01"));
-    const b = getDailyPuzzle("test", puzzles, new Date("2024-01-02"));
+    const a = getDailyPuzzle("test", puzzles, new Date("2024-01-01"))!;
+    const b = getDailyPuzzle("test", puzzles, new Date("2024-01-02"))!;
     expect(a).not.toBe(b);
+  });
+
+  test("returns null when no puzzles are available", () => {
+    const result = getDailyPuzzle("test", []);
+    expect(result).toBeNull();
   });
 });

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -19,6 +19,11 @@ const CLUE_SPACE = 60; // space for row/column clues around grid
 
 const Nonogram = () => {
   const puzzle = useMemo(() => getDailyPuzzle("nonogram", puzzles), []);
+
+  if (!puzzle) {
+    return <div>No puzzle available.</div>;
+  }
+
   const rows = puzzle.rows;
   const cols = puzzle.cols;
   const height = rows.length;

--- a/utils/dailyPuzzle.ts
+++ b/utils/dailyPuzzle.ts
@@ -12,9 +12,10 @@ export const getDailyPuzzle = <T>(
   gameId: string,
   puzzles: T[],
   date: Date = new Date(),
-): T => {
+  defaultPuzzle: T | null = null,
+): T | null => {
   if (puzzles.length === 0) {
-    throw new Error("No puzzles available");
+    return defaultPuzzle;
   }
   const seed = getDailySeed(gameId, date);
   const idx = hash(seed) % puzzles.length;


### PR DESCRIPTION
## Summary
- Return `null` or a provided fallback instead of throwing when no daily puzzles are available
- Teach Nonogram component to show a user-friendly message when `getDailyPuzzle` returns `null`
- Add tests for both populated and empty puzzle arrays

## Testing
- `npm test` *(fails: themePersistence.test.ts ReferenceError: setTheme is not defined)*
- `npm test __tests__/dailyPuzzle.test.ts __tests__/nonogram.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b935bb2e2483288e30114f222416ed