### PR TITLE
feat: close modal on global escape

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -36,3 +36,28 @@ test('modal traps focus and restores focus on close', async () => {
   fireEvent.keyDown(first, { key: 'Escape' });
   await waitFor(() => expect(openButton).toHaveFocus());
 });
+
+test('modal closes when Escape pressed globally', async () => {
+  const Wrapper: React.FC = () => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <>
+        <button onClick={() => setOpen(true)}>open</button>
+        <Modal isOpen={open} onClose={() => setOpen(false)}>
+          <button>first</button>
+        </Modal>
+      </>
+    );
+  };
+
+  const { getByText } = render(<Wrapper />);
+  const openButton = getByText('open');
+  openButton.focus();
+  fireEvent.click(openButton);
+
+  const first = getByText('first');
+  expect(first).toHaveFocus();
+
+  fireEvent.keyDown(document, { key: 'Escape' });
+  await waitFor(() => expect(openButton).toHaveFocus());
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -25,11 +25,6 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
     const triggerRef = useRef<HTMLElement | null>(null);
 
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-        if (e.key === 'Escape') {
-            e.preventDefault();
-            onClose();
-            return;
-        }
         if (e.key !== 'Tab') return;
         const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
         if (!elements || elements.length === 0) return;
@@ -43,7 +38,19 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
             e.preventDefault();
             last.focus();
         }
-    }, [onClose]);
+    }, []);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, [isOpen, onClose]);
 
     useEffect(() => {
         if (isOpen) {


### PR DESCRIPTION
## Summary
- listen for Escape key globally while modals are open
- close modal and restore focus to trigger element
- test keyboard-based closure behaviour

## Testing
- `npx eslint components/base/Modal.tsx __tests__/Modal.test.tsx`
- `yarn test __tests__/Modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96f8384a883289b13685d24291109