### PR TITLE
Improve keyboard navigation with roving tab index

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import useRovingTabIndex from "../../hooks/useRovingTabIndex";
 
 export default function Settings() {
   const {
@@ -102,6 +103,8 @@ export default function Settings() {
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
+  const wallpaperGridRef = useRef<HTMLDivElement>(null);
+  useRovingTabIndex(wallpaperGridRef);
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -159,14 +162,18 @@ export default function Settings() {
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
           </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
+          <div
+            ref={wallpaperGridRef}
+            role="listbox"
+            aria-label="Available wallpapers"
+            className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900"
+          >
             {wallpapers.map((name) => (
               <div
                 key={name}
-                role="button"
+                role="option"
                 aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
+                aria-selected={name === wallpaper}
                 onClick={() => changeBackground(name)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React from "react";
+import React, { useRef } from "react";
+import useRovingTabIndex from "../hooks/useRovingTabIndex";
 
 type Tab<T extends string> = {
   id: T;
@@ -11,6 +12,7 @@ interface TabsProps<T extends string> {
   active: T;
   onChange: (id: T) => void;
   className?: string;
+  orientation?: "horizontal" | "vertical";
 }
 
 export default function Tabs<T extends string>({
@@ -18,9 +20,18 @@ export default function Tabs<T extends string>({
   active,
   onChange,
   className = "",
+  orientation = "horizontal",
 }: TabsProps<T>) {
+  const ref = useRef<HTMLDivElement>(null);
+  useRovingTabIndex(ref, true, orientation);
+
   return (
-    <div role="tablist" className={`flex ${className}`.trim()}>
+    <div
+      ref={ref}
+      role="tablist"
+      aria-orientation={orientation}
+      className={`flex ${className}`.trim()}
+    >
       {tabs.map((t) => (
         <button
           key={t.id}


### PR DESCRIPTION
## Summary
- enable arrow-key navigation for shared Tabs component using a roving tab index
- convert Settings wallpaper chooser to a roving listbox, removing blanket tabindex usage
- add missing `setTheme` import for theme persistence tests

## Testing
- `yarn test` *(fails: ReferenceError: structuredClone is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f80c80c8328b442d6a2138219e9