### PR TITLE
Add drag-resizable window chrome with resize handles

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -107,18 +107,6 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     width: 0;
 }
 
-.window-y-border {
-    height: calc(100% - 10px);
-    width: calc(100% + 10px);
-    cursor: e-resize;
-}
-
-.window-x-border {
-    height: calc(100% + 10px);
-    width: calc(100% - 10px);
-    cursor: n-resize;
-}
-
 .notFocused {
     filter: brightness(90%);
 }


### PR DESCRIPTION
## Summary
- add invisible 8px resize handles on all window edges and corners
- update cursor styles and implement drag-based resize logic
- clean up obsolete window border styles

## Testing
- `yarn test` *(fails: themePersistence.test.ts – setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9497944ec8328ab17925fe7545ae6