### PR TITLE
feat: add whisker menu

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import Image from 'next/image';
+import UbuntuApp from '../base/ubuntu_app';
+import apps, { utilities, games } from '../../apps.config';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+type AppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+};
+
+const CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'favorites', label: 'Favorites' },
+  { id: 'recent', label: 'Recent' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'games', label: 'Games' }
+];
+
+const WhiskerMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('all');
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const allApps: AppMeta[] = apps as any;
+  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const recentApps = useMemo(() => {
+    try {
+      const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
+      return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
+    } catch {
+      return [];
+    }
+  }, [allApps, open]);
+  const utilityApps: AppMeta[] = utilities as any;
+  const gameApps: AppMeta[] = games as any;
+
+  const currentApps = useMemo(() => {
+    let list: AppMeta[];
+    switch (category) {
+      case 'favorites':
+        list = favoriteApps;
+        break;
+      case 'recent':
+        list = recentApps;
+        break;
+      case 'utilities':
+        list = utilityApps;
+        break;
+      case 'games':
+        list = gameApps;
+        break;
+      default:
+        list = allApps;
+    }
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter(a => a.title.toLowerCase().includes(q));
+    }
+    return list;
+  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlight(0);
+  }, [open, category, query]);
+
+  const openSelectedApp = (id: string) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        setOpen(o => !o);
+        return;
+      }
+      if (!open) return;
+      if (e.key === 'Escape') {
+        setOpen(false);
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlight(h => Math.max(h - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const app = currentApps[highlight];
+        if (app) openSelectedApp(app.id);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, currentApps, highlight]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!open) return;
+      const target = e.target as Node;
+      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        <Image
+          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          alt="Menu"
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
+        Applications
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          tabIndex={-1}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setOpen(false);
+            }
+          }}
+        >
+          <div className="flex flex-col bg-gray-800 p-2">
+            {CATEGORIES.map(cat => (
+              <button
+                key={cat.id}
+                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                onClick={() => setCategory(cat.id)}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+          <div className="p-3">
+            <input
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              placeholder="Search"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              autoFocus
+            />
+            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+              {currentApps.map((app, idx) => (
+                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
+                  <UbuntuApp
+                    id={app.id}
+                    icon={app.icon}
+                    name={app.title}
+                    openApp={() => openSelectedApp(app.id)}
+                    disabled={app.disabled}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WhiskerMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -88,12 +88,14 @@ export class Desktop extends Component {
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
+        window.addEventListener('open-app', this.handleOpenAppEvent);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        window.removeEventListener('open-app', this.handleOpenAppEvent);
     }
 
     checkForNewFolders = () => {
@@ -574,6 +576,13 @@ export class Desktop extends Component {
         return result;
     }
 
+    handleOpenAppEvent = (e) => {
+        const id = e.detail;
+        if (id) {
+            this.openApp(id);
+        }
+    }
+
     openApp = (objId) => {
 
         // google analytics
@@ -627,6 +636,13 @@ export class Desktop extends Component {
             });
 
             safeLocalStorage?.setItem('frequentApps', JSON.stringify(frequentApps));
+
+            let recentApps = [];
+            try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
+            recentApps = recentApps.filter(id => id !== objId);
+            recentApps.unshift(objId);
+            recentApps = recentApps.slice(0, 10);
+            safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
 
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -18,18 +19,7 @@ export default class Navbar extends Component {
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
-                                <div
-                                        className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
-                                >
-                                        <Image
-                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
-                                                alt="Decompiler"
-                                                width={16}
-                                                height={16}
-                                                className="inline mr-1"
-                                        />
-                                        Activities
-                                </div>
+                                <WhiskerMenu />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'


### PR DESCRIPTION
## Summary
- add WhiskerMenu with favorites, recents, search, categories, keyboard navigation, and Super-key toggle
- hook WhiskerMenu into navbar launcher
- dispatch open-app events from WhiskerMenu and track recent apps on desktop

## Testing
- `npm run lint` *(fails: Unexpected global 'document', Component definition missing display name)*
- `npm test` *(fails: window snapping finalize and release, NmapNSEApp copies example output to clipboard, getDensity/getAllowNetwork in modal test, AI computes move under 500ms)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04c85d208328be9571bd980e83d0