### PR TITLE
refactor: convert _app to TypeScript

### DIFF
--- a/types/global-window.d.ts
+++ b/types/global-window.d.ts
@@ -13,6 +13,8 @@ declare global {
     documentPictureInPicture?: {
       requestWindow: (options?: PictureInPictureWindowOptions) => Promise<Window>;
     };
+    initA2HS?: () => void;
+    manualRefresh?: () => void;
   }
 }
 


### PR DESCRIPTION
## Summary
- migrate _app from JavaScript to TypeScript with `AppProps`
- add explicit types for analytics and service worker helpers
- extend global Window type with custom helpers

## Testing
- `npx eslint pages/_app.tsx types/global-window.d.ts --max-warnings=0`
- `yarn typecheck`
- `yarn test pages/_app.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9388281e08328a458a7e9e881e678