### PR TITLE
Use Next.js Image for responsive media

### DIFF
--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
@@ -57,10 +58,13 @@ export default function BackgroundSlideshow() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
         {available.map((file) => (
           <label key={file} className="flex flex-col items-center cursor-pointer">
-            <img
+            <Image
               src={`/images/wallpapers/${file}`}
               alt={file}
-              className="w-24 h-16 object-cover mb-1 border border-ubt-cool-grey"
+              width={96}
+              height={64}
+              sizes="96px"
+              className="object-cover mb-1 border border-ubt-cool-grey"
             />
             <input
               type="checkbox"

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
@@ -42,7 +43,16 @@ const AppsPage = () => {
             className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
             aria-label={app.title}
           >
-            {app.icon && <img src={app.icon} alt="" className="h-16 w-16" />}
+            {app.icon && (
+              <Image
+                src={app.icon}
+                alt=""
+                width={64}
+                height={64}
+                sizes="64px"
+                className="h-16 w-16"
+              />
+            )}
             <span className="mt-2">{app.title}</span>
           </Link>
         ))}

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from 'next/image';
 import React, { useState } from 'react';
 
 const HookFlow: React.FC = () => {
@@ -23,9 +24,12 @@ const HookFlow: React.FC = () => {
 
   return (
     <main className="p-4 space-y-4">
-      <img
+      <Image
         src="/hook-flow.svg"
         alt="React hook flow diagram"
+        width={420}
+        height={120}
+        sizes="(max-width: 420px) 100vw, 420px"
         className="mx-auto"
       />
       <iframe

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
@@ -324,7 +325,14 @@ const QRPage: React.FC = () => {
         {error && <FormError className="mt-2">{error}</FormError>}
         {qrPng && (
           <div className="mt-4 flex flex-col items-center gap-2">
-            <img src={qrPng} alt="Generated QR code" className="h-48 w-48" />
+            <Image
+              src={qrPng}
+              alt="Generated QR code"
+              width={192}
+              height={192}
+              sizes="192px"
+              className="h-48 w-48"
+            />
             <div className="flex gap-2">
               <button
                 onClick={downloadPng}

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 
@@ -110,7 +111,16 @@ const VCardPage: React.FC = () => {
       {vcard && (
         <div className="flex flex-col items-center gap-2">
           <pre className="whitespace-pre-wrap break-all text-xs">{vcard}</pre>
-          {png && <img src={png} alt="vCard QR" className="h-48 w-48" />}
+          {png && (
+            <Image
+              src={png}
+              alt="vCard QR"
+              width={192}
+              height={192}
+              sizes="192px"
+              className="h-48 w-48"
+            />
+          )}
           <div className="flex gap-2">
             <button
               type="button"

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 
 interface Video {
@@ -66,9 +67,12 @@ const VideoGallery: React.FC = () => {
             className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
             onClick={() => setPlaying(video.id)}
           >
-            <img
-              src={`https://img.youtube.com/vi/${video.id}/hqdefault.jpg`}
+            <Image
+              src={`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`}
               alt={video.title}
+              width={480}
+              height={360}
+              sizes="(max-width: 768px) 100vw, 480px"
               className="w-full"
             />
             <p className="mt-2 text-sm" style={{ maxInlineSize: '60ch' }}>{video.title}</p>


### PR DESCRIPTION
## Summary
- refactor several pages to use `next/image` instead of raw `<img>` tags
- provide explicit dimensions and `sizes` for responsive thumbnails and graphics to minimize layout shift

## Testing
- `npx eslint apps/settings/components/BackgroundSlideshow.tsx pages/video-gallery.tsx pages/hook-flow.tsx pages/apps/index.jsx pages/qr/index.tsx pages/qr/vcard.tsx --ext .ts,.tsx,.js,.jsx && echo 'Lint OK'`
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96fa081c48328b17d357ca28f11d4