### PR TITLE
Add high-contrast Pa11y scenario and fix orange button contrast

### DIFF
--- a/pa11yci.json
+++ b/pa11yci.json
@@ -14,5 +14,12 @@
   "urls": [
     "http://localhost:3000",
     "http://localhost:3000/apps"
+  ],
+  "scenarios": [
+    {},
+    {
+      "label": "high-contrast",
+      "beforeScript": "scripts/a11y-high-contrast.js"
+    }
   ]
 }

--- a/scripts/a11y-high-contrast.js
+++ b/scripts/a11y-high-contrast.js
@@ -1,0 +1,6 @@
+module.exports = async page => {
+  await page.evaluateOnNewDocument(() => {
+    localStorage.setItem('high-contrast', 'true');
+  });
+};
+

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -2,20 +2,26 @@ import fs from 'fs';
 import pa11y from 'pa11y';
 
 const configPath = new URL('../pa11yci.json', import.meta.url);
-const { defaults = {}, urls = [] } = JSON.parse(fs.readFileSync(configPath));
+const { defaults = {}, urls = [], scenarios = [{}] } = JSON.parse(
+  fs.readFileSync(configPath),
+);
 
 (async () => {
   let hasErrors = false;
   for (const url of urls) {
-    console.log(`Testing ${url}`);
-    const results = await pa11y(url, defaults);
-    if (results.issues.length > 0) {
-      hasErrors = true;
-      for (const issue of results.issues) {
-        console.log(`  [${issue.code}] ${issue.message} (${issue.selector})`);
+    for (const scenario of scenarios) {
+      const options = { ...defaults, ...scenario };
+      const label = scenario.label ? ` (${scenario.label})` : '';
+      console.log(`Testing ${url}${label}`);
+      const results = await pa11y(url, options);
+      if (results.issues.length > 0) {
+        hasErrors = true;
+        for (const issue of results.issues) {
+          console.log(`  [${issue.code}] ${issue.message} (${issue.selector})`);
+        }
+      } else {
+        console.log('  No issues found');
       }
-    } else {
-      console.log('  No issues found');
     }
   }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -541,3 +541,9 @@ textarea:focus-visible {
 .gallery-container > * {
     scroll-snap-align: start;
 }
+
+/* High contrast overrides */
+.high-contrast .bg-ub-orange {
+    color: #000 !important;
+}
+


### PR DESCRIPTION
## Summary
- run Pa11y against a high-contrast scenario
- adjust scripts to execute multiple scenarios
- ensure orange buttons render readable text in high-contrast mode

## Testing
- `node scripts/a11y.mjs` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000)*
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9499c2aec8328857bdfa59da86449