### PR TITLE
feat: add markdown editor with preview and export

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const MarkdownApp = createDynamicApp('markdown', 'Markdown Editor');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayMarkdown = createDisplay(MarkdownApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'markdown',
+    title: 'Markdown Editor',
+    icon: '/themes/Yaru/apps/gedit.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayMarkdown,
   },
 ];
 

--- a/apps/markdown/index.tsx
+++ b/apps/markdown/index.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+import useOPFS from '../../hooks/useOPFS';
+
+export default function MarkdownEditor() {
+  const [markdown, setMarkdown] = useState('');
+  const [html, setHtml] = useState('');
+  const { supported, writeFile } = useOPFS();
+
+  useEffect(() => {
+    setHtml(DOMPurify.sanitize(marked.parse(markdown)));
+  }, [markdown]);
+
+  const save = async (ext: 'md' | 'html') => {
+    if (!supported) return;
+    const name = prompt('Filename', `note.${ext}`) || `note.${ext}`;
+    const data = ext === 'md' ? markdown : `<!DOCTYPE html><html><body>${html}</body></html>`;
+    await writeFile(name, data);
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 grid md:grid-cols-2 gap-2 overflow-hidden">
+        <textarea
+          className="w-full h-full p-2 border border-gray-300 bg-white text-black resize-none"
+          value={markdown}
+          onChange={(e) => setMarkdown(e.target.value)}
+          aria-label="Markdown editor"
+        />
+        <div
+          className="w-full h-full p-2 overflow-auto border border-gray-300 bg-white text-black"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button onClick={() => save('md')} disabled={!supported}>
+          Export .md
+        </button>
+        <button onClick={() => save('html')} disabled={!supported}>
+          Export .html
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/markdown/index.tsx
+++ b/components/apps/markdown/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/markdown';


### PR DESCRIPTION
## Summary
- add markdown editor with live preview
- allow exporting markdown or html to OPFS

## Testing
- `npx eslint apps/markdown/index.tsx components/apps/markdown/index.tsx apps.config.js`
- `yarn test __tests__/blackjack.test.ts`
- `yarn test __tests__/game2048.test.tsx` *(fails: `(0 , _GameLayout.useInputRecorder) is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ccae203c8328a311f17419a65ca8