### PR TITLE
feat: add dock context menu

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -90,7 +90,7 @@ export class SideBarApp extends Component {
             <button
                 type="button"
                 aria-label={this.props.title}
-                data-context="app"
+                data-context="dock"
                 data-app-id={this.props.id}
                 onClick={this.openApp}
                 onMouseEnter={() => {

--- a/components/context-menus/dock-menu.js
+++ b/components/context-menus/dock-menu.js
@@ -1,0 +1,95 @@
+import React, { useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+
+function DockMenu(props) {
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
+
+    const handleQuit = () => {
+        props.onQuit && props.onQuit()
+        props.onClose && props.onClose()
+    }
+
+    const handleHide = () => {
+        props.onHide && props.onHide()
+        props.onClose && props.onClose()
+    }
+
+    const handleNewWindow = () => {
+        props.onNewWindow && props.onNewWindow()
+        props.onClose && props.onClose()
+    }
+
+    const handleUnpin = () => {
+        props.onUnpin && props.onUnpin()
+        props.onClose && props.onClose()
+    }
+
+    return (
+        <div
+            id="dock-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        >
+            <button
+                type="button"
+                onClick={handleQuit}
+                role="menuitem"
+                aria-label="Quit"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Quit</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleHide}
+                role="menuitem"
+                aria-label="Hide"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Hide</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleNewWindow}
+                role="menuitem"
+                aria-label="New Window"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">New Window</span>
+            </button>
+            <Devider />
+            <button
+                type="button"
+                onClick={handleUnpin}
+                role="menuitem"
+                aria-label="Unpin"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Unpin</span>
+            </button>
+        </div>
+    )
+}
+
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    );
+}
+
+export default DockMenu
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -16,6 +16,7 @@ import ShortcutSelector from '../screen/shortcut-selector'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
+import DockMenu from '../context-menus/dock-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -41,6 +42,7 @@ export class Desktop extends Component {
                 desktop: false,
                 default: false,
                 app: false,
+                dock: false,
             },
             context_app: null,
             showNameBar: false,
@@ -158,6 +160,13 @@ export class Desktop extends Component {
                 });
                 this.showContextMenu(e, "desktop");
                 break;
+            case "dock":
+                ReactGA.event({
+                    category: `Context Menu`,
+                    action: `Opened Dock Context Menu`
+                });
+                this.setState({ context_app: appId }, () => this.showContextMenu(e, "dock"));
+                break;
             case "app":
                 ReactGA.event({
                     category: `Context Menu`,
@@ -187,6 +196,10 @@ export class Desktop extends Component {
             case "desktop-area":
                 ReactGA.event({ category: `Context Menu`, action: `Opened Desktop Context Menu` });
                 this.showContextMenu(fakeEvent, "desktop");
+                break;
+            case "dock":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Dock Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "dock"));
                 break;
             case "app":
                 ReactGA.event({ category: `Context Menu`, action: `Opened App Context Menu` });
@@ -779,6 +792,14 @@ export class Desktop extends Component {
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
+                <DockMenu
+                    active={this.state.context_menus.dock}
+                    onClose={this.hideAllContextMenu}
+                    onQuit={() => this.closeApp(this.state.context_app)}
+                    onHide={() => this.hasMinimised(this.state.context_app)}
+                    onNewWindow={() => this.openApp(this.state.context_app)}
+                    onUnpin={() => this.unpinApp(this.state.context_app)}
+                />
                 <AppMenu
                     active={this.state.context_menus.app}
                     pinned={this.initFavourite[this.state.context_app]}


### PR DESCRIPTION
## Summary
- add DockMenu with Quit, Hide, New Window, and Unpin actions
- wire dock icons to open DockMenu on right-click
- integrate DockMenu handling in desktop context logic

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined & structuredClone is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9497822708328aa4d8e5b100e6275