### PR TITLE
feat: add plugin set export and import

### DIFF
--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -120,6 +120,44 @@ export default function PluginManager() {
     URL.revokeObjectURL(url);
   };
 
+  const exportInstalled = async () => {
+    try {
+      const dir = await (navigator as any).storage.getDirectory();
+      const fileHandle = await dir.getFileHandle(
+        `plugins-${Date.now()}.json`,
+        { create: true }
+      );
+      const writable = await fileHandle.createWritable();
+      await writable.write(JSON.stringify(installed));
+      await writable.close();
+      alert('Plugin set exported');
+    } catch {
+      alert('Export failed');
+    }
+  };
+
+  const importInstalled = async (file: File) => {
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      setInstalled(data);
+      localStorage.setItem('installedPlugins', JSON.stringify(data));
+    } catch {
+      alert('Import failed');
+    }
+  };
+
+  const triggerImport = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'application/json';
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (file) importInstalled(file);
+    };
+    input.click();
+  };
+
   return (
     <div className="p-4 text-white">
       <h1 className="text-xl mb-4">Plugin Catalog</h1>
@@ -145,6 +183,20 @@ export default function PluginManager() {
           </li>
         ))}
       </ul>
+      <div className="mt-4 space-x-2">
+        <button
+          className="bg-ub-blue px-2 py-1 rounded"
+          onClick={exportInstalled}
+        >
+          Export Set
+        </button>
+        <button
+          className="bg-ub-blue px-2 py-1 rounded"
+          onClick={triggerImport}
+        >
+          Import Set
+        </button>
+      </div>
       {lastRun && (
         <div className="mt-4">
           <h2 className="text-lg mb-2">Last Run: {lastRun.id}</h2>


### PR DESCRIPTION
## Summary
- allow exporting installed plugin set to OPFS
- import plugin sets from a selected backup file
- add UI buttons to back up and restore plugin sets

## Testing
- `npx eslint components/apps/plugin-manager/index.tsx && echo 'eslint succeeded'`
- `yarn test components/apps/plugin-manager/index.tsx` *(no tests found)*
- `npx tsc components/apps/plugin-manager/index.tsx --noEmit` *(missing --jsx flag)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc832ce08328ad2fd235b656d36f