### PR TITLE
feat: add log viewer with redaction

### DIFF
--- a/__tests__/logParser.test.ts
+++ b/__tests__/logParser.test.ts
@@ -1,0 +1,19 @@
+import { parseLogs, redactLine } from '../utils/logParser';
+
+describe('log parser', () => {
+  it('parses timestamp and marker', () => {
+    const text = '2024-01-01 12:00:00 INFO Hello world';
+    expect(parseLogs(text)).toEqual([
+      {
+        timestamp: '2024-01-01 12:00:00',
+        marker: 'INFO',
+        message: 'Hello world',
+      },
+    ]);
+  });
+
+  it('redacts emails and IP addresses', () => {
+    const line = 'Contact user@example.com from 192.168.0.1';
+    expect(redactLine(line)).toBe('Contact [REDACTED] from [REDACTED]');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -77,6 +77,7 @@ const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
 const SerialTerminalApp = createDynamicApp('serial-terminal', 'Serial Terminal');
+const LogViewerApp = createDynamicApp('log-viewer', 'Log Viewer');
 
 
 const WiresharkApp = createDynamicApp('wireshark', 'Wireshark');
@@ -163,6 +164,7 @@ const displayProjectGallery = createDisplay(ProjectGalleryApp);
 const displayTrash = createDisplay(TrashApp);
 const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
+const displayLogViewer = createDisplay(LogViewerApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 
@@ -960,6 +962,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySerialTerminal,
+  },
+  {
+    id: 'log-viewer',
+    title: 'Log Viewer',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLogViewer,
   },
   {
     id: 'radare2',

--- a/apps/log-viewer/index.tsx
+++ b/apps/log-viewer/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { useState } from 'react';
+import { parseLogs, redactLine, ParsedLog } from '../../utils/logParser';
+
+export default function LogViewer() {
+  const [logs, setLogs] = useState<ParsedLog[]>([]);
+  const [redact, setRedact] = useState(false);
+
+  const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      setLogs(parseLogs(text));
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="p-4 text-white bg-gray-900 min-h-screen">
+      <div className="flex items-center gap-2">
+        <input type="file" accept="text/*" onChange={handleFile} />
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={redact}
+            onChange={() => setRedact((r) => !r)}
+          />
+          Redact sensitive data
+        </label>
+      </div>
+      <ul className="mt-4 space-y-1 text-sm">
+        {logs.map((log, idx) => (
+          <li key={idx} className="border-b border-gray-700 pb-1">
+            <span className="text-gray-400 mr-2">{log.timestamp}</span>
+            {log.marker && (
+              <span className="font-bold mr-2">{log.marker}</span>
+            )}
+            <span>{redact ? redactLine(log.message) : log.message}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/apps/log-viewer.jsx
+++ b/pages/apps/log-viewer.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const LogViewer = dynamic(() => import('../../apps/log-viewer'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default LogViewer;

--- a/utils/logParser.ts
+++ b/utils/logParser.ts
@@ -1,0 +1,32 @@
+export interface ParsedLog {
+  timestamp: string;
+  marker: string;
+  message: string;
+}
+
+const timestampRegex = /^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})/;
+const markerRegex = /\b(INFO|WARN|ERROR|DEBUG)\b/;
+
+export function parseLogs(text: string): ParsedLog[] {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      const timestampMatch = line.match(timestampRegex);
+      const markerMatch = line.match(markerRegex);
+      const timestamp = timestampMatch ? timestampMatch[1] : '';
+      const marker = markerMatch ? markerMatch[1] : '';
+      const message = line
+        .replace(timestampRegex, '')
+        .replace(markerRegex, '')
+        .trim();
+      return { timestamp, marker, message };
+    });
+}
+
+const ipRegex = /\b\d{1,3}(?:\.\d{1,3}){3}\b/g;
+const emailRegex = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+
+export function redactLine(line: string): string {
+  return line.replace(ipRegex, '[REDACTED]').replace(emailRegex, '[REDACTED]');
+}


### PR DESCRIPTION
## Summary
- add log parser utilities for timestamps, markers, and redaction
- create log viewer app for importing text logs and toggling redaction
- register log viewer in app configuration

## Testing
- `yarn test __tests__/logParser.test.ts`
- `yarn lint utils/logParser.ts apps/log-viewer/index.tsx pages/apps/log-viewer.jsx` *(fails: numerous existing lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc961f2c8328a8c64be541f0e7ed