### PR TITLE
fix 2048 move timing and merges

### DIFF
--- a/__tests__/game2048.test.ts
+++ b/__tests__/game2048.test.ts
@@ -7,6 +7,11 @@ describe('2048 logic', () => {
     expect(slide([2, 2, 2, 0]).row).toEqual([4, 2, 0, 0]);
   });
 
+  it('prevents double merges in a single move', () => {
+    expect(slide([2, 2, 2, 2]).row).toEqual([4, 4, 0, 0]);
+    expect(slide([4, 4, 4, 4]).row).toEqual([8, 8, 0, 0]);
+  });
+
   it('moves left across the board', () => {
     const board: Board = [
       [2, 0, 2, 0],

--- a/__tests__/game2048.test.tsx
+++ b/__tests__/game2048.test.tsx
@@ -75,6 +75,7 @@ test('ignores browser key repeat events', () => {
   expect(getByText(/Moves: 0/)).toBeTruthy();
 });
 
+
 test('tracks moves and allows multiple undos', async () => {
   window.localStorage.setItem('2048-board', JSON.stringify([
     [2, 2, 0, 0],
@@ -86,7 +87,7 @@ test('tracks moves and allows multiple undos', async () => {
   const initial = JSON.parse(window.localStorage.getItem('2048-board') || '[]');
   fireEvent.keyDown(window, { key: 'ArrowLeft' });
   await act(async () => {
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise((r) => setTimeout(r, 500));
   });
   fireEvent.keyDown(window, { key: 'ArrowRight' });
   expect(getByText(/Moves: 2/)).toBeTruthy();
@@ -131,7 +132,7 @@ test('ignores key repeats while a move is in progress', async () => {
   fireEvent.keyDown(window, { key: 'ArrowLeft' });
   expect(getByText(/Moves: 1/)).toBeTruthy();
   await act(async () => {
-    await new Promise((r) => setTimeout(r, 250));
+    await new Promise((r) => setTimeout(r, 500));
   });
   fireEvent.keyDown(window, { key: 'ArrowLeft' });
   expect(getByText(/Moves: 2/)).toBeTruthy();

--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -52,16 +52,19 @@ const slide = (row) => {
   let merged = false;
   let score = 0;
   const mergedPositions = [];
-  for (let i = 0; i < arr.length - 1; i++) {
+  const newRow = [];
+  for (let i = 0; i < arr.length; i++) {
     if (arr[i] === arr[i + 1]) {
-      arr[i] *= 2;
-      score += arr[i];
-      arr[i + 1] = 0;
+      const val = arr[i] * 2;
+      newRow.push(val);
+      score += val;
       merged = true;
-      mergedPositions.push(i);
+      mergedPositions.push(newRow.length - 1);
+      i++;
+    } else {
+      newRow.push(arr[i]);
     }
   }
-  const newRow = arr.filter((n) => n !== 0);
   while (newRow.length < SIZE) newRow.push(0);
   return { row: newRow, merged, score, mergedPositions };
 };
@@ -278,6 +281,12 @@ const Game2048 = () => {
     }
   }, [scorePop]);
 
+  useEffect(() => {
+    if (moveLock.current && animCells.size === 0 && mergeCells.size === 0) {
+      moveLock.current = false;
+    }
+  }, [animCells, mergeCells]);
+
   const today = typeof window !== 'undefined' ? new Date().toISOString().slice(0, 10) : '';
 
   useEffect(() => {
@@ -370,9 +379,6 @@ const Game2048 = () => {
         }
         if (checkWin(moved)) setWon(true);
         else if (!hasMoves(moved)) setLost(true);
-        setTimeout(() => {
-          moveLock.current = false;
-        }, 200);
       }
     },
     [


### PR DESCRIPTION
## Summary
- prevent double merges by revising tile slide logic
- lock user input until animations finish
- adjust 2048 tests for longer move delay

## Testing
- `npx eslint components/apps/2048.js __tests__/game2048.test.tsx __tests__/game2048.test.ts`
- `yarn test __tests__/game2048.test.tsx`
- `yarn test __tests__/game2048.test.ts --runTestsByPath`
- `yarn test __tests__/daily2048Seed.test.tsx`
- `yarn test __tests__/HelpOverlay.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95457e5d483289fea16bc23eb0a8f