### PR TITLE
Add descriptive alt text for app icons and thumbnails

### DIFF
--- a/components/apps/chrome/AddressBar.tsx
+++ b/components/apps/chrome/AddressBar.tsx
@@ -251,7 +251,11 @@ const AddressBar: React.FC<AddressBarProps> = ({
                 onContextMenu={(e) => openContext(e, s)}
               >
                 {fav && fav.favicon && (
-                  <img src={fav.favicon} alt="" className="w-4 h-4 mr-2" />
+                  <img
+                    src={fav.favicon}
+                    alt={`${new URL(fav.url).hostname} favicon`}
+                    className="w-4 h-4 mr-2"
+                  />
                 )}
                 <span className="truncate">{s}</span>
               </li>

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -547,7 +547,7 @@ const Chrome: React.FC = () => {
                 return (
                   <img
                     src={`https://www.google.com/s2/favicons?sz=64&domain_url=${origin}`}
-                    alt=""
+                    alt={`${origin} favicon`}
                     className="w-8 h-8 mb-1"
                   />
                 );
@@ -733,7 +733,7 @@ const Chrome: React.FC = () => {
                 return src ? (
                   <img
                     src={src}
-                    alt=""
+                    alt={`${origin} favicon`}
                     className="w-4 h-4 mr-1 flex-shrink-0"
                   />
                 ) : null;

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -110,7 +110,11 @@ function Sidebar({
             className="mb-[6px] cursor-pointer"
             onClick={() => onPlay(v)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img
+              src={v.thumbnail}
+              alt={`${v.title} thumbnail`}
+              className="h-24 w-full rounded object-cover"
+            />
             <div>{v.title}</div>
           </div>
         ))}
@@ -130,7 +134,11 @@ function Sidebar({
             tabIndex={0}
             onKeyDown={(e) => handleKey(i, e)}
           >
-            <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
+            <img
+              src={v.thumbnail}
+              alt={`${v.name || v.title} thumbnail`}
+              className="h-24 w-full rounded object-cover"
+            />
             <div>{v.name || v.title}</div>
           </div>
         ))}

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -42,7 +42,9 @@ const AppsPage = () => {
             className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
             aria-label={app.title}
           >
-            {app.icon && <img src={app.icon} alt="" className="h-16 w-16" />}
+            {app.icon && (
+              <img src={app.icon} alt={`${app.title} icon`} className="h-16 w-16" />
+            )}
             <span className="mt-2">{app.title}</span>
           </Link>
         ))}


### PR DESCRIPTION
## Summary
- include accessible alt text for app icons and YouTube thumbnails
- describe favicons in Chrome app components for better screen reader support

## Testing
- `npm test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined)*
- `npm run a11y` *(fails: [WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID] This link points to a named anchor "window-area" within the document, but no anchor exists with that name. (#__next > div > a); [document-title] Documents must have <title> element to aid in navigation (https://dequeuniversity.com/rules/axe/4.10/document-title?application=axeAPI) (html); [WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl] A title should be provided for the document, using a non-empty title element in the head section. (html > head))*
- `npm run lint` *(terminated due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f0d8bb4832899f95c2e89b8cb29