### PR TITLE
fix: polyfill UUID and skip missing manifest

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'crypto';
-
 const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'key']);
 
 export interface Logger {
@@ -42,6 +40,26 @@ class ConsoleLogger implements Logger {
   }
 }
 
-export function createLogger(correlationId: string = randomUUID()): Logger {
+function generateCorrelationId(): string {
+  if (typeof globalThis === 'object') {
+    const cryptoObj: any = (globalThis as any).crypto;
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      return cryptoObj.randomUUID();
+    }
+  }
+  try {
+    const { randomUUID } = require('crypto');
+    return randomUUID();
+  } catch {
+    // Fallback for environments without crypto support
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}
+
+export function createLogger(correlationId: string = generateCorrelationId()): Logger {
   return new ConsoleLogger(correlationId);
 }

--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development',
+  buildExcludes: [/dynamic-css-manifest\.json$/],
   workboxOptions: {
     navigateFallback: '/offline.html',
     additionalManifestEntries: [


### PR DESCRIPTION
## Summary
- use a cross-environment UUID generator to avoid randomUUID errors in browsers
- skip dynamic-css-manifest from PWA precache to avoid 404s

## Testing
- `yarn test __tests__/game2048.test.tsx __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: TypeError: (0 , _GameLayout.useInputRecorder) is not a function; e.preventDefault is not a function; Unable to find role="alert" )*

------
https://chatgpt.com/codex/tasks/task_e_68b9d8e9d144832883a236d10cc63403