### PR TITLE
feat: add gamepad haptics flag

### DIFF
--- a/__tests__/gamepad.test.ts
+++ b/__tests__/gamepad.test.ts
@@ -14,6 +14,9 @@ beforeEach(() => {
   global.cancelAnimationFrame = jest.fn();
   ({ gamepad, pollTwinStick } = require('../utils/gamepad'));
   (navigator as any).getGamepads = jest.fn(() => []);
+  (navigator as any).vibrationActuator = {};
+  const { features } = require('../utils/features');
+  features.gamepadHaptics = true;
 });
 
 describe('GamepadManager', () => {

--- a/components/apps/Games/common/haptics/index.ts
+++ b/components/apps/Games/common/haptics/index.ts
@@ -1,10 +1,21 @@
+import { features } from '../../../../../utils/features';
+
 export type HapticPattern = number | number[];
 
+const hasNavigatorActuator = () =>
+  typeof navigator !== 'undefined' && !!(navigator as any).vibrationActuator;
+
 const supportsVibration = () =>
-  typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+  hasNavigatorActuator() && typeof navigator.vibrate === 'function';
 
 const supportsGamepadVibration = () => {
-  if (typeof navigator === 'undefined' || !('getGamepads' in navigator)) return false;
+  if (
+    !features.gamepadHaptics ||
+    !hasNavigatorActuator() ||
+    typeof navigator === 'undefined' ||
+    !('getGamepads' in navigator)
+  )
+    return false;
   const pads = navigator.getGamepads ? navigator.getGamepads() : [];
   return Array.from(pads).some(
     (p) => p && p.vibrationActuator && typeof p.vibrationActuator.playEffect === 'function'
@@ -30,6 +41,8 @@ const triggerGamepad = (duration: number) => {
 };
 
 export const vibrate = (pattern: HapticPattern) => {
+  if (!features.gamepadHaptics || !hasNavigatorActuator()) return;
+
   const duration = Array.isArray(pattern)
     ? pattern.reduce((sum, n) => sum + (n > 0 ? n : 0), 0)
     : pattern;

--- a/public/apps/pong/main.js
+++ b/public/apps/pong/main.js
@@ -1,4 +1,5 @@
 // Simple Pong game with spin mechanics and gamepad rumble/audio feedback
+(function () {
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 canvas.width = 600;
@@ -145,6 +146,7 @@ function playBeep(freq = 440) {
 }
 
 function rumble() {
+  if (!(navigator.vibrationActuator && window.features?.gamepadHaptics)) return;
   const pads = navigator.getGamepads ? navigator.getGamepads() : [];
   for (const p of pads) {
     const actuator = p && p.vibrationActuator;
@@ -157,3 +159,5 @@ function rumble() {
     }
   }
 }
+
+})();

--- a/utils/features.ts
+++ b/utils/features.ts
@@ -1,0 +1,16 @@
+export interface Features {
+  gamepadHaptics: boolean;
+}
+
+export const features: Features = {
+  gamepadHaptics: true,
+};
+
+if (typeof globalThis !== 'undefined') {
+  (globalThis as any).features = {
+    ...(globalThis as any).features,
+    ...features,
+  } as Features;
+}
+
+export default features;

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -1,3 +1,5 @@
+import { features } from './features';
+
 export interface ButtonEvent {
   gamepad: Gamepad;
   index: number;
@@ -58,7 +60,7 @@ class GamepadManager {
   }
 
   private poll = () => {
-    const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
     for (const pad of pads) {
       if (!pad) continue;
 
@@ -70,7 +72,14 @@ class GamepadManager {
           const pressed = b.value > 0.5;
           const prevPressed = prevVal > 0.5;
           this.emit('button', { gamepad: pad, index: i, value: b.value, pressed });
-          if (pressed && !prevPressed && pad.vibrationActuator?.playEffect) {
+          const nav = navigator as any;
+          if (
+            pressed &&
+            !prevPressed &&
+            features.gamepadHaptics &&
+            nav.vibrationActuator &&
+            pad.vibrationActuator?.playEffect
+          ) {
             try {
               pad.vibrationActuator.playEffect('dual-rumble', {
                 duration: 30,


### PR DESCRIPTION
## Summary
- add `features.gamepadHaptics` flag
- guard haptics with navigator.vibrationActuator and feature flag
- update tests for new gamepad haptics flag

## Testing
- `npx eslint utils/gamepad.ts components/apps/Games/common/haptics/index.ts public/apps/pong/main.js __tests__/gamepad.test.ts utils/features.ts`
- `yarn test __tests__/gamepad.test.ts`
- `npx tsc --noEmit utils/gamepad.ts components/apps/Games/common/haptics/index.ts utils/features.ts` *(fails: 'cytoscape' has no exported member named 'Stylesheet')*

------
https://chatgpt.com/codex/tasks/task_e_68b96f7a3138832889994a811287fde6