### PR TITLE
feat: add global focus outline

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,7 +73,16 @@ html[data-theme='matrix'] {
   color: var(--color-inverse);
 }
 
-*:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+:where(
+  a,
+  button,
+  input,
+  select,
+  textarea,
+  summary,
+  [role='button'],
+  [tabindex]:not([tabindex='-1'])
+):focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
   outline-offset: 2px;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -16,11 +16,6 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     min-height: var(--hit-area);
 }
 
-a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
-}
 
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
@@ -507,13 +502,6 @@ textarea,
 pre {
     font-family: monospace;
     line-height: 1.2;
-}
-
-/* Visible focus rings for copy buttons and text areas */
-button:focus-visible,
-textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
 }
 
 /* Enable scroll snapping for gallery containers */


### PR DESCRIPTION
## Summary
- apply high-contrast focus outline globally to links, buttons and form controls
- remove scattered focus styles in index.css

## Testing
- `yarn test` *(fails: TypeError in game2048 tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1b7b6508328831e2876c9ea276d