### PR TITLE
feat: centralize game audio tones

### DIFF
--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -16,6 +16,7 @@ import GameLayout from './GameLayout';
 import { vibrate } from './Games/common/haptics';
 import { getMapping } from './Games/common/input-remap/useInputMapping';
 import useOPFS from '../../hooks/useOPFS';
+import { playTone } from '../../utils/audio';
 
 // Arcade-style tuning constants
 const THRUST = 0.1;
@@ -108,7 +109,6 @@ class Quadtree {
 const Asteroids = () => {
   const canvasRef = useRef(null);
   const requestRef = useRef();
-  const audioCtx = useRef(null);
   const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
   const controlsRef = useRef(useGameControls(canvasRef));
   const [paused, setPaused] = useState(false);
@@ -263,17 +263,7 @@ const Asteroids = () => {
 
     // Audio using WebAudio lazily
     const playSound = (freq) => {
-      if (!audioCtx.current) audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
-      const ctxAudio = audioCtx.current;
-      const osc = ctxAudio.createOscillator();
-      const gain = ctxAudio.createGain();
-      osc.frequency.value = freq;
-      osc.connect(gain);
-      gain.connect(ctxAudio.destination);
-      osc.start();
-      gain.gain.setValueAtTime(0.2, ctxAudio.currentTime);
-      gain.gain.exponentialRampToValueAtTime(0.0001, ctxAudio.currentTime + 0.3);
-      osc.stop(ctxAudio.currentTime + 0.3);
+      playTone({ freq, ms: 300 });
     };
 
     // Spawn asteroids for a level

--- a/components/apps/blackjack.js
+++ b/components/apps/blackjack.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { playTone } from '../../utils/audio';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import { BlackjackGame, basicStrategy, cardValue, handValue } from './blackjack/engine';
 
@@ -13,7 +14,6 @@ const Blackjack = () => {
   const gameRef = useRef(null);
   const animRef = useRef(null);
   const animationsRef = useRef([]); // active tweens
-  const audioCtxRef = useRef(null);
 
   const [bet, setBet] = useState(0);
   const [bankroll, setBankroll] = useState(1000);
@@ -97,28 +97,12 @@ const Blackjack = () => {
 
   const playSound = () => {
     if (!sound) return;
-    const ctx = audioCtxRef.current || (audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)());
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.frequency.value = 440;
-    gain.gain.value = 0.1;
-    osc.start();
-    osc.stop(ctx.currentTime + 0.1);
+    playTone({ freq: 440, ms: 100 });
   };
 
   const playChipSound = () => {
     if (!sound) return;
-    const ctx = audioCtxRef.current || (audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)());
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.frequency.value = 600 + Math.random() * 400; // pitch jitter
-    gain.gain.value = 0.15;
-    osc.start();
-    osc.stop(ctx.currentTime + 0.05);
+    playTone({ freq: 600 + Math.random() * 400, ms: 50 });
   };
 
   const start = () => {

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import { CAR_SKINS, loadSkinAssets } from '../../apps/games/car-racer/customization';
 import { hasOffscreenCanvas } from '../../utils/feature';
+import { playTone } from '../../utils/audio';
 
 // Canvas dimensions
 const WIDTH = 300;
@@ -86,21 +87,10 @@ const CarRacer = () => {
 
   const currentSkin = CAR_SKINS.find((s) => s.key === skin) || CAR_SKINS[0];
 
-  const audioCtxRef = useRef(null);
   const playBeep = React.useCallback(() => {
     if (!soundRef.current || typeof window === 'undefined') return;
-    if (!audioCtxRef.current)
-      audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
-    const ctx = audioCtxRef.current;
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    gain.gain.value = 0.1;
-    osc.frequency.value = 440;
-    osc.start();
-    osc.stop(ctx.currentTime + 0.1);
-  }, [soundRef, audioCtxRef]);
+    playTone({ freq: 440, ms: 100 });
+  }, [soundRef]);
 
   useEffect(() => {
     const stored = localStorage.getItem('car_racer_high');

--- a/components/apps/checkers.js
+++ b/components/apps/checkers.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { playTone } from '../../utils/audio';
 import GameLayout from './GameLayout';
 import usePersistedState from '../../hooks/usePersistedState';
 import {
@@ -143,17 +144,7 @@ const Checkers = () => {
 
   const playBeep = useCallback(() => {
     if (!sound) return;
-    try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
-      const osc = ctx.createOscillator();
-      osc.type = 'square';
-      osc.frequency.value = 500;
-      osc.connect(ctx.destination);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.1);
-    } catch (e) {
-      // ignore
-    }
+    playTone({ freq: 500, ms: 100, wave: 'square' });
   }, [sound]);
 
   const draw = useCallback(

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from "react";
 import { Chess } from "chess.js";
 import { suggestMoves } from "../../games/chess/engine/wasmEngine";
+import { playTone } from "../../utils/audio";
 
 // 0x88 board representation utilities
 const EMPTY = 0;
@@ -280,12 +281,7 @@ const getBestMove = (board, side, depth) => {
 };
 
 const playBeep = () => {
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  const osc = ctx.createOscillator();
-  osc.frequency.value = 400;
-  osc.connect(ctx.destination);
-  osc.start();
-  osc.stop(ctx.currentTime + 0.1);
+  playTone({ freq: 400, ms: 100 });
 };
 
 const ChessGame = () => {

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -7,6 +7,7 @@ import {
   getRandomSkin,
 } from '../../apps/games/frogger/config';
 import { getLevelConfig } from '../../apps/games/frogger/levels';
+import { playTone } from '../../utils/audio';
 
 const WIDTH = 7;
 const HEIGHT = 8;
@@ -145,7 +146,6 @@ const Frogger = () => {
   const [reduceMotion, setReduceMotion] = useState(false);
   const reduceMotionRef = useRef(reduceMotion);
   const canvasRef = useRef(null);
-  const audioCtxRef = useRef(null);
   const nextLife = useRef(500);
   const holdRef = useRef();
   const rippleRef = useRef(0);
@@ -198,19 +198,9 @@ const Frogger = () => {
     return () => mql.removeEventListener('change', handler);
   }, []);
 
-  const playTone = (freq, duration = 0.1) => {
+  const tone = (freq, duration = 0.1) => {
     if (!soundRef.current) return;
-    if (!audioCtxRef.current)
-      audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
-    const ctx = audioCtxRef.current;
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.frequency.value = freq;
-    gain.gain.setValueAtTime(0.1, ctx.currentTime);
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + duration);
+    playTone({ freq, ms: duration * 1000 });
   };
 
   const moveFrog = useCallback((dx, dy) => {
@@ -221,7 +211,7 @@ const Frogger = () => {
       if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT) return prev;
       vibrate(50);
       if (dy === -1) setScore((s) => s + 10);
-      playTone(440, 0.05);
+      tone(440, 0.05);
       return { x, y };
     });
   }, [setFrog, setScore]);
@@ -322,7 +312,7 @@ const Frogger = () => {
       deathStreakRef.current += 1;
       if (deathStreakRef.current >= 2) safeFlashRef.current = 2;
       ReactGA.event({ category: 'Frogger', action: 'death', value: level });
-      playTone(220, 0.2);
+      tone(220, 0.2);
       setLives((l) => {
         const newLives = l - 1;
         if (newLives <= 0) {
@@ -542,7 +532,7 @@ const Frogger = () => {
         } else if (padResult.levelComplete) {
           setStatus('Level Complete!');
           setScore((s) => s + 100);
-          playTone(880, 0.2);
+          tone(880, 0.2);
           ReactGA.event({
             category: 'Frogger',
             action: 'level_complete',
@@ -562,7 +552,7 @@ const Frogger = () => {
         } else if (padResult.padHit) {
           setScore((s) => s + 100);
           setPads([...padsRef.current]);
-          playTone(660, 0.1);
+          tone(660, 0.1);
           deathStreakRef.current = 0;
           frogRef.current = { ...initialFrog };
         }

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import GameLayout from './GameLayout';
 import { createDeck, PATTERN_THEMES, fisherYatesShuffle } from './memory_utils';
+import { playTone } from '../../utils/audio';
 
 const DEFAULT_TIME = { 2: 30, 4: 60, 6: 120 };
 
@@ -83,20 +84,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
 
   const beep = useCallback(() => {
     if (!sound || typeof window === 'undefined') return;
-    try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
-      const osc = ctx.createOscillator();
-      osc.type = 'sine';
-      osc.frequency.value = 600;
-      osc.connect(ctx.destination);
-      osc.start();
-      setTimeout(() => {
-        osc.stop();
-        ctx.close();
-      }, 100);
-    } catch {
-      // ignore audio errors
-    }
+    playTone({ freq: 600, ms: 100 });
   }, [sound]);
 
   const reset = useCallback(() => {

--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { playTone } from '../../utils/audio';
 import usePersistedState from '../../hooks/usePersistedState';
 import calculate3BV from '../../games/minesweeper/metrics';
 import { serializeBoard, deserializeBoard } from '../../games/minesweeper/save';
@@ -162,7 +163,6 @@ const calculateRiskMap = (board) => {
 
 const Minesweeper = () => {
   const canvasRef = useRef(null);
-  const audioRef = useRef(null);
   const workerRef = useRef(null);
   const initWorker = () => {
     if (typeof window !== 'undefined' && typeof Worker === 'function') {
@@ -401,18 +401,8 @@ const Minesweeper = () => {
 
   const playSound = (type) => {
     if (!sound || typeof window === 'undefined') return;
-    if (!audioRef.current)
-      audioRef.current = new (window.AudioContext || window.webkitAudioContext)();
-    const ctx = audioRef.current;
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'square';
-    osc.frequency.value =
-      type === 'boom' ? 120 : type === 'flag' ? 330 : 440;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 0.15);
+    const freq = type === 'boom' ? 120 : type === 'flag' ? 330 : 440;
+    playTone({ freq, ms: 150, wave: 'square' });
   };
 
   const checkAndHandleWin = (newBoard) => {

--- a/components/apps/nonogram.js
+++ b/components/apps/nonogram.js
@@ -12,6 +12,7 @@ import {
   autoFillLines,
 } from "./nonogramUtils";
 import { getDailyPuzzle } from "../../utils/dailyPuzzle";
+import { playTone } from "../../utils/audio";
 
 // visual settings
 const CELL_SIZE = 30;
@@ -79,16 +80,7 @@ const Nonogram = () => {
 
   const playSound = useCallback(() => {
     if (!sound) return;
-    try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
-      const osc = ctx.createOscillator();
-      osc.frequency.value = 880;
-      osc.connect(ctx.destination);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.05);
-    } catch {
-      /* ignore */
-    }
+    playTone({ freq: 880, ms: 50 });
   }, [sound]);
 
   const checkSolved = useCallback(

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import useAssetLoader from '../../hooks/useAssetLoader';
 import SpeedControls from '../../games/pacman/components/SpeedControls';
+import { playTone } from '../../utils/audio';
 
 /**
  * Small Pacman implementation used inside the portfolio. The goal of this
@@ -118,7 +119,6 @@ const Pacman = () => {
   const nextFruitRef = useRef(0);
   const levelTimerRef = useRef(0);
   const statusRef = useRef('Playing');
-  const audioCtxRef = useRef(null);
   const touchStartRef = useRef(null);
   const [paused, setPaused] = useState(false);
   const pausedRef = useRef(false);
@@ -161,21 +161,7 @@ const Pacman = () => {
 
   const playSound = (freq) => {
     if (!soundRef.current) return;
-    try {
-      if (!audioCtxRef.current) {
-        audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
-      }
-      const ctx = audioCtxRef.current;
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.frequency.value = freq;
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.start();
-      osc.stop(ctx.currentTime + 0.1);
-    } catch {
-      // ignore audio errors
-    }
+    playTone({ freq, ms: 100 });
   };
 
   const resetPositions = () => {

--- a/components/apps/platformer.js
+++ b/components/apps/platformer.js
@@ -7,25 +7,9 @@ import {
   movePlayer,
   physics,
 } from '../../public/apps/platformer/engine.js';
+import { playTone } from '../../utils/audio';
 
 const TILE_SIZE = 16;
-
-// simple beep for coin collection
-function playCoinSound() {
-  try {
-    const ac = new (window.AudioContext || window.webkitAudioContext)();
-    const osc = ac.createOscillator();
-    const gain = ac.createGain();
-    osc.frequency.value = 800;
-    osc.connect(gain);
-    gain.connect(ac.destination);
-    osc.start();
-    gain.gain.exponentialRampToValueAtTime(0.001, ac.currentTime + 0.2);
-    osc.stop(ac.currentTime + 0.2);
-  } catch (e) {
-    /* ignore */
-  }
-}
 
 const Platformer = () => {
   const canvasRef = useRef(null);
@@ -182,7 +166,7 @@ const Platformer = () => {
       if (collectCoin(tiles, cx, cy)) {
         score++;
         setAriaMsg(`Score ${score}`);
-        if (sound) playCoinSound();
+        if (sound) playTone({ freq: 800, ms: 200 });
         if (score > progress.highscore)
           setProgress((p) => ({ ...p, highscore: score }));
       }

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { playTone } from '../../utils/audio';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import useGameControls from './useGameControls';
 import usePersistentState from '../../hooks/usePersistentState';
@@ -35,7 +36,6 @@ const PongInner = () => {
   const [offerSDP, setOfferSDP] = useState('');
   const [answerSDP, setAnswerSDP] = useState('');
   const [connected, setConnected] = useState(false);
-  const audioCtxRef = useRef(null);
   const [sound, setSound] = useState(true);
   const [paused, setPaused] = useState(false);
   const pausedRef = useRef(false);
@@ -76,21 +76,7 @@ const PongInner = () => {
     const playSound = useCallback(
       (freq) => {
         if (!sound) return;
-        try {
-          if (!audioCtxRef.current) {
-            audioCtxRef.current = new (window.AudioContext || window.webkitAudioContext)();
-          }
-          const ctx = audioCtxRef.current;
-          const osc = ctx.createOscillator();
-          const gain = ctx.createGain();
-          osc.frequency.value = freq;
-          osc.connect(gain);
-          gain.connect(ctx.destination);
-          osc.start();
-          osc.stop(ctx.currentTime + 0.1);
-        } catch {
-          // ignore audio errors
-        }
+        playTone({ freq, ms: 100 });
       },
       [sound],
     );

--- a/components/apps/reversi.js
+++ b/components/apps/reversi.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { playTone } from '../../utils/audio';
 import {
   SIZE,
   DIRECTIONS,
@@ -19,7 +20,6 @@ const Reversi = () => {
   const playerRef = useRef('B');
   const pausedRef = useRef(false);
   const animRef = useRef(0);
-  const audioRef = useRef(null);
   const workerRef = useRef(null);
   const aiThinkingRef = useRef(false);
   const reduceMotionRef = useRef(false);
@@ -98,18 +98,7 @@ const Reversi = () => {
 
   const playSound = React.useCallback(() => {
     if (!sound) return;
-    const ctx =
-      audioRef.current || new (window.AudioContext || window.webkitAudioContext)();
-    audioRef.current = ctx;
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.frequency.value = 500;
-    osc.start();
-    gain.gain.setValueAtTime(0.3, ctx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.1);
-    osc.stop(ctx.currentTime + 0.1);
+    playTone({ freq: 500, ms: 100 });
   }, [sound]);
 
   const queueFlips = (r, c, player, prevBoard) => {

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -6,6 +6,7 @@ import useGameHaptics from '../../hooks/useGameHaptics';
 import usePersistentState from '../../hooks/usePersistentState';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { playTone } from '../../utils/audio';
 import {
   GRID_SIZE,
   randomFood,
@@ -44,7 +45,6 @@ const Snake = () => {
   const rafRef = useRef();
   const lastRef = useRef(0);
   const runningRef = useRef(true);
-  const audioCtx = useRef(null);
   const haptics = useGameHaptics();
   const prefersReducedMotion = usePrefersReducedMotion();
 
@@ -113,26 +113,7 @@ const Snake = () => {
   const beep = useCallback(
     (freq) => {
       if (!sound) return;
-      try {
-        const ctx =
-          audioCtx.current ||
-          new (window.AudioContext || window.webkitAudioContext)();
-        audioCtx.current = ctx;
-        const osc = ctx.createOscillator();
-        const gain = ctx.createGain();
-        osc.frequency.value = freq;
-        osc.connect(gain);
-        gain.connect(ctx.destination);
-        gain.gain.setValueAtTime(0.2, ctx.currentTime);
-        gain.gain.exponentialRampToValueAtTime(
-          0.001,
-          ctx.currentTime + 0.15,
-        );
-        osc.start();
-        osc.stop(ctx.currentTime + 0.15);
-      } catch {
-        // ignore audio errors
-      }
+      playTone({ freq, ms: 150 });
     },
     [sound],
   );

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import GameLayout from './GameLayout';
 import useGameControls from './useGameControls';
 import levelPack from './sokoban_levels.json';
+import { playTone } from '../../utils/audio';
 
 const TILE = 32;
 
@@ -151,21 +152,6 @@ const loadState = (idx, lvls) => {
     setHistoryIndex(0);
   }, [levelIndex, levels]);
 
-  const playBeep = () => {
-    if (!sound) return;
-    try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.frequency.value = 440;
-      osc.start();
-      osc.stop(ctx.currentTime + 0.05);
-    } catch {
-      // ignore audio errors
-    }
-  };
 
 const move = ({ x, y }) => {
   if (paused) return;
@@ -183,7 +169,7 @@ const move = ({ x, y }) => {
     .concat([newState]);
   setHistoryIndex(historyRef.current.length - 1);
   setState(newState);
-  playBeep();
+  if (sound) playTone({ freq: 440, ms: 50 });
   const progressKey = `sokoban-progress-${levelIndex}`;
   if (checkWin(res.board)) {
     const bestKey = `sokoban-best-${levelIndex}`;

--- a/components/apps/space-invaders.js
+++ b/components/apps/space-invaders.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import { playTone } from '../../utils/audio';
 import GameLayout from './GameLayout';
 import useAssetLoader from '../../hooks/useAssetLoader';
 
@@ -87,16 +88,7 @@ const SpaceInvaders = () => {
 
   const playSound = (freq) => {
     if (!soundRef.current) return;
-    if (!audioCtx.current)
-      audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
-    const osc = audioCtx.current.createOscillator();
-    const gain = audioCtx.current.createGain();
-    osc.frequency.value = freq;
-    osc.connect(gain);
-    gain.connect(audioCtx.current.destination);
-    gain.gain.value = 0.1;
-    osc.start();
-    osc.stop(audioCtx.current.currentTime + 0.1);
+    playTone({ freq, ms: 100 });
   };
 
   const playSweep = (start, end, duration) => {

--- a/components/apps/tetris.js
+++ b/components/apps/tetris.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import confetti from 'canvas-confetti';
 import usePersistentState from '../usePersistentState';
 import { PieceGenerator } from '../../games/tetris/logic';
+import { playTone } from '../../utils/audio';
 
 const WIDTH = 10;
 const HEIGHT = 20;
@@ -277,34 +278,14 @@ const Tetris = () => {
 
   const dropInterval = Math.max(100, 1000 - (level - 1) * 100);
 
-  const audioCtxRef = useRef(null);
   const playSound = useCallback(
     (freq = 440, duration = 0.1) => {
       if (!sound) return;
-      try {
-        const ctx =
-          audioCtxRef.current ||
-          new (window.AudioContext || window.webkitAudioContext)();
-        audioCtxRef.current = ctx;
-        const osc = ctx.createOscillator();
-        osc.type = 'square';
-        osc.frequency.value = freq;
-        osc.connect(ctx.destination);
-        osc.start();
-        osc.stop(ctx.currentTime + duration);
-      } catch {
-        /* ignore */
-      }
+      playTone({ freq, ms: duration * 1000, wave: 'square' });
     },
     [sound],
   );
 
-  useEffect(
-    () => () => {
-      audioCtxRef.current?.close?.();
-    },
-    [],
-  );
 
   const thud = useCallback(() => {
     playSound(120, 0.05);

--- a/components/apps/word-search.js
+++ b/components/apps/word-search.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { playTone } from "../../utils/audio";
 import seedrandom from "seedrandom";
 import useOPFS from "../../hooks/useOPFS.js";
 
@@ -287,21 +288,7 @@ const WordSearch = () => {
 
   const playBeep = () => {
     if (!sound) return;
-    try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.frequency.value = 600;
-      osc.start();
-      setTimeout(() => {
-        osc.stop();
-        ctx.close();
-      }, 150);
-    } catch {
-      // ignore audio errors
-    }
+    playTone({ freq: 600, ms: 150 });
   };
 
   useEffect(() => {

--- a/utils/audio.ts
+++ b/utils/audio.ts
@@ -1,0 +1,34 @@
+export interface ToneOptions {
+  freq: number; // frequency in Hz
+  ms: number; // duration in milliseconds
+  wave?: OscillatorType; // waveform type
+}
+
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (ctx) return ctx;
+  const AudioCtor = (window as any).AudioContext || (window as any).webkitAudioContext;
+  if (!AudioCtor) return null;
+  ctx = new AudioCtor();
+  return ctx;
+}
+
+export function playTone({ freq, ms, wave = 'sine' }: ToneOptions): void {
+  if (typeof window === 'undefined') return;
+  const audioCtx = getCtx();
+  if (!audioCtx) return;
+  if (audioCtx.state === 'suspended') audioCtx.resume();
+  const oscillator = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  oscillator.type = wave;
+  oscillator.frequency.value = freq;
+  oscillator.connect(gain);
+  gain.connect(audioCtx.destination);
+  const start = audioCtx.currentTime;
+  gain.gain.setValueAtTime(0.0001, start);
+  gain.gain.exponentialRampToValueAtTime(0.5, start + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + ms / 1000);
+  oscillator.start(start);
+  oscillator.stop(start + ms / 1000 + 0.05);
+}


### PR DESCRIPTION
## Summary
- add `playTone` helper using Web Audio API
- unify game tone logic across apps to use `playTone`

## Testing
- `npm test` *(fails: ReferenceError: setTheme is not defined in themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b95447dbcc8328b7497c337f9eacb7