### PR TITLE
Add tray popover icons to panel

### DIFF
--- a/components/panel/Tray/Battery.tsx
+++ b/components/panel/Tray/Battery.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+const Battery = () => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label="Battery"
+        className="px-2 py-1"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span role="img" aria-hidden="true">
+          🔋
+        </span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 rounded bg-ub-cool-grey p-2 text-xs shadow">
+          Battery status
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Battery;
+

--- a/components/panel/Tray/Network.tsx
+++ b/components/panel/Tray/Network.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+const Network = () => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label="Network"
+        className="px-2 py-1"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span role="img" aria-hidden="true">
+          📶
+        </span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 rounded bg-ub-cool-grey p-2 text-xs shadow">
+          Network settings
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Network;
+

--- a/components/panel/Tray/Volume.tsx
+++ b/components/panel/Tray/Volume.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+const Volume = () => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label="Volume"
+        className="px-2 py-1"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span role="img" aria-hidden="true">
+          🔊
+        </span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 rounded bg-ub-cool-grey p-2 text-xs shadow">
+          Volume control
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Volume;
+

--- a/components/panel/Tray/index.tsx
+++ b/components/panel/Tray/index.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Network from "./Network";
+import Volume from "./Volume";
+import Battery from "./Battery";
+
+const Tray = () => (
+  <div className="flex items-center">
+    <Network />
+    <Volume />
+    <Battery />
+  </div>
+);
+
+export default Tray;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import Tray from '../panel/Tray';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -15,9 +16,6 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
                                 <div
                                         className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
                                 >
@@ -30,28 +28,27 @@ export default class Navbar extends Component {
                                         />
                                         Activities
                                 </div>
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
+                                <div className="flex items-center">
+                                        <div
+                                                className={'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'}
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <Tray />
+                                        <button
+                                                type="button"
+                                                id="status-bar"
+                                                aria-label="System status"
+                                                onClick={() => {
+                                                        this.setState({ status_card: !this.state.status_card });
+                                                }}
+                                                className={'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '}
+                                        >
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </button>
                                 </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- add Network, Volume, and Battery tray icons with placeholder imagery
- show lightweight popovers that dismiss on outside click
- integrate grouped tray icons into the panel's right side

## Testing
- `npm run lint` (fails: Unexpected global 'document' in public/apps/tetris/main.js)
- `npm test` (fails: e.preventDefault is not a function in Window snapping; useInputRecorder is not a function in Game2048; unable to find role="alert" in NmapNSEApp; TypeError reading '_origin' in settings store)


------
https://chatgpt.com/codex/tasks/task_e_68b9e17805e88328a2c056a6fbe7fa6e