### PR TITLE
Add weather fetch wrapper and widget preferences

### DIFF
--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -22,7 +22,8 @@ const errorMessageEl = document.getElementById('error-message');
 let apiKey = safeLocalStorage?.getItem('weatherApiKey') || '';
 if (apiKey) apiKeyInput.value = apiKey;
 
-let unit = unitToggle.value;
+let unit = safeLocalStorage?.getItem('weatherUnit') || unitToggle.value;
+unitToggle.value = unit;
 
 let savedCities = JSON.parse(safeLocalStorage?.getItem('savedCities') || '[]');
 
@@ -176,6 +177,11 @@ citySearch.addEventListener('input', () => {
 
 unitToggle.addEventListener('change', () => {
   unit = unitToggle.value;
+  try {
+    safeLocalStorage?.setItem('weatherUnit', unit);
+  } catch {
+    // ignore storage errors
+  }
   updateWeather();
 });
 

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,9 +1,59 @@
 import dynamic from 'next/dynamic';
 
+// Dynamically load the full Weather application. This remains the default
+// export so existing imports continue to work.
 const WeatherApp = dynamic(() => import('../../apps/weather'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
+
+/**
+ * A provider agnostic weather fetcher with basic service worker caching.
+ *
+ * This wrapper accepts a provider name and an options object. Each provider
+ * defines a function for building the request URL. Results are cached using
+ * the Cache Storage API so subsequent calls can be served while offline.
+ */
+export async function fetchWeather(provider, opts = {}) {
+  const providers = {
+    openWeather: ({ city, apiKey }) =>
+      `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(
+        city,
+      )}&units=metric&appid=${apiKey}`,
+    openMeteo: ({ lat, lon }) =>
+      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&daily=weathercode,temperature_2m_max&forecast_days=5&timezone=auto`,
+  };
+
+  const buildUrl = providers[provider];
+  if (!buildUrl) throw new Error(`Unsupported weather provider: ${provider}`);
+
+  const url = buildUrl(opts);
+
+  // Attempt to serve from service worker cache first
+  let cached;
+  try {
+    const cache = await caches.open('weather-data');
+    cached = await cache.match(url);
+    if (cached) {
+      return await cached.json();
+    }
+  } catch {
+    // Cache API might be unavailable; ignore errors
+  }
+
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch weather');
+
+  // Cache the fresh response for offline use
+  try {
+    const cache = await caches.open('weather-data');
+    cache.put(url, res.clone());
+  } catch {
+    // Ignore cache errors
+  }
+
+  return await res.json();
+}
 
 export default WeatherApp;
 

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
@@ -5,7 +6,44 @@ const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   loading: () => <p>Loading...</p>,
 });
 
+// Display stored unit preference and the browser's location consent status.
 export default function WeatherWidgetPage() {
-  return <WeatherWidget />;
+  const [unit, setUnit] = useState('metric');
+  const [locationConsent, setLocationConsent] = useState('unknown');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    // Load persisted unit preference if available
+    try {
+      const stored = localStorage.getItem('weatherUnit');
+      if (stored) setUnit(stored);
+    } catch {
+      // ignore storage errors
+    }
+
+    // Query geolocation permission state
+    if (navigator?.permissions?.query) {
+      navigator.permissions
+        .query({ name: 'geolocation' })
+        .then((res) => {
+          setLocationConsent(res.state);
+          res.onchange = () => setLocationConsent(res.state);
+        })
+        .catch(() => setLocationConsent('unknown'));
+    }
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-2 text-sm">
+        Unit preference: {unit === 'imperial' ? 'Fahrenheit' : 'Celsius'}
+      </div>
+      <div className="mb-4 text-sm">
+        Location consent: {locationConsent}
+      </div>
+      <WeatherWidget />
+    </div>
+  );
 }
 


### PR DESCRIPTION
## Summary
- add provider-agnostic weather fetcher with service worker cache
- show unit preference and geolocation consent in weather widget
- persist unit choice in widget script

## Testing
- `npx eslint components/apps/weather.js pages/apps/weather_widget.jsx apps/weather_widget/main.js`
- `yarn test components/apps/weather.js pages/apps/weather_widget.jsx apps/weather_widget/main.js --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b9546e974c8328bc16d271b35a0213