### PR TITLE
feat(plugin-manager): display metadata badges

### DIFF
--- a/__tests__/pluginManager.test.tsx
+++ b/__tests__/pluginManager.test.tsx
@@ -23,7 +23,15 @@ describe('PluginManager', () => {
     (global as any).fetch = jest.fn((url: string) => {
       if (url === '/api/plugins') {
         return Promise.resolve({
-          json: () => Promise.resolve([{ id: 'demo', file: 'demo.json' }]),
+          json: () =>
+            Promise.resolve([
+              {
+                id: 'demo',
+                file: 'demo.json',
+                permission: 'network',
+                sandbox: 'worker',
+              },
+            ]),
         });
       }
       if (url === '/api/plugins/demo.json') {
@@ -32,6 +40,7 @@ describe('PluginManager', () => {
             Promise.resolve({
               id: 'demo',
               sandbox: 'worker',
+              permission: 'network',
               code: "self.postMessage('content');",
             }),
         });
@@ -42,6 +51,8 @@ describe('PluginManager', () => {
 
   test('installs plugin from catalog', async () => {
     render(<PluginManager />);
+    expect(await screen.findByText('network')).toBeInTheDocument();
+    expect(await screen.findByText('worker')).toBeInTheDocument();
     const button = await screen.findByText('Install');
     fireEvent.click(button);
     await waitFor(() =>

--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -1,12 +1,18 @@
 'use client';
 import { useEffect, useState } from 'react';
 
-interface PluginInfo { id: string; file: string; }
+interface PluginInfo {
+  id: string;
+  file: string;
+  permission: string;
+  sandbox: 'worker' | 'iframe';
+}
 
 interface PluginManifest {
   id: string;
   sandbox: 'worker' | 'iframe';
   code: string;
+  permission?: string;
 }
 
 export default function PluginManager() {
@@ -126,7 +132,15 @@ export default function PluginManager() {
       <ul>
         {plugins.map((p) => (
           <li key={p.id} className="flex items-center mb-2">
-            <span className="flex-grow">{p.id}</span>
+            <div className="flex-grow">
+              <span>{p.id}</span>
+              <span className="ml-2 text-xs bg-ub-cool-grey px-1 py-0.5 rounded">
+                {p.permission}
+              </span>
+              <span className="ml-1 text-xs bg-ub-cool-grey px-1 py-0.5 rounded">
+                {p.sandbox}
+              </span>
+            </div>
             <button
               className="bg-ub-orange px-2 py-1 rounded disabled:opacity-50"
               onClick={() => install(p)}

--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -7,7 +7,21 @@ export default function handler(_req, res) {
     const files = fs.readdirSync(catalogDir);
     const plugins = files
       .filter((f) => !f.startsWith('.') && f.endsWith('.json'))
-      .map((f) => ({ id: path.parse(f).name, file: f }));
+      .map((f) => {
+        const filePath = path.join(catalogDir, f);
+        let meta = {};
+        try {
+          meta = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        } catch {
+          /* ignore */
+        }
+        return {
+          id: path.parse(f).name,
+          file: f,
+          permission: meta.permission || '',
+          sandbox: meta.sandbox,
+        };
+      });
     res.status(200).json(plugins);
   } catch {
     res.status(200).json([]);

--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,5 +1,6 @@
 {
   "id": "demo",
+  "permission": "network",
   "sandbox": "worker",
   "code": "self.postMessage('content');"
 }


### PR DESCRIPTION
## Summary
- show permission and sandbox badges in Plugin Manager
- expose permission and sandbox fields from /api/plugins
- add permission metadata to demo plugin

## Testing
- `npm test __tests__/pluginManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc68e898832888f970f6934decb6