### PR TITLE
feat(games): offscreen canvas worker

### DIFF
--- a/workers/game-loop.worker.ts
+++ b/workers/game-loop.worker.ts
@@ -1,0 +1,72 @@
+let canvas: OffscreenCanvas;
+let ctx: OffscreenCanvasRenderingContext2D | null = null;
+let width = 0;
+let height = 0;
+let x = 0;
+let dir = 1;
+let last = 0;
+
+function raf(cb: FrameRequestCallback): number {
+  const rAF = (self as any).requestAnimationFrame;
+  if (typeof rAF === 'function') return rAF(cb);
+  return (self as any).setTimeout(() => cb(performance.now()), 16);
+}
+
+function start() {
+  last = performance.now();
+  raf(loop);
+}
+
+function loop(now: number) {
+  const dt = (now - last) / 1000;
+  last = now;
+  update(dt);
+  draw();
+  raf(loop);
+}
+
+function update(dt: number) {
+  x += dir * dt * 100; // move 100px per second
+  if (x < 0) {
+    x = 0;
+    dir = 1;
+  } else if (x > width - 20) {
+    x = width - 20;
+    dir = -1;
+  }
+}
+
+function draw() {
+  if (!ctx) return;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#0f0';
+  ctx.fillRect(x, height / 2 - 10, 20, 20);
+}
+
+self.onmessage = (e: MessageEvent) => {
+  const { type } = (e.data || {}) as any;
+  if (type === 'init') {
+    canvas = e.data.canvas as OffscreenCanvas;
+    width = e.data.width;
+    height = e.data.height;
+    const dpr = e.data.dpr || 1;
+    ctx = canvas.getContext('2d');
+    if (ctx) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    start();
+  } else if (type === 'resize') {
+    width = e.data.width;
+    height = e.data.height;
+    const dpr = e.data.dpr || 1;
+    if (canvas && ctx) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- use OffscreenCanvas and worker when supported for game canvas
- add worker with simple game loop running off main thread

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b949908fa88328b4f50be2fe2112a3