### PR TITLE
Re-export useInputRecorder hook from GameLayout

### DIFF
--- a/components/apps/GameLayout.js
+++ b/components/apps/GameLayout.js
@@ -1,1 +1,1 @@
-export { default } from './GameLayout.tsx';
+export { default, useInputRecorder } from './GameLayout.tsx';


### PR DESCRIPTION
## Summary
- Re-export `useInputRecorder` alongside the default GameLayout export so apps can import the hook.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9f71008bc8328bb1e667dcd613754