### PR TITLE
Add skip link to app grid for accessibility

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -149,6 +149,12 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
+        <a
+          href="#app-grid"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+        >
+          Skip to app grid
+        </a>
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -34,7 +34,11 @@ const AppsPage = () => {
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
       />
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      <div
+        id="app-grid"
+        tabIndex="-1"
+        className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+      >
         {filteredApps.map((app) => (
           <Link
             key={app.id}


### PR DESCRIPTION
## Summary
- add hidden skip link in `_app.jsx` to jump focus directly to app grid
- mark apps grid container as focusable target

## Testing
- `yarn test` *(fails: setTheme is not defined in themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9499b2de48328ab927243128b81e5