### PR TITLE
feat: add control overlay with input remapping

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -14,6 +14,6 @@ describe('HelpOverlay', () => {
     expect(
       screen.getByText('Reach the 2048 tile by merging numbers.')
     ).toBeInTheDocument();
-    expect(screen.getByText(/up: ArrowUp/i)).toBeInTheDocument();
+    expect(screen.getByText(/up: ArrowUp \/ B12/i)).toBeInTheDocument();
   });
 });

--- a/__tests__/gamepad.test.ts
+++ b/__tests__/gamepad.test.ts
@@ -1,7 +1,7 @@
 import type { TwinStickState } from '../utils/gamepad';
 
 let gamepad: any;
-let pollTwinStick: (deadzone?: number) => TwinStickState;
+let pollTwinStick: (deadzone?: number, fireButtons?: number[]) => TwinStickState;
 let rafCallback: FrameRequestCallback | null;
 
 beforeEach(() => {
@@ -59,11 +59,18 @@ describe('GamepadManager', () => {
 
 describe('pollTwinStick', () => {
   test('returns state for first gamepad respecting deadzone and fire button', () => {
-    const pad1: any = { axes: [0.3, 0.1, 0.2, 0.6], buttons: [{ pressed: true }] };
+    const pad1: any = { axes: [0.3, 0.1, 0.2, 0.6], buttons: [{ pressed: true }, { pressed: false }] };
     const pad2: any = { axes: [1, 1, 1, 1], buttons: [] };
     (navigator as any).getGamepads = () => [pad1, pad2];
 
-    const state = pollTwinStick();
-    expect(state).toEqual({ moveX: 0.3, moveY: 0, aimX: 0, aimY: 0.6, fire: true });
+    const state = pollTwinStick(undefined, [0]);
+    expect(state).toEqual({
+      moveX: 0.3,
+      moveY: 0,
+      aimX: 0,
+      aimY: 0.6,
+      fire: true,
+      buttons: [true, false],
+    });
   });
 });

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -168,7 +168,25 @@ export const GAME_INSTRUCTIONS: Record<string, Instruction> = {
 
 const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
   const info = GAME_INSTRUCTIONS[gameId];
-  const [mapping, setKey] = useInputMapping(gameId, info?.actions || {});
+  const defaultPads: Record<string, number> = {
+    up: 12,
+    down: 13,
+    left: 14,
+    right: 15,
+    action: 0,
+    pause: 9,
+    fire: 0,
+    hyperspace: 3,
+  };
+  const defaults: Record<string, { key: string; pad?: number }> = info?.actions
+    ? Object.fromEntries(
+        Object.entries(info.actions).map(([a, k]) => [
+          a,
+          { key: k as string, pad: defaultPads[a] },
+        ]),
+      )
+    : {};
+  const [mapping, setKey] = useInputMapping(gameId, defaults);
   const overlayRef = useRef<HTMLDivElement>(null);
   const prevFocus = useRef<HTMLElement | null>(null);
   const noop = () => null;
@@ -226,14 +244,17 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
             <p>
               <strong>Controls:</strong>{" "}
               {Object.entries(mapping)
-                .map(([a, k]) => `${a}: ${k}`)
+                .map(
+                  ([a, m]) =>
+                    `${a}: ${m.key || "-"}${m.pad !== undefined ? ` / B${m.pad}` : ""}`,
+                )
                 .join(", ")}
             </p>
             <div className="mt-2">
               <InputRemap
                 mapping={mapping}
-                setKey={setKey as (action: string, key: string) => string | null}
-                actions={info.actions}
+                setKey={setKey as any}
+                actions={defaults as any}
               />
             </div>
           </>

--- a/components/apps/asteroids.js
+++ b/components/apps/asteroids.js
@@ -27,11 +27,11 @@ const EXHAUST_COLOR = '#ffa500';
 const SHIELD_DURATION = 600; // frames
 const RADAR_COLORS = { outline: '#0f0', ship: '#fff', asteroid: '#0f0', ufo: '#f00' };
 const DEFAULT_MAP = {
-  up: 'ArrowUp',
-  left: 'ArrowLeft',
-  right: 'ArrowRight',
-  fire: ' ',
-  hyperspace: 'h',
+  up: { key: 'ArrowUp', pad: 12 },
+  left: { key: 'ArrowLeft', pad: 14 },
+  right: { key: 'ArrowRight', pad: 15 },
+  fire: { key: ' ', pad: 0 },
+  hyperspace: { key: 'h', pad: 3 },
 };
 
 // Simple Quadtree for collision queries
@@ -336,10 +336,11 @@ const Asteroids = () => {
     function pollGamepad() {
       const pad = navigator.getGamepads ? navigator.getGamepads()[0] : null;
       if (pad) {
+        const map = getMapping('asteroids', DEFAULT_MAP);
         padState.turn = pad.axes[0] || 0;
         padState.thrust = pad.axes[1] < -0.2 ? -pad.axes[1] : 0;
-        padState.fire = pad.buttons[0].pressed;
-        padState.hyperspace = pad.buttons[1].pressed;
+        padState.fire = !!pad.buttons[map.fire.pad]?.pressed;
+        padState.hyperspace = !!pad.buttons[map.hyperspace.pad]?.pressed;
       }
     }
 
@@ -458,12 +459,12 @@ const Asteroids = () => {
       const { keys, joystick, fire, hyperspace: hyper } = controlsRef.current;
       const map = getMapping('asteroids', DEFAULT_MAP);
       const turn =
-        (keys[map.left] ? -1 : 0) +
-        (keys[map.right] ? 1 : 0) +
+        (keys[map.left.key] ? -1 : 0) +
+        (keys[map.right.key] ? 1 : 0) +
         padState.turn +
         (joystick.active ? joystick.x : 0);
       const thrust =
-        (keys[map.up] ? 1 : 0) +
+        (keys[map.up.key] ? 1 : 0) +
         padState.thrust +
         (joystick.active ? -joystick.y : 0);
       if (fire) {

--- a/hooks/useGamepad.ts
+++ b/hooks/useGamepad.ts
@@ -1,18 +1,23 @@
 import { useEffect, useState } from 'react';
 import { pollTwinStick, TwinStickState } from '../utils/gamepad';
 
-export default function useGamepad(deadzone: number = 0.25): TwinStickState {
-  const [state, setState] = useState<TwinStickState>(() => pollTwinStick(deadzone));
+export default function useGamepad(
+  deadzone: number = 0.25,
+  fireButtons?: number[],
+): TwinStickState {
+  const [state, setState] = useState<TwinStickState>(() =>
+    pollTwinStick(deadzone, fireButtons),
+  );
 
   useEffect(() => {
     let raf: number;
     const read = () => {
-      setState(pollTwinStick(deadzone));
+      setState(pollTwinStick(deadzone, fireButtons));
       raf = requestAnimationFrame(read);
     };
     raf = requestAnimationFrame(read);
     return () => cancelAnimationFrame(raf);
-  }, [deadzone]);
+  }, [deadzone, fireButtons]);
 
   return state;
 }

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -123,15 +123,27 @@ export interface TwinStickState {
   aimX: number;
   aimY: number;
   fire: boolean;
+  buttons: boolean[];
 }
 
 /**
  * Polls the first connected gamepad and returns a simplified twin stick state.
  * Left stick controls movement while the right stick controls aiming.
- * Any face button triggers the `fire` flag.
+ * Any face button triggers the `fire` flag unless specific button indexes are
+ * provided. All button press states are returned for custom mappings.
  */
-export function pollTwinStick(deadzone = 0.25): TwinStickState {
-  const state: TwinStickState = { moveX: 0, moveY: 0, aimX: 0, aimY: 0, fire: false };
+export function pollTwinStick(
+  deadzone = 0.25,
+  fireButtons?: number[],
+): TwinStickState {
+  const state: TwinStickState = {
+    moveX: 0,
+    moveY: 0,
+    aimX: 0,
+    aimY: 0,
+    fire: false,
+    buttons: [],
+  };
   const pads = navigator.getGamepads ? navigator.getGamepads() : [];
   for (const pad of pads) {
     if (!pad) continue;
@@ -140,7 +152,10 @@ export function pollTwinStick(deadzone = 0.25): TwinStickState {
     state.moveY = Math.abs(ly) > deadzone ? ly : 0;
     state.aimX = Math.abs(rx) > deadzone ? rx : 0;
     state.aimY = Math.abs(ry) > deadzone ? ry : 0;
-    state.fire = pad.buttons.some((b) => b.pressed);
+    state.buttons = pad.buttons.map((b) => b.pressed);
+    state.fire = fireButtons
+      ? fireButtons.some((i) => state.buttons[i])
+      : pad.buttons.some((b) => b.pressed);
     break; // only use first gamepad
   }
   return state;


### PR DESCRIPTION
## Summary
- add unified gamepad helper with button state support
- enable per-game keyboard and gamepad remapping with overlay UI
- wire games to new mapping system and update tests

## Testing
- `npm test` *(fails: themePersistence tests: setTheme is not defined, structuredClone ReferenceError)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f959a988328ae5578d32ac15508