### PR TITLE
fix: improve component semantics and lint

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -358,18 +358,26 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
-          <img
+          <button
             key={badge.alt}
-            className="m-1 cursor-pointer"
-            src={badge.src}
-            alt={badge.alt}
-            title={badge.description}
+            type="button"
+            className="m-1 cursor-pointer bg-transparent border-0 p-0"
             onClick={() => setSelected(badge)}
-          />
+          >
+            <img src={badge.src} alt={badge.alt} title={badge.description} />
+          </button>
         ))}
       </div>
       {selected && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50" onClick={() => setSelected(null)}>
+        <div
+          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+          role="button"
+          tabIndex={0}
+          onClick={() => setSelected(null)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') setSelected(null);
+          }}
+        >
           <div className="bg-ub-cool-grey p-4 rounded max-w-xs" onClick={(e) => e.stopPropagation()}>
             <div className="font-bold mb-2 text-center">{selected.alt}</div>
             <p className="text-sm text-center">{selected.description}</p>

--- a/components/apps/archive/Terminal/index.tsx
+++ b/components/apps/archive/Terminal/index.tsx
@@ -530,7 +530,15 @@ const TerminalPaneInner = (
     );
 
     return (
-      <div className="flex-1 w-full h-full relative" onClick={onFocus}>
+      <div
+        className="flex-1 w-full h-full relative"
+        role="button"
+        tabIndex={0}
+        onClick={onFocus}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onFocus();
+        }}
+      >
         <div
           className="h-full w-full bg-ub-cool-grey"
           ref={containerRef}

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -761,9 +761,14 @@ const Solitaire = () => {
         </label>
       </div>
       <div className="flex space-x-4 mb-4">
-        <div className="w-16 h-24 min-w-[24px] min-h-[24px]" onClick={draw}>
+        <button
+          type="button"
+          className="w-16 h-24 min-w-[24px] min-h-[24px] bg-transparent border-0 p-0"
+          onClick={draw}
+          aria-label="Draw from stock"
+        >
           {game.stock.length ? renderFaceDown() : <div />}
-        </div>
+        </button>
         <div className="w-16 h-24 min-w-[24px] min-h-[24px]" onDragOver={(e) => e.preventDefault()}>
           {game.waste.length ? (
             <div

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -105,34 +105,35 @@ function Sidebar({
       <h2 className="mb-[6px] text-lg font-semibold">Queue</h2>
       <div data-testid="queue-list">
         {queue.map((v) => (
-          <div
+          <button
             key={v.id}
-            className="mb-[6px] cursor-pointer"
+            type="button"
+            className="mb-[6px] cursor-pointer text-left bg-transparent border-0 p-0 w-full"
             onClick={() => onPlay(v)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.title}</div>
-          </div>
+          </button>
         ))}
         {!queue.length && <div className="text-ubt-grey">Empty</div>}
       </div>
       <h2 className="mb-[6px] mt-[24px] text-lg font-semibold">Watch Later</h2>
       <div data-testid="watch-later-list">
         {watchLater.map((v, i) => (
-          <div
+          <button
             key={`${v.id}-${v.start ?? 0}-${v.end ?? 0}`}
-            className="mb-[6px] cursor-pointer"
+            type="button"
+            className="mb-[6px] cursor-pointer text-left bg-transparent border-0 p-0 w-full"
             onClick={() => onPlay(v)}
             draggable
             onDragStart={(e) => e.dataTransfer.setData('text/plain', String(i))}
             onDragOver={(e) => e.preventDefault()}
             onDrop={(e) => handleDrop(i, e)}
-            tabIndex={0}
             onKeyDown={(e) => handleKey(i, e)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
             <div>{v.name || v.title}</div>
-          </div>
+          </button>
         ))}
         {!watchLater.length && <div className="text-ubt-grey">Empty</div>}
       </div>
@@ -208,7 +209,11 @@ function VirtualGrid({
                 padding: '6px',
               }}
             >
-              <div className="cursor-pointer" onClick={() => onPlay(v)}>
+              <button
+                type="button"
+                className="cursor-pointer block text-left bg-transparent border-0 p-0"
+                onClick={() => onPlay(v)}
+              >
                 <div className="relative">
                   <img
                     src={v.thumbnail}
@@ -223,7 +228,7 @@ function VirtualGrid({
                 <div className="mt-[6px] text-sm line-clamp-2">
                   {truncateTitle(v.title)}
                 </div>
-              </div>
+              </button>
               <div className="mt-[6px] flex justify-between text-xs">
                 <ChannelHovercard id={v.channelId} name={v.channelName} />
                 <div className="space-x-[6px]">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 
 const compat = new FlatCompat();
@@ -26,4 +27,16 @@ export default [
       '@next/next/no-img-element': 'off',
     },
   }),
+  {
+    files: [
+      'components/**/*.{ts,tsx,js,jsx}',
+      'games/space-invaders/components/**/*.{ts,tsx,js,jsx}',
+    ],
+    plugins: {
+      'jsx-a11y': jsxA11y,
+    },
+    rules: {
+      'jsx-a11y/no-noninteractive-element-interactions': 'error',
+    },
+  },
 ];

--- a/games/space-invaders/components/Shield.tsx
+++ b/games/space-invaders/components/Shield.tsx
@@ -51,7 +51,12 @@ const Shield: React.FC<ShieldProps> = ({ regenDuration = 3000, maxHp = 6 }) => {
   const widthPercent = (hp / maxHp) * 100;
 
   return (
-    <div className="relative inline-block" onClick={takeDamage} aria-label="shield">
+    <button
+      type="button"
+      className="relative inline-block bg-transparent border-0 p-0"
+      onClick={takeDamage}
+      aria-label="shield"
+    >
       <div
         className="h-4 w-12 bg-green-600"
         style={{ opacity: hp === 0 ? 0.3 : 1 }}
@@ -69,7 +74,7 @@ const Shield: React.FC<ShieldProps> = ({ regenDuration = 3000, maxHp = 6 }) => {
           />
         </div>
       )}
-    </div>
+    </button>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace `div`/`img` click targets with semantic `button` elements
- close overlays and focus areas with keyboard support
- enable `jsx-a11y/no-noninteractive-element-interactions` for components

## Testing
- `npx eslint games/space-invaders/components/Shield.tsx components/apps/About/index.tsx components/apps/solitaire/index.tsx components/apps/archive/Terminal/index.tsx components/apps/youtube/index.tsx`
- `yarn lint` *(fails: Component definition is missing display name)*
- `yarn test` *(fails: theme persistence and unlocking › dark class applied for neon and matrix themes)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f82f9cc83289d0f272c6400ab66