### PR TITLE
feat(wireshark): highlight packet layer bytes

### DIFF
--- a/apps/wireshark/components/LayerView.tsx
+++ b/apps/wireshark/components/LayerView.tsx
@@ -1,17 +1,29 @@
 import React, { useState } from 'react';
 
-interface Props {
-  name: string;
-  fields: Record<string, string>;
+interface Field {
+  label: string;
+  value: string;
+  start: number;
+  end: number;
 }
 
-const LayerView: React.FC<Props> = ({ name, fields }) => {
+interface Props {
+  name: string;
+  start: number;
+  end: number;
+  fields: Field[];
+  onHover: (range: [number, number] | null) => void;
+}
+
+const LayerView: React.FC<Props> = ({ name, start, end, fields, onHover }) => {
   const [open, setOpen] = useState(true);
 
   return (
     <div className="text-xs">
       <button
         onClick={() => setOpen(!open)}
+        onMouseEnter={() => onHover([start, end])}
+        onMouseLeave={() => onHover(null)}
         className="flex items-center cursor-pointer select-none"
         type="button"
       >
@@ -26,9 +38,14 @@ const LayerView: React.FC<Props> = ({ name, fields }) => {
       </button>
       {open && (
         <ul className="pl-5 mt-1 space-y-0.5">
-          {Object.entries(fields).map(([k, v]) => (
-            <li key={k} className="whitespace-pre-wrap">
-              {k}: {v}
+          {fields.map((f) => (
+            <li
+              key={f.label}
+              className="whitespace-pre-wrap"
+              onMouseEnter={() => onHover([f.start, f.end])}
+              onMouseLeave={() => onHover(null)}
+            >
+              {f.label}: {f.value}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- parse Ethernet, IPv4, TCP and UDP headers with byte offsets
- highlight selected layer bytes within packet hex view

## Testing
- `yarn test __tests__/wireshark.test.tsx`
- `yarn lint apps/wireshark/components/LayerView.tsx apps/wireshark/components/PcapViewer.tsx` *(fails: 145 problems in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b9547c2c7c8328b8431fff574ca4ad