### PR TITLE
feat: add show desktop panel button

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -574,6 +574,52 @@ export class Desktop extends Component {
         return result;
     }
 
+    showDesktop = () => {
+        const minimized_windows = { ...this.state.minimized_windows };
+        const focused_windows = { ...this.state.focused_windows };
+        this._desktopMinimized = new Set();
+        for (const id in this.state.closed_windows) {
+            if (!this.state.closed_windows[id] && !minimized_windows[id]) {
+                minimized_windows[id] = true;
+                focused_windows[id] = false;
+                this._desktopMinimized.add(id);
+            }
+        }
+        this.setState({ minimized_windows, focused_windows });
+    }
+
+    restoreDesktop = () => {
+        if (!this._desktopMinimized) return;
+        const minimized_windows = { ...this.state.minimized_windows };
+        const focused_windows = { ...this.state.focused_windows };
+        this._desktopMinimized.forEach(id => {
+            minimized_windows[id] = false;
+            focused_windows[id] = false;
+        });
+        this._desktopMinimized = null;
+        this.setState({ minimized_windows, focused_windows });
+    }
+
+    toggleDesktop = () => {
+        if (this._desktopMinimized) {
+            this.restoreDesktop();
+        } else {
+            this.showDesktop();
+        }
+    }
+
+    showDesktopDrag = () => {
+        if (this._desktopMinimized) return;
+        this.showDesktop();
+        const restore = () => {
+            this.restoreDesktop();
+            document.removeEventListener('drop', restore);
+            document.removeEventListener('dragend', restore);
+        };
+        document.addEventListener('drop', restore, { once: true });
+        document.addEventListener('dragend', restore, { once: true });
+    }
+
     openApp = (objId) => {
 
         // google analytics
@@ -884,6 +930,8 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    toggleDesktop={this.toggleDesktop}
+                    showDesktopDrag={this.showDesktopDrag}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -42,6 +42,23 @@ export default function Taskbar(props) {
                     )}
                 </button>
             ))}
+            <button
+                type="button"
+                aria-label="Show Desktop"
+                onClick={props.toggleDesktop}
+                onDragEnter={props.showDesktopDrag}
+                onDragOver={(e) => e.preventDefault()}
+                className="ml-auto mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 flex items-center justify-center"
+            >
+                <Image
+                    width={24}
+                    height={24}
+                    className="w-5 h-5"
+                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
+                    alt="Show desktop"
+                    sizes="24px"
+                />
+            </button>
         </div>
     );
 }

--- a/plugins/catalog/show-desktop.json
+++ b/plugins/catalog/show-desktop.json
@@ -1,0 +1,5 @@
+{
+  "id": "show-desktop",
+  "sandbox": "window",
+  "code": "if (typeof registerPanelItem === 'function') { registerPanelItem('show-desktop'); }"
+}


### PR DESCRIPTION
## Summary
- add taskbar button to toggle minimized windows and show desktop
- support drag-triggered desktop reveal for drop operations
- register show desktop plugin in panel catalog

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04d69e9883289f3933e20798071a