### PR TITLE
feat(pwa): add install prompt trigger

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -14,7 +14,8 @@ const InstallButton: React.FC = () => {
   }, []);
 
   const handleInstall = async () => {
-    const shown = await showA2HS();
+    const fn = (window as any).showA2HS || showA2HS;
+    const shown = await fn();
     if (shown) {
       trackEvent('cta_click', { location: 'install_button' });
       setVisible(false);

--- a/public/a2hs.js
+++ b/public/a2hs.js
@@ -3,7 +3,16 @@
 window.initA2HS ||= function () {
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
-    const deferred = e;
-    // trigger deferred.prompt() from your UI when ready
+    window.deferredA2HS = e;
+    window.dispatchEvent(new Event('a2hs:available'));
   });
+};
+
+window.showA2HS ||= async function () {
+  const evt = window.deferredA2HS;
+  if (!evt) return false;
+  window.deferredA2HS = null;
+  await evt.prompt();
+  await evt.userChoice;
+  return true;
 };


### PR DESCRIPTION
## Summary
- store `beforeinstallprompt` event and expose `showA2HS` in public script
- update install button to invoke global prompt function when available

## Testing
- `yarn test __tests__/installButton.test.tsx`
- `npx eslint components/InstallButton.tsx public/a2hs.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9f297a8448328bf7e5c422d308c44