### PR TITLE
feat: add module error boundary

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,39 +1,79 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import Link from 'next/link';
+import { reportClientError } from '../../lib/client-error-reporter';
 
 interface Props {
   children: ReactNode;
+  /**
+   * Custom fallback. When provided as a function it receives the error and a
+   * reset callback to recover from the error state.
+   */
+  fallback?:
+    | ReactNode
+    | ((error: Error, reset: () => void) => ReactNode);
 }
 
 interface State {
-  hasError: boolean;
+  error: Error | null;
 }
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { error: null };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
   }
 
-  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
-    // You can log the error to an error reporting service
-    console.error('ErrorBoundary caught an error', error, errorInfo);
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    reportClientError(error, errorInfo.componentStack).catch((err) => {
+      console.error('Failed to report client error', err);
+    });
   }
+
+  private reset = () => {
+    this.setState({ error: null });
+  };
 
   render() {
-    if (this.state.hasError) {
+    const { error } = this.state;
+    const { fallback, children } = this.props;
+
+    if (error) {
+      if (typeof fallback === 'function') {
+        return fallback(error, this.reset);
+      }
+
+      if (fallback) {
+        return fallback;
+      }
+
       return (
         <div role="alert" className="p-4 text-center">
           <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
+          <p className="mb-4">You can try again or report the issue.</p>
+          <div className="flex items-center justify-center gap-2">
+            <button
+              type="button"
+              onClick={this.reset}
+              className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              Try again
+            </button>
+            <Link
+              href="/apps/contact"
+              className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              Report issue
+            </Link>
+          </div>
         </div>
       );
     }
 
-    return this.props.children;
+    return children;
   }
 }
 

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { logEvent } from './analytics';
+import ErrorBoundary from '../components/core/ErrorBoundary';
 
 export const createDynamicApp = (id, title) =>
   dynamic(
@@ -10,14 +12,44 @@ export const createDynamicApp = (id, title) =>
           /* webpackPrefetch: true */ `../components/apps/${id}`
         );
         logEvent({ category: 'Application', action: `Loaded ${title}` });
-        return mod.default;
+        const Component = mod.default;
+        const Wrapped = (props) => (
+          <ErrorBoundary
+            fallback={(error, reset) => (
+              <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-ub-cool-grey text-white p-4 text-center">
+                <p>{`Something went wrong in ${title}.`}</p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="rounded bg-slate-100 px-4 py-2 text-sm text-black hover:bg-slate-200"
+                  >
+                    Try again
+                  </button>
+                  <Link
+                    href="/apps/contact"
+                    className="rounded bg-slate-100 px-4 py-2 text-sm text-black hover:bg-slate-200"
+                  >
+                    Report issue
+                  </Link>
+                </div>
+              </div>
+            )}
+          >
+            <Component {...props} />
+          </ErrorBoundary>
+        );
+        Wrapped.displayName = `${title}WithErrorBoundary`;
+        return Wrapped;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const Failed = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        Failed.displayName = `${title}LoadError`;
+        return Failed;
       }
     },
     {


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component with reset and feedback
- wrap dynamic app modules in ErrorBoundary

## Testing
- `npx eslint components/core/ErrorBoundary.tsx utils/createDynamicApp.js`
- `npx jest components/core/ErrorBoundary.tsx utils/createDynamicApp.js --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b96fa09d80832884e4db00356cf735