### PR TITLE
feat(trash): add restore and empty with path tracking

### DIFF
--- a/__tests__/trashState.test.ts
+++ b/__tests__/trashState.test.ts
@@ -8,8 +8,8 @@ describe('useTrashState restoreFromHistory', () => {
 
   test('renames on conflict when confirmed', () => {
     const { result } = renderHook(() => useTrashState());
-    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
-    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
+    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1, path: '/app' };
+    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2, path: '/app2' };
 
     act(() => {
       result.current.setItems([existing]);
@@ -36,8 +36,8 @@ describe('useTrashState restoreFromHistory', () => {
 
   test('replaces on confirm', () => {
     const { result } = renderHook(() => useTrashState());
-    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
-    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
+    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1, path: '/app' };
+    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2, path: '/app2' };
 
     act(() => {
       result.current.setItems([existing]);
@@ -53,6 +53,33 @@ describe('useTrashState restoreFromHistory', () => {
     expect(result.current.items).toEqual([{ ...fromHistory }]);
 
     confirm.mockRestore();
+  });
+
+  test('moveToTrash and restore preserve path', () => {
+    const { result } = renderHook(() => useTrashState());
+    act(() => {
+      result.current.moveToTrash({ id: '3', title: 'A', path: '/a' });
+    });
+    expect(result.current.items).toHaveLength(1);
+    let restored: TrashItem | null = null;
+    act(() => {
+      restored = result.current.restore(0);
+    });
+    expect(restored?.path).toBe('/a');
+  });
+
+  test('emptyTrash clears items and returns them', () => {
+    const { result } = renderHook(() => useTrashState());
+    act(() => {
+      result.current.moveToTrash({ id: '4', title: 'A', path: '/a' });
+      result.current.moveToTrash({ id: '5', title: 'B', path: '/b' });
+    });
+    let removed: TrashItem[] = [];
+    act(() => {
+      removed = result.current.emptyTrash();
+    });
+    expect(removed.length).toBe(2);
+    expect(result.current.items).toHaveLength(0);
   });
 });
 

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -11,11 +11,12 @@ const FULL_ICON = '/themes/Yaru/status/user-trash-full-symbolic.svg';
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const {
     items,
-    setItems,
     history,
     pushHistory,
     restoreFromHistory,
     restoreAllFromHistory,
+    restore: restoreItem,
+    emptyTrash,
   } = useTrashState();
   const [selected, setSelected] = useState<number | null>(null);
   const [purgeDays, setPurgeDays] = useState(30);
@@ -47,22 +48,21 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     if (selected === null) return;
     const item = items[selected];
     if (!window.confirm(`Restore ${item.title}?`)) return;
+    restoreItem(selected);
     openApp(item.id);
-    setItems(items => items.filter((_, i) => i !== selected));
     setSelected(null);
     notifyChange();
-  }, [items, selected, openApp, setItems]);
+  }, [items, selected, openApp, restoreItem]);
 
   const remove = useCallback(() => {
     if (selected === null) return;
     const item = items[selected];
     if (!window.confirm(`Delete ${item.title}?`)) return;
-    const next = items.filter((_, i) => i !== selected);
-    setItems(next);
+    restoreItem(selected);
     pushHistory(item);
     setSelected(null);
     notifyChange();
-  }, [items, selected, setItems, pushHistory]);
+  }, [items, selected, restoreItem, pushHistory]);
 
   const purge = useCallback(() => {
     if (selected === null) return;
@@ -73,16 +73,16 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
       )
     )
       return;
-    setItems(items => items.filter((_, i) => i !== selected));
+    restoreItem(selected);
     setSelected(null);
     notifyChange();
-  }, [items, selected, setItems]);
+  }, [items, selected, restoreItem]);
 
   const restoreAll = () => {
     if (items.length === 0) return;
     if (!window.confirm('Restore all windows?')) return;
     items.forEach(item => openApp(item.id));
-    setItems([]);
+    emptyTrash();
     setSelected(null);
     notifyChange();
   };
@@ -96,8 +96,8 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
       count -= 1;
       if (count <= 0) {
         clearInterval(timer);
-        pushHistory(items);
-        setItems([]);
+        const removed = emptyTrash();
+        pushHistory(removed);
         setSelected(null);
         setEmptyCountdown(null);
         notifyChange();

--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -4,6 +4,12 @@ import usePersistentState from '../../hooks/usePersistentState';
 export interface TrashItem {
   id: string;
   title: string;
+  /**
+   * Original location of the item before it was moved to trash.
+   * For application windows this is simply the app id, but for
+   * future file-system integration it represents the full path.
+   */
+  path: string;
   icon?: string;
   image?: string;
   closedAt: number;
@@ -37,6 +43,30 @@ export default function useTrashState() {
     },
     [setHistory],
   );
+
+  const moveToTrash = useCallback(
+    (item: Omit<TrashItem, 'closedAt'>) => {
+      const payload: TrashItem = { ...item, closedAt: Date.now() };
+      setItems(prev => [...prev, payload]);
+    },
+    [setItems],
+  );
+
+  const restore = useCallback(
+    (index: number): TrashItem | null => {
+      const restored = items[index];
+      if (!restored) return null;
+      setItems(prev => prev.filter((_, i) => i !== index));
+      return restored;
+    },
+    [items, setItems],
+  );
+
+  const emptyTrash = useCallback((): TrashItem[] => {
+    const removed = items;
+    setItems([]);
+    return removed;
+  }, [items, setItems]);
 
   const resolveNameConflict = (
     restored: TrashItem,
@@ -104,6 +134,16 @@ export default function useTrashState() {
     });
   }, [setHistory, setItems]);
 
-  return { items, setItems, history, pushHistory, restoreFromHistory, restoreAllFromHistory };
+  return {
+    items,
+    setItems,
+    history,
+    pushHistory,
+    restoreFromHistory,
+    restoreAllFromHistory,
+    moveToTrash,
+    restore,
+    emptyTrash,
+  };
 }
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -667,6 +667,7 @@ export class Desktop extends Component {
             icon: appMeta.icon,
             image,
             closedAt: now,
+            path: objId,
         });
         safeLocalStorage?.setItem('window-trash', JSON.stringify(trash));
         this.updateTrashIcon();
@@ -779,8 +780,17 @@ export class Desktop extends Component {
             const icon = trash.length
                 ? '/themes/Yaru/status/user-trash-full-symbolic.svg'
                 : '/themes/Yaru/status/user-trash-symbolic.svg';
+            const count = trash.length;
+            let shouldUpdate = false;
             if (apps[appIndex].icon !== icon) {
                 apps[appIndex].icon = icon;
+                shouldUpdate = true;
+            }
+            if (apps[appIndex].tasks !== count) {
+                apps[appIndex].tasks = count;
+                shouldUpdate = true;
+            }
+            if (shouldUpdate) {
                 this.forceUpdate();
             }
         }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -7,7 +7,19 @@ let renderApps = (props) => {
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                notifications={app.notifications}
+                tasks={app.tasks}
+            />
         );
     });
     return sideBarAppsJsx;


### PR DESCRIPTION
## Summary
- track original path for trashed items and expose move, restore, and empty helpers
- wire trash UI to new helpers and dispatch change notifications
- show trash item count on dock icon and include path metadata when closing apps

## Testing
- `npx jest __tests__/trashState.test.ts`
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04edec6c83288c3033bd8bdfec3c