### PR TITLE
feat: offload game loops to workers

### DIFF
--- a/apps/pinball/worker.ts
+++ b/apps/pinball/worker.ts
@@ -1,0 +1,208 @@
+import { Engine, Render, World, Bodies, Body, Runner, Events } from 'matter-js';
+
+const themes: Record<string, { bg: string; flipper: string }> = {
+  classic: { bg: '#0b3d91', flipper: '#ffd700' },
+  space: { bg: '#000000', flipper: '#00ffff' },
+  forest: { bg: '#064e3b', flipper: '#9acd32' },
+};
+
+interface InitMessage {
+  type: 'init';
+  canvas: OffscreenCanvas;
+  theme: keyof typeof themes;
+  power: number;
+  bounce: number;
+}
+
+interface KeyMessage {
+  type: 'keydown' | 'keyup';
+  code: string;
+}
+
+interface SettingsMessage {
+  type: 'settings';
+  theme: keyof typeof themes;
+  power: number;
+  bounce: number;
+}
+
+interface TiltMessage {
+  type: 'tilt';
+  value: boolean;
+}
+
+type WorkerMessage =
+  | InitMessage
+  | KeyMessage
+  | SettingsMessage
+  | TiltMessage
+  | { type: 'nudge' };
+
+let engine: Engine | null = null;
+let render: Render | null = null;
+let runner: Runner | null = null;
+let ball: Body | null = null;
+let leftFlipper: Body | null = null;
+let rightFlipper: Body | null = null;
+let power = 1;
+let bounce = 0.5;
+let currentTheme: keyof typeof themes = 'classic';
+let score = 0;
+let tilt = false;
+const sparks: { x: number; y: number; life: number }[] = [];
+const laneGlow = { left: false, right: false };
+
+self.onmessage = ({ data }: MessageEvent<WorkerMessage>) => {
+  if (data.type === 'init') {
+    power = data.power;
+    bounce = data.bounce;
+    currentTheme = data.theme;
+    const canvas = data.canvas;
+    engine = Engine.create();
+    engine.gravity.y = 1;
+    render = Render.create({
+      canvas: canvas as any,
+      engine,
+      options: {
+        width: 400,
+        height: 600,
+        wireframes: false,
+        background: themes[currentTheme].bg,
+      },
+    });
+
+    ball = Bodies.circle(200, 100, 12, { restitution: 0.9, render: { visible: false } });
+    const walls = [
+      Bodies.rectangle(200, 0, 400, 40, { isStatic: true }),
+      Bodies.rectangle(200, 600, 400, 40, { isStatic: true }),
+      Bodies.rectangle(0, 300, 40, 600, { isStatic: true }),
+      Bodies.rectangle(400, 300, 40, 600, { isStatic: true }),
+    ];
+    leftFlipper = Bodies.rectangle(120, 560, 80, 20, {
+      isStatic: true,
+      angle: Math.PI / 8,
+      restitution: bounce,
+      render: { fillStyle: themes[currentTheme].flipper },
+    });
+    rightFlipper = Bodies.rectangle(280, 560, 80, 20, {
+      isStatic: true,
+      angle: -Math.PI / 8,
+      restitution: bounce,
+      render: { fillStyle: themes[currentTheme].flipper },
+    });
+    const leftLane = Bodies.rectangle(80, 80, 40, 10, { isStatic: true, isSensor: true });
+    const rightLane = Bodies.rectangle(320, 80, 40, 10, { isStatic: true, isSensor: true });
+    World.add(engine.world, [ball, ...walls, leftFlipper, rightFlipper, leftLane, rightLane]);
+    Render.run(render);
+    runner = Runner.create();
+    Runner.run(runner, engine);
+
+    Events.on(engine, 'collisionStart', (evt) => {
+      evt.pairs.forEach((pair) => {
+        const bodies = [pair.bodyA, pair.bodyB];
+        if (ball && bodies.includes(ball) && bodies.includes(leftFlipper!)) {
+          const { x, y } = pair.collision.supports[0];
+          sparks.push({ x, y, life: 1 });
+        }
+        if (ball && bodies.includes(ball) && bodies.includes(rightFlipper!)) {
+          const { x, y } = pair.collision.supports[0];
+          sparks.push({ x, y, life: 1 });
+        }
+        if (ball && bodies.includes(ball) && bodies.includes(leftLane)) {
+          laneGlow.left = true;
+          score += 100;
+          self.postMessage({ type: 'score', score });
+          setTimeout(() => (laneGlow.left = false), 500);
+        }
+        if (ball && bodies.includes(ball) && bodies.includes(rightLane)) {
+          laneGlow.right = true;
+          score += 100;
+          self.postMessage({ type: 'score', score });
+          setTimeout(() => (laneGlow.right = false), 500);
+        }
+      });
+    });
+
+    Events.on(render, 'afterRender', () => {
+      if (!ball || !render) return;
+      const ctx = render.context as CanvasRenderingContext2D;
+      const { x, y } = ball.position;
+      const radius = 12;
+      const gradient = ctx.createRadialGradient(x - 4, y - 4, radius / 4, x, y, radius);
+      gradient.addColorStop(0, '#fff');
+      gradient.addColorStop(1, '#999');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      [
+        { lane: leftLane, glow: laneGlow.left },
+        { lane: rightLane, glow: laneGlow.right },
+      ].forEach(({ lane, glow }) => {
+        const { x: lx, y: ly } = lane.position;
+        ctx.save();
+        if (glow) {
+          ctx.shadowColor = '#ffff00';
+          ctx.shadowBlur = 20;
+          ctx.fillStyle = '#ff0';
+        } else {
+          ctx.fillStyle = '#555';
+        }
+        ctx.fillRect(lx - 20, ly - 5, 40, 10);
+        ctx.restore();
+      });
+
+      for (let i = sparks.length - 1; i >= 0; i -= 1) {
+        const s = sparks[i];
+        const r = 8 * s.life;
+        const g = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, r);
+        g.addColorStop(0, 'rgba(255,255,200,0.8)');
+        g.addColorStop(1, 'rgba(255,200,0,0)');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, Math.PI * 2);
+        ctx.fill();
+        s.life -= 0.05;
+        if (s.life <= 0) sparks.splice(i, 1);
+      }
+    });
+  } else if (data.type === 'settings') {
+    power = data.power;
+    bounce = data.bounce;
+    currentTheme = data.theme;
+    if (leftFlipper) {
+      leftFlipper.restitution = bounce;
+      leftFlipper.render.fillStyle = themes[currentTheme].flipper;
+    }
+    if (rightFlipper) {
+      rightFlipper.restitution = bounce;
+      rightFlipper.render.fillStyle = themes[currentTheme].flipper;
+    }
+    if (render) {
+      (render.options as any).background = themes[currentTheme].bg;
+    }
+  } else if (data.type === 'keydown') {
+    if (tilt) return;
+    if (data.code === 'ArrowLeft' && leftFlipper) {
+      Body.setAngle(leftFlipper, -Math.PI / 4 * power);
+    } else if (data.code === 'ArrowRight' && rightFlipper) {
+      Body.setAngle(rightFlipper, Math.PI / 4 * power);
+    }
+  } else if (data.type === 'keyup') {
+    if (data.code === 'ArrowLeft' && leftFlipper) {
+      Body.setAngle(leftFlipper, Math.PI / 8);
+    } else if (data.code === 'ArrowRight' && rightFlipper) {
+      Body.setAngle(rightFlipper, -Math.PI / 8);
+    }
+  } else if (data.type === 'nudge') {
+    if (ball) {
+      Body.applyForce(ball, ball.position, { x: 0.02, y: 0 });
+    }
+  } else if (data.type === 'tilt') {
+    tilt = data.value;
+  }
+};
+
+export {};
+

--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -4,50 +4,57 @@ import { useEffect, useRef, useState } from "react";
 import GameLayout from "../../components/apps/GameLayout";
 import DpsCharts from "../games/tower-defense/components/DpsCharts";
 import RangeUpgradeTree from "../games/tower-defense/components/RangeUpgradeTree";
-import {
-  ENEMY_TYPES,
-  Tower,
-  upgradeTower,
-  Enemy,
-  createEnemyPool,
-  spawnEnemy,
-} from "../games/tower-defense";
+import { Tower, upgradeTower } from "../games/tower-defense";
 
 const GRID_SIZE = 10;
 const CELL_SIZE = 40;
 const CANVAS_SIZE = GRID_SIZE * CELL_SIZE;
 
-interface EnemyInstance extends Enemy {
-  pathIndex: number;
-  progress: number;
-}
-
 const TowerDefense = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const workerRef = useRef<Worker | null>(null);
   const [editing, setEditing] = useState(true);
   const [path, setPath] = useState<{ x: number; y: number }[]>([]);
   const pathSetRef = useRef<Set<string>>(new Set());
   const [towers, setTowers] = useState<Tower[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
   const [hovered, setHovered] = useState<number | null>(null);
-  const enemiesRef = useRef<EnemyInstance[]>([]);
-  const enemyPool = useRef(createEnemyPool(50));
-  const lastTime = useRef(0);
-  const running = useRef(false);
-  const spawnTimer = useRef(0);
-  const waveRef = useRef(1);
-  const waveCountdownRef = useRef<number | null>(null);
-  const [, forceRerender] = useState(0);
-  const enemiesSpawnedRef = useRef(0);
-  const damageNumbersRef = useRef<
-    {
-      x: number;
-      y: number;
-      value: number;
-      life: number;
-    }[]
-  >([]);
-  const damageTicksRef = useRef<{ x: number; y: number; life: number }[]>([]);
+  const [wave, setWave] = useState(1);
+  const [waveCountdown, setWaveCountdown] = useState<number | null>(null);
+
+  const send = (msg: any, transfer?: Transferable[]) =>
+    workerRef.current?.postMessage(msg, transfer || []);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const worker = new Worker(new URL("./worker.ts", import.meta.url));
+    workerRef.current = worker;
+    const offscreen = canvasRef.current.transferControlToOffscreen();
+    worker.onmessage = (e: MessageEvent<any>) => {
+      if (e.data.type === "state") {
+        setWave(e.data.wave);
+        setWaveCountdown(e.data.countdown);
+      }
+    };
+    worker.postMessage(
+      { type: "init", canvas: offscreen, path, towers },
+      [offscreen],
+    );
+    return () => worker.terminate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    send({ type: "path", path });
+  }, [path]);
+
+  useEffect(() => {
+    send({ type: "towers", towers });
+  }, [towers]);
+
+  useEffect(() => {
+    send({ type: "highlight", selected, hovered });
+  }, [selected, hovered]);
 
   const togglePath = (x: number, y: number) => {
     const key = `${x},${y}`;
@@ -90,210 +97,10 @@ const TowerDefense = () => {
 
   const handleCanvasLeave = () => setHovered(null);
 
-  const draw = () => {
-    const ctx = canvasRef.current?.getContext("2d");
-    if (!ctx) return;
-    ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
-    ctx.strokeStyle = "#555";
-    for (let i = 0; i <= GRID_SIZE; i += 1) {
-      ctx.beginPath();
-      ctx.moveTo(i * CELL_SIZE, 0);
-      ctx.lineTo(i * CELL_SIZE, CANVAS_SIZE);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.moveTo(0, i * CELL_SIZE);
-      ctx.lineTo(CANVAS_SIZE, i * CELL_SIZE);
-      ctx.stroke();
-    }
-    ctx.fillStyle = "rgba(255,255,0,0.2)";
-    path.forEach((c) => {
-      ctx.fillRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
-      ctx.strokeStyle = "yellow";
-      ctx.strokeRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
-    });
-    ctx.fillStyle = "blue";
-    towers.forEach((t, i) => {
-      ctx.beginPath();
-      ctx.arc(
-        t.x * CELL_SIZE + CELL_SIZE / 2,
-        t.y * CELL_SIZE + CELL_SIZE / 2,
-        CELL_SIZE / 3,
-        0,
-        Math.PI * 2,
-      );
-      ctx.fill();
-      if (selected === i || hovered === i) {
-        ctx.strokeStyle = "yellow";
-        ctx.beginPath();
-        ctx.arc(
-          t.x * CELL_SIZE + CELL_SIZE / 2,
-          t.y * CELL_SIZE + CELL_SIZE / 2,
-          t.range * CELL_SIZE,
-          0,
-          Math.PI * 2,
-        );
-        ctx.stroke();
-      }
-    });
-    ctx.fillStyle = "red";
-    enemiesRef.current.forEach((en) => {
-      ctx.beginPath();
-      ctx.arc(
-        en.x * CELL_SIZE + CELL_SIZE / 2,
-        en.y * CELL_SIZE + CELL_SIZE / 2,
-        CELL_SIZE / 4,
-        0,
-        Math.PI * 2,
-      );
-      ctx.fill();
-    });
-    damageTicksRef.current.forEach((t) => {
-      ctx.strokeStyle = `rgba(255,0,0,${t.life})`;
-      ctx.beginPath();
-      ctx.arc(
-        t.x * CELL_SIZE + CELL_SIZE / 2,
-        t.y * CELL_SIZE + CELL_SIZE / 2,
-        (CELL_SIZE / 2) * (1 - t.life),
-        0,
-        Math.PI * 2,
-      );
-      ctx.stroke();
-    });
-    damageNumbersRef.current.forEach((d) => {
-      ctx.fillStyle = `rgba(255,255,255,${d.life})`;
-      ctx.font = "12px sans-serif";
-      ctx.fillText(
-        d.value.toString(),
-        d.x * CELL_SIZE + CELL_SIZE / 2,
-        d.y * CELL_SIZE + CELL_SIZE / 2 - (1 - d.life) * 10,
-      );
-    });
-  };
-
-  const spawnEnemyInstance = () => {
-    if (!path.length) return;
-    const types = Object.keys(ENEMY_TYPES) as (keyof typeof ENEMY_TYPES)[];
-    const type = types[Math.floor(Math.random() * types.length)];
-    const spec = ENEMY_TYPES[type];
-    const enemy = spawnEnemy(enemyPool.current, {
-      id: Date.now(),
-      x: path[0].x,
-      y: path[0].y,
-      pathIndex: 0,
-      progress: 0,
-      health: spec.health,
-      resistance: 0,
-      baseSpeed: spec.speed,
-      slow: null,
-      dot: null,
-      type,
-    });
-    if (enemy) enemiesRef.current.push(enemy as EnemyInstance);
-  };
-
-  const update = (time: number) => {
-    const dt = (time - lastTime.current) / 1000;
-    lastTime.current = time;
-
-    if (waveCountdownRef.current !== null) {
-      waveCountdownRef.current -= dt;
-      forceRerender((n) => n + 1);
-      if (waveCountdownRef.current <= 0) {
-        waveCountdownRef.current = null;
-        running.current = true;
-        spawnTimer.current = 0;
-        enemiesSpawnedRef.current = 0;
-      }
-    } else if (running.current) {
-      spawnTimer.current += dt;
-      if (
-        spawnTimer.current > 1 &&
-        enemiesSpawnedRef.current < waveRef.current * 5
-      ) {
-        spawnTimer.current = 0;
-        spawnEnemyInstance();
-        enemiesSpawnedRef.current += 1;
-      }
-      enemiesRef.current.forEach((en) => {
-        const next = path[en.pathIndex + 1];
-        if (!next) return;
-        const dx = next.x - en.x;
-        const dy = next.y - en.y;
-        const dist = Math.hypot(dx, dy);
-        const step = (en.baseSpeed * dt) / CELL_SIZE;
-        if (step >= dist) {
-          en.x = next.x;
-          en.y = next.y;
-          en.pathIndex += 1;
-        } else {
-          en.x += (dx / dist) * step;
-          en.y += (dy / dist) * step;
-        }
-      });
-      enemiesRef.current = enemiesRef.current.filter((e) => {
-        const reached = e.pathIndex >= path.length - 1;
-        return e.health > 0 && !reached;
-      });
-      towers.forEach((t) => {
-        (t as any).cool = (t as any).cool ? (t as any).cool - dt : 0;
-        if ((t as any).cool <= 0) {
-          const enemy = enemiesRef.current.find(
-            (e) => Math.hypot(e.x - t.x, e.y - t.y) <= t.range,
-          );
-          if (enemy) {
-            enemy.health -= t.damage;
-            damageNumbersRef.current.push({
-              x: enemy.x,
-              y: enemy.y,
-              value: t.damage,
-              life: 1,
-            });
-            damageTicksRef.current.push({
-              x: enemy.x,
-              y: enemy.y,
-              life: 1,
-            });
-            (t as any).cool = 1;
-          }
-        }
-      });
-      damageNumbersRef.current.forEach((d) => {
-        d.y -= dt * 0.5;
-        d.life -= dt * 2;
-      });
-      damageNumbersRef.current = damageNumbersRef.current.filter(
-        (d) => d.life > 0,
-      );
-      damageTicksRef.current.forEach((t) => {
-        t.life -= dt * 2;
-      });
-      damageTicksRef.current = damageTicksRef.current.filter((t) => t.life > 0);
-      if (
-        enemiesSpawnedRef.current >= waveRef.current * 5 &&
-        enemiesRef.current.length === 0
-      ) {
-        running.current = false;
-        waveRef.current += 1;
-        waveCountdownRef.current = 5;
-        forceRerender((n) => n + 1);
-      }
-    }
-    draw();
-    requestAnimationFrame(update);
-  };
-
-  useEffect(() => {
-    lastTime.current = performance.now();
-    requestAnimationFrame(update);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const start = () => {
     if (!path.length) return;
     setEditing(false);
-    waveRef.current = 1;
-    waveCountdownRef.current = 3;
-    forceRerender((n) => n + 1);
+    send({ type: "start" });
   };
 
   const upgrade = (type: "range" | "damage") => {
@@ -310,9 +117,9 @@ const TowerDefense = () => {
   return (
     <GameLayout gameId="tower-defense">
       <div className="p-2 space-y-2">
-        {waveCountdownRef.current !== null && (
+        {waveCountdown !== null && (
           <div className="text-center bg-gray-700 text-white py-1 rounded">
-            Wave {waveRef.current} in {Math.ceil(waveCountdownRef.current)}
+            Wave {wave} in {Math.ceil(waveCountdown)}
           </div>
         )}
         <div className="space-x-2 mb-2">
@@ -325,7 +132,7 @@ const TowerDefense = () => {
           <button
             className="px-2 py-1 bg-gray-700 rounded"
             onClick={start}
-            disabled={running.current || waveCountdownRef.current !== null}
+            disabled={waveCountdown !== null}
           >
             Start
           </button>
@@ -365,3 +172,4 @@ const TowerDefense = () => {
 };
 
 export default TowerDefense;
+

--- a/apps/tower-defense/worker.ts
+++ b/apps/tower-defense/worker.ts
@@ -1,0 +1,259 @@
+import {
+  ENEMY_TYPES,
+  Tower,
+  Enemy,
+  createEnemyPool,
+  spawnEnemy,
+} from '../games/tower-defense';
+
+const GRID_SIZE = 10;
+const CELL_SIZE = 40;
+const CANVAS_SIZE = GRID_SIZE * CELL_SIZE;
+
+interface Cell { x: number; y: number }
+
+interface EnemyInstance extends Enemy {
+  pathIndex: number;
+  progress: number;
+}
+
+interface InitMessage {
+  type: 'init';
+  canvas: OffscreenCanvas;
+  path: Cell[];
+  towers: Tower[];
+}
+
+type WorkerMessage =
+  | InitMessage
+  | { type: 'path'; path: Cell[] }
+  | { type: 'towers'; towers: Tower[] }
+  | { type: 'highlight'; selected: number | null; hovered: number | null }
+  | { type: 'start' };
+
+let ctx: OffscreenCanvasRenderingContext2D | null = null;
+let path: Cell[] = [];
+let towers: Tower[] = [];
+let selected: number | null = null;
+let hovered: number | null = null;
+const enemies: EnemyInstance[] = [];
+const enemyPool = createEnemyPool(50);
+let lastTime = 0;
+let running = false;
+let spawnTimer = 0;
+let wave = 1;
+let waveCountdown: number | null = null;
+let enemiesSpawned = 0;
+const damageNumbers: { x: number; y: number; value: number; life: number }[] = [];
+const damageTicks: { x: number; y: number; life: number }[] = [];
+
+function draw() {
+  if (!ctx) return;
+  ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  ctx.strokeStyle = '#555';
+  for (let i = 0; i <= GRID_SIZE; i += 1) {
+    ctx.beginPath();
+    ctx.moveTo(i * CELL_SIZE, 0);
+    ctx.lineTo(i * CELL_SIZE, CANVAS_SIZE);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, i * CELL_SIZE);
+    ctx.lineTo(CANVAS_SIZE, i * CELL_SIZE);
+    ctx.stroke();
+  }
+  ctx.fillStyle = 'rgba(255,255,0,0.2)';
+  path.forEach((c) => {
+    ctx.fillRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+    ctx.strokeStyle = 'yellow';
+    ctx.strokeRect(c.x * CELL_SIZE, c.y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+  });
+  ctx.fillStyle = 'blue';
+  towers.forEach((t, i) => {
+    ctx.beginPath();
+    ctx.arc(
+      t.x * CELL_SIZE + CELL_SIZE / 2,
+      t.y * CELL_SIZE + CELL_SIZE / 2,
+      CELL_SIZE / 3,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+    if (selected === i || hovered === i) {
+      ctx.strokeStyle = 'yellow';
+      ctx.beginPath();
+      ctx.arc(
+        t.x * CELL_SIZE + CELL_SIZE / 2,
+        t.y * CELL_SIZE + CELL_SIZE / 2,
+        t.range * CELL_SIZE,
+        0,
+        Math.PI * 2,
+      );
+      ctx.stroke();
+    }
+  });
+  ctx.fillStyle = 'red';
+  enemies.forEach((en) => {
+    ctx.beginPath();
+    ctx.arc(
+      en.x * CELL_SIZE + CELL_SIZE / 2,
+      en.y * CELL_SIZE + CELL_SIZE / 2,
+      CELL_SIZE / 4,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  });
+  damageTicks.forEach((t) => {
+    ctx.strokeStyle = `rgba(255,0,0,${t.life})`;
+    ctx.beginPath();
+    ctx.arc(
+      t.x * CELL_SIZE + CELL_SIZE / 2,
+      t.y * CELL_SIZE + CELL_SIZE / 2,
+      (CELL_SIZE / 2) * (1 - t.life),
+      0,
+      Math.PI * 2,
+    );
+    ctx.stroke();
+  });
+  damageNumbers.forEach((d) => {
+    ctx.fillStyle = `rgba(255,255,255,${d.life})`;
+    ctx.font = '12px sans-serif';
+    ctx.fillText(
+      d.value.toString(),
+      d.x * CELL_SIZE + CELL_SIZE / 2,
+      d.y * CELL_SIZE + CELL_SIZE / 2 - (1 - d.life) * 10,
+    );
+  });
+}
+
+function spawnEnemyInstance() {
+  if (!path.length) return;
+  const types = Object.keys(ENEMY_TYPES) as (keyof typeof ENEMY_TYPES)[];
+  const type = types[Math.floor(Math.random() * types.length)];
+  const spec = ENEMY_TYPES[type];
+  const enemy = spawnEnemy(enemyPool, {
+    id: Date.now(),
+    x: path[0].x,
+    y: path[0].y,
+    pathIndex: 0,
+    progress: 0,
+    health: spec.health,
+    resistance: 0,
+    baseSpeed: spec.speed,
+    slow: null,
+    dot: null,
+    type,
+  });
+  if (enemy) enemies.push(enemy as EnemyInstance);
+}
+
+function update(time: number) {
+  const dt = (time - lastTime) / 1000;
+  lastTime = time;
+
+  if (waveCountdown !== null) {
+    waveCountdown -= dt;
+    if (waveCountdown <= 0) {
+      waveCountdown = null;
+      running = true;
+      spawnTimer = 0;
+      enemiesSpawned = 0;
+    }
+  } else if (running) {
+    spawnTimer += dt;
+    if (spawnTimer > 1 && enemiesSpawned < wave * 5) {
+      spawnTimer = 0;
+      spawnEnemyInstance();
+      enemiesSpawned += 1;
+    }
+    enemies.forEach((en) => {
+      const next = path[en.pathIndex + 1];
+      if (!next) return;
+      const dx = next.x - en.x;
+      const dy = next.y - en.y;
+      const dist = Math.hypot(dx, dy);
+      const step = (en.baseSpeed * dt) / CELL_SIZE;
+      if (step >= dist) {
+        en.x = next.x;
+        en.y = next.y;
+        en.pathIndex += 1;
+      } else {
+        en.x += (dx / dist) * step;
+        en.y += (dy / dist) * step;
+      }
+    });
+    for (let i = enemies.length - 1; i >= 0; i -= 1) {
+      const e = enemies[i];
+      const reached = e.pathIndex >= path.length - 1;
+      if (e.health <= 0 || reached) enemies.splice(i, 1);
+    }
+    towers.forEach((t) => {
+      (t as any).cool = (t as any).cool ? (t as any).cool - dt : 0;
+      if ((t as any).cool <= 0) {
+        const enemy = enemies.find(
+          (e) => Math.hypot(e.x - t.x, e.y - t.y) <= t.range,
+        );
+        if (enemy) {
+          enemy.health -= t.damage;
+          damageNumbers.push({
+            x: enemy.x,
+            y: enemy.y,
+            value: t.damage,
+            life: 1,
+          });
+          damageTicks.push({ x: enemy.x, y: enemy.y, life: 1 });
+          (t as any).cool = 1;
+        }
+      }
+    });
+    damageNumbers.forEach((d) => {
+      d.y -= dt * 0.5;
+      d.life -= dt * 2;
+    });
+    for (let i = damageNumbers.length - 1; i >= 0; i -= 1) {
+      if (damageNumbers[i].life <= 0) damageNumbers.splice(i, 1);
+    }
+    damageTicks.forEach((t) => {
+      t.life -= dt * 2;
+    });
+    for (let i = damageTicks.length - 1; i >= 0; i -= 1) {
+      if (damageTicks[i].life <= 0) damageTicks.splice(i, 1);
+    }
+    if (enemiesSpawned >= wave * 5 && enemies.length === 0) {
+      running = false;
+      wave += 1;
+      waveCountdown = 5;
+    }
+  }
+
+  draw();
+  self.postMessage({ type: 'state', wave, countdown: waveCountdown });
+  requestAnimationFrame(update);
+}
+
+self.onmessage = ({ data }: MessageEvent<WorkerMessage>) => {
+  if (data.type === 'init') {
+    path = data.path;
+    towers = data.towers;
+    ctx = data.canvas.getContext('2d');
+    lastTime = performance.now();
+    requestAnimationFrame(update);
+  } else if (data.type === 'path') {
+    path = data.path;
+  } else if (data.type === 'towers') {
+    towers = data.towers;
+  } else if (data.type === 'highlight') {
+    selected = data.selected;
+    hovered = data.hovered;
+  } else if (data.type === 'start') {
+    running = false;
+    wave = 1;
+    waveCountdown = 3;
+    enemies.length = 0;
+    damageNumbers.length = 0;
+    damageTicks.length = 0;
+  }
+};
+
+export {};
+


### PR DESCRIPTION
## Summary
- move pinball rendering/physics into a web worker using OffscreenCanvas
- run tower-defense simulation in a worker and keep UI on main thread

## Testing
- `yarn lint apps/pinball/index.tsx apps/pinball/worker.ts apps/tower-defense/index.tsx apps/tower-defense/worker.ts`
- `yarn test apps/pinball/index.tsx apps/pinball/worker.ts apps/tower-defense/index.tsx apps/tower-defense/worker.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b954483ddc8328bd3ac0f2f1cbd50e