### PR TITLE
chore: use official file system access types

### DIFF
--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -5,13 +5,7 @@ const LAST_SCAN_KEY = 'qrLastScan';
 const LAST_GEN_KEY = 'qrLastGeneration';
 const FILE_NAME = 'qr-scans.json';
 
-type StorageWithDirectory = StorageManager & {
-  // TODO: refine type when File System Access API types are finalized
-  getDirectory: () => Promise<FileSystemDirectoryHandle>;
-};
-
-const getStorage = (): StorageWithDirectory =>
-  navigator.storage as StorageWithDirectory;
+const getStorage = (): StorageManager => navigator.storage;
 
 const hasOpfs =
   isBrowser && 'storage' in navigator && Boolean(getStorage().getDirectory);


### PR DESCRIPTION
## Summary
- use standard StorageManager type for File System Access API
- remove outdated TODO comment

## Testing
- `npx eslint utils/qrStorage.ts`
- `npx tsc --noEmit utils/qrStorage.ts` *(fails: 'cytoscape' has no exported member named 'Stylesheet')*
- `yarn test utils/qrStorage` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9387d8ad88328932ba8ce551b570e