### PR TITLE
Add alt text to application icons and thumbnails

### DIFF
--- a/components/apps/chrome/AddressBar.tsx
+++ b/components/apps/chrome/AddressBar.tsx
@@ -251,7 +251,11 @@ const AddressBar: React.FC<AddressBarProps> = ({
                 onContextMenu={(e) => openContext(e, s)}
               >
                 {fav && fav.favicon && (
-                  <img src={fav.favicon} alt="" className="w-4 h-4 mr-2" />
+                  <img
+                    src={fav.favicon}
+                    alt={`${s} favicon`}
+                    className="w-4 h-4 mr-2"
+                  />
                 )}
                 <span className="truncate">{s}</span>
               </li>

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -547,7 +547,7 @@ const Chrome: React.FC = () => {
                 return (
                   <img
                     src={`https://www.google.com/s2/favicons?sz=64&domain_url=${origin}`}
-                    alt=""
+                    alt={`${t.title} favicon`}
                     className="w-8 h-8 mb-1"
                   />
                 );
@@ -733,7 +733,7 @@ const Chrome: React.FC = () => {
                 return src ? (
                   <img
                     src={src}
-                    alt=""
+                    alt={`${origin} favicon`}
                     className="w-4 h-4 mr-1 flex-shrink-0"
                   />
                 ) : null;

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -110,7 +110,11 @@ function Sidebar({
             className="mb-[6px] cursor-pointer"
             onClick={() => onPlay(v)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img
+              src={v.thumbnail}
+              alt={`${v.title} thumbnail`}
+              className="h-24 w-full rounded object-cover"
+            />
             <div>{v.title}</div>
           </div>
         ))}
@@ -130,7 +134,11 @@ function Sidebar({
             tabIndex={0}
             onKeyDown={(e) => handleKey(i, e)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img
+              src={v.thumbnail}
+              alt={`${v.name || v.title} thumbnail`}
+              className="h-24 w-full rounded object-cover"
+            />
             <div>{v.name || v.title}</div>
           </div>
         ))}

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -42,7 +42,13 @@ const AppsPage = () => {
             className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
             aria-label={app.title}
           >
-            {app.icon && <img src={app.icon} alt="" className="h-16 w-16" />}
+            {app.icon && (
+              <img
+                src={app.icon}
+                alt={`${app.title} icon`}
+                className="h-16 w-16"
+              />
+            )}
             <span className="mt-2">{app.title}</span>
           </Link>
         ))}


### PR DESCRIPTION
## Summary
- provide meaningful alt text for app icons in apps page
- add descriptive alt attributes for video thumbnails in YouTube app
- label favicon images in Chrome app components

## Testing
- `npm test` *(fails: ReferenceError: setTheme is not defined)*
- `npx eslint pages/apps/index.jsx components/apps/youtube/index.tsx components/apps/chrome/index.tsx components/apps/chrome/AddressBar.tsx` *(warning: file ignored because no matching configuration was supplied)*
- `npm run a11y`

------
https://chatgpt.com/codex/tasks/task_e_68b93d5e56fc83289447994fd757fe00