### PR TITLE
Use structured logging in error boundary

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import { createLogger } from '../../lib/logger';
 
 interface Props {
   children: ReactNode;
@@ -7,6 +8,8 @@ interface Props {
 interface State {
   hasError: boolean;
 }
+
+const log = createLogger();
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
@@ -19,8 +22,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
-    // You can log the error to an error reporting service
-    console.error('ErrorBoundary caught an error', error, errorInfo);
+    log.error('ErrorBoundary caught an error', { error, errorInfo });
   }
 
   render() {


### PR DESCRIPTION
## Summary
- import and initialize logger in ErrorBoundary component
- replace `console.error` with structured `log.error`

## Testing
- `npx eslint components/core/ErrorBoundary.tsx`
- `npx tsc --noEmit --jsx react-jsx components/core/ErrorBoundary.tsx` *(fails: 'cytoscape' has no exported member 'Stylesheet')*
- `npx jest __tests__/chatManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b93f0f6b508328a9bcfd74d0b1fd44