### PR TITLE
feat: add dismissible beta badge with design tokens

### DIFF
--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,6 +1,41 @@
+import { useEffect, useState } from "react";
+
 export default function BetaBadge() {
-  if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem("betaBadgeDismissed");
+      if (stored === "1") setDismissed(true);
+    } catch {
+      // localStorage might be unavailable; ignore
+    }
+  }, []);
+
+  if (process.env.NEXT_PUBLIC_SHOW_BETA !== "1" || dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem("betaBadgeDismissed", "1");
+    } catch {
+      // localStorage might be unavailable; ignore
+    }
+  };
+
   return (
-    <div className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black">Beta</div>
+    <div className="fixed bottom-[var(--space-4)] right-[var(--space-4)] flex items-center gap-[var(--space-2)] rounded-[var(--radius-md)] bg-ubt-gedit-orange px-[var(--space-2)] py-[var(--space-1)] text-xs font-semibold text-ubt-cool-grey">
+      <span role="status" aria-live="polite">
+        Beta
+      </span>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss beta badge"
+        className="rounded-[var(--radius-sm)] p-[var(--space-1)] focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+      >
+        ×
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- make beta badge aria-live polite and track dismissal
- use project design tokens for spacing, color and radius
- add keyboard-accessible dismiss control

## Testing
- `yarn lint components/BetaBadge.jsx` *(fails: 146 problems in repository)*
- `yarn test components/BetaBadge.test.jsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93cebbec4832884e39637dc3f81a3