### PR TITLE
feat: add plugin filtering

### DIFF
--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -7,7 +7,21 @@ export default function handler(_req, res) {
     const files = fs.readdirSync(catalogDir);
     const plugins = files
       .filter((f) => !f.startsWith('.') && f.endsWith('.json'))
-      .map((f) => ({ id: path.parse(f).name, file: f }));
+      .map((f) => {
+        try {
+          const data = JSON.parse(
+            fs.readFileSync(path.join(catalogDir, f), 'utf-8')
+          );
+          return {
+            id: path.parse(f).name,
+            file: f,
+            category: data.category,
+            tags: data.tags,
+          };
+        } catch {
+          return { id: path.parse(f).name, file: f };
+        }
+      });
     res.status(200).json(plugins);
   } catch {
     res.status(200).json([]);

--- a/plugins/catalog/demo.json
+++ b/plugins/catalog/demo.json
@@ -1,5 +1,7 @@
 {
   "id": "demo",
   "sandbox": "worker",
+  "category": "examples",
+  "tags": ["sample", "demo"],
   "code": "self.postMessage('content');"
 }


### PR DESCRIPTION
## Summary
- enrich plugin metadata with categories and tags
- allow plugin manager to filter catalog via category/tag checkboxes

## Testing
- `npx eslint components/apps/plugin-manager/index.tsx pages/api/plugins/index.js`
- `yarn test components/apps/plugin-manager --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc814fcc83288e328583bb4e6817