### PR TITLE
feat: add dismissible BetaBadge

### DIFF
--- a/__tests__/betaBadge.test.tsx
+++ b/__tests__/betaBadge.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BetaBadge from '../components/BetaBadge';
+
+describe('BetaBadge', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    process.env.NEXT_PUBLIC_SHOW_BETA = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_SHOW_BETA;
+  });
+
+  it('mounts, dismisses, and persists after dismissal', () => {
+    const { unmount } = render(<BetaBadge />);
+    expect(screen.getByTestId('beta-badge')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss beta badge/i }));
+    expect(screen.queryByTestId('beta-badge')).not.toBeInTheDocument();
+    expect(localStorage.getItem('beta-badge-dismissed')).toBe('1');
+
+    unmount();
+    render(<BetaBadge />);
+    expect(screen.queryByTestId('beta-badge')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,6 +1,46 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'beta-badge-dismissed';
+
 export default function BetaBadge() {
-  if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) !== '1') {
+        setVisible(true);
+      }
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {
+      // ignore persistence errors
+    }
+  };
+
+  if (!visible) return null;
+
   return (
-    <div className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black">Beta</div>
+    <div
+      data-testid="beta-badge"
+      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+    >
+      <span>Beta</span>
+      <button
+        type="button"
+        aria-label="Dismiss beta badge"
+        className="ml-2"
+        onClick={dismiss}
+      >
+        ×
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- make BetaBadge dismissible and persist state in localStorage
- cover badge behavior with RTL test
- fix missing setTheme import in theme persistence tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96f7701a08328af71751610cfefd3