### PR TITLE
feat: add session actions menu

### DIFF
--- a/__tests__/SessionActionsButton.test.tsx
+++ b/__tests__/SessionActionsButton.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SessionActionsButton from '../components/SessionActionsButton';
+
+describe('SessionActionsButton', () => {
+  beforeEach(() => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens and lists actions', () => {
+    render(<SessionActionsButton />);
+    const trigger = screen.getByLabelText('Session actions');
+    fireEvent.click(trigger);
+    expect(screen.getByText('Restart session')).toBeInTheDocument();
+    expect(screen.getByText('Disconnect')).toBeInTheDocument();
+  });
+
+  it('closes after selecting an action', () => {
+    render(<SessionActionsButton />);
+    const trigger = screen.getByLabelText('Session actions');
+    fireEvent.click(trigger);
+    const action = screen.getByText('Restart session');
+    fireEvent.click(action);
+    expect(window.confirm).toHaveBeenCalledWith('Restart session?');
+    expect(screen.queryByText('Restart session')).toBeNull();
+  });
+
+  it('closes when clicking outside the menu', () => {
+    render(<SessionActionsButton />);
+    const trigger = screen.getByLabelText('Session actions');
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByTestId('session-actions-overlay'));
+    expect(screen.queryByText('Restart session')).toBeNull();
+  });
+});

--- a/components/SessionActionsButton.tsx
+++ b/components/SessionActionsButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+export default function SessionActionsButton() {
+  const [open, setOpen] = useState(false);
+
+  const actions = [
+    {
+      label: "Restart session",
+      confirm: () => window.confirm("Restart session?"),
+    },
+    {
+      label: "Disconnect",
+      confirm: () => window.confirm("Disconnect session?"),
+    },
+  ];
+
+  const toggle = () => setOpen((o) => !o);
+
+  const handleAction = (action: () => boolean) => {
+    action();
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Session actions"
+        aria-expanded={open}
+        onClick={toggle}
+        className="fixed top-2 right-12 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+      >
+        ☰
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-30"
+          onClick={() => setOpen(false)}
+          data-testid="session-actions-overlay"
+        >
+          <div
+            className="absolute top-12 right-2 bg-white text-black shadow-lg rounded p-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ul>
+              {actions.map((a) => (
+                <li key={a.label}>
+                  <button
+                    type="button"
+                    onClick={() => handleAction(a.confirm)}
+                    className="block w-full text-left px-2 py-1 hover:bg-gray-100"
+                  >
+                    {a.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import SessionActionsButton from '../components/SessionActionsButton';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <SessionActionsButton />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add a global session actions button that lists restart and disconnect options
- ask for confirmation before running an action
- cover session actions menu with tests

## Testing
- `yarn test`
- `yarn test __tests__/SessionActionsButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1b09b64832882a2e4748fd9936e