### PR TITLE
feat: add accessibility thresholds

### DIFF
--- a/playwright/a11y.spec.ts
+++ b/playwright/a11y.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
+// Maximum allowed accessibility violations by impact level
+const thresholds: Record<string, number> = {
+  critical: 0,
+  serious: 0,
+  // Allow a limited number of moderate/minor issues until they are fixed
+  moderate: 10,
+  minor: 50,
+};
+
 const urls = [
   '/',
   '/apps',
@@ -18,14 +27,27 @@ const urls = [
 ];
 
 for (const path of urls) {
-  test(`no critical accessibility violations on ${path}`, async ({ page }) => {
+  test(`accessibility audit for ${path}`, async ({ page }) => {
     await page.goto(`http://localhost:3000${path}`);
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa'])
       .analyze();
-    const critical = results.violations.filter(
-      (v) => v.impact === 'critical',
+
+    const counts = results.violations.reduce<Record<string, number>>(
+      (acc, v) => {
+        const impact = v.impact || 'minor';
+        acc[impact] = (acc[impact] || 0) + 1;
+        return acc;
+      },
+      {},
     );
-    expect(critical).toEqual([]);
+
+    for (const [impact, max] of Object.entries(thresholds)) {
+      const count = counts[impact] || 0;
+      expect(
+        count,
+        `${path} has ${count} ${impact} violations (threshold ${max})`,
+      ).toBeLessThanOrEqual(max);
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add per-impact accessibility thresholds to the Playwright audit
- report and fail when violations exceed the allowed counts

## Testing
- `npx playwright test playwright/a11y.spec.ts` *(fails: No tests found)*
- `yarn test __tests__/gamepad.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b96f88f284832884cfa9f9013b2a12