### PR TITLE
Add desktop guided tour

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -39,6 +39,15 @@ export default class Navbar extends Component {
                                 </div>
                                 <button
                                         type="button"
+                                        id="help-button"
+                                        aria-label="Help"
+                                        onClick={this.props.openTour}
+                                        className={'pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1'}
+                                >
+                                        ?
+                                </button>
+                                <button
+                                        type="button"
                                         id="status-bar"
                                         aria-label="System status"
                                         onClick={() => {

--- a/components/ui/GuidedTour.tsx
+++ b/components/ui/GuidedTour.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from 'react';
+import Tour from '@rc-component/tour';
+
+const steps = [
+  {
+    title: 'Gestures',
+    description:
+      'Drag windows by the title bar. Right-click or long-press for context menus.',
+    target: () => document.querySelector('.bg-ub-window-title') as HTMLElement | null,
+  },
+  {
+    title: 'Snaps',
+    description: 'Drag windows to screen edges to snap left, right, or top.',
+    target: () => document.querySelector('.opened-window') as HTMLElement | null,
+  },
+  {
+    title: 'Shortcuts',
+    description: 'Click Help or press ? to view keyboard shortcuts.',
+    target: () => document.getElementById('help-button'),
+  },
+  {
+    title: 'Controls',
+    description: 'Open Quick Settings from the status area.',
+    target: () => document.getElementById('status-bar'),
+  },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const GuidedTour: React.FC<Props> = ({ open, onClose }) => {
+  return <Tour open={open} onClose={onClose} steps={steps} />;
+};
+
+export default GuidedTour;


### PR DESCRIPTION
## Summary
- add reusable guided tour with steps for gestures, window snaps, shortcuts and controls overlay
- show tour on first launch and via new Help button in the top bar

## Testing
- `yarn lint` *(fails: 145 problems)*
- `npx eslint components/ui/GuidedTour.tsx components/ubuntu.js components/screen/navbar.js`
- `yarn test __tests__/ubuntu.test.tsx __tests__/ShortcutOverlay.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b96f9246f08328b1464b7065d84592