### PR TITLE
feat: add guided tour with replay option

### DIFF
--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -49,7 +49,12 @@ export default function FixturesLoader({ onData }: LoaderProps) {
   return (
     <div className="text-xs" aria-label="fixtures loader">
       <div className="mb-2 flex items-center">
-        <button onClick={loadSample} className="px-2 py-1 bg-ub-cool-grey text-white mr-2" type="button">
+        <button
+          id="load-sample"
+          onClick={loadSample}
+          className="px-2 py-1 bg-ub-cool-grey text-white mr-2"
+          type="button"
+        >
           Load Sample
         </button>
         <label className="px-2 py-1 bg-ub-cool-grey text-white mr-2 cursor-pointer">

--- a/components/GuidedTour.tsx
+++ b/components/GuidedTour.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Tour } from 'antd';
+
+interface Step {
+  title: string;
+  description: string;
+  target: () => HTMLElement | null;
+}
+
+export default function GuidedTour() {
+  const [open, setOpen] = useState(false);
+  const [steps, setSteps] = useState<Step[]>([]);
+
+  useEffect(() => {
+    const s: Step[] = [
+      {
+        title: 'Settings',
+        description: 'Adjust theme, sound, and more in Quick Settings.',
+        target: () => document.getElementById('status-bar'),
+      },
+      {
+        title: 'Help',
+        description: 'Access documentation or replay this tour.',
+        target: () => document.getElementById('help-button'),
+      },
+      {
+        title: 'Sample Data',
+        description: 'Load example data for hands-on practice.',
+        target: () => document.getElementById('load-sample'),
+      },
+    ].filter((step) => step.target());
+    setSteps(s);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener('replay-tour', handler as EventListener);
+    try {
+      const seen = localStorage.getItem('tour-seen');
+      if (!seen) {
+        setOpen(true);
+        localStorage.setItem('tour-seen', 'true');
+      }
+    } catch {
+      // ignore storage errors
+    }
+    return () => {
+      window.removeEventListener('replay-tour', handler as EventListener);
+    };
+  }, []);
+
+  return <Tour open={open} onClose={() => setOpen(false)} steps={steps} />;
+}
+

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -52,6 +52,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
     <>
       <button
         type="button"
+        id="help-button"
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
@@ -69,6 +70,13 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
             onClick={(e) => e.stopPropagation()}
           >
             <div dangerouslySetInnerHTML={{ __html: html }} />
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new Event('replay-tour'))}
+              className="mt-4 underline"
+            >
+              Replay Tour
+            </button>
           </div>
         </div>
       )}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,12 +10,14 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
+import 'antd/dist/reset.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import GuidedTour from '../components/GuidedTour';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -154,6 +156,7 @@ function MyApp(props) {
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
+            <GuidedTour />
             <ShortcutOverlay />
             <Analytics
               beforeSend={(e) => {


### PR DESCRIPTION
## Summary
- add GuidedTour component using Ant Design
- wire tour into app to spotlight settings, help, and sample data
- allow replay via Help panel

## Testing
- `yarn test __tests__/window.test.tsx` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ccaafc1c8328a452f202fedcb6a2