### PR TITLE
feat: add bootstrap-style grid utilities

### DIFF
--- a/docs/internal-layouts.md
+++ b/docs/internal-layouts.md
@@ -1,0 +1,22 @@
+# Internal Layouts
+
+This project provides Tailwind utilities that mimic Bootstrap's 12-column grid. Use them to create internal layouts without relying on Bootstrap itself.
+
+## Usage
+
+Wrap columns in a flex container and apply the `col-*` classes to control widths.
+
+```html
+<div class="flex flex-wrap">
+  <div class="col-6">Left</div>
+  <div class="col-6">Right</div>
+</div>
+```
+
+Offsets are also available through `offset-*` classes.
+
+```html
+<div class="flex flex-wrap">
+  <div class="col-4 offset-4">Centered</div>
+</div>
+```

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require('tailwindcss/plugin');
+
 module.exports = {
   darkMode: 'class',
   mode: 'jit',
@@ -93,5 +95,17 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      const cols = {};
+      for (let i = 1; i <= 12; i++) {
+        const width = `${(i / 12) * 100}%`;
+        cols[`.col-${i}`] = { flex: `0 0 ${width}`, maxWidth: width };
+        if (i < 12) {
+          cols[`.offset-${i}`] = { marginLeft: width };
+        }
+      }
+      addUtilities(cols, ['responsive']);
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- add Tailwind plugin generating col-* and offset-* utilities for 12-column layouts
- document how to use the new grid classes

## Testing
- `yarn lint` *(fails: 130 errors, 15 warnings)*
- `yarn test` *(fails: themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9498463a48328a849ca2d73d2cd09