### PR TITLE
feat: add whisker-style session actions

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 
 class AllApplications extends React.Component {
@@ -55,15 +56,71 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
+            <div className="fixed inset-0 z-50 flex bg-ub-grey bg-opacity-95 all-apps-anim">
+                <div className="flex-1 flex flex-col items-center overflow-y-auto">
+                    <input
+                        className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                        placeholder="Search"
+                        aria-label="Search applications"
+                        value={this.state.query}
+                        onChange={this.handleChange}
+                    />
+                    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                        {this.renderApps()}
+                    </div>
+                </div>
+                <div className="w-24 flex flex-col items-center justify-end gap-4 p-4 border-l border-black border-opacity-20">
+                    <button
+                        type="button"
+                        aria-label="All Applications"
+                        className="opacity-50 cursor-default"
+                        disabled
+                    >
+                        <Image
+                            src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+                            alt="All Applications"
+                            width={24}
+                            height={24}
+                        />
+                    </button>
+                    <button
+                        type="button"
+                        aria-label="Settings"
+                        onClick={() => this.openApp('settings')}
+                    >
+                        <Image
+                            src="/themes/Yaru/apps/gnome-control-center.png"
+                            alt="Settings"
+                            width={24}
+                            height={24}
+                        />
+                    </button>
+                    <button
+                        type="button"
+                        aria-label="Lock"
+                        className="opacity-50 cursor-default"
+                        disabled
+                    >
+                        <Image
+                            src="/themes/Yaru/status/changes-prevent-symbolic.svg"
+                            alt="Lock"
+                            width={24}
+                            height={24}
+                        />
+                    </button>
+                    <button
+                        type="button"
+                        aria-label="Log Out"
+                        className="opacity-50 cursor-default"
+                        disabled
+                    >
+                        <Image
+                            src="/themes/Yaru/status/system-shutdown-symbolic.svg"
+                            alt="Log Out"
+                            width={24}
+                            height={24}
+                        />
+                    </button>
                 </div>
             </div>
         );


### PR DESCRIPTION
## Summary
- add right-pane buttons for All Applications, Settings, Lock, and Log Out
- show inactive stubs for Lock and Log Out actions
- label search field for accessibility

## Testing
- `npx eslint components/screen/all-applications.js`
- `yarn test --passWithNoTests components/screen/all-applications.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba04cdbf5c8328aafbaf140488ccbb