### PR TITLE
Improve window focus styling and stacking order

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -497,7 +497,18 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.props.isFocused
+                                ? " z-50 border-2 border-opacity-80 "
+                                : " z-40 notFocused border border-opacity-40 ") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/styles/index.css
+++ b/styles/index.css
@@ -121,6 +121,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .notFocused {
     filter: brightness(90%);
+    box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2) !important;
+    -webkit-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2) !important;
+    -moz-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2) !important;
 }
 
 .root,
@@ -131,9 +134,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
-    -webkit-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
-    -moz-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 2px 8px 20px 6px rgba(0, 0, 0, 0.45);
+    -webkit-box-shadow: 2px 8px 20px 6px rgba(0, 0, 0, 0.45);
+    -moz-box-shadow: 2px 8px 20px 6px rgba(0, 0, 0, 0.45);
 }
 
 .closed-window {


### PR DESCRIPTION
## Summary
- Intensify window shadow and border when focused
- Restore softer shadow and border for unfocused windows
- Raise z-index so the active window stays above others

## Testing
- `npx eslint components/base/window.js styles/index.css`
- `yarn test --passWithNoTests components/base/window.js`


------
https://chatgpt.com/codex/tasks/task_e_68b94976c6a48328b759a8b6a75033c9