### PR TITLE
Remove window shadow while dragging

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -497,7 +497,16 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 window-dragging " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/styles/index.css
+++ b/styles/index.css
@@ -136,6 +136,12 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
 }
 
+.window-dragging {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }


### PR DESCRIPTION
## Summary
- dim window shadow while dragging to improve drag visibility
- add CSS helper for shadowless drag state

## Testing
- `yarn test __tests__/window.test.tsx`
- `npx eslint components/base/window.js`
- `npx eslint styles/index.css`

------
https://chatgpt.com/codex/tasks/task_e_68b94992109c8328a325e7cbe845d71c