### PR TITLE
Add demo Radare2 component using precomputed data

### DIFF
--- a/components/apps/radare2.jsx
+++ b/components/apps/radare2.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import CoreRadare2 from './radare2/index.js';
+
+// Precomputed disassembly for a tiny demo binary. This avoids requiring the full
+// radare2 toolchain by bundling hex dump, disassembly, cross-references and
+// basic block graph in JSON form.
+const demo = {
+  file: 'demo.bin',
+  hex: '554889e5b8000000005dc3',
+  disasm: [
+    { addr: '0x1000', text: 'push rbp' },
+    { addr: '0x1001', text: 'mov rbp, rsp' },
+    { addr: '0x1004', text: 'mov eax, 0' },
+    { addr: '0x1009', text: 'pop rbp' },
+    { addr: '0x100a', text: 'ret' }
+  ],
+  xrefs: {
+    '0x1004': ['0x1009']
+  },
+  blocks: [
+    { addr: '0x1000', edges: ['0x1004'] },
+    { addr: '0x1004', edges: ['0x1009'] },
+    { addr: '0x1009', edges: [] }
+  ]
+};
+
+const Radare2 = ({ initialData = demo }) => <CoreRadare2 initialData={initialData} />;
+
+export default Radare2;


### PR DESCRIPTION
## Summary
- add `components/apps/radare2.jsx` with precomputed hex dump, disassembly, xrefs and basic block graph for a tiny sample binary
- wrap existing Radare2 core component to showcase demo data without requiring the full toolchain

## Testing
- `yarn test radare2`


------
https://chatgpt.com/codex/tasks/task_e_68b9548307e8832886367a259046f68f