### PR TITLE
feat: persist and import game keymaps

### DIFF
--- a/__tests__/game-controls.test.jsx
+++ b/__tests__/game-controls.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Controls from '../games/common/controls';
+
+describe('game controls keymap persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.pushState({}, '', '/testgame');
+  });
+
+  it('saves and loads keymap from localStorage', () => {
+    const { getByText, unmount } = render(<Controls />);
+    const upButton = getByText(/up: ArrowUp/i);
+    fireEvent.click(upButton);
+    fireEvent.keyDown(window, { key: 'w' });
+    expect(
+      JSON.parse(
+        window.localStorage.getItem('game-keymap:/testgame') || '{}',
+      ).up,
+    ).toBe('w');
+    unmount();
+    const { getByText: getByTextAgain } = render(<Controls />);
+    getByTextAgain(/up: w/i);
+  });
+
+  it('resets mapping to defaults', () => {
+    const { getByText } = render(<Controls />);
+    const upButton = getByText(/up: ArrowUp/i);
+    fireEvent.click(upButton);
+    fireEvent.keyDown(window, { key: 'w' });
+    const resetButton = getByText(/Reset Mapping/i);
+    fireEvent.click(resetButton);
+    getByText(/up: ArrowUp/i);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem('game-keymap:/testgame') || '{}',
+      ).up,
+    ).toBe('ArrowUp');
+  });
+
+  it('imports mapping from file', async () => {
+    const { getByText, getByTestId } = render(<Controls />);
+    const file = new File([JSON.stringify({ up: 'w' })], 'map.json', {
+      type: 'application/json',
+    });
+    const input = getByTestId('import-file');
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => getByText(/up: w/i));
+  });
+});

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
-import { getTheme, getUnlockedThemes } from '../utils/theme';
+import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
 
 describe('theme persistence and unlocking', () => {

--- a/hooks/useGameInput.js
+++ b/hooks/useGameInput.js
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react';
 
 // Default keyboard mapping. Users can override via settings stored in
-// localStorage under the `game-keymap` key.
+// localStorage under a per-game key.
 const DEFAULT_MAP = {
   up: 'ArrowUp',
   down: 'ArrowDown',
@@ -18,17 +18,23 @@ const DEFAULT_MAP = {
 export default function useGameInput({ onInput } = {}) {
   const mapRef = useRef(DEFAULT_MAP);
 
+  // Determine storage key based on current path so each game has its own map
+  const key =
+    typeof window !== 'undefined'
+      ? `game-keymap:${window.location.pathname}`
+      : 'game-keymap';
+
   // Load mapping once on mount
   useEffect(() => {
     try {
-      const stored = window.localStorage.getItem('game-keymap');
+      const stored = window.localStorage.getItem(key);
       if (stored) {
         mapRef.current = { ...DEFAULT_MAP, ...JSON.parse(stored) };
       }
     } catch {
       /* ignore */
     }
-  }, []);
+  }, [key]);
 
   useEffect(() => {
     const handle = (e) => {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -18,6 +18,13 @@ if (!global.fetch) {
   global.fetch = () => Promise.reject(new Error('fetch not implemented'));
 }
 
+// Node versions used in CI may lack structuredClone; provide a simple polyfill.
+// @ts-ignore
+if (typeof global.structuredClone !== 'function') {
+  // @ts-ignore
+  global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
+}
+
 // jsdom does not provide a global Image constructor which is used by
 // some components (e.g. window borders). A minimal mock is sufficient
 // for our tests because we only rely on the instance existing.


### PR DESCRIPTION
## Summary
- use current URL to persist each game's input mapping in localStorage
- add import and reset buttons to game control mapping UI
- polyfill structuredClone for tests and add keymap persistence tests

## Testing
- `yarn test --runTestsByPath __tests__/game-controls.test.jsx`
- `yarn test` *(fails: Cannot read properties of null (reading '_origin'))*


------
https://chatgpt.com/codex/tasks/task_e_68b96f7ad2048328bda88468bd573f6f