### PR TITLE
feat: add skip link for main content

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -149,10 +149,25 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
+        <a
+          href="#main-content"
+          className="skip-link"
+          onClick={(e) => {
+            const main = document.getElementById('main-content');
+            if (main) {
+              e.preventDefault();
+              main.focus();
+            }
+          }}
+        >
+          Skip to main content
+        </a>
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
+            <div id="main-content" tabIndex={-1}>
+              <Component {...pageProps} />
+            </div>
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -63,3 +63,18 @@ html[data-theme='matrix'] {
   --color-dark: #000000;
 
 }
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}


### PR DESCRIPTION
## Summary
- add skip link and focus handling to main layout
- style skip link to appear on focus

## Testing
- `yarn test __tests__/calc.test.tsx`
- `npx eslint pages/_app.jsx styles/globals.css`


------
https://chatgpt.com/codex/tasks/task_e_68b96f7fb67c8328a5523d41338fd6bd