### PR TITLE
feat: improve PWA offline support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,22 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development',
+  workboxOptions: {
+    navigateFallback: '/offline.html',
+    additionalManifestEntries: [
+      { url: '/', revision: null },
+      { url: '/feeds', revision: null },
+      { url: '/about', revision: null },
+      { url: '/projects', revision: null },
+      { url: '/projects.json', revision: null },
+      { url: '/apps', revision: null },
+      { url: '/apps/weather', revision: null },
+      { url: '/apps/terminal', revision: null },
+      { url: '/apps/checkers', revision: null },
+      { url: '/offline.html', revision: null },
+      { url: '/manifest.webmanifest', revision: null },
+    ],
+  },
 });
 
 const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';

--- a/public/offline.html
+++ b/public/offline.html
@@ -6,12 +6,55 @@
   <title>Offline</title>
   <style>
     body { font-family: sans-serif; padding: 2rem; text-align: center; }
+    ul { list-style: none; padding: 0; }
   </style>
 </head>
 <body>
   <main>
     <h1>Offline</h1>
     <p>You appear to be offline. Please check your connection.</p>
+    <button id="retry">Retry</button>
+    <section>
+      <h2>Cached Apps</h2>
+      <ul id="apps"></ul>
+    </section>
   </main>
+  <script>
+    document.getElementById('retry').addEventListener('click', () => {
+      window.location.reload();
+    });
+
+    (async () => {
+      const list = document.getElementById('apps');
+      try {
+        const names = await caches.keys();
+        const urls = new Set();
+        for (const name of names) {
+          const cache = await caches.open(name);
+          const keys = await cache.keys();
+          for (const request of keys) {
+            const url = new URL(request.url);
+            if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
+              urls.add(url.pathname);
+            }
+          }
+        }
+        if (urls.size === 0) {
+          list.innerHTML = '<li>No apps available offline.</li>';
+        } else {
+          urls.forEach((path) => {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = path;
+            a.textContent = path.replace('/apps/', '');
+            li.appendChild(a);
+            list.appendChild(li);
+          });
+        }
+      } catch (err) {
+        list.innerHTML = '<li>Unable to access cached apps.</li>';
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache core routes and app pages in generated service worker
- add offline page with retry and cached app links

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: structuredClone is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b949a291b48328ab9ad6a764b9be31