### PR TITLE
Add properties dialog with rename in file explorer

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import PropertiesDialog from '../ui/PropertiesDialog';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -115,6 +116,8 @@ export default function FileExplorer() {
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+  const [showProps, setShowProps] = useState(false);
+  const [propsTarget, setPropsTarget] = useState(null);
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -186,6 +189,34 @@ export default function FileExplorer() {
       text = await f.text();
     }
     setContent(text);
+  };
+
+  const openProperties = async (entry) => {
+    const meta = { name: entry.name, handle: entry.handle };
+    meta.kind = entry.handle.kind;
+    if (entry.handle.kind === 'file') {
+      try {
+        const f = await entry.handle.getFile();
+        meta.size = f.size;
+        meta.modified = f.lastModified;
+        meta.type = f.type || 'File';
+        if (f.type && f.type.startsWith('image/')) {
+          meta.preview = URL.createObjectURL(f);
+        }
+      } catch {}
+    }
+    setPropsTarget(meta);
+    setShowProps(true);
+  };
+
+  const closeProperties = () => {
+    if (propsTarget?.preview) URL.revokeObjectURL(propsTarget.preview);
+    setShowProps(false);
+    setPropsTarget(null);
+  };
+
+  const handleRenamed = async () => {
+    if (dirHandle) await readDir(dirHandle);
   };
 
   const readDir = async (handle) => {
@@ -262,7 +293,13 @@ export default function FileExplorer() {
   if (!supported) {
     return (
       <div className="p-4 flex flex-col h-full">
-        <input ref={fallbackInputRef} type="file" onChange={openFallback} className="hidden" />
+        <input
+          ref={fallbackInputRef}
+          type="file"
+          onChange={openFallback}
+          className="hidden"
+          aria-hidden="true"
+        />
         {!currentFile && (
           <button
             onClick={() => fallbackInputRef.current?.click()}
@@ -273,11 +310,12 @@ export default function FileExplorer() {
         )}
         {currentFile && (
           <>
-            <textarea
-              className="flex-1 mt-2 p-2 bg-ub-cool-grey outline-none"
-              value={content}
-              onChange={onChange}
-            />
+              <textarea
+                className="flex-1 mt-2 p-2 bg-ub-cool-grey outline-none"
+                value={content}
+                onChange={onChange}
+                aria-label="File content"
+              />
             <button
               onClick={async () => {
                 const handle = await saveFileDialog({ suggestedName: currentFile.name });
@@ -296,80 +334,106 @@ export default function FileExplorer() {
   }
 
   return (
-    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
-      <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
-        <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-          Open Folder
-        </button>
-        {path.length > 1 && (
-          <button onClick={goBack} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-            Back
+    <>
+      <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
+        <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
+          <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+            Open Folder
           </button>
-        )}
-        <Breadcrumbs path={path} onNavigate={navigateTo} />
-        {currentFile && (
-          <button onClick={saveFile} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-            Save
-          </button>
-        )}
-      </div>
-      <div className="flex flex-1 overflow-hidden">
-        <div className="w-40 overflow-auto border-r border-gray-600">
-          <div className="p-2 font-bold">Recent</div>
-          {recent.map((r, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openRecent(r)}
-            >
-              {r.name}
-            </div>
-          ))}
-          <div className="p-2 font-bold">Directories</div>
-          {dirs.map((d, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
-            >
-              {d.name}
-            </div>
-          ))}
-          <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
-            </div>
-          ))}
-        </div>
-        <div className="flex-1 flex flex-col">
-          {currentFile && (
-            <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
-          )}
-          <div className="p-2 border-t border-gray-600">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Find in files"
-              className="px-1 py-0.5 text-black"
-            />
-            <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
-              Search
+          {path.length > 1 && (
+            <button onClick={goBack} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+              Back
             </button>
-            <div className="max-h-40 overflow-auto mt-2">
-              {results.map((r, i) => (
-                <div key={i}>
-                  <span className="font-bold">{r.file}:{r.line}</span> {r.text}
-                </div>
-              ))}
+          )}
+          <Breadcrumbs path={path} onNavigate={navigateTo} />
+          {currentFile && (
+            <button onClick={saveFile} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+              Save
+            </button>
+          )}
+        </div>
+        <div className="flex flex-1 overflow-hidden">
+          <div className="w-40 overflow-auto border-r border-gray-600">
+            <div className="p-2 font-bold">Recent</div>
+            {recent.map((r, i) => (
+              <div
+                key={i}
+                className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                onClick={() => openRecent(r)}
+              >
+                {r.name}
+              </div>
+            ))}
+            <div className="p-2 font-bold">Directories</div>
+            {dirs.map((d, i) => (
+              <div
+                key={i}
+                className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                onClick={() => openDir(d)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  openProperties(d);
+                }}
+              >
+                {d.name}
+              </div>
+            ))}
+            <div className="p-2 font-bold">Files</div>
+            {files.map((f, i) => (
+              <div
+                key={i}
+                className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                onClick={() => openFile(f)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  openProperties(f);
+                }}
+              >
+                {f.name}
+              </div>
+            ))}
+          </div>
+          <div className="flex-1 flex flex-col">
+            {currentFile && (
+            <textarea
+              className="flex-1 p-2 bg-ub-cool-grey outline-none"
+              value={content}
+              onChange={onChange}
+              aria-label="File content"
+            />
+            )}
+            <div className="p-2 border-t border-gray-600">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Find in files"
+                className="px-1 py-0.5 text-black"
+                aria-label="Search query"
+              />
+              <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
+                Search
+              </button>
+              <div className="max-h-40 overflow-auto mt-2">
+                {results.map((r, i) => (
+                  <div key={i}>
+                    <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+      {showProps && propsTarget && (
+        <PropertiesDialog
+          item={propsTarget}
+          onClose={closeProperties}
+          onRenamed={(newName) => {
+            handleRenamed();
+            setPropsTarget((p) => (p ? { ...p, name: newName } : p));
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/components/ui/PropertiesDialog.tsx
+++ b/components/ui/PropertiesDialog.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react';
+
+interface Props {
+  item: {
+    name: string;
+    kind: 'file' | 'directory';
+    size?: number;
+    modified?: number;
+    type?: string;
+    preview?: string;
+    handle: any;
+  };
+  onClose: () => void;
+  onRenamed?: (newName: string) => void;
+}
+
+const PropertiesDialog: React.FC<Props> = ({ item, onClose, onRenamed }) => {
+  const [name, setName] = useState(item.name);
+
+  useEffect(() => {
+    return () => {
+      if (item.preview) URL.revokeObjectURL(item.preview);
+    };
+  }, [item.preview]);
+
+  const save = async () => {
+    if (name !== item.name && item.handle?.move) {
+      try {
+        await item.handle.move(name);
+        onRenamed?.(name);
+      } catch {
+        // ignore rename errors
+      }
+    }
+  };
+
+  const iconSrc =
+    item.preview ||
+    (item.kind === 'directory'
+      ? '/themes/Yaru/system/folder.png'
+      : '/themes/Yaru/system/user-home.png');
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-ub-cool-grey p-4 rounded shadow-md text-white w-64">
+        <div className="flex items-center mb-4">
+          <img src={iconSrc} alt="" className="w-12 h-12 mr-2 object-cover" />
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex-1 bg-transparent border-b border-gray-500 focus:outline-none"
+            aria-label="Name"
+          />
+        </div>
+        <div className="space-y-1 text-sm">
+          <div>Type: {item.kind === 'directory' ? 'Directory' : item.type || 'File'}</div>
+          {item.size !== undefined && <div>Size: {item.size} bytes</div>}
+          {item.modified !== undefined && (
+            <div>Modified: {new Date(item.modified).toLocaleString()}</div>
+          )}
+        </div>
+        <div className="mt-4 flex justify-end space-x-2">
+          <button onClick={onClose} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+            Close
+          </button>
+          <button onClick={save} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PropertiesDialog;
+


### PR DESCRIPTION
## Summary
- add context menu integration in file explorer to open properties dialog
- implement properties dialog with metadata and rename support

## Testing
- `npx eslint components/apps/file-explorer.js components/ui/PropertiesDialog.tsx`
- `npx jest components/apps/file-explorer.js components/ui/PropertiesDialog.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba04ec8c708328a2c1f55e8941fdd2