### PR TITLE
feat(plugin-manager): support manifest and sandboxed plugin execution

### DIFF
--- a/__tests__/pluginManager.test.tsx
+++ b/__tests__/pluginManager.test.tsx
@@ -4,14 +4,37 @@ import PluginManager from '../components/apps/plugin-manager';
 describe('PluginManager', () => {
   beforeEach(() => {
     localStorage.clear();
+    (global as any).URL.createObjectURL = jest.fn(() => 'blob:mock');
+    (global as any).URL.revokeObjectURL = jest.fn();
+
+    class MockWorker {
+      onmessage: ((e: { data: any }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(_url: string) {
+        setTimeout(() => {
+          this.onmessage && this.onmessage({ data: 'content' });
+        }, 0);
+      }
+      postMessage() {}
+      terminate() {}
+    }
+    (global as any).Worker = MockWorker;
+
     (global as any).fetch = jest.fn((url: string) => {
       if (url === '/api/plugins') {
         return Promise.resolve({
-          json: () => Promise.resolve([{ id: 'demo', file: 'demo.txt' }]),
+          json: () => Promise.resolve([{ id: 'demo', file: 'demo.json' }]),
         });
       }
-      if (url === '/api/plugins/demo.txt') {
-        return Promise.resolve({ text: () => Promise.resolve('content') });
+      if (url === '/api/plugins/demo.json') {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              id: 'demo',
+              sandbox: 'worker',
+              code: "self.postMessage('content');",
+            }),
+        });
       }
       return Promise.reject(new Error('unknown url'));
     });
@@ -22,7 +45,7 @@ describe('PluginManager', () => {
     const button = await screen.findByText('Install');
     fireEvent.click(button);
     await waitFor(() =>
-      expect(localStorage.getItem('installedPlugins')).toContain('demo')
+      expect(localStorage.getItem('installedPlugins')).toContain('sandbox')
     );
     expect(button.textContent).toBe('Installed');
   });
@@ -37,10 +60,10 @@ describe('PluginManager', () => {
     const runBtn = await screen.findByText('Run');
     fireEvent.click(runBtn);
     await waitFor(() =>
-      expect(localStorage.getItem('lastPluginRun')).toContain('demo')
+      expect(localStorage.getItem('lastPluginRun')).toContain('content')
     );
     unmount();
-    (global as any).URL.createObjectURL = jest.fn();
+    (global as any).URL.createObjectURL = jest.fn(() => 'blob:csv');
     (global as any).URL.revokeObjectURL = jest.fn();
     render(<PluginManager />);
     expect(await screen.findByText(/Last Run: demo/)).toBeInTheDocument();

--- a/pages/api/plugins/[name].js
+++ b/pages/api/plugins/[name].js
@@ -12,7 +12,11 @@ export default function handler(req, res) {
   }
   try {
     const data = fs.readFileSync(filePath);
-    res.setHeader('Content-Type', 'application/octet-stream');
+    if (filePath.endsWith('.json')) {
+      res.setHeader('Content-Type', 'application/json');
+    } else {
+      res.setHeader('Content-Type', 'application/octet-stream');
+    }
     res.send(data);
   } catch {
     res.status(404).end('Not found');

--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -6,7 +6,7 @@ export default function handler(_req, res) {
   try {
     const files = fs.readdirSync(catalogDir);
     const plugins = files
-      .filter((f) => !f.startsWith('.'))
+      .filter((f) => !f.startsWith('.') && f.endsWith('.json'))
       .map((f) => ({ id: path.parse(f).name, file: f }));
     res.status(200).json(plugins);
   } catch {

--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,0 +1,5 @@
+{
+  "id": "demo",
+  "sandbox": "worker",
+  "code": "self.postMessage('content');"
+}

--- a/plugins/catalog/demo.txt
+++ b/plugins/catalog/demo.txt
@@ -1,1 +1,0 @@
-demo plugin content


### PR DESCRIPTION
## Summary
- load plugin manifests from catalog
- run plugins in sandboxed workers or iframes via postMessage
- update tests for manifest install and execution

## Testing
- `npm test __tests__/pluginManager.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9547235ac8328beec646dbe9ee6d4