### PR TITLE
feat: add keyboard window controls

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -227,6 +227,39 @@ export class Window extends Component {
         }
     }
 
+    snapWindow = (position) => {
+        this.setWinowsPosition();
+        const { width, height } = this.state;
+        let newWidth = width;
+        let newHeight = height;
+        let transform = '';
+        if (position === 'left') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'right') {
+            newWidth = 50;
+            newHeight = 96.3;
+            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (position === 'top') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        }
+        const r = document.querySelector("#" + this.id);
+        if (r && transform) {
+            r.style.transform = transform;
+        }
+        this.setState({
+            snapPreview: null,
+            snapPosition: null,
+            snapped: position,
+            lastSize: { width, height },
+            width: newWidth,
+            height: newHeight
+        }, this.resizeBoundries);
+    }
+
     checkOverlap = () => {
         var r = document.querySelector("#" + this.id);
         var rect = r.getBoundingClientRect();
@@ -284,38 +317,8 @@ export class Window extends Component {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
         if (snapPos) {
-            this.setWinowsPosition();
-            const { width, height } = this.state;
-            let newWidth = width;
-            let newHeight = height;
-            let transform = '';
-            if (snapPos === 'left') {
-                newWidth = 50;
-                newHeight = 96.3;
-                transform = 'translate(-1pt,-2pt)';
-            } else if (snapPos === 'right') {
-                newWidth = 50;
-                newHeight = 96.3;
-                transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-            } else if (snapPos === 'top') {
-                newWidth = 100.2;
-                newHeight = 50;
-                transform = 'translate(-1pt,-2pt)';
-            }
-            var r = document.querySelector("#" + this.id);
-            if (r && transform) {
-                r.style.transform = transform;
-            }
-            this.setState({
-                snapPreview: null,
-                snapPosition: null,
-                snapped: snapPos,
-                lastSize: { width, height },
-                width: newWidth,
-                height: newHeight
-            }, this.resizeBoundries);
-        }
-        else {
+            this.snapWindow(snapPos);
+        } else {
             this.setState({ snapPreview: null, snapPosition: null });
         }
     }
@@ -468,8 +471,45 @@ export class Window extends Component {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
-        } else if (e.key === 'ArrowDown' && e.altKey) {
-            this.unsnapWindow();
+        } else if (e.altKey) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.unsnapWindow();
+            } else if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.snapWindow('left');
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.snapWindow('right');
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.snapWindow('top');
+            }
+            this.focusWindow();
+        } else if (e.shiftKey) {
+            const step = 1;
+            if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
+            }
+            this.focusWindow();
         }
     }
 

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -1,0 +1,23 @@
+# Keyboard-Only Window Management Test Plan
+
+## Resizing
+1. Open any window.
+2. Focus the window.
+3. Hold **Shift** and press arrow keys:
+   - **Shift + ArrowRight** increases width.
+   - **Shift + ArrowLeft** decreases width.
+   - **Shift + ArrowDown** increases height.
+   - **Shift + ArrowUp** decreases height.
+4. Verify the window resizes accordingly.
+
+## Snapping
+1. With the window focused, press arrow keys with **Alt**:
+   - **Alt + ArrowLeft** snaps the window to the left half of the screen.
+   - **Alt + ArrowRight** snaps it to the right half.
+   - **Alt + ArrowUp** snaps it to the top half.
+   - **Alt + ArrowDown** restores the window to its previous size and position.
+
+## Focus
+1. After resizing or snapping, press **Tab** to move focus inside the window.
+2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
+3. Shift+Tab moves focus backward as expected.


### PR DESCRIPTION
## Summary
- enable alt+arrow to snap windows and shift+arrow to resize
- keep focus inside the window while allowing normal tab navigation
- document keyboard-only manual test steps

## Testing
- `npx eslint components/base/window.js`
- `npx jest components/base/window.test.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b96f878e908328828ae2bc36cb0950