### PR TITLE
feat: add standard transition classes

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -100,7 +100,8 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") + " w-auto p-2 outline-none relative transition hover:bg-white hover:bg-opacity-10 rounded m-1"}
+                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -41,7 +41,8 @@ export class UbuntuApp extends Component {
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") + " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white "}
+                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -51,7 +51,7 @@ export function AllApps(props) {
 
     return (
         <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center`}
+            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -2,3 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .transition-hover {
+    @apply transition ease-out duration-150;
+  }
+  .transition-active {
+    @apply transition ease-out duration-100;
+  }
+}
+
+@layer base {
+  button {
+    @apply transition-hover transition-active;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable `transition-hover` and `transition-active` Tailwind utilities
- use new transition utilities on dock tiles, app grid items, and default buttons

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined)*
- `npx eslint components/base/side_bar_app.js components/base/ubuntu_app.js components/screen/side_bar.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9498adf5c8328a187a0fbe4bb171e