### PR TITLE
Refactor clickable divs to accessible buttons

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -369,7 +369,13 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
         ))}
       </div>
       {selected && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50" onClick={() => setSelected(null)}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <button
+            type="button"
+            aria-label="Close badge details"
+            className="absolute inset-0 bg-black bg-opacity-50"
+            onClick={() => setSelected(null)}
+          />
           <div className="bg-ub-cool-grey p-4 rounded max-w-xs" onClick={(e) => e.stopPropagation()}>
             <div className="font-bold mb-2 text-center">{selected.alt}</div>
             <p className="text-sm text-center">{selected.description}</p>

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -90,14 +90,19 @@ export class AboutAlex extends Component {
                 <div className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black">
                     {this.renderNavLinks()}
                 </div>
-                <div onClick={this.showNavBar} className="md:hidden flex flex-col items-center justify-center absolute bg-ub-cool-grey rounded w-6 h-6 top-1 left-1">
+                <button
+                    type="button"
+                    aria-label="Toggle navigation"
+                    onClick={this.showNavBar}
+                    className="md:hidden flex flex-col items-center justify-center absolute bg-ub-cool-grey rounded w-6 h-6 top-1 left-1"
+                >
                     <div className=" w-3.5 border-t border-white"></div>
                     <div className=" w-3.5 border-t border-white" style={{ marginTop: "2pt", marginBottom: "2pt" }}></div>
                     <div className=" w-3.5 border-t border-white"></div>
                     <div className={(this.state.navbar ? " visible animateShow z-30 " : " invisible ") + " md:hidden text-xs absolute bg-ub-cool-grey py-0.5 px-1 rounded-sm top-full mt-1 left-0 shadow border-black border border-opacity-20"}>
                         {this.renderNavLinks()}
                     </div>
-                </div>
+                </button>
                 <div className="flex flex-col w-3/4 md:w-4/5 justify-start items-center flex-grow bg-ub-grey overflow-y-auto windowMainScreen">
                     {this.state.screen}
                 </div>

--- a/components/apps/archive/Terminal/index.tsx
+++ b/components/apps/archive/Terminal/index.tsx
@@ -530,7 +530,12 @@ const TerminalPaneInner = (
     );
 
     return (
-      <div className="flex-1 w-full h-full relative" onClick={onFocus}>
+      <button
+        type="button"
+        aria-label="Focus terminal"
+        className="flex-1 w-full h-full relative text-left bg-transparent p-0"
+        onClick={onFocus}
+      >
         <div
           className="h-full w-full bg-ub-cool-grey"
           ref={containerRef}
@@ -544,7 +549,7 @@ const TerminalPaneInner = (
             (reverse-i-search)`{revSearch.query}`: {revSearch.match}
           </div>
         )}
-      </div>
+      </button>
     );
 };
 

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -279,15 +279,25 @@ export default function FileExplorer() {
         <div className="w-40 overflow-auto border-r border-gray-600">
           <div className="p-2 font-bold">Recent</div>
           {recent.map((r, i) => (
-            <div key={i} className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30" onClick={() => openRecent(r)}>
+            <button
+              key={i}
+              type="button"
+              className="w-full text-left px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+              onClick={() => openRecent(r)}
+            >
               {r.name}
-            </div>
+            </button>
           ))}
           <div className="p-2 font-bold">Files</div>
           {files.map((f, i) => (
-            <div key={i} className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30" onClick={() => openFile(f)}>
+            <button
+              key={i}
+              type="button"
+              className="w-full text-left px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+              onClick={() => openFile(f)}
+            >
               {f.name}
-            </div>
+            </button>
           ))}
         </div>
         <div className="flex-1 flex flex-col">

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -147,7 +147,13 @@ export class Gedit extends Component {
                 <div className="flex items-center justify-between w-full bg-ub-gedit-light bg-opacity-60 border-b border-t border-blue-400 text-sm">
                     <span className="font-bold ml-2">Send a Message to Me</span>
                     <div className="flex">
-                        <div onClick={this.sendMessage} className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80">Send</div>
+                        <button
+                            type="button"
+                            onClick={this.sendMessage}
+                            className="border border-black bg-black bg-opacity-50 px-3 py-0.5 my-1 mx-1 rounded hover:bg-opacity-80"
+                        >
+                            Send
+                        </button>
                     </div>
                 </div>
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -761,9 +761,14 @@ const Solitaire = () => {
         </label>
       </div>
       <div className="flex space-x-4 mb-4">
-        <div className="w-16 h-24 min-w-[24px] min-h-[24px]" onClick={draw}>
+        <button
+          type="button"
+          className="w-16 h-24 min-w-[24px] min-h-[24px] bg-transparent p-0"
+          onClick={draw}
+          aria-label="Draw card"
+        >
           {game.stock.length ? renderFaceDown() : <div />}
-        </div>
+        </button>
         <div className="w-16 h-24 min-w-[24px] min-h-[24px]" onDragOver={(e) => e.preventDefault()}>
           {game.waste.length ? (
             <div

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -208,7 +208,12 @@ function VirtualGrid({
                 padding: '6px',
               }}
             >
-              <div className="cursor-pointer" onClick={() => onPlay(v)}>
+              <button
+                type="button"
+                className="block w-full text-left cursor-pointer"
+                onClick={() => onPlay(v)}
+                aria-label={`Play ${v.title}`}
+              >
                 <div className="relative">
                   <img
                     src={v.thumbnail}
@@ -223,7 +228,7 @@ function VirtualGrid({
                 <div className="mt-[6px] text-sm line-clamp-2">
                   {truncateTitle(v.title)}
                 </div>
-              </div>
+              </button>
               <div className="mt-[6px] flex justify-between text-xs">
                 <ChannelHovercard id={v.channelId} name={v.channelName} />
                 <div className="space-x-[6px]">

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -19,11 +19,16 @@ function BootingScreen(props) {
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
+            <button
+                type="button"
+                aria-label="Power button"
+                className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer bg-transparent"
+                onClick={props.turnOn}
+            >
                 {(props.isShutDown
                     ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
                     : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
-            </div>
+            </button>
             <Image
                 width={200}
                 height={100}


### PR DESCRIPTION
## Summary
- Replace interactive divs with semantic buttons across various components
- Add ARIA labels for power, play, navigation, modal close, and other controls
- Improve modal and list item semantics for keyboard and screen reader accessibility

## Testing
- `yarn lint components/screen/booting_screen.js components/apps/gedit.js components/apps/file-explorer.js components/apps/youtube/index.tsx components/apps/archive/Terminal/index.tsx components/apps/solitaire/index.tsx components/apps/About/index.tsx components/apps/alex.js` *(fails: Component definition is missing display name; 145 problems)*
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*
- `yarn a11y` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f7937148328bdbcc579514f9842