### PR TITLE
feat(radare2): add zoom and selection sync

### DIFF
--- a/components/apps/radare2/index.js
+++ b/components/apps/radare2/index.js
@@ -117,6 +117,7 @@ const Radare2 = ({ initialData = {} }) => {
           value={seekAddr}
           onChange={(e) => setSeekAddr(e.target.value)}
           placeholder="seek 0x..."
+          aria-label="seek address"
           className="px-2 py-1 rounded"
           style={{
             backgroundColor: "var(--r2-surface)",
@@ -138,6 +139,7 @@ const Radare2 = ({ initialData = {} }) => {
           value={findTerm}
           onChange={(e) => setFindTerm(e.target.value)}
           placeholder="find"
+          aria-label="find term"
           className="px-2 py-1 rounded"
           style={{
             backgroundColor: "var(--r2-surface)",
@@ -178,7 +180,12 @@ const Radare2 = ({ initialData = {} }) => {
       </div>
 
       {mode === "graph" ? (
-        <GraphView blocks={blocks} theme={theme} />
+        <GraphView
+          blocks={blocks}
+          theme={theme}
+          selectedAddr={currentAddr || undefined}
+          onSelect={scrollToAddr}
+        />
       ) : (
         <div className="grid md:grid-cols-2 gap-4">
           <HexEditor hex={hex} theme={theme} />
@@ -261,6 +268,7 @@ const Radare2 = ({ initialData = {} }) => {
             value={noteText}
             onChange={(e) => setNoteText(e.target.value)}
             placeholder="Add note"
+            aria-label="note text"
             className="w-full p-2 rounded"
             style={{
               backgroundColor: "var(--r2-surface)",


### PR DESCRIPTION
## Summary
- integrate d3-zoom to handle pan and zoom in radare2 graph view
- sync graph node selection with disassembly view
- label radare2 search inputs for accessibility

## Testing
- `npx eslint apps/radare2/components/GraphView.tsx components/apps/radare2/index.js`
- `yarn test apps/radare2 --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc9f5400832896ff30d22584af11