### PR TITLE
Offload 2048 AI to web worker

### DIFF
--- a/components/apps/2048.worker.js
+++ b/components/apps/2048.worker.js
@@ -1,0 +1,14 @@
+let aiPromise;
+
+onmessage = async (e) => {
+  const { type, board } = e.data;
+  aiPromise = aiPromise || import('../../apps/games/_2048/ai');
+  const { findHint, scoreMoves } = await aiPromise;
+  if (type === 'hint') {
+    const move = findHint(board);
+    postMessage({ type: 'hint', move });
+  } else if (type === 'score') {
+    const scores = scoreMoves(board);
+    postMessage({ type: 'score', scores });
+  }
+};


### PR DESCRIPTION
## Summary
- load 2048 AI logic lazily via dynamic import in a dedicated worker
- route hint and move scoring through the worker so the main thread stays responsive

## Testing
- `yarn test __tests__/game2048.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b96f9dd80883289ac57f6d76911241