### PR TITLE
feat: add opfs note storage and search

### DIFF
--- a/pages/notes.tsx
+++ b/pages/notes.tsx
@@ -1,37 +1,122 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
-
-interface NotesPageState {
-  notes: unknown[] | null;
-  error?: string;
-}
+import { useEffect, useRef, useState } from 'react';
+import {
+  loadNotes,
+  saveNotes,
+  StoredNote,
+  exportNotes as exportNotesJson,
+  importNotes as importNotesJson,
+} from '../utils/storage-opfs';
 
 export default function NotesPage() {
-  const [state, setState] = useState<NotesPageState>({ notes: null });
+  const [notes, setNotes] = useState<StoredNote[]>([]);
+  const [query, setQuery] = useState('');
+  const textRef = useRef<HTMLTextAreaElement>(null);
+  const tagsRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    supabase
-      .from('notes')
-      .select()
-      .then(({ data, error }) => {
-        if (error) {
-          setState({ notes: null, error: error.message });
-        } else {
-          setState({ notes: data ?? null });
-        }
-      });
+    void (async () => {
+      setNotes(await loadNotes());
+    })();
   }, []);
 
-  if (state.error) {
-    return <pre>{JSON.stringify({ error: state.error }, null, 2)}</pre>;
-  }
+  const addNote = async () => {
+    const text = textRef.current?.value.trim();
+    if (!text) return;
+    const tags = tagsRef.current?.value
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean) || [];
+    const newNotes = [
+      ...notes,
+      { id: Date.now().toString(), text, tags },
+    ];
+    setNotes(newNotes);
+    await saveNotes(newNotes);
+    if (textRef.current) textRef.current.value = '';
+    if (tagsRef.current) tagsRef.current.value = '';
+  };
 
-  return <pre>{JSON.stringify(state.notes, null, 2)}</pre>;
+  const filteredNotes = notes.filter((n) => {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    return (
+      n.text.toLowerCase().includes(q) ||
+      n.tags.some((tag) => tag.toLowerCase().includes(q))
+    );
+  });
+
+  const exportNotes = async () => {
+    const json = await exportNotesJson();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'notes.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importNotes = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const imported = await importNotesJson(text);
+    setNotes(imported);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="space-y-2">
+        <textarea
+          ref={textRef}
+          placeholder="Note"
+          className="border w-full p-2"
+        />
+        <input
+          ref={tagsRef}
+          placeholder="tags (comma separated)"
+          className="border w-full p-2"
+        />
+        <button onClick={addNote} className="bg-blue-500 text-white px-3 py-1">
+          Add
+        </button>
+      </div>
+      <div className="space-y-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search"
+          className="border w-full p-2"
+        />
+        <div className="flex items-center gap-2">
+          <button
+            onClick={exportNotes}
+            className="bg-green-600 text-white px-3 py-1"
+          >
+            Export
+          </button>
+          <input type="file" accept="application/json" onChange={importNotes} />
+        </div>
+      </div>
+      <ul className="space-y-4">
+        {filteredNotes.map((note) => (
+          <li key={note.id} className="border p-2">
+            <p>{note.text}</p>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {note.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="bg-gray-200 rounded px-2 py-1 text-sm"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
-

--- a/utils/storage-opfs.ts
+++ b/utils/storage-opfs.ts
@@ -1,0 +1,74 @@
+import { isBrowser } from './isBrowser';
+
+const FILE_NAME = 'notes.json';
+const STORAGE_KEY = 'notes';
+
+type StorageWithDirectory = StorageManager & {
+  getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+};
+
+const getStorage = (): StorageWithDirectory =>
+  navigator.storage as StorageWithDirectory;
+
+const hasOpfs =
+  isBrowser && 'storage' in navigator && typeof getStorage().getDirectory === 'function';
+
+export interface StoredNote {
+  id: string;
+  text: string;
+  tags: string[];
+}
+
+export const loadNotes = async (): Promise<StoredNote[]> => {
+  if (!isBrowser) return [];
+  if (hasOpfs) {
+    try {
+      const root = await getStorage().getDirectory!();
+      const handle = await root.getFileHandle(FILE_NAME);
+      const file = await handle.getFile();
+      return JSON.parse(await file.text());
+    } catch {
+      return [];
+    }
+  }
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const saveNotes = async (notes: StoredNote[]): Promise<void> => {
+  if (!isBrowser) return;
+  if (hasOpfs) {
+    const root = await getStorage().getDirectory!();
+    const handle = await root.getFileHandle(FILE_NAME, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(JSON.stringify(notes));
+    await writable.close();
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+};
+
+export const exportNotes = async (): Promise<string> => {
+  const notes = await loadNotes();
+  return JSON.stringify(notes);
+};
+
+export const importNotes = async (json: string): Promise<StoredNote[]> => {
+  try {
+    const notes = JSON.parse(json);
+    if (Array.isArray(notes)) {
+      await saveNotes(notes);
+      return notes as StoredNote[];
+    }
+  } catch {
+    /* ignore */
+  }
+  return [];
+};
+
+const api = { loadNotes, saveNotes, exportNotes, importNotes };
+
+export default api;


### PR DESCRIPTION
## Summary
- implement OPFS-backed storage helper for notes
- add note page with tag chips, search, and JSON export/import

## Testing
- `npx eslint pages/notes.tsx utils/storage-opfs.ts`
- `yarn test` *(fails: theme persistence and unlocking › setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9546cc888832882e21b2c5a84e814