### PR TITLE
Fix dock and window chrome layout stability

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -134,10 +134,13 @@ export class SideBarApp extends Component {
                             " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
                         }
                     >
-                        <img
+                        <Image
+                            width={128}
+                            height={80}
                             src={this.state.thumbnail}
                             alt={`Preview of ${this.props.title}`}
-                            className="w-32 h-auto"
+                            className="w-32 h-20 object-cover"
+                            sizes="128px"
                         />
                     </div>
                 )}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -539,14 +539,14 @@ export default Window
 export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 py-1.5 px-3 text-white w-full select-none rounded-b-none"}
+            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
         >
-            <div className="flex justify-center text-sm font-bold">{title}</div>
+            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>
     )
 }
@@ -590,7 +590,7 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center">
+        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
             {pipSupported && props.pip && (
                 <button
                     type="button"

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -29,7 +29,8 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") + " absolute transform duration-300 select-none z-40 left-0 top-0 h-full pt-7 w-auto flex flex-col justify-start items-center border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={(props.hide ? " -translate-x-full " : "") +
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (


### PR DESCRIPTION
## Summary
- prevent dock layout shifts by applying fixed width and screen-height
- stabilize window chrome height and control width
- ensure sidebar previews use Next `<Image>` with explicit dimensions

## Testing
- `npx eslint components/base/side_bar_app.js components/base/window.js components/screen/side_bar.js`
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9498dc7cc8328a6688371c4145f1d