### PR TITLE
feat: switch to XFCE-style top panel

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -57,7 +57,9 @@ export class UbuntuApp extends Component {
                     alt={"Kali " + this.props.name}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
+                <span className="label">
+                    {this.props.displayName || this.props.name}
+                </span>
 
             </div>
         )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -7,7 +7,7 @@ const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
     { ssr: false }
 );
-import SideBar from './side_bar';
+// import SideBar from './side_bar'; // XFCE layout: no left dock
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
@@ -764,20 +764,12 @@ export class Desktop extends Component {
                 {/* Background Image */}
                 <BackgroundImage />
 
-                {/* Ubuntu Side Menu Bar */}
-                <SideBar apps={apps}
-                    hide={this.state.hideSideBar}
-                    hideSideBar={this.hideSideBar}
-                    favourite_apps={this.state.favourite_apps}
-                    showAllApps={this.showAllApps}
-                    allAppsView={this.state.allAppsView}
-                    closed_windows={this.state.closed_windows}
-                    focused_windows={this.state.focused_windows}
-                    isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
+                {/* XFCE layout hides the left dock */}
 
                 {/* Desktop Apps */}
-                {this.renderDesktopApps()}
+                <div className="left-stack-icons">
+                    {this.renderDesktopApps()}
+                </div>
 
                 {/* Context Menus */}
                 <DesktopMenu

--- a/components/screen/xfce-navbar.js
+++ b/components/screen/xfce-navbar.js
@@ -1,0 +1,74 @@
+"use client";
+
+import Image from "next/image";
+import Clock from "../util-components/clock";
+import Status from "../util-components/status";
+import apps from "../../apps.config";
+
+const PINNED = ["terminal", "chrome", "vscode", "file-explorer", "alex"];
+const pinnedApps = apps.filter(a => PINNED.includes(a.id) && !a.disabled);
+
+export default function XfceNavbar() {
+  return (
+    <header
+      role="navigation"
+      aria-label="Top panel"
+      className="fixed top-0 left-0 right-0 h-10 px-2 bg-[var(--color-surface)]/95 backdrop-blur-sm border-b border-[var(--color-border)] text-sm z-[60] flex items-center"
+    >
+      {/* left cluster: menu + launchers */}
+      <div className="flex items-center gap-1">
+        <button
+          aria-label="Applications"
+          className="px-2 h-8 rounded hover:bg-white/10 focus:outline-none focus:ring"
+        >
+          <Image
+            src="/themes/Yaru/status/view-app-grid-symbolic.svg"
+            alt="Applications"
+            width={16}
+            height={16}
+            priority
+          />
+        </button>
+
+        <div className="h-6 w-px mx-1 bg-[var(--color-border)]" />
+
+        {pinnedApps.map(app => (
+          <a
+            key={app.id}
+            href={`/apps/${app.id}`}
+            title={app.title}
+            className="p-1 rounded hover:bg-white/10 focus:outline-none focus:ring"
+            aria-label={`Open ${app.title}`}
+          >
+            <Image src={app.icon} alt={app.title} width={20} height={20} />
+          </a>
+        ))}
+      </div>
+
+      {/* center: workspace switcher */}
+      <nav aria-label="Workspaces" className="mx-auto">
+        <ul className="flex gap-2">
+          {[1, 2, 3, 4].map(n => (
+            <li key={n}>
+              <button
+                className="min-w-6 px-1.5 h-7 rounded hover:bg-white/10 focus:outline-none focus:ring data-[active=true]:bg-white/15"
+                data-active={n === 1}
+                aria-label={`Workspace ${n}`}
+              >
+                {n}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* right cluster: clock + status */}
+      <div className="ml-auto flex items-center gap-2">
+        <Clock />
+        <div className="h-6 w-px mx-1 bg-[var(--color-border)]" />
+        <Status />
+      </div>
+    </header>
+  );
+}
+

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
-import Navbar from './screen/navbar';
+import XfceNavbar from './screen/xfce-navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
@@ -126,8 +126,8 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                <XfceNavbar />
+                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>
 		);
 	}

--- a/styles/index.css
+++ b/styles/index.css
@@ -199,6 +199,21 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     background: transparent;
 }
 
+/* XFCE-like desktop icons on the left */
+.left-stack-icons {
+    position: absolute;
+    top: 6rem;
+    left: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: center;
+}
+.left-stack-icons .label {
+    margin-top: 0.25rem;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.8);
+}
+
 .xterm .xterm-cursor {
     animation: cursor-pulse 1s steps(2) infinite;
 }


### PR DESCRIPTION
## Summary
- replace GNOME navbar with new XFCE top panel featuring app launcher, workspace buttons, and system status
- remove left dock and stack desktop icons along the left edge
- style desktop icons for left column placement

## Testing
- `npx eslint components/ubuntu.js components/screen/xfce-navbar.js components/screen/desktop.js components/base/ubuntu_app.js`
- `yarn test` *(fails: ReferenceError: setTheme is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c684d37c83289ef3f18645c32e8f