### PR TITLE
feat: add gamepad bindings and haptic support

### DIFF
--- a/__tests__/gamepad.test.ts
+++ b/__tests__/gamepad.test.ts
@@ -1,7 +1,7 @@
 import type { TwinStickState } from '../utils/gamepad';
 
 let gamepad: any;
-let pollTwinStick: (deadzone?: number) => TwinStickState;
+let pollTwinStick: (deadzone?: number, vibrate?: boolean) => TwinStickState;
 let rafCallback: FrameRequestCallback | null;
 
 beforeEach(() => {
@@ -65,5 +65,16 @@ describe('pollTwinStick', () => {
 
     const state = pollTwinStick();
     expect(state).toEqual({ moveX: 0.3, moveY: 0, aimX: 0, aimY: 0.6, fire: true });
+  });
+
+  test('triggers vibration when enabled and firing', () => {
+    const pad: any = {
+      axes: [0, 0, 0, 0],
+      buttons: [{ pressed: true }],
+      vibrationActuator: { playEffect: jest.fn() },
+    };
+    (navigator as any).getGamepads = () => [pad];
+    pollTwinStick(0.25, true);
+    expect(pad.vibrationActuator.playEffect).toHaveBeenCalled();
   });
 });

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import HelpOverlay from './HelpOverlay';
+import HelpOverlay, { GAME_INSTRUCTIONS } from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
+import InputRemap from './Games/common/input-remap/InputRemap';
+import useInputMapping from './Games/common/input-remap/useInputMapping';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
 interface GameLayoutProps {
@@ -25,11 +27,15 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   editor,
 }) => {
   const [showHelp, setShowHelp] = useState(false);
+  const [showBindings, setShowBindings] = useState(false);
   const [paused, setPaused] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
+  const info = GAME_INSTRUCTIONS[gameId];
+  const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
+  const toggleBindings = useCallback(() => setShowBindings((b) => !b), []);
 
   const fallbackCopy = useCallback((text: string) => {
     if (navigator.clipboard) {
@@ -127,6 +133,28 @@ const GameLayout: React.FC<GameLayoutProps> = ({
 
   return (
     <div className="relative h-full w-full" data-reduced-motion={prefersReducedMotion}>
+      {showBindings && info?.actions && (
+        <div
+          className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="p-4 bg-gray-800 rounded shadow-lg">
+            <InputRemap
+              mapping={mapping}
+              setKey={setKey as (action: string, key: string) => string | null}
+              actions={info.actions}
+            />
+            <button
+              type="button"
+              onClick={toggleBindings}
+              className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
       {showHelp && <HelpOverlay gameId={gameId} onClose={close} />}
       {paused && (
         <div
@@ -159,6 +187,15 @@ const GameLayout: React.FC<GameLayoutProps> = ({
             className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
           >
             Share Score
+          </button>
+        )}
+        {info?.actions && (
+          <button
+            type="button"
+            onClick={toggleBindings}
+            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          >
+            Controls
           </button>
         )}
         <button

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -40,6 +40,7 @@ const MULTIPLIER_DURATION = 5000;
 const COMBO_WINDOW = 3000;
 const FLIPPER_MAX = 0.5;
 const FLIPPER_SPEED = 0.25;
+const GAMEPAD_DEADZONE = 0.2;
 
 const Pinball = () => {
   const canvasRef = useCanvasResize(WIDTH, HEIGHT);
@@ -335,10 +336,16 @@ const Pinball = () => {
       const gps = navigator.getGamepads ? navigator.getGamepads() : [];
       const gp = gps && gps[0];
       if (!gp) return;
-      const pressed = gp.buttons[5]?.pressed || gp.axes[1] < -0.8;
+      const pressed =
+        gp.buttons[5]?.pressed || gp.axes[1] < -1 + GAMEPAD_DEADZONE;
       if (pressed && performance.now() - lastGamepadNudge.current > 300) {
         handleNudge();
         lastGamepadNudge.current = performance.now();
+        gp.vibrationActuator?.playEffect?.('dual-rumble', {
+          duration: 40,
+          strongMagnitude: 1.0,
+          weakMagnitude: 1.0,
+        });
       }
     };
 

--- a/hooks/useGamepad.ts
+++ b/hooks/useGamepad.ts
@@ -1,18 +1,23 @@
 import { useEffect, useState } from 'react';
 import { pollTwinStick, TwinStickState } from '../utils/gamepad';
 
-export default function useGamepad(deadzone: number = 0.25): TwinStickState {
-  const [state, setState] = useState<TwinStickState>(() => pollTwinStick(deadzone));
+export default function useGamepad(
+  deadzone: number = 0.25,
+  vibrate = false,
+): TwinStickState {
+  const [state, setState] = useState<TwinStickState>(() =>
+    pollTwinStick(deadzone, vibrate),
+  );
 
   useEffect(() => {
     let raf: number;
     const read = () => {
-      setState(pollTwinStick(deadzone));
+      setState(pollTwinStick(deadzone, vibrate));
       raf = requestAnimationFrame(read);
     };
     raf = requestAnimationFrame(read);
     return () => cancelAnimationFrame(raf);
-  }, [deadzone]);
+  }, [deadzone, vibrate]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
- add per-game gamepad binding overlay
- support gamepad button capture in input remapper
- extend gamepad utilities for deadzones and vibration, including pinball support

## Testing
- `npx eslint components/apps/GameLayout.tsx components/apps/Games/common/input-remap/InputRemap.tsx hooks/useGamepad.ts utils/gamepad.ts components/apps/pinball.js __tests__/gamepad.test.ts`
- `yarn test __tests__/gamepad.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b95446ebe48328a81b672049eb3f3a