### PR TITLE
Respect reduced motion preferences globally

### DIFF
--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { useSettings } from './useSettings';
 
 export default function usePrefersReducedMotion() {
+  const { reducedMotion } = useSettings();
   const [prefersReduced, setPrefersReduced] = useState(false);
 
   useEffect(() => {
@@ -11,5 +13,5 @@ export default function usePrefersReducedMotion() {
     return () => mq.removeEventListener('change', update);
   }, []);
 
-  return prefersReduced;
+  return reducedMotion || prefersReduced;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -22,6 +22,22 @@ button:focus-visible {
     outline-offset: 2px;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+.reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -47,7 +47,11 @@ export async function setDensity(density) {
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  return window.localStorage.getItem('reduced-motion') === 'true';
+  const stored = window.localStorage.getItem('reduced-motion');
+  if (stored !== null) {
+    return stored === 'true';
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 export async function setReducedMotion(value) {


### PR DESCRIPTION
## Summary
- honor system `prefers-reduced-motion` in settings store and hook
- disable animations and transitions when reduced motion is requested

## Testing
- `npx eslint hooks/usePrefersReducedMotion.ts utils/settingsStore.js`
- `yarn test themePersistence.test.ts` *(fails: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9499968048328965642e8f5aae23b