### PR TITLE
feat: add CVE advisory panel to Nmap NSE app

### DIFF
--- a/apps/nmap-nse/components/CvePanel.tsx
+++ b/apps/nmap-nse/components/CvePanel.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import { getDb } from '../../utils/safeIDB';
+
+interface CveRecord {
+  id: string;
+  summary: string;
+}
+
+interface CvePanelProps {
+  script: string | null;
+}
+
+const dbPromise = getDb('nmap-nse-cves', 1, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains('cves')) {
+      db.createObjectStore('cves');
+    }
+  },
+});
+
+const CvePanel: React.FC<CvePanelProps> = ({ script }) => {
+  const [cves, setCves] = useState<CveRecord[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!script) {
+      setCves(null);
+      return;
+    }
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const db = await dbPromise;
+        const cached = await db?.get('cves', script);
+        if (cached) {
+          setCves(cached as CveRecord[]);
+          setLoading(false);
+          return;
+        }
+        const res = await fetch(
+          `https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=${encodeURIComponent(
+            script,
+          )}`,
+        );
+        const json = await res.json();
+        const vulns = Array.isArray(json.vulnerabilities) ? json.vulnerabilities : [];
+        const mapped: CveRecord[] = vulns.map((v: any) => ({
+          id: v.cve.id,
+          summary: v.cve.descriptions?.[0]?.value || '',
+        }));
+        setCves(mapped);
+        await db?.put('cves', mapped, script);
+      } catch {
+        setCves([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [script]);
+
+  if (!script) return <p className="text-sm">Select a script to view advisories.</p>;
+
+  if (loading) return <p className="text-sm">Loading advisories…</p>;
+
+  if (!cves || cves.length === 0)
+    return <p className="text-sm">No advisories found.</p>;
+
+  return (
+    <div>
+      <h2 className="text-lg mb-2 font-mono">Advisories</h2>
+      <ul className="space-y-2 text-sm">
+        {cves.map((cve) => (
+          <li key={cve.id}>
+            <a
+              href={`https://cve.mitre.org/cgi-bin/cvename.cgi?name=${cve.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-400"
+            >
+              {cve.id}
+            </a>
+            <p className="text-xs mt-0.5">{cve.summary}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CvePanel;
+

--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import share, { canShare } from '../../utils/share';
+import CvePanel from './components/CvePanel';
 
 interface Script {
   name: string;
@@ -124,7 +125,7 @@ const NmapNSE: React.FC = () => {
       </header>
       <div className="flex flex-1">
         {/* script browser */}
-        <aside className="w-1/3 border-r border-gray-700 flex flex-col">
+        <aside className="w-1/4 border-r border-gray-700 flex flex-col">
           <div className="sticky top-0 p-2 bg-gray-900 z-10 flex flex-wrap items-center gap-2">
             {tags.map((tag) => (
               <button
@@ -209,6 +210,11 @@ const NmapNSE: React.FC = () => {
             <p>Select a script to view details.</p>
           )}
         </main>
+
+        {/* advisories */}
+        <aside className="w-1/4 border-l border-gray-700 p-4 overflow-y-auto">
+          <CvePanel script={selected?.name || null} />
+        </aside>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show CVE advisories for selected scripts in Nmap NSE
- cache advisory data via IndexedDB for offline use

## Testing
- `yarn test` *(fails: game2048.test.tsx, window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc92fc448328b8e242e9c1f303d6