### PR TITLE
Virtualize plugin output tables for smoother scrolling

### DIFF
--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from 'react';
+import VirtualList from 'rc-virtual-list';
 
 interface ViewerProps {
   data: any[];
@@ -65,43 +66,55 @@ export default function ResultViewer({ data }: ViewerProps) {
       {tab === 'raw' && <pre className="bg-black text-white p-1 h-40 overflow-auto">{JSON.stringify(data, null, 2)}</pre>}
       {tab === 'parsed' && (
         <div>
-          <div className="mb-2">
-            <label>
-              Filter:
-              <input value={filter} onChange={(e) => setFilter(e.target.value)} className="border p-1 text-black ml-1" />
-            </label>
-            {keys.map((k) => (
-              <button key={k} onClick={() => setSortKey(k)} className="px-2 py-1 bg-ub-cool-grey text-white ml-2">
-                {k}
-              </button>
-            ))}
-            <button onClick={exportCsv} className="px-2 py-1 bg-ub-green text-black ml-2" type="button">
+            <div className="mb-2">
+              <label htmlFor="rv-filter">Filter:</label>
+              <input
+                id="rv-filter"
+                aria-label="Filter"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="border p-1 text-black ml-1"
+              />
+              {keys.map((k) => (
+                <button key={k} onClick={() => setSortKey(k)} className="px-2 py-1 bg-ub-cool-grey text-white ml-2">
+                  {k}
+                </button>
+              ))}
+              <button onClick={exportCsv} className="px-2 py-1 bg-ub-green text-black ml-2" type="button">
               CSV
             </button>
           </div>
-          <div className="overflow-auto max-h-60">
-            <table className="w-full text-left">
-              <thead>
-                <tr>
+          <div className="max-h-60">
+            <div
+              className="grid bg-gray-700"
+              style={{ gridTemplateColumns: `repeat(${keys.length}, minmax(0,1fr))` }}
+            >
+              {keys.map((k) => (
+                <div key={k} className="border px-1">
+                  {k}
+                </div>
+              ))}
+            </div>
+            <VirtualList
+              data={sorted}
+              height={240}
+              itemHeight={24}
+              itemKey={(row, index) => index}
+            >
+              {(row, i) => (
+                <div
+                  key={i}
+                  className="grid"
+                  style={{ gridTemplateColumns: `repeat(${keys.length}, minmax(0,1fr))` }}
+                >
                   {keys.map((k) => (
-                    <th key={k} className="border px-1">
-                      {k}
-                    </th>
+                    <div key={k} className="border px-1">
+                      {String(row[k])}
+                    </div>
                   ))}
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((row, i) => (
-                  <tr key={i}>
-                    {keys.map((k) => (
-                      <td key={k} className="border px-1">
-                        {String(row[k])}
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                </div>
+              )}
+            </VirtualList>
           </div>
         </div>
       )}

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -5,6 +5,7 @@ import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthr
 import memoryFixture from '../../../public/demo-data/volatility/memory.json';
 import pslistJson from '../../../public/demo-data/volatility/pslist.json';
 import netscanJson from '../../../public/demo-data/volatility/netscan.json';
+import VirtualList from 'rc-virtual-list';
 
 // pull demo data for various volatility plugins from the memory fixture
 const pstree = Array.isArray(memoryFixture.pstree)
@@ -83,37 +84,46 @@ const SortableTable = ({ columns, data, onRowClick }) => {
     }));
   };
 
+  const columnTemplate = `repeat(${columns.length}, minmax(0,1fr))`;
+
   return (
-    <table className="w-full text-xs table-auto">
-      <thead>
-        <tr>
-          {columns.map((col) => (
-            <th
-              key={col.key}
-              onClick={() => toggleSort(col.key)}
-              className="cursor-pointer px-2 py-1 text-left bg-gray-700"
-            >
-              {col.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {sorted.map((row, i) => (
-          <tr
-            key={i}
-            className="odd:bg-gray-800 cursor-pointer"
+    <div className="text-xs">
+      <div
+        className="grid bg-gray-700 cursor-pointer"
+        style={{ gridTemplateColumns: columnTemplate }}
+      >
+        {columns.map((col) => (
+          <div
+            key={col.key}
+            onClick={() => toggleSort(col.key)}
+            className="px-2 py-1 text-left"
+          >
+            {col.label}
+          </div>
+        ))}
+      </div>
+      <VirtualList
+        data={sorted}
+        height={240}
+        itemHeight={32}
+        itemKey={(row, index) => index}
+      >
+        {(row, index) => (
+          <div
+            key={index}
+            className="grid odd:bg-gray-800 cursor-pointer"
+            style={{ gridTemplateColumns: columnTemplate }}
             onClick={() => onRowClick && onRowClick(row)}
           >
             {columns.map((col) => (
-              <td key={col.key} className="px-2 py-1 whitespace-nowrap">
+              <div key={col.key} className="px-2 py-1 whitespace-nowrap">
                 {col.render ? col.render(row) : row[col.key]}
-              </td>
+              </div>
             ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+          </div>
+        )}
+      </VirtualList>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Replace volatility plugin tables with rc-virtual-list for efficient rendering
- Virtualize ResultViewer parsed output for smoother scrolling on large data sets

## Testing
- `npx eslint components/ResultViewer.tsx components/apps/volatility/index.js`
- `yarn test __tests__/volatilityPluginBrowser.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc9a002c83288e83d61b1932e8b7