### PR TITLE
Add haptics setting and vibration fallback

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -27,6 +27,8 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    haptics,
+    setHaptics,
     theme,
     setTheme,
   } = useSettings();
@@ -238,6 +240,14 @@ export default function Settings() {
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Haptics:</span>
+            <ToggleSwitch
+              checked={haptics}
+              onChange={setHaptics}
+              ariaLabel="Haptics"
             />
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">

--- a/components/apps/Games/common/haptics/index.ts
+++ b/components/apps/Games/common/haptics/index.ts
@@ -1,7 +1,11 @@
 export type HapticPattern = number | number[];
 
-const supportsVibration = () =>
+export const supportsVibration = () =>
   typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+
+const hapticsEnabled = () =>
+  typeof window === 'undefined' ||
+  window.localStorage.getItem('haptics') !== 'false';
 
 const supportsGamepadVibration = () => {
   if (typeof navigator === 'undefined' || !('getGamepads' in navigator)) return false;
@@ -30,6 +34,7 @@ const triggerGamepad = (duration: number) => {
 };
 
 export const vibrate = (pattern: HapticPattern) => {
+  if (!hapticsEnabled()) return;
   const duration = Array.isArray(pattern)
     ? pattern.reduce((sum, n) => sum + (n > 0 ? n : 0), 0)
     : pattern;
@@ -58,6 +63,7 @@ const haptics = {
   danger,
   gameOver,
   patterns,
+  supportsVibration,
 };
 
 export default haptics;

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -147,6 +147,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Allow Network Requests
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={haptics}
+                        onChange={(e) => setHaptics(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Haptics
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -1,19 +1,20 @@
 "use client";
 
 import { useCallback } from 'react';
-import usePersistedState from './usePersistedState';
+import { useSettings } from './useSettings';
 import {
   vibrate as vibrateNative,
   patterns,
+  supportsVibration,
 } from '../components/apps/Games/common/haptics';
 
 // Exposes helpers for triggering game haptics with an on/off toggle.
 export default function useGameHaptics() {
-  const [enabled, setEnabled] = usePersistedState('game:haptics', true);
+  const { haptics: enabled, setHaptics } = useSettings();
 
   const vibrate = useCallback(
     (pattern) => {
-      if (!enabled) return;
+      if (!enabled || !supportsVibration()) return;
       vibrateNative(pattern);
     },
     [enabled]
@@ -23,7 +24,7 @@ export default function useGameHaptics() {
   const danger = useCallback(() => vibrate(patterns.danger), [vibrate]);
   const gameOver = useCallback(() => vibrate(patterns.gameOver), [vibrate]);
 
-  const toggle = useCallback(() => setEnabled((e) => !e), [setEnabled]);
+  const toggle = useCallback(() => setHaptics(!enabled), [setHaptics, enabled]);
 
   return { enabled, toggle, vibrate, score, danger, gameOver };
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -18,6 +18,8 @@ import {
   setPongSpin as savePongSpin,
   getAllowNetwork as loadAllowNetwork,
   setAllowNetwork as saveAllowNetwork,
+  getHaptics as loadHaptics,
+  setHaptics as saveHaptics,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -49,6 +51,7 @@ interface SettingsContextValue {
   largeHitAreas: boolean;
   pongSpin: boolean;
   allowNetwork: boolean;
+  haptics: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -59,6 +62,7 @@ interface SettingsContextValue {
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
+  setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -72,6 +76,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
+  haptics: defaults.haptics,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -82,6 +87,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
   setAllowNetwork: () => {},
+  setHaptics: () => {},
   setTheme: () => {},
 });
 
@@ -95,6 +101,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -109,6 +116,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
+      setHaptics(await loadHaptics());
       setTheme(loadTheme());
     })();
   }, []);
@@ -211,6 +219,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [allowNetwork]);
 
+  useEffect(() => {
+    saveHaptics(haptics);
+  }, [haptics]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -223,6 +235,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         largeHitAreas,
         pongSpin,
         allowNetwork,
+        haptics,
         theme,
         setAccent,
         setWallpaper,
@@ -233,6 +246,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setLargeHitAreas,
         setPongSpin,
         setAllowNetwork,
+        setHaptics,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   largeHitAreas: false,
   pongSpin: true,
   allowNetwork: false,
+  haptics: true,
 };
 
 export async function getAccent() {
@@ -86,6 +87,17 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getHaptics() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
+  const val = window.localStorage.getItem('haptics');
+  return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
+}
+
+export async function setHaptics(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -120,6 +132,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
+  window.localStorage.removeItem('haptics');
 }
 
 export async function exportSettings() {
@@ -133,6 +146,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    haptics,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -143,6 +157,7 @@ export async function exportSettings() {
     getLargeHitAreas(),
     getPongSpin(),
     getAllowNetwork(),
+    getHaptics(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -155,6 +170,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    haptics,
     theme,
   });
 }
@@ -178,6 +194,7 @@ export async function importSettings(json) {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    haptics,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -189,6 +206,7 @@ export async function importSettings(json) {
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
+  if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add persistent haptics preference and settings toggles
- gate vibration calls on both user preference and API support

## Testing
- `npm test` *(fails: ReferenceError: setTheme is not defined)*
- `npx eslint apps/settings/index.tsx components/apps/Games/common/haptics/index.ts components/apps/settings.js hooks/useGameHaptics.js hooks/useSettings.tsx utils/settingsStore.js`

------
https://chatgpt.com/codex/tasks/task_e_68b96f9733c8832887155807bbeae341