### PR TITLE
feat: standardize typography spacing

### DIFF
--- a/apps/html-rewriter/index.tsx
+++ b/apps/html-rewriter/index.tsx
@@ -63,7 +63,7 @@ const HtmlRewriterApp: React.FC = () => {
             value={ruleText}
             onChange={(e) => setRuleText(e.target.value)}
           />
-          {error && <p className="text-red-400 mt-1">{error}</p>}
+          {error && <p className="text-red-400 mt-2">{error}</p>}
         </div>
         <div className="flex-1 flex flex-col">
           <label className="mb-1">Sample HTML</label>

--- a/apps/input-lab/index.tsx
+++ b/apps/input-lab/index.tsx
@@ -54,7 +54,7 @@ export default function InputLab() {
             onChange={(e) => setText(e.target.value)}
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
           />
-          {error && <p className="mt-1 text-sm text-red-400">{error}</p>}
+          {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
         </div>
       </form>
       <div role="status" aria-live="polite" className="mt-4 text-sm text-green-400">

--- a/apps/mimikatz/components/BlueTeamPanel.tsx
+++ b/apps/mimikatz/components/BlueTeamPanel.tsx
@@ -31,8 +31,8 @@ const BlueTeamPanel: React.FC<Props> = ({ logs }) => {
           </button>
           {open[idx] && (
             <div className="p-2 bg-blue-600 text-sm">
-              <p className="mb-1">{entry.log}</p>
-              <p className="mb-1">
+              <p className="mb-2">{entry.log}</p>
+              <p className="mb-2">
                 <span className="font-semibold">Mitigation:</span> {entry.mitigation}
               </p>
               {entry.resource && (

--- a/apps/nikto/components/HeaderLab.tsx
+++ b/apps/nikto/components/HeaderLab.tsx
@@ -95,7 +95,7 @@ const HeaderLab: React.FC = () => {
       />
       {Object.keys(headers).length > 0 && (
         <div>
-          <h3 className="text-md mb-1">Parsed Headers</h3>
+          <h3 className="text-md mb-2">Parsed Headers</h3>
           <table className="w-full text-sm">
             <tbody>
               {Object.entries(headers).map(([name, value]) => (
@@ -110,8 +110,8 @@ const HeaderLab: React.FC = () => {
       )}
       {hints.length > 0 && (
         <div>
-          <h3 className="text-md mb-1">Security Tips</h3>
-          <ul className="list-disc ml-6 space-y-1 text-green-300">
+          <h3 className="text-md mb-2">Security Tips</h3>
+          <ul className="list-disc ml-6 space-y-2 text-green-300">
             {hints.map((tip, i) => (
               <li key={i}>{tip}</li>
             ))}

--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -169,8 +169,8 @@ const NiktoPage: React.FC = () => {
           </p>
           {headers.length > 0 && (
             <div className="mb-4">
-              <h3 className="text-md mb-1">Headers</h3>
-              <ul className="text-sm space-y-1 font-mono">
+              <h3 className="text-md mb-2">Headers</h3>
+              <ul className="text-sm space-y-2 font-mono">
                 {headers.map((h) => (
                   <li key={h.name}>
                     <span className="font-bold">{h.name}:</span> {h.value}

--- a/apps/openvas/index.tsx
+++ b/apps/openvas/index.tsx
@@ -223,7 +223,7 @@ const OpenVASReport: React.FC = () => {
                   {expanded[key] && (
                     <tr>
                       <td colSpan={3} className="p-2 bg-gray-800">
-                        <p className="text-sm mb-1">{f.description}</p>
+                        <p className="text-sm mb-2">{f.description}</p>
                         <p className="text-xs text-yellow-300">{f.remediation}</p>
                       </td>
                     </tr>

--- a/apps/quote/components/PlaylistBuilder.tsx
+++ b/apps/quote/components/PlaylistBuilder.tsx
@@ -126,7 +126,7 @@ export default function PlaylistBuilder({ quotes, playlist, setPlaylist }: Playl
       </div>
       {Object.keys(saved).length > 0 && (
         <div className="mb-2">
-          <h3 className="text-md mb-1">Saved Playlists</h3>
+          <h3 className="text-md mb-2">Saved Playlists</h3>
           <ul className="max-h-32 overflow-auto border border-gray-700 rounded">
             {Object.entries(saved).map(([name, list]) => (
               <li
@@ -155,7 +155,7 @@ export default function PlaylistBuilder({ quotes, playlist, setPlaylist }: Playl
           </ul>
         </div>
       )}
-      <h3 className="text-md mb-1">Current Playlist</h3>
+      <h3 className="text-md mb-2">Current Playlist</h3>
       <ol className="max-h-32 overflow-auto border border-gray-700 rounded">
         {playlist.map((i, idx) => (
           <li

--- a/apps/reaver/components/RouterProfiles.tsx
+++ b/apps/reaver/components/RouterProfiles.tsx
@@ -78,12 +78,12 @@ const RouterProfiles: React.FC<RouterProfilesProps> = ({ onChange }) => {
         ))}
       </select>
       {selected.lockAttempts !== Infinity && (
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-gray-400 mt-2">
           Locks after {selected.lockAttempts} failed attempts for {selected.lockDuration}s
         </p>
       )}
       {selected.lockAttempts === Infinity && (
-        <p className="text-xs text-gray-400 mt-1">No WPS lockout behaviour</p>
+        <p className="text-xs text-gray-400 mt-2">No WPS lockout behaviour</p>
       )}
     </div>
   );

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -33,7 +33,7 @@ export default function NetworkInsights() {
 
   return (
     <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
-      <h2 className="font-bold mb-1">Active Fetches</h2>
+      <h2 className="font-bold mb-2">Active Fetches</h2>
       <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
         {active.map((f) => (
@@ -47,7 +47,7 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <div className="flex items-center mb-1">
+      <div className="flex items-center mb-2">
         <h2 className="font-bold">History</h2>
         <button
           onClick={() => exportMetrics(history)}

--- a/apps/wireshark/components/LayerView.tsx
+++ b/apps/wireshark/components/LayerView.tsx
@@ -25,7 +25,7 @@ const LayerView: React.FC<Props> = ({ name, fields }) => {
         {name}
       </button>
       {open && (
-        <ul className="pl-5 mt-1 space-y-0.5">
+        <ul className="pl-6 mt-2 space-y-2">
           {Object.entries(fields).map(([k, v]) => (
             <li key={k} className="whitespace-pre-wrap">
               {k}: {v}

--- a/components/apps/About/SafetyNote.tsx
+++ b/components/apps/About/SafetyNote.tsx
@@ -11,7 +11,7 @@ export default function SafetyNote() {
       aria-labelledby="safety-note-heading"
       className="mt-8 w-5/6 md:w-3/4 text-xs md:text-sm text-center border border-yellow-500 rounded p-3 bg-ub-cool-grey"
     >
-      <h2 id="safety-note-heading" className="text-sm md:text-base font-bold mb-1">
+      <h2 id="safety-note-heading" className="text-sm md:text-base font-bold mb-2">
         Safety Notice
       </h2>
       <p>

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -456,9 +456,9 @@ function Projects({ projects }: { projects: any[] }) {
                 </div>
                 <div className="text-gray-300 font-light text-sm">{project.date}</div>
               </div>
-              <ul className=" tracking-normal leading-tight text-sm font-light ml-4 mt-1">
+              <ul className=" tracking-normal leading-tight text-sm font-light ml-4 mt-2">
                 {project.description.map((desc: string) => (
-                  <li key={desc} className="list-disc mt-1 text-gray-100">
+                  <li key={desc} className="list-disc mt-2 text-gray-100">
                     {desc}
                   </li>
                 ))}

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -429,9 +429,9 @@ function Projects({ projects }) {
                                     </div>
                                     <div className="text-gray-300 font-light text-sm">{project.date}</div>
                                 </div>
-                                <ul className=" tracking-normal leading-tight text-sm font-light ml-4 mt-1">
+                                <ul className=" tracking-normal leading-tight text-sm font-light ml-4 mt-2">
                                     {project.description.map((desc, idx) => (
-                                        <li key={idx} className="list-disc mt-1 text-gray-100">{desc}</li>
+                                        <li key={idx} className="list-disc mt-2 text-gray-100">{desc}</li>
                                     ))}
                                 </ul>
                                 <div className="flex flex-wrap items-start justify-start text-xs py-2">
@@ -559,7 +559,7 @@ function Resume({ data: resume }) {
                 </div>
                 <div className="mb-4">
                     <div className="font-bold text-lg">Projects</div>
-                    <ul className="list-disc ml-5 mt-2">
+                    <ul className="list-disc ml-6 mt-2">
                         {resume.projects.map((p) => (
                             <li key={p.name} className="text-sm">
                                 <a

--- a/components/apps/beef/HookGraph.js
+++ b/components/apps/beef/HookGraph.js
@@ -22,7 +22,7 @@ export default function HookGraph({ hooks, steps }) {
             rel="noopener noreferrer"
             className="bg-ub-gray-50 text-black p-3 rounded shadow transition-transform duration-300 transform hover:scale-105 fade-in"
           >
-            <h3 className="font-bold text-sm mb-1">{mod.name}</h3>
+            <h3 className="font-bold text-sm mb-2">{mod.name}</h3>
             <p className="text-xs mb-2">{mod.description}</p>
             {mod.demo && (
               <pre className="text-[10px] bg-black text-green-400 p-1 rounded mb-2 overflow-x-auto">

--- a/components/apps/converter/UnitConverter.js
+++ b/components/apps/converter/UnitConverter.js
@@ -280,9 +280,9 @@ const UnitConverter = () => {
       <div className="mt-4">
         <h3 className="text-lg">Favorites</h3>
         {favorites.length === 0 && <div className="text-sm">No favorites</div>}
-        <ul className="flex flex-col gap-1 mt-1">
+        <ul className="flex flex-col gap-2 mt-2">
           {favorites.map((fav, idx) => (
-            <li key={`${fav.category}-${fav.fromUnit}-${fav.toUnit}-${idx}`} className="flex items-center gap-2 bg-gray-600 p-1 rounded">
+            <li key={`${fav.category}-${fav.fromUnit}-${fav.toUnit}-${idx}`} className="flex items-center gap-2 bg-gray-600 p-2 rounded">
               <button
                 className="flex-grow text-left"
                 onClick={() => {

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -495,7 +495,7 @@ const Dsniff = () => {
           Copy selected row
         </button>
         <div className="bg-black p-2">
-          <h3 className="font-bold mb-1 text-sm">Remediation</h3>
+          <h3 className="font-bold mb-2 text-sm">Remediation</h3>
           <ul className="list-disc pl-5 text-xs">
             {remediation.map((item, i) => (
               <li key={i}>{item}</li>

--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -153,7 +153,7 @@ const EvidenceVaultApp = () => {
                 </div>
               )}
               {item.tags.length > 0 && (
-                <p className="text-xs mt-1 text-gray-400">
+                <p className="text-xs mt-2 text-gray-400">
                   Tags: {item.tags.join(', ')}
                 </p>
               )}

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -174,7 +174,7 @@ export class Gedit extends Component {
                 {
                     this.state.location &&
                     <div className="bg-ub-gedit-dark border-t border-b border-ubt-gedit-blue p-2">
-                        <h2 className="font-bold text-sm mb-1">Your Local Time</h2>
+                        <h2 className="font-bold text-sm mb-2">Your Local Time</h2>
                         <Image
                             src={`https://staticmap.openstreetmap.de/staticmap.php?center=${this.state.location.latitude},${this.state.location.longitude}&zoom=3&size=300x150&markers=${this.state.location.latitude},${this.state.location.longitude},red-dot`}
                             alt="Map showing your approximate location"

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -570,7 +570,7 @@ const HydraApp = () => {
             className="w-full p-2 rounded text-black"
             placeholder="1:3"
           />
-          <p className="mt-1 text-sm">
+          <p className="mt-2 text-sm">
             Candidate space: {candidateSpace.toLocaleString()}
           </p>
           <canvas

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -394,7 +394,7 @@ const JohnApp = () => {
           <div className="text-xs bg-gray-900 p-2 rounded">
             {candidates.length > 0 && (
               <>
-                <p className="mb-1">Candidate preview:</p>
+                <p className="mb-2">Candidate preview:</p>
                 <ul className="max-h-24 overflow-auto">
                   {candidates.map((c, i) => (
                     <li key={i}>{c}</li>
@@ -462,7 +462,7 @@ const JohnApp = () => {
                 {`${Math.round(progress)}%`}
               </span>
             </div>
-            <p className="text-xs mt-1 text-white" aria-live="polite">
+            <p className="text-xs mt-2 text-white" aria-live="polite">
               {`Keyspace ${Math.round(progress)}% - ${phase}`}
             </p>
           </>

--- a/components/apps/metasploit/index.js
+++ b/components/apps/metasploit/index.js
@@ -459,7 +459,7 @@ const MetasploitApp = ({
             {showLoot && (
               <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
                 <div>
-                  <h4 className="font-bold mb-1">Loot</h4>
+                  <h4 className="font-bold mb-2">Loot</h4>
                   <ul className="max-h-24 overflow-auto">
                     {loot.map((l, i) => (
                       <li key={i}>
@@ -469,7 +469,7 @@ const MetasploitApp = ({
                   </ul>
                 </div>
                 <div>
-                  <h4 className="font-bold mb-1">Notes</h4>
+                  <h4 className="font-bold mb-2">Notes</h4>
                   <ul className="max-h-24 overflow-auto">
                     {notes.map((n, i) => (
                       <li key={i}>
@@ -485,15 +485,15 @@ const MetasploitApp = ({
         <aside className="w-1/3 bg-ub-grey p-2 overflow-auto text-xs">
           {selectedModule ? (
             <>
-              <h3 className="font-bold mb-1">{selectedModule.name}</h3>
-              <p className="mb-1">{selectedModule.description}</p>
+              <h3 className="font-bold mb-2">{selectedModule.name}</h3>
+              <p className="mb-2">{selectedModule.description}</p>
               {selectedModule.disclosure_date && (
-                <p className="mb-1">
+                <p className="mb-2">
                   <strong>Disclosed:</strong> {selectedModule.disclosure_date}
                 </p>
               )}
               {selectedModule.teaches && (
-                <p className="mb-1">
+                <p className="mb-2">
                   <strong>Teaches:</strong> {selectedModule.teaches}
                 </p>
               )}

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -195,7 +195,7 @@ const MsfPostApp = () => {
         <div className="w-2/3 pl-4 flex flex-col">
           {selectedModule ? (
             <div>
-              <h3 className="text-md font-semibold mb-1">
+              <h3 className="text-md font-semibold mb-2">
                 {selectedModule.path}
               </h3>
               <p className="text-sm text-gray-400 mb-2">

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -344,8 +344,8 @@ const Nessus = () => {
       </form>
       {jobs.length > 0 && (
         <div className="mb-4">
-          <h3 className="text-lg mb-1">Scheduled Jobs</h3>
-          <ul className="space-y-1">
+          <h3 className="text-lg mb-2">Scheduled Jobs</h3>
+          <ul className="space-y-2">
             {jobs.map((job, idx) => (
               <li key={idx} className="text-sm">
                 Scan {job.scanId} - {job.schedule}
@@ -354,9 +354,9 @@ const Nessus = () => {
           </ul>
         </div>
       )}
-      <ul className="space-y-1">
+      <ul className="space-y-2">
         {scans.map((scan) => (
-          <li key={scan.id} className="border-b border-gray-700 pb-1">
+          <li key={scan.id} className="border-b border-gray-700 pb-2">
             <div className="flex justify-between items-center">
               <span>
                 {scan.name} - {scan.status}

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -228,8 +228,8 @@ const NmapNSEApp = () => {
                   />
                   <span className="font-mono">{s.name}</span>
                 </label>
-                <p className="text-xs mb-1">{s.description}</p>
-                <div className="flex flex-wrap gap-1 mb-1">
+                <p className="text-xs mb-2">{s.description}</p>
+                <div className="flex flex-wrap gap-2 mb-2">
                   {s.tags.map((t) => (
                     <span key={t} className="px-1 text-xs bg-gray-200 rounded">
                       {t}
@@ -258,7 +258,7 @@ const NmapNSEApp = () => {
           </div>
         </div>
         <div className="mb-4">
-          <p className="block text-sm mb-1">Port presets</p>
+          <p className="block text-sm mb-2">Port presets</p>
           <div className="flex gap-2">
             {portPresets.map((p) => (
               <button
@@ -291,7 +291,7 @@ const NmapNSEApp = () => {
         <h2 className="text-lg mb-2">Script phases</h2>
         {activeScript ? (
           <>
-            <p className="text-sm mb-1">
+            <p className="text-sm mb-2">
               Phases for <span className="font-mono">{activeScript}</span>
             </p>
             <div className="flex space-x-2 mb-2">

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -14,9 +14,9 @@ const TaskOverview = () => {
       <FeedStatusCard />
       <div className="p-4 bg-gray-800 rounded">
         <h3 className="text-md font-bold mb-2">Demo Task Overview</h3>
-        <h4 className="text-sm font-bold mb-1">Run History</h4>
+        <h4 className="text-sm font-bold mb-2">Run History</h4>
         <TaskRunChart />
-        <ul className="text-sm space-y-1 mt-2">
+        <ul className="text-sm space-y-2 mt-2">
           {tasks.map((t) => (
             <li key={t.name} className="flex justify-between">
               <span>{t.name}</span>

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -142,7 +142,7 @@ export default function SecurityTools() {
             <div className="mb-2">
               <h3 className="text-sm font-bold">Suricata</h3>
               {suricataResults.map((log, i) => (
-                <pre key={i} className="bg-black p-1 mb-1 overflow-auto">
+                <pre key={i} className="bg-black p-2 mb-2 overflow-auto">
                   {JSON.stringify(log, null, 2)}
                 </pre>
               ))}
@@ -152,7 +152,7 @@ export default function SecurityTools() {
             <div className="mb-2">
               <h3 className="text-sm font-bold">Zeek</h3>
               {zeekResults.map((log, i) => (
-                <pre key={i} className="bg-black p-1 mb-1 overflow-auto">
+                <pre key={i} className="bg-black p-2 mb-2 overflow-auto">
                   {JSON.stringify(log, null, 2)}
                 </pre>
               ))}
@@ -164,7 +164,7 @@ export default function SecurityTools() {
               {sigmaResults.map(rule => (
                 <div key={rule.id} className="mb-2">
                   <h4 className="font-bold">{rule.title}</h4>
-                  <pre className="bg-black p-1 overflow-auto">
+                  <pre className="bg-black p-2 overflow-auto">
                     {JSON.stringify(rule, null, 2)}
                   </pre>
                 </div>
@@ -209,7 +209,7 @@ export default function SecurityTools() {
             <div>
               <p className="text-xs mb-2">Sample Suricata alerts from local JSON fixture.</p>
               {suricata.map((log, i) => (
-                <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
+                <pre key={i} className="text-xs bg-black p-2 mb-2 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
               ))}
             </div>
           )}
@@ -218,7 +218,7 @@ export default function SecurityTools() {
             <div>
               <p className="text-xs mb-2">Sample Zeek logs from local JSON fixture.</p>
               {zeek.map((log, i) => (
-                <pre key={i} className="text-xs bg-black p-1 mb-1 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
+                <pre key={i} className="text-xs bg-black p-2 mb-2 overflow-auto">{JSON.stringify(log, null, 2)}</pre>
               ))}
             </div>
           )}

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -666,13 +666,13 @@ export default function Todoist() {
         role="list"
         aria-label={name}
       >
-        <h2 className="mb-1.5 font-bold text-lg text-gray-800">
+        <h2 className="mb-2 font-bold text-lg text-gray-800">
           {name}
           {WIP_LIMITS[name] ? ` (${groups[name].length}/${WIP_LIMITS[name]})` : ''}
         </h2>
         {filtered.length === 0 ? (
           <div className="flex flex-col items-center text-gray-500 mt-3">
-            <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
+            <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-2" />
             <span className="text-sm">No tasks</span>
           </div>
         ) : (

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -147,7 +147,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             ) : item.icon ? (
               <img src={item.icon} alt={item.title} className="h-20 w-20 mx-auto object-contain" />
             ) : null}
-            <p className="text-center text-xs truncate mt-1" title={item.title}>
+            <p className="text-center text-xs truncate mt-2" title={item.title}>
               {item.title}
             </p>
             <p className="text-center text-[10px] text-gray-400" aria-label={`Closed ${formatAge(item.closedAt)}`}>

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -73,7 +73,7 @@ const PluginBrowser = () => {
               Requires Volatility {p.minVersion}
             </p>
           )}
-          <p className="text-xs mb-1">{p.description}</p>
+          <p className="text-xs mb-2">{p.description}</p>
           <a
             href={p.doc}
             target="_blank"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -63,3 +63,30 @@ html[data-theme='matrix'] {
   --color-dark: #000000;
 
 }
+
+/* Base typography spacing aligned to 8px grid */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-block-start: 0;
+  margin-block-end: 16px; /* 2 x 8px */
+}
+
+p {
+  margin-block-start: 0;
+  margin-block-end: 16px; /* 2 x 8px */
+}
+
+ul,
+ol {
+  margin-block-start: 0;
+  margin-block-end: 16px; /* 2 x 8px */
+  padding-inline-start: 24px; /* 3 x 8px */
+}
+
+li {
+  margin-block-end: 8px; /* 1 x 8px */
+}


### PR DESCRIPTION
## Summary
- align global typography spacing to an 8px grid
- adjust margins and padding on headings, paragraphs, and lists across apps for consistent spacing

## Testing
- `npm test` *(fails: ReferenceError: setTheme is not defined in themePersistence.test.ts; structuredClone not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b949a19640832891da0c34e8a04429