### PR TITLE
feat: add shared help panel component

### DIFF
--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+interface HelpPanelProps {
+  appId: string;
+  docPath?: string;
+}
+
+export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [html, setHtml] = useState("<p>Loading...</p>");
+
+  useEffect(() => {
+    if (!open) return;
+    const path = docPath || `/docs/apps/${appId}.md`;
+    fetch(path)
+      .then((res) => (res.ok ? res.text() : ""))
+      .then((md) => {
+        if (!md) {
+          setHtml("<p>No help available.</p>");
+          return;
+        }
+        const rendered = DOMPurify.sanitize(marked.parse(md) as string);
+        setHtml(rendered);
+      })
+      .catch(() => setHtml("<p>No help available.</p>"));
+  }, [open, appId, docPath]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable;
+      if (isInput) return;
+      if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const toggle = () => setOpen((o) => !o);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Help"
+        aria-expanded={open}
+        onClick={toggle}
+        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+      >
+        ?
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-start justify-end p-4"
+          onClick={toggle}
+        >
+          <div
+            className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import HelpPanel from '../HelpPanel';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
 const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
@@ -18,6 +19,7 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
 export default function Terminal() {
   return (
     <div className="h-full w-full overflow-y-auto">
+      <HelpPanel appId="terminal" />
       <TerminalApp />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
+    "marked": "^16.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",
     "monaco-editor": "^0.52.2",

--- a/public/docs/apps/terminal.md
+++ b/public/docs/apps/terminal.md
@@ -1,0 +1,7 @@
+# Terminal Help
+
+This terminal emulates basic shell commands. Type commands and press Enter to execute.
+
+- Use arrow keys to navigate history.
+- Press `Ctrl+C` to cancel a running command.
+- The `help` command lists available commands.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9737,6 +9737,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:^16.2.1":
+  version: 16.2.1
+  resolution: "marked@npm:16.2.1"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/0f4a259c8a7884a14830f06b4b44c0e5fab27924102f2713606e0627c8473d130ab9070900a40c18b0e8d39ba2f31194ce6931999ba4c7bd3b6240f6cfe9cbb3
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -13893,6 +13902,7 @@ __metadata:
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
     magic-string: "npm:0.30.18"
+    marked: "npm:^16.2.1"
     mathjs: "npm:^14.6.0"
     matter-js: "npm:0.20.0"
     monaco-editor: "npm:^0.52.2"


### PR DESCRIPTION
## Summary
- add reusable HelpPanel to display per-app markdown docs with '?' toggle
- wire HelpPanel into terminal app and include sample docs
- add marked dependency for markdown parsing

## Testing
- `yarn lint components/HelpPanel.tsx components/apps/terminal.tsx` *(fails: existing lint errors across repo)*
- `yarn test components/HelpPanel.tsx --passWithNoTests`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b95477acb48328871556ac9715cbf5