### PR TITLE
feat(plugin-manager): add channel selection and changelog modal

### DIFF
--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -7,7 +7,25 @@ export default function handler(_req, res) {
     const files = fs.readdirSync(catalogDir);
     const plugins = files
       .filter((f) => !f.startsWith('.') && f.endsWith('.json'))
-      .map((f) => ({ id: path.parse(f).name, file: f }));
+      .map((f) => {
+        const filePath = path.join(catalogDir, f);
+        try {
+          const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+          return {
+            id: data.id || path.parse(f).name,
+            file: f,
+            channel: data.channel || 'stable',
+            changelog: data.changelog || '',
+          };
+        } catch {
+          return {
+            id: path.parse(f).name,
+            file: f,
+            channel: 'stable',
+            changelog: '',
+          };
+        }
+      });
     res.status(200).json(plugins);
   } catch {
     res.status(200).json([]);

--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,5 +1,7 @@
 {
   "id": "demo",
   "sandbox": "worker",
-  "code": "self.postMessage('content');"
+  "code": "self.postMessage('content');",
+  "channel": "stable",
+  "changelog": "Initial release"
 }


### PR DESCRIPTION
## Summary
- extend plugin catalog metadata with channel and changelog
- allow channel selection, changelog modal, and persist choice
- test channel persistence and changelog display

## Testing
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/game2048.test.tsx, __tests__/nmapNse.test.tsx, __tests__/Modal.test.tsx)*
- `yarn lint components/apps/plugin-manager/index.tsx pages/api/plugins/index.js __tests__/pluginManager.test.tsx plugins/catalog/demo.json` *(fails: 591 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc80e22083289eed27160267b3d8