### PR TITLE
feat: compositor toggle and panel transparency control

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,10 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    compositor,
+    setCompositor,
+    panelTransparency,
+    setPanelTransparency,
     theme,
     setTheme,
   } = useSettings();
@@ -133,6 +137,23 @@ export default function Settings() {
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>
             </select>
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Compositor:</span>
+            <ToggleSwitch
+              checked={compositor}
+              onChange={setCompositor}
+              ariaLabel="Compositor"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Panel Transparency:</span>
+            <ToggleSwitch
+              checked={panelTransparency}
+              onChange={setPanelTransparency}
+              ariaLabel="Panel Transparency"
+              disabled={!compositor}
+            />
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -6,6 +6,7 @@ interface ToggleSwitchProps {
   onChange: (checked: boolean) => void;
   className?: string;
   ariaLabel: string;
+  disabled?: boolean;
 }
 
 export default function ToggleSwitch({
@@ -13,16 +14,18 @@ export default function ToggleSwitch({
   onChange,
   className = "",
   ariaLabel,
+  disabled = false,
 }: ToggleSwitchProps) {
   return (
     <button
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
+      disabled={disabled}
+      onClick={() => !disabled && onChange(!checked)}
       className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`.trim()}
     >
       <span
         className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,18 +3,21 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { SettingsContext } from '../../hooks/useSettings';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false
+                };
+        }
+
+        static contextType = SettingsContext;
 
 	render() {
 		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className={`main-navbar-vp absolute top-0 right-0 w-screen flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 ${this.context.compositor ? 'shadow-md' : ''}`}>
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import { useSettings } from '../../hooks/useSettings';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -14,7 +15,7 @@ let renderApps = (props) => {
 }
 
 export default function SideBar(props) {
-
+    const { panelTransparency } = useSettings();
     function showSideBar() {
         props.hideSideBar(null, false);
     }
@@ -30,7 +31,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    ` absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 ${panelTransparency ? 'bg-black bg-opacity-50' : 'bg-black'}`}
             >
                 {
                     (

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import Image from 'next/image';
+import { useSettings } from '../../hooks/useSettings';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const { panelTransparency } = useSettings();
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,7 +18,12 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className={`absolute bottom-0 left-0 w-full h-10 flex items-center z-40 ${
+                panelTransparency ? 'bg-black bg-opacity-50' : 'bg-black'
+            }`}
+            role="toolbar"
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getCompositor as loadCompositor,
+  setCompositor as saveCompositor,
+  getPanelTransparency as loadPanelTransparency,
+  setPanelTransparency as savePanelTransparency,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +66,8 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  compositor: boolean;
+  panelTransparency: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +79,8 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setCompositor: (value: boolean) => void;
+  setPanelTransparency: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +95,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  compositor: defaults.compositor,
+  panelTransparency: defaults.panelTransparency,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +108,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setCompositor: () => {},
+  setPanelTransparency: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +124,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [compositor, setCompositor] = useState<boolean>(defaults.compositor);
+  const [panelTransparency, setPanelTransparency] = useState<boolean>(
+    defaults.panelTransparency,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +143,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setCompositor(await loadCompositor());
+      setPanelTransparency(await loadPanelTransparency());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +254,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle('no-compositor', !compositor);
+    saveCompositor(compositor);
+    if (!compositor) setPanelTransparency(false);
+  }, [compositor]);
+
+  useEffect(() => {
+    savePanelTransparency(panelTransparency);
+  }, [panelTransparency]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +277,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        compositor,
+        panelTransparency,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +290,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setCompositor,
+        setPanelTransparency,
         setTheme,
       }}
     >

--- a/styles/index.css
+++ b/styles/index.css
@@ -110,6 +110,12 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
+.no-compositor .window-shadow {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  compositor: true,
+  panelTransparency: true,
 };
 
 export async function getAccent() {
@@ -123,6 +125,28 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getCompositor() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.compositor;
+  const val = window.localStorage.getItem('compositor');
+  return val === null ? DEFAULT_SETTINGS.compositor : val === 'true';
+}
+
+export async function setCompositor(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('compositor', value ? 'true' : 'false');
+}
+
+export async function getPanelTransparency() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelTransparency;
+  const val = window.localStorage.getItem('panel-transparency');
+  return val === null ? DEFAULT_SETTINGS.panelTransparency : val === 'true';
+}
+
+export async function setPanelTransparency(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('panel-transparency', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +161,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('compositor');
+  window.localStorage.removeItem('panel-transparency');
 }
 
 export async function exportSettings() {
@@ -151,6 +177,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    compositor,
+    panelTransparency,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +190,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getCompositor(),
+    getPanelTransparency(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +205,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    compositor,
+    panelTransparency,
     theme,
   });
 }
@@ -199,6 +231,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    compositor,
+    panelTransparency,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +245,9 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (compositor !== undefined) await setCompositor(compositor);
+  if (panelTransparency !== undefined)
+    await setPanelTransparency(panelTransparency);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add compositor setting controlling shadows and opacity
- toggle panel transparency and disable when compositor is off
- expose new settings via UI and remove window shadows when disabled

## Testing
- `npx eslint utils/settingsStore.js hooks/useSettings.tsx components/ToggleSwitch.tsx apps/settings/index.tsx components/screen/taskbar.js components/screen/side_bar.js components/screen/navbar.js styles/index.css`
- `yarn test __tests__/themePersistence.test.ts` *(fails: Cannot read properties of null (reading '_origin'))*


------
https://chatgpt.com/codex/tasks/task_e_68ba04e5caa48328bd545772f665d2a7