### PR TITLE
Improve window snapping feedback and resistance

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -284,6 +284,44 @@ describe('Window keyboard dragging', () => {
   });
 });
 
+describe('Edge resistance', () => {
+  it('clamps drag movement near boundaries', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag({}, { node: winEl, x: -100, y: -50 } as any);
+    });
+
+    expect(winEl.style.transform).toBe('translate(0px, 0px)');
+  });
+});
+
 describe('Window overlay inert behaviour', () => {
   it('sets and removes inert on default __next root restoring focus', () => {
     const ref = React.createRef<Window>();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -275,7 +275,31 @@ export class Window extends Component {
         }
     }
 
-    handleDrag = () => {
+    applyEdgeResistance = (node, data) => {
+        if (!node || !data) return;
+        const threshold = 30;
+        const resistance = 0.35; // how much to slow near edges
+        let { x, y } = data;
+        const maxX = this.state.parentSize.width;
+        const maxY = this.state.parentSize.height;
+
+        const resist = (pos, min, max) => {
+            if (pos < min) return min;
+            if (pos < min + threshold) return min + (pos - min) * resistance;
+            if (pos > max) return max;
+            if (pos > max - threshold) return max - (max - pos) * resistance;
+            return pos;
+        }
+
+        x = resist(x, 0, maxX);
+        y = resist(y, 0, maxY);
+        node.style.transform = `translate(${x}px, ${y}px)`;
+    }
+
+    handleDrag = (e, data) => {
+        if (data && data.node) {
+            this.applyEdgeResistance(data.node, data);
+        }
         this.checkOverlap();
         this.checkSnapPreview();
     }
@@ -479,7 +503,7 @@ export class Window extends Component {
                 {this.state.snapPreview && (
                     <div
                         data-testid="snap-preview"
-                        className="fixed border-2 border-dashed border-white pointer-events-none z-40"
+                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-40 transition-opacity"
                         style={{ left: this.state.snapPreview.left, top: this.state.snapPreview.top, width: this.state.snapPreview.width, height: this.state.snapPreview.height }}
                     />
                 )}
@@ -497,7 +521,7 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,12 @@
-import 'fake-indexeddb/auto';
-import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
+// Polyfill structuredClone before requiring modules that depend on it
+// @ts-ignore
+if (typeof global.structuredClone !== 'function') {
+  // @ts-ignore
+  global.structuredClone = (val) => (val === undefined ? val : JSON.parse(JSON.stringify(val)));
+}
+require('fake-indexeddb/auto');
+import '@testing-library/jest-dom';
 
 // Provide TextEncoder/TextDecoder for libraries that expect them in the test environment
 // @ts-ignore


### PR DESCRIPTION
## Summary
- Add edge resistance when dragging windows to slow movement near screen edges
- Show translucent ghost preview and ring highlight when a window is about to snap
- Include tests and setup fixes for structuredClone and theme persistence

## Testing
- `npm test` *(fails: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8cecac83288ce4532dfd7f23ac