### PR TITLE
feat: add toast notifications

### DIFF
--- a/__tests__/notify.test.tsx
+++ b/__tests__/notify.test.tsx
@@ -1,0 +1,19 @@
+import { act } from 'react';
+import { notify } from '../utils/notify';
+
+describe('notify', () => {
+  it('renders toast with provided data', async () => {
+    const originalError = console.error;
+    console.error = jest.fn();
+    await act(async () => {
+      notify({ title: 'Hello', body: 'World', icon: 'test-icon.svg' });
+      await new Promise(r => setTimeout(r, 0));
+    });
+    const toast = document.querySelector('[role="status"]') as HTMLElement;
+    expect(toast).toHaveTextContent('Hello');
+    expect(toast).toHaveTextContent('World');
+    const img = toast.querySelector('img');
+    expect(img).toHaveAttribute('src', 'test-icon.svg');
+    console.error = originalError;
+  });
+});

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState.js';
 import { useEffect } from 'react';
+import { notify } from '../../utils/notify';
 
 interface Props {
   open: boolean;
@@ -42,7 +43,21 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => {
+            const next = !online;
+            setOnline(next);
+            notify({
+              title: 'Network',
+              body: next ? 'Online' : 'Offline',
+              icon: next
+                ? '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
+                : '/themes/Yaru/status/network-wireless-signal-none-symbolic.svg',
+            });
+          }}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 interface ToastProps {
-  message: string;
+  message?: string;
+  title?: string;
+  body?: string;
+  icon?: string;
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
@@ -10,6 +13,9 @@ interface ToastProps {
 
 const Toast: React.FC<ToastProps> = ({
   message,
+  title,
+  body,
+  icon,
   actionLabel,
   onAction,
   onClose,
@@ -34,7 +40,11 @@ const Toast: React.FC<ToastProps> = ({
       aria-live="polite"
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
-      <span>{message}</span>
+      {icon && <img src={icon} alt="" className="w-4 h-4 mr-2" />}
+      <div className="flex flex-col">
+        {title && <strong className="font-semibold">{title}</strong>}
+        <span>{body ?? message}</span>
+      </div>
       {onAction && actionLabel && (
         <button
           onClick={onAction}

--- a/utils/notify.tsx
+++ b/utils/notify.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Toast from '../components/ui/Toast';
+
+interface NotifyOptions {
+  title: string;
+  body: string;
+  icon?: string;
+}
+
+export function notify({ title, body, icon }: NotifyOptions): void {
+  if (typeof document === 'undefined') return;
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const handleClose = () => {
+    root.unmount();
+    container.remove();
+  };
+
+  root.render(
+    <Toast title={title} body={body} icon={icon} onClose={handleClose} />
+  );
+}


### PR DESCRIPTION
## Summary
- expose `notify` helper to render toast messages
- fire a network status toast from Quick Settings tray
- expand Toast component with title/body/icon support and add unit test

## Testing
- `npm test __tests__/notify.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9e1aee6408328887293dfe39ac4ef