### PR TITLE
Add focus follows mouse option

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,8 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
+import { SettingsContext } from '../hooks/useSettings';
+import { defaults as settingDefaults } from '../utils/settingsStore';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock('react-draggable', () => ({
@@ -199,7 +201,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -402,7 +404,56 @@ describe('Window overlay inert behaviour', () => {
 
     expect(root).not.toHaveAttribute('inert');
 
-    document.body.removeChild(root);
-    document.body.removeChild(opener);
+  document.body.removeChild(root);
+  document.body.removeChild(opener);
+});
+});
+
+describe('Focus follows mouse', () => {
+  it('focuses on mouse enter when enabled', () => {
+    const focus = jest.fn();
+    const contextValue = {
+      accent: settingDefaults.accent,
+      wallpaper: settingDefaults.wallpaper,
+      density: settingDefaults.density,
+      reducedMotion: settingDefaults.reducedMotion,
+      fontScale: settingDefaults.fontScale,
+      highContrast: settingDefaults.highContrast,
+      largeHitAreas: settingDefaults.largeHitAreas,
+      pongSpin: settingDefaults.pongSpin,
+      allowNetwork: settingDefaults.allowNetwork,
+      haptics: settingDefaults.haptics,
+      focusFollowsMouse: true,
+      theme: 'default',
+      setAccent: () => {},
+      setWallpaper: () => {},
+      setDensity: () => {},
+      setReducedMotion: () => {},
+      setFontScale: () => {},
+      setHighContrast: () => {},
+      setLargeHitAreas: () => {},
+      setPongSpin: () => {},
+      setAllowNetwork: () => {},
+      setHaptics: () => {},
+      setTheme: () => {},
+      setFocusFollowsMouse: () => {},
+    };
+    render(
+      <SettingsContext.Provider value={contextValue}>
+        <Window
+          id="test-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={focus}
+          hasMinimised={() => {}}
+          closed={() => {}}
+          hideSideBar={() => {}}
+          openApp={() => {}}
+        />
+      </SettingsContext.Provider>
+    );
+    const win = document.getElementById('test-window')!;
+    fireEvent.mouseEnter(win);
+    expect(focus).toHaveBeenCalledWith('test-window');
   });
 });

--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
+import { displayWindowManagerTweaks } from './components/apps/window-manager-tweaks';
 
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
@@ -691,6 +692,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'window-manager-tweaks',
+    title: 'Window Manager Tweaks',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayWindowManagerTweaks,
   },
   {
     id: 'files',

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, setFocusFollowsMouse, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -251,6 +251,7 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setFocusFollowsMouse(defaults.focusFollowsMouse);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"

--- a/components/apps/window-manager-tweaks.js
+++ b/components/apps/window-manager-tweaks.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+function WindowManagerTweaks() {
+  const { focusFollowsMouse, setFocusFollowsMouse } = useSettings();
+  return (
+    <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
+      <div className="flex justify-center my-4">
+        <span className="mr-2 text-ubt-grey">Window Focus:</span>
+        <label className="mr-4 text-ubt-grey flex items-center">
+          <input
+            type="radio"
+            name="focus-mode"
+            className="mr-1"
+            checked={!focusFollowsMouse}
+            onChange={() => setFocusFollowsMouse(false)}
+          />
+          Click to Focus
+        </label>
+        <label className="text-ubt-grey flex items-center">
+          <input
+            type="radio"
+            name="focus-mode"
+            className="mr-1"
+            checked={focusFollowsMouse}
+            onChange={() => setFocusFollowsMouse(true)}
+          />
+          Focus Follows Mouse
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export default WindowManagerTweaks;
+
+export const displayWindowManagerTweaks = () => <WindowManagerTweaks />;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,9 +6,11 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import { SettingsContext } from '../../hooks/useSettings';
 import styles from './window.module.css';
 
 export class Window extends Component {
+    static contextType = SettingsContext;
     constructor(props) {
         super(props);
         this.id = null;
@@ -379,6 +381,12 @@ export class Window extends Component {
         this.props.focus(this.id);
     }
 
+    handleMouseEnter = () => {
+        if (this.context.focusFollowsMouse) {
+            this.focusWindow();
+        }
+    }
+
     minimizeWindow = () => {
         let posx = -310;
         if (this.state.maximized) {
@@ -641,6 +649,8 @@ export class Window extends Component {
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onMouseDown={this.focusWindow}
+                        onMouseEnter={this.handleMouseEnter}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getFocusFollowsMouse as loadFocusFollowsMouse,
+  setFocusFollowsMouse as saveFocusFollowsMouse,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  focusFollowsMouse: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setFocusFollowsMouse: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  focusFollowsMouse: defaults.focusFollowsMouse,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setFocusFollowsMouse: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [focusFollowsMouse, setFocusFollowsMouse] = useState<boolean>(defaults.focusFollowsMouse);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setFocusFollowsMouse(await loadFocusFollowsMouse());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveFocusFollowsMouse(focusFollowsMouse);
+  }, [focusFollowsMouse]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        focusFollowsMouse,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setFocusFollowsMouse,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  focusFollowsMouse: false,
 };
 
 export async function getAccent() {
@@ -91,6 +92,17 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getFocusFollowsMouse() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.focusFollowsMouse;
+  const val = window.localStorage.getItem('focus-follows-mouse');
+  return val === null ? DEFAULT_SETTINGS.focusFollowsMouse : val === 'true';
+}
+
+export async function setFocusFollowsMouse(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('focus-follows-mouse', value ? 'true' : 'false');
+}
+
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
   const val = window.localStorage.getItem('haptics');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('focus-follows-mouse');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getFocusFollowsMouse(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    focusFollowsMouse,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (focusFollowsMouse !== undefined) await setFocusFollowsMouse(focusFollowsMouse);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add Window Manager Tweaks panel with focus mode toggle
- persist focus follows mouse preference in settings store
- update window component to honor click-to-focus or focus-follows-mouse

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: nmapNse.test.tsx unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68ba04e4f2f8832891b031ba1da3a1a3