### PR TITLE
feat: add Wireshark sample gallery metadata

### DIFF
--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -5,6 +5,8 @@ import { protocolName } from '../../../components/apps/wireshark/utils';
 import FilterHelper from './FilterHelper';
 import presets from '../filters/presets.json';
 import LayerView from './LayerView';
+import SampleGallery from './SampleGallery';
+import samples from '../samples';
 
 
 interface PcapViewerProps {
@@ -16,11 +18,6 @@ const protocolColors: Record<string, string> = {
   UDP: 'bg-green-900',
   ICMP: 'bg-yellow-800',
 };
-
-const samples = [
-  { label: 'HTTP', path: '/samples/wireshark/http.pcap' },
-  { label: 'DNS', path: '/samples/wireshark/dns.pcap' },
-];
 
 // Convert bytes to hex dump string
 const toHex = (bytes: Uint8Array) =>
@@ -302,36 +299,15 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
 
   return (
     <div className="p-4 text-white bg-ub-cool-grey h-full w-full flex flex-col space-y-2">
-      <div className="flex items-center space-x-2">
+      <div>
         <input
           type="file"
           accept=".pcap,.pcapng"
           onChange={handleFile}
           className="text-sm"
         />
-        <select
-          onChange={(e) => {
-            if (e.target.value) handleSample(e.target.value);
-            e.target.value = '';
-          }}
-          className="text-sm bg-gray-700 text-white rounded"
-        >
-          <option value="">Open sample</option>
-          {samples.map(({ label, path }) => (
-            <option key={path} value={path}>
-              {label}
-            </option>
-          ))}
-        </select>
-        <a
-          href="https://wiki.wireshark.org/SampleCaptures"
-          target="_blank"
-          rel="noreferrer"
-          className="text-xs underline"
-        >
-          Sample sources
-        </a>
       </div>
+      <SampleGallery samples={samples} onSelect={handleSample} />
       {packets.length > 0 && (
         <>
           <div className="flex items-center space-x-2">

--- a/apps/wireshark/components/SampleGallery.tsx
+++ b/apps/wireshark/components/SampleGallery.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Image from 'next/image';
+import React from 'react';
+import type { Sample } from '../samples';
+
+interface Props {
+  samples: Sample[];
+  onSelect: (path: string) => void;
+}
+
+const SampleGallery: React.FC<Props> = ({ samples, onSelect }) => (
+  <div className="flex space-x-2 overflow-x-auto mb-2 pb-2" role="list">
+    {samples.map((s) => (
+      <div
+        key={s.path}
+        className="flex-shrink-0 w-40 bg-gray-700 rounded p-2 text-xs"
+        role="listitem"
+      >
+        <button
+          type="button"
+          onClick={() => onSelect(s.path)}
+          className="w-full text-left"
+        >
+          <Image
+            src={s.thumbnail}
+            alt={`${s.label} sample thumbnail`}
+            width={160}
+            height={90}
+            className="rounded mb-1 object-cover"
+          />
+          <div className="font-semibold mb-1 text-sm">{s.label}</div>
+          <p className="mb-1">{s.description}</p>
+        </button>
+        <a
+          href={s.source}
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          Source
+        </a>
+      </div>
+    ))}
+  </div>
+);
+
+export default SampleGallery;

--- a/apps/wireshark/samples.ts
+++ b/apps/wireshark/samples.ts
@@ -1,0 +1,28 @@
+export interface Sample {
+  label: string;
+  path: string;
+  thumbnail: string;
+  description: string;
+  source: string;
+}
+
+const samples: Sample[] = [
+  {
+    label: 'HTTP',
+    path: '/samples/wireshark/http.pcap',
+    thumbnail: '/samples/wireshark/http.svg',
+    description: 'Basic HTTP request and response capture',
+    source:
+      'https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/http.cap',
+  },
+  {
+    label: 'DNS',
+    path: '/samples/wireshark/dns.pcap',
+    thumbnail: '/samples/wireshark/dns.svg',
+    description: 'DNS query and response traffic',
+    source:
+      'https://gitlab.com/wireshark/wireshark/-/raw/master/test/captures/dns.cap',
+  },
+];
+
+export default samples;

--- a/public/samples/wireshark/dns.svg
+++ b/public/samples/wireshark/dns.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" fill="#1f2937"/>
+  <text x="50%" y="50%" fill="#fff" font-size="24" font-family="monospace" text-anchor="middle" dominant-baseline="central">DNS</text>
+</svg>

--- a/public/samples/wireshark/http.svg
+++ b/public/samples/wireshark/http.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" fill="#1f2937"/>
+  <text x="50%" y="50%" fill="#fff" font-size="24" font-family="monospace" text-anchor="middle" dominant-baseline="central">HTTP</text>
+</svg>


### PR DESCRIPTION
## Summary
- add HTTP and DNS sample metadata for Wireshark
- show thumbnails, descriptions, and source links in a new sample gallery

## Testing
- `yarn test` *(fails: game2048.test.tsx, window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc8aa2cc8328bcbe114cf6f84843