### PR TITLE
feat(solitaire): support draw and pass variants

### DIFF
--- a/components/apps/solitaire/engine.ts
+++ b/components/apps/solitaire/engine.ts
@@ -54,6 +54,7 @@ export const initializeGame = (
   draw: 1 | 3 = 1,
   deck?: Card[],
   seed?: number,
+  passLimit: number = 3,
 ): GameState => {
   const workingDeck = deck || createDeck(seed);
   const tableau: Card[][] = Array.from({ length: 7 }, () => []);
@@ -75,7 +76,7 @@ export const initializeGame = (
     foundations: Array.from({ length: 4 }, () => []),
     draw,
     score: 0,
-    redeals: 3,
+    redeals: passLimit,
   };
 };
 


### PR DESCRIPTION
## Summary
- allow configuring draw-1 vs draw-3 and number of passes
- track solitaire statistics per draw/pass variant

## Testing
- `npx eslint components/apps/solitaire/engine.ts components/apps/solitaire/index.tsx`
- `npx tsc -p tsconfig.json --noEmit`
- `yarn test solitaire`


------
https://chatgpt.com/codex/tasks/task_e_68b9545b666883288e9dd44bb8b4d794