### PR TITLE
Run ESLint during build and lint before building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,15 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build

--- a/next.config.js
+++ b/next.config.js
@@ -107,9 +107,9 @@ module.exports = withBundleAnalyzer(
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
 
-    // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
+    // Fail the build on ESLint errors
     eslint: {
-      ignoreDuringBuilds: true,
+      ignoreDuringBuilds: false,
     },
     images: {
       unoptimized: true,


### PR DESCRIPTION
## Summary
- fail Next.js builds on lint errors instead of ignoring them
- add a CI build job that runs after lint to ensure linting happens before `yarn build`

## Testing
- `npx eslint next.config.js`
- `yarn lint` *(fails: 145 problems (130 errors, 15 warnings))*
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9387af4948328a46ffc7cc3dbf658