### PR TITLE
Add keymap overlay Playwright test and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: npx playwright test tests/keymap-overlay.spec.ts
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/tests/keymap-overlay.spec.ts
+++ b/tests/keymap-overlay.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// Playwright test to exercise keymap overlay: open overlay, rebind keys, resolve conflicts, and persist state.
+
+test.describe('Keyboard shortcut overlay', () => {
+  test('rebinds keys and resolves conflicts', async ({ page }) => {
+    // Clear any persisted keymap before navigating
+    await page.addInitScript(() => localStorage.clear());
+
+    await page.goto('/apps/settings');
+
+    // Navigate to the Accessibility tab and open the shortcut editor
+    await page.getByRole('tab', { name: 'Accessibility' }).click();
+    await page.getByRole('button', { name: 'Edit Shortcuts' }).click();
+
+    // Rebind "Show keyboard shortcuts" to Alt+S
+    const showShortcuts = page.locator('li', { hasText: 'Show keyboard shortcuts' });
+    await showShortcuts.getByRole('button').click();
+    await page.keyboard.press('Alt+S');
+    await expect(showShortcuts.locator('span.font-mono')).toHaveText('Alt+S');
+
+    // Rebind "Open settings" to the same keys to create a conflict
+    const openSettings = page.locator('li', { hasText: 'Open settings' });
+    await openSettings.getByRole('button').click();
+    await page.keyboard.press('Alt+S');
+    await expect(showShortcuts).toHaveAttribute('data-conflict', 'true');
+    await expect(openSettings).toHaveAttribute('data-conflict', 'true');
+
+    // Resolve conflict by giving "Open settings" a different combo
+    await openSettings.getByRole('button').click();
+    await page.keyboard.press('Alt+O');
+    await expect(showShortcuts).toHaveAttribute('data-conflict', 'false');
+    await expect(openSettings).toHaveAttribute('data-conflict', 'false');
+
+    // Close the overlay and verify mapping persisted
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    const stored = await page.evaluate(() => localStorage.getItem('keymap'));
+    const map = stored ? JSON.parse(stored) : {};
+    expect(map['Show keyboard shortcuts']).toBe('Alt+S');
+    expect(map['Open settings']).toBe('Alt+O');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright test for keyboard shortcut remapping overlay
- ensure conflicts are detected and mappings persist
- run Playwright test in CI

## Testing
- `npx eslint tests/keymap-overlay.spec.ts`
- `npx playwright test tests/keymap-overlay.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f7c86ac8328a9d188c504b7504b