### PR TITLE
fix: label icon-only buttons

### DIFF
--- a/__tests__/calculator.app.test.js
+++ b/__tests__/calculator.app.test.js
@@ -8,16 +8,16 @@ function setupDom() {
     `<!DOCTYPE html><html><body>
       <input id="display" />
       <div class="buttons"></div>
-      <button id="toggle-scientific"></button>
-      <button id="toggle-precise"></button>
-      <button id="toggle-programmer"></button>
-      <button id="toggle-history"></button>
+      <button id="toggle-scientific" aria-label="toggle scientific mode"></button>
+      <button id="toggle-precise" aria-label="toggle precise mode"></button>
+      <button id="toggle-programmer" aria-label="toggle programmer mode"></button>
+      <button id="toggle-history" aria-label="toggle history"></button>
       <div id="scientific"></div>
       <div id="programmer"></div>
       <select id="base-select"></select>
       <div id="history"></div>
       <div id="paren-indicator"></div>
-      <button id="print-tape"></button>
+      <button id="print-tape" aria-label="print tape"></button>
     </body></html>`,
     { url: 'https://example.com' }
   );

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -143,8 +143,9 @@ export default function Settings() {
             />
           </div>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Wallpaper:</label>
+            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
             <input
+              id="wallpaper-slider"
               type="range"
               min="0"
               max={wallpapers.length - 1}
@@ -154,6 +155,7 @@ export default function Settings() {
                 changeBackground(wallpapers[parseInt(e.target.value, 10)])
               }
               className="ubuntu-slider"
+              aria-label="Wallpaper"
             />
           </div>
           <div className="flex justify-center my-4">
@@ -202,8 +204,9 @@ export default function Settings() {
       {activeTab === "accessibility" && (
         <>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Icon Size:</label>
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
             <input
+              id="font-scale"
               type="range"
               min="0.75"
               max="1.5"
@@ -211,6 +214,7 @@ export default function Settings() {
               value={fontScale}
               onChange={(e) => setFontScale(parseFloat(e.target.value))}
               className="ubuntu-slider"
+              aria-label="Icon size"
             />
           </div>
           <div className="flex justify-center my-4">
@@ -268,17 +272,18 @@ export default function Settings() {
           </div>
         </>
       )}
-      <input
-        type="file"
-        accept="application/json"
-        ref={fileInputRef}
-        onChange={(e) => {
-          const file = e.target.files && e.target.files[0];
-          if (file) handleImport(file);
-          e.target.value = "";
-        }}
-        className="hidden"
-      />
+        <input
+          type="file"
+          accept="application/json"
+          ref={fileInputRef}
+          aria-label="Import settings file"
+          onChange={(e) => {
+            const file = e.target.files && e.target.files[0];
+            if (file) handleImport(file);
+            e.target.value = "";
+          }}
+          className="hidden"
+        />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/chrome-extension/pip.html
+++ b/chrome-extension/pip.html
@@ -12,8 +12,8 @@
 <body>
   <div id="controls">
     <input id="omnibox" placeholder="Search or URL" />
-    <button id="play">▶</button>
-    <button id="pause">❚❚</button>
+    <button id="play" aria-label="Play">▶</button>
+    <button id="pause" aria-label="Pause">❚❚</button>
   </div>
   <script src="pip.js"></script>
 </body>

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -5,7 +5,7 @@ interface ToggleSwitchProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   className?: string;
-  ariaLabel?: string;
+  ariaLabel: string;
 }
 
 export default function ToggleSwitch({

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
     rules: {
       '@next/next/no-page-custom-font': 'off',
       '@next/next/no-img-element': 'off',
+      'jsx-a11y/control-has-associated-label': 'error',
     },
   }),
 ];

--- a/public/apps/platformer/index.html
+++ b/public/apps/platformer/index.html
@@ -13,9 +13,9 @@
   </div>
   <div id="complete" class="hidden" role="status" aria-live="assertive">Level Complete!</div>
   <div id="controls" class="hidden">
-    <button id="btnLeft">◀</button>
-    <button id="btnRight">▶</button>
-    <button id="btnJump">⮝</button>
+    <button id="btnLeft" aria-label="Move left">◀</button>
+    <button id="btnRight" aria-label="Move right">▶</button>
+    <button id="btnJump" aria-label="Jump">⮝</button>
   </div>
   <div id="settings">
     <div>
@@ -68,13 +68,13 @@
       <label><input type="checkbox" id="buttonsToggle" /> Show Buttons</label>
     </div>
     <div>
-      Pad Left: <button id="padLeft"></button>
+      Pad Left: <button id="padLeft" aria-label="Move left"></button>
     </div>
     <div>
-      Pad Right: <button id="padRight"></button>
+      Pad Right: <button id="padRight" aria-label="Move right"></button>
     </div>
     <div>
-      Pad Jump: <button id="padJump"></button>
+      Pad Jump: <button id="padJump" aria-label="Jump"></button>
     </div>
   </div>
   <a href="editor.html" id="editorLink">Level Editor</a>


### PR DESCRIPTION
## Summary
- require ariaLabel prop for ToggleSwitch
- add missing aria-labels to icon-only buttons in chrome extension, platformer, and tests
- enforce control labeling with ESLint rule and label range inputs in settings

## Testing
- `yarn lint` *(fails: 567 errors, 15 warnings)*
- `npx eslint components/ToggleSwitch.tsx apps/settings/index.tsx chrome-extension/pip.html public/apps/platformer/index.html __tests__/calculator.app.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b96f86233c8328a93dc1338786a01c