### PR TITLE
feat: add window edge snapping

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -160,6 +160,89 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.height).toBe(96.3);
   });
 
+  it('snaps window on drag stop near right edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: window.innerWidth - 105,
+      top: 10,
+      right: window.innerWidth - 5,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: window.innerWidth - 105,
+      y: 10,
+      toJSON: () => {},
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.snapped).toBe('right');
+    expect(ref.current!.state.width).toBe(50);
+    expect(ref.current!.state.height).toBe(96.3);
+  });
+
+  it('maximizes window on drag stop near top edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 50,
+      top: 5,
+      right: 150,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 50,
+      y: 5,
+      toJSON: () => {},
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.maximized).toBe(true);
+    expect(ref.current!.state.width).toBe(100.2);
+    expect(ref.current!.state.height).toBe(96.3);
+    expect(ref.current!.state.snapped).toBeNull();
+  });
+
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -267,7 +267,7 @@ export class Window extends Component {
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
         else if (rect.top <= threshold) {
-            snap = { left: '0', top: '0', width: '100%', height: '50%' };
+            snap = { left: '0', top: '0', width: '100%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
         }
         else {
@@ -284,6 +284,11 @@ export class Window extends Component {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
         if (snapPos) {
+            if (snapPos === 'top') {
+                this.maximizeWindow();
+                this.setState({ snapPreview: null, snapPosition: null });
+                return;
+            }
             this.setWinowsPosition();
             const { width, height } = this.state;
             let newWidth = width;
@@ -297,10 +302,6 @@ export class Window extends Component {
                 newWidth = 50;
                 newHeight = 96.3;
                 transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-            } else if (snapPos === 'top') {
-                newWidth = 100.2;
-                newHeight = 50;
-                transform = 'translate(-1pt,-2pt)';
             }
             var r = document.querySelector("#" + this.id);
             if (r && transform) {


### PR DESCRIPTION
## Summary
- detect window drags to screen edges
- snap left/right to half-screen and maximize when dragged to top
- add tests for right-edge snapping and top-edge maximization

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b94973c37c8328bd49524ed6b85f23