### PR TITLE
Use polite live regions for status messages

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Toast from '../components/ui/Toast';
+import FormError from '../components/ui/FormError';
+
+describe('live region components', () => {
+  it('Toast uses polite live region', () => {
+    const { unmount } = render(<Toast message="Saved" />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    unmount();
+  });
+
+  it('FormError announces politely', () => {
+    render(<FormError>Required field</FormError>);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -452,8 +452,8 @@ const Pinball = () => {
         {tilt && (
           <span
             className="ml-2 text-red-500 motion-safe:animate-pulse"
-            aria-live="assertive"
-            role="alert"
+            aria-live="polite"
+            role="status"
           >
             TILT <button onClick={resetTilt}>Reset</button>
           </span>
@@ -472,8 +472,8 @@ const Pinball = () => {
       {tilt && (
         <div
           className="absolute inset-0 flex items-center justify-center bg-red-900 bg-opacity-70 pointer-events-none animate-pulse"
-          role="alert"
-          aria-live="assertive"
+          role="status"
+          aria-live="polite"
         >
           TILT
         </div>

--- a/components/apps/simon.js
+++ b/components/apps/simon.js
@@ -424,7 +424,7 @@ const Simon = () => {
             </button>
           ))}
         </div>
-        <div className="mb-4" aria-live="assertive" role="status">
+        <div className="mb-4" aria-live="polite" role="status">
           {status}
         </div>
         <div className="flex flex-wrap gap-4 items-center">

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -408,8 +408,8 @@ const Snake = () => {
           {gameOver && (
             <div
               className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50"
-              role="alert"
-              aria-live="assertive"
+              role="status"
+              aria-live="polite"
             >
               Game Over
             </div>

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -9,8 +9,8 @@ interface FormErrorProps {
 const FormError = ({ id, className = '', children }: FormErrorProps) => (
   <p
     id={id}
-    role="alert"
-    aria-live="assertive"
+    role="status"
+    aria-live="polite"
     className={`text-red-600 text-sm mt-2 ${className}`.trim()}
   >
     {children}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -30,8 +30,8 @@ const Toast: React.FC<ToastProps> = ({
 
   return (
     <div
-      role="alert"
-      aria-live="assertive"
+      role="status"
+      aria-live="polite"
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -226,7 +226,7 @@ const InputHub = () => {
         </button>
       </form>
       {status && (
-        <div role="status" className="mt-2 text-sm">
+        <div role="status" aria-live="polite" className="mt-2 text-sm">
           {status}
         </div>
       )}

--- a/public/apps/platformer/index.html
+++ b/public/apps/platformer/index.html
@@ -11,7 +11,7 @@
     <div id="timer" aria-live="off"></div>
     <div id="hints">Move: ←/→ Jump: Space</div>
   </div>
-  <div id="complete" class="hidden" role="status" aria-live="assertive">Level Complete!</div>
+  <div id="complete" class="hidden" role="status" aria-live="polite">Level Complete!</div>
   <div id="controls" class="hidden">
     <button id="btnLeft">◀</button>
     <button id="btnRight">▶</button>


### PR DESCRIPTION
## Summary
- convert noncritical status messages to `aria-live="polite"`
- ensure Input Hub status div is a polite live region
- add tests confirming Toast and FormError announce via polite live regions

## Testing
- `yarn test __tests__/liveRegion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96f86a5808328a7b8be7bbeb15fdf