### PR TITLE
fix: stabilize theme and storage utilities

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,13 @@ global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder as any;
 
+// Polyfill structuredClone for environments lacking it (e.g., Jest's jsdom)
+// @ts-ignore
+if (typeof global.structuredClone !== 'function') {
+  // @ts-ignore
+  global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
+
 // Ensure a global `fetch` exists for tests. Jest's jsdom environment
 // doesn't provide one on the Node `global` object, which causes
 // `jest.spyOn(global, 'fetch')` to fail. Providing a simple stub allows

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,100 +15,104 @@ const DEFAULT_SETTINGS = {
   allowNetwork: false,
 };
 
+// Utility to check if localStorage is accessible (guarding against jsdom teardown)
+const hasStorage = () =>
+  typeof window !== 'undefined' && window.document && typeof window.localStorage !== 'undefined';
+
 export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  if (!hasStorage()) return DEFAULT_SETTINGS.accent;
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   await set('accent', accent);
 }
 
 export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  if (!hasStorage()) return DEFAULT_SETTINGS.wallpaper;
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   await set('bg-image', wallpaper);
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
+  if (!hasStorage()) return DEFAULT_SETTINGS.density;
   return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  if (!hasStorage()) return DEFAULT_SETTINGS.reducedMotion;
   return window.localStorage.getItem('reduced-motion') === 'true';
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
+  if (!hasStorage()) return DEFAULT_SETTINGS.fontScale;
   const stored = window.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  if (!hasStorage()) return DEFAULT_SETTINGS.highContrast;
   return window.localStorage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
+  if (!hasStorage()) return DEFAULT_SETTINGS.largeHitAreas;
   return window.localStorage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
+  if (!hasStorage()) return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
+  if (!hasStorage()) return DEFAULT_SETTINGS.allowNetwork;
   return window.localStorage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
@@ -160,7 +164,7 @@ export async function exportSettings() {
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
+  if (!hasStorage()) return;
   let settings;
   try {
     settings = typeof json === 'string' ? JSON.parse(json) : json;


### PR DESCRIPTION
## Summary
- polyfill structuredClone in jest setup to prevent fake-indexeddb crashes
- fix theme persistence test by importing setTheme
- guard localStorage access in settings store to avoid DOM teardown errors

## Testing
- `CI=1 yarn test`
- `yarn lint` *(fails: no output after extended wait)*

------
https://chatgpt.com/codex/tasks/task_e_68b934a12fbc8328b56337caf8b64080