### PR TITLE
feat: add density tokens and responsive dock padding

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -14,7 +14,7 @@ export default class Navbar extends Component {
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 px-2">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -29,7 +29,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-7 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-6 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,6 +35,14 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
+      spacing: {
+        '1': 'var(--space-1)',
+        '2': 'var(--space-2)',
+        '3': 'var(--space-3)',
+        '4': 'var(--space-4)',
+        '5': 'var(--space-5)',
+        '6': 'var(--space-6)',
+      },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- add density-driven spacing tokens to Tailwind theme
- use density-aware spacing for dock and taskbar

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9497f12288328a258fb07d79411d3