### PR TITLE
feat: add input recorder and replay controls

### DIFF
--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useState, useRef } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import useOPFS from '../../hooks/useOPFS.js';
-import GameLayout from './GameLayout';
+import GameLayout, { useInputRecorder } from './GameLayout';
 import useGameControls from './useGameControls';
 import { findHint, scoreMoves } from '../../apps/games/_2048/ai';
 import { vibrate } from './Games/common/haptics';
@@ -238,6 +238,7 @@ const Game2048 = () => {
   const [undosLeft, setUndosLeft] = useState(UNDO_LIMIT);
   const moveLock = useRef(false);
   const { highContrast } = useSettings();
+  const { record, registerReplay } = useInputRecorder();
 
   useEffect(() => {
     if (animCells.size > 0) {
@@ -323,6 +324,7 @@ const Game2048 = () => {
   const handleDirection = useCallback(
     ({ x, y }) => {
       if (won || lost || moveLock.current) return;
+      record({ x, y });
       let result;
       if (x === -1) result = moveLeft(board);
       else if (x === 1) result = moveRight(board);
@@ -392,6 +394,7 @@ const Game2048 = () => {
       seed,
       bestMap,
       setBestMap,
+      record,
     ],
   );
 
@@ -457,6 +460,13 @@ const Game2048 = () => {
     setScore,
     setUndosLeft,
   ]);
+
+  useEffect(() => {
+    registerReplay((dir, idx) => {
+      if (idx === 0) reset();
+      handleDirection(dir);
+    });
+  }, [registerReplay, handleDirection, reset]);
 
   const close = () => {
     document.getElementById('close-2048')?.click();


### PR DESCRIPTION
## Summary
- add input recorder context with pause, snapshot, and replay controls
- hook 2048 game into recorder to log moves and replay deterministically

## Testing
- `npx eslint components/apps/GameLayout.tsx components/apps/2048.js`
- `yarn test components/apps/GameLayout.tsx components/apps/2048.js` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95448de2083288f75697d13765b3f