### PR TITLE
Add about dialog with GPU info

### DIFF
--- a/components/ui/AboutDialog.tsx
+++ b/components/ui/AboutDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import pkg from '../../package.json';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const AboutDialog = ({ open, onClose }: Props) => {
+  const [gpuInfo, setGpuInfo] = useState('Detecting...');
+
+  useEffect(() => {
+    let mounted = true;
+    async function detectGpu() {
+      if (typeof navigator !== 'undefined' && (navigator as any).gpu) {
+        try {
+          const adapter: GPUAdapter | null = await (navigator as any).gpu.requestAdapter();
+          const info = (adapter as any)?.requestAdapterInfo
+            ? await (adapter as any).requestAdapterInfo()
+            : null;
+          const text = info
+            ? `${info.vendor || ''} ${info.architecture || info.description || ''}`.trim()
+            : (adapter as any)?.name || 'Unknown GPU';
+          if (mounted) setGpuInfo(text);
+        } catch (e) {
+          if (mounted) setGpuInfo('Unavailable');
+        }
+      } else {
+        if (mounted) setGpuInfo('Not supported');
+      }
+    }
+    detectGpu();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!open) return null;
+
+  const commit =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ||
+    process.env.NEXT_PUBLIC_COMMIT_HASH ||
+    'unknown';
+
+  return (
+    <div
+      role="dialog"
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 p-4 rounded"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg mb-2">About</h2>
+        <p>Version: {pkg.version}</p>
+        <p>Commit: {commit}</p>
+        <p>GPU: {gpuInfo}</p>
+        <button
+          className="mt-4 px-2 py-1 bg-blue-500 text-white"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AboutDialog;
+

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState.js';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import AboutDialog from './AboutDialog';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [aboutOpen, setAboutOpen] = useState(false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -52,6 +54,12 @@ const QuickSettings = ({ open }: Props) => {
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>
+      <div className="px-4 pt-2">
+        <button className="w-full text-left" onClick={() => setAboutOpen(true)}>
+          About
+        </button>
+      </div>
+      <AboutDialog open={aboutOpen} onClose={() => setAboutOpen(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add About dialog showing app version, commit hash, and WebGPU adapter info
- link About dialog from Quick Settings menu in taskbar

## Testing
- `npx eslint components/ui/AboutDialog.tsx components/ui/QuickSettings.tsx`
- `yarn test` (partial run; exited early)

------
https://chatgpt.com/codex/tasks/task_e_68b96f9016108328b50a4f04d062eaf1