### PR TITLE
feat: add global settings store

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -27,6 +27,12 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    sound,
+    setSound,
+    haptics,
+    setHaptics,
+    colorblind,
+    setColorblind,
     theme,
     setTheme,
   } = useSettings();
@@ -238,6 +244,30 @@ export default function Settings() {
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Sound:</span>
+            <ToggleSwitch
+              checked={sound}
+              onChange={setSound}
+              ariaLabel="Sound"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Haptics:</span>
+            <ToggleSwitch
+              checked={haptics}
+              onChange={setHaptics}
+              ariaLabel="Haptics"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Colorblind Mode:</span>
+            <ToggleSwitch
+              checked={colorblind}
+              onChange={setColorblind}
+              ariaLabel="Colorblind Mode"
             />
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">

--- a/components/apps/2048.js
+++ b/components/apps/2048.js
@@ -237,7 +237,12 @@ const Game2048 = () => {
   const [best, setBest] = useState(0);
   const [undosLeft, setUndosLeft] = useState(UNDO_LIMIT);
   const moveLock = useRef(false);
-  const { highContrast } = useSettings();
+  const { highContrast, colorblind } = useSettings();
+
+  useEffect(() => {
+    if (colorblind) setSkin('colorblind');
+    else if (skin === 'colorblind') setSkin('classic');
+  }, [colorblind, skin, setSkin]);
 
   useEffect(() => {
     if (animCells.size > 0) {

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -12,6 +12,7 @@ import GameLayout from './battleship/GameLayout';
 import usePersistentState from '../hooks/usePersistentState';
 import useGameControls from './useGameControls';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { useSettings } from '../../hooks/useSettings';
 
 const CELL = 32; // px
 
@@ -91,10 +92,7 @@ const Battleship = () => {
     losses: 0,
   });
   const [cursor, setCursor] = useState(0);
-  const [colorblind, setColorblind] = usePersistentState(
-    'battleship-colorblind',
-    false,
-  );
+  const { colorblind, setColorblind } = useSettings();
   const [dragHint, setDragHint] = useState(null);
 
   const tryPlace = (shipId, x, y, dir) => {

--- a/components/apps/wordle.js
+++ b/components/apps/wordle.js
@@ -4,6 +4,7 @@ import {
   buildResultMosaic,
   dictionaries as wordleDictionaries,
 } from '../../utils/wordle';
+import { useSettings } from '../../hooks/useSettings';
 
 // Determine today's puzzle key for local storage
 const todayKey = new Date().toISOString().split('T')[0];
@@ -97,10 +98,7 @@ const Wordle = () => {
   const [revealMap, setRevealMap] = useState({});
 
   // settings
-  const [colorBlind, setColorBlind] = usePersistentState(
-    'wordle-colorblind',
-    false
-  );
+  const { colorblind: colorBlind, setColorblind: setColorBlind } = useSettings();
   const [hardMode, setHardMode] = usePersistentState('wordle-hardmode', false);
 
   const isSolved = guesses.some((g) => g.guess === solution);

--- a/hooks/useGameAudio.js
+++ b/hooks/useGameAudio.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback, useState } from 'react';
-import usePersistedState from './usePersistedState';
+import { useSettings } from './useSettings';
 
 /**
  * Global game audio hook.  Lazily creates an `AudioContext` in response to the
@@ -20,9 +20,11 @@ export default function useGameAudio() {
   const sfxBuffersRef = useRef({});
   const musicLayersRef = useRef({});
 
-  // Global mute is persisted across the portfolio, but per‑game volume lives
+  // Global mute is persisted via Settings context, but per‑game volume lives
   // only for the lifetime of the hook instance.
-  const [muted, setMuted] = usePersistedState('settings:audioMuted', false);
+  const { sound, setSound } = useSettings();
+  const muted = !sound;
+  const setMuted = (m) => setSound(!m);
   const [gameVolume, setGameVolume] = useState(1);
   const [ready, setReady] = useState(false);
 

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback } from 'react';
-import usePersistedState from './usePersistedState';
+import { useSettings } from './useSettings';
 import {
   vibrate as vibrateNative,
   patterns,
@@ -9,7 +9,7 @@ import {
 
 // Exposes helpers for triggering game haptics with an on/off toggle.
 export default function useGameHaptics() {
-  const [enabled, setEnabled] = usePersistedState('game:haptics', true);
+  const { haptics: enabled, setHaptics } = useSettings();
 
   const vibrate = useCallback(
     (pattern) => {
@@ -23,7 +23,7 @@ export default function useGameHaptics() {
   const danger = useCallback(() => vibrate(patterns.danger), [vibrate]);
   const gameOver = useCallback(() => vibrate(patterns.gameOver), [vibrate]);
 
-  const toggle = useCallback(() => setEnabled((e) => !e), [setEnabled]);
+  const toggle = useCallback(() => setHaptics(!enabled), [setHaptics, enabled]);
 
   return { enabled, toggle, vibrate, score, danger, gameOver };
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -21,6 +21,16 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import {
+  getSound as loadSound,
+  setSound as saveSound,
+  getHaptics as loadHaptics,
+  setHaptics as saveHaptics,
+  getColorblind as loadColorblind,
+  setColorblind as saveColorblind,
+  defaults as controlDefaults,
+  subscribe as subscribeControls,
+} from '../utils/settings';
 type Density = 'regular' | 'compact';
 
 // Utility to lighten or darken a hex color by a percentage
@@ -49,6 +59,9 @@ interface SettingsContextValue {
   largeHitAreas: boolean;
   pongSpin: boolean;
   allowNetwork: boolean;
+  sound: boolean;
+  haptics: boolean;
+  colorblind: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -59,6 +72,9 @@ interface SettingsContextValue {
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
+  setSound: (value: boolean) => void;
+  setHaptics: (value: boolean) => void;
+  setColorblind: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -72,6 +88,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
+  sound: controlDefaults.sound,
+  haptics: controlDefaults.haptics,
+  colorblind: controlDefaults.colorblind,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -82,6 +101,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
   setAllowNetwork: () => {},
+  setSound: () => {},
+  setHaptics: () => {},
+  setColorblind: () => {},
   setTheme: () => {},
 });
 
@@ -95,6 +117,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [sound, setSound] = useState<boolean>(controlDefaults.sound);
+  const [haptics, setHaptics] = useState<boolean>(controlDefaults.haptics);
+  const [colorblind, setColorblind] = useState<boolean>(controlDefaults.colorblind);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -109,8 +134,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
+      setSound(loadSound());
+      setHaptics(loadHaptics());
+      setColorblind(loadColorblind());
       setTheme(loadTheme());
     })();
+  }, []);
+
+  useEffect(() => {
+    const unsub = subscribeControls((s) => {
+      setSound(s.sound);
+      setHaptics(s.haptics);
+      setColorblind(s.colorblind);
+    });
+    return unsub;
   }, []);
 
   useEffect(() => {
@@ -211,6 +248,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [allowNetwork]);
 
+  useEffect(() => {
+    saveSound(sound);
+  }, [sound]);
+
+  useEffect(() => {
+    saveHaptics(haptics);
+  }, [haptics]);
+
+  useEffect(() => {
+    saveColorblind(colorblind);
+  }, [colorblind]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -223,6 +272,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         largeHitAreas,
         pongSpin,
         allowNetwork,
+        sound,
+        haptics,
+        colorblind,
         theme,
         setAccent,
         setWallpaper,
@@ -233,6 +285,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setLargeHitAreas,
         setPongSpin,
         setAllowNetwork,
+        setSound,
+        setHaptics,
+        setColorblind,
         setTheme,
       }}
     >

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -1,0 +1,74 @@
+export interface GlobalSettings {
+  sound: boolean;
+  haptics: boolean;
+  colorblind: boolean;
+}
+
+export const defaults: GlobalSettings = {
+  sound: true,
+  haptics: true,
+  colorblind: false,
+};
+
+let state: GlobalSettings = { ...defaults };
+
+try {
+  if (typeof window !== 'undefined') {
+    const raw = window.localStorage.getItem('global-settings');
+    if (raw) state = { ...state, ...JSON.parse(raw) };
+  }
+} catch {
+  /* ignore */
+}
+
+type Listener = (s: GlobalSettings) => void;
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((l) => l(state));
+}
+
+function persist() {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('global-settings', JSON.stringify(state));
+    }
+  } catch {
+    // ignore write errors
+  }
+}
+
+export function getSettings(): GlobalSettings {
+  return state;
+}
+
+export function setSettings(partial: Partial<GlobalSettings>): void {
+  state = { ...state, ...partial };
+  persist();
+  notify();
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export const getSound = () => state.sound;
+export const setSound = (v: boolean) => setSettings({ sound: v });
+export const getHaptics = () => state.haptics;
+export const setHaptics = (v: boolean) => setSettings({ haptics: v });
+export const getColorblind = () => state.colorblind;
+export const setColorblind = (v: boolean) => setSettings({ colorblind: v });
+
+export default {
+  getSettings,
+  setSettings,
+  subscribe,
+  getSound,
+  setSound,
+  getHaptics,
+  setHaptics,
+  getColorblind,
+  setColorblind,
+  defaults,
+};


### PR DESCRIPTION
## Summary
- add utils/settings store to manage sound, haptics, and colorblind modes globally
- expose new controls through settings UI and context
- update game hooks and apps to respect global settings

## Testing
- `yarn test`
- `yarn test __tests__/themePersistence.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b95475c4dc83288424f2eb8ab04b85