### PR TITLE
Wrap standalone pages with base window component

### DIFF
--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
+import { WindowMainScreen } from '../components/base/window';
 
 const NessusDashboard: React.FC = () => {
   const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });
@@ -13,23 +14,27 @@ const NessusDashboard: React.FC = () => {
   const max = Math.max(totals.jobs, totals.falsePositives, 1);
 
   return (
-    <div className="p-4 bg-gray-900 min-h-screen text-white">
-      <h1 className="text-2xl mb-4">Nessus Dashboard</h1>
-      <div className="flex items-end space-x-4 h-48">
-        <div
-          className="bg-blue-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.jobs / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">Jobs {totals.jobs}</span>
+    <WindowMainScreen
+      screen={() => (
+        <div className="p-4 text-white">
+          <h1 className="mb-4 text-2xl">Nessus Dashboard</h1>
+          <div className="flex h-48 items-end space-x-4">
+            <div
+              className="flex w-24 flex-col justify-end bg-blue-600 text-center"
+              style={{ height: `${(totals.jobs / max) * 100}%` }}
+            >
+              <span className="pb-2 text-sm">Jobs {totals.jobs}</span>
+            </div>
+            <div
+              className="flex w-24 flex-col justify-end bg-green-600 text-center"
+              style={{ height: `${(totals.falsePositives / max) * 100}%` }}
+            >
+              <span className="pb-2 text-sm">False {totals.falsePositives}</span>
+            </div>
+          </div>
         </div>
-        <div
-          className="bg-green-600 w-24 text-center flex flex-col justify-end"
-          style={{ height: `${(totals.falsePositives / max) * 100}%` }}
-        >
-          <span className="pb-2 text-sm">False {totals.falsePositives}</span>
-        </div>
-      </div>
-    </div>
+      )}
+    />
   );
 };
 

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import WorkflowCard from '../components/WorkflowCard';
+import { WindowMainScreen } from '../components/base/window';
 
 interface FrameProps {
   title: string;
@@ -19,36 +20,47 @@ const InfoFrame = ({ title, link, description }: FrameProps) => (
 );
 
 const SecurityEducation = () => (
-  <main>
-    <div style={{ backgroundColor: '#fcd34d', padding: '1rem', textAlign: 'center', fontWeight: 'bold' }}>
-      Use Kali Linux and related tools legally and ethically with proper authorization.
-    </div>
-    <div className="grid gap-4 p-4 md:grid-cols-2">
-      <InfoFrame
-        title="What"
-        link="https://www.kali.org/docs/introduction/what-is-kali-linux/"
-        description="Overview of Kali Linux and its purpose."
-      />
-      <InfoFrame
-        title="Why"
-        link="https://www.kali.org/docs/introduction/should-i-use-kali-linux/"
-        description="Reasons to use Kali Linux for authorized security assessments."
-      />
-      <InfoFrame
-        title="Risks"
-        link="https://owasp.org/www-project-top-ten/"
-        description="Common security risks highlighted by the OWASP Top Ten."
-      />
-      <InfoFrame
-        title="Defenses"
-        link="https://www.cisa.gov/secure-our-world"
-        description="CISA guidance on defending against cyber threats."
-      />
-    </div>
-    <div className="p-4">
-      <WorkflowCard />
-    </div>
-  </main>
+  <WindowMainScreen
+    screen={() => (
+      <div>
+        <div
+          style={{
+            backgroundColor: '#fcd34d',
+            padding: '1rem',
+            textAlign: 'center',
+            fontWeight: 'bold',
+          }}
+        >
+          Use Kali Linux and related tools legally and ethically with proper authorization.
+        </div>
+        <div className="grid gap-4 p-4 md:grid-cols-2">
+          <InfoFrame
+            title="What"
+            link="https://www.kali.org/docs/introduction/what-is-kali-linux/"
+            description="Overview of Kali Linux and its purpose."
+          />
+          <InfoFrame
+            title="Why"
+            link="https://www.kali.org/docs/introduction/should-i-use-kali-linux/"
+            description="Reasons to use Kali Linux for authorized security assessments."
+          />
+          <InfoFrame
+            title="Risks"
+            link="https://owasp.org/www-project-top-ten/"
+            description="Common security risks highlighted by the OWASP Top Ten."
+          />
+          <InfoFrame
+            title="Defenses"
+            link="https://www.cisa.gov/secure-our-world"
+            description="CISA guidance on defending against cyber threats."
+          />
+        </div>
+        <div className="p-4">
+          <WorkflowCard />
+        </div>
+      </div>
+    )}
+  />
 );
 
 export default SecurityEducation;


### PR DESCRIPTION
## Summary
- use `WindowMainScreen` for security education page
- wrap Nessus dashboard content with base window component

## Testing
- `yarn test` *(fails: process exceeded time; partial output shows tests running)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ba33eb4832885201b780e31f8f7