### PR TITLE
feat: add colorblind palettes and high contrast options to games

### DIFF
--- a/__tests__/games-theme.test.ts
+++ b/__tests__/games-theme.test.ts
@@ -3,7 +3,9 @@ import {
   validateContrast,
   contrastRatio,
   defaultPalette,
-  colorBlindPalette,
+  protanopiaPalette,
+  deuteranopiaPalette,
+  tritanopiaPalette,
 } from '../components/apps/Games/common/theme';
 
 describe('game theme accessibility', () => {
@@ -11,8 +13,16 @@ describe('game theme accessibility', () => {
     expect(validateContrast(defaultPalette)).toBe(true);
   });
 
-  test('colorblind palette meets WCAG AA contrast', () => {
-    expect(validateContrast(colorBlindPalette)).toBe(true);
+  test('protanopia palette meets WCAG AA contrast', () => {
+    expect(validateContrast(protanopiaPalette)).toBe(true);
+  });
+
+  test('deuteranopia palette meets WCAG AA contrast', () => {
+    expect(validateContrast(deuteranopiaPalette)).toBe(true);
+  });
+
+  test('tritanopia palette meets WCAG AA contrast', () => {
+    expect(validateContrast(tritanopiaPalette)).toBe(true);
   });
 
   test('high contrast mode exceeds WCAG AAA contrast', () => {

--- a/components/apps/GameSettingsContext.tsx
+++ b/components/apps/GameSettingsContext.tsx
@@ -2,14 +2,15 @@ import React, { createContext, useContext } from 'react';
 import usePersistedState from '../../hooks/usePersistedState';
 
 type Difficulty = 'easy' | 'normal' | 'hard';
+type PaletteName = 'default' | 'protanopia' | 'deuteranopia' | 'tritanopia';
 
 interface Settings {
   difficulty: Difficulty;
   setDifficulty: (d: Difficulty) => void;
   assists: boolean;
   setAssists: (v: boolean) => void;
-  colorBlind: boolean;
-  setColorBlind: (v: boolean) => void;
+  palette: PaletteName;
+  setPalette: (v: PaletteName) => void;
   highContrast: boolean;
   setHighContrast: (v: boolean) => void;
   quality: number;
@@ -21,7 +22,10 @@ const SettingsContext = createContext<Settings | undefined>(undefined);
 export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [difficulty, setDifficulty] = usePersistedState<Difficulty>('settings:difficulty', 'normal');
   const [assists, setAssists] = usePersistedState('settings:assists', true);
-  const [colorBlind, setColorBlind] = usePersistedState('settings:colorBlind', false);
+  const [palette, setPalette] = usePersistedState<PaletteName>(
+    'settings:palette',
+    'default',
+  );
   const [highContrast, setHighContrast] = usePersistedState('settings:highContrast', false);
   const [quality, setQuality] = usePersistedState('settings:quality', 1);
 
@@ -32,8 +36,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         setDifficulty,
         assists,
         setAssists,
-        colorBlind,
-        setColorBlind,
+        palette,
+        setPalette,
         highContrast,
         setHighContrast,
         quality,

--- a/components/apps/Games/common/theme/index.ts
+++ b/components/apps/Games/common/theme/index.ts
@@ -1,4 +1,12 @@
-import { Palette, PaletteColor, defaultPalette, colorBlindPalette } from './palette';
+import {
+  Palette,
+  PaletteColor,
+  defaultPalette,
+  protanopiaPalette,
+  deuteranopiaPalette,
+  tritanopiaPalette,
+  highContrastPalette,
+} from './palette';
 
 // Calculate relative luminance according to WCAG 2.1
 const luminance = (hex: string): number => {
@@ -26,20 +34,29 @@ export const contrastRatio = (fg: string, bg: string): number => {
 export const validateContrast = (palette: Palette, minRatio = 4.5): boolean =>
   Object.values(palette).every(({ fg, bg }) => contrastRatio(fg, bg) >= minRatio);
 
-// Generate a high contrast variant of a palette using black backgrounds and white text
-const toHighContrast = (palette: Palette): Palette =>
-  Object.fromEntries(
-    Object.entries(palette).map(([k, v]) => [k, { ...v, bg: '#000000', fg: '#ffffff' }]),
-  ) as Palette;
+// Retrieve the appropriate palette based on color vision profile and contrast settings
+type ColorProfile = 'default' | 'protanopia' | 'deuteranopia' | 'tritanopia';
 
-// Retrieve the appropriate palette based on color blindness and contrast settings
+const palettes: Record<ColorProfile, Palette> = {
+  default: defaultPalette,
+  protanopia: protanopiaPalette,
+  deuteranopia: deuteranopiaPalette,
+  tritanopia: tritanopiaPalette,
+};
+
 export const getThemePalette = (
-  opts: { colorBlind?: boolean; highContrast?: boolean } = {},
+  opts: { palette?: ColorProfile; highContrast?: boolean } = {},
 ): Palette => {
-  let base: Palette = opts.colorBlind ? colorBlindPalette : defaultPalette;
-  if (opts.highContrast) base = toHighContrast(base);
-  return base;
+  if (opts.highContrast) return highContrastPalette;
+  const name = opts.palette ?? 'default';
+  return palettes[name];
 };
 
 export type { Palette, PaletteColor } from './palette';
-export { defaultPalette, colorBlindPalette } from './palette';
+export {
+  defaultPalette,
+  protanopiaPalette,
+  deuteranopiaPalette,
+  tritanopiaPalette,
+  highContrastPalette,
+} from './palette';

--- a/components/apps/Games/common/theme/palette.ts
+++ b/components/apps/Games/common/theme/palette.ts
@@ -15,12 +15,39 @@ export const defaultPalette: Palette = {
   danger: { bg: '#b91c1c', fg: '#ffffff', icon: '✖' }, // red-700
 };
 
-// Colorblind-friendly palette based on Okabe-Ito colors
-export const colorBlindPalette: Palette = {
+// Protanopia-friendly palette derived from Okabe-Ito colors
+export const protanopiaPalette: Palette = {
   primary: { bg: '#f3f4f6', fg: '#111827', icon: '●' },
   secondary: { bg: '#0072b2', fg: '#ffffff', icon: '▲' },
   success: { bg: '#009e73', fg: '#111827', icon: '✔' },
-  warning: { bg: '#d55e00', fg: '#111827', icon: '!' },
+  warning: { bg: '#56b4e9', fg: '#111827', icon: '!' },
   danger: { bg: '#cc79a7', fg: '#111827', icon: '✖' },
+};
+
+// Deuteranopia-friendly palette with high-contrast hues
+export const deuteranopiaPalette: Palette = {
+  primary: { bg: '#f3f4f6', fg: '#111827', icon: '●' },
+  secondary: { bg: '#0072b2', fg: '#ffffff', icon: '▲' },
+  success: { bg: '#e69f00', fg: '#111827', icon: '✔' },
+  warning: { bg: '#f0e442', fg: '#111827', icon: '!' },
+  danger: { bg: '#cc79a7', fg: '#111827', icon: '✖' },
+};
+
+// Tritanopia-friendly palette avoiding blue/yellow confusion
+export const tritanopiaPalette: Palette = {
+  primary: { bg: '#f3f4f6', fg: '#111827', icon: '●' },
+  secondary: { bg: '#d55e00', fg: '#111827', icon: '▲' },
+  success: { bg: '#009e73', fg: '#111827', icon: '✔' },
+  warning: { bg: '#e69f00', fg: '#111827', icon: '!' },
+  danger: { bg: '#cc79a7', fg: '#111827', icon: '✖' },
+};
+
+// High contrast palette using distinct tokens
+export const highContrastPalette: Palette = {
+  primary: { bg: '#000000', fg: '#ffffff', icon: '●' },
+  secondary: { bg: '#ffff00', fg: '#000000', icon: '▲' },
+  success: { bg: '#00ffff', fg: '#000000', icon: '✔' },
+  warning: { bg: '#ff33ff', fg: '#000000', icon: '!' },
+  danger: { bg: '#990000', fg: '#ffffff', icon: '✖' },
 };
 

--- a/components/game/GameSettingsPanel.jsx
+++ b/components/game/GameSettingsPanel.jsx
@@ -99,6 +99,10 @@ export default function GameSettingsPanel({
 
   // --- Display -----------------------------------------------------------
   const [palette, setPalette] = usePersistentState("game-palette", "default");
+  const [highContrast, setHighContrast] = usePersistentState(
+    "game-high-contrast",
+    false
+  );
   const [screenShake, setScreenShake] = usePersistentState(
     "game-screen-shake",
     true
@@ -177,6 +181,14 @@ export default function GameSettingsPanel({
             <option value="deuteranopia">Deuteranopia</option>
             <option value="tritanopia">Tritanopia</option>
           </select>
+        </label>
+        <label className="flex items-center gap-2 mb-2">
+          <input
+            type="checkbox"
+            checked={highContrast}
+            onChange={(e) => setHighContrast(e.target.checked)}
+          />
+          High Contrast
         </label>
         <label className="flex items-center gap-2">
           <input

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,12 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
 
+  /* Game palette tokens */
+  --game-color-secondary: #1d4ed8;
+  --game-color-success: #15803d;
+  --game-color-warning: #d97706;
+  --game-color-danger: #b91c1c;
+
   /* Spacing scale */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -63,6 +69,10 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --game-color-secondary: #ffff00;
+  --game-color-success: #00ffff;
+  --game-color-warning: #ff00ff;
+  --game-color-danger: #ff0000;
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- add protanopia, deuteranopia, tritanopia and high-contrast palettes
- expose palette and high contrast settings in game settings panel
- provide design tokens and tests for accessible contrast

## Testing
- `yarn test __tests__/games-theme.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b96f97a34c8328a56946a933181920