### PR TITLE
feat: log non-secret env vars

### DIFF
--- a/lib/log-env.js
+++ b/lib/log-env.js
@@ -1,0 +1,20 @@
+const SECRET_PATTERN = /password|secret|token|key/i;
+
+function logEnvVars(env = process.env) {
+  const keys = Object.keys(env);
+  const nonSecret = keys.filter((k) => !SECRET_PATTERN.test(k));
+  const secret = keys.filter((k) => SECRET_PATTERN.test(k));
+
+  if (nonSecret.length > 0) {
+    console.log('Non-secret env vars:', nonSecret.join(', '));
+  }
+
+  if (secret.length > 0) {
+    console.log(
+      'Redacted env vars:',
+      secret.map((k) => `${k}=[REDACTED]`).join(', ')
+    );
+  }
+}
+
+module.exports = { logEnvVars };

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
 // Update README (section "CSP External Domains") when editing domains below.
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const { logEnvVars } = require('./lib/log-env.js');
+
+// Log non-secret environment variables during build
+logEnvVars(process.env);
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -110,6 +114,9 @@ module.exports = withBundleAnalyzer(
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {
       ignoreDuringBuilds: true,
+    },
+    experimental: {
+      outputFileTracing: true,
     },
     images: {
       unoptimized: true,


### PR DESCRIPTION
## Summary
- log non-secret environment variables during build while redacting secrets
- enable experimental output file tracing in Next.js config

## Testing
- `yarn lint` *(fails: 130 errors, 15 warnings)*
- `yarn test __tests__/themePersistence.test.ts` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f74f0b4832890e31288ea622f68