### PR TITLE
feat: add help overlay shortcut and accessibility docs

### DIFF
--- a/__tests__/GameLayoutHelp.test.tsx
+++ b/__tests__/GameLayoutHelp.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GameLayout from '../components/apps/GameLayout';
+
+describe('GameLayout help overlay shortcut', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('seen_tutorial_2048', '1');
+    window.localStorage.removeItem('keymap');
+  });
+
+  it('opens help overlay when pressing the shortcut', () => {
+    render(
+      <GameLayout gameId="2048">
+        <div>game</div>
+      </GameLayout>
+    );
+    expect(screen.queryByText('2048 Help')).toBeNull();
+    fireEvent.keyDown(window, { key: 'F1' });
+    expect(screen.getByText('2048 Help')).toBeInTheDocument();
+  });
+});

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -2,22 +2,13 @@
 
 import { useEffect, useState } from 'react';
 import useKeymap from '../keymapRegistry';
+import formatKeyboardEvent from '../../../utils/formatKeyboardEvent';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
 
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
   const { shortcuts, updateShortcut } = useKeymap();
@@ -27,7 +18,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
     if (!rebinding) return;
     const handler = (e: KeyboardEvent) => {
       e.preventDefault();
-      const combo = formatEvent(e);
+      const combo = formatKeyboardEvent(e);
       updateShortcut(rebinding, combo);
       setRebinding(null);
     };

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -248,6 +248,14 @@ export default function Settings() {
               Edit Shortcuts
             </button>
           </div>
+          <div className="flex justify-center mt-4">
+            <a
+              href="/accessibility"
+              className="text-ubt-grey underline"
+            >
+              Accessibility guide
+            </a>
+          </div>
         </>
       )}
       {activeTab === "privacy" && (

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Show help overlay', keys: 'F1' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import useKeymap from '../../apps/settings/keymapRegistry';
+import formatKeyboardEvent from '../../utils/formatKeyboardEvent';
 
 interface GameLayoutProps {
   gameId?: string;
@@ -64,6 +66,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   }, [fallbackCopy, highScore, gameId]);
 
   // Keyboard shortcut to toggle help overlay
+  const { shortcuts } = useKeymap();
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
@@ -72,14 +75,17 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         target.tagName === 'TEXTAREA' ||
         target.isContentEditable;
       if (isInput) return;
-      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+      const show =
+        shortcuts.find((s) => s.description === 'Show help overlay')?.keys ||
+        'F1';
+      if (formatKeyboardEvent(e) === show) {
         e.preventDefault();
         setShowHelp((h) => !h);
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [shortcuts]);
 
   // Show tutorial overlay on first visit
   useEffect(() => {

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -2,17 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import useKeymap from '../../apps/settings/keymapRegistry';
-
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
+import formatKeyboardEvent from '../../utils/formatKeyboardEvent';
 
 const ShortcutOverlay: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -31,7 +21,7 @@ const ShortcutOverlay: React.FC = () => {
       const show =
         shortcuts.find((s) => s.description === 'Show keyboard shortcuts')?.keys ||
         '?';
-      if (formatEvent(e) === show) {
+      if (formatKeyboardEvent(e) === show) {
         e.preventDefault();
         toggle();
       } else if (e.key === 'Escape' && open) {

--- a/pages/accessibility.tsx
+++ b/pages/accessibility.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { GAME_INSTRUCTIONS } from '../components/apps/HelpOverlay';
+
+export default function AccessibilityPage() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Accessibility & Shortcuts</h1>
+      <p>
+        Press <kbd>F1</kbd> in any game to open its help overlay. Press <kbd>?</kbd> to
+        view global keyboard shortcuts. Accessibility preferences such as reduced
+        motion, high contrast, and font scaling are available in the Settings app.
+      </p>
+      <h2 className="text-xl font-semibold mt-4">Game Controls</h2>
+      <ul className="space-y-4">
+        {Object.entries(GAME_INSTRUCTIONS).map(([id, info]) => (
+          <li key={id}>
+            <h3 className="font-medium">{id}</h3>
+            <p>
+              <strong>Objective:</strong> {info.objective}
+            </p>
+            <p>
+              <strong>Controls:</strong> {info.controls}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/utils/formatKeyboardEvent.ts
+++ b/utils/formatKeyboardEvent.ts
@@ -1,0 +1,10 @@
+export default function formatKeyboardEvent(e: KeyboardEvent): string {
+  const parts = [
+    e.ctrlKey ? 'Ctrl' : '',
+    e.altKey ? 'Alt' : '',
+    e.shiftKey ? 'Shift' : '',
+    e.metaKey ? 'Meta' : '',
+    e.key.length === 1 ? e.key.toUpperCase() : e.key,
+  ];
+  return parts.filter(Boolean).join('+');
+}


### PR DESCRIPTION
## Summary
- centralize keyboard shortcut parsing
- add F1-mapped help overlay and document game controls
- link to new accessibility guide from Settings

## Testing
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn test` *(fails: theme persistence and unlocking › dark class applied for neon and matrix themes)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8853f88328b140df90eee48943