### PR TITLE
Remove desktop SideBar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -292,10 +292,10 @@ export class Window extends Component {
         var r = document.querySelector("#" + this.id);
         var rect = r.getBoundingClientRect();
         if (rect.x.toFixed(1) < 50) { // if this window overlapps with SideBar
-            this.props.hideSideBar(this.id, true);
+            this.props.hideSideBar?.(this.id, true);
         }
         else {
-            this.props.hideSideBar(this.id, false);
+            this.props.hideSideBar?.(this.id, false);
         }
     }
 
@@ -462,7 +462,7 @@ export class Window extends Component {
             // translate window to maximize position
             r.style.transform = `translate(-1pt,-2pt)`;
             this.setState({ maximized: true, height: 96.3, width: 100.2 });
-            this.props.hideSideBar(this.id, true);
+            this.props.hideSideBar?.(this.id, true);
         }
     }
 
@@ -470,7 +470,7 @@ export class Window extends Component {
         this.setWinowsPosition();
         this.setState({ closed: true }, () => {
             this.deactivateOverlay();
-            this.props.hideSideBar(this.id, false);
+            this.props.hideSideBar?.(this.id, false);
             setTimeout(() => {
                 this.props.closed(this.id)
             }, 300) // after 300ms this window will be unmounted from parent (Desktop)

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -7,7 +7,6 @@ const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
     { ssr: false }
 );
-import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
@@ -37,7 +36,6 @@ export class Desktop extends Component {
             overlapped_windows: {},
             disabled_apps: {},
             favourite_apps: {},
-            hideSideBar: false,
             minimized_windows: {},
             window_positions: {},
             desktop_apps: [],
@@ -467,7 +465,6 @@ export class Desktop extends Component {
                     openApp: this.openApp,
                     focus: this.focus,
                     isFocused: this.state.focused_windows[app.id],
-                    hideSideBar: this.hideSideBar,
                     hasMinimised: this.hasMinimised,
                     minimized: this.state.minimized_windows[app.id],
                     resizable: app.resizable,
@@ -509,35 +506,6 @@ export class Desktop extends Component {
         this.props.setSession({ ...this.props.session, windows, dock });
     }
 
-    hideSideBar = (objId, hide) => {
-        if (hide === this.state.hideSideBar) return;
-
-        if (objId === null) {
-            if (hide === false) {
-                this.setState({ hideSideBar: false });
-            }
-            else {
-                for (const key in this.state.overlapped_windows) {
-                    if (this.state.overlapped_windows[key]) {
-                        this.setState({ hideSideBar: true });
-                        return;
-                    }  // if any window is overlapped then hide the SideBar
-                }
-            }
-            return;
-        }
-
-        if (hide === false) {
-            for (const key in this.state.overlapped_windows) {
-                if (this.state.overlapped_windows[key] && key !== objId) return; // if any window is overlapped then don't show the SideBar
-            }
-        }
-
-        let overlapped_windows = this.state.overlapped_windows;
-        overlapped_windows[objId] = hide;
-        this.setState({ hideSideBar: hide, overlapped_windows });
-    }
-
     hasMinimised = (objId) => {
         let minimized_windows = this.state.minimized_windows;
         var focused_windows = this.state.focused_windows;
@@ -546,8 +514,6 @@ export class Desktop extends Component {
         minimized_windows[objId] = true;
         focused_windows[objId] = false;
         this.setState({ minimized_windows, focused_windows });
-
-        this.hideSideBar(null, false);
 
         this.giveFocusToLastApp();
     }
@@ -675,8 +641,6 @@ export class Desktop extends Component {
         this.app_stack.splice(this.app_stack.indexOf(objId), 1);
 
         this.giveFocusToLastApp();
-
-        this.hideSideBar(null, false);
 
         // close window
         let closed_windows = this.state.closed_windows;
@@ -863,18 +827,6 @@ export class Desktop extends Component {
 
                 {/* Background Image */}
                 <BackgroundImage />
-
-                {/* Ubuntu Side Menu Bar */}
-                <SideBar apps={apps}
-                    hide={this.state.hideSideBar}
-                    hideSideBar={this.hideSideBar}
-                    favourite_apps={this.state.favourite_apps}
-                    showAllApps={this.showAllApps}
-                    allAppsView={this.state.allAppsView}
-                    closed_windows={this.state.closed_windows}
-                    focused_windows={this.state.focused_windows}
-                    isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
 
                 {/* Taskbar */}
                 <Taskbar


### PR DESCRIPTION
## Summary
- drop SideBar usage from desktop and associated state
- guard window hideSideBar calls so they are optional

## Testing
- `yarn test` *(fails: window.test.tsx, game2048.test.tsx, nmapNse.test.tsx, installButton.test.tsx, contact.api.test.ts due to localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68b9daf0db8c83289b10aea00c94488a