### PR TITLE
feat: add decimal.js precision for calculator

### DIFF
--- a/__tests__/decimal.test.ts
+++ b/__tests__/decimal.test.ts
@@ -1,0 +1,19 @@
+import { add, subtract, multiply, divide, pow } from '../utils/decimal';
+
+describe('decimal arithmetic', () => {
+  test('addition', () => {
+    expect(add(0.1, 0.2).toString()).toBe('0.3');
+  });
+  test('subtraction', () => {
+    expect(subtract(0.3, 0.1).toString()).toBe('0.2');
+  });
+  test('multiplication', () => {
+    expect(multiply(0.6, 3).toString()).toBe('1.8');
+  });
+  test('division', () => {
+    expect(divide(0.3, 0.2).toString()).toBe('1.5');
+  });
+  test('power', () => {
+    expect(pow(1.2, 3).toString()).toBe('1.728');
+  });
+});

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -33,6 +33,7 @@ export default function Calculator() {
     let formatBase: any;
     let getLastResult: any;
     let setBase: any;
+    let setPreciseMode: any;
 
     const load = async () => {
       if (typeof window !== 'undefined' && !(window as any).math) {
@@ -52,6 +53,7 @@ export default function Calculator() {
       formatBase = mod.formatBase;
       getLastResult = mod.getLastResult;
       setBase = mod.setBase;
+      setPreciseMode = mod.setPreciseMode;
 
       const display = document.getElementById('display') as HTMLInputElement;
       const buttons = document.querySelectorAll<HTMLButtonElement>('.btn');
@@ -60,6 +62,7 @@ export default function Calculator() {
       const formulasToggle = document.getElementById('toggle-formulas');
       const formulasEl = document.getElementById('formulas');
       const baseSelect = document.getElementById('base-select') as HTMLSelectElement | null;
+      const preciseToggle = document.getElementById('toggle-precise');
 
       const insertAtCursor = (text: string) => {
         const start = display.selectionStart ?? display.value.length;
@@ -171,6 +174,14 @@ export default function Calculator() {
 
       formulasToggle?.addEventListener('click', () => {
         formulasEl?.classList.toggle('hidden');
+      });
+
+      preciseToggle?.addEventListener('click', () => {
+        const on = preciseToggle.getAttribute('aria-pressed') === 'true';
+        const next = !on;
+        preciseToggle.setAttribute('aria-pressed', String(next));
+        preciseToggle.textContent = `Precise Mode: ${next ? 'On' : 'Off'}`;
+        setPreciseMode(next);
       });
 
       baseSelect?.addEventListener('change', () => {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cron-parser": "^5.3.0",
     "cytoscape": "^3.33.1",
     "cytoscape-cose-bilkent": "^4.1.0",
+    "decimal.js": "10.4.3",
     "diff": "^8",
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",

--- a/utils/decimal.ts
+++ b/utils/decimal.ts
@@ -1,0 +1,9 @@
+import Decimal from 'decimal.js';
+
+export const decimal = (value: Decimal.Value) => new Decimal(value);
+export const add = (a: Decimal.Value, b: Decimal.Value) => new Decimal(a).add(b);
+export const subtract = (a: Decimal.Value, b: Decimal.Value) => new Decimal(a).sub(b);
+export const multiply = (a: Decimal.Value, b: Decimal.Value) => new Decimal(a).mul(b);
+export const divide = (a: Decimal.Value, b: Decimal.Value) => new Decimal(a).div(b);
+export const pow = (a: Decimal.Value, b: Decimal.Value) => new Decimal(a).pow(b);
+export const toNumber = (value: Decimal.Value) => new Decimal(value).toNumber();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6192,6 +6192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decimal.js@npm:10.4.3":
+  version: 10.4.3
+  resolution: "decimal.js@npm:10.4.3"
+  checksum: 10c0/6d60206689ff0911f0ce968d40f163304a6c1bc739927758e6efc7921cfa630130388966f16bf6ef6b838cb33679fbe8e7a78a2f3c478afce841fd55ac8fb8ee
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.4.3, decimal.js@npm:^10.5.0":
   version: 10.6.0
   resolution: "decimal.js@npm:10.6.0"
@@ -13873,6 +13880,7 @@ __metadata:
     cron-parser: "npm:^5.3.0"
     cytoscape: "npm:^3.33.1"
     cytoscape-cose-bilkent: "npm:^4.1.0"
+    decimal.js: "npm:10.4.3"
     diff: "npm:^8"
     dompurify: "npm:^3.2.6"
     eslint: "npm:^9.13.0"


### PR DESCRIPTION
## Summary
- add decimal.js helper for precise decimal arithmetic
- integrate decimal operations into calculator with UI toggle
- include unit tests for decimal math

## Testing
- `yarn test __tests__/decimal.test.ts`
- `yarn test __tests__/calculator.app.test.js`
- `yarn lint utils/decimal.ts apps/calculator/main.js apps/calculator/index.tsx __tests__/decimal.test.ts` *(fails: repo-wide eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9543c64f083288c48dbc2f60c1d1c