### PR TITLE
feat(kismet): add CSV/JSON export buttons

### DIFF
--- a/apps/kismet/components/ExportButtons.tsx
+++ b/apps/kismet/components/ExportButtons.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+
+interface Network {
+  ssid: string;
+  bssid: string;
+  channel: number | null | undefined;
+  frames: number;
+}
+
+interface ExportButtonsProps {
+  data: Network[];
+}
+
+const ExportButtons: React.FC<ExportButtonsProps> = ({ data }) => {
+  const download = (content: string, filename: string, type: string) => {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCSV = () => {
+    const header = ['SSID', 'BSSID', 'Channel', 'Frames'];
+    const rows = data.map((n) => [
+      n.ssid || '(hidden)',
+      n.bssid,
+      n.channel ?? '',
+      n.frames,
+    ]);
+    const csv = [header, ...rows]
+      .map((row) => row.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+    download(csv, 'networks.csv', 'text/csv');
+  };
+
+  const exportJSON = () => {
+    const json = JSON.stringify(data, null, 2);
+    download(json, 'networks.json', 'application/json');
+  };
+
+  return (
+    <div className="flex space-x-2 mb-2 text-sm">
+      <button
+        onClick={exportCSV}
+        className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
+      >
+        Export CSV
+      </button>
+      <button
+        onClick={exportJSON}
+        className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
+      >
+        Export JSON
+      </button>
+    </div>
+  );
+};
+
+export default ExportButtons;

--- a/components/apps/kismet.jsx
+++ b/components/apps/kismet.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ExportButtons from '../../apps/kismet/components/ExportButtons';
 
 // Helper to convert bytes to MAC address string
 const macToString = (bytes) =>
@@ -162,6 +163,7 @@ const KismetApp = ({ onNetworkDiscovered }) => {
 
       {networks.length > 0 && (
         <>
+          <ExportButtons data={networks} />
           <table className="text-sm w-full" aria-label="Networks">
             <thead>
               <tr className="text-left">


### PR DESCRIPTION
## Summary
- add ExportButtons component to download current network table as CSV or JSON
- integrate export buttons into Kismet app

## Testing
- `yarn eslint apps/kismet/components/ExportButtons.tsx components/apps/kismet.jsx`
- `yarn test apps/kismet/components/ExportButtons.tsx --passWithNoTests`
- `yarn tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc8d65a08328b4c96eb1cd1444c4