### PR TITLE
feat: add animated alt-tab overlay

### DIFF
--- a/components/screen/AltTabOverlay.tsx
+++ b/components/screen/AltTabOverlay.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from 'react';
+import Image from 'next/image';
+
+interface AppInfo {
+  id: string;
+  title: string;
+  icon: string;
+}
+
+interface AltTabOverlayProps {
+  apps: AppInfo[];
+  active: number;
+  show: boolean;
+}
+
+const AltTabOverlay: React.FC<AltTabOverlayProps> = ({ apps, active, show }) => {
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 transition-opacity duration-150 ${
+        show ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <div
+        className={`flex gap-4 p-4 bg-ub-cool-grey rounded-lg transform transition-transform duration-150 ${
+          show ? 'scale-100' : 'scale-95'
+        }`}
+      >
+        {apps.map((app, i) => (
+          <div
+            key={app.id}
+            className={`flex flex-col items-center w-20 ${i === active ? '' : 'opacity-60'}`}
+          >
+            <Image
+              src={app.icon.replace('./', '/')}
+              alt={`Kali ${app.title}`}
+              width={48}
+              height={48}
+              className="mb-1 w-12 h-12"
+              sizes="48px"
+            />
+            <span className="text-xs text-white text-center truncate w-full">{app.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AltTabOverlay;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -13,6 +13,7 @@ import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
+import AltTabOverlay from './AltTabOverlay'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
@@ -45,6 +46,8 @@ export class Desktop extends Component {
             context_app: null,
             showNameBar: false,
             showShortcutSelector: false,
+            altTabVisible: false,
+            altTabIndex: 0,
         }
     }
 
@@ -81,12 +84,16 @@ export class Desktop extends Component {
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
+        window.addEventListener('keydown', this.handleAltTab);
+        window.addEventListener('keyup', this.handleAltRelease);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        window.removeEventListener('keydown', this.handleAltTab);
+        window.removeEventListener('keyup', this.handleAltRelease);
     }
 
     checkForNewFolders = () => {
@@ -120,6 +127,31 @@ export class Desktop extends Component {
             openSettings.addEventListener("click", () => {
                 this.openApp("settings");
             });
+        }
+    }
+
+    getOpenApps = () => {
+        return this.app_stack.filter(id => !this.state.closed_windows[id]);
+    }
+
+    handleAltTab = (e) => {
+        if (e.key === 'Tab' && e.altKey) {
+            e.preventDefault();
+            const open = this.getOpenApps();
+            if (!open.length) return;
+            this.setState((prev) => ({
+                altTabVisible: true,
+                altTabIndex: (prev.altTabIndex + 1) % open.length,
+            }));
+        }
+    }
+
+    handleAltRelease = (e) => {
+        if (e.key === 'Alt') {
+            const open = this.getOpenApps();
+            const id = open[this.state.altTabIndex];
+            if (id) this.focus(id);
+            this.setState({ altTabVisible: false, altTabIndex: 0 });
         }
     }
 
@@ -806,6 +838,12 @@ export class Desktop extends Component {
                         games={games}
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
+
+                <AltTabOverlay
+                    apps={this.getOpenApps().map(id => apps.find(a => a.id === id)).filter(Boolean)}
+                    active={this.state.altTabIndex}
+                    show={this.state.altTabVisible}
+                />
 
             </main>
         )


### PR DESCRIPTION
## Summary
- add AltTabOverlay with fade + scale animation
- handle Alt+Tab to cycle open apps and show overlay
- render a row of app icons with labels during app switching

## Testing
- `npx eslint components/screen/desktop.js components/screen/AltTabOverlay.tsx`
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9497c29b88328ac821d34f97e1df7