### PR TITLE
feat: add window resize presets

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -46,6 +46,7 @@ export class Window extends Component {
         // Listen for context menu events to toggle inert background
         window.addEventListener('context-menu-open', this.setInertBackground);
         window.addEventListener('context-menu-close', this.removeInertBackground);
+        window.addEventListener('resize-window-preset', this.handlePresetResize);
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
@@ -57,6 +58,7 @@ export class Window extends Component {
         window.removeEventListener('resize', this.resizeBoundries);
         window.removeEventListener('context-menu-open', this.setInertBackground);
         window.removeEventListener('context-menu-close', this.removeInertBackground);
+        window.removeEventListener('resize-window-preset', this.handlePresetResize);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
@@ -137,6 +139,15 @@ export class Window extends Component {
             });
         };
         shrink();
+    }
+
+    handlePresetResize = (e) => {
+        const { id, width, height } = e.detail || {}
+        if (id && id !== this.id) return
+        if (!width || !height) return
+        const newWidth = width / window.innerWidth * 100
+        const newHeight = height / window.innerHeight * 100
+        this.setState({ width: newWidth, height: newHeight }, this.resizeBoundries)
     }
 
     getOverlayRoot = () => {

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,17 @@ function AppMenu(props) {
         }
     }
 
+    const handleResize = (w, h) => {
+        window.dispatchEvent(new CustomEvent('resize-window-preset', { detail: { id: props.appId, width: w, height: h } }))
+        props.onClose && props.onClose()
+    }
+
+    const presets = [
+        { width: 640, height: 480 },
+        { width: 800, height: 600 },
+        { width: 1024, height: 768 }
+    ]
+
     return (
         <div
             id="app-menu"
@@ -39,8 +50,29 @@ function AppMenu(props) {
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>
+            <Devider />
+            {presets.map(p => (
+                <button
+                    key={`${p.width}x${p.height}`}
+                    type="button"
+                    onClick={() => handleResize(p.width, p.height)}
+                    role="menuitem"
+                    aria-label={`Resize window to ${p.width}x${p.height}`}
+                    className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                >
+                    <span className="ml-5">{p.width}×{p.height}</span>
+                </button>
+            ))}
         </div>
     )
+}
+
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    );
 }
 
 export default AppMenu

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -13,6 +13,17 @@ function DefaultMenu(props) {
         }
     }
 
+    const handleResize = (w, h) => {
+        window.dispatchEvent(new CustomEvent('resize-window-preset', { detail: { id: props.appId, width: w, height: h } }))
+        props.onClose && props.onClose()
+    }
+
+    const presets = [
+        { width: 640, height: 480 },
+        { width: 800, height: 600 },
+        { width: 1024, height: 768 }
+    ]
+
     return (
         <div
             id="default-menu"
@@ -22,6 +33,18 @@ function DefaultMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
+            {presets.map(p => (
+                <button
+                    key={`${p.width}x${p.height}`}
+                    type="button"
+                    onClick={() => handleResize(p.width, p.height)}
+                    role="menuitem"
+                    aria-label={`Resize window to ${p.width}x${p.height}`}
+                    className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                >
+                    <span className="ml-5">{p.width}×{p.height}</span>
+                </button>
+            ))}
 
             <Devider />
             <a

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -43,6 +43,17 @@ function DesktopMenu(props) {
         }
     }
 
+    const handleResize = (w, h) => {
+        window.dispatchEvent(new CustomEvent('resize-window-preset', { detail: { id: props.appId, width: w, height: h } }))
+        props.onClose && props.onClose()
+    }
+
+    const presets = [
+        { width: 640, height: 480 },
+        { width: 800, height: 600 },
+        { width: 1024, height: 768 }
+    ]
+
     return (
         <div
             id="desktop-menu"
@@ -50,6 +61,19 @@ function DesktopMenu(props) {
             aria-label="Desktop context menu"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
+            {presets.map(p => (
+                <button
+                    key={`${p.width}x${p.height}`}
+                    type="button"
+                    onClick={() => handleResize(p.width, p.height)}
+                    role="menuitem"
+                    aria-label={`Resize window to ${p.width}x${p.height}`}
+                    className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                >
+                    <span className="ml-5">{p.width}×{p.height}</span>
+                </button>
+            ))}
+            <Devider />
             <button
                 onClick={props.addNewFolder}
                 type="button"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -773,14 +773,16 @@ export class Desktop extends Component {
                 {/* Context Menus */}
                 <DesktopMenu
                     active={this.state.context_menus.desktop}
+                    appId={this.state.context_app}
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
-                <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
+                <DefaultMenu active={this.state.context_menus.default} appId={this.state.context_app} onClose={this.hideAllContextMenu} />
                 <AppMenu
                     active={this.state.context_menus.app}
+                    appId={this.state.context_app}
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}


### PR DESCRIPTION
## Summary
- add preset window dimensions to all context menus
- allow `Window` component to resize itself when a preset is selected

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9497103fc8328a86bd689dbaefc6c