### PR TITLE
feat: add command palette to vscode

### DIFF
--- a/components/apps/vscode.js
+++ b/components/apps/vscode.js
@@ -1,9 +1,0 @@
-// VSCode app uses a Stack iframe, so no editor dependencies are required
-import dynamic from 'next/dynamic';
-
-const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
-
-
-export default VsCode;
-
-export const displayVsCode = () => <VsCode />;

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React, { useState, useEffect, useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import apps from '../../apps.config';
+
+// Load the actual VSCode app lazily so no editor dependencies are required
+const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
+
+// Simple fuzzy match: returns true if query characters appear in order
+function fuzzyMatch(text, query) {
+  const t = text.toLowerCase();
+  const q = query.toLowerCase();
+  let ti = 0;
+  let qi = 0;
+  while (ti < t.length && qi < q.length) {
+    if (t[ti] === q[qi]) qi++;
+    ti++;
+  }
+  return qi === q.length;
+}
+
+// Static files that can be opened directly in a new tab
+const files = ['README.md', 'CHANGELOG.md', 'package.json'];
+
+export default function VsCodeWrapper({ openApp }) {
+  const [visible, setVisible] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const items = useMemo(() => {
+    const list = [
+      ...apps.map((a) => ({ type: 'app', id: a.id, title: a.title })),
+      ...files.map((f) => ({ type: 'file', id: f, title: f })),
+    ];
+    if (!query) return list;
+    return list.filter((item) => fuzzyMatch(item.title, query));
+  }, [query]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'p') {
+        e.preventDefault();
+        setVisible((v) => !v);
+      } else if (e.key === 'Escape') {
+        setVisible(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const selectItem = (item) => {
+    setVisible(false);
+    setQuery('');
+    if (item.type === 'app' && openApp) {
+      openApp(item.id);
+    } else if (item.type === 'file') {
+      window.open(item.id, '_blank');
+    }
+  };
+
+  return (
+    <div className="relative h-full w-full">
+      <VsCode />
+      {visible && (
+        <div className="absolute inset-0 flex items-start justify-center pt-24 bg-black/50">
+          <div className="bg-gray-800 text-white w-11/12 max-w-md rounded shadow-lg p-2">
+            <input
+              autoFocus
+              className="w-full p-2 mb-2 bg-gray-700 rounded outline-none"
+              placeholder="Search apps or files"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <ul className="max-h-60 overflow-y-auto">
+              {items.map((item) => (
+                <li key={`${item.type}-${item.id}`}>
+                  <button
+                    onClick={() => selectItem(item)}
+                    className="w-full text-left px-2 py-1 rounded hover:bg-gray-700"
+                  >
+                    {item.title}
+                  </button>
+                </li>
+              ))}
+              {items.length === 0 && (
+                <li className="px-2 py-1 text-sm text-gray-400">No results</li>
+              )}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const displayVsCode = (openApp) => <VsCodeWrapper openApp={openApp} />;
+


### PR DESCRIPTION
## Summary
- add command palette to VS Code app with Ctrl/Cmd+P shortcut
- fuzzy search apps and common files

## Testing
- `yarn test components/apps/vscode --passWithNoTests`
- `yarn lint components/apps/vscode.jsx` *(fails: Component definition is missing display name and other repo-wide errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b954736f3c8328b09d54c511ad2f58