### PR TITLE
feat(calculator): add scrollable history tape

### DIFF
--- a/__tests__/calculator.tape.test.tsx
+++ b/__tests__/calculator.tape.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Tape from '../apps/calculator/components/Tape';
+
+describe('Calculator Tape', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<input id="display" />';
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  it('recalls result to display', () => {
+    const { getByLabelText } = render(
+      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+    );
+    fireEvent.click(getByLabelText('recall result'));
+    const display = document.getElementById('display') as HTMLInputElement;
+    expect(display.value).toBe('2');
+  });
+
+  it('copies result to clipboard', async () => {
+    const { getByLabelText } = render(
+      <Tape entries={[{ expr: '1+1', result: '2' }]} />,
+    );
+    fireEvent.click(getByLabelText('copy result'));
+    await waitFor(() =>
+      expect((navigator.clipboard as any).writeText).toHaveBeenCalledWith('2'),
+    );
+  });
+});

--- a/apps/calculator/components/Tape.tsx
+++ b/apps/calculator/components/Tape.tsx
@@ -1,15 +1,56 @@
 'use client';
 
+import { useCallback, useEffect, useRef } from 'react';
+
 interface TapeProps {
   entries: { expr: string; result: string }[];
 }
 
 export default function Tape({ entries }: TapeProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) el.scrollTop = 0;
+  }, [entries]);
+
+  const handleRecall = useCallback((result: string) => {
+    const display = document.getElementById('display') as HTMLInputElement | null;
+    if (display) display.value = result;
+  }, []);
+
+  const handleCopy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // ignore clipboard errors
+    }
+  }, []);
+
   return (
-    <div className="tape font-mono">
+    <div ref={containerRef} className="tape font-mono max-h-40 overflow-y-auto">
       {entries.map(({ expr, result }, i) => (
-        <div key={i} className="p-1 odd:bg-black/20 even:bg-black/10">
-          {expr} = {result}
+        <div
+          key={i}
+          className="p-1 odd:bg-black/20 even:bg-black/10 flex items-center gap-2"
+        >
+          <div className="flex-1">
+            {expr} = {result}
+          </div>
+          <button
+            className="text-xs px-1 py-0.5 bg-black/20 rounded"
+            onClick={() => handleRecall(result)}
+            aria-label="recall result"
+          >
+            Ans
+          </button>
+          <button
+            className="text-xs px-1 py-0.5 bg-black/20 rounded"
+            onClick={() => handleCopy(result)}
+            aria-label="copy result"
+          >
+            Copy
+          </button>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- make calculator history tape scrollable
- add Ans recall and copy-to-clipboard actions
- test tape recall and copy behavior

## Testing
- `npx eslint apps/calculator/components/Tape.tsx __tests__/calculator.tape.test.tsx`
- `yarn test __tests__/calculator.tape.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95464812c8328a26fb50686093faf