### PR TITLE
Add scan diff utility with configurable options

### DIFF
--- a/__tests__/scanDiff.test.ts
+++ b/__tests__/scanDiff.test.ts
@@ -1,0 +1,22 @@
+import { diffScans, normalizeServiceName, type PortService } from '../utils/scanDiff';
+
+describe('diffScans', () => {
+  test('ignores ephemeral ports by default', () => {
+    const a: PortService[] = [{ port: 80, service: 'http' }];
+    const b: PortService[] = [
+      { port: 80, service: 'http' },
+      { port: 50000, service: 'random' },
+    ];
+    const diff = diffScans(a, b, { ignoreEphemeral: true });
+    expect(diff.added).toHaveLength(0);
+  });
+
+  test('normalizes service names', () => {
+    const a: PortService[] = [{ port: 80, service: 'http' }];
+    const b: PortService[] = [{ port: 80, service: 'www-http' }];
+    const diff = diffScans(a, b, {
+      normalizeService: normalizeServiceName,
+    });
+    expect(diff.changed).toHaveLength(0);
+  });
+});

--- a/components/ScanDiff.tsx
+++ b/components/ScanDiff.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { diffScans, normalizeServiceName, type PortService } from '../utils/scanDiff';
+
+export default function ScanDiff() {
+  const [left, setLeft] = useState<PortService[]>([]);
+  const [right, setRight] = useState<PortService[]>([]);
+  const [ignoreEphemeral, setIgnoreEphemeral] = useState(true);
+  const [normalize, setNormalize] = useState(true);
+
+  const loadFile = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    setter: (data: PortService[]) => void,
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const text = ev.target?.result as string;
+        const json = JSON.parse(text);
+        setter(Array.isArray(json) ? json : []);
+      } catch {
+        setter([]);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const diff = useMemo(
+    () =>
+      diffScans(left, right, {
+        ignoreEphemeral,
+        normalizeService: normalize ? normalizeServiceName : undefined,
+      }),
+    [left, right, ignoreEphemeral, normalize],
+  );
+
+  const changedPorts = new Set(diff.changed.map((c) => c.port));
+  const addedPorts = new Set(diff.added.map((c) => c.port));
+  const removedPorts = new Set(diff.removed.map((c) => c.port));
+
+  const format = (p: PortService) => `${p.port}/${p.service}`;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <div className="flex-1 text-sm">
+          <label htmlFor="scan-a" className="block mb-1">
+            Scan A
+          </label>
+          <input
+            id="scan-a"
+            type="file"
+            aria-label="Scan A file"
+            accept="application/json"
+            onChange={(e) => loadFile(e, setLeft)}
+            className="block w-full text-black"
+          />
+        </div>
+        <div className="flex-1 text-sm">
+          <label htmlFor="scan-b" className="block mb-1">
+            Scan B
+          </label>
+          <input
+            id="scan-b"
+            type="file"
+            aria-label="Scan B file"
+            accept="application/json"
+            onChange={(e) => loadFile(e, setRight)}
+            className="block w-full text-black"
+          />
+        </div>
+      </div>
+      <fieldset className="text-sm space-y-1">
+        <legend className="font-semibold">Options</legend>
+        <div>
+          <input
+            id="opt-ephemeral"
+            type="checkbox"
+            checked={ignoreEphemeral}
+            onChange={(e) => setIgnoreEphemeral(e.target.checked)}
+            className="mr-1"
+            aria-label="Ignore ephemeral ports"
+          />
+          <label htmlFor="opt-ephemeral">Ignore ephemeral ports</label>
+        </div>
+        <div>
+          <input
+            id="opt-normalize"
+            type="checkbox"
+            checked={normalize}
+            onChange={(e) => setNormalize(e.target.checked)}
+            className="mr-1"
+            aria-label="Normalize service names"
+          />
+          <label htmlFor="opt-normalize">Normalize service names</label>
+        </div>
+      </fieldset>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+        <div>
+          <h3 className="font-bold mb-2">Scan A</h3>
+          <ul className="space-y-1">
+            {left.map((p) => (
+              <li
+                key={p.port}
+                className={`p-2 rounded ${
+                  removedPorts.has(p.port)
+                    ? 'bg-red-800'
+                    : changedPorts.has(p.port)
+                    ? 'bg-yellow-800'
+                    : 'bg-gray-800'
+                }`}
+              >
+                {format(p)}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-bold mb-2">Scan B</h3>
+          <ul className="space-y-1">
+            {right.map((p) => (
+              <li
+                key={p.port}
+                className={`p-2 rounded ${
+                  addedPorts.has(p.port)
+                    ? 'bg-green-800'
+                    : changedPorts.has(p.port)
+                    ? 'bg-yellow-800'
+                    : 'bg-gray-800'
+                }`}
+              >
+                {format(p)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/utils/scanDiff.ts
+++ b/utils/scanDiff.ts
@@ -1,0 +1,73 @@
+export interface PortService {
+  port: number;
+  service: string;
+}
+
+export interface DiffOptions {
+  ignoreEphemeral?: boolean;
+  normalizeService?: (name: string) => string;
+  ephemeralStart?: number;
+}
+
+export interface DiffResult {
+  added: PortService[];
+  removed: PortService[];
+  changed: { port: number; from: string; to: string }[];
+}
+
+const aliasMap: Record<string, string> = {
+  'www': 'http',
+  'www-http': 'http',
+  'http-alt': 'http',
+  'ssl/http': 'https',
+};
+
+export const normalizeServiceName = (name: string): string => {
+  const clean = name.toLowerCase().trim();
+  return aliasMap[clean] || clean;
+};
+
+export function diffScans(
+  left: PortService[],
+  right: PortService[],
+  opts: DiffOptions = {},
+): DiffResult {
+  const {
+    ignoreEphemeral = false,
+    normalizeService,
+    ephemeralStart = 49152,
+  } = opts;
+
+  const norm = (s: string) =>
+    normalizeService ? normalizeService(s) : s.toLowerCase();
+
+  const filter = (entries: PortService[]) =>
+    ignoreEphemeral ? entries.filter((e) => e.port < ephemeralStart) : entries;
+
+  const a = filter(left).map((e) => ({ port: e.port, service: norm(e.service) }));
+  const b = filter(right).map((e) => ({ port: e.port, service: norm(e.service) }));
+
+  const mapA = new Map<number, string>(a.map((e) => [e.port, e.service]));
+  const mapB = new Map<number, string>(b.map((e) => [e.port, e.service]));
+
+  const added: PortService[] = [];
+  const removed: PortService[] = [];
+  const changed: { port: number; from: string; to: string }[] = [];
+
+  for (const [port, service] of mapB) {
+    if (!mapA.has(port)) {
+      added.push({ port, service });
+    } else if (mapA.get(port) !== service) {
+      changed.push({ port, from: mapA.get(port)! , to: service });
+    }
+  }
+
+  for (const [port, service] of mapA) {
+    if (!mapB.has(port)) {
+      removed.push({ port, service });
+    }
+  }
+
+  return { added, removed, changed };
+}
+


### PR DESCRIPTION
## Summary
- add port scan diff algorithm that normalizes service names and skips ephemeral ports
- provide React UI to compare two scan files with diff options
- cover diff engine with unit tests for normalization and ephemeral filtering

## Testing
- `npx eslint components/ScanDiff.tsx utils/scanDiff.ts __tests__/scanDiff.test.ts`
- `yarn test __tests__/scanDiff.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc90a4948328a21dae687056ad8a