### PR TITLE
feat: make design tokens configurable

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, radius, setRadius, shadow, setShadow, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -98,6 +98,28 @@ export function Settings() {
                     <option value="regular">Regular</option>
                     <option value="compact">Compact</option>
                 </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Radius:</label>
+                <input
+                    type="range"
+                    min="0"
+                    max="32"
+                    value={radius}
+                    onChange={(e) => setRadius(parseInt(e.target.value))}
+                    className="ubuntu-slider"
+                />
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Shadow:</label>
+                <input
+                    type="range"
+                    min="0"
+                    max="24"
+                    value={shadow}
+                    onChange={(e) => setShadow(parseInt(e.target.value))}
+                    className="ubuntu-slider"
+                />
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Font Size:</label>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,7 +635,17 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType +
+                            " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-[var(--radius)] rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused ? " z-30 " : " z-20 notFocused") +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"
+                        }
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState.js';
 import { useEffect } from 'react';
+import { useSettings } from '../../hooks/useSettings';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { density, setDensity, radius, setRadius, shadow, setShadow } = useSettings();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,9 +25,10 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-[var(--radius)] top-9 right-3 border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
+      style={{ boxShadow: 'var(--shadow)', padding: 'var(--space-4)' }}
     >
       <div className="px-4 pb-2">
         <button
@@ -44,12 +47,39 @@ const QuickSettings = ({ open }: Props) => {
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
       </div>
-      <div className="px-4 flex justify-between">
+      <div className="px-4 pb-2 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+        />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Density</span>
+        <select value={density} onChange={(e) => setDensity(e.target.value as any)}>
+          <option value="regular">Regular</option>
+          <option value="compact">Compact</option>
+        </select>
+      </div>
+      <div className="px-4 pb-2 flex justify-between items-center">
+        <span>Radius</span>
+        <input
+          type="range"
+          min={0}
+          max={32}
+          value={radius}
+          onChange={(e) => setRadius(parseInt(e.target.value))}
+        />
+      </div>
+      <div className="px-4 flex justify-between items-center">
+        <span>Shadow</span>
+        <input
+          type="range"
+          min={0}
+          max={24}
+          value={shadow}
+          onChange={(e) => setShadow(parseInt(e.target.value))}
         />
       </div>
     </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -6,6 +6,10 @@ import {
   setWallpaper as saveWallpaper,
   getDensity as loadDensity,
   setDensity as saveDensity,
+  getRadius as loadRadius,
+  setRadius as saveRadius,
+  getShadow as loadShadow,
+  setShadow as saveShadow,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
@@ -55,6 +59,8 @@ interface SettingsContextValue {
   accent: string;
   wallpaper: string;
   density: Density;
+  radius: number;
+  shadow: number;
   reducedMotion: boolean;
   fontScale: number;
   highContrast: boolean;
@@ -66,6 +72,8 @@ interface SettingsContextValue {
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
+  setRadius: (value: number) => void;
+  setShadow: (value: number) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
@@ -80,6 +88,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
+  radius: defaults.radius,
+  shadow: defaults.shadow,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
@@ -91,6 +101,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
+  setRadius: () => {},
+  setShadow: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
   setHighContrast: () => {},
@@ -105,6 +117,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
+  const [radius, setRadius] = useState<number>(defaults.radius);
+  const [shadow, setShadow] = useState<number>(defaults.shadow);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
@@ -120,6 +134,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
+      setRadius(await loadRadius());
+      setShadow(await loadShadow());
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
@@ -157,30 +173,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [wallpaper]);
 
   useEffect(() => {
-    const spacing: Record<Density, Record<string, string>> = {
-      regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
-      },
-      compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
-      },
-    };
-    const vars = spacing[density];
-    Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
-    });
+    const value = density === 'compact' ? '0.75' : '1';
+    document.documentElement.style.setProperty('--density', value);
     saveDensity(density);
   }, [density]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--radius', `${radius}px`);
+    saveRadius(radius);
+  }, [radius]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--shadow', `0 4px ${shadow}px rgba(0,0,0,0.5)`);
+    saveShadow(shadow);
+  }, [shadow]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('reduced-motion', reducedMotion);
@@ -242,6 +248,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         accent,
         wallpaper,
         density,
+        radius,
+        shadow,
         reducedMotion,
         fontScale,
         highContrast,
@@ -253,6 +261,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAccent,
         setWallpaper,
         setDensity,
+        setRadius,
+        setShadow,
         setReducedMotion,
         setFontScale,
         setHighContrast,

--- a/styles/index.css
+++ b/styles/index.css
@@ -105,9 +105,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--shadow);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,15 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
 
+  /* Global scale */
+  --density: 1;
+
+  /* Default corner radius */
+  --radius: 8px;
+
+  /* Default shadow */
+  --shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;
@@ -33,17 +42,17 @@
   --game-color-danger: #b91c1c;
 
   /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  --space-1: calc(0.25rem * var(--density));
+  --space-2: calc(0.5rem * var(--density));
+  --space-3: calc(0.75rem * var(--density));
+  --space-4: calc(1rem * var(--density));
+  --space-5: calc(1.5rem * var(--density));
+  --space-6: calc(2rem * var(--density));
 
   /* Radius */
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius-lg: 8px;
+  --radius-sm: calc(var(--radius) / 4);
+  --radius-md: calc(var(--radius) / 2);
+  --radius-lg: var(--radius);
   --radius-round: 9999px;
 
   /* Motion durations */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -7,6 +7,8 @@ const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
   density: 'regular',
+  radius: 8,
+  shadow: 12,
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,
@@ -44,6 +46,28 @@ export async function getDensity() {
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('density', density);
+}
+
+export async function getRadius() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.radius;
+  const val = window.localStorage.getItem('radius');
+  return val ? parseInt(val, 10) : DEFAULT_SETTINGS.radius;
+}
+
+export async function setRadius(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('radius', String(value));
+}
+
+export async function getShadow() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.shadow;
+  const val = window.localStorage.getItem('shadow');
+  return val ? parseInt(val, 10) : DEFAULT_SETTINGS.shadow;
+}
+
+export async function setShadow(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('shadow', String(value));
 }
 
 export async function getReducedMotion() {
@@ -130,6 +154,8 @@ export async function resetSettings() {
     del('bg-image'),
   ]);
   window.localStorage.removeItem('density');
+  window.localStorage.removeItem('radius');
+  window.localStorage.removeItem('shadow');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
@@ -144,6 +170,8 @@ export async function exportSettings() {
     accent,
     wallpaper,
     density,
+    radius,
+    shadow,
     reducedMotion,
     fontScale,
     highContrast,
@@ -155,6 +183,8 @@ export async function exportSettings() {
     getAccent(),
     getWallpaper(),
     getDensity(),
+    getRadius(),
+    getShadow(),
     getReducedMotion(),
     getFontScale(),
     getHighContrast(),
@@ -168,6 +198,8 @@ export async function exportSettings() {
     accent,
     wallpaper,
     density,
+    radius,
+    shadow,
     reducedMotion,
     fontScale,
     highContrast,
@@ -192,6 +224,8 @@ export async function importSettings(json) {
     accent,
     wallpaper,
     density,
+    radius,
+    shadow,
     reducedMotion,
     fontScale,
     highContrast,
@@ -204,6 +238,8 @@ export async function importSettings(json) {
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
+  if (radius !== undefined) await setRadius(radius);
+  if (shadow !== undefined) await setShadow(shadow);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);


### PR DESCRIPTION
## Summary
- add global `--radius`, `--shadow`, and `--density` CSS tokens and wire spacing and radius to them
- use those tokens in window and QuickSettings components
- add settings controls to tweak radius, shadow, and density

## Testing
- `yarn test` *(fails: e.preventDefault is not a function, unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1aae3c88328a82d99f8583803a6