### PR TITLE
Show running app indicator and focus existing windows

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -122,7 +122,7 @@ export class SideBarApp extends Component {
                 {
                     (
                         this.props.isClose[this.id] === false
-                            ? <div className=" w-1 h-1 absolute left-0 top-1/2 bg-white rounded-sm"></div>
+                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
                             : null
                     )
                 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -485,27 +485,22 @@ export class Desktop extends Component {
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
 
-        if (this.state.minimized_windows[objId]) {
-            // focus this app's window
-            this.focus(objId);
-
-            // set window's last position
-            var r = document.querySelector("#" + objId);
-            r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
-
-            // tell childs that his app has been not minimised
-            let minimized_windows = this.state.minimized_windows;
-            minimized_windows[objId] = false;
-            this.setState({ minimized_windows: minimized_windows }, this.saveSession);
+        // if app is already open, focus it instead of spawning a new window
+        if (this.state.closed_windows[objId] === false) {
+            // if it's minimised, restore its last position
+            if (this.state.minimized_windows[objId]) {
+                this.focus(objId);
+                var r = document.querySelector("#" + objId);
+                r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
+                let minimized_windows = this.state.minimized_windows;
+                minimized_windows[objId] = false;
+                this.setState({ minimized_windows: minimized_windows }, this.saveSession);
+            } else {
+                this.focus(objId);
+                this.saveSession();
+            }
             return;
-        }
-
-        //if app is already opened
-        if (this.app_stack.includes(objId)) {
-            this.focus(objId);
-            this.saveSession();
-        }
-        else {
+        } else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
             let frequentApps = [];


### PR DESCRIPTION
## Summary
- Show a small pill below dock icons for apps with open windows
- Update openApp logic to focus existing window before launching a new one

## Testing
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b949779b2c832886dd427895d91714