### PR TITLE
feat: add keyboard navigation for app menu

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -90,6 +90,7 @@ export class SideBarApp extends Component {
             <button
                 type="button"
                 aria-label={this.props.title}
+                role="menuitem"
                 data-context="app"
                 data-app-id={this.props.id}
                 onClick={this.openApp}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,74 +1,26 @@
-import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import React, { useEffect } from 'react';
+import AppGrid from '../apps/app-grid';
 
-class AllApplications extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            query: '',
-            apps: [],
-            unfilteredApps: [],
-        };
-    }
+export default function AllApplications({ openApp, onClose }) {
+  const focusSidebar = () => {
+    const first = document.querySelector('nav[aria-label="Dock"] [role="menuitem"]');
+    if (first && first instanceof HTMLElement) first.focus();
+  };
 
-    componentDidMount() {
-        const { apps = [], games = [] } = this.props;
-        const combined = [...apps];
-        games.forEach((game) => {
-            if (!combined.some((app) => app.id === game.id)) combined.push(game);
-        });
-        this.setState({ apps: combined, unfilteredApps: combined });
-    }
-
-    handleChange = (e) => {
-        const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose && onClose();
+      }
     };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
 
-    openApp = (id) => {
-        if (typeof this.props.openApp === 'function') {
-            this.props.openApp(id);
-        }
-    };
-
-    renderApps = () => {
-        const apps = this.state.apps || [];
-        return apps.map((app) => (
-            <UbuntuApp
-                key={app.id}
-                name={app.title}
-                id={app.id}
-                icon={app.icon}
-                openApp={() => this.openApp(app.id)}
-                disabled={app.disabled}
-                prefetch={app.screen?.prefetch}
-            />
-        ));
-    };
-
-    render() {
-        return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
-                </div>
-            </div>
-        );
-    }
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+      <AppGrid openApp={openApp} onFocusSidebar={focusSidebar} />
+    </div>
+  );
 }
-
-export default AllApplications;
-

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -937,7 +937,8 @@ export class Desktop extends Component {
                     <AllApplications apps={apps}
                         games={games}
                         recentApps={this.app_stack}
-                        openApp={this.openApp} /> : null}
+                        openApp={this.openApp}
+                        onClose={this.showAllApps} /> : null}
 
                 { this.state.showShortcutSelector ?
                     <ShortcutSelector apps={apps}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -25,10 +26,28 @@ export default function SideBar(props) {
         }, 2000);
     }
 
+    const navRef = useRef(null);
+    useRovingTabIndex(navRef, !props.hide, 'vertical');
+
+    const focusAppGrid = () => {
+        const firstApp = document.querySelector('#app-grid [tabindex="0"], #app-grid [data-app-id]');
+        if (firstApp && firstApp instanceof HTMLElement) firstApp.focus();
+    };
+
+    const handleKeyDown = (e) => {
+        if (!props.allAppsView) return;
+        if (e.key === 'ArrowRight' || e.key === 'Tab') {
+            e.preventDefault();
+            focusAppGrid();
+        }
+    };
+
     return (
         <>
             <nav
                 aria-label="Dock"
+                ref={navRef}
+                onKeyDown={handleKeyDown}
                 className={(props.hide ? " -translate-x-full " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
@@ -51,7 +70,9 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
+        <button
+            type="button"
+            role="menuitem"
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
@@ -80,6 +101,6 @@ export function AllApps(props) {
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }


### PR DESCRIPTION
## Summary
- enable arrow key navigation in dock and app grid
- add Escape to close All Applications overlay
- support Shift+Tab cycling between sidebar and app grid

## Testing
- `yarn test` *(fails: TypeError e.preventDefault is not a function, unable to find role="alert")*
- `yarn lint` *(no output, process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04d22fb48328aee5f4f0cb62f901