### PR TITLE
feat(converter): add numeric notation and trailing zero toggles

### DIFF
--- a/pages/apps/converter.jsx
+++ b/pages/apps/converter.jsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from "next/dynamic";
 
-const Converter = dynamic(() => import('../../apps/converter'), {
+const Converter = dynamic(() => import("../../apps/converter"), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });


### PR DESCRIPTION
## Summary
- allow converter to format results as fixed, engineering, or scientific
- add option to include or strip trailing zeros

## Testing
- `yarn lint apps/converter/index.tsx pages/apps/converter.jsx` *(fails: Component definition is missing display name, etc.)*
- `yarn test apps/converter` *(fails: No tests found, exiting with code 1)*
- `yarn typecheck apps/converter/index.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b9546662108328bd6314fc16fb9591