### PR TITLE
feat: colorized tags with drag-and-drop ordering

### DIFF
--- a/apps/project-gallery/components/FilterChip.tsx
+++ b/apps/project-gallery/components/FilterChip.tsx
@@ -5,15 +5,17 @@ interface FilterChipProps {
   active: boolean;
   onClick: () => void;
   icon: ReactNode;
+  color?: string;
 }
 
-export default function FilterChip({ label, active, onClick, icon }: FilterChipProps) {
+export default function FilterChip({ label, active, onClick, icon, color }: FilterChipProps) {
   return (
     <button
       onClick={onClick}
       className={`flex items-center gap-1 px-3 py-1 rounded-full border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 ${
-        active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'
+        active ? 'text-white' : 'bg-gray-200 text-black'
       }`}
+      style={active ? { backgroundColor: color } : undefined}
     >
       {icon}
       <span className="text-sm">{label}</span>

--- a/apps/project-gallery/components/TagManager.tsx
+++ b/apps/project-gallery/components/TagManager.tsx
@@ -1,0 +1,62 @@
+import { useRef } from 'react';
+
+export interface TagMeta {
+  name: string;
+  color: string;
+}
+
+interface Props {
+  tags: TagMeta[];
+  onChange: (tags: TagMeta[]) => void;
+}
+
+export default function TagManager({ tags, onChange }: Props) {
+  const dragIndex = useRef<number | null>(null);
+
+  const handleDragStart = (index: number) => () => {
+    dragIndex.current = index;
+  };
+
+  const handleDrop = (index: number) => () => {
+    const from = dragIndex.current;
+    if (from === null) return;
+    const updated = [...tags];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(index, 0, moved);
+    dragIndex.current = null;
+    onChange(updated);
+  };
+
+  const updateColor = (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const updated = tags.map((t, i) => (i === index ? { ...t, color: e.target.value } : t));
+    onChange(updated);
+  };
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {tags.map((tag, index) => (
+        <li
+          key={tag.name}
+          draggable
+          onDragStart={handleDragStart(index)}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={handleDrop(index)}
+          className="flex items-center gap-2"
+        >
+          <span
+            className="px-2 py-1 rounded text-sm text-white"
+            style={{ backgroundColor: tag.color }}
+          >
+            {tag.name}
+          </span>
+          <input
+            type="color"
+            aria-label={`Color for ${tag.name}`}
+            value={tag.color}
+            onChange={updateColor(index)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/data/tag-metadata.json
+++ b/data/tag-metadata.json
@@ -1,0 +1,5 @@
+[
+  { "name": "frontend", "color": "#60a5fa" },
+  { "name": "react", "color": "#34d399" },
+  { "name": "backend", "color": "#f87171" }
+]

--- a/public/tag-metadata.json
+++ b/public/tag-metadata.json
@@ -1,0 +1,5 @@
+[
+  { "name": "frontend", "color": "#60a5fa" },
+  { "name": "react", "color": "#34d399" },
+  { "name": "backend", "color": "#f87171" }
+]


### PR DESCRIPTION
## Summary
- add tag metadata with configurable colors
- allow drag-and-drop reordering and color editing of tags
- colorize tag filters and project tag badges in project gallery

## Testing
- `npx eslint apps/project-gallery/components/TagManager.tsx apps/project-gallery/components/FilterChip.tsx apps/project-gallery/pages/index.tsx`
- `yarn test apps/project-gallery --passWithNoTests`
- `npx tsc --noEmit apps/project-gallery/components/TagManager.tsx apps/project-gallery/components/FilterChip.tsx apps/project-gallery/pages/index.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ccadcb4083288f96dcc80f719ae0