### PR TITLE
feat: add session lock screen

### DIFF
--- a/__tests__/LockScreen.test.tsx
+++ b/__tests__/LockScreen.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import LockScreen from '../components/session/LockScreen';
+
+jest.mock('../hooks/useSettings', () => ({
+  useSettings: () => ({ wallpaper: 'test-wall' }),
+}));
+
+describe('LockScreen', () => {
+  it('submits password and handles escape', () => {
+    const onUnlock = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <LockScreen username="alex" onUnlock={onUnlock} onCancel={onCancel} />,
+    );
+    const input = screen.getByLabelText(/password/i);
+    fireEvent.change(input, { target: { value: 'secret' } });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    expect(onUnlock).toHaveBeenCalledWith('secret');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    expect(screen.getByText('alex')).toBeInTheDocument();
+  });
+});
+

--- a/components/session/LockScreen.tsx
+++ b/components/session/LockScreen.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+interface LockScreenProps {
+  /** Username to display on the lock screen */
+  username: string;
+  /** Callback invoked when the user submits a password */
+  onUnlock: (password: string) => void;
+  /** Callback invoked when the lock screen is cancelled (e.g. via ESC) */
+  onCancel: () => void;
+}
+
+export default function LockScreen({
+  username,
+  onUnlock,
+  onCancel,
+}: LockScreenProps) {
+  const { wallpaper } = useSettings();
+  const [password, setPassword] = useState('');
+  const [time, setTime] = useState(() => new Date());
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Update clock every second
+  useEffect(() => {
+    const id = setInterval(() => setTime(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Focus password field and handle ESC key to cancel
+  useEffect(() => {
+    inputRef.current?.focus();
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onUnlock(password);
+    setPassword('');
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center">
+      <img
+        src={`/wallpapers/${wallpaper}.webp`}
+        alt=""
+        className="absolute inset-0 w-full h-full object-cover blur-md"
+      />
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="relative z-10 text-center text-white">
+        <div className="text-6xl font-bold" data-testid="lock-time">
+          {time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </div>
+        <div className="mt-4 text-2xl">{username}</div>
+        <form onSubmit={submit} className="mt-8" aria-label="unlock form">
+          <input
+            ref={inputRef}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="px-4 py-2 rounded bg-black/60 text-white focus:outline-none"
+            placeholder="Password"
+            aria-label="Password"
+          />
+        </form>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LockScreen component for session with blurred wallpaper and password unlock
- test LockScreen interactions for password submit and escape cancel

## Testing
- `npx eslint components/session/LockScreen.tsx __tests__/LockScreen.test.tsx`
- `yarn test __tests__/LockScreen.test.tsx`
- `npx tsc --noEmit --jsx react-jsx components/session/LockScreen.tsx` *(fails: cytoscape types missing Stylesheet)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1b145548328b3a9a760ff6e1f56