### PR TITLE
feat(radare2): allow uploading local binaries

### DIFF
--- a/apps/radare2/index.tsx
+++ b/apps/radare2/index.tsx
@@ -1,11 +1,44 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import Radare2 from '../../components/apps/radare2';
 import sample from './sample.json';
 
 const Radare2Page: React.FC = () => {
-  return <Radare2 initialData={sample} />;
+  const [data, setData] = useState(sample);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const buffer = await file.arrayBuffer();
+      const hex = Array.from(new Uint8Array(buffer))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      const disasm =
+        hex.match(/.{1,2}/g)?.map((b, i) => ({
+          addr: `0x${i.toString(16)}`,
+          text: `db 0x${b}`,
+        })) ?? [];
+      if (!disasm.length) throw new Error('empty');
+      setData({ file: file.name, hex, disasm, xrefs: {}, blocks: [] });
+    } catch (err) {
+      console.error('Parsing failed', err);
+      setData(sample);
+    }
+  };
+
+  return (
+    <div className="h-full">
+      <input
+        type="file"
+        onChange={onFile}
+        className="mb-2"
+        aria-label="binary file"
+      />
+      <Radare2 initialData={data} />
+    </div>
+  );
 };
 
 export default Radare2Page;


### PR DESCRIPTION
## Summary
- support loading local binaries in Radare2 app
- parse binaries in browser and fall back to sample data if parsing fails

## Testing
- `yarn test` *(fails: game2048.test.tsx, window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cca679a88328806f231e986f4ba5