### PR TITLE
Remove duplicate darkMode setting in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   darkMode: 'class',
   mode: 'jit',
-  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- remove redundant darkMode entry from `tailwind.config.js`

## Testing
- `./node_modules/.bin/tailwindcss -i styles/tailwind.css -o /tmp/tailwind-output.css --config tailwind.config.js`
- `./node_modules/.bin/eslint tailwind.config.js`
- `./node_modules/.bin/jest tailwind.config.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b93ba44d348328b994086f322b336c