### PR TITLE
feat: add icon pack theming

### DIFF
--- a/__tests__/iconTheme.test.tsx
+++ b/__tests__/iconTheme.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { IconPackProvider, useIconPack } from '@/hooks/useIconPack';
+import { CloseIcon } from '@/components/ToolbarIcons';
+import { useEffect } from 'react';
+
+function ThemeSwitcher() {
+  const { setTheme } = useIconPack();
+  useEffect(() => {
+    setTheme('flat-remix-blue');
+  }, [setTheme]);
+  return <CloseIcon />;
+}
+
+describe('IconPackProvider', () => {
+  it('updates icon sources when theme changes', async () => {
+    render(
+      <IconPackProvider initialTheme="Yaru">
+        <ThemeSwitcher />
+      </IconPackProvider>
+    );
+
+    await waitFor(() => {
+      const next = screen.getByAltText('Close') as HTMLImageElement;
+      expect(next.getAttribute('src') || '').toContain('flat-remix-blue');
+    });
+  });
+});

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,56 +1,28 @@
 import Image from 'next/image';
+import { useIconPack } from '@/hooks/useIconPack';
+
+function Icon({ name, alt }: { name: string; alt: string }) {
+  const { icons } = useIconPack();
+  const src = icons[name];
+  return <Image src={src} alt={alt} width={16} height={16} />;
+}
 
 export function CloseIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
-      alt="Close"
-      width={16}
-      height={16}
-    />
-  );
+  return <Icon name="close" alt="Close" />;
 }
 
 export function MinimizeIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
-      alt="Minimize"
-      width={16}
-      height={16}
-    />
-  );
+  return <Icon name="minimize" alt="Minimize" />;
 }
 
 export function MaximizeIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
-      alt="Maximize"
-      width={16}
-      height={16}
-    />
-  );
+  return <Icon name="maximize" alt="Maximize" />;
 }
 
 export function RestoreIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
-      alt="Restore"
-      width={16}
-      height={16}
-    />
-  );
+  return <Icon name="restore" alt="Restore" />;
 }
 
 export function PinIcon() {
-  return (
-    <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
-      alt="Pin"
-      width={16}
-      height={16}
-    />
-  );
+  return <Icon name="pin" alt="Pin" />;
 }

--- a/hooks/useIconPack.tsx
+++ b/hooks/useIconPack.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { DEFAULT_ICON_PACK, IconPack, loadIconPack } from '../utils/iconLoader';
+
+interface IconPackContextValue {
+  icons: IconPack;
+  theme: string;
+  setTheme: (theme: string) => void;
+}
+
+const IconPackContext = createContext<IconPackContextValue>({
+  icons: DEFAULT_ICON_PACK,
+  theme: 'Yaru',
+  setTheme: () => {},
+});
+
+export function IconPackProvider({
+  children,
+  initialTheme = 'Yaru',
+}: {
+  children: ReactNode;
+  initialTheme?: string;
+}) {
+  const [theme, setTheme] = useState(initialTheme);
+  const [icons, setIcons] = useState<IconPack>(DEFAULT_ICON_PACK);
+
+  useEffect(() => {
+    let mounted = true;
+    loadIconPack(theme).then((pack) => {
+      if (mounted) {
+        setIcons(pack);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [theme]);
+
+  return (
+    <IconPackContext.Provider value={{ icons, theme, setTheme }}>
+      {children}
+    </IconPackContext.Provider>
+  );
+}
+
+export function useIconPack() {
+  return useContext(IconPackContext);
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { IconPackProvider } from '../hooks/useIconPack';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <IconPackProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </IconPackProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/themes/flat-remix-blue/icons.json
+++ b/themes/flat-remix-blue/icons.json
@@ -1,0 +1,7 @@
+{
+  "close": "/themes/flat-remix-blue/window-close.svg",
+  "minimize": "/themes/flat-remix-blue/window-minimize.svg",
+  "maximize": "/themes/flat-remix-blue/window-maximize.svg",
+  "restore": "/themes/flat-remix-blue/window-restore.svg",
+  "pin": "/themes/flat-remix-blue/window-pin.svg"
+}

--- a/utils/iconLoader.ts
+++ b/utils/iconLoader.ts
@@ -1,0 +1,28 @@
+export type IconPack = Record<string, string>;
+
+export const DEFAULT_ICON_PACK: IconPack = {
+  close: '/themes/Yaru/window/window-close-symbolic.svg',
+  minimize: '/themes/Yaru/window/window-minimize-symbolic.svg',
+  maximize: '/themes/Yaru/window/window-maximize-symbolic.svg',
+  restore: '/themes/Yaru/window/window-restore-symbolic.svg',
+  pin: '/themes/Yaru/window/window-pin-symbolic.svg',
+};
+
+export async function loadIconPack(theme: string): Promise<IconPack> {
+  switch (theme) {
+    case 'flat-remix-blue': {
+      try {
+        const mod = await import('../themes/flat-remix-blue/icons.json', {
+          assert: { type: 'json' },
+        } as any);
+        return (mod as any).default ?? mod;
+      } catch (err) {
+        console.warn(`Unable to load icon pack "${theme}":`, err);
+        return DEFAULT_ICON_PACK;
+      }
+    }
+    case 'Yaru':
+    default:
+      return DEFAULT_ICON_PACK;
+  }
+}


### PR DESCRIPTION
## Summary
- add Flat Remix Blue icon mapping
- create icon pack loader and context for swapping themes
- wire provider through app and update toolbar icons
- test icon theme switching

## Testing
- `npm test __tests__/iconTheme.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9e1a713b48328b0654e4c4ea87a92