### PR TITLE
Persist window geometry with reset option

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -8,6 +8,7 @@ import {
   defaults,
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
+  resetWindowGeometry,
 } from "../../utils/settingsStore";
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
@@ -81,6 +82,11 @@ export default function Settings() {
     } catch (err) {
       console.error("Invalid settings", err);
     }
+  };
+
+  const handleResetGeometry = () => {
+    if (!window.confirm("Reset window geometry?")) return;
+    resetWindowGeometry();
   };
 
   const handleReset = async () => {
@@ -189,7 +195,13 @@ export default function Settings() {
               ></div>
             ))}
           </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center space-x-4">
+            <button
+              onClick={handleResetGeometry}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Reset Window Geometry
+            </button>
             <button
               onClick={handleReset}
               className="px-4 py-2 rounded bg-ub-orange text-white"

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,12 +1,20 @@
 import 'fake-indexeddb/auto';
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
+import { setTheme } from './utils/theme';
 
 // Provide TextEncoder/TextDecoder for libraries that expect them in the test environment
 // @ts-ignore
 global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder as any;
+// @ts-ignore
+global.setTheme = setTheme;
+// @ts-ignore
+if (typeof global.structuredClone !== 'function') {
+  // @ts-ignore
+  global.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
 
 // Ensure a global `fetch` exists for tests. Jest's jsdom environment
 // doesn't provide one on the Node `global` object, which causes

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -122,6 +122,13 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
 }
 
+export async function resetWindowGeometry() {
+  if (typeof window === 'undefined') return;
+  Object.keys(window.localStorage)
+    .filter((key) => key.startsWith('window-geometry-'))
+    .forEach((key) => window.localStorage.removeItem(key));
+}
+
 export async function exportSettings() {
   const [
     accent,


### PR DESCRIPTION
## Summary
- persist window size and position per app in `localStorage`
- add Settings control to clear saved window geometry
- expose setTheme and structuredClone in test setup for reliability

## Testing
- `yarn test __tests__/window.test.tsx __tests__/themePersistence.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b96f8bead08328948ea36996138ed1