### PR TITLE
Add Playwright smoke tests and Vercel preview CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,27 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - name: Get Vercel preview URL
+        id: vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          url=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" "https://api.vercel.com/v13/deployments?projectId=${VERCEL_PROJECT_ID}&limit=1" | jq -r '.deployments[0].url')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Run Playwright tests
+        env:
+          BASE_URL: https://${{ steps.vercel.outputs.url }}
+        run: yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "test:e2e": "playwright test"
   },
   "engines": {
     "node": "20.16.0"

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies Nessus login form handles invalid credentials gracefully
+// by displaying an error message.
+test('nessus login shows error with invalid credentials', async ({ page }) => {
+  await page.goto('/apps/nessus');
+
+  await page.fill('#nessus-url', 'http://invalid');
+  await page.fill('#nessus-username', 'user');
+  await page.fill('#nessus-password', 'pass');
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  await expect(page.locator('#nessus-error')).toBeVisible();
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// Basic navigation smoke test covering home -> apps -> Nessus app
+// to ensure primary routes load correctly.
+test('navigate from home to Nessus app', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('link', { name: /Apps/i }).click();
+  await expect(page).toHaveURL(/\/apps/);
+
+  await page.locator('a[href="/apps/nessus"]').click();
+  await expect(page).toHaveURL(/\/apps\/nessus/);
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke tests for navigation and Nessus login flows
- expose `test:e2e` script
- run Playwright tests against Vercel preview in CI

## Testing
- `BASE_URL=https://example.com npx playwright test tests/login.spec.ts tests/navigation.spec.ts` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*
- `yarn lint tests/login.spec.ts tests/navigation.spec.ts .github/workflows/ci.yml package.json` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f75ed5483289da66456e073d446