### PR TITLE
Add basic Playwright specs and npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:e2e": "playwright test",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,4 +6,9 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/apps.smoke.spec.ts
+++ b/tests/apps.smoke.spec.ts
@@ -23,9 +23,16 @@ const routes = getRoutes(appDir)
   .map((r) => r.replace(/\/index$/, ''));
 
 for (const route of routes) {
-  test(`loads ${route}`, async ({ page }) => {
-    await page.goto('/apps');
-    await page.locator(`a[href="${route}"]`).click();
+  test(`loads ${route}`, async ({ page }, testInfo) => {
+    await page.goto(route);
+
+    // perform a simple action on the page
+    await page.click('body');
+
+    // capture a screenshot for documentation
+    const file = route.replace(/\//g, '_') + '.png';
+    await page.screenshot({ path: testInfo.outputPath(file) });
+
     await expect(page.locator('main')).toBeVisible();
   });
 }

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('loads home page', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await page.click('body');
+  await page.screenshot({ path: testInfo.outputPath('home.png') });
+  await expect(page.locator('main')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright specs that load the home page and every `/apps` route, perform a simple action, and take a screenshot
- configure Playwright to spin up the Next.js dev server and expose an `npm run test:e2e` script

## Testing
- `npm run test:e2e` *(fails: Module not found: Can't resolve 'marked')*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc5e8d5c8328a9746743d497405e