### PR TITLE
Ensure modal components trap focus for accessibility

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings } from '../hooks/useSettings';
+import Modal from './base/Modal';
 
 interface Props {
   highScore?: number;
@@ -16,8 +17,8 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
       <button aria-label="settings" onClick={() => setOpen(!open)}>
         Settings
       </button>
-      {open && (
-        <div role="dialog">
+      <Modal isOpen={open} onClose={() => setOpen(false)}>
+        <div className="p-4 bg-ub-cool-grey rounded-md shadow">
           <label>
             Theme
             <select
@@ -42,7 +43,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             />
           </label>
         </div>
-      )}
+      </Modal>
     </div>
   );
 };

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,33 +1,51 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import Modal from '../base/Modal';
 
 export default function LockScreen(props) {
-
     const { wallpaper } = useSettings();
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
-    };
+    useEffect(() => {
+        if (props.isLocked) {
+            window.addEventListener('click', props.unLockScreen);
+            window.addEventListener('keypress', props.unLockScreen);
+        }
+        return () => {
+            window.removeEventListener('click', props.unLockScreen);
+            window.removeEventListener('keypress', props.unLockScreen);
+        };
+    }, [props.isLocked, props.unLockScreen]);
 
     return (
-        <div
-            id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <div style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPositionX: "center" }} className="absolute top-0 left-0 w-full h-full transform z-20 blur-md "></div>
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
-                </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
+        <Modal isOpen={props.isLocked} onClose={props.unLockScreen}>
+            <div
+                id="ubuntu-lock-screen"
+                style={{ zIndex: '100', contentVisibility: 'auto' }}
+                className="absolute outline-none bg-black bg-opacity-90 top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"
+            >
+                <div
+                    style={{
+                        backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+                        backgroundSize: 'cover',
+                        backgroundRepeat: 'no-repeat',
+                        backgroundPositionX: 'center'
+                    }}
+                    className="absolute top-0 left-0 w-full h-full transform z-20 blur-md"
+                ></div>
+                <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
+                    <div className=" text-7xl">
+                        <Clock onlyTime={true} />
+                    </div>
+                    <div className="mt-4 text-xl font-medium">
+                        <Clock onlyDay={true} />
+                    </div>
+                    <div className=" mt-16 text-base">
+                        Click or Press a key to unlock
+                    </div>
                 </div>
             </div>
-        </div>
-    )
+        </Modal>
+    );
 }
+

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import Modal from '../base/Modal';
 
 class ShortcutSelector extends React.Component {
     constructor() {
@@ -55,23 +56,25 @@ class ShortcutSelector extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
+            <Modal isOpen={true} onClose={this.props.onClose}>
+                <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+                    <input
+                        className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                        placeholder="Search"
+                        value={this.state.query}
+                        onChange={this.handleChange}
+                    />
+                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                        {this.renderApps()}
+                    </div>
+                    <button
+                        className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
+                        onClick={this.props.onClose}
+                    >
+                        Cancel
+                    </button>
                 </div>
-                <button
-                    className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
-                    onClick={this.props.onClose}
-                >
-                    Cancel
-                </button>
-            </div>
+            </Modal>
         );
     }
 }


### PR DESCRIPTION
## Summary
- Wrap lock screen, settings drawer, and shortcut selector content in `Modal` with `role="dialog"` and `aria-modal="true"`
- Add focus trapping and cleanup for lock screen events

## Testing
- `yarn eslint components/SettingsDrawer.tsx components/screen/lock_screen.js components/screen/shortcut-selector.js`
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9499b5ad083288a3255bc3714d8ce