### PR TITLE
Add Autopsy help panel and docs

### DIFF
--- a/__tests__/autopsy.test.tsx
+++ b/__tests__/autopsy.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('marked', () => ({ marked: { parse: (md: string) => md } }));
+jest.mock('dompurify', () => ({ sanitize: (html: string) => html }));
+
 import Autopsy from '../components/apps/autopsy';
 
 describe('Autopsy plugins and timeline', () => {

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -5,6 +5,7 @@ import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
 import ReportExport from '../../../apps/autopsy/components/ReportExport';
 import demoCase from '../../../apps/autopsy/data/case.json';
+import HelpPanel from '../../HelpPanel';
 
 const escapeFilename = (str = '') =>
   str
@@ -587,6 +588,7 @@ function Autopsy({ initialArtifacts = null }) {
 
   return (
     <div className="h-full w-full flex flex-col bg-ub-cool-grey text-white p-4 space-y-4">
+      <HelpPanel appId="autopsy" />
       <div
         aria-live="polite"
         className="sr-only"

--- a/public/docs/apps/autopsy.md
+++ b/public/docs/apps/autopsy.md
@@ -1,0 +1,16 @@
+# Autopsy Help
+
+This simulated Autopsy interface demonstrates core digital forensics workflows.
+
+- Create a case to organise your investigation.
+- Install ingest modules from the plugin marketplace to analyse files.
+- Review extracted artifacts and filter by type, user or plugin.
+- Examine events in the timeline view to spot activity patterns.
+- Run keyword searches across evidence.
+
+## Further Reading
+- [Case Management](https://sleuthkit.org/autopsy/docs/user-docs/latest/case_management_page.html)
+- [Ingest Modules](https://sleuthkit.org/autopsy/docs/user-docs/latest/ingest_page.html)
+- [Timeline Analysis](https://sleuthkit.org/autopsy/docs/user-docs/latest/timeline_page.html)
+- [Keyword Search](https://sleuthkit.org/autopsy/docs/user-docs/latest/keyword_search_page.html)
+- [Full Autopsy Documentation](https://sleuthkit.org/autopsy/docs/user-docs/latest/)


### PR DESCRIPTION
## Summary
- Wire Autopsy app into shared HelpPanel component
- Provide Autopsy help content with deep links to official docs
- Mock ESM dependencies in Autopsy tests

## Testing
- `yarn test __tests__/autopsy.test.tsx`
- `yarn lint components/apps/autopsy/index.js __tests__/autopsy.test.tsx` *(fails: 574 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc9f3ae083289329961b207d15ac