### PR TITLE
Add vendor lookups and highlight duplicate SSIDs in Kismet app

### DIFF
--- a/data/oui.json
+++ b/data/oui.json
@@ -1,0 +1,5 @@
+{
+  "00:11:22": "Acme Corp",
+  "66:77:88": "Globex",
+  "AA:BB:CC": "Initech"
+}


### PR DESCRIPTION
## Summary
- add local OUI database and import into Kismet app for vendor lookup
- show vendor next to BSSID and flag duplicate SSIDs

## Testing
- `npx eslint components/apps/kismet.jsx data/oui.json`
- `yarn test` *(fails: window, game2048, nmapNSE, Modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc8e3df48328ae3ee77e6bad82da