### PR TITLE
chore: standardize border color

### DIFF
--- a/apps/color_picker/index.html
+++ b/apps/color_picker/index.html
@@ -34,7 +34,7 @@
     .swatch {
       width: 40px;
       height: 40px;
-      border: 1px solid #ccc;
+      border: 1px solid #2a2e36;
       border-radius: 4px;
       cursor: pointer;
       transition: transform 0.2s ease, box-shadow 0.2s ease;

--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -27,7 +27,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
     surface: "#374151",
     text: "#fff",
     accent: "#fbbf24",
-    border: "#4b5563",
+    border: "#2a2e36",
   });
 
   const graphData = useMemo(() => {
@@ -47,7 +47,7 @@ const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {
       surface: style.getPropertyValue("--r2-surface").trim() || "#374151",
       text: style.getPropertyValue("--r2-text").trim() || "#fff",
       accent: style.getPropertyValue("--r2-accent").trim() || "#fbbf24",
-      border: style.getPropertyValue("--r2-border").trim() || "#4b5563",
+      border: style.getPropertyValue("--r2-border").trim() || "#2a2e36",
     });
   }, [theme]);
 

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -16,7 +16,7 @@ const HexEditor = ({ hex, theme }) => {
     surface: '#374151',
     accent: '#fbbf24',
     text: '#ffffff',
-    border: '#4b5563',
+    border: '#2a2e36',
   });
 
   useEffect(() => {
@@ -26,7 +26,7 @@ const HexEditor = ({ hex, theme }) => {
       surface: style.getPropertyValue('--r2-surface').trim() || '#374151',
       accent: style.getPropertyValue('--r2-accent').trim() || '#fbbf24',
       text: style.getPropertyValue('--r2-text').trim() || '#ffffff',
-      border: style.getPropertyValue('--r2-border').trim() || '#4b5563',
+      border: style.getPropertyValue('--r2-border').trim() || '#2a2e36',
     };
   }, [theme]);
 

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -265,7 +265,7 @@ const ReconNG = () => {
         style: {
           padding: '10px',
           'background-opacity': 0.1,
-          'border-color': '#555',
+          'border-color': '#2a2e36',
         },
       },
     ],

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -99,7 +99,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        'cursor-default w-52 context-menu-bg border text-left border-ub-border rounded text-white py-4 absolute z-50 text-sm'}
     >
       {items.map((item, i) => (
         <button

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -28,7 +28,7 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-ub-border rounded text-white py-4 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -20,7 +20,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-ub-border rounded text-white py-4 absolute z-50 text-sm"}
         >
 
             <Devider />
@@ -71,7 +71,7 @@ function DefaultMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className=" border-t border-ub-border py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -48,7 +48,7 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-ub-border rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button
                 onClick={props.addNewFolder}
@@ -135,7 +135,7 @@ function DesktopMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className=" border-t border-ub-border py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -30,7 +30,7 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-ub-border rounded text-white py-2 absolute z-50 text-sm'}
         >
             <button
                 type="button"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -823,14 +823,14 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-ub-border rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
                         type="button"
                         onClick={addFolder}
                         aria-label="Create folder"
-                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                        className="w-1/2 px-4 py-2 border border-ub-border border-opacity-50 border-r-0 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
                     >
                         Create
                     </button>
@@ -838,7 +838,7 @@ export class Desktop extends Component {
                         type="button"
                         onClick={removeCard}
                         aria-label="Cancel folder creation"
-                        className="w-1/2 px-4 py-2 border border-gray-900 border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
+                        className="w-1/2 px-4 py-2 border border-ub-border border-opacity-50 hover:bg-ub-warm-grey hover:bg-opacity-10 hover:border-opacity-50"
                     >
                         Cancel
                     </button>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-ub-border px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -35,21 +35,6 @@ export const ACCENT_OPTIONS = [
   '#ed64a6', // pink
 ];
 
-// Utility to lighten or darken a hex color by a percentage
-const shadeColor = (color: string, percent: number): string => {
-  const f = parseInt(color.slice(1), 16);
-  const t = percent < 0 ? 0 : 255;
-  const p = Math.abs(percent);
-  const R = f >> 16;
-  const G = (f >> 8) & 0x00ff;
-  const B = f & 0x0000ff;
-  const newR = Math.round((t - R) * p) + R;
-  const newG = Math.round((t - G) * p) + G;
-  const newB = Math.round((t - B) * p) + B;
-  return `#${(0x1000000 + newR * 0x10000 + newG * 0x100 + newB)
-    .toString(16)
-    .slice(1)}`;
-};
 
 interface SettingsContextValue {
   accent: string;
@@ -136,10 +121,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [theme]);
 
   useEffect(() => {
-    const border = shadeColor(accent, -0.2);
     const vars: Record<string, string> = {
       '--color-ub-orange': accent,
-      '--color-ub-border-orange': border,
       '--color-primary': accent,
       '--color-accent': accent,
       '--color-focus-ring': accent,

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -186,7 +186,7 @@ const NiktoReport: React.FC = () => {
             <tr
               key={f.path}
               className="odd:bg-gray-800 cursor-pointer hover:bg-gray-700 border-l-4"
-              style={{ borderLeftColor: severityColors[f.severity] || '#4b5563' }}
+              style={{ borderLeftColor: severityColors[f.severity] || '#2a2e36' }}
               onClick={() => setSelected(f)}
             >
               <td className="p-2">{f.path}</td>

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -15,7 +15,7 @@ const InfoFrame = ({ title, link, description }: FrameProps) => (
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture"
     referrerPolicy="no-referrer"
     srcDoc={`<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'></head><body><h2>${title}</h2><p>${description}</p><p><a href='${link}' target='_blank' rel='noopener noreferrer'>Official Documentation</a></p></body></html>`}
-    style={{ width: '100%', border: '1px solid #ccc', height: '200px' }}
+    style={{ width: '100%', border: '1px solid #2a2e36', height: '200px' }}
   />
 );
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@ html[data-theme='dark'] {
   --color-muted: #1f1f1f;
   --color-surface: #121212;
   --color-inverse: #ffffff;
-  --color-border: #333333;
+  --color-border: #2a2e36;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
 }
@@ -47,7 +47,7 @@ html[data-theme='neon'] {
   --color-muted: #222222;
   --color-surface: #111111;
   --color-inverse: #ffffff;
-  --color-border: #333333;
+  --color-border: #2a2e36;
   --color-terminal: #39ff14;
   --color-dark: #000000;
 }
@@ -62,7 +62,7 @@ html[data-theme='matrix'] {
   --color-muted: #003300;
   --color-surface: #001100;
   --color-inverse: #ffffff;
-  --color-border: #003300;
+  --color-border: #2a2e36;
   --color-terminal: #00ff00;
   --color-dark: #000000;
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -21,7 +21,7 @@
   --color-ubt-gedit-orange: #F39A21;
   --color-ubt-gedit-blue: #50B6C6;
   --color-ubt-gedit-dark: #003B70;
-  --color-ub-border-orange: #1793d1;
+  --color-ub-border-orange: #2a2e36;
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
@@ -71,7 +71,7 @@
   --color-ubt-cool-grey: #ffffff;
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
-  --color-ub-border-orange: #ffff00;
+  --color-ub-border-orange: #2a2e36;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -114,6 +114,6 @@
     --color-ubt-cool-grey: #ffffff;
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
-    --color-ub-border-orange: #ffff00;
+    --color-ub-border-orange: #2a2e36;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,7 +34,7 @@ module.exports = {
         'ubt-gedit-orange': 'var(--color-ubt-gedit-orange)',
         'ubt-gedit-blue': 'var(--color-ubt-gedit-blue)',
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
-        'ub-border-orange': 'var(--color-ub-border-orange)',
+        'ub-border': 'var(--color-border)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- unify border color tokens to `#2a2e36`
- expose `ub-border` color in Tailwind and apply to context menus and dialogs
- remove dynamic border color setting from UI settings

## Testing
- `yarn lint` *(fails: Unexpected global 'document' ...)*
- `yarn test` *(fails: window.test.tsx TypeError, game2048.test.tsx TypeError, nmapNse.test.tsx alert not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1acbcf88328b0b959712e8e6692