### PR TITLE
chore: add env preflight

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Type Check
         run: yarn tsc --noEmit
 
+      - name: Preflight
+        run: npm run preflight
+        env:
+          NEXT_PUBLIC_TRACKING_ID: ${{ secrets.NEXT_PUBLIC_TRACKING_ID }}
+          NEXT_PUBLIC_SERVICE_ID: ${{ secrets.NEXT_PUBLIC_SERVICE_ID }}
+          NEXT_PUBLIC_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_TEMPLATE_ID }}
+          NEXT_PUBLIC_USER_ID: ${{ secrets.NEXT_PUBLIC_USER_ID }}
+
       - name: Building
         run: yarn build
         env:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
+    "preflight": "node scripts/check-env.js",
     "verify:all": "node scripts/verify.mjs"
   },
   "engines": {

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+// Determine which env file to read
+const envFile = ['.env', '.env.local'].find((f) => fs.existsSync(path.join(process.cwd(), f)));
+
+if (!envFile) {
+  console.error('No .env file found');
+  process.exit(1);
+}
+
+const content = fs.readFileSync(envFile, 'utf8');
+const lines = content.split(/\r?\n/);
+const missing = [];
+
+for (const line of lines) {
+  const match = line.match(/^\s*(NEXT_PUBLIC_[A-Z0-9_]+)\s*=\s*(.*)?$/);
+  if (!match) continue;
+  const key = match[1];
+  let value = (match[2] || '').trim();
+  // Remove surrounding quotes if any
+  value = value.replace(/^['"]|['"]$/g, '');
+  if (!value) {
+    value = process.env[key];
+  }
+  if (!value) {
+    missing.push(key);
+  }
+}
+
+if (missing.length > 0) {
+  console.error(`Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+console.log('All required NEXT_PUBLIC variables are set.');


### PR DESCRIPTION
## Summary
- add script to verify NEXT_PUBLIC env vars
- run preflight in deploy workflow before build
- expose preflight via package.json

## Testing
- `npm test` *(fails: setTheme is not defined)*
- `npm run lint`
- `npm run typecheck`
- `npm run preflight` *(fails: Missing required environment variables: NEXT_PUBLIC_RECAPTCHA_SITE_KEY, NEXT_PUBLIC_TRACKING_ID, NEXT_PUBLIC_USER_ID, NEXT_PUBLIC_SERVICE_ID, NEXT_PUBLIC_TEMPLATE_ID, NEXT_PUBLIC_YOUTUBE_API_KEY, NEXT_PUBLIC_CURRENCY_API_URL, NEXT_PUBLIC_GHIDRA_WASM, NEXT_PUBLIC_GHIDRA_URL, NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f6fa73883288c6dddbca3eb1825