### PR TITLE
feat: enhance window snapping and layout persistence

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -284,6 +284,33 @@ describe('Window keyboard dragging', () => {
   });
 });
 
+describe('Window keyboard resizing', () => {
+  it('resizes window using Shift + Arrow keys', () => {
+    const onPositionChange = jest.fn();
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        onPositionChange={onPositionChange}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    fireEvent.keyDown(winEl, { key: 'ArrowRight', shiftKey: true });
+
+    expect(ref.current!.state.width).toBeGreaterThan(60);
+    expect(onPositionChange).toHaveBeenCalled();
+  });
+});
+
 describe('Window overlay inert behaviour', () => {
   it('sets and removes inert on default __next root restoring focus', () => {
     const ref = React.createRef<Window>();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -202,7 +202,7 @@ export class Window extends Component {
         r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
         r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
         if (this.props.onPositionChange) {
-            this.props.onPositionChange(x, y);
+            this.props.onPositionChange(x, y, this.state.width, this.state.height);
         }
     }
 
@@ -221,9 +221,9 @@ export class Window extends Component {
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
                 snapped: null
-            }, this.resizeBoundries);
+            }, () => { this.resizeBoundries(); this.setWinowsPosition(); });
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null }, () => { this.resizeBoundries(); this.setWinowsPosition(); });
         }
     }
 
@@ -313,9 +313,10 @@ export class Window extends Component {
                 lastSize: { width, height },
                 width: newWidth,
                 height: newHeight
-            }, this.resizeBoundries);
+            }, () => { this.resizeBoundries(); this.setWinowsPosition(); });
         }
         else {
+            this.setWinowsPosition();
             this.setState({ snapPreview: null, snapPosition: null });
         }
     }
@@ -470,6 +471,18 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.key === 'ArrowDown' && e.altKey) {
             this.unsnapWindow();
+        } else if (e.shiftKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+            e.preventDefault();
+            const delta = 1;
+            if (e.key === 'ArrowLeft') {
+                this.setState(prev => ({ width: Math.max(prev.width - delta, 20) }), () => { this.resizeBoundries(); this.setWinowsPosition(); });
+            } else if (e.key === 'ArrowRight') {
+                this.setState(prev => ({ width: prev.width + delta }), () => { this.resizeBoundries(); this.setWinowsPosition(); });
+            } else if (e.key === 'ArrowUp') {
+                this.setState(prev => ({ height: Math.max(prev.height - delta, 20) }), () => { this.resizeBoundries(); this.setWinowsPosition(); });
+            } else if (e.key === 'ArrowDown') {
+                this.setState(prev => ({ height: prev.height + delta }), () => { this.resizeBoundries(); this.setWinowsPosition(); });
+            }
         }
     }
 

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,6 +5,8 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  width: number;
+  height: number;
 }
 
 export interface DesktopSession {


### PR DESCRIPTION
## Summary
- persist window sizes in session storage and restore on load
- allow Shift+Arrow to resize windows and store new layout
- keep layout data in local storage when snapping or unsnapping

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint hooks/useSession.ts components/screen/desktop.js components/base/window.js __tests__/window.test.tsx` *(fails: Component definition is missing display name and many repository-wide lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8b26a08328adf15f42b5d0f66a