### PR TITLE
feat: add focus design tokens for global accessibility

### DIFF
--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -63,7 +63,7 @@ const VideoGallery: React.FC = () => {
           <button
             key={video.id}
             type="button"
-            className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
+            className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-[var(--focus-color)] focus-visible:outline-[var(--focus-color)]"
             onClick={() => setPlaying(video.id)}
           >
             <img

--- a/styles/index.css
+++ b/styles/index.css
@@ -16,10 +16,9 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
-a:focus-visible,
-button:focus-visible {
-    outline: 2px solid var(--color-ubt-blue) !important;
-    outline-offset: 2px;
+:where(a, button, [role="button"], input, select, textarea, summary, [tabindex]:not([tabindex="-1"])):focus-visible {
+    outline: var(--focus-width) solid var(--focus-color) !important;
+    outline-offset: var(--focus-offset);
 }
 
 /* Top NavBar styling */
@@ -532,13 +531,6 @@ textarea,
 pre {
     font-family: monospace;
     line-height: 1.2;
-}
-
-/* Visible focus rings for copy buttons and text areas */
-button:focus-visible,
-textarea:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
 }
 
 /* Enable scroll snapping for gallery containers */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -50,6 +50,11 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
+
+  /* Focus indicators */
+  --focus-color: var(--color-ubt-blue);
+  --focus-width: 2px;
+  --focus-offset: 2px;
 }
 
 /* High contrast theme */
@@ -63,6 +68,7 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --focus-color: #ffff00;
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- add focus design tokens for color, width, and offset
- apply token-driven focus outline to interactive elements and video gallery items
- document high-contrast override for focus color

## Testing
- `node -e "function lum(r,g,b){[r,g,b]=[r,g,b].map(v=>{v/=255;return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4)});return 0.2126*r+0.7152*g+0.0722*b;} function contrast(h1,h2){function c(h){h=h.replace('#','');return [parseInt(h.substr(0,2),16),parseInt(h.substr(2,2),16),parseInt(h.substr(4,2),16)];} const l1=lum(...c(h1)), l2=lum(...c(h2)); const L1=Math.max(l1,l2), L2=Math.min(l1,l2); return (L1+0.05)/(L2+0.05);} console.log('default', contrast('#62A0EA','#0f1317')); console.log('high-contrast', contrast('#ffff00','#000000'));"`
- `yarn test` *(fails: ReferenceError setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f816f688328abf9d79cbe839bb9