### PR TITLE
Improve accessibility focus outlines and add checklist

### DIFF
--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -44,7 +44,7 @@ const GitHubStars = ({ user, repo }) => {
   if (!repo) return null;
 
   return (
-    <div ref={ref} className="inline-flex items-center text-xs text-gray-300">
+    <div ref={ref} className="inline-flex items-center text-xs text-ubt-grey">
       {loading ? (
         <div className="h-5 w-12 bg-gray-200 animate-pulse rounded" />
       ) : (
@@ -53,7 +53,10 @@ const GitHubStars = ({ user, repo }) => {
           <button
             onClick={fetchStars}
             aria-label="Refresh star count"
-            className="ml-2 text-gray-400 hover:text-white"
+            className={[
+              "ml-2 text-ubt-grey hover:text-white",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-outline-color)]",
+            ].join(" ")}
           >
             ↻
           </button>

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -26,7 +26,8 @@ const InstallButton: React.FC = () => {
   return (
     <button
       onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
+      aria-label="Install application"
+      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-outline-color)]"
     >
       Install
     </button>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -28,9 +28,11 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
-            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
-          }`}
+          className={[
+            "px-4 py-2",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-outline-color)]",
+            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey",
+          ].join(" ")}
         >
           {t.label}
         </button>

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -20,9 +20,12 @@ export default function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
-        checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
+      className={[
+        "relative inline-flex w-10 h-5 rounded-full transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-outline-color)]",
+        checked ? "bg-ub-orange" : "bg-ubt-cool-grey",
+        className,
+      ].join(" ")}
     >
       <span
         className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${

--- a/docs/accessibility-checklist.md
+++ b/docs/accessibility-checklist.md
@@ -1,0 +1,11 @@
+# Accessibility Checklist
+
+This project aims to provide an inclusive experience. When adding or modifying components, consider the following:
+
+- **Focus visibility**: All interactive elements must show a visible focus outline. Use the `var(--focus-outline-color)` token to ensure compatibility with high-contrast and colorblind modes.
+- **Descriptive labeling**: Provide `aria-label`, `aria-labelledby`, or visible text for controls so assistive technologies can convey purpose.
+- **Color contrast**: Use design tokens and CSS variables to maintain at least a 4.5:1 contrast ratio between text and its background. Avoid conveying information with color alone to respect global colorblind settings.
+- **Keyboard navigation**: Verify components are operable using only the keyboard and that tab order is logical.
+- **Testing**: Run `yarn lint` and `yarn test` before committing, and consider running `yarn a11y` for automated accessibility audits.
+
+Following this checklist helps ensure new features remain accessible to all users.


### PR DESCRIPTION
## Summary
- add focus-visible outlines and aria labels to toggles, tabs, install and GitHub star buttons
- document accessibility checklist for future components

## Testing
- `yarn lint` *(fails: Component definition is missing display name, etc.)*
- `yarn test` *(fails: TypeError: useInputRecorder is not a function, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9cc5fd2988328b5b8649e8461467d