### PR TITLE
feat: use Noto fonts and tighten base typography

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -12,7 +12,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       className={`text-white ${className}`}
       style={{
         background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
+        fontFamily: 'var(--font-family-mono, monospace)',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,12 +17,6 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
-import { Ubuntu } from 'next/font/google';
-
-const ubuntu = Ubuntu({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '700'],
-});
 
 
 function MyApp(props) {
@@ -149,7 +143,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -17,6 +17,12 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&family=Noto+Sans+Mono&display=swap"
+            rel="stylesheet"
+          />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
         </Head>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,7 @@
 @import './globals.css';
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: calc(13px * var(--font-multiplier));
 }
 
 body{
@@ -9,6 +9,11 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+}
+
+[class*="panel"],
+[role="tabpanel"] {
+    font-size: calc(12px * var(--font-multiplier));
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
@@ -505,7 +510,7 @@ dialog {
 /* Ensure monospace layout for app outputs */
 textarea,
 pre {
-    font-family: monospace;
+    font-family: var(--font-family-mono);
     line-height: 1.2;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,7 +52,8 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: 'Noto Sans', sans-serif;
+  --font-family-mono: 'Noto Sans Mono', monospace;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;


### PR DESCRIPTION
## Summary
- link Noto Sans & Noto Sans Mono in the document head
- switch base UI to Noto Sans and use Noto Sans Mono for terminal/monospace text
- standardize font sizing to 13px base and 12px panels

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in tetris and missing display name in createDynamicApp)*
- `yarn test` *(fails: game2048, window snapping, Nmap NSE clipboard)*
- `curl -s -I https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&family=Noto+Sans+Mono&display=swap | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68b9e1a9e00883289ec477b47b5dc6c0