### PR TITLE
feat: add desktop icon arrangement toggle

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -11,8 +11,11 @@ export class UbuntuApp extends Component {
         this.setState({ dragging: true });
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (e) => {
         this.setState({ dragging: false });
+        if (this.props.onDragEnd) {
+            this.props.onDragEnd(e);
+        }
     }
 
     openApp = () => {
@@ -49,6 +52,7 @@ export class UbuntuApp extends Component {
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
+                style={this.props.style}
             >
                 <Image
                     width={40}

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -68,6 +68,15 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
+            <button
+                onClick={props.toggleAutoArrange}
+                type="button"
+                role="menuitem"
+                aria-label="Arrange Desktop Icons"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Arrange Desktop Icons</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>


### PR DESCRIPTION
## Summary
- add context menu action to arrange desktop icons
- support manual desktop icon positions with auto-arrange toggle
- allow icons to reflow to grid order when toggled

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, TypeError in settingsStore)*
- `yarn lint components/base/ubuntu_app.js components/context-menus/desktop-menu.js components/screen/desktop.js` *(fails: 576 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04e7ac2c8328a0ac6cee41c56f16