### PR TITLE
feat: add window context menu

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -33,6 +33,10 @@ export class Window extends Component {
             snapped: null,
             lastSize: null,
             grabbed: false,
+            alwaysOnTop: false,
+            shaded: false,
+            stuck: false,
+            resizing: false,
         }
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
@@ -198,6 +202,38 @@ export class Window extends Component {
 
     changeCursorToDefault = () => {
         this.setState({ cursorType: "cursor-default", grabbed: false })
+    }
+
+    startResize = () => {
+        if (this.props.resizable === false) return;
+        this.focusWindow();
+        if (this.state.maximized) {
+            this.restoreWindow();
+        }
+        this.setState({ cursorType: "cursor-nwse-resize", resizing: true });
+    }
+
+    endResize = () => {
+        this.setState({ cursorType: "cursor-default", resizing: false });
+    }
+
+    toggleAlwaysOnTop = () => {
+        this.setState(prev => ({ alwaysOnTop: !prev.alwaysOnTop }));
+    }
+
+    toggleShade = () => {
+        this.setState(prev => {
+            if (prev.shaded) {
+                const height = prev.lastSize && prev.lastSize.height ? prev.lastSize.height : prev.height;
+                return { shaded: false, height };
+            } else {
+                return { shaded: true, lastSize: { ...prev.lastSize, height: prev.height }, height: 8 };
+            }
+        }, this.resizeBoundries);
+    }
+
+    toggleStick = () => {
+        this.setState(prev => ({ stuck: !prev.stuck }));
     }
 
     snapToGrid = (value) => {
@@ -519,6 +555,32 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        if (this.state.resizing) {
+            const step = 1;
+            if (e.key === 'Enter' || e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.endResize();
+            } else if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
+            } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
+            }
+            this.focusWindow();
+            return;
+        }
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
@@ -635,8 +697,20 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={
+                            this.state.cursorType + " " +
+                            (this.state.closed ? " closed-window " : "") +
+                            (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") +
+                            (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
+                            (this.state.grabbed ? " opacity-70 " : "") +
+                            (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
+                            (this.props.isFocused
+                                ? (this.state.alwaysOnTop ? " z-50 " : " z-30 ")
+                                : (this.state.alwaysOnTop ? " z-40 " : " z-20 notFocused")) +
+                            " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
+                        data-context="window"
+                        data-app-id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}
@@ -659,7 +733,7 @@ export class Window extends Component {
                             allowMaximize={this.props.allowMaximize !== false}
                             pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
                         />
-                        {(this.id === "settings"
+                        {(!this.state.shaded) && (this.id === "settings"
                             ? <Settings />
                             : <WindowMainScreen screen={this.props.screen} title={this.props.title}
                                 addFolder={this.props.id === "terminal" ? this.props.addFolder : null}

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,41 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function WindowMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onCloseMenu && props.onCloseMenu();
+        }
+    };
+
+    const wrap = (fn) => () => {
+        fn && fn();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-48 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button type="button" aria-label="Move" onClick={wrap(props.onMove)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Move</span></button>
+            <button type="button" aria-label="Resize" onClick={wrap(props.onResize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Resize</span></button>
+            <button type="button" aria-label="Always on top" onClick={wrap(props.onTop)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Always on top</span></button>
+            <button type="button" aria-label="Shade" onClick={wrap(props.onShade)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Shade</span></button>
+            <button type="button" aria-label="Stick" onClick={wrap(props.onStick)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Stick</span></button>
+            <button type="button" aria-label="Maximize" onClick={wrap(props.onMaximize)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"><span className="ml-5">Maximize</span></button>
+            <button type="button" aria-label="Close" onClick={wrap(props.onClose)} role="menuitem" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"><span className="ml-5">Close</span></button>
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -19,6 +19,7 @@ import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
+import WindowMenu from '../context-menus/window-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -30,6 +31,7 @@ export class Desktop extends Component {
         this.app_stack = [];
         this.initFavourite = {};
         this.allWindowClosed = false;
+        this.windowRefs = {};
         this.state = {
             focused_windows: {},
             closed_windows: {},
@@ -46,6 +48,7 @@ export class Desktop extends Component {
                 default: false,
                 app: false,
                 taskbar: false,
+                window: false,
             },
             context_app: null,
             showNameBar: false,
@@ -162,6 +165,18 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if (e.altKey && e.code === 'Space') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const node = document.getElementById(id);
+                if (node) {
+                    const rect = node.getBoundingClientRect();
+                    const fakeEvent = { pageX: rect.left, pageY: rect.top + rect.height };
+                    this.setState({ context_app: id }, () => this.showContextMenu(fakeEvent, 'window'));
+                }
+            }
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
@@ -257,6 +272,13 @@ export class Desktop extends Component {
                 });
                 this.setState({ context_app: appId }, () => this.showContextMenu(e, "taskbar"));
                 break;
+            case "window":
+                ReactGA.event({
+                    category: `Context Menu`,
+                    action: `Opened Window Context Menu`
+                });
+                this.setState({ context_app: appId }, () => this.showContextMenu(e, "window"));
+                break;
             default:
                 ReactGA.event({
                     category: `Context Menu`,
@@ -287,6 +309,10 @@ export class Desktop extends Component {
             case "taskbar":
                 ReactGA.event({ category: `Context Menu`, action: `Opened Taskbar Context Menu` });
                 this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "taskbar"));
+                break;
+            case "window":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Window Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "window"));
                 break;
             default:
                 ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
@@ -481,7 +507,11 @@ export class Desktop extends Component {
                 }
 
                 windowsJsx.push(
-                    <Window key={app.id} {...props} />
+                    <Window
+                        key={app.id}
+                        ref={ref => { if (ref) this.windowRefs[app.id] = ref; }}
+                        {...props}
+                    />
                 )
             }
         });
@@ -823,7 +853,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -922,6 +952,17 @@ export class Desktop extends Component {
                         if (!id) return;
                         this.closeApp(id);
                     }}
+                    onCloseMenu={this.hideAllContextMenu}
+                />
+                <WindowMenu
+                    active={this.state.context_menus.window}
+                    onMove={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.changeCursorToMove(); }}
+                    onResize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.startResize(); }}
+                    onTop={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleAlwaysOnTop(); }}
+                    onShade={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleShade(); }}
+                    onStick={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.toggleStick(); }}
+                    onMaximize={() => { const id = this.state.context_app; if (id) this.windowRefs[id]?.maximizeWindow(); }}
+                    onClose={() => { const id = this.state.context_app; if (id) this.closeApp(id); }}
                     onCloseMenu={this.hideAllContextMenu}
                 />
 


### PR DESCRIPTION
## Summary
- add window context menu with move, resize, on-top, shade, stick, maximize and close
- open window context menu via Alt+Space for the focused window
- update window model with toggles for new actions

## Testing
- `npx eslint components/base/window.js components/screen/desktop.js components/context-menus/window-menu.js`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04ddae308328b4c1f540ec71e757