### PR TITLE
feat: render scripts from saved Nmap results

### DIFF
--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -352,16 +352,51 @@ const NmapNSEApp = () => {
           {results.hosts.map((host) => (
             <li key={host.ip}>
               <div className="text-blue-400 font-mono">{host.ip}</div>
-              <ul className="ml-4">
+              <ul className="ml-4 space-y-1">
                 {host.ports.map((p) => (
-                  <li key={p.port} className="flex items-center gap-2">
-                    <span className="font-mono">{p.port}/tcp {p.service}</span>
-                    <span
-                      className={`px-1.5 py-0.5 rounded text-xs ${cvssColor(p.cvss)}`}
-                      aria-label={`CVSS score ${p.cvss}`}
-                    >
-                      CVSS {p.cvss}
-                    </span>
+                  <li key={p.port}>
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono">
+                        {p.port}/tcp {p.service}
+                      </span>
+                      <span
+                        className={`px-1.5 py-0.5 rounded text-xs ${cvssColor(p.cvss)}`}
+                        aria-label={`CVSS score ${p.cvss}`}
+                      >
+                        CVSS {p.cvss}
+                      </span>
+                    </div>
+                    {p.scripts?.length > 0 && (
+                      <ul className="ml-4 mt-1 space-y-1">
+                        {p.scripts.map((sc) => {
+                          const meta = scripts.find((s) => s.name === sc.name);
+                          return (
+                            <li key={sc.name}>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className="font-mono">{sc.name}</span>
+                                {meta && (
+                                  <div className="flex flex-wrap gap-1">
+                                    {meta.tags.map((t) => (
+                                      <span
+                                        key={t}
+                                        className="px-1.5 py-0.5 rounded text-xs bg-gray-700"
+                                      >
+                                        {t}
+                                      </span>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                              {sc.output && (
+                                <pre className="ml-4 text-green-400 whitespace-pre-wrap">
+                                  {sc.output}
+                                </pre>
+                              )}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/public/demo/nmap-results.json
+++ b/public/demo/nmap-results.json
@@ -3,20 +3,64 @@
     {
       "ip": "192.0.2.10",
       "ports": [
-        { "port": 80, "service": "http", "cvss": 5.0 },
-        { "port": 443, "service": "https", "cvss": 3.1 }
+        {
+          "port": 80,
+          "service": "http",
+          "cvss": 5.0,
+          "scripts": [
+            {
+              "name": "http-title",
+              "output": "Example Domain"
+            },
+            {
+              "name": "http-enum",
+              "output": "/admin/: Potential admin interface\n/images/: Potentially interesting directory w/ listing"
+            }
+          ]
+        },
+        {
+          "port": 443,
+          "service": "https",
+          "cvss": 3.1,
+          "scripts": [
+            {
+              "name": "ssl-cert",
+              "output": "Subject: commonName=example.com\nNot valid before: 2020-06-01\nNot valid after: 2022-06-01"
+            }
+          ]
+        }
       ]
     },
     {
       "ip": "192.0.2.20",
       "ports": [
-        { "port": 21, "service": "ftp", "cvss": 7.5 }
+        {
+          "port": 21,
+          "service": "ftp",
+          "cvss": 7.5,
+          "scripts": [
+            {
+              "name": "ftp-anon",
+              "output": "Anonymous FTP login allowed\nwelcome.msg"
+            }
+          ]
+        }
       ]
     },
     {
       "ip": "192.0.2.30",
       "ports": [
-        { "port": 445, "service": "microsoft-ds", "cvss": 4.0 }
+        {
+          "port": 445,
+          "service": "microsoft-ds",
+          "cvss": 4.0,
+          "scripts": [
+            {
+              "name": "smb-os-discovery",
+              "output": "OS: Windows 10 Pro\nComputer name: HOST\nWorkgroup: WORKGROUP"
+            }
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- parse saved Nmap results and display host -> service -> script hierarchy
- badge script categories and include sample outputs
- cover script category rendering with unit tests

## Testing
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn lint components/apps/nmap-nse/index.js __tests__/nmapNse.test.tsx` *(fails: Component definition is missing display name and other existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9547fb8f08328a195dfa23060c696