### PR TITLE
feat(reversi): add difficulty presets and weighted evaluation

### DIFF
--- a/components/apps/reversi.worker.js
+++ b/components/apps/reversi.worker.js
@@ -1,7 +1,0 @@
-import { bestMove } from './reversiLogic';
-
-onmessage = (e) => {
-  const { board, player, depth } = e.data;
-  const move = bestMove(board, player, depth);
-  postMessage({ move });
-};

--- a/workers/reversi.worker.js
+++ b/workers/reversi.worker.js
@@ -1,0 +1,7 @@
+import { bestMove, DEFAULT_WEIGHTS } from '../components/apps/reversiLogic';
+
+self.onmessage = (e) => {
+  const { board, player, depth, weights = DEFAULT_WEIGHTS } = e.data;
+  const move = bestMove(board, player, depth, weights);
+  self.postMessage({ move });
+};


### PR DESCRIPTION
## Summary
- integrate mobility, corner, and edge weights into Reversi evaluation
- expose configurable difficulty presets in Reversi UI
- move Reversi AI to shared worker with weighted evaluation support

## Testing
- `yarn test __tests__/reversi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9545025a483288daa10ed9d713e65