### PR TITLE
feat: add FPS overlay and low-spec mode toggle

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,7 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, lowSpec, setLowSpec } = useSettings();
 
   return (
     <div>
@@ -40,6 +40,14 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               value={accent}
               onChange={(e) => setAccent(e.target.value)}
             />
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={lowSpec}
+              onChange={(e) => setLowSpec(e.target.checked)}
+            />
+            Low-spec mode
           </label>
         </div>
       )}

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { useSettings } from '../../hooks/useSettings';
 
 interface GameLayoutProps {
   gameId?: string;
@@ -27,6 +28,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const [showHelp, setShowHelp] = useState(false);
   const [paused, setPaused] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
+  const { lowSpec } = useSettings();
 
   const close = useCallback(() => setShowHelp(false), []);
   const toggle = useCallback(() => setShowHelp((h) => !h), []);
@@ -178,7 +180,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         {score !== undefined && <div>Score: {score}</div>}
         {highScore !== undefined && <div>High: {highScore}</div>}
       </div>
-      {!prefersReducedMotion && <PerfOverlay />}
+      {!prefersReducedMotion && !lowSpec && <PerfOverlay />}
       {editor && (
         <div className="absolute bottom-2 left-2 z-30">{editor}</div>
       )}

--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -11,6 +11,7 @@ interface PerfSample {
 
 const MAX_SAMPLES = 120;
 const MAX_MS = 50; // cap graph at 50ms (20 FPS)
+const FRAME_BUDGET = 16; // ideal frame time in ms for 60 FPS
 
 export const exportPerfReport = (samples: PerfSample[]) => {
   if (!samples.length || typeof document === 'undefined') return;
@@ -89,6 +90,12 @@ const PerfOverlay: React.FC = () => {
           const w = canvas.width;
           const h = canvas.height;
           ctx.clearRect(0, 0, w, h);
+          const budgetY = h - (FRAME_BUDGET / MAX_MS) * h;
+          ctx.strokeStyle = '#ff0000';
+          ctx.beginPath();
+          ctx.moveTo(0, budgetY);
+          ctx.lineTo(w, budgetY);
+          ctx.stroke();
           ctx.strokeStyle = '#00ff00';
           ctx.beginPath();
           samples.forEach((s, i) => {
@@ -101,9 +108,10 @@ const PerfOverlay: React.FC = () => {
           ctx.stroke();
           const latest = samples[samples.length - 1];
           const fps = latest ? (1000 / latest.dt).toFixed(1) : '0';
+          const ms = latest ? latest.dt.toFixed(1) : '0';
           ctx.fillStyle = '#ffffff';
           ctx.font = '12px sans-serif';
-          ctx.fillText(`${fps} FPS`, 4, 12);
+          ctx.fillText(`${fps} FPS / ${ms}ms`, 4, 12);
         }
       }
       lastRef.current = now;

--- a/components/apps/Games/common/perf/perf.worker.js
+++ b/components/apps/Games/common/perf/perf.worker.js
@@ -1,5 +1,6 @@
 const MAX_SAMPLES = 120;
 const MAX_MS = 50;
+const FRAME_BUDGET = 16;
 
 let ctx;
 let samples = [];
@@ -24,6 +25,13 @@ function draw() {
   const w = ctx.canvas.width;
   const h = ctx.canvas.height;
   ctx.clearRect(0, 0, w, h);
+  // frame budget line
+  const budgetY = h - (FRAME_BUDGET / MAX_MS) * h;
+  ctx.strokeStyle = '#ff0000';
+  ctx.beginPath();
+  ctx.moveTo(0, budgetY);
+  ctx.lineTo(w, budgetY);
+  ctx.stroke();
   ctx.strokeStyle = '#00ff00';
   ctx.beginPath();
   samples.forEach((s, i) => {
@@ -38,6 +46,7 @@ function draw() {
   const fps = latest ? (1000 / latest.dt).toFixed(1) : '0';
   ctx.fillStyle = '#ffffff';
   ctx.font = '12px sans-serif';
-  ctx.fillText(`${fps} FPS`, 4, 12);
+  const ms = latest ? latest.dt.toFixed(1) : '0';
+  ctx.fillText(`${fps} FPS / ${ms}ms`, 4, 12);
 }
 

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -18,6 +18,8 @@ import {
   setPongSpin as savePongSpin,
   getAllowNetwork as loadAllowNetwork,
   setAllowNetwork as saveAllowNetwork,
+  getLowSpec as loadLowSpec,
+  setLowSpec as saveLowSpec,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -50,6 +52,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   theme: string;
+  lowSpec: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -60,6 +63,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setLowSpec: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -73,6 +77,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   theme: 'default',
+  lowSpec: defaults.lowSpec,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -83,6 +88,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setTheme: () => {},
+  setLowSpec: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -95,6 +101,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [lowSpec, setLowSpec] = useState<boolean>(defaults.lowSpec);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -109,6 +116,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
+      setLowSpec(await loadLowSpec());
       setTheme(loadTheme());
     })();
   }, []);
@@ -211,6 +219,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [allowNetwork]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('low-spec', lowSpec);
+    saveLowSpec(lowSpec);
+  }, [lowSpec]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -223,6 +236,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         largeHitAreas,
         pongSpin,
         allowNetwork,
+        lowSpec,
         theme,
         setAccent,
         setWallpaper,
@@ -234,6 +248,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setTheme,
+        setLowSpec,
       }}
     >
       {children}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -63,3 +63,13 @@ html[data-theme='matrix'] {
   --color-dark: #000000;
 
 }
+
+/* Low-spec mode disables heavy visual effects */
+.low-spec *,
+.low-spec *::before,
+.low-spec *::after {
+  animation: none !important;
+  transition: none !important;
+  box-shadow: none !important;
+  filter: none !important;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   largeHitAreas: false,
   pongSpin: true,
   allowNetwork: false,
+  lowSpec: false,
 };
 
 export async function getAccent() {
@@ -107,6 +108,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getLowSpec() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lowSpec;
+  return window.localStorage.getItem('low-spec') === 'true';
+}
+
+export async function setLowSpec(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('low-spec', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -120,6 +131,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
+  window.localStorage.removeItem('low-spec');
 }
 
 export async function exportSettings() {
@@ -133,6 +145,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    lowSpec,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -143,6 +156,7 @@ export async function exportSettings() {
     getLargeHitAreas(),
     getPongSpin(),
     getAllowNetwork(),
+    getLowSpec(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -155,6 +169,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    lowSpec,
     theme,
   });
 }
@@ -178,6 +193,7 @@ export async function importSettings(json) {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    lowSpec,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -189,6 +205,7 @@ export async function importSettings(json) {
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
+  if (lowSpec !== undefined) await setLowSpec(lowSpec);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add frame budget line and ms readout to FPS overlay
- introduce low-spec setting to disable visual effects
- wire up low-spec toggle in settings and hide perf overlay when enabled

## Testing
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*
- `yarn lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f98d7908328886807af8fa37d50