### PR TITLE
feat(panel): add window list component

### DIFF
--- a/components/panel/WindowList.tsx
+++ b/components/panel/WindowList.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface WindowListProps {
+  apps: { id: string; title: string }[];
+  closed_windows: Record<string, boolean>;
+  minimized_windows: Record<string, boolean>;
+  focused_windows: Record<string, boolean>;
+  openApp: (id: string) => void;
+  closeApp: (id: string) => void;
+}
+
+export default function WindowList({
+  apps,
+  closed_windows,
+  minimized_windows,
+  focused_windows,
+  openApp,
+  closeApp,
+}: WindowListProps) {
+  const windows = apps.filter((app) => closed_windows[app.id] === false);
+
+  const handleMouseDown = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    id: string,
+  ) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      closeApp(id);
+    }
+  };
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="absolute bottom-10 left-0 w-full flex justify-center z-40">
+      <ul className="flex gap-2 bg-black bg-opacity-50 rounded px-2 py-1">
+        {windows.map((app) => {
+          const active =
+            focused_windows[app.id] && !minimized_windows[app.id];
+          return (
+            <li key={app.id}>
+              <button
+                type="button"
+                onClick={() => openApp(app.id)}
+                onMouseDown={(e) => handleMouseDown(e, app.id)}
+                className={`max-w-[8rem] px-2 py-1 text-sm truncate rounded focus:outline-none ${
+                  active
+                    ? 'bg-ub-orange text-black'
+                    : 'text-white hover:bg-white hover:bg-opacity-10'
+                }`}
+              >
+                {app.title}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -18,6 +18,7 @@ import DesktopMenu from '../context-menus/desktop-menu';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
+import WindowList from '../panel/WindowList';
 import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
@@ -823,7 +824,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input aria-label="Folder name" className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -875,6 +876,16 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     isMinimized={this.state.minimized_windows}
                     openAppByAppId={this.openApp} />
+
+                {/* Window List Panel */}
+                <WindowList
+                    apps={apps}
+                    closed_windows={this.state.closed_windows}
+                    minimized_windows={this.state.minimized_windows}
+                    focused_windows={this.state.focused_windows}
+                    openApp={this.openApp}
+                    closeApp={this.closeApp}
+                />
 
                 {/* Taskbar */}
                 <Taskbar


### PR DESCRIPTION
## Summary
- add WindowList component to list open window titles with active highlight
- integrate WindowList into desktop panel

## Testing
- `npx eslint components/panel/WindowList.tsx components/screen/desktop.js`
- `yarn test` *(fails: window.test.tsx, game2048.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1768c948328bc8666921a90aa5c