### PR TITLE
feat(autopsy): add event details drawer

### DIFF
--- a/apps/autopsy/components/EventDrawer.tsx
+++ b/apps/autopsy/components/EventDrawer.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Artifact } from '../types';
+import copyToClipboard from '../../../utils/clipboard';
+
+interface EventDrawerProps {
+  artifact: Artifact | null;
+  onClose: () => void;
+}
+
+const EventDrawer: React.FC<EventDrawerProps> = ({ artifact, onClose }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (artifact) {
+      setVisible(true);
+    }
+  }, [artifact]);
+
+  const handleClose = () => {
+    setVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  const copy = (text: string) => {
+    if (text) {
+      copyToClipboard(text);
+    }
+  };
+
+  if (!artifact && !visible) return null;
+
+  return (
+    <div
+      className={`fixed top-0 right-0 h-full w-64 bg-ub-grey p-4 overflow-y-auto transform transition-transform duration-300 ${
+        visible ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      <button onClick={handleClose} className="mb-2 text-right w-full">
+        Close
+      </button>
+      {artifact && (
+        <>
+          <div className="font-bold break-words">{artifact.name}</div>
+          {artifact.type && <div className="text-gray-400">{artifact.type}</div>}
+          {artifact.timestamp && (
+            <div className="text-xs">
+              {new Date(artifact.timestamp).toLocaleString()}
+            </div>
+          )}
+          {artifact.description && (
+            <div className="text-xs">{artifact.description}</div>
+          )}
+          {artifact.plugin && (
+            <div className="text-xs">Plugin: {artifact.plugin}</div>
+          )}
+          {artifact.user && <div className="text-xs">User: {artifact.user}</div>}
+          {artifact.size !== undefined && (
+            <div className="text-xs">Size: {artifact.size}</div>
+          )}
+
+          <div className="mt-2 text-xs break-all">
+            <div className="mb-2">
+              <div>Path:</div>
+              <div className="flex items-center gap-1">
+                <span className="flex-1">{artifact.path || 'Unknown'}</span>
+                <button
+                  onClick={() => copy(artifact.path || '')}
+                  className="bg-ub-orange text-black px-1 rounded"
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+            <div>
+              <div>Hash:</div>
+              <div className="flex items-center gap-1">
+                <span className="flex-1">{artifact.hash || 'Unknown'}</span>
+                <button
+                  onClick={() => copy(artifact.hash || '')}
+                  className="bg-ub-orange text-black px-1 rounded"
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default EventDrawer;

--- a/apps/autopsy/events.json
+++ b/apps/autopsy/events.json
@@ -6,7 +6,9 @@
       "description": "Resume found on user's desktop",
       "size": 12345,
       "plugin": "metadata",
-      "timestamp": "2023-08-01T10:00:00Z"
+      "timestamp": "2023-08-01T10:00:00Z",
+      "path": "/home/alice/Desktop/resume.docx",
+      "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     },
     {
       "name": "photo.jpg",
@@ -14,7 +16,9 @@
       "description": "Photo from mobile device",
       "size": 23456,
       "plugin": "hash",
-      "timestamp": "2023-08-01T12:30:00Z"
+      "timestamp": "2023-08-01T12:30:00Z",
+      "path": "/home/bob/Pictures/photo.jpg",
+      "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     },
     {
       "name": "system.log",
@@ -22,7 +26,9 @@
       "description": "System log entry",
       "size": 34567,
       "plugin": "metadata",
-      "timestamp": "2023-08-01T14:45:00Z"
+      "timestamp": "2023-08-01T14:45:00Z",
+      "path": "/var/log/system.log",
+      "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     },
     {
       "name": "run.exe",
@@ -30,7 +36,9 @@
       "description": "Executable recovered from temp folder",
       "size": 45678,
       "plugin": "hash",
-      "timestamp": "2023-08-01T16:15:00Z"
+      "timestamp": "2023-08-01T16:15:00Z",
+      "path": "/tmp/run.exe",
+      "hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     },
     {
       "name": "HKCU\\Software\\Example",
@@ -38,8 +46,9 @@
       "description": "Registry key with suspicious value",
       "size": 0,
       "plugin": "regParser",
-      "timestamp": "2023-08-01T18:20:00Z"
+      "timestamp": "2023-08-01T18:20:00Z",
+      "path": "HKCU\\Software\\Example",
+      "hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     }
   ]
 }
-

--- a/apps/autopsy/types.ts
+++ b/apps/autopsy/types.ts
@@ -6,4 +6,6 @@ export interface Artifact {
   plugin: string;
   timestamp: string;
   user?: string;
+  path?: string;
+  hash?: string;
 }

--- a/components/apps/autopsy/data/sample-artifacts.json
+++ b/components/apps/autopsy/data/sample-artifacts.json
@@ -6,7 +6,9 @@
     "size": 12345,
     "plugin": "metadata",
     "timestamp": "2023-08-01T10:00:00Z",
-    "user": "alice"
+    "user": "alice",
+    "path": "/home/alice/Desktop/resume.docx",
+    "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   },
   {
     "name": "photo.jpg",
@@ -15,7 +17,9 @@
     "size": 23456,
     "plugin": "hash",
     "timestamp": "2023-08-01T12:30:00Z",
-    "user": "bob"
+    "user": "bob",
+    "path": "/home/bob/Pictures/photo.jpg",
+    "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   },
   {
     "name": "system.log",
@@ -24,7 +28,9 @@
     "size": 34567,
     "plugin": "metadata",
     "timestamp": "2023-08-01T14:45:00Z",
-    "user": "alice"
+    "user": "alice",
+    "path": "/var/log/system.log",
+    "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
   },
   {
     "name": "run.exe",
@@ -33,15 +39,19 @@
     "size": 45678,
     "plugin": "hash",
     "timestamp": "2023-08-01T16:15:00Z",
-    "user": "bob"
+    "user": "bob",
+    "path": "/tmp/run.exe",
+    "hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
   },
   {
-    "name": "HKCU\\\\Software\\\\Example",
+    "name": "HKCU\\Software\\Example",
     "type": "Registry",
     "description": "Registry key with suspicious value",
     "size": 0,
     "plugin": "regParser",
     "timestamp": "2023-08-01T18:20:00Z",
-    "user": "system"
+    "user": "system",
+    "path": "HKCU\\Software\\Example",
+    "hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   }
 ]

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
 import ReportExport from '../../../apps/autopsy/components/ReportExport';
+import EventDrawer from '../../../apps/autopsy/components/EventDrawer';
 import demoCase from '../../../apps/autopsy/data/case.json';
 
 const escapeFilename = (str = '') =>
@@ -586,6 +587,7 @@ function Autopsy({ initialArtifacts = null }) {
   }, [artifacts]);
 
   return (
+    <>
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 space-y-4">
       <div
         aria-live="polite"
@@ -710,7 +712,15 @@ function Autopsy({ initialArtifacts = null }) {
           {visibleTimeline.length > 0 && (
             <>
               <div className="text-sm font-bold">Timeline</div>
-              <Timeline events={visibleTimeline} onSelect={() => {}} />
+              <Timeline
+                events={visibleTimeline}
+                onSelect={(ev) => {
+                  const match = artifacts.find((a) =>
+                    ev.name.includes(a.name)
+                  );
+                  if (match) setSelectedArtifact(match);
+                }}
+              />
             </>
           )}
           {fileTree && (
@@ -786,29 +796,12 @@ function Autopsy({ initialArtifacts = null }) {
           <ReportExport caseName={currentCase || 'case'} artifacts={artifacts} />
         </div>
       )}
-      {selectedArtifact && (
-        <div className="fixed right-0 top-0 w-64 h-full bg-ub-grey p-4 overflow-y-auto">
-          <button
-            onClick={() => setSelectedArtifact(null)}
-            className="mb-2 text-right w-full"
-          >
-            Close
-          </button>
-          <div
-            className="font-bold"
-            dangerouslySetInnerHTML={{ __html: escapeFilename(selectedArtifact.name) }}
-          />
-          <div className="text-gray-400">{selectedArtifact.type}</div>
-          <div className="text-xs">
-            {new Date(selectedArtifact.timestamp).toLocaleString()}
-          </div>
-          <div className="text-xs">{selectedArtifact.description}</div>
-          <div className="text-xs">Plugin: {selectedArtifact.plugin}</div>
-          <div className="text-xs">User: {selectedArtifact.user || 'Unknown'}</div>
-          <div className="text-xs">Size: {selectedArtifact.size}</div>
-        </div>
-      )}
     </div>
+    <EventDrawer
+      artifact={selectedArtifact}
+      onClose={() => setSelectedArtifact(null)}
+    />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add sliding EventDrawer to display artifact path and hash with copy buttons
- populate sample artifacts and events with path/hash metadata
- wire timeline and Autopsy view to open drawer on event selection

## Testing
- `npx eslint apps/autopsy components/apps/autopsy` *(fails: A control must be associated with a text label)*
- `yarn test apps/autopsy --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc9e9cc883289619a95af5395e22