### PR TITLE
feat(settings): add accent color options

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSettings } from "../../hooks/useSettings";
+import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -134,13 +134,19 @@ export default function Settings() {
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
-            <input
-              type="color"
-              aria-label="Accent color picker"
-              value={accent}
-              onChange={(e) => setAccent(e.target.value)}
-              className="w-10 h-10 border border-ubt-cool-grey bg-ub-cool-grey"
-            />
+            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+              {ACCENT_OPTIONS.map((c) => (
+                <button
+                  key={c}
+                  aria-label={`select-accent-${c}`}
+                  role="radio"
+                  aria-checked={accent === c}
+                  onClick={() => setAccent(c)}
+                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
-import { useSettings } from '../hooks/useSettings';
+import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
 
 interface Props {
   highScore?: number;
@@ -34,12 +34,23 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
           </label>
           <label>
             Accent
-            <input
+            <div
               aria-label="accent-color-picker"
-              type="color"
-              value={accent}
-              onChange={(e) => setAccent(e.target.value)}
-            />
+              role="radiogroup"
+              className="flex gap-2 mt-1"
+            >
+              {ACCENT_OPTIONS.map((c) => (
+                <button
+                  key={c}
+                  aria-label={`select-accent-${c}`}
+                  role="radio"
+                  aria-checked={accent === c}
+                  onClick={() => setAccent(c)}
+                  className={`w-6 h-6 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  style={{ backgroundColor: c }}
+                />
+              ))}
+            </div>
           </label>
         </div>
       )}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useSettings } from '../../hooks/useSettings';
+import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
@@ -74,13 +74,19 @@ export function Settings() {
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
-                <input
-                    type="color"
-                    aria-label="Accent color picker"
-                    value={accent}
-                    onChange={(e) => setAccent(e.target.value)}
-                    className="w-10 h-10 border border-ubt-cool-grey bg-ub-cool-grey"
-                />
+                <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+                    {ACCENT_OPTIONS.map((c) => (
+                        <button
+                            key={c}
+                            aria-label={`select-accent-${c}`}
+                            role="radio"
+                            aria-checked={accent === c}
+                            onClick={() => setAccent(c)}
+                            className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                            style={{ backgroundColor: c }}
+                        />
+                    ))}
+                </div>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Density:</label>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,6 +23,16 @@ import {
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
+// Predefined accent palette exposed to settings UI
+export const ACCENT_OPTIONS = [
+  '#1793d1', // kali blue (default)
+  '#e53e3e', // red
+  '#d97706', // orange
+  '#38a169', // green
+  '#805ad5', // purple
+  '#ed64a6', // pink
+];
+
 // Utility to lighten or darken a hex color by a percentage
 const shadeColor = (color: string, percent: number): string => {
   const f = parseInt(color.slice(1), 16);
@@ -124,6 +134,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       '--color-ub-border-orange': border,
       '--color-primary': accent,
       '--color-accent': accent,
+      '--color-focus-ring': accent,
+      '--color-selection': accent,
+      '--color-control-accent': accent,
     };
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,10 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
+  --color-focus-ring: var(--color-accent);
+  --color-selection: var(--color-accent);
+  --color-control-accent: var(--color-accent);
+  accent-color: var(--color-control-accent);
 }
 
 /* Dark theme */
@@ -62,4 +66,14 @@ html[data-theme='matrix'] {
   --color-terminal: #00ff00;
   --color-dark: #000000;
 
+}
+
+::selection {
+  background: var(--color-selection);
+  color: var(--color-inverse);
+}
+
+*:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add predefined accent color palette and expose in settings UI
- propagate chosen accent through new CSS variables for focus ring, selection, and control accents

## Testing
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn test` *(fails: setTheme is not defined in themePersistence.test.ts)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b94988586c8328a42c95df9ec53884