### PR TITLE
feat: run commands in terminal

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Run in Terminal', keys: 'Ctrl+Enter' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -247,6 +247,16 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       [runWorker],
     );
 
+    useEffect(() => {
+      const handler = (e: Event) => {
+        const cmd = (e as CustomEvent<string>).detail;
+        runCommand(cmd);
+      };
+      window.addEventListener('terminal-run', handler as EventListener);
+      return () =>
+        window.removeEventListener('terminal-run', handler as EventListener);
+    }, [runCommand]);
+
     const autocomplete = useCallback(() => {
       const current = commandRef.current;
       const registry = registryRef.current;
@@ -421,6 +431,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
                   termRef.current?.focus();
                 }
               }}
+              aria-label="command palette input"
             />
             <ul className="max-h-40 overflow-y-auto">
               {Object.keys(registryRef.current)

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,18 +1,61 @@
-import { useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import TerminalOutput from './TerminalOutput';
+import usePersistentState from '../hooks/usePersistentState';
+import useKeymap from '../apps/settings/keymapRegistry';
 
 interface BuilderProps {
   doc: string;
   build: (params: Record<string, string>) => string;
+  openApp?: (id: string) => void;
 }
 
-export default function CommandBuilder({ doc, build }: BuilderProps) {
+export default function CommandBuilder({ doc, build, openApp }: BuilderProps) {
   const [params, setParams] = useState<Record<string, string>>({});
+  const [runInTerminal, setRunInTerminal] = usePersistentState<boolean>(
+    'command-builder:run-terminal',
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+  const { shortcuts } = useKeymap();
+  const runShortcut =
+    shortcuts.find((s) => s.description === 'Run in Terminal')?.keys ||
+    'Ctrl+Enter';
+
   const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
     setParams({ ...params, [key]: e.target.value });
   };
 
   const command = build(params);
+
+  const run = useCallback(() => {
+    if (!openApp) return;
+    openApp('terminal');
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('terminal-run', { detail: command })
+      );
+    }, 100);
+  }, [openApp, command]);
+
+  useEffect(() => {
+    if (!runInTerminal) return;
+    const parts = runShortcut.split('+');
+    const key = parts.pop() || '';
+    const handler = (e: KeyboardEvent) => {
+      const match =
+        e.key.toLowerCase() === key.toLowerCase() &&
+        (!parts.includes('Ctrl') || e.ctrlKey) &&
+        (!parts.includes('Alt') || e.altKey) &&
+        (!parts.includes('Shift') || e.shiftKey) &&
+        (!parts.includes('Meta') || e.metaKey);
+      if (match) {
+        e.preventDefault();
+        run();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [runInTerminal, runShortcut, run]);
 
   return (
     <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
@@ -35,9 +78,28 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
           className="border p-1 text-black w-full"
         />
       </label>
+      <label className="block mb-1">
+        <input
+          type="checkbox"
+          checked={runInTerminal}
+          onChange={(e) => setRunInTerminal(e.target.checked)}
+          className="mr-1"
+          aria-label="run in terminal"
+        />
+        Run in Terminal
+      </label>
       <div className="mt-2">
         <TerminalOutput text={command} ariaLabel="command output" />
       </div>
+      {runInTerminal && (
+        <button
+          type="button"
+          onClick={run}
+          className="mt-2 px-2 py-1 bg-ub-green text-black"
+        >
+          Run
+        </button>
+      )}
     </form>
   );
 }

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -15,7 +15,7 @@ const tabs = [
   { id: 'fixtures', label: 'Fixtures' },
 ];
 
-export default function SecurityTools() {
+export default function SecurityTools({ openApp }) {
   const [active, setActive] = useState('repeater');
   const [query, setQuery] = useState('');
   const [authorized, setAuthorized] = useState(false);
@@ -135,6 +135,7 @@ export default function SecurityTools() {
             onChange={e => setQuery(e.target.value)}
             placeholder="Search all tools"
             className="w-full mb-2 p-1 text-black text-xs"
+            aria-label="search all tools"
           />
           {query ? (
             <div className="text-xs">
@@ -201,6 +202,7 @@ export default function SecurityTools() {
                 <CommandBuilder
                   doc="Build a curl command. Output is copy-only and not executed."
                   build={({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim()}
+                  openApp={openApp}
                 />
               </div>
             )}
@@ -238,9 +240,19 @@ export default function SecurityTools() {
             {active === 'yara' && (
             <div>
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
+              <textarea
+                value={yaraRule}
+                onChange={e=>setYaraRule(e.target.value)}
+                className="w-full h-24 text-black p-1"
+                aria-label="yara rule"
+              />
               <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+              <textarea
+                value={sampleText}
+                readOnly
+                className="w-full h-24 text-black p-1"
+                aria-label="sample file"
+              />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>


### PR DESCRIPTION
## Summary
- add configurable Run in Terminal shortcut
- allow CommandBuilder to launch Terminal with built command
- wire Terminal to execute commands from external builders

## Testing
- `npx eslint apps/settings/keymapRegistry.ts components/CommandBuilder.tsx components/apps/security-tools/index.js apps/terminal/index.tsx`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba04f3908083288af15413831d497f