### PR TITLE
feat: persist window positions

### DIFF
--- a/__tests__/windowPersistence.test.ts
+++ b/__tests__/windowPersistence.test.ts
@@ -1,0 +1,40 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('window state persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, 'innerWidth', { writable: true, value: 800 });
+    Object.defineProperty(window, 'innerHeight', { writable: true, value: 600 });
+  });
+
+  test('restores clamped bounds and z-order', () => {
+    window.localStorage.setItem(
+      'window-states',
+      JSON.stringify({
+        second: { x: 1000, y: -50, width: 60, height: 80, z: 2 },
+        first: { x: 10, y: 20, width: 40, height: 50, z: 1 },
+      })
+    );
+
+    const desk = new Desktop();
+    // mock setState to apply updates synchronously
+    // @ts-ignore
+    desk.setState = (update: any, cb?: () => void) => {
+      const u = typeof update === 'function' ? update(desk.state) : update;
+      desk.state = { ...desk.state, ...u };
+      cb && cb();
+    };
+    const opened: string[] = [];
+    jest.spyOn(desk, 'openApp').mockImplementation((id: string) => {
+      opened.push(id);
+    });
+
+    const restored = desk.restoreWindowStates();
+    expect(restored).toBe(true);
+    expect(opened).toEqual(['first', 'second']);
+    const state = desk.state.window_positions['second'];
+    expect(state.x).toBe(800 - 0.6 * 800); // clamped to viewport
+    expect(state.y).toBe(0); // negative y clamped to 0
+  });
+});
+

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -56,6 +56,8 @@ export class Window extends Component {
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
+        // persist initial bounds
+        this.setWinowsPosition();
     }
 
     componentWillUnmount() {
@@ -210,7 +212,10 @@ export class Window extends Component {
         const px = (this.state.height / 100) * window.innerHeight + 1;
         const snapped = this.snapToGrid(px);
         const heightPercent = snapped / window.innerHeight * 100;
-        this.setState({ height: heightPercent }, this.resizeBoundries);
+        this.setState({ height: heightPercent }, () => {
+            this.resizeBoundries();
+            this.setWinowsPosition();
+        });
     }
 
     handleHorizontalResize = () => {
@@ -218,7 +223,10 @@ export class Window extends Component {
         const px = (this.state.width / 100) * window.innerWidth + 1;
         const snapped = this.snapToGrid(px);
         const widthPercent = snapped / window.innerWidth * 100;
-        this.setState({ width: widthPercent }, this.resizeBoundries);
+        this.setState({ width: widthPercent }, () => {
+            this.resizeBoundries();
+            this.setWinowsPosition();
+        });
     }
 
     setWinowsPosition = () => {
@@ -230,7 +238,7 @@ export class Window extends Component {
         r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
         r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
         if (this.props.onPositionChange) {
-            this.props.onPositionChange(x, y);
+            this.props.onPositionChange(x, y, this.state.width, this.state.height);
         }
     }
 
@@ -249,9 +257,15 @@ export class Window extends Component {
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
                 snapped: null
-            }, this.resizeBoundries);
+            }, () => {
+                this.resizeBoundries();
+                this.setWinowsPosition();
+            });
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null }, () => {
+                this.resizeBoundries();
+                this.setWinowsPosition();
+            });
         }
     }
 
@@ -423,7 +437,10 @@ export class Window extends Component {
 
         if (prefersReducedMotion) {
             node.style.transform = endTransform;
-            this.setState({ maximized: false });
+            this.setState({ maximized: false }, () => {
+                this.resizeBoundries();
+                this.setWinowsPosition();
+            });
             this.checkOverlap();
             return;
         }
@@ -431,7 +448,10 @@ export class Window extends Component {
         if (this._dockAnimation) {
             this._dockAnimation.onfinish = () => {
                 node.style.transform = endTransform;
-                this.setState({ maximized: false });
+                this.setState({ maximized: false }, () => {
+                    this.resizeBoundries();
+                    this.setWinowsPosition();
+                });
                 this.checkOverlap();
                 this._dockAnimation.onfinish = null;
             };
@@ -443,7 +463,10 @@ export class Window extends Component {
             );
             this._dockAnimation.onfinish = () => {
                 node.style.transform = endTransform;
-                this.setState({ maximized: false });
+                this.setState({ maximized: false }, () => {
+                    this.resizeBoundries();
+                    this.setWinowsPosition();
+                });
                 this.checkOverlap();
                 this._dockAnimation.onfinish = null;
             };
@@ -461,7 +484,10 @@ export class Window extends Component {
             this.setWinowsPosition();
             // translate window to maximize position
             r.style.transform = `translate(-1pt,-2pt)`;
-            this.setState({ maximized: true, height: 96.3, width: 100.2 });
+            this.setState({ maximized: true, height: 96.3, width: 100.2 }, () => {
+                this.resizeBoundries();
+                this.setWinowsPosition();
+            });
             this.props.hideSideBar(this.id, true);
         }
     }
@@ -608,7 +634,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: newWidth,
             height: newHeight
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            this.setWinowsPosition();
+        });
     }
 
     render() {
@@ -634,8 +663,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%`, zIndex: this.props.zIndex ?? (this.props.isFocused ? 30 : 20) }}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? "" : " notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}


### PR DESCRIPTION
## Summary
- persist window bounds and z-order for each app
- restore saved window states on desktop load
- test window state clamping and z-order restoration

## Testing
- `yarn test`
- `yarn lint components/base/window.js components/screen/desktop.js __tests__/windowPersistence.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9e18cde3883288fe34ae1bd79cf3c