### PR TITLE
Ellipsize window title text

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -545,8 +545,9 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            title={title}
         >
-            <div className="flex justify-center text-sm font-bold">{title}</div>
+            <div className="w-full text-sm font-bold text-center truncate">{title}</div>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- ellipsize window title bar text and show full title tooltip on hover

## Testing
- `yarn lint components/base/window.js` *(fails: numerous existing lint errors)*
- `yarn test WindowTopBar` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b94982fb8483289e2ae834fc24ce30