### PR TITLE
feat: add focus outline tokens and tests

### DIFF
--- a/__tests__/betaBadge.test.tsx
+++ b/__tests__/betaBadge.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BetaBadge from '../components/BetaBadge';
+
+describe('BetaBadge', () => {
+  test('is focusable via keyboard', async () => {
+    process.env.NEXT_PUBLIC_SHOW_BETA = '1';
+    render(<BetaBadge />);
+    const button = screen.getByRole('button', { name: /beta/i });
+    await userEvent.tab();
+    expect(button).toHaveFocus();
+  });
+});

--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -38,4 +38,19 @@ describe('InstallButton', () => {
 
     await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
   });
+
+  test('can be focused via keyboard', async () => {
+    render(<InstallButton />);
+    initA2HS();
+    const event: any = new Event('beforeinstallprompt');
+    event.preventDefault = jest.fn();
+    event.prompt = jest.fn();
+    event.userChoice = Promise.resolve({ outcome: 'dismissed' });
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+    const button = await screen.findByRole('button', { name: /install/i });
+    await userEvent.tab();
+    expect(button).toHaveFocus();
+  });
 });

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,6 +1,11 @@
 export default function BetaBadge() {
   if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
   return (
-    <div className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black">Beta</div>
+    <button
+      type="button"
+      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+    >
+      Beta
+    </button>
   );
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,7 +18,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: 2px solid var(--color-ubt-blue) !important;
+    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
     outline-offset: 2px;
 }
 
@@ -537,7 +537,7 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: 2px;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -50,6 +50,9 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
+  /* Focus outline */
+  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-width: 2px;
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add CSS tokens for focus outline color and width
- convert BetaBadge to a button so it can receive focus
- test keyboard navigation for InstallButton and BetaBadge

## Testing
- `npm run lint -- __tests__/installButton.test.tsx __tests__/betaBadge.test.tsx components/BetaBadge.jsx styles/index.css styles/tokens.css` *(fails: Component definition is missing display name, 130 errors)*
- `npm test -- __tests__/betaBadge.test.tsx __tests__/installButton.test.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b96f7dc0f88328a30e7abb86a018f3