### PR TITLE
feat: add network tray icon with connection options

### DIFF
--- a/components/util-components/network.js
+++ b/components/util-components/network.js
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { useSettings } from '../../hooks/useSettings';
+
+const WIFI_CONNECTED = '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg';
+const WIFI_DISCONNECTED = '/themes/Yaru/status/network-wireless-signal-none-symbolic.svg';
+const ETH_CONNECTED = '/themes/Yaru/status/network-wired-symbolic.svg';
+const ETH_DISCONNECTED = '/themes/Yaru/status/network-wired-disconnected-symbolic.svg';
+
+const SSIDS = ['kali-linux', 'hackerspace', 'airport'];
+
+export default function Network() {
+  const { allowNetwork } = useSettings();
+  const [type, setType] = useState('wifi');
+  const [connected, setConnected] = useState(false);
+  const [ssid, setSsid] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const iconSrc = type === 'ethernet'
+    ? (connected ? ETH_CONNECTED : ETH_DISCONNECTED)
+    : (connected ? WIFI_CONNECTED : WIFI_DISCONNECTED);
+
+  const tooltip = connected
+    ? (type === 'ethernet' ? 'Ethernet connected' : `Connected to ${ssid}`)
+    : 'Disconnected';
+
+  const connectWifi = (name) => {
+    setType('wifi');
+    setConnected(true);
+    setSsid(name);
+    setOpen(false);
+  };
+
+  const useEthernet = () => {
+    setType('ethernet');
+    setConnected(true);
+    setSsid('');
+    setOpen(false);
+  };
+
+  const disconnect = () => {
+    setConnected(false);
+    setSsid('');
+    setOpen(false);
+  };
+
+  return (
+    <div className="mx-1.5 relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        title={tooltip}
+        className="relative"
+      >
+        <Image
+          width={16}
+          height={16}
+          src={iconSrc}
+          alt="network status"
+          className="inline status-symbol w-4 h-4"
+          sizes="16px"
+        />
+        {!allowNetwork && (
+          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 bg-ub-cool-grey rounded-md shadow border border-black border-opacity-20 z-50">
+          <ul className="py-1 text-left">
+            <li>
+              <button onClick={useEthernet} className="w-full px-4 py-1 hover:bg-ub-warm-grey hover:bg-opacity-20">
+                Use Ethernet
+              </button>
+            </li>
+            <li className="border-t border-ubt-grey my-1" />
+            {SSIDS.map((name) => (
+              <li key={name}>
+                <button
+                  onClick={() => connectWifi(name)}
+                  className="w-full px-4 py-1 hover:bg-ub-warm-grey hover:bg-opacity-20"
+                >
+                  {name}
+                </button>
+              </li>
+            ))}
+            <li className="border-t border-ubt-grey my-1" />
+            <li>
+              <button onClick={disconnect} className="w-full px-4 py-1 hover:bg-ub-warm-grey hover:bg-opacity-20">
+                Disconnect
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,61 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
-import { useSettings } from '../../hooks/useSettings';
+import Network from "./network";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
-  const { allowNetwork } = useSettings();
-  const [online, setOnline] = useState(true);
-
-  useEffect(() => {
-    const pingServer = async () => {
-      if (!window?.location) return;
-      try {
-        const url = new URL('/favicon.ico', window.location.href).toString();
-        await fetch(url, { method: 'HEAD', cache: 'no-store' });
-        setOnline(true);
-      } catch (e) {
-        setOnline(false);
-      }
-    };
-
-    const updateStatus = () => {
-      const isOnline = navigator.onLine;
-      setOnline(isOnline);
-      if (isOnline) {
-        pingServer();
-      }
-    };
-
-    updateStatus();
-    window.addEventListener('online', updateStatus);
-    window.addEventListener('offline', updateStatus);
-    return () => {
-      window.removeEventListener('online', updateStatus);
-      window.removeEventListener('offline', updateStatus);
-    };
-  }, []);
-
   return (
     <div className="flex justify-center items-center">
-      <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
-      >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-        {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
-        )}
-      </span>
+      <Network />
       <span className="mx-1.5">
         <Image
           width={16}

--- a/public/themes/Yaru/status/network-wired-disconnected-symbolic.svg
+++ b/public/themes/Yaru/status/network-wired-disconnected-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+  <path d="M2 3h12v6h-3v4H5V9H2V3zm1 1v4h3v4h4V8h3V4H3z"/>
+  <path d="M3 2l10 10" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/public/themes/Yaru/status/network-wired-symbolic.svg
+++ b/public/themes/Yaru/status/network-wired-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+  <path d="M2 3h12v6h-3v4H5V9H2V3zm1 1v4h3v4h4V8h3V4H3z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add network component to show wifi/ethernet connection status
- allow selecting mock SSIDs via popover and update tooltip
- wire tray to use new network component and include wired icons

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ba04da44b88328a695f8567ef0fc1e