### PR TITLE
feat: improve terminal accessibility with live region

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -124,6 +124,25 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     '#FFFFFF',
   ];
 
+  const ariaLiveRef = useRef<HTMLDivElement | null>(null);
+  const liveBufferRef = useRef<string[]>([]);
+  const liveTimerRef = useRef<number>();
+
+  const announce = useCallback((line: string) => {
+    liveBufferRef.current.push(line);
+    if (liveTimerRef.current) return;
+    liveTimerRef.current = window.setTimeout(() => {
+      if (ariaLiveRef.current) {
+        ariaLiveRef.current.textContent = liveBufferRef.current.join('\n');
+        setTimeout(() => {
+          if (ariaLiveRef.current) ariaLiveRef.current.textContent = '';
+        }, 1000);
+      }
+      liveBufferRef.current = [];
+      liveTimerRef.current = undefined;
+    }, 500);
+  }, []);
+
   const updateOverflow = useCallback(() => {
     const term = termRef.current;
     if (!term || !term.buffer) return;
@@ -138,9 +157,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       if (opfsSupported && dirRef.current) {
         writeFile('history.txt', contentRef.current, dirRef.current);
       }
+      announce(text);
       updateOverflow();
     },
-    [opfsSupported, updateOverflow, writeFile],
+    [opfsSupported, updateOverflow, writeFile, announce],
   );
 
   contextRef.current.writeLine = writeLine;
@@ -493,6 +513,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
               lineHeight: 1.4,
             }}
           />
+          <div ref={ariaLiveRef} aria-live="polite" className="sr-only" />
           {overflow.top && (
             <div className="pointer-events-none absolute top-0 left-0 right-0 h-4 bg-gradient-to-b from-black" />
           )}


### PR DESCRIPTION
## Summary
- add aria-live region to terminal output
- throttle screen reader announcements

## Testing
- `npx eslint apps/terminal/index.tsx`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9499876788328960f5e01bd555ebf