### PR TITLE
Track recently used applications

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -38,9 +38,33 @@ class AllApplications extends React.Component {
         }
     };
 
+    renderRecentApps = () => {
+        const ids = this.props.recentApps || [];
+        const { unfilteredApps } = this.state;
+        const recent = ids
+            .map((id) => unfilteredApps.find((app) => app.id === id))
+            .filter(Boolean);
+        return recent.map((app) => (
+            <UbuntuApp
+                key={`recent-${app.id}`}
+                name={app.title}
+                id={app.id}
+                icon={app.icon}
+                openApp={() => this.openApp(app.id)}
+                disabled={app.disabled}
+                prefetch={app.screen?.prefetch}
+            />
+        ));
+    };
+
     renderApps = () => {
         const apps = this.state.apps || [];
-        return apps.map((app) => (
+        const exclude = new Set(this.props.recentApps || []);
+        const filtered =
+            this.state.query === ''
+                ? apps.filter((app) => !exclude.has(app.id))
+                : apps;
+        return filtered.map((app) => (
             <UbuntuApp
                 key={app.id}
                 name={app.title}
@@ -62,6 +86,14 @@ class AllApplications extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
+                {!this.state.query && this.props.recentApps && this.props.recentApps.length ? (
+                    <>
+                        <h2 className="mb-4 text-white">Recently Used</h2>
+                        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 mb-8 place-items-center">
+                            {this.renderRecentApps()}
+                        </div>
+                    </>
+                ) : null}
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { addRecentApp, getRecentApps } from '../../utils/recent';
 
 export class Desktop extends Component {
     constructor() {
@@ -41,6 +42,7 @@ export class Desktop extends Component {
             minimized_windows: {},
             window_positions: {},
             desktop_apps: [],
+            recentApps: getRecentApps(),
             context_menus: {
                 desktop: false,
                 default: false,
@@ -636,6 +638,8 @@ export class Desktop extends Component {
                     this.saveSession();
                 });
                 this.app_stack.push(objId);
+                const recentApps = addRecentApp(objId);
+                this.setState({ recentApps });
             }, 200);
         }
     }
@@ -936,7 +940,7 @@ export class Desktop extends Component {
                 { this.state.allAppsView ?
                     <AllApplications apps={apps}
                         games={games}
-                        recentApps={this.app_stack}
+                        recentApps={this.state.recentApps}
                         openApp={this.openApp} /> : null}
 
                 { this.state.showShortcutSelector ?

--- a/utils/recent.ts
+++ b/utils/recent.ts
@@ -1,0 +1,37 @@
+import { safeLocalStorage } from './safeStorage';
+
+const RECENT_KEY = 'recentApps';
+const MAX_RECENT = 10;
+
+// Retrieve the list of recently used app IDs
+export function getRecentApps(): string[] {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// Add an app ID to the recent list with LRU semantics
+export function addRecentApp(id: string): string[] {
+  const recent = getRecentApps();
+  const existingIndex = recent.indexOf(id);
+  if (existingIndex !== -1) {
+    recent.splice(existingIndex, 1);
+  }
+  recent.unshift(id);
+  if (recent.length > MAX_RECENT) {
+    recent.length = MAX_RECENT;
+  }
+  try {
+    safeLocalStorage?.setItem(RECENT_KEY, JSON.stringify(recent));
+  } catch {
+    // ignore storage errors
+  }
+  return recent;
+}
+


### PR DESCRIPTION
## Summary
- Add `recent.ts` utility to manage a persistent LRU list of the last 10 app IDs
- Update desktop to record launched apps and expose the list to the Whisker menu
- Show a “Recently Used” section in the all-applications view

## Testing
- `yarn lint` *(fails: Unexpected global `document` in various files)*
- `yarn test` *(fails: window snapping finalize and release; NmapNSE app copy output; modal focus tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04c9ba1c8328a5bfed45aa755d2a