### PR TITLE
Improve token contrast and expand pa11y coverage

### DIFF
--- a/pa11yci.json
+++ b/pa11yci.json
@@ -13,6 +13,9 @@
   },
   "urls": [
     "http://localhost:3000",
-    "http://localhost:3000/apps"
+    "http://localhost:3000/apps",
+    "http://localhost:3000/apps/calculator",
+    "http://localhost:3000/games/blackjack",
+    "http://localhost:3000/profile"
   ]
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -16,10 +16,11 @@
   --color-ubt-grey: #F6F6F5;
   --color-ubt-warm-grey: #AEA79F;
   --color-ubt-cool-grey: #333333;
-  --color-ubt-blue: #62A0EA;
-  --color-ubt-green: #73D216;
-  --color-ubt-gedit-orange: #F39A21;
-  --color-ubt-gedit-blue: #50B6C6;
+  /* High contrast-friendly token colors */
+  --color-ubt-blue: #1E40AF;
+  --color-ubt-green: #2F5D12;
+  --color-ubt-gedit-orange: #A55B00;
+  --color-ubt-gedit-blue: #006A80;
   --color-ubt-gedit-dark: #003B70;
   --color-ub-border-orange: #1793d1;
   --color-ub-dark-grey: #2a2e36;


### PR DESCRIPTION
## Summary
- tweak Tailwind tokens to use WCAG AA-compliant colors
- run pa11y-contrast checks across key pages

## Testing
- `yarn lint` *(fails: Component definition is missing display name, 130 errors)*
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b94999bf248328b414c4a853e066e1