### PR TITLE
Fix window control icons overflowing title bar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -595,32 +595,32 @@ export function WindowEditButtons(props) {
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                     onClick={togglePin}
                 >
                     <NextImage
                         src="/themes/Yaru/window/window-pin-symbolic.svg"
                         alt="Kali window pin"
-                        className="h-5 w-5 inline"
-                        width={20}
-                        height={20}
-                        sizes="20px"
+                        className="h-4 w-4 inline"
+                        width={16}
+                        height={16}
+                        sizes="16px"
                     />
                 </button>
             )}
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.minimize}
             >
                 <NextImage
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
                     alt="Kali window minimize"
-                    className="h-5 w-5 inline"
-                    width={20}
-                    height={20}
-                    sizes="20px"
+                    className="h-4 w-4 inline"
+                    width={16}
+                    height={16}
+                    sizes="16px"
                 />
             </button>
             {props.allowMaximize && (
@@ -629,32 +629,32 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-restore-symbolic.svg"
                                 alt="Kali window restore"
-                                className="h-5 w-5 inline"
-                                width={20}
-                                height={20}
-                                sizes="20px"
+                                className="h-4 w-4 inline"
+                                width={16}
+                                height={16}
+                                sizes="16px"
                             />
                         </button>
                     ) : (
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-maximize-symbolic.svg"
                                 alt="Kali window maximize"
-                                className="h-5 w-5 inline"
-                                width={20}
-                                height={20}
-                                sizes="20px"
+                                className="h-4 w-4 inline"
+                                width={16}
+                                height={16}
+                                sizes="16px"
                             />
                         </button>
                     )
@@ -663,16 +663,16 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-11 w-11"
+                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
             >
                 <NextImage
                     src="/themes/Yaru/window/window-close-symbolic.svg"
                     alt="Kali window close"
-                    className="h-5 w-5 inline"
-                    width={20}
-                    height={20}
-                    sizes="20px"
+                    className="h-4 w-4 inline"
+                    width={16}
+                    height={16}
+                    sizes="16px"
                 />
             </button>
         </div>


### PR DESCRIPTION
## Summary
- shrink window bar buttons and icons for better Kali-like look

## Testing
- `npx eslint components/base/window.js`
- `npx jest __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b93a4d127c8328996d3c0d0ed21a29