### PR TITLE
feat: add whisker menu styling variables

### DIFF
--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -30,7 +30,13 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen flex flex-col justify-start items-center pt-7 border-black border-opacity-60"}
+                style={{
+                    width: 'var(--sidebar-width)',
+                    backgroundColor: 'var(--menu-bg)',
+                    opacity: 'var(--menu-opacity)',
+                    borderRadius: 'var(--menu-border-radius)'
+                }}
             >
                 {
                     (

--- a/docs/whisker-theme.md
+++ b/docs/whisker-theme.md
@@ -1,0 +1,11 @@
+# Whisker Theme Variables
+
+CSS variables for the Whisker menu and sidebar are defined in `styles/whisker.css`.
+Adjusting these values updates the appearance of the interface without modifying component code.
+
+- `--menu-bg`: Background color for menus and the sidebar. Defaults to `var(--color-bg)`.
+- `--sidebar-width`: Width of the sidebar/dock. Defaults to `4rem`.
+- `--menu-border-radius`: Corner radius applied to menus and the sidebar. Defaults to `0.5rem`.
+- `--menu-opacity`: Overall opacity for menu and sidebar backgrounds. Defaults to `0.9`.
+
+Override these variables in a global stylesheet or within the `:root` selector to customize themes.

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './whisker.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
@@ -367,7 +368,9 @@ dialog {
 /* Context Menu & Panels */
 .context-menu-bg,
 .windowMainScreen {
-    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
+    background-color: var(--menu-bg);
+    border-radius: var(--menu-border-radius);
+    opacity: var(--menu-opacity);
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
@@ -375,7 +378,7 @@ dialog {
     .windowMainScreen {
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
-        background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
+        background-color: var(--menu-bg);
     }
 }
 

--- a/styles/whisker.css
+++ b/styles/whisker.css
@@ -1,0 +1,11 @@
+/* Theme variables for Whisker-style menu and sidebar */
+:root {
+  /* Background color for menus and sidebar */
+  --menu-bg: var(--color-bg);
+  /* Width of the sidebar/dock */
+  --sidebar-width: 4rem;
+  /* Rounded corners for menus and sidebar */
+  --menu-border-radius: 0.5rem;
+  /* Overall menu opacity (0 - 1) */
+  --menu-opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- define theme variables for the whisker menu and sidebar
- hook sidebar and context menu styles into new CSS variables
- document whisker variables for easy theming

## Testing
- `yarn lint` *(fails: Unexpected global 'document', missing display name)*
- `yarn test` *(fails: window.snap and nmap NSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04d2eb908328ba2d1e89499ac779