### PR TITLE
feat(nmap-nse): add XML parser and import UI

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/nmapNseImport.test.tsx
+++ b/__tests__/nmapNseImport.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NmapNSE from '../apps/nmap-nse';
+
+describe('NmapNSE import', () => {
+  const setupFileReader = (content: string) => {
+    const fileReaderMock = {
+      result: content,
+      onload: null as ((this: any, ev: any) => void) | null,
+      readAsText: jest.fn(function (this: any) {
+        this.onload?.(new Event('load'));
+      }),
+    } as any;
+    const spy = jest
+      .spyOn(window as any, 'FileReader')
+      .mockImplementation(() => fileReaderMock);
+    return { readAsText: fileReaderMock.readAsText, spy };
+  };
+
+  it('parses a valid XML report', async () => {
+    const mockFetch = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ json: () => Promise.resolve({}) } as any);
+
+    const xml = `<?xml version="1.0"?><nmaprun><host><address addr="10.0.0.1"/><ports><port portid="80"><service name="http"/><script id="test" output="ok"/></port></ports></host></nmaprun>`;
+    const { readAsText, spy } = setupFileReader(xml);
+
+    render(<NmapNSE />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const input = screen.getByLabelText(/nmap xml file/i);
+    const file = new File(['dummy'], 'scan.xml', { type: 'text/xml' });
+    await userEvent.upload(input, file);
+    expect(readAsText).toHaveBeenCalled();
+
+    expect(await screen.findByText('10.0.0.1')).toBeInTheDocument();
+
+    mockFetch.mockRestore();
+    spy.mockRestore();
+  });
+
+  it('shows an error for malformed XML', async () => {
+    const mockFetch = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ json: () => Promise.resolve({}) } as any);
+
+    const { readAsText, spy } = setupFileReader('<nmap');
+
+    render(<NmapNSE />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const input = screen.getByLabelText(/nmap xml file/i);
+    const badFile = new File(['bad'], 'bad.xml', { type: 'text/xml' });
+    await userEvent.upload(input, badFile);
+    expect(readAsText).toHaveBeenCalled();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/invalid/i);
+
+    mockFetch.mockRestore();
+    spy.mockRestore();
+  });
+});

--- a/apps/nmap-nse/utils/parseNmapXml.ts
+++ b/apps/nmap-nse/utils/parseNmapXml.ts
@@ -1,0 +1,40 @@
+import { XMLParser } from 'fast-xml-parser';
+import type { Report, Host, Service, Vulnerability } from '../components/ReportView';
+
+export default function parseNmapXml(xml: string): Report {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  let json: any;
+  try {
+    json = parser.parse(xml);
+  } catch {
+    throw new Error('Invalid XML');
+  }
+  const hostData = json?.nmaprun?.host;
+  const hostsArr = Array.isArray(hostData) ? hostData : hostData ? [hostData] : [];
+  const hosts: Host[] = hostsArr.map((host: any) => {
+    const addrNode = host.address;
+    const addrVal = Array.isArray(addrNode) ? addrNode[0]?.['@_addr'] : addrNode?.['@_addr'];
+    const address = addrVal || 'unknown';
+    const ports = host.ports?.port;
+    const portArr = Array.isArray(ports) ? ports : ports ? [ports] : [];
+    const services: Service[] = portArr.map((p: any) => {
+      const port = parseInt(p['@_portid'] || '0', 10);
+      const name = p.service?.['@_name'] || '';
+      const scripts = p.script;
+      const scriptArr = Array.isArray(scripts) ? scripts : scripts ? [scripts] : [];
+      const vulnerabilities: Vulnerability[] = scriptArr.map((s: any) => ({
+        id: s['@_id'] || '',
+        output: s['@_output'] || '',
+      }));
+      return { port, name, vulnerabilities };
+    });
+    const hostScripts = host.hostscript?.script;
+    const hostScriptArr = Array.isArray(hostScripts) ? hostScripts : hostScripts ? [hostScripts] : [];
+    const vulnerabilities: Vulnerability[] = hostScriptArr.map((s: any) => ({
+      id: s['@_id'] || '',
+      output: s['@_output'] || '',
+    }));
+    return { address, services, vulnerabilities };
+  });
+  return { hosts };
+}

--- a/apps/nmap-nse/workers/xmlParser.ts
+++ b/apps/nmap-nse/workers/xmlParser.ts
@@ -1,63 +1,9 @@
-import { XMLParser } from 'fast-xml-parser';
-
-interface Vulnerability {
-  id: string;
-  output: string;
-}
-
-interface Service {
-  port: number;
-  name: string;
-  vulnerabilities: Vulnerability[];
-}
-
-interface Host {
-  address: string;
-  services: Service[];
-  vulnerabilities: Vulnerability[];
-}
-
-interface Report {
-  hosts: Host[];
-}
+import type { Report } from '../components/ReportView';
+import parseNmapXml from '../utils/parseNmapXml';
 
 self.onmessage = ({ data }: MessageEvent<string>) => {
   try {
-    const parser = new XMLParser({ ignoreAttributes: false });
-    const json = parser.parse(data);
-    const hostData = json?.nmaprun?.host;
-    const hostsArr = Array.isArray(hostData) ? hostData : hostData ? [hostData] : [];
-    const hosts: Host[] = hostsArr.map((host: any) => {
-      const addr = Array.isArray(host.address)
-        ? host.address[0]?.['@_addr']
-        : host.address?.['@_addr'];
-      const address = addr || 'unknown';
-      const ports = host.ports?.port;
-      const portArr = Array.isArray(ports) ? ports : ports ? [ports] : [];
-      const services: Service[] = portArr.map((p: any) => {
-        const port = parseInt(p['@_portid'] || '0', 10);
-        const name = p.service?.['@_name'] || '';
-        const scripts = p.script;
-        const scriptArr = Array.isArray(scripts) ? scripts : scripts ? [scripts] : [];
-        const vulnerabilities: Vulnerability[] = scriptArr.map((s: any) => ({
-          id: s['@_id'] || '',
-          output: s['@_output'] || '',
-        }));
-        return { port, name, vulnerabilities };
-      });
-      const hostScripts = host.hostscript?.script;
-      const hostScriptArr = Array.isArray(hostScripts)
-        ? hostScripts
-        : hostScripts
-        ? [hostScripts]
-        : [];
-      const vulnerabilities: Vulnerability[] = hostScriptArr.map((s: any) => ({
-        id: s['@_id'] || '',
-        output: s['@_output'] || '',
-      }));
-      return { address, services, vulnerabilities };
-    });
-    const report: Report = { hosts };
+    const report: Report = parseNmapXml(data);
     self.postMessage(report);
   } catch (err: any) {
     self.postMessage({ error: err?.message || 'Parse failed' });
@@ -65,4 +11,3 @@ self.onmessage = ({ data }: MessageEvent<string>) => {
 };
 
 export {};
-


### PR DESCRIPTION
## Summary
- add reusable parser for standard Nmap XML reports
- allow importing XML files with error handling in Nmap NSE app
- expand tests for XML import and update existing expectations

## Testing
- `yarn test __tests__/nmapNseImport.test.tsx __tests__/nmapNse.test.tsx`
- `yarn lint apps/nmap-nse/utils/parseNmapXml.ts apps/nmap-nse/index.tsx __tests__/nmapNseImport.test.tsx` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc8fd3b8832880c1c05febe0e5f3