### PR TITLE
feat(plugins): add manifest schema validation

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,23 @@
+# Plugin Manifests
+
+Plugins are described by JSON manifests stored in `plugins/catalog`. Each manifest must match a versioned schema defined in `plugins/schema.ts`.
+
+## Schema Versions
+
+### Version 1
+
+```
+{
+  "version": 1,
+  "id": "demo",
+  "sandbox": "worker",
+  "code": "self.postMessage('content');"
+}
+```
+
+- `version` – schema version number.
+- `id` – unique plugin identifier.
+- `sandbox` – execution environment (`worker` or `iframe`).
+- `code` – JavaScript executed in the sandbox.
+
+Future schema versions will be documented here.

--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "id": "demo",
   "sandbox": "worker",
   "code": "self.postMessage('content');"

--- a/plugins/schema.ts
+++ b/plugins/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const manifestV1 = z.object({
+  version: z.literal(1),
+  id: z.string(),
+  sandbox: z.enum(['worker', 'iframe']),
+  code: z.string(),
+});
+
+export const pluginManifest = z.discriminatedUnion('version', [manifestV1]);
+export type PluginManifest = z.infer<typeof pluginManifest>;
+
+export function validateManifest(data: unknown): PluginManifest {
+  return pluginManifest.parse(data);
+}


### PR DESCRIPTION
## Summary
- define versioned plugin manifest schema using zod
- validate manifests on catalog load and show inline errors in PluginManager UI
- document schema versioning for plugins

## Testing
- `yarn test __tests__/pluginManager.test.tsx`
- `yarn lint components/apps/plugin-manager/index.tsx __tests__/pluginManager.test.tsx plugins/schema.ts` *(fails: Component definition is missing display name and other existing repo warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc7f8fec8328b040ec102153b406