### PR TITLE
fix use snap hook and add service worker stub

### DIFF
--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 
 /**

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());


### PR DESCRIPTION
## Summary
- mark `usePersistentState` as client-side to provide `useSnapSetting`
- add minimal `service-worker.js` to satisfy registration and avoid 404s

## Testing
- `yarn test __tests__/solitaireEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9f1a2eaf88328b0f3b036914c7846