### PR TITLE
feat: add window snap setting

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -183,22 +183,33 @@ export class Window extends Component {
         this.setState({ cursorType: "cursor-default", grabbed: false })
     }
 
+    snapToGrid = (value) => {
+        if (!this.props.snapEnabled) return value;
+        return Math.round(value / 8) * 8;
+    }
+
     handleVerticleResize = () => {
         if (this.props.resizable === false) return;
-        this.setState({ height: this.state.height + 0.1 }, this.resizeBoundries);
+        const px = (this.state.height / 100) * window.innerHeight + 1;
+        const snapped = this.snapToGrid(px);
+        const heightPercent = snapped / window.innerHeight * 100;
+        this.setState({ height: heightPercent }, this.resizeBoundries);
     }
 
     handleHorizontalResize = () => {
         if (this.props.resizable === false) return;
-        this.setState({ width: this.state.width + 0.1 }, this.resizeBoundries);
+        const px = (this.state.width / 100) * window.innerWidth + 1;
+        const snapped = this.snapToGrid(px);
+        const widthPercent = snapped / window.innerWidth * 100;
+        this.setState({ width: widthPercent }, this.resizeBoundries);
     }
 
     setWinowsPosition = () => {
         var r = document.querySelector("#" + this.id);
         if (!r) return;
         var rect = r.getBoundingClientRect();
-        const x = rect.x;
-        const y = rect.y - 32;
+        const x = this.snapToGrid(rect.x);
+        const y = this.snapToGrid(rect.y - 32);
         r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
         r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
         if (this.props.onPositionChange) {
@@ -486,7 +497,7 @@ export class Window extends Component {
                 <Draggable
                     axis="both"
                     handle=".bg-ub-window-title"
-                    grid={[1, 1]}
+                    grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
                     scale={1}
                     onStart={this.changeCursorToMove}
                     onStop={this.handleStop}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -19,6 +19,7 @@ import AppMenu from '../context-menus/app-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { useSnapSetting } from '../../hooks/usePersistentState';
 
 export class Desktop extends Component {
     constructor() {
@@ -381,6 +382,7 @@ export class Desktop extends Component {
                     initialX: pos ? pos.x : undefined,
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
+                    snapEnabled: this.props.snapEnabled,
                 }
 
                 windowsJsx.push(
@@ -392,8 +394,11 @@ export class Desktop extends Component {
     }
 
     updateWindowPosition = (id, x, y) => {
+        const snap = this.props.snapEnabled
+            ? (v) => Math.round(v / 8) * 8
+            : (v) => v;
         this.setState(prev => ({
-            window_positions: { ...prev.window_positions, [id]: { x, y } }
+            window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
         }), this.saveSession);
     }
 
@@ -812,4 +817,7 @@ export class Desktop extends Component {
     }
 }
 
-export default Desktop
+export default function DesktopWithSnap(props) {
+    const [snapEnabled] = useSnapSetting();
+    return <Desktop {...props} snapEnabled={snapEnabled} />;
+}

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -51,3 +51,10 @@ export default function usePersistentState<T>(
 
   return [state, setState, reset, clear] as const;
 }
+
+export const useSnapSetting = () =>
+  usePersistentState<boolean>(
+    'snap-enabled',
+    true,
+    (value): value is boolean => typeof value === 'boolean',
+  );


### PR DESCRIPTION
## Summary
- add persistent snap setting hook
- snap window drag & resize to 8px grid
- expose snap toggle via desktop and window components

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9496fa04c83288e9b857d88f37e23