### PR TITLE
refactor: replace color literals with theme variables

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,6 +1,6 @@
 body {
   font-family: Arial, sans-serif;
-  background: #f5f5f5;
+  background: var(--color-bg);
   height: 100vh;
   display: flex;
   align-items: center;
@@ -9,17 +9,17 @@ body {
 }
 
 .calculator {
-  background: #ffffff;
+  background: var(--color-surface);
   padding: 1rem;
   border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   width: 100%;
   max-width: 240px;
   container-type: inline-size;
 }
 
 .display {
-  background: #eaeaea;
+  background: var(--color-muted);
   height: 40px;
   margin-bottom: 0.5rem;
   padding: 0.5rem;
@@ -32,7 +32,7 @@ body {
 }
 
 .display.error {
-  background: #ffdddd;
+  background: color-mix(in srgb, var(--color-accent), transparent 80%);
 }
 
 .toggle {
@@ -40,7 +40,7 @@ body {
   margin-bottom: 0.5rem;
   padding: 0.5rem;
   border: none;
-  background: #f0f0f0;
+  background: var(--color-muted);
   border-radius: 4px;
   cursor: pointer;
 }
@@ -66,7 +66,7 @@ body {
 
 .btn {
   padding: 0.75rem;
-  background: #f0f0f0;
+  background: var(--color-muted);
   border: none;
   border-radius: 4px;
   font-size: 1rem;
@@ -76,12 +76,12 @@ body {
 }
 
 .btn:hover {
-  background: #e0e0e0;
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 10%);
   transform: translateY(-2px);
 }
 
 .btn.active-key {
-  background: #d0d0d0;
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 20%);
 }
 
 .span-two {
@@ -104,11 +104,11 @@ body {
   width: 200px;
   height: 100%;
   overflow-y: auto;
-  background: #fafafa;
-  border-left: 1px solid #ddd;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
   padding: 0.5rem;
   font-size: 0.9rem;
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  box-shadow: -2px 0 5px color-mix(in srgb, var(--color-inverse), transparent 90%);
   display: flex;
   flex-direction: column;
   z-index: 1000;

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -3,7 +3,7 @@ body {
   margin: 0;
   padding: 0;
   height: 100vh;
-  background: #f0f0f0;
+  background: var(--color-bg);
 }
 
 #add-note {
@@ -28,7 +28,8 @@ body {
   padding: 10px;
   resize: both;
   overflow: auto;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 6px color-mix(in srgb, var(--color-inverse), transparent 90%),
+    0 1px 3px color-mix(in srgb, var(--color-inverse), transparent 92%);
   border-radius: 4px;
 }
 

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -5,7 +5,7 @@ body {
   align-items: center;
   justify-content: flex-start;
   margin-top: 50px;
-  background: #f0f0f0;
+  background: var(--color-bg);
 }
 .display {
   font-size: 4rem;
@@ -19,7 +19,7 @@ button {
 }
 /* Tab styles */
 .tabs .tab[aria-selected='true'] {
-  background: #ddd;
+  background: color-mix(in srgb, var(--color-muted), var(--color-text) 20%);
   font-weight: bold;
 }
 
@@ -48,7 +48,7 @@ ul {
   max-width: 300px;
 }
 li {
-  background: #fff;
+  background: var(--color-surface);
   margin: 2px 0;
   padding: 5px 10px;
   border-radius: 4px;

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -1,6 +1,6 @@
 body {
   font-family: sans-serif;
-  background: #f0f0f0;
+  background: var(--color-bg);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -9,9 +9,9 @@ body {
 }
 
 .widget-container {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--color-inverse), transparent 90%);
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -33,7 +33,7 @@ body {
 }
 
 #error-message {
-  color: #d00;
+  color: var(--color-accent);
   text-align: center;
 }
 

--- a/components/apps/radare2/theme.module.css
+++ b/components/apps/radare2/theme.module.css
@@ -1,15 +1,8 @@
-.r2-light {
-  --r2-bg: #f9fafb;
-  --r2-text: #111827;
-  --r2-surface: #e5e7eb;
-  --r2-border: #d1d5db;
-  --r2-accent: #fbbf24;
-}
-
+.r2-light,
 .r2-dark {
-  --r2-bg: #1a1f26;
-  --r2-text: #f3f4f6;
-  --r2-surface: #374151;
-  --r2-border: #4b5563;
-  --r2-accent: #fbbf24;
+  --r2-bg: var(--color-bg);
+  --r2-text: var(--color-text);
+  --r2-surface: var(--color-surface);
+  --r2-border: var(--color-border);
+  --r2-accent: var(--color-accent);
 }

--- a/public/apps/platformer/styles.css
+++ b/public/apps/platformer/styles.css
@@ -1,14 +1,14 @@
 body {
   margin: 0;
-  background: #202020;
-  color: #fff;
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: sans-serif;
 }
 .hidden {
   display: none;
 }
 #game {
-  border: 1px solid #555;
+  border: 1px solid var(--color-border);
   display: block;
   margin: 0 auto;
 }
@@ -63,7 +63,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.7);
+  background: color-mix(in srgb, var(--color-bg), transparent 30%);
   font-size: 24px;
 }
 
@@ -87,7 +87,7 @@ body {
   position: absolute;
   top: 10px;
   left: 10px;
-  background: rgba(0, 0, 0, 0.5);
+  background: color-mix(in srgb, var(--color-bg), transparent 50%);
   padding: 4px;
   font-size: 12px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -55,7 +55,11 @@ button:focus-visible {
 input[type=range].ubuntu-slider {
     outline: none;
     -webkit-appearance: none;
-    background: linear-gradient(to right, rgba(175, 175, 175, 0.3) 0%, rgba(175, 175, 175, 0.3) 100%);
+    background: linear-gradient(
+        to right,
+        color-mix(in srgb, var(--color-text), transparent 70%) 0%,
+        color-mix(in srgb, var(--color-text), transparent 70%) 100%
+    );
     background-position: center;
     background-size: 99% 3px;
     background-repeat: no-repeat;
@@ -65,8 +69,8 @@ input[type=range].ubuntu-slider {
 }
 
 input[type=range].ubuntu-slider::-webkit-slider-thumb {
-    -webkit-box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.2);
-    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-inverse), transparent 80%);
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
     -webkit-appearance: none;
@@ -131,9 +135,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
-    -webkit-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
-    -moz-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
 .closed-window {
@@ -159,7 +163,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .windowMainScreen::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    -webkit-box-shadow: inset 0 0 6px color-mix(in srgb, var(--color-inverse), transparent 70%);
     background-color: transparent;
 }
 
@@ -187,7 +191,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     background: var(--color-inverse);
     color: var(--color-terminal);
     text-shadow: 0 0 2px var(--color-terminal);
-    box-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--color-terminal), transparent 50%);
 }
 
 .crt-terminal .xterm-screen,
@@ -201,13 +205,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 /* High contrast handling for precipitation text */
 .precip-text {
-    color: #0ea5e9;
+    color: var(--color-primary);
 }
 
 @media (prefers-contrast: more), (forced-colors: active) {
     .precip-text {
-        color: #000;
-        background-color: #fff;
+        color: var(--color-bg);
+        background-color: var(--color-text);
         padding-inline: 2px;
     }
 }
@@ -388,7 +392,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 /* Context Menu & Panels */
 .context-menu-bg,
 .windowMainScreen {
-    background-color: rgba(43, 43, 43, 0.85); /* Fallback for unsupported browsers */
+    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
@@ -396,7 +400,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     .windowMainScreen {
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
-        background-color: rgba(43, 43, 43, 0.4);
+        background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
     }
 }
 
@@ -472,7 +476,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    background: rgba(255, 255, 255, 0.5);
+    background: color-mix(in srgb, var(--color-text), transparent 50%);
     animation: merge-ripple 0.4s ease-out;
     pointer-events: none;
 }
@@ -506,7 +510,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .word-found {
-    background: linear-gradient(90deg, rgba(255, 255, 0, 0.4) 0%, rgba(255, 255, 0, 0.4) 100%);
+    background: linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--color-accent), transparent 60%) 0%,
+        color-mix(in srgb, var(--color-accent), transparent 60%) 100%
+    );
     background-repeat: no-repeat;
     background-size: 0% 100%;
     animation: word-found-highlight 0.6s forwards;
@@ -516,7 +524,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 /* Highlight currently selected cells in word search */
 .selection {
     /* amber tone for colorblind-safe contrast */
-    background-color: #fbbf24;
+    background-color: var(--color-accent);
 }
 
 /* Ensure monospace layout for app outputs */
@@ -529,7 +537,7 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: 2px solid #3B82F6;
+    outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- replace hex colors in core styles with theme variables
- use global `--color-*` tokens across sticky notes, weather widget, calculator, timer/stopwatch and platformer apps
- align radare2 theme with global color variables

## Testing
- `yarn lint` *(fails: Component definition is missing display name, 145 problems)*
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ba2223c83288dff6cc55679ad39