### PR TITLE
Improve color contrast tokens and document design system updates

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,16 @@
+# Design System Overrides
+
+The following color tokens were updated to meet WCAG 2.1 AA contrast guidelines.
+
+| Token | Old value | New value | Contrast ratio* |
+|-------|-----------|-----------|----------------|
+| `--color-ub-lite-abrgn` | `#22262c` | `#7d7f83` | 4.65:1 against `--color-bg` |
+| `--color-ubt-warm-grey` | `#AEA79F` | `#6a625c` | 5.53:1 against `--color-ubt-grey` |
+| `--color-ubt-blue` | `#62A0EA` | `#0b5cad` | 6.17:1 against `--color-ubt-grey` |
+| `--color-ubt-gedit-blue` | `#50B6C6` | `#006a78` | 5.83:1 against `--color-ubt-grey` |
+| `--color-ubt-gedit-orange` | `#F39A21` | `#a14100` | 5.94:1 against `--color-ubt-grey` |
+| `--color-ubt-green` | `#73D216` | `#0d7a0d` | 5.10:1 against `--color-ubt-grey` |
+
+*Ratios calculated using relative luminance formula.
+
+These updates ensure text and interactive elements maintain sufficient contrast for accessibility.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -6,7 +6,7 @@
   --color-ub-warm-grey: #7d7f83;
   --color-ub-cool-grey: #1a1f26;
   --color-ub-orange: #1793d1;
-  --color-ub-lite-abrgn: #22262c;
+  --color-ub-lite-abrgn: #7d7f83;
   --color-ub-med-abrgn: #1b1f24;
   --color-ub-drk-abrgn: #13171b;
   --color-ub-window-title: #0c0f12;
@@ -14,12 +14,12 @@
   --color-ub-gedit-light: #003B70;
   --color-ub-gedit-darker: #010D1A;
   --color-ubt-grey: #F6F6F5;
-  --color-ubt-warm-grey: #AEA79F;
+  --color-ubt-warm-grey: #6a625c;
   --color-ubt-cool-grey: #333333;
-  --color-ubt-blue: #62A0EA;
-  --color-ubt-green: #73D216;
-  --color-ubt-gedit-orange: #F39A21;
-  --color-ubt-gedit-blue: #50B6C6;
+  --color-ubt-blue: #0b5cad;
+  --color-ubt-green: #0d7a0d;
+  --color-ubt-gedit-orange: #a14100;
+  --color-ubt-gedit-blue: #006a78;
   --color-ubt-gedit-dark: #003B70;
   --color-ub-border-orange: #1793d1;
   --color-ub-dark-grey: #2a2e36;


### PR DESCRIPTION
## Summary
- strengthen theme color tokens to meet WCAG contrast ratios
- document updated tokens in design system

## Testing
- `yarn a11y` *(fails: libXcomposite.so.1 missing)*
- `npx lighthouse https://example.com --only-categories=accessibility --chrome-flags="--headless"` *(fails: CHROME_PATH environment variable must be set)*
- `yarn lint` *(fails: 130 errors, 15 warnings)*
- `yarn test` *(fails: themePersistence.test.ts ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8482b08328bec6defdd0e7cafa