### PR TITLE
feat: replace Navbar with XfceNavbar

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -5,7 +5,7 @@ import Ubuntu from '../components/ubuntu';
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
 });
-jest.mock('../components/screen/navbar', () => function NavbarMock() {
+jest.mock('../components/screen/xfce-navbar', () => function XfceNavbarMock() {
   return <div data-testid="navbar" />;
 });
 jest.mock('../components/screen/lock_screen', () => function LockScreenMock() {

--- a/components/screen/xfce-navbar.js
+++ b/components/screen/xfce-navbar.js
@@ -1,0 +1,1 @@
+export { default } from './navbar';

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
-import Navbar from './screen/navbar';
+import XfceNavbar from './screen/xfce-navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
@@ -126,7 +126,7 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <XfceNavbar />
 				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>
 		);


### PR DESCRIPTION
## Summary
- switch Ubuntu component to use XfceNavbar and drop unused lockScreen/shutDown props
- add XfceNavbar alias module
- adjust tests to mock new XfceNavbar component

## Testing
- `yarn test __tests__/ubuntu.test.tsx`
- `npx eslint components/ubuntu.js __tests__/ubuntu.test.tsx components/screen/xfce-navbar.js && echo 'eslint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68b9daeff2fc8328a39c3a18660d4e64