### PR TITLE
feat: add toggleable monitor overlay

### DIFF
--- a/components/Desktop.tsx
+++ b/components/Desktop.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+import DesktopBase from './screen/desktop';
+
+interface DesktopProps {
+  [key: string]: any;
+}
+
+const Desktop: React.FC<DesktopProps> = (props) => {
+  const [showOverlay, setShowOverlay] = useState(false);
+
+  useEffect(() => {
+    const handleToggle = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'm') {
+        e.preventDefault();
+        setShowOverlay((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleToggle);
+    return () => window.removeEventListener('keydown', handleToggle);
+  }, []);
+
+  return (
+    <div className="relative w-full h-full">
+      <DesktopBase {...props} />
+      {showOverlay && (
+        <div
+          className="absolute inset-0 pointer-events-none z-50"
+          style={{
+            backgroundImage:
+              'linear-gradient(to right, rgba(255,255,255,0.2) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.2) 1px, transparent 1px)',
+            backgroundSize: '40px 40px',
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Desktop;

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
-import Desktop from './screen/desktop';
+import Desktop from './Desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';


### PR DESCRIPTION
## Summary
- add desktop wrapper with toggleable grid overlay using Ctrl+Shift+M
- ensure overlay ignores pointer events
- update Ubuntu component to use new wrapper

## Testing
- `npm test` *(fails: game2048.test.tsx, window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `npx eslint components/Desktop.tsx components/ubuntu.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9e184c1648328a1d3c5a10c373d41