### PR TITLE
Wrap desktop app rendering and refine UbuntuApp label

### DIFF
--- a/__tests__/ubuntuApp.shortcuts.test.tsx
+++ b/__tests__/ubuntuApp.shortcuts.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UbuntuApp } from '../components/base/ubuntu_app';
+
+describe('UbuntuApp desktop shortcut', () => {
+  it('opens app on double click and keyboard activation', async () => {
+    const openApp = jest.fn();
+    const { getByRole } = render(
+      <UbuntuApp id="test" name="Test" icon="/icon.png" openApp={openApp} />
+    );
+    const button = getByRole('button', { name: /test/i });
+
+    await userEvent.dblClick(button);
+    expect(openApp).toHaveBeenCalledWith('test');
+
+    openApp.mockClear();
+    button.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(openApp).toHaveBeenCalledWith('test');
+
+    openApp.mockClear();
+    button.focus();
+    await userEvent.keyboard(' ');
+    expect(openApp).toHaveBeenCalledWith('test');
+  });
+});
+

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -58,7 +58,7 @@ export class UbuntuApp extends Component {
                     alt={"Kali " + this.props.name}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
+                <span className="label">{this.props.displayName || this.props.name}</span>
 
             </div>
         )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -822,7 +822,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
                     <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
@@ -887,7 +888,7 @@ export class Desktop extends Component {
                 />
 
                 {/* Desktop Apps */}
-                {this.renderDesktopApps()}
+                <div className="left-stack-icons">{this.renderDesktopApps()}</div>
 
                 {/* Context Menus */}
                 <DesktopMenu


### PR DESCRIPTION
## Summary
- group desktop shortcuts inside a left stack container
- display app names in a `.label` span
- test double-click and keyboard activation of desktop shortcuts

## Testing
- `npx eslint components/screen/desktop.js components/base/ubuntu_app.js __tests__/ubuntuApp.shortcuts.test.tsx`
- `npx jest __tests__/desktopNameBar.test.tsx`
- `npx jest __tests__/ubuntuApp.shortcuts.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9daf2529c8328a74ffa2f96c70787