### PR TITLE
Add resilient theme loading with feature detection

### DIFF
--- a/public/theme.js
+++ b/public/theme.js
@@ -1,11 +1,23 @@
 (function () {
   var THEME_KEY = 'app:theme';
   try {
-    var stored = localStorage.getItem(THEME_KEY);
-    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var stored = null;
+    if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
+      stored = window.localStorage.getItem(THEME_KEY);
+    }
+
+    var prefersDark = false;
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
     var theme = stored || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
     var darkThemes = ['dark', 'neon', 'matrix'];
     document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
-  } catch (e) {}
+  } catch (e) {
+    console.error('Failed to apply theme', e);
+    document.documentElement.dataset.theme = 'default';
+    document.documentElement.classList.remove('dark');
+  }
 })();


### PR DESCRIPTION
## Summary
- ensure theme script checks for `localStorage` and `matchMedia` support
- log failures and fall back to default theme if theme application fails

## Testing
- `npm test` *(fails: setTheme is not defined in themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b93883a5588328bf126d11b30690ac