### PR TITLE
feat: add window z-order management

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/__tests__/windowManager.test.ts
+++ b/__tests__/windowManager.test.ts
@@ -1,0 +1,27 @@
+import WindowManager from '../utils/windowManager';
+
+describe('WindowManager z-order', () => {
+  it('assigns increasing z-index as windows are registered', () => {
+    const wm = new WindowManager(10);
+    wm.register('a');
+    wm.register('b');
+    wm.register('c');
+    expect(wm.getZIndex('a')).toBe(10);
+    expect(wm.getZIndex('b')).toBe(11);
+    expect(wm.getZIndex('c')).toBe(12);
+  });
+
+  it('moves focused window to top and maintains stack', () => {
+    const wm = new WindowManager(5);
+    wm.register('w1');
+    wm.register('w2');
+    wm.register('w3');
+    expect(wm.getOrder()).toEqual(['w1', 'w2', 'w3']);
+    wm.focus('w2');
+    expect(wm.getOrder()).toEqual(['w1', 'w3', 'w2']);
+    expect(wm.getZIndex('w2')).toBe(7); // 5 base + index 2
+    wm.focus('w1');
+    expect(wm.getOrder()).toEqual(['w3', 'w2', 'w1']);
+    expect(wm.getZIndex('w1')).toBe(7);
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -496,8 +496,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%`, zIndex: this.props.zIndex }}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.props.isFocused ? "" : " notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,13 @@ global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder as any;
 
+// Provide a structuredClone polyfill for environments lacking it
+// @ts-ignore
+if (typeof global.structuredClone !== 'function') {
+  // @ts-ignore
+  global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
+}
+
 // Ensure a global `fetch` exists for tests. Jest's jsdom environment
 // doesn't provide one on the Node `global` object, which causes
 // `jest.spyOn(global, 'fetch')` to fail. Providing a simple stub allows

--- a/utils/windowManager.ts
+++ b/utils/windowManager.ts
@@ -1,0 +1,34 @@
+export default class WindowManager {
+  private order: string[] = [];
+  private baseZ: number;
+
+  constructor(baseZ = 1) {
+    this.baseZ = baseZ;
+  }
+
+  register(id: string): number {
+    if (!this.order.includes(id)) {
+      this.order.push(id);
+    }
+    return this.getZIndex(id);
+  }
+
+  focus(id: string): number {
+    this.order = this.order.filter(w => w !== id);
+    this.order.push(id);
+    return this.getZIndex(id);
+  }
+
+  remove(id: string): void {
+    this.order = this.order.filter(w => w !== id);
+  }
+
+  getZIndex(id: string): number {
+    const idx = this.order.indexOf(id);
+    return idx === -1 ? this.baseZ - 1 : this.baseZ + idx;
+  }
+
+  getOrder(): string[] {
+    return [...this.order];
+  }
+}


### PR DESCRIPTION
## Summary
- manage window z-order with a dedicated manager
- update desktop window rendering to apply dynamic z-index
- test z-order stack transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96f89839c83288e0d2171d16953ee