### PR TITLE
feat: centralize toast notifications with hooks

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { render, screen } from '@testing-library/react';
-import Toast from '../components/ui/Toast';
+import {
+  ToastProvider,
+  useSuccessToast,
+} from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
 
+function TriggerToast() {
+  const success = useSuccessToast();
+  useEffect(() => {
+    success('Saved');
+  }, [success]);
+  return null;
+}
+
 describe('live region components', () => {
-  it('Toast uses polite live region', () => {
-    const { unmount } = render(<Toast message="Saved" />);
-    const region = screen.getByRole('status');
+  it('Toast uses polite live region', async () => {
+    const { unmount } = render(
+      <ToastProvider>
+        <TriggerToast />
+      </ToastProvider>,
+    );
+    const region = await screen.findByRole('status');
     expect(region).toHaveAttribute('aria-live', 'polite');
     unmount();
   });

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import FormError from "../../components/ui/FormError";
-import Toast from "../../components/ui/Toast";
+import { useSuccessToast, useErrorToast } from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
@@ -28,8 +28,9 @@ const ContactApp: React.FC = () => {
   const [message, setMessage] = useState("");
   const [honeypot, setHoneypot] = useState("");
   const [error, setError] = useState("");
-  const [toast, setToast] = useState("");
   const [csrfToken, setCsrfToken] = useState("");
+  const successToast = useSuccessToast();
+  const errorToast = useErrorToast();
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
@@ -67,7 +68,7 @@ const ContactApp: React.FC = () => {
         recaptchaToken,
       });
       if (result.success) {
-        setToast("Message sent");
+        successToast("Message sent");
         setName("");
         setEmail("");
         setMessage("");
@@ -76,12 +77,12 @@ const ContactApp: React.FC = () => {
         trackEvent("contact_submit", { method: "form" });
       } else {
         setError(result.error || "Submission failed");
-        setToast("Failed to send");
+        errorToast("Failed to send");
         trackEvent("contact_submit_error", { method: "form" });
       }
     } catch {
       setError("Submission failed");
-      setToast("Failed to send");
+      errorToast("Failed to send");
       trackEvent("contact_submit_error", { method: "form" });
     }
   };
@@ -209,7 +210,6 @@ const ContactApp: React.FC = () => {
           Send
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </div>
   );
 };

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
-import Toast from '../../components/ui/Toast';
+import { useSuccessToast } from '../../components/ui/Toast';
 
 interface Module {
   name: string;
@@ -47,7 +47,7 @@ const MetasploitPage: React.FC = () => {
   const [split, setSplit] = useState(60);
   const splitRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
-  const [toast, setToast] = useState('');
+  const successToast = useSuccessToast();
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('');
 
@@ -99,7 +99,7 @@ const MetasploitPage: React.FC = () => {
     };
   }, []);
 
-  const handleGenerate = () => setToast('Payload generated');
+  const handleGenerate = () => successToast('Payload generated');
 
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
@@ -209,7 +209,6 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import Toast from '../../ui/Toast';
+import { useSuccessToast } from '../../ui/Toast';
 import DiscoveryMap from './DiscoveryMap';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
@@ -84,7 +84,7 @@ const NmapNSEApp = () => {
   const [scriptOptions, setScriptOptions] = useState({});
   const [activeScript, setActiveScript] = useState(scripts[0].name);
   const [phaseStep, setPhaseStep] = useState(0);
-  const [toast, setToast] = useState('');
+  const successToast = useSuccessToast();
   const outputRef = useRef(null);
   const phases = ['prerule', 'hostrule', 'portrule'];
 
@@ -134,7 +134,7 @@ const NmapNSEApp = () => {
     if (typeof window !== 'undefined') {
       try {
         await navigator.clipboard.writeText(command);
-        setToast('Command copied');
+        successToast('Command copied');
       } catch (e) {
         // ignore
       }
@@ -148,7 +148,7 @@ const NmapNSEApp = () => {
     if (!text.trim()) return;
     try {
       await navigator.clipboard.writeText(text);
-      setToast('Output copied');
+      successToast('Output copied');
     } catch (e) {
       // ignore
     }
@@ -162,7 +162,7 @@ const NmapNSEApp = () => {
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);
-    setToast('Output selected');
+    successToast('Output selected');
   };
 
   const handleOutputKey = (e) => {
@@ -435,7 +435,6 @@ const NmapNSEApp = () => {
           </button>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,50 +1,124 @@
-import React, { useEffect, useRef, useState } from 'react';
+'use client';
 
-interface ToastProps {
-  message: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  onClose?: () => void;
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  ReactNode,
+} from 'react';
+
+interface ToastOptions {
   duration?: number;
 }
 
-const Toast: React.FC<ToastProps> = ({
-  message,
-  actionLabel,
-  onAction,
-  onClose,
-  duration = 6000,
-}) => {
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const [visible, setVisible] = useState(false);
+export type ToastType = 'success' | 'error' | 'info';
 
-  useEffect(() => {
-    setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
-  }, [duration, onClose]);
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+  duration: number | null; // null = persist until dismissed
+}
+
+interface ToastContextValue {
+  success: (message: string, options?: ToastOptions) => void;
+  error: (message: string, options?: ToastOptions) => void;
+  longTask: (message: string) => () => void; // returns dismiss function
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION = 6000;
+
+function useToastContext() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}
+
+export const useSuccessToast = () => useToastContext().success;
+export const useErrorToast = () => useToastContext().error;
+export const useLongTaskToast = () => useToastContext().longTask;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const remove = useCallback((id: number) => {
+    setToasts((t) => t.filter((toast) => toast.id !== id));
+  }, []);
+
+  const add = useCallback(
+    (type: ToastType, message: string, duration: number | null) => {
+      const id = Date.now() + Math.random();
+      setToasts((t) => [...t, { id, message, type, duration }]);
+      if (duration) {
+        setTimeout(() => remove(id), duration);
+      }
+      return id;
+    },
+    [remove],
+  );
+
+  const success = useCallback(
+    (message: string, options?: ToastOptions) => {
+      add('success', message, options?.duration ?? DEFAULT_DURATION);
+    },
+    [add],
+  );
+
+  const error = useCallback(
+    (message: string, options?: ToastOptions) => {
+      add('error', message, options?.duration ?? DEFAULT_DURATION);
+    },
+    [add],
+  );
+
+  const longTask = useCallback(
+    (message: string) => {
+      const id = add('info', message, null);
+      return () => remove(id);
+    },
+    [add, remove],
+  );
+
+  return (
+    <ToastContext.Provider value={{ success, error, longTask }}>
+      {children}
+      <div className="fixed top-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
+        {toasts.map((t) => (
+          <ToastView key={t.id} message={t.message} type={t.type} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+interface ToastViewProps {
+  message: string;
+  type: ToastType;
+}
+
+function ToastView({ message, type }: ToastViewProps) {
+
+  const typeClass =
+    type === 'success'
+      ? 'bg-green-600 border-green-500'
+      : type === 'error'
+        ? 'bg-red-600 border-red-500'
+        : 'bg-gray-900 border-gray-700';
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`rounded-md shadow-md text-white border px-4 py-3 flex items-center ${typeClass}`}
     >
       <span>{message}</span>
-      {onAction && actionLabel && (
-        <button
-          onClick={onAction}
-          className="ml-4 underline focus:outline-none"
-        >
-          {actionLabel}
-        </button>
-      )}
     </div>
   );
-};
+}
 
-export default Toast;
+export default ToastProvider;

--- a/docs/toast.md
+++ b/docs/toast.md
@@ -1,0 +1,33 @@
+# Toast Utility
+
+A global toast system is available in `components/ui/Toast.tsx`.
+
+## Usage
+
+Wrap your app with the `ToastProvider` (already done in `_app.jsx`). Then use one of the hooks:
+
+- `useSuccessToast()` – show a success message.
+- `useErrorToast()` – show an error message.
+- `useLongTaskToast()` – show a persistent message for long-running tasks; returns a function to dismiss the toast.
+
+```tsx
+import { useSuccessToast, useLongTaskToast } from '../components/ui/Toast';
+
+const Example = () => {
+  const success = useSuccessToast();
+  const longTask = useLongTaskToast();
+
+  const handleSave = () => {
+    const dismiss = longTask('Saving...');
+    // perform async work then dismiss
+    setTimeout(() => {
+      dismiss();
+      success('Saved');
+    }, 1000);
+  };
+
+  return <button onClick={handleSave}>Save</button>;
+};
+```
+
+All toasts share consistent styling and default to a 6&nbsp;second duration.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { ToastProvider } from '../components/ui/Toast';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -152,19 +153,21 @@ function MyApp(props) {
       <div className={ubuntu.className}>
         <SettingsProvider>
           <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+            <ToastProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </ToastProvider>
           </PipPortalProvider>
         </SettingsProvider>
       </div>


### PR DESCRIPTION
## Summary
- add ToastProvider with success, error and long task hooks
- replace ad-hoc toast state in apps with global hooks
- document toast usage

## Testing
- `node_modules/.bin/eslint components/ui/Toast.tsx components/apps/Games/common/Overlay.tsx components/apps/nmap-nse/index.js apps/metasploit/index.tsx apps/contact/index.tsx __tests__/liveRegion.test.tsx pages/_app.jsx docs/toast.md` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/liveRegion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc5f2c2483288bf542bc10743f53