### PR TITLE
Refactor CSP to use nonces and add vercel.live frame source

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,11 +11,11 @@ export function middleware(req: NextRequest) {
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
-    "style-src 'self' https://fonts.googleapis.com",
+    `style-src 'self' 'nonce-${n}' https://fonts.googleapis.com`,
     "font-src 'self' https://fonts.gstatic.com",
     `script-src 'self' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
-    "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
+    "frame-src 'self' https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com https://vercel.live",
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",

--- a/next.config.js
+++ b/next.config.js
@@ -14,18 +14,18 @@ const ContentSecurityPolicy = [
   "object-src 'none'",
   // Allow external images and data URIs for badges/icons
   "img-src 'self' https: data:",
-  // Allow inline styles
-  "style-src 'self' 'unsafe-inline'",
-  // Explicitly allow inline style tags
-  "style-src-elem 'self' 'unsafe-inline'",
+  // Allow styles from same origin; inline styles rely on CSP nonces
+  "style-src 'self'",
+  // Allow style elements from same origin (nonce applied at runtime)
+  "style-src-elem 'self'",
   // Restrict fonts to same origin
   "font-src 'self'",
-  // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  // External scripts required for embedded timelines; inline scripts use nonces
+  "script-src 'self' https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
-  "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  "frame-src 'self' https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org https://vercel.live",
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",


### PR DESCRIPTION
## Summary
- remove `unsafe-inline` from CSP directives in next.config
- add `https://vercel.live` to allowed frame sources
- apply CSP nonce to inline styles in middleware

## Testing
- `npx eslint next.config.js middleware.ts`
- `npx jest middleware --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9e89e497c8328b2adc34974113d46