### PR TITLE
chore: log errors via ErrorBoundary logger

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,4 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger();
 
 interface Props {
   children: ReactNode;
@@ -20,7 +23,10 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
     // You can log the error to an error reporting service
-    console.error('ErrorBoundary caught an error', error, errorInfo);
+    log.error('ErrorBoundary caught an error', {
+      error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      errorInfo,
+    });
   }
 
   render() {


### PR DESCRIPTION
## Summary
- use structured logger in `ErrorBoundary`
- capture error and component stack metadata

## Testing
- `npx eslint components/core/ErrorBoundary.tsx`
- `npx jest components/core/ErrorBoundary.tsx --passWithNoTests`
- `npx tsc --noEmit --skipLibCheck components/core/ErrorBoundary.tsx` *(fails: Cannot find module '@/lib/logger')*

------
https://chatgpt.com/codex/tasks/task_e_68b93d6014c48328bef8b8d9297b692d