### PR TITLE
refactor: replace clickable divs with buttons

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -90,10 +90,17 @@ export class AboutAlex extends Component {
                 <div className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black">
                     {this.renderNavLinks()}
                 </div>
-                <div onClick={this.showNavBar} className="md:hidden flex flex-col items-center justify-center absolute bg-ub-cool-grey rounded w-6 h-6 top-1 left-1">
-                    <div className=" w-3.5 border-t border-white"></div>
-                    <div className=" w-3.5 border-t border-white" style={{ marginTop: "2pt", marginBottom: "2pt" }}></div>
-                    <div className=" w-3.5 border-t border-white"></div>
+                <div className="md:hidden absolute top-1 left-1">
+                    <button
+                        type="button"
+                        aria-label="Toggle navigation"
+                        onClick={this.showNavBar}
+                        className="flex flex-col items-center justify-center bg-ub-cool-grey rounded w-6 h-6 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    >
+                        <div className=" w-3.5 border-t border-white"></div>
+                        <div className=" w-3.5 border-t border-white" style={{ marginTop: "2pt", marginBottom: "2pt" }}></div>
+                        <div className=" w-3.5 border-t border-white"></div>
+                    </button>
                     <div className={(this.state.navbar ? " visible animateShow z-30 " : " invisible ") + " md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20"}>
                         {this.renderNavLinks()}
                     </div>

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -279,15 +279,27 @@ export default function FileExplorer() {
         <div className="w-40 overflow-auto border-r border-gray-600">
           <div className="p-2 font-bold">Recent</div>
           {recent.map((r, i) => (
-            <div key={i} className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30" onClick={() => openRecent(r)}>
+            <button
+              key={i}
+              type="button"
+              aria-label={`Open ${r.name}`}
+              className="block w-full px-2 text-left hover:bg-black hover:bg-opacity-30 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              onClick={() => openRecent(r)}
+            >
               {r.name}
-            </div>
+            </button>
           ))}
           <div className="p-2 font-bold">Files</div>
           {files.map((f, i) => (
-            <div key={i} className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30" onClick={() => openFile(f)}>
+            <button
+              key={i}
+              type="button"
+              aria-label={`Open ${f.name}`}
+              className="block w-full px-2 text-left hover:bg-black hover:bg-opacity-30 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              onClick={() => openFile(f)}
+            >
               {f.name}
-            </div>
+            </button>
           ))}
         </div>
         <div className="flex-1 flex flex-col">

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -105,34 +105,37 @@ function Sidebar({
       <h2 className="mb-[6px] text-lg font-semibold">Queue</h2>
       <div data-testid="queue-list">
         {queue.map((v) => (
-          <div
+          <button
             key={v.id}
-            className="mb-[6px] cursor-pointer"
+            type="button"
+            aria-label={`Play ${v.title}`}
+            className="mb-[6px] w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-400"
             onClick={() => onPlay(v)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.title}</div>
-          </div>
+          </button>
         ))}
         {!queue.length && <div className="text-ubt-grey">Empty</div>}
       </div>
       <h2 className="mb-[6px] mt-[24px] text-lg font-semibold">Watch Later</h2>
       <div data-testid="watch-later-list">
         {watchLater.map((v, i) => (
-          <div
+          <button
             key={`${v.id}-${v.start ?? 0}-${v.end ?? 0}`}
-            className="mb-[6px] cursor-pointer"
+            type="button"
+            aria-label={`Play ${v.name || v.title}`}
+            className="mb-[6px] w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-400"
             onClick={() => onPlay(v)}
             draggable
             onDragStart={(e) => e.dataTransfer.setData('text/plain', String(i))}
             onDragOver={(e) => e.preventDefault()}
             onDrop={(e) => handleDrop(i, e)}
-            tabIndex={0}
             onKeyDown={(e) => handleKey(i, e)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.name || v.title}</div>
-          </div>
+          </button>
         ))}
         {!watchLater.length && <div className="text-ubt-grey">Empty</div>}
       </div>
@@ -208,7 +211,12 @@ function VirtualGrid({
                 padding: '6px',
               }}
             >
-              <div className="cursor-pointer" onClick={() => onPlay(v)}>
+              <button
+                type="button"
+                aria-label={`Play ${v.title}`}
+                className="w-full cursor-pointer text-left focus:outline-none focus:ring-2 focus:ring-blue-400"
+                onClick={() => onPlay(v)}
+              >
                 <div className="relative">
                   <img
                     src={v.thumbnail}
@@ -223,7 +231,7 @@ function VirtualGrid({
                 <div className="mt-[6px] text-sm line-clamp-2">
                   {truncateTitle(v.title)}
                 </div>
-              </div>
+              </button>
               <div className="mt-[6px] flex justify-between text-xs">
                 <ChannelHovercard id={v.channelId} name={v.channelName} />
                 <div className="space-x-[6px]">


### PR DESCRIPTION
## Summary
- convert YouTube queue, watch later, and grid items from divs to accessible buttons
- replace Alex mobile nav toggle with button and focus styles
- update File Explorer list items to buttons with labels and focus rings

## Testing
- `npx eslint -f json components/apps/alex.js components/apps/file-explorer.js components/apps/youtube/index.tsx`
- `yarn test` *(fails: ReferenceError: setTheme is not defined in themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f0c92a0832893a31a5db06f5e5d