### PR TITLE
feat: add Alt+Tab window switcher

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -13,6 +13,7 @@ import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
+import WindowSwitcher from '../screen/window-switcher'
 import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
@@ -45,6 +46,8 @@ export class Desktop extends Component {
             context_app: null,
             showNameBar: false,
             showShortcutSelector: false,
+            showWindowSwitcher: false,
+            switcherWindows: [],
         }
     }
 
@@ -138,10 +141,35 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
-        if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+        if (e.altKey && e.key === 'Tab') {
+            e.preventDefault();
+            if (!this.state.showWindowSwitcher) {
+                this.openWindowSwitcher();
+            }
+        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
         }
+    }
+
+    openWindowSwitcher = () => {
+        const windows = this.app_stack
+            .filter(id => this.state.closed_windows[id] === false)
+            .map(id => apps.find(a => a.id === id))
+            .filter(Boolean);
+        if (windows.length) {
+            this.setState({ showWindowSwitcher: true, switcherWindows: windows });
+        }
+    }
+
+    closeWindowSwitcher = () => {
+        this.setState({ showWindowSwitcher: false, switcherWindows: [] });
+    }
+
+    selectWindow = (id) => {
+        this.setState({ showWindowSwitcher: false, switcherWindows: [] }, () => {
+            this.openApp(id);
+        });
     }
 
     checkContextMenu = (e) => {
@@ -815,6 +843,12 @@ export class Desktop extends Component {
                         games={games}
                         onSelect={this.addShortcutToDesktop}
                         onClose={() => this.setState({ showShortcutSelector: false })} /> : null}
+
+                { this.state.showWindowSwitcher ?
+                    <WindowSwitcher
+                        windows={this.state.switcherWindows}
+                        onSelect={this.selectWindow}
+                        onClose={this.closeWindowSwitcher} /> : null}
 
             </main>
         )

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useState, useRef } from 'react';
+
+export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef(null);
+
+  const filtered = windows.filter((w) =>
+    w.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyUp = (e) => {
+      if (e.key === 'Alt') {
+        const win = filtered[selected];
+        if (win && typeof onSelect === 'function') {
+          onSelect(win.id);
+        } else if (typeof onClose === 'function') {
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keyup', handleKeyUp);
+    return () => window.removeEventListener('keyup', handleKeyUp);
+  }, [filtered, selected, onSelect, onClose]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const len = filtered.length;
+      if (!len) return;
+      const dir = e.shiftKey ? -1 : 1;
+      setSelected((selected + dir + len) % len);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const len = filtered.length;
+      if (!len) return;
+      setSelected((selected + 1) % len);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const len = filtered.length;
+      if (!len) return;
+      setSelected((selected - 1 + len) % len);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      if (typeof onClose === 'function') onClose();
+    }
+  };
+
+  const handleChange = (e) => {
+    setQuery(e.target.value);
+    setSelected(0);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
+      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          placeholder="Search windows"
+        />
+        <ul>
+          {filtered.map((w, i) => (
+            <li
+              key={w.id}
+              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
+            >
+              {w.title}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add WindowSwitcher overlay listing open windows with search
- handle Alt+Tab to open overlay and switch windows

## Testing
- `npx eslint --max-warnings=0 .` *(fails: command timed out)*
- `npx jest __tests__/themePersistence.test.ts` *(fails: ReferenceError setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8aa10c8328bf70cb88345c7f61