### PR TITLE
feat(qr): add annotations to scans

### DIFF
--- a/__tests__/qrStorage.test.ts
+++ b/__tests__/qrStorage.test.ts
@@ -1,4 +1,9 @@
-import { clearScans, loadScans, saveScans } from '../utils/qrStorage';
+import {
+  clearScans,
+  loadScans,
+  saveScans,
+  type QRScan,
+} from '../utils/qrStorage';
 
 describe('qrStorage', () => {
   beforeEach(() => {
@@ -6,15 +11,25 @@ describe('qrStorage', () => {
   });
 
   it('saves and loads scans', async () => {
-    await saveScans(['a', 'b']);
+    const scans: QRScan[] = [
+      { data: 'a', annotation: 'note a' },
+      { data: 'b', annotation: '' },
+    ];
+    await saveScans(scans);
     const loaded = await loadScans();
-    expect(loaded).toEqual(['a', 'b']);
+    expect(loaded).toEqual(scans);
   });
 
   it('clears scans', async () => {
-    await saveScans(['c']);
+    await saveScans([{ data: 'c', annotation: '' }]);
     await clearScans();
     const loaded = await loadScans();
     expect(loaded).toEqual([]);
+  });
+
+  it('loads legacy string array format', async () => {
+    localStorage.setItem('qrScans', JSON.stringify(['x']));
+    const loaded = await loadScans();
+    expect(loaded).toEqual([{ data: 'x', annotation: '' }]);
   });
 });


### PR DESCRIPTION
## Summary
- add `annotation` field to QR scan storage and persist via OPFS/localStorage
- allow annotating each scan and export CSV with annotations
- test scan storage including legacy compatibility

## Testing
- `yarn test __tests__/qrStorage.test.ts __tests__/qrLast.test.ts`
- `npx eslint utils/qrStorage.ts pages/qr/index.tsx __tests__/qrStorage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc914d308328898ba2497522fd3d