### PR TITLE
Display module options in table with copy commands

### DIFF
--- a/__tests__/postExploitation.test.tsx
+++ b/__tests__/postExploitation.test.tsx
@@ -13,4 +13,15 @@ describe('PostExploitation', () => {
       screen.queryByRole('button', { name: /getsystem/i })
     ).not.toBeInTheDocument();
   });
+
+  it('shows option table with copyable commands', () => {
+    render(<PostExploitation />);
+    fireEvent.click(screen.getByRole('button', { name: /getsystem/i }));
+    // Option row should appear in table
+    expect(screen.getByRole('cell', { name: /^SESSION$/i })).toBeInTheDocument();
+    const copyBtn = screen.getByRole('button', {
+      name: /copy command for SESSION/i,
+    });
+    expect(copyBtn).toBeInTheDocument();
+  });
 });

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -5,6 +5,7 @@ import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
 import VirtualList from 'rc-virtual-list';
+import copyToClipboard from '../utils/clipboard';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
@@ -100,14 +101,42 @@ export default function PostExploitation() {
               <h2>{selected.name}</h2>
               <p>{selected.description}</p>
               <h3>Options</h3>
-              <ul>
-                {selected.options.map((opt) => (
-                  <li key={opt.name}>
-                    <strong>{opt.name}</strong>{' '}
-                    {opt.required ? '(required)' : '(optional)'} - {opt.description}
-                  </li>
-                ))}
-              </ul>
+              <table className="w-full border border-gray-300 text-sm">
+                <thead>
+                  <tr>
+                    <th className="border px-2 py-1 text-left">Option</th>
+                    <th className="border px-2 py-1 text-left">Required</th>
+                    <th className="border px-2 py-1 text-left">Description</th>
+                    <th className="border px-2 py-1 text-left">Example Command</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selected.options.map((opt) => {
+                    const cmd = `${selected.name} ${opt.name}=<value>`;
+                    return (
+                      <tr key={opt.name}>
+                        <td className="border px-2 py-1 font-mono">{opt.name}</td>
+                        <td className="border px-2 py-1">
+                          {opt.required ? 'Yes' : 'No'}
+                        </td>
+                        <td className="border px-2 py-1">{opt.description}</td>
+                        <td className="border px-2 py-1">
+                          <div className="flex items-center gap-2">
+                            <code className="flex-1">{cmd}</code>
+                            <button
+                              onClick={() => void copyToClipboard(cmd)}
+                              aria-label={`Copy command for ${opt.name}`}
+                              className="px-2 py-1 text-xs rounded bg-gray-700"
+                            >
+                              Copy
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </>
           ) : (
             <p>Select a module to view details.</p>


### PR DESCRIPTION
## Summary
- render post-exploitation module options in a read-only table
- show example commands with per-option copy buttons
- add test covering new table and copy button

## Testing
- `npm test __tests__/postExploitation.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc9577d083289b4591cb28521b37