### PR TITLE
feat: improve wallpaper handling

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -16,7 +16,11 @@ export default function LockScreen(props) {
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <div style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPositionX: "center" }} className="absolute top-0 left-0 w-full h-full transform z-20 blur-md "></div>
+            <img
+                src={`/wallpapers/${wallpaper}.webp`}
+                alt=""
+                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+            />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">
                     <Clock onlyTime={true} />

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -39,15 +39,12 @@ export default function BackgroundImage() {
     }, [wallpaper]);
 
     return (
-        <div
-            style={{
-                backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-                backgroundSize: "cover",
-                backgroundRepeat: "no-repeat",
-                backgroundPositionX: "center"
-            }}
-            className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
-        >
+        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+            <img
+                src={`/wallpapers/${wallpaper}.webp`}
+                alt=""
+                className="w-full h-full object-cover"
+            />
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
             )}


### PR DESCRIPTION
## Summary
- display wallpapers via `<img>` tags with `object-fit: cover`
- blur desktop background during lock-screen transitions

## Testing
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn test` *(fails: themePersistence.test.ts setTheme not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b949891a308328858fff452823a473