### PR TITLE
feat: respect reduced motion globally

### DIFF
--- a/__tests__/reducedMotionStyles.test.ts
+++ b/__tests__/reducedMotionStyles.test.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+
+test('reduced motion styles disable transitions', () => {
+  const cssPath = path.join(__dirname, '..', 'styles', 'index.css');
+  const css = fs.readFileSync(cssPath, 'utf8');
+  expect(css).toMatch(/\.reduced-motion \*, \.reduced-motion \*::before, \.reduced-motion \*::after \{[\s\S]*transition-duration: 0.01ms !important;/);
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,8 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
+import { SettingsContext } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock('react-draggable', () => ({
@@ -37,6 +39,58 @@ describe('Window lifecycle', () => {
       jest.advanceTimersByTime(300);
     });
 
+    expect(closed).toHaveBeenCalledWith('test-window');
+    jest.useRealTimers();
+  });
+
+  it('closes immediately when reduced motion is enabled', () => {
+    jest.useFakeTimers();
+    const closed = jest.fn();
+    const hideSideBar = jest.fn();
+    const context = {
+      accent: defaults.accent,
+      wallpaper: defaults.wallpaper,
+      density: defaults.density as any,
+      reducedMotion: true,
+      fontScale: defaults.fontScale,
+      highContrast: defaults.highContrast,
+      largeHitAreas: defaults.largeHitAreas,
+      pongSpin: defaults.pongSpin,
+      allowNetwork: defaults.allowNetwork,
+      haptics: defaults.haptics,
+      theme: 'default',
+      setAccent: () => {},
+      setWallpaper: () => {},
+      setDensity: () => {},
+      setReducedMotion: () => {},
+      setFontScale: () => {},
+      setHighContrast: () => {},
+      setLargeHitAreas: () => {},
+      setPongSpin: () => {},
+      setAllowNetwork: () => {},
+      setHaptics: () => {},
+      setTheme: () => {},
+    };
+
+    render(
+      <SettingsContext.Provider value={context}>
+        <Window
+          id="test-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={() => {}}
+          hasMinimised={() => {}}
+          closed={closed}
+          hideSideBar={hideSideBar}
+          openApp={() => {}}
+        />
+      </SettingsContext.Provider>
+    );
+
+    const closeButton = screen.getByRole('button', { name: /window close/i });
+    fireEvent.click(closeButton);
+
+    expect(hideSideBar).toHaveBeenCalledWith('test-window', false);
     expect(closed).toHaveBeenCalledWith('test-window');
     jest.useRealTimers();
   });
@@ -199,7 +253,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,9 +6,11 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import { SettingsContext } from '../../hooks/useSettings';
 import styles from './window.module.css';
 
 export class Window extends Component {
+    static contextType = SettingsContext;
     constructor(props) {
         super(props);
         this.id = null;
@@ -468,12 +470,21 @@ export class Window extends Component {
 
     closeWindow = () => {
         this.setWinowsPosition();
-        this.setState({ closed: true }, () => {
+        const reduced = this.context?.reducedMotion;
+        const cleanup = () => {
             this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
+        };
+        if (reduced) {
+            cleanup();
+            this.props.closed(this.id);
+            return;
+        }
+        this.setState({ closed: true }, () => {
+            cleanup();
             setTimeout(() => {
                 this.props.closed(this.id)
-            }, 300) // after 300ms this window will be unmounted from parent (Desktop)
+            }, 300); // after 300ms this window will be unmounted from parent (Desktop)
         });
     }
 

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -156,6 +156,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
 
+  // Update reduced motion setting when system preference changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    // Skip if user has explicitly chosen a preference
+    if (window.localStorage.getItem('reduced-motion') !== null) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReducedMotion(mq.matches);
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
       regular: {


### PR DESCRIPTION
## Summary
- update settings provider to track `prefers-reduced-motion`
- skip window close animation when reduced motion is enabled
- add tests validating reduced motion styles and behavior

## Testing
- `npx eslint hooks/useSettings.tsx components/base/window.js __tests__/window.test.tsx __tests__/reducedMotionStyles.test.ts`
- `yarn test __tests__/window.test.tsx __tests__/reducedMotionStyles.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1b8e01083289feab5713fa820d3