### PR TITLE
feat: add hierarchical nmap report views

### DIFF
--- a/apps/nmap-nse/components/ReportView.tsx
+++ b/apps/nmap-nse/components/ReportView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 
 export interface Vulnerability {
@@ -22,31 +22,79 @@ export interface Report {
   hosts: Host[];
 }
 
-const HostSection: React.FC<{ host: Host }> = ({ host }) => {
+interface BreadcrumbItem {
+  label: string;
+  onClick?: () => void;
+}
+
+const Breadcrumbs: React.FC<{ items: BreadcrumbItem[] }> = ({ items }) => (
+  <nav className="text-sm mb-4">
+    {items.map((item, idx) => (
+      <span key={idx}>
+        {idx > 0 && ' / '}
+        {item.onClick ? (
+          <button
+            className="text-blue-400 hover:underline"
+            onClick={item.onClick}
+            type="button"
+          >
+            {item.label}
+          </button>
+        ) : (
+          <span>{item.label}</span>
+        )}
+      </span>
+    ))}
+  </nav>
+);
+
+const HostList: React.FC<{ hosts: Host[]; onSelect: (h: Host) => void }> = ({
+  hosts,
+  onSelect,
+}) => (
+  <div className="space-y-2">
+    {hosts.map((h) => (
+      <button
+        key={h.address}
+        onClick={() => onSelect(h)}
+        className="block w-full text-left p-2 bg-gray-800 hover:bg-gray-700 rounded"
+        type="button"
+      >
+        {h.address}
+      </button>
+    ))}
+  </div>
+);
+
+const ServiceList: React.FC<{
+  host: Host;
+  onSelect: (s: Service) => void;
+}> = ({ host, onSelect }) => {
   const [note, setNote] = usePersistentState(
     `nmap-nse:note:${host.address}`,
     '',
     (v): v is string => typeof v === 'string'
   );
   return (
-    <div className="mb-4 border border-gray-700 p-2 rounded">
-      <h3 className="text-lg font-bold mb-2">{host.address}</h3>
-      {host.services.map((s) => (
-        <div key={s.port} className="ml-4 mb-2">
-          <div className="font-mono">
+    <div>
+      <h2 className="text-xl font-bold mb-2">{host.address}</h2>
+      <div className="space-y-2 mb-4">
+        {host.services.map((s) => (
+          <button
+            key={s.port}
+            onClick={() => onSelect(s)}
+            className="block w-full text-left p-2 bg-gray-800 hover:bg-gray-700 rounded"
+            type="button"
+          >
             {s.port} {s.name}
-          </div>
-          {s.vulnerabilities.map((v, idx) => (
-            <div key={idx} className="ml-4 text-sm text-red-400">
-              {v.id}: {v.output}
-            </div>
-          ))}
-        </div>
-      ))}
+          </button>
+        ))}
+      </div>
       {host.vulnerabilities.length > 0 && (
-        <div className="ml-4 text-sm text-red-400 mb-2">
+        <div className="mb-4">
+          <h3 className="font-bold">Host Scripts</h3>
           {host.vulnerabilities.map((v, idx) => (
-            <div key={idx}>
+            <div key={idx} className="ml-2 text-sm text-red-400">
               {v.id}: {v.output}
             </div>
           ))}
@@ -55,6 +103,7 @@ const HostSection: React.FC<{ host: Host }> = ({ host }) => {
       <textarea
         className="w-full p-1 rounded text-black"
         placeholder="Annotations"
+        aria-label="Annotations"
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
@@ -62,13 +111,59 @@ const HostSection: React.FC<{ host: Host }> = ({ host }) => {
   );
 };
 
-const ReportView: React.FC<{ report: Report }> = ({ report }) => (
+const ScriptList: React.FC<{ service: Service }> = ({ service }) => (
   <div>
-    {report.hosts.map((h) => (
-      <HostSection key={h.address} host={h} />
+    <h2 className="text-xl font-bold mb-2">
+      {service.port} {service.name}
+    </h2>
+    {service.vulnerabilities.map((v, idx) => (
+      <div key={idx} className="mb-4">
+        <div className="font-mono text-sm mb-1">{v.id}</div>
+        <pre className="bg-black text-green-400 p-2 rounded overflow-auto font-mono leading-[1.2]">
+          {v.output}
+        </pre>
+      </div>
     ))}
+    {service.vulnerabilities.length === 0 && <p>No scripts reported.</p>}
   </div>
 );
+
+const ReportView: React.FC<{ report: Report }> = ({ report }) => {
+  const [host, setHost] = useState<Host | null>(null);
+  const [service, setService] = useState<Service | null>(null);
+
+  const breadcrumbs: BreadcrumbItem[] = [
+    {
+      label: 'Hosts',
+      onClick: () => {
+        setHost(null);
+        setService(null);
+      },
+    },
+  ];
+  if (host) {
+    breadcrumbs.push({ label: host.address, onClick: () => setService(null) });
+  }
+  if (service) {
+    breadcrumbs.push({ label: `${service.port} ${service.name}` });
+  }
+
+  let content: React.ReactNode;
+  if (!host) {
+    content = <HostList hosts={report.hosts} onSelect={setHost} />;
+  } else if (!service) {
+    content = <ServiceList host={host} onSelect={setService} />;
+  } else {
+    content = <ScriptList service={service} />;
+  }
+
+  return (
+    <div>
+      <Breadcrumbs items={breadcrumbs} />
+      {content}
+    </div>
+  );
+};
 
 export default ReportView;
 


### PR DESCRIPTION
## Summary
- implement host, service, and script views for Nmap NSE reports
- add breadcrumb navigation to drill down and back up results

## Testing
- `npx eslint apps/nmap-nse/components/ReportView.tsx`
- `yarn test apps/nmap-nse/components/ReportView.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc8fb63c83289ffff9dd22e2d87b