### PR TITLE
feat: add breadcrumbs to file explorer

### DIFF
--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface Segment {
+  name: string;
+}
+
+interface Props {
+  path: Segment[];
+  onNavigate: (index: number) => void;
+}
+
+const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
+  return (
+    <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
+      {path.map((seg, idx) => (
+        <React.Fragment key={idx}>
+          <button
+            type="button"
+            onClick={() => onNavigate(idx)}
+            className="hover:underline focus:outline-none"
+          >
+            {seg.name || '/'}
+          </button>
+          {idx < path.length - 1 && <span>/</span>}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+};
+
+export default Breadcrumbs;


### PR DESCRIPTION
## Summary
- add reusable `Breadcrumbs` UI component
- enhance File Explorer with breadcrumb navigation and back button

## Testing
- `npx eslint components/apps/file-explorer.js components/ui/Breadcrumbs.tsx`
- `yarn test components/apps/file-explorer.js components/ui/Breadcrumbs.tsx` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f935d848328880cb4d69f409507