### PR TITLE
feat: document Chrome sandbox and refine CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,17 +239,19 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `cdn.syndication.twimg.com` | Twitter asset CDN |
 | `*.twitter.com` | Additional Twitter content |
 | `*.x.com` | X (Twitter) domain equivalents |
-| `*.google.com` | Google services used by demos (e.g., reCAPTCHA) |
+| `*.google.com` | Google services and Chrome app favicons |
+| `example.com` | Chrome app demo origin |
+| `developer.mozilla.org` | Chrome app demo origin |
+| `en.wikipedia.org` | Chrome app demo origin |
 | `cdn.jsdelivr.net` | Math.js library |
 | `cdnjs.cloudflare.com` | PDF.js worker |
 | `stackblitz.com` | StackBlitz IDE embeds |
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
-| `https://*` / `http://*` / `ws://*` / `wss://*` | Wide dev allowance for external resources; tighten for production |
 
 **Notes for prod hardening**
-- The sample CSP currently **permits wide `connect-src` and `frame-src`** to enable sandboxed iframes (Chrome app) and demos. In production, **tighten** these to the exact domains you embed. Remove `http:` origins; prefer `https:` only.
+- Review `connect-src` and `frame-src` to ensure only required domains are present for your deployment.
 - Consider removing `'unsafe-inline'` from `style-src` once all inline styles are eliminated.
 - If deploying on a domain that serves a PDF resume via `<object>`, keep `X-Frame-Options: SAMEORIGIN`. Otherwise you can rely on CSP `frame-ancestors` instead.
 

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -797,7 +797,14 @@ const Chrome: React.FC = () => {
           {showFlags && (
             <div className="absolute bottom-0 left-0 right-0 bg-black/70 text-white text-xs p-2 space-y-1">
               <p>Active sandbox flags: {SANDBOX_FLAGS.join(', ') || '(none)'}</p>
-              <p>Note: combining <code>allow-scripts</code> with <code>allow-same-origin</code> defeats isolation.</p>
+              <p>
+                Pages run in an isolated iframe. Scripts, forms and popups work, but network
+                access is blocked by CSP.
+              </p>
+              <p>
+                Note: combining <code>allow-scripts</code> with <code>allow-same-origin</code> defeats
+                isolation.
+              </p>
             </div>
           )}
         </div>

--- a/next.config.js
+++ b/next.config.js
@@ -23,9 +23,9 @@ const ContentSecurityPolicy = [
   // External scripts required for embedded timelines
   "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://* http://* ws://* wss://* https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
-  // Allow iframes from any website and specific providers so the Chrome and StackBlitz apps can load arbitrary content
-  "frame-src 'self' https://* http://* https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
+  // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
+  "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
@@ -120,6 +120,10 @@ module.exports = withBundleAnalyzer(
         'i.ytimg.com',
         'yt3.ggpht.com',
         'i.scdn.co',
+        'www.google.com',
+        'example.com',
+        'developer.mozilla.org',
+        'en.wikipedia.org',
       ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],


### PR DESCRIPTION
## Summary
- explain sandbox limitations in the in-browser Chrome app
- tighten CSP connect-src/frame-src and allow demo origins
- whitelist demo hosts and Google favicons for Next.js images and docs

## Testing
- `yarn lint` *(fails: Component definition is missing display name...)*
- `yarn test` *(fails: themePersistence ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9499e93608328a5b412dd4ec4ae7a