### PR TITLE
Add column heuristics to Connect Four AI and hover highlighting

### DIFF
--- a/games/connect-four/solver.ts
+++ b/games/connect-four/solver.ts
@@ -192,3 +192,19 @@ export const getBestMove = (
   return { column: bestColumn, scores };
 };
 
+export const evaluateColumns = (
+  board: Board,
+  player: 'red' | 'yellow',
+): (number | null)[] => {
+  const base = scorePosition(board, player);
+  const scores: (number | null)[] = Array(COLS).fill(null);
+  for (let c = 0; c < COLS; c++) {
+    const row = getValidRow(board, c);
+    if (row === -1) continue;
+    const newBoard = board.map((r) => [...r]);
+    newBoard[row][c] = player;
+    scores[c] = scorePosition(newBoard, player) - base;
+  }
+  return scores;
+};
+


### PR DESCRIPTION
## Summary
- expose evaluateColumns in Connect Four solver to score moves by center preference and 3-in-a-row potential
- use these scores in the Connect Four component to color columns on hover

## Testing
- `npm run lint -- games/connect-four/solver.ts components/apps/connect-four.js`
- `npm test -- --passWithNoTests games/connect-four`

------
https://chatgpt.com/codex/tasks/task_e_68b9544bac348328993435cd5fa3692f