### PR TITLE
feat: add pinned and recent desktop sections

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -36,8 +36,9 @@ export class UbuntuApp extends Component {
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
-                data-context="app"
+                data-context={this.props.context || "app"}
                 data-app-id={this.props.id}
+                data-section={this.props.section}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}

--- a/components/context-menus/item-menu.js
+++ b/components/context-menus/item-menu.js
@@ -1,0 +1,47 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function ItemMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose();
+        }
+    };
+
+    return (
+        <div
+            id="item-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        >
+            <button
+                type="button"
+                onClick={() => { props.onOpen && props.onOpen(); }}
+                role="menuitem"
+                aria-label="Open"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Open</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => { props.onRemove && props.onRemove(); }}
+                role="menuitem"
+                aria-label="Remove"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Remove</span>
+            </button>
+        </div>
+    );
+}
+
+export default ItemMenu;


### PR DESCRIPTION
## Summary
- show pinned and recent app sections on desktop
- add quick action context menu with open/remove
- persist pinned and recent apps in localStorage

## Testing
- `yarn test` *(fails: ReferenceError: setTheme is not defined in themePersistence.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f9146148328ac0ed7f6882ca9bc