### PR TITLE
feat: add taskbar for running apps

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Taskbar from '../components/screen/taskbar';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
+
+describe('Taskbar', () => {
+  it('minimizes focused window on click', () => {
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: true }}
+        openApp={openApp}
+        minimize={minimize}
+      />
+    );
+    const button = screen.getByRole('button', { name: /app one/i });
+    fireEvent.click(button);
+    expect(minimize).toHaveBeenCalledWith('app1');
+    expect(button).toHaveAttribute('data-context', 'taskbar');
+  });
+
+  it('restores minimized window on click', () => {
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: true }}
+        focused_windows={{ app1: false }}
+        openApp={openApp}
+        minimize={minimize}
+      />
+    );
+    const button = screen.getByRole('button', { name: /app one/i });
+    fireEvent.click(button);
+    expect(openApp).toHaveBeenCalledWith('app1');
+  });
+});

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,0 +1,57 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function TaskbarMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onCloseMenu && props.onCloseMenu();
+        }
+    };
+
+    const handleMinimize = () => {
+        props.onMinimize && props.onMinimize();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    const handleClose = () => {
+        props.onClose && props.onClose();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    return (
+        <div
+            id="taskbar-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button
+                type="button"
+                onClick={handleMinimize}
+                role="menuitem"
+                aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleClose}
+                role="menuitem"
+                aria-label="Close Window"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Close</span>
+            </button>
+        </div>
+    );
+}
+
+export default TaskbarMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -16,6 +16,8 @@ import ShortcutSelector from '../screen/shortcut-selector'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
+import Taskbar from './taskbar';
+import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -41,6 +43,7 @@ export class Desktop extends Component {
                 desktop: false,
                 default: false,
                 app: false,
+                taskbar: false,
             },
             context_app: null,
             showNameBar: false,
@@ -165,6 +168,13 @@ export class Desktop extends Component {
                 });
                 this.setState({ context_app: appId }, () => this.showContextMenu(e, "app"));
                 break;
+            case "taskbar":
+                ReactGA.event({
+                    category: `Context Menu`,
+                    action: `Opened Taskbar Context Menu`
+                });
+                this.setState({ context_app: appId }, () => this.showContextMenu(e, "taskbar"));
+                break;
             default:
                 ReactGA.event({
                     category: `Context Menu`,
@@ -191,6 +201,10 @@ export class Desktop extends Component {
             case "app":
                 ReactGA.event({ category: `Context Menu`, action: `Opened App Context Menu` });
                 this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "app"));
+                break;
+            case "taskbar":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Taskbar Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "taskbar"));
                 break;
             default:
                 ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
@@ -776,6 +790,16 @@ export class Desktop extends Component {
                     isMinimized={this.state.minimized_windows}
                     openAppByAppId={this.openApp} />
 
+                {/* Taskbar */}
+                <Taskbar
+                    apps={apps}
+                    closed_windows={this.state.closed_windows}
+                    minimized_windows={this.state.minimized_windows}
+                    focused_windows={this.state.focused_windows}
+                    openApp={this.openApp}
+                    minimize={this.hasMinimised}
+                />
+
                 {/* Desktop Apps */}
                 {this.renderDesktopApps()}
 
@@ -794,6 +818,25 @@ export class Desktop extends Component {
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
                     onClose={this.hideAllContextMenu}
+                />
+                <TaskbarMenu
+                    active={this.state.context_menus.taskbar}
+                    minimized={this.state.context_app ? this.state.minimized_windows[this.state.context_app] : false}
+                    onMinimize={() => {
+                        const id = this.state.context_app;
+                        if (!id) return;
+                        if (this.state.minimized_windows[id]) {
+                            this.openApp(id);
+                        } else {
+                            this.hasMinimised(id);
+                        }
+                    }}
+                    onClose={() => {
+                        const id = this.state.context_app;
+                        if (!id) return;
+                        this.closeApp(id);
+                    }}
+                    onCloseMenu={this.hideAllContextMenu}
                 />
 
                 {/* Folder Input Name Bar */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Image from 'next/image';
+
+export default function Taskbar(props) {
+    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+
+    const handleClick = (app) => {
+        const id = app.id;
+        if (props.minimized_windows[id]) {
+            props.openApp(id);
+        } else if (props.focused_windows[id]) {
+            props.minimize(id);
+        } else {
+            props.openApp(id);
+        }
+    };
+
+    return (
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+            {runningApps.map(app => (
+                <button
+                    key={app.id}
+                    type="button"
+                    aria-label={app.title}
+                    data-context="taskbar"
+                    data-app-id={app.id}
+                    onClick={() => handleClick(app)}
+                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                >
+                    <Image
+                        width={24}
+                        height={24}
+                        className="w-5 h-5"
+                        src={app.icon.replace('./', '/')}
+                        alt=""
+                        sizes="24px"
+                    />
+                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                    )}
+                </button>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add taskbar listing open windows with active indicator
- support taskbar context menu for minimize/restore and close
- integrate taskbar into desktop state and interactions

## Testing
- `npx eslint components/screen/taskbar.js components/context-menus/taskbar-menu.js components/screen/desktop.js __tests__/taskbar.test.tsx`
- `yarn test __tests__/taskbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96f8e04748328a2a33e7803ed3516