### PR TITLE
feat: add categories to whisker menu

### DIFF
--- a/__tests__/whiskerMenu.test.tsx
+++ b/__tests__/whiskerMenu.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Whisker, { AppItem } from '@/components/menu/Whisker';
+
+describe('Whisker menu', () => {
+  const apps: AppItem[] = [
+    { id: 'nmap', name: 'Nmap', category: 'Information Gathering', favorite: true },
+    { id: 'hydra', name: 'Hydra', category: 'Password Attacks' },
+    { id: 'wireshark', name: 'Wireshark', category: 'Information Gathering', recent: true },
+  ];
+
+  it('filters apps by category and marks the active category', () => {
+    render(<Whisker apps={apps} />);
+
+    // All Applications shown by default
+    expect(screen.getByText('Nmap')).toBeInTheDocument();
+    expect(screen.getByText('Hydra')).toBeInTheDocument();
+    expect(screen.getByText('Wireshark')).toBeInTheDocument();
+
+    // Favorites filter
+    fireEvent.click(screen.getByText('Favorites'));
+    const favButton = screen.getByText('Favorites');
+    expect(favButton).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByText('Nmap')).toBeInTheDocument();
+    expect(screen.queryByText('Hydra')).toBeNull();
+
+    // Category filter
+    fireEvent.click(screen.getByText('Information Gathering'));
+    const infoButton = screen.getByText('Information Gathering');
+    expect(infoButton).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByText('Nmap')).toBeInTheDocument();
+    expect(screen.getByText('Wireshark')).toBeInTheDocument();
+    expect(screen.queryByText('Hydra')).toBeNull();
+  });
+});
+

--- a/components/menu/Whisker.tsx
+++ b/components/menu/Whisker.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo, useState } from 'react';
+
+export interface AppItem {
+  id: string;
+  name: string;
+  category: string;
+  favorite?: boolean;
+  recent?: boolean;
+}
+
+interface WhiskerProps {
+  apps: AppItem[];
+}
+
+const staticCategories = ['Favorites', 'Recently Used', 'All Applications'] as const;
+
+type StaticCategory = (typeof staticCategories)[number];
+
+type Category = StaticCategory | string;
+
+const Whisker: React.FC<WhiskerProps> = ({ apps }) => {
+  const [active, setActive] = useState<Category>('All Applications');
+
+  const categories = useMemo(() => {
+    const toolCats = Array.from(new Set(apps.map((a) => a.category))).sort();
+    return [...staticCategories, ...toolCats];
+  }, [apps]);
+
+  const filteredApps = useMemo(() => {
+    if (active === 'Favorites') return apps.filter((a) => a.favorite);
+    if (active === 'Recently Used') return apps.filter((a) => a.recent);
+    if (active === 'All Applications') return apps;
+    return apps.filter((a) => a.category === active);
+  }, [active, apps]);
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-48 border-r border-gray-700">
+        <ul>
+          {categories.map((cat) => (
+            <li key={cat}>
+              <button
+                type="button"
+                onClick={() => setActive(cat)}
+                aria-current={active === cat ? 'true' : undefined}
+                className={`w-full text-left px-2 py-1 hover:bg-gray-700 ${
+                  active === cat ? 'bg-gray-700 font-bold' : ''
+                }`}
+              >
+                {cat}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="flex-1 p-2 grid grid-cols-2 gap-2 overflow-auto">
+        {filteredApps.map((app) => (
+          <div key={app.id} className="p-2 border border-gray-700 rounded">
+            {app.name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Whisker;
+


### PR DESCRIPTION
## Summary
- add Whisker menu with category sidebar for filtering applications
- highlight active category when filtering
- test Whisker menu filtering logic

## Testing
- `npx eslint components/menu/Whisker.tsx __tests__/whiskerMenu.test.tsx`
- `yarn test __tests__/whiskerMenu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1731a40832887e07e32c50178b6