### PR TITLE
feat(games): add shared help overlay

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import HelpOverlay from '../components/apps/HelpOverlay';
+import HelpOverlay from '../components/apps/Games/common/HelpOverlay';
 
 describe('HelpOverlay', () => {
   it('returns null when no instructions exist for the game', () => {

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import HelpOverlay from './HelpOverlay';
+import { HelpOverlay, OVERLAY_TOGGLE_KEY } from './Games/common';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
@@ -72,7 +72,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         target.tagName === 'TEXTAREA' ||
         target.isContentEditable;
       if (isInput) return;
-      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+      if (e.key === OVERLAY_TOGGLE_KEY || (e.key === '/' && e.shiftKey)) {
         e.preventDefault();
         setShowHelp((h) => !h);
       }

--- a/components/apps/Games/common/HelpOverlay.tsx
+++ b/components/apps/Games/common/HelpOverlay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
-import InputRemap from "./Games/common/input-remap/InputRemap";
-import useInputMapping from "./Games/common/input-remap/useInputMapping";
+import InputRemap from "./input-remap/InputRemap";
+import useInputMapping from "./input-remap/useInputMapping";
 
 interface HelpOverlayProps {
   gameId: string;

--- a/components/apps/Games/common/index.ts
+++ b/components/apps/Games/common/index.ts
@@ -4,3 +4,5 @@ export { default as useGamepad } from './useGamepad';
 export { default as useGameLoop } from './useGameLoop';
 export { default as useSaveSlots } from './useSaveSlots';
 export { default as useLeaderboard } from './useLeaderboard';
+export { default as HelpOverlay, GAME_INSTRUCTIONS } from './HelpOverlay';
+export { OVERLAY_TOGGLE_KEY } from './overlayKey';

--- a/components/apps/Games/common/overlayKey.ts
+++ b/components/apps/Games/common/overlayKey.ts
@@ -1,0 +1,1 @@
+export const OVERLAY_TOGGLE_KEY = '?';


### PR DESCRIPTION
## Summary
- move HelpOverlay into games common folder for reuse
- export a shared overlay toggle key
- use the shared key in GameLayout to toggle help overlay

## Testing
- `yarn test __tests__/HelpOverlay.test.tsx`
- `yarn lint components/apps/GameLayout.tsx components/apps/Games/common/HelpOverlay.tsx components/apps/Games/common/index.ts components/apps/Games/common/overlayKey.ts __tests__/HelpOverlay.test.tsx` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68b949a02558832880ce4dcb8bfd0a96