### PR TITLE
refactor: isolate arrow and window styles

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import styles from './window.module.css';
 
 export class Window extends Component {
     constructor(props) {
@@ -562,12 +563,15 @@ export class WindowYBorder extends Component {
         this.trpImg.style.opacity = 0;
     }
     render() {
-        return (
-            <div className=" window-y-border border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }} onDrag={this.props.resize}>
-            </div>
-        )
+            return (
+                <div
+                    className={`${styles.windowYBorder} cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
+                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
+                    onDrag={this.props.resize}
+                ></div>
+            )
+        }
     }
-}
 
 export class WindowXBorder extends Component {
     componentDidMount() {
@@ -578,12 +582,15 @@ export class WindowXBorder extends Component {
         this.trpImg.style.opacity = 0;
     }
     render() {
-        return (
-            <div className=" window-x-border border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }} onDrag={this.props.resize}>
-            </div>
-        )
+            return (
+                <div
+                    className={`${styles.windowXBorder} cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
+                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
+                    onDrag={this.props.resize}
+                ></div>
+            )
+        }
     }
-}
 
 // Window's Edit Buttons
 export function WindowEditButtons(props) {

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,0 +1,9 @@
+.windowYBorder {
+  height: calc(100% - 10px);
+  width: calc(100% + 10px);
+}
+
+.windowXBorder {
+  height: calc(100% + 10px);
+  width: calc(100% - 10px);
+}

--- a/components/util-components/small_arrow.js
+++ b/components/util-components/small_arrow.js
@@ -1,8 +1,13 @@
-import React from 'react'
+import React from 'react';
+import styles from './small_arrow.module.css';
 
-export default function SmallArrow(props) {
-    let angle = props.angle ? props.angle : "up"; // default value is up
-    return (
-        <div className={" arrow-custom-" + angle}></div>
-    )
+export default function SmallArrow({ angle = 'up' }) {
+    const rotations = {
+        up: '',
+        down: 'rotate-180',
+        left: '-rotate-90',
+        right: 'rotate-90',
+    };
+
+    return <div className={`${styles.arrow} ${rotations[angle] ?? ''}`}></div>;
 }

--- a/components/util-components/small_arrow.module.css
+++ b/components/util-components/small_arrow.module.css
@@ -1,0 +1,6 @@
+.arrow {
+  @apply w-0;
+  border-inline-start: 5px solid transparent;
+  border-inline-end: 5px solid transparent;
+  border-block-end: 5px solid var(--color-text);
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -30,11 +30,6 @@ button:focus-visible {
     border-block-end: 5px solid var(--color-muted);
 }
 
-.arrow-custom {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-text);
-}
 
 .animateShow {
     animation: transformDownShow 200ms 1 forwards;
@@ -76,47 +71,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     width: 12px;
     height: 12px;
     position: relative;
-}
-
-/* Window's styling */
-.arrow-custom-up {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-end: 5px solid var(--color-text);
-    width: 0;
-}
-
-.arrow-custom-down {
-    border-inline-start: 5px solid transparent;
-    border-inline-end: 5px solid transparent;
-    border-block-start: 5px solid var(--color-text);
-    width: 0;
-}
-
-.arrow-custom-left {
-    border-block-end: 5px solid transparent;
-    border-block-start: 5px solid transparent;
-    border-inline-end: 5px solid var(--color-text);
-    width: 0;
-}
-
-.arrow-custom-right {
-    border-block-start: 5px solid transparent;
-    border-block-end: 5px solid transparent;
-    border-inline-start: 5px solid var(--color-text);
-    width: 0;
-}
-
-.window-y-border {
-    height: calc(100% - 10px);
-    width: calc(100% + 10px);
-    cursor: e-resize;
-}
-
-.window-x-border {
-    height: calc(100% + 10px);
-    width: calc(100% - 10px);
-    cursor: n-resize;
 }
 
 .notFocused {


### PR DESCRIPTION
## Summary
- extract arrow visuals into `small_arrow.module.css` and use Tailwind rotation utilities
- define window resize borders in `window.module.css` and apply cursor utilities
- remove legacy arrow and window border rules from global stylesheet

## Testing
- `npx eslint components/util-components/small_arrow.js components/base/window.js styles/index.css 2>&1 | tail -n 20`
- `npx jest --runTestsByPath components/util-components/small_arrow.js components/base/window.js >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b93ce983e48328869727bf9e8e1edd