### PR TITLE
refactor: replace folder dialog divs with buttons

### DIFF
--- a/__tests__/desktopNameBar.test.tsx
+++ b/__tests__/desktopNameBar.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop name bar accessibility', () => {
+  test('buttons respond to keyboard activation', async () => {
+    const desktop = new Desktop();
+    const addSpy = jest.spyOn(desktop, 'addToDesktop').mockImplementation(() => {});
+    const setStateSpy = jest.spyOn(desktop, 'setState').mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    const { getByRole } = render(desktop.renderNameBar());
+    const input = getByRole('textbox');
+    await user.type(input, 'new folder');
+
+    const createButton = getByRole('button', { name: /create/i });
+    createButton.focus();
+    await user.keyboard('{Enter}');
+    expect(addSpy).toHaveBeenCalledWith('new folder');
+
+    const cancelButton = getByRole('button', { name: /cancel/i });
+    cancelButton.focus();
+    await user.keyboard('{Enter}');
+    expect(setStateSpy).toHaveBeenCalledWith({ showNameBar: false });
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -731,8 +731,22 @@ export class Desktop extends Component {
                     <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
-                    <div onClick={addFolder} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Create</div>
-                    <div onClick={removeCard} className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50">Cancel</div>
+                    <button
+                        type="button"
+                        onClick={addFolder}
+                        aria-label="Create folder"
+                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                    >
+                        Create
+                    </button>
+                    <button
+                        type="button"
+                        onClick={removeCard}
+                        aria-label="Cancel folder creation"
+                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                    >
+                        Cancel
+                    </button>
                 </div>
             </div>
         );


### PR DESCRIPTION
## Summary
- replace folder dialog divs with button elements and aria-labels
- add keyboard activation test for folder dialog

## Testing
- `yarn lint components/screen/desktop.js __tests__/desktopNameBar.test.tsx` (fails: 145 problems)
- `yarn test __tests__/desktopNameBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b93ce8b30c8328868170ef9da228d0