### PR TITLE
feat: add copy/delete progress modal

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import ProgressModal from '../ui/ProgressModal';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -115,6 +116,10 @@ export default function FileExplorer() {
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+  const [progress, setProgress] = useState(0);
+  const [progressOpen, setProgressOpen] = useState(false);
+  const [progressTitle, setProgressTitle] = useState('');
+  const abortRef = useRef(null);
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -222,6 +227,87 @@ export default function FileExplorer() {
     await readDir(prev.handle);
   };
 
+  const startProgress = (title) => {
+    setProgress(0);
+    setProgressTitle(title);
+    setProgressOpen(true);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    return controller;
+  };
+
+  const cancelOperation = () => {
+    abortRef.current?.abort();
+  };
+
+  const copyFileWithProgress = async (
+    handle,
+    newName,
+    dir,
+    signal,
+  ) => {
+    const file = await handle.getFile();
+    const total = file.size || 1;
+    const dest = await dir.getFileHandle(newName, { create: true });
+    const writable = await dest.createWritable();
+    const reader = file.stream().getReader();
+    let written = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+        await writable.write(value);
+        written += value.length;
+        setProgress((written / total) * 100);
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      await writable.close();
+    } catch (err) {
+      await reader.cancel().catch(() => {});
+      await writable.abort().catch(() => {});
+      await dir.removeEntry(newName).catch(() => {});
+      throw err;
+    }
+  };
+
+  const deleteFileWithProgress = async (name, dir, signal) => {
+    setProgress(0);
+    await new Promise((r) => setTimeout(r, 0));
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    await dir.removeEntry(name);
+    setProgress(100);
+  };
+
+  const copyItem = async (file) => {
+    if (!dirHandle) return;
+    const controller = startProgress(`Copying ${file.name}`);
+    try {
+      const copyName = `${file.name}.copy`;
+      await copyFileWithProgress(file.handle, copyName, dirHandle, controller.signal);
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error('Copy failed:', err);
+    } finally {
+      setProgressOpen(false);
+      abortRef.current = null;
+      await readDir(dirHandle);
+    }
+  };
+
+  const deleteItem = async (file) => {
+    if (!dirHandle) return;
+    const controller = startProgress(`Deleting ${file.name}`);
+    try {
+      await deleteFileWithProgress(file.name, dirHandle, controller.signal);
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error('Delete failed:', err);
+    } finally {
+      setProgressOpen(false);
+      abortRef.current = null;
+      await readDir(dirHandle);
+    }
+  };
+
   const saveFile = async () => {
     if (!currentFile) return;
     try {
@@ -296,11 +382,12 @@ export default function FileExplorer() {
   }
 
   return (
-    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
-      <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
-        <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
-          Open Folder
-        </button>
+    <>
+      <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
+        <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
+          <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+            Open Folder
+          </button>
         {path.length > 1 && (
           <button onClick={goBack} className="px-2 py-1 bg-black bg-opacity-50 rounded">
             Back
@@ -339,10 +426,30 @@ export default function FileExplorer() {
           {files.map((f, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+              className="px-2 flex items-center justify-between hover:bg-black hover:bg-opacity-30"
               onClick={() => openFile(f)}
             >
-              {f.name}
+              <span className="cursor-pointer">{f.name}</span>
+              <span className="space-x-1">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyItem(f);
+                  }}
+                  className="text-xs px-1 py-0.5 bg-black bg-opacity-50 rounded"
+                >
+                  Copy
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deleteItem(f);
+                  }}
+                  className="text-xs px-1 py-0.5 bg-black bg-opacity-50 rounded"
+                >
+                  Delete
+                </button>
+              </span>
             </div>
           ))}
         </div>
@@ -370,6 +477,12 @@ export default function FileExplorer() {
           </div>
         </div>
       </div>
-    </div>
+      <ProgressModal
+        open={progressOpen}
+        progress={progress}
+        onCancel={cancelOperation}
+        title={progressTitle}
+      />
+    </>
   );
 }

--- a/components/ui/ProgressModal.tsx
+++ b/components/ui/ProgressModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Modal from '../base/Modal';
+import ProgressBar from './ProgressBar';
+
+interface ProgressModalProps {
+  open: boolean;
+  progress: number;
+  onCancel: () => void;
+  title?: string;
+}
+
+export default function ProgressModal({ open, progress, onCancel, title }: ProgressModalProps) {
+  return (
+    <Modal isOpen={open} onClose={onCancel}>
+      <div className="p-4 bg-ub-dark-grey text-white rounded shadow-lg space-y-4" role="alertdialog">
+        {title && <div className="font-bold">{title}</div>}
+        <ProgressBar progress={progress} className="w-full" />
+        <div className="flex justify-end">
+          <button onClick={onCancel} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+


### PR DESCRIPTION
## Summary
- show progress modal with cancel during file copy or delete
- add reusable ProgressModal component

## Testing
- `yarn test` *(fails: window and nmapNse tests, jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04ef5b408328aa58920e765e6f57