### PR TITLE
refactor: convert Window to functional component

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -44,7 +44,7 @@ describe('Window lifecycle', () => {
 
 describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     render(
       <Window
         id="test-window"
@@ -81,7 +81,7 @@ describe('Window snapping preview', () => {
   });
 
   it('hides preview when away from edge', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     render(
       <Window
         id="test-window"
@@ -120,7 +120,7 @@ describe('Window snapping preview', () => {
 
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     render(
       <Window
         id="test-window"
@@ -161,7 +161,7 @@ describe('Window snapping finalize and release', () => {
   });
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     render(
       <Window
         id="test-window"
@@ -208,7 +208,7 @@ describe('Window snapping finalize and release', () => {
   });
 
   it('releases snap when starting drag', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     render(
       <Window
         id="test-window"
@@ -286,7 +286,7 @@ describe('Window keyboard dragging', () => {
 
 describe('Window overlay inert behaviour', () => {
   it('sets and removes inert on default __next root restoring focus', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     const root = document.createElement('div');
     root.id = '__next';
     document.body.appendChild(root);
@@ -327,7 +327,7 @@ describe('Window overlay inert behaviour', () => {
   });
 
   it('respects overlayRoot prop when provided', () => {
-    const ref = React.createRef<Window>();
+    const ref = React.createRef<any>();
     const root = document.createElement('div');
     root.id = 'custom-root';
     document.body.appendChild(root);


### PR DESCRIPTION
## Summary
- refactor `Window` from class-based to functional React component
- manage state with `useState` and side effects with `useEffect`
- update window tests to use refs with the new functional API

## Testing
- `CI=1 npm test __tests__/window.test.tsx`
- `npm test` *(fails: ReferenceError: structuredClone is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f0ef8b483289cfd71b7ff5f292d