### PR TITLE
feat: add xfce navbar launchers

### DIFF
--- a/__tests__/navbar-xfce.test.tsx
+++ b/__tests__/navbar-xfce.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NavbarXfce from '../components/screen/navbar-xfce';
+import fs from 'fs';
+import path from 'path';
+
+describe('NavbarXfce', () => {
+  it('renders whisker and three launcher buttons', () => {
+    render(<NavbarXfce />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+  });
+
+  it('triggers click handlers', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    render(<NavbarXfce />);
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    expect(logSpy).toHaveBeenCalledWith('whisker clicked');
+    expect(logSpy).toHaveBeenCalledWith('launcher1 clicked');
+    logSpy.mockRestore();
+  });
+
+  it('defines hover overlay style', () => {
+    const file = path.join(__dirname, '..', 'components', 'screen', 'navbar-xfce.js');
+    const source = fs.readFileSync(file, 'utf-8');
+    expect(source).toContain(
+      'color-mix(in srgb, var(--kali-accent) 15%, transparent)'
+    );
+  });
+});
+

--- a/components/screen/navbar-xfce.js
+++ b/components/screen/navbar-xfce.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import Image from 'next/image';
+
+const defaultIcons = {
+  whisker: '/themes/Kali/whisker.svg',
+  launcher1: '/themes/Kali/firefox.svg',
+  launcher2: '/themes/Kali/terminal.svg',
+  launcher3: '/themes/Kali/files.svg',
+};
+
+export default function NavbarXfce({ icons = {} }) {
+  const allIcons = { ...defaultIcons, ...icons };
+  const launchers = [allIcons.launcher1, allIcons.launcher2, allIcons.launcher3];
+
+  const handleClick = (name) => {
+    console.log(`${name} clicked`);
+  };
+
+  return (
+    <div className="xfce-navbar flex items-center space-x-1 p-1">
+      <button
+        aria-label="Whisker menu"
+        onClick={() => handleClick('whisker')}
+        className="launcher-btn p-1 rounded"
+      >
+        <Image src={allIcons.whisker} alt="Whisker menu" width={24} height={24} />
+      </button>
+      {launchers.map((src, i) => (
+        <button
+          key={i}
+          aria-label={`Launcher ${i + 1}`}
+          onClick={() => handleClick(`launcher${i + 1}`)}
+          className="launcher-btn p-1 rounded"
+        >
+          <Image src={src} alt={`Launcher ${i + 1}`} width={24} height={24} />
+        </button>
+      ))}
+      <style jsx>{`
+        .launcher-btn:hover {
+          background-color: color-mix(in srgb, var(--kali-accent) 15%, transparent);
+        }
+      `}</style>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add XFCE navbar with Whisker menu and three launcher slots
- support theming via icon slots and accent-colored hover overlay
- test launcher click responses and styling

## Testing
- `npx eslint components/screen/navbar-xfce.js __tests__/navbar-xfce.test.tsx`
- `yarn test __tests__/navbar-xfce.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9e17540b8832897ca1e28676ea7e0