### PR TITLE
style: add left stack icon styling

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -58,7 +58,7 @@ export class UbuntuApp extends Component {
                     alt={"Kali " + this.props.name}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
+                <span className="label">{this.props.displayName || this.props.name}</span>
 
             </div>
         )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -887,7 +887,9 @@ export class Desktop extends Component {
                 />
 
                 {/* Desktop Apps */}
-                {this.renderDesktopApps()}
+                <div className="left-stack-icons">
+                    {this.renderDesktopApps()}
+                </div>
 
                 {/* Context Menus */}
                 <DesktopMenu

--- a/styles/index.css
+++ b/styles/index.css
@@ -530,3 +530,18 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+/* XFCE-like desktop icons on the left */
+.left-stack-icons {
+  position: absolute;
+  top: 6rem;
+  left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+}
+.left-stack-icons .label {
+  margin-top: 0.25rem;
+  text-shadow: 0 1px 1px rgba(0,0,0,.8);
+}
+


### PR DESCRIPTION
## Summary
- style left-side desktop icons
- wrap desktop icons container and add label element

## Testing
- `yarn test` *(fails: TypeError in game2048, unable to find role=alert in nmapNse, TypeError in window)*
- `yarn lint` *(fails: no-top-level-window, display-name)*

------
https://chatgpt.com/codex/tasks/task_e_68b9daf426148328b5c3967b10e56a49