### PR TITLE
refactor offline page to use external assets

### DIFF
--- a/public/offline.css
+++ b/public/offline.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; padding: 2rem; text-align: center; }
+ul { list-style: none; padding: 0; }

--- a/public/offline.html
+++ b/public/offline.html
@@ -4,10 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Offline</title>
-  <style>
-    body { font-family: sans-serif; padding: 2rem; text-align: center; }
-    ul { list-style: none; padding: 0; }
-  </style>
+  <link rel="stylesheet" href="/offline.css">
 </head>
 <body>
   <main>
@@ -19,42 +16,6 @@
       <ul id="apps"></ul>
     </section>
   </main>
-  <script>
-    document.getElementById('retry').addEventListener('click', () => {
-      window.location.reload();
-    });
-
-    (async () => {
-      const list = document.getElementById('apps');
-      try {
-        const names = await caches.keys();
-        const urls = new Set();
-        for (const name of names) {
-          const cache = await caches.open(name);
-          const keys = await cache.keys();
-          for (const request of keys) {
-            const url = new URL(request.url);
-            if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
-              urls.add(url.pathname);
-            }
-          }
-        }
-        if (urls.size === 0) {
-          list.innerHTML = '<li>No apps available offline.</li>';
-        } else {
-          urls.forEach((path) => {
-            const li = document.createElement('li');
-            const a = document.createElement('a');
-            a.href = path;
-            a.textContent = path.replace('/apps/', '');
-            li.appendChild(a);
-            list.appendChild(li);
-          });
-        }
-      } catch (err) {
-        list.innerHTML = '<li>Unable to access cached apps.</li>';
-      }
-    })();
-  </script>
+  <script src="/offline.js" defer></script>
 </body>
 </html>

--- a/public/offline.js
+++ b/public/offline.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-top-level-window/no-top-level-window-or-document */
+document.getElementById('retry').addEventListener('click', () => {
+  window.location.reload();
+});
+
+(async () => {
+  const list = document.getElementById('apps');
+  try {
+    const names = await caches.keys();
+    const urls = new Set();
+    for (const name of names) {
+      const cache = await caches.open(name);
+      const keys = await cache.keys();
+      for (const request of keys) {
+        const url = new URL(request.url);
+        if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
+          urls.add(url.pathname);
+        }
+      }
+    }
+    if (urls.size === 0) {
+      list.innerHTML = '<li>No apps available offline.</li>';
+    } else {
+      urls.forEach((path) => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = path;
+        a.textContent = path.replace('/apps/', '');
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+    }
+  } catch (err) {
+    list.innerHTML = '<li>Unable to access cached apps.</li>';
+  }
+})();


### PR DESCRIPTION
## Summary
- extract offline page styles into `public/offline.css`
- extract offline page script into `public/offline.js`
- update `public/offline.html` to reference external assets

## Testing
- `node - <<'NODE' ... NODE`
- `yarn test` *(fails: TypeError: Cannot read properties of null (reading '_origin'))*
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn eslint public/offline.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9e89baa5483288881629163bd278f