### PR TITLE
feat: add workspace management to window menu

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,43 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        if (!e) return;
+        const prevent = () => {
+            if (typeof e.preventDefault === 'function') e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -23,6 +23,11 @@ function TaskbarMenu(props) {
         props.onCloseMenu && props.onCloseMenu();
     };
 
+    const handleMove = (ws) => {
+        props.onMove && props.onMove(ws);
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
     return (
         <div
             id="taskbar-menu"
@@ -50,6 +55,31 @@ function TaskbarMenu(props) {
             >
                 <span className="ml-5">Close</span>
             </button>
+            {props.workspaces && props.workspaces.length > 0 && (
+                <>
+                    <Devider />
+                    {props.workspaces.map((w) => (
+                        <button
+                            key={w}
+                            type="button"
+                            role="menuitem"
+                            aria-label={`Move to workspace ${w + 1}`}
+                            onClick={() => handleMove(w)}
+                            className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                        >
+                            <span className="ml-5">Workspace {w + 1}</span>
+                        </button>
+                    ))}
+                </>
+            )}
+        </div>
+    );
+}
+
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -2,7 +2,8 @@ import React from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const activeWorkspace = props.activeWorkspace ?? 0;
+    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false && (!props.windowWorkspaces || props.windowWorkspaces[app.id] === activeWorkspace));
 
     const handleClick = (app) => {
         const id = app.id;
@@ -17,6 +18,21 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+            {props.workspaces && props.workspaces.length > 0 && (
+                <div className="flex ml-1 mr-2">
+                    {props.workspaces.map((w) => (
+                        <button
+                            key={w}
+                            type="button"
+                            aria-label={`Switch to workspace ${w + 1}`}
+                            onClick={() => props.onSelectWorkspace && props.onSelectWorkspace(w)}
+                            className={(activeWorkspace === w ? ' bg-white bg-opacity-20 ' : ' hover:bg-white hover:bg-opacity-10 ') + 'mx-1 px-2 py-1 rounded text-white'}
+                        >
+                            {w + 1}
+                        </button>
+                    ))}
+                </div>
+            )}
             {runningApps.map(app => (
                 <button
                     key={app.id}


### PR DESCRIPTION
## Summary
- track active workspace and assign each window to a workspace
- allow moving windows between workspaces via taskbar menu
- show workspace buttons in taskbar and render only windows/apps for active workspace
- guard window key handler against missing event methods

## Testing
- `npm test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert" in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04e27f0c832881aa220fa2693586