### PR TITLE
style: refine window chrome

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -497,7 +497,16 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow window-chrome flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
@@ -539,7 +548,7 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 py-1.5 px-3 text-white w-full select-none rounded-b-none"}
+            className={" relative bg-ub-window-title border-b border-white border-opacity-5 py-1.5 px-3 text-white w-full select-none rounded-t-lg"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
@@ -694,7 +703,7 @@ export class WindowMainScreen extends Component {
     }
     render() {
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen rounded-b-lg" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}> 
                 {this.props.screen(this.props.addFolder, this.props.openApp)}
             </div>
         )

--- a/styles/index.css
+++ b/styles/index.css
@@ -130,6 +130,11 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     --window-transform-y: 0px;
 }
 
+.window-chrome {
+    border: 1px solid var(--color-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
 .window-shadow {
     box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);
     -webkit-box-shadow: 1px 4px 12px 4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- add window-chrome style with subtle inner highlight and 1px border
- unify window border radius across container, title bar, and main screen

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9498cbbd08328a8d97ff5759ef35a