### PR TITLE
feat: add window and workspace shortcuts

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,10 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Window switcher', keys: 'Alt+Tab' },
+  { description: 'Close window', keys: 'Alt+F4' },
+  { description: 'Switch workspace left', keys: 'Ctrl+Alt+ArrowLeft' },
+  { description: 'Switch workspace right', keys: 'Ctrl+Alt+ArrowRight' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -33,6 +33,8 @@ export class Desktop extends Component {
         this.state = {
             focused_windows: {},
             closed_windows: {},
+            currentWorkspace: 0,
+            window_workspaces: {},
             allAppsView: false,
             overlapped_windows: {},
             disabled_apps: {},
@@ -150,13 +152,19 @@ export class Desktop extends Component {
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
             }
-        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
+        }
+        else if (e.altKey && e.key === 'F4') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) this.closeApp(id);
+        }
+        else if (e.ctrlKey && e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+            e.preventDefault();
+            this.switchWorkspace(e.key === 'ArrowRight' ? 1 : -1);
+        }
+        else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
-        }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
         }
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
@@ -217,6 +225,21 @@ export class Desktop extends Component {
         if (windows.length) {
             this.setState({ showWindowSwitcher: true, switcherWindows: windows });
         }
+    }
+
+    switchWorkspace = (direction) => {
+        const WORKSPACE_COUNT = 3;
+        this.setState(prev => {
+            const next = (prev.currentWorkspace + direction + WORKSPACE_COUNT) % WORKSPACE_COUNT;
+            const closed_windows = { ...prev.closed_windows };
+            const focused_windows = { ...prev.focused_windows };
+            Object.keys(prev.window_workspaces).forEach(id => {
+                const same = prev.window_workspaces[id] === next;
+                closed_windows[id] = !same;
+                if (!same) focused_windows[id] = false;
+            });
+            return { currentWorkspace: next, closed_windows, focused_windows };
+        }, this.giveFocusToLastApp);
     }
 
     closeWindowSwitcher = () => {
@@ -556,8 +579,9 @@ export class Desktop extends Component {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {
             for (const index in this.app_stack) {
-                if (!this.state.minimized_windows[this.app_stack[index]]) {
-                    this.focus(this.app_stack[index]);
+                const id = this.app_stack[index];
+                if (!this.state.closed_windows[id] && !this.state.minimized_windows[id]) {
+                    this.focus(id);
                     break;
                 }
             }
@@ -603,6 +627,7 @@ export class Desktop extends Component {
         } else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
+            let window_workspaces = this.state.window_workspaces;
             let frequentApps = [];
             try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
             var currentApp = frequentApps.find(app => app.id === objId);
@@ -631,7 +656,8 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
+                window_workspaces[objId] = this.state.currentWorkspace;
+                this.setState({ closed_windows, favourite_apps, window_workspaces, allAppsView: false }, () => {
                     this.focus(objId);
                     this.saveSession();
                 });
@@ -681,11 +707,13 @@ export class Desktop extends Component {
         // close window
         let closed_windows = this.state.closed_windows;
         let favourite_apps = this.state.favourite_apps;
+        let window_workspaces = { ...this.state.window_workspaces };
 
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
+        delete window_workspaces[objId];
 
-        this.setState({ closed_windows, favourite_apps }, this.saveSession);
+        this.setState({ closed_windows, favourite_apps, window_workspaces }, this.saveSession);
     }
 
     pinApp = (id) => {

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -32,6 +32,14 @@ const KeyboardReference = () => (
           <td className="p-2 border border-ubt-grey">Alt + F4</td>
           <td className="p-2 border border-ubt-grey">Close current window</td>
         </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Ctrl + Alt + ←</td>
+          <td className="p-2 border border-ubt-grey">Switch to previous workspace</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Ctrl + Alt + →</td>
+          <td className="p-2 border border-ubt-grey">Switch to next workspace</td>
+        </tr>
       </tbody>
     </table>
   </main>


### PR DESCRIPTION
## Summary
- handle Alt+Tab with overlay and Alt+F4 to close windows
- add Ctrl+Alt+Arrow workspace switching logic
- document new shortcuts in settings and reference page

## Testing
- `npm test` *(fails: TypeError: e.preventDefault is not a function, Unable to find role="alert", localStorage origin null)*
- `npm run lint` *(fails: 576 problems, e.g., Unexpected global 'document')*

------
https://chatgpt.com/codex/tasks/task_e_68ba04e382f88328ba027e02b5d95260