### PR TITLE
style: apply kali accent states for interactive elements

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,10 @@
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
+  --kali-accent: var(--color-accent);
+  --kali-accent-hover: color-mix(in srgb, var(--kali-accent), transparent 88%);
+  --kali-accent-active: color-mix(in srgb, var(--kali-accent), transparent 80%);
+  --kali-accent-focus: var(--kali-accent);
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */

--- a/styles/index.css
+++ b/styles/index.css
@@ -17,9 +17,33 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+li:focus-visible,
+menu li:focus-visible,
+[role="menuitem"]:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
     outline-offset: 2px;
+}
+
+button:hover,
+li:hover,
+menu li:hover,
+[role="menuitem"]:hover {
+    background-color: var(--kali-accent-hover);
+}
+
+button:active,
+li:active,
+menu li:active,
+[role="menuitem"]:active {
+    background-color: var(--kali-accent-active);
+}
+
+button:focus-visible,
+li:focus-visible,
+menu li:focus-visible,
+[role="menuitem"]:focus-visible {
+    background-color: var(--kali-accent-focus);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,7 +57,7 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--kali-accent-focus);
   --focus-outline-width: 2px;
 }
 


### PR DESCRIPTION
## Summary
- add `--kali-accent` state variables for hover, active and focus
- use accent focus for outline color tokens
- apply accent hover/active/focus backgrounds to buttons, list items and menu entries

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: game2048, window, nmapNse, reconng tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1abac648328b310eca3ba9680ee