### PR TITLE
Add density presets and appearance options

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -232,8 +232,9 @@ export default function Settings() {
               onChange={(e) => setDensity(e.target.value as any)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="regular">Regular</option>
               <option value="compact">Compact</option>
+              <option value="comfortable">Comfortable</option>
+              <option value="spacious">Spacious</option>
             </select>
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -95,8 +95,9 @@ export function Settings() {
                     onChange={(e) => setDensity(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="regular">Regular</option>
                     <option value="compact">Compact</option>
+                    <option value="comfortable">Comfortable</option>
+                    <option value="spacious">Spacious</option>
                 </select>
             </div>
             <div className="flex justify-center my-4">

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex items-center z-40" style={{ height: 'var(--panel-height)' }} role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -26,7 +26,8 @@ export default function Taskbar(props) {
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                        'relative flex items-center mx-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    style={{ padding: 'var(--control-padding-y) var(--control-padding-x)' }}
                 >
                     <Image
                         width={24}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,7 +23,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
-type Density = 'regular' | 'compact';
+type Density = 'compact' | 'comfortable' | 'spacious';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -157,15 +157,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [wallpaper]);
 
   useEffect(() => {
-    const spacing: Record<Density, Record<string, string>> = {
-      regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
-      },
+    const presets: Record<Density, Record<string, string>> = {
       compact: {
         '--space-1': '0.125rem',
         '--space-2': '0.25rem',
@@ -173,9 +165,34 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-4': '0.75rem',
         '--space-5': '1rem',
         '--space-6': '1.5rem',
+        '--panel-height': '28px',
+        '--control-padding-y': '0.125rem',
+        '--control-padding-x': '0.25rem',
+      },
+      comfortable: {
+        '--space-1': '0.25rem',
+        '--space-2': '0.5rem',
+        '--space-3': '0.75rem',
+        '--space-4': '1rem',
+        '--space-5': '1.5rem',
+        '--space-6': '2rem',
+        '--panel-height': '40px',
+        '--control-padding-y': '0.25rem',
+        '--control-padding-x': '0.5rem',
+      },
+      spacious: {
+        '--space-1': '0.5rem',
+        '--space-2': '1rem',
+        '--space-3': '1.5rem',
+        '--space-4': '2rem',
+        '--space-5': '3rem',
+        '--space-6': '4rem',
+        '--panel-height': '48px',
+        '--control-padding-y': '0.5rem',
+        '--control-padding-x': '1rem',
       },
     };
-    const vars = spacing[density];
+    const vars = presets[density];
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);
     });

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -40,6 +40,11 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
 
+  /* Component sizing */
+  --panel-height: 40px;
+  --control-padding-y: 0.25rem;
+  --control-padding-x: 0.5rem;
+
   /* Radius */
   --radius-sm: 2px;
   --radius-md: 4px;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,7 +6,7 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
-  density: 'regular',
+  density: 'comfortable',
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,


### PR DESCRIPTION
## Summary
- add compact, comfortable, and spacious density presets with component spacing variables
- keep panel height 28px in compact mode and expose tokens for controls
- surface density setting in Appearance tab and Settings app with persistence

## Testing
- `yarn test` *(fails: TypeError: (0 , _GameLayout.useInputRecorder) is not a function)*
- `yarn lint` *(no output, process appeared to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1b52d888328a86d21160942170c