### PR TITLE
perf: prioritize wallpaper and heading load

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -17,12 +17,12 @@ function BootingScreen(props) {
                 src="/themes/Yaru/status/cof_orange_hex.svg"
                 alt="Ubuntu Logo"
                 sizes="(max-width: 768px) 50vw, 25vw"
-                priority
+                loading="lazy"
             />
             <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
                 {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" loading="lazy"/></div>
+                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" loading="lazy"/>)}
             </div>
             <Image
                 width={200}
@@ -31,6 +31,7 @@ function BootingScreen(props) {
                 src="/themes/Yaru/status/ubuntu_white_hex.svg"
                 alt="Kali Linux Name"
                 sizes="(max-width: 768px) 50vw, 20vw"
+                priority
             />
             <div className="text-white mb-4">
                 <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from 'react'
+import Image from 'next/image';
 import { useSettings } from '../../hooks/useSettings';
 import useDailyQuote from '../../hooks/useDailyQuote';
 
@@ -39,15 +40,15 @@ export default function BackgroundImage() {
     }, [wallpaper]);
 
     return (
-        <div
-            style={{
-                backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-                backgroundSize: "cover",
-                backgroundRepeat: "no-repeat",
-                backgroundPositionX: "center"
-            }}
-            className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
-        >
+        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+            <Image
+                src={`/wallpapers/${wallpaper}.webp`}
+                alt=""
+                fill
+                priority
+                sizes="100vw"
+                style={{ objectFit: 'cover', objectPosition: 'center' }}
+            />
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
             )}


### PR DESCRIPTION
## Summary
- use Next.js `<Image>` with priority and proper sizes for initial wallpaper
- lazily load non-critical boot images while prioritizing boot heading

## Testing
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*
- `yarn eslint components/screen/booting_screen.js components/util-components/background-image.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9498d955083288f984a5dc245b91e