### PR TITLE
feat: add window switching and tiling shortcuts

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -46,6 +46,8 @@ export class Window extends Component {
         // Listen for context menu events to toggle inert background
         window.addEventListener('context-menu-open', this.setInertBackground);
         window.addEventListener('context-menu-close', this.removeInertBackground);
+        const root = document.getElementById(this.id);
+        root?.addEventListener('super-arrow', this.handleSuperArrow);
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
@@ -57,6 +59,8 @@ export class Window extends Component {
         window.removeEventListener('resize', this.resizeBoundries);
         window.removeEventListener('context-menu-open', this.setInertBackground);
         window.removeEventListener('context-menu-close', this.removeInertBackground);
+        const root = document.getElementById(this.id);
+        root?.removeEventListener('super-arrow', this.handleSuperArrow);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
@@ -471,6 +475,52 @@ export class Window extends Component {
         } else if (e.key === 'ArrowDown' && e.altKey) {
             this.unsnapWindow();
         }
+    }
+
+    handleSuperArrow = (e) => {
+        const key = e.detail;
+        if (key === 'ArrowLeft') {
+            if (this.state.snapped === 'left') this.unsnapWindow();
+            else this.snapWindow('left');
+        } else if (key === 'ArrowRight') {
+            if (this.state.snapped === 'right') this.unsnapWindow();
+            else this.snapWindow('right');
+        } else if (key === 'ArrowUp') {
+            this.maximizeWindow();
+        } else if (key === 'ArrowDown') {
+            if (this.state.maximized) {
+                this.restoreWindow();
+            } else if (this.state.snapped) {
+                this.unsnapWindow();
+            }
+        }
+    }
+
+    snapWindow = (pos) => {
+        this.focusWindow();
+        const { width, height } = this.state;
+        let newWidth = width;
+        let newHeight = height;
+        let transform = '';
+        if (pos === 'left') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (pos === 'right') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        }
+        const node = document.getElementById(this.id);
+        if (node && transform) {
+            node.style.transform = transform;
+        }
+        this.setState({
+            snapped: pos,
+            lastSize: { width, height },
+            width: newWidth,
+            height: newHeight
+        }, this.resizeBoundries);
     }
 
     render() {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -142,6 +142,59 @@ export class Desktop extends Component {
             e.preventDefault();
             this.openApp('clipboard-manager');
         }
+        else if (e.altKey && e.key === 'Tab') {
+            e.preventDefault();
+            this.cycleApps(e.shiftKey ? -1 : 1);
+        }
+        else if (e.altKey && (e.key === '`' || e.key === '~')) {
+            e.preventDefault();
+            this.cycleAppWindows(e.shiftKey ? -1 : 1);
+        }
+        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const event = new CustomEvent('super-arrow', { detail: e.key });
+                document.getElementById(id)?.dispatchEvent(event);
+            }
+        }
+    }
+
+    getFocusedWindowId = () => {
+        for (const key in this.state.focused_windows) {
+            if (this.state.focused_windows[key]) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    cycleApps = (direction) => {
+        if (!this.app_stack.length) return;
+        const currentId = this.getFocusedWindowId();
+        let index = this.app_stack.indexOf(currentId);
+        if (index === -1) index = 0;
+        let next = (index + direction + this.app_stack.length) % this.app_stack.length;
+        // Skip minimized windows
+        for (let i = 0; i < this.app_stack.length; i++) {
+            const id = this.app_stack[next];
+            if (!this.state.minimized_windows[id]) {
+                this.focus(id);
+                break;
+            }
+            next = (next + direction + this.app_stack.length) % this.app_stack.length;
+        }
+    }
+
+    cycleAppWindows = (direction) => {
+        const currentId = this.getFocusedWindowId();
+        if (!currentId) return;
+        const base = currentId.split('#')[0];
+        const windows = this.app_stack.filter(id => id.startsWith(base));
+        if (windows.length <= 1) return;
+        let index = windows.indexOf(currentId);
+        let next = (index + direction + windows.length) % windows.length;
+        this.focus(windows[next]);
     }
 
     checkContextMenu = (e) => {


### PR DESCRIPTION
## Summary
- support Alt+Tab to switch apps and Alt+` for cycling windows within an app
- add Super+Arrow handling to tile or maximize focused window

## Testing
- `yarn test __tests__/window.test.tsx`
- `npx eslint components/base/window.js components/screen/desktop.js`


------
https://chatgpt.com/codex/tasks/task_e_68b94974a4d883288755a81d58530fb0