### PR TITLE
Constrain embedded media and unify scrollbar styling

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -2,6 +2,8 @@
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) transparent;
 }
 
 body{
@@ -156,19 +158,27 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .windowMainScreen {
     container-type: inline-size;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) transparent;
+}
+.windowMainScreen iframe,
+.windowMainScreen canvas {
+    max-width: 100%;
+    max-height: 100%;
 }
 
-.windowMainScreen::-webkit-scrollbar-track {
+::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
     background-color: transparent;
 }
 
-.windowMainScreen::-webkit-scrollbar {
+::-webkit-scrollbar {
+    height: 6px;
     width: 6px;
     background-color: transparent;
 }
 
-.windowMainScreen::-webkit-scrollbar-thumb {
+::-webkit-scrollbar-thumb {
     background-color: var(--color-border);
     border-radius: 5px;
 }


### PR DESCRIPTION
## Summary
- limit iframe/canvas elements to their window bounds
- add global scrollbar styling for consistent look across app shells

## Testing
- `yarn lint` *(fails: yarn: No such file or directory)*
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b949824c1483288a49a04379dd0716