### PR TITLE
feat: verify plugin signatures

### DIFF
--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,5 +1,6 @@
 {
   "id": "demo",
   "sandbox": "worker",
-  "code": "self.postMessage('content');"
+  "code": "self.postMessage('content');",
+  "signature": "09018c2d80c94f95a14e4e6ad6615e077ce2a3913f4c7571e8d55f7bc1335b99"
 }


### PR DESCRIPTION
## Summary
- add signature field to plugin manifests
- verify plugin code using SubtleCrypto and surface toast on failure
- test plugin manager verification

## Testing
- `npx eslint components/apps/plugin-manager/index.tsx __tests__/pluginManager.test.tsx`
- `npx jest __tests__/pluginManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc807ce88328b69d2cd45aac46d2