### PR TITLE
feat: improve tooltip accessibility

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -3,6 +3,7 @@ import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
 import TerminalOutput from '../../TerminalOutput';
+import Tooltip from '../../ui/Tooltip';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes
@@ -114,14 +115,11 @@ const LogRow = ({ log, prefersReduced }) => {
     <tr ref={rowRef} className="odd:bg-black even:bg-ub-grey">
       <td className="pr-2 text-gray-400 whitespace-nowrap">{log.timestamp}</td>
       <td className="pr-2 text-green-400">
-
-        <abbr
-          title={protocolInfo[log.protocol] || log.protocol}
-          className="underline decoration-dotted cursor-help"
-          tabIndex={0}
-        >
-          {log.protocol}
-        </abbr>
+        <Tooltip label={protocolInfo[log.protocol] || log.protocol}>
+          <abbr className="underline decoration-dotted cursor-help">
+            {log.protocol}
+          </abbr>
+        </Tooltip>
       </td>
       <td className="px-2 py-[6px] text-white">{log.host}</td>
       <td className="px-2 py-[6px] text-green-400">{log.details}</td>
@@ -182,24 +180,28 @@ const SessionTile = ({ session, onView }) => (
           {protocolIcons[session.protocol] || '❓'}
         </span>
         <div className="flex space-x-1">
-          <button
-            className="w-6 h-6 flex items-center justify-center bg-gray-700 rounded"
-            title="Copy session"
-            onClick={() =>
-              navigator.clipboard?.writeText(
-                `${session.src}\t${session.dst}\t${session.protocol}\t${session.info}`,
-              )
-            }
-          >
-            📋
-          </button>
-          <button
-            className="w-6 h-6 flex items-center justify-center bg-gray-700 rounded"
-            title="View details"
-            onClick={onView}
-          >
-            🔍
-          </button>
+          <Tooltip label="Copy session">
+            <button
+              className="w-6 h-6 flex items-center justify-center bg-gray-700 rounded"
+              aria-label="Copy session"
+              onClick={() =>
+                navigator.clipboard?.writeText(
+                  `${session.src}\t${session.dst}\t${session.protocol}\t${session.info}`,
+                )
+              }
+            >
+              📋
+            </button>
+          </Tooltip>
+          <Tooltip label="View details">
+            <button
+              className="w-6 h-6 flex items-center justify-center bg-gray-700 rounded"
+              aria-label="View details"
+              onClick={onView}
+            >
+              🔍
+            </button>
+          </Tooltip>
         </div>
       </div>
       <div className="text-xs text-white">

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,0 +1,28 @@
+import React, { cloneElement, useId } from 'react';
+
+interface TooltipProps {
+  children: React.ReactElement;
+  label: React.ReactNode;
+}
+
+export default function Tooltip({ children, label }: TooltipProps) {
+  const id = useId();
+  const trigger = cloneElement(children, {
+    tabIndex: children.props.tabIndex ?? 0,
+    'aria-describedby': id,
+  });
+
+  return (
+    <span className="relative inline-block group">
+      {trigger}
+      <span
+        id={id}
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 -translate-x-1/2 mt-2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable Tooltip component that shows content on hover or focus and links targets via aria-describedby
- replace title attributes in dsniff with new accessible tooltip

## Testing
- `yarn eslint components/apps/dsniff/index.js components/ui/Tooltip.tsx -f json`
- `yarn test components/apps/dsniff/index.js components/ui/Tooltip.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9499ce7708328992f1b7220b9788c