### PR TITLE
feat: add shared app header

### DIFF
--- a/components/base/AppHeader.tsx
+++ b/components/base/AppHeader.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import NextImage from 'next/image';
+import useDocPiP from '../../hooks/useDocPiP';
+
+interface AppHeaderProps {
+  title: string;
+  minimize: () => void;
+  maximize: () => void;
+  isMaximised: boolean;
+  close: () => void;
+  allowMaximize?: boolean;
+  pip?: () => void;
+  onHelp?: () => void;
+  onFeedback?: () => void;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+  onBlur?: React.FocusEventHandler<HTMLDivElement>;
+  grabbed?: boolean;
+}
+
+const AppHeader: React.FC<AppHeaderProps> = ({
+  title,
+  minimize,
+  maximize,
+  isMaximised,
+  close,
+  allowMaximize = true,
+  pip,
+  onHelp,
+  onFeedback,
+  onKeyDown,
+  onBlur,
+  grabbed,
+}) => {
+  const { togglePin } = useDocPiP(pip || (() => null));
+  const pipSupported =
+    typeof window !== 'undefined' && !!(window as any).documentPictureInPicture;
+  return (
+    <div
+      className="relative bg-ub-window-title border-t-2 border-white border-opacity-5 py-1.5 px-3 text-white w-full select-none rounded-b-none"
+      tabIndex={0}
+      role="button"
+      aria-grabbed={grabbed}
+      aria-label={title}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
+    >
+      <div className="flex justify-center text-sm font-bold">{title}</div>
+      <div className="absolute left-0 top-0 mt-1 ml-1 flex items-center">
+        {onHelp && (
+          <button
+            type="button"
+            aria-label="Help"
+            className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 text-sm"
+            onClick={onHelp}
+          >
+            ?
+          </button>
+        )}
+        {onFeedback && (
+          <button
+            type="button"
+            aria-label="Feedback"
+            className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6 text-sm"
+            onClick={onFeedback}
+          >
+            💬
+          </button>
+        )}
+      </div>
+      <div className="absolute right-0 top-0 mt-1 mr-1 flex justify-center items-center">
+        {pipSupported && pip && (
+          <button
+            type="button"
+            aria-label="Window pin"
+            className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+            onClick={togglePin}
+          >
+            <NextImage
+              src="/themes/Yaru/window/window-pin-symbolic.svg"
+              alt="Kali window pin"
+              className="h-5 w-5 inline"
+              width={20}
+              height={20}
+              sizes="20px"
+            />
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label="Window minimize"
+          className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+          onClick={minimize}
+        >
+          <NextImage
+            src="/themes/Yaru/window/window-minimize-symbolic.svg"
+            alt="Kali window minimize"
+            className="h-5 w-5 inline"
+            width={20}
+            height={20}
+            sizes="20px"
+          />
+        </button>
+        {allowMaximize &&
+          (isMaximised ? (
+            <button
+              type="button"
+              aria-label="Window restore"
+              className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+              onClick={maximize}
+            >
+              <NextImage
+                src="/themes/Yaru/window/window-restore-symbolic.svg"
+                alt="Kali window restore"
+                className="h-5 w-5 inline"
+                width={20}
+                height={20}
+                sizes="20px"
+              />
+            </button>
+          ) : (
+            <button
+              type="button"
+              aria-label="Window maximize"
+              className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
+              onClick={maximize}
+            >
+              <NextImage
+                src="/themes/Yaru/window/window-maximize-symbolic.svg"
+                alt="Kali window maximize"
+                className="h-5 w-5 inline"
+                width={20}
+                height={20}
+                sizes="20px"
+              />
+            </button>
+          ))}
+        <button
+          type="button"
+          aria-label="Window close"
+          className="mx-1.5 bg-white bg-opacity-0 hover:bg-ub-red rounded-full flex justify-center items-center h-11 w-11"
+          onClick={close}
+        >
+          <NextImage
+            src="/themes/Yaru/window/window-close-symbolic.svg"
+            alt="Kali window close"
+            className="h-5 w-5 inline"
+            width={20}
+            height={20}
+            sizes="20px"
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AppHeader;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,11 +1,10 @@
 "use client";
 
 import React, { Component } from 'react';
-import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
-import useDocPiP from '../../hooks/useDocPiP';
+import AppHeader from './AppHeader';
 
 export class Window extends Component {
     constructor(props) {
@@ -506,20 +505,19 @@ export class Window extends Component {
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
-                        <WindowTopBar
+                        <AppHeader
                             title={this.props.title}
-                            onKeyDown={this.handleTitleBarKeyDown}
-                            onBlur={this.releaseGrab}
-                            grabbed={this.state.grabbed}
-                        />
-                        <WindowEditButtons
                             minimize={this.minimizeWindow}
                             maximize={this.maximizeWindow}
                             isMaximised={this.state.maximized}
                             close={this.closeWindow}
-                            id={this.id}
                             allowMaximize={this.props.allowMaximize !== false}
                             pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
+                            onKeyDown={this.handleTitleBarKeyDown}
+                            onBlur={this.releaseGrab}
+                            grabbed={this.state.grabbed}
+                            onHelp={this.props.onHelp}
+                            onFeedback={this.props.onFeedback}
                         />
                         {(this.id === "settings"
                             ? <Settings />
@@ -534,23 +532,6 @@ export class Window extends Component {
 }
 
 export default Window
-
-// Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
-    return (
-        <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 py-1.5 px-3 text-white w-full select-none rounded-b-none"}
-            tabIndex={0}
-            role="button"
-            aria-grabbed={grabbed}
-            onKeyDown={onKeyDown}
-            onBlur={onBlur}
-        >
-            <div className="flex justify-center text-sm font-bold">{title}</div>
-        </div>
-    )
-}
-
 // Window's Borders
 export class WindowYBorder extends Component {
     componentDidMount() {
@@ -584,101 +565,6 @@ export class WindowXBorder extends Component {
         )
     }
 }
-
-// Window's Edit Buttons
-export function WindowEditButtons(props) {
-    const { togglePin } = useDocPiP(props.pip || (() => null));
-    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
-    return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center">
-            {pipSupported && props.pip && (
-                <button
-                    type="button"
-                    aria-label="Window pin"
-                    className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
-                    onClick={togglePin}
-                >
-                    <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
-                        className="h-5 w-5 inline"
-                        width={20}
-                        height={20}
-                        sizes="20px"
-                    />
-                </button>
-            )}
-            <button
-                type="button"
-                aria-label="Window minimize"
-                className="mx-1.5 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
-                onClick={props.minimize}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
-                    className="h-5 w-5 inline"
-                    width={20}
-                    height={20}
-                    sizes="20px"
-                />
-            </button>
-            {props.allowMaximize && (
-                props.isMaximised
-                    ? (
-                        <button
-                            type="button"
-                            aria-label="Window restore"
-                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
-                                className="h-5 w-5 inline"
-                                width={20}
-                                height={20}
-                                sizes="20px"
-                            />
-                        </button>
-                    ) : (
-                        <button
-                            type="button"
-                            aria-label="Window maximize"
-                            className="mx-2 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-11 w-11"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
-                                className="h-5 w-5 inline"
-                                width={20}
-                                height={20}
-                                sizes="20px"
-                            />
-                        </button>
-                    )
-            )}
-            <button
-                type="button"
-                id={`close-${props.id}`}
-                aria-label="Window close"
-                className="mx-1.5 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-11 w-11"
-                onClick={props.close}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
-                    className="h-5 w-5 inline"
-                    width={20}
-                    height={20}
-                    sizes="20px"
-                />
-            </button>
-        </div>
-    )
-}
-
 // Window's Main Screen
 export class WindowMainScreen extends Component {
     constructor() {


### PR DESCRIPTION
## Summary
- introduce reusable AppHeader with title, controls, and help/feedback icons
- wire Window to use AppHeader for consistent controls across apps

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn test __tests__/themePersistence.test.ts` *(fails: setTheme is not defined, structuredClone is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f93f8088328845210dc762f9dfe