### PR TITLE
feat: add virtualized search highlighting

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -5,9 +5,31 @@ interface ModuleCardProps {
   module: ModuleMetadata;
   onSelect: (module: ModuleMetadata) => void;
   selected: boolean;
+  /** Current search query for highlighting */
+  query?: string;
 }
 
-export default function ModuleCard({ module, onSelect, selected }: ModuleCardProps) {
+function highlight(text: string, query: string | undefined) {
+  if (!query) return text;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const idx = lower.indexOf(q);
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark>{text.slice(idx, idx + q.length)}</mark>
+      {text.slice(idx + q.length)}
+    </>
+  );
+}
+
+export default function ModuleCard({
+  module,
+  onSelect,
+  selected,
+  query,
+}: ModuleCardProps) {
   return (
     <button
       onClick={() => onSelect(module)}
@@ -16,8 +38,8 @@ export default function ModuleCard({ module, onSelect, selected }: ModuleCardPro
       }`}
     >
       <div className="flex-1 pr-2 font-mono">
-        <h3 className="font-bold">{module.name}</h3>
-        <p className="text-sm">{module.description}</p>
+        <h3 className="font-bold">{highlight(module.name, query)}</h3>
+        <p className="text-sm">{highlight(module.description, query)}</p>
       </div>
       <div className="flex flex-col gap-2 items-center">
         <Image

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "prettier": "^3.6.2",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
+    "rc-virtual-list": "3.19.1",
     "react": "19.1.1",
     "react-activity-calendar": "^2.7.13",
     "react-bootstrap": "^2.10.4",

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
+import VirtualList from 'rc-virtual-list';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
@@ -69,18 +70,29 @@ export default function PostExploitation() {
               </label>
             ))}
           </div>
-          <ul className="grid gap-4 list-none p-0">
-            {filtered.map((m) => (
-              <li key={m.name}>
-                <ModuleCard
-                  module={m}
-                  onSelect={setSelected}
-                  selected={selected?.name === m.name}
-                />
-              </li>
-            ))}
-            {filtered.length === 0 && <li>No modules match your search.</li>}
-          </ul>
+          {filtered.length === 0 ? (
+            <p>No modules match your search.</p>
+          ) : (
+            <VirtualList
+              data={filtered}
+              height={600}
+              itemHeight={120}
+              itemKey="name"
+              component="ul"
+              className="grid gap-4 list-none p-0"
+            >
+              {(m: ModuleMetadata) => (
+                <li key={m.name}>
+                  <ModuleCard
+                    module={m}
+                    onSelect={setSelected}
+                    selected={selected?.name === m.name}
+                    query={query}
+                  />
+                </li>
+              )}
+            </VirtualList>
+          )}
         </section>
         <aside className="prose">
           {selected ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11773,7 +11773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-virtual-list@npm:^3.14.2, rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
+"rc-virtual-list@npm:3.19.1, rc-virtual-list@npm:^3.14.2, rc-virtual-list@npm:^3.5.1, rc-virtual-list@npm:^3.5.2":
   version: 3.19.1
   resolution: "rc-virtual-list@npm:3.19.1"
   dependencies:
@@ -13908,6 +13908,7 @@ __metadata:
     prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     qrcode: "npm:^1.5.4"
+    rc-virtual-list: "npm:3.19.1"
     react: "npm:19.1.1"
     react-activity-calendar: "npm:^2.7.13"
     react-bootstrap: "npm:^2.10.4"


### PR DESCRIPTION
## Summary
- highlight matching text within post-exploitation module cards
- virtualize module list for performant searching of large data sets
- add rc-virtual-list dependency

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f94741883288cbd48a836aedf11