### PR TITLE
feat: add tray API with SNI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ play/pause and track controls include keyboard hotkeys.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
 - **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
+- **`hooks/useTray.tsx`** & **`components/util-components/status.js`** - unified tray grouping StatusNotifierItem icons with legacy systray fallback. See [`docs/system-tray.md`](./docs/system-tray.md).
 
 ---
 

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import { useTray } from '../../hooks/useTray';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
+  const { icons, register, unregister } = useTray();
   const [online, setOnline] = useState(true);
 
   useEffect(() => {
@@ -38,44 +40,55 @@ export default function Status() {
     };
   }, []);
 
+  useEffect(() => {
+    const id = 'network';
+    register({
+      id,
+      tooltip: online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline',
+      sni: online
+        ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+        : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg",
+      legacy: online
+        ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+        : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg",
+    });
+    return () => unregister(id);
+  }, [online, allowNetwork, register, unregister]);
+
+  useEffect(() => {
+    const id = 'volume';
+    register({ id, tooltip: 'Volume', sni: VOLUME_ICON, legacy: VOLUME_ICON });
+    return () => unregister(id);
+  }, [register, unregister]);
+
+  useEffect(() => {
+    const id = 'battery';
+    register({
+      id,
+      tooltip: 'Battery',
+      sni: '/themes/Yaru/status/battery-good-symbolic.svg',
+      legacy: '/themes/Yaru/status/battery-good-symbolic.svg',
+    });
+    return () => unregister(id);
+  }, [register, unregister]);
+
   return (
-    <div className="flex justify-center items-center">
-      <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
-      >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-        {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
-        )}
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
+    <div className="flex justify-center items-center" role="group" aria-label="System tray">
+      {icons.map((icon) => (
+        <span key={icon.id} className="mx-1.5 relative" title={icon.tooltip}>
+          <Image
+            width={16}
+            height={16}
+            src={icon.sni || icon.legacy}
+            alt={icon.tooltip || icon.id}
+            className="inline status-symbol w-4 h-4"
+            sizes="16px"
+          />
+          {icon.id === 'network' && !allowNetwork && (
+            <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </span>
+      ))}
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>

--- a/docs/system-tray.md
+++ b/docs/system-tray.md
@@ -1,0 +1,38 @@
+# System Tray
+
+The desktop UI now exposes a unified system tray that accepts modern
+[StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/)
+icons with a graceful fallback to legacy systray imagery.
+Icons are grouped together for accessibility and discoverability.
+
+## Usage
+
+Wrap your app with `TrayProvider` (already included in `_app.jsx`) and
+use the `useTray` hook to register or remove simulated tray icons.
+When an SNI icon is provided it will be preferred; if omitted the legacy
+icon path is used instead.
+
+```tsx
+import { useTray } from '../hooks/useTray';
+import { useEffect } from 'react';
+
+export default function DemoIcon() {
+  const { register, unregister } = useTray();
+
+  useEffect(() => {
+    register({
+      id: 'demo',
+      sni: '/icons/demo-symbolic.svg',
+      legacy: '/icons/demo.png',
+      tooltip: 'Demo app',
+    });
+    return () => unregister('demo');
+  }, [register, unregister]);
+
+  return null;
+}
+```
+
+This API enables simulated applications to surface status, background
+activity or quick actions directly in the tray area while maintaining
+backward compatibility with traditional systray icons.

--- a/hooks/useTray.tsx
+++ b/hooks/useTray.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface TrayIcon {
+  id: string;
+  sni?: string;
+  legacy: string;
+  tooltip?: string;
+}
+
+interface TrayContextValue {
+  icons: TrayIcon[];
+  register: (icon: TrayIcon) => void;
+  unregister: (id: string) => void;
+}
+
+const TrayContext = createContext<TrayContextValue>({
+  icons: [],
+  register: () => {},
+  unregister: () => {},
+});
+
+export function TrayProvider({ children }: { children: ReactNode }) {
+  const [icons, setIcons] = useState<TrayIcon[]>([]);
+
+  const register = (icon: TrayIcon) => {
+    setIcons((prev) => {
+      const filtered = prev.filter((i) => i.id !== icon.id);
+      return [...filtered, icon];
+    });
+  };
+
+  const unregister = (id: string) => {
+    setIcons((prev) => prev.filter((i) => i.id !== id));
+  };
+
+  return (
+    <TrayContext.Provider value={{ icons, register, unregister }}>
+      {children}
+    </TrayContext.Provider>
+  );
+}
+
+export function useTray() {
+  return useContext(TrayContext);
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <TrayProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </TrayProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add `useTray` hook and provider for simulated app tray icons
- render StatusNotifierItem icons with legacy systray fallback in status bar
- document unified system tray API

## Testing
- `yarn lint` (fails: 576 problems)
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` (fails: 2 failed, 12 passed)


------
https://chatgpt.com/codex/tasks/task_e_68ba04d9bc908328ab18b6a06c21c294