### PR TITLE
feat: add run dialog finder mode with categories

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import UbuntuApp from '../base/ubuntu_app';
-import apps from '../../apps.config';
+import apps, { games, utilities } from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Grid } from 'react-window';
 
@@ -22,25 +22,47 @@ function fuzzyHighlight(text, query) {
 
 export default function AppGrid({ openApp }) {
   const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('All');
   const gridRef = useRef(null);
   const columnCountRef = useRef(1);
   const [focusedIndex, setFocusedIndex] = useState(0);
 
+  const baseSet = useMemo(
+    () => new Set([...games.map((g) => g.id), ...utilities.map((u) => u.id)]),
+    []
+  );
+  const baseApps = useMemo(
+    () => apps.filter((a) => !baseSet.has(a.id)),
+    [baseSet]
+  );
+
+  const categories = useMemo(
+    () => ({
+      All: apps,
+      Applications: baseApps,
+      Utilities: utilities,
+      Games: games,
+    }),
+    [baseApps]
+  );
+
+  const items = categories[category] || [];
+
   const filtered = useMemo(() => {
-    if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
-    return apps
+    if (!query) return items.map((app) => ({ ...app, nodes: app.title }));
+    return items
       .map((app) => {
         const { matched, nodes } = fuzzyHighlight(app.title, query);
         return matched ? { ...app, nodes } : null;
       })
       .filter(Boolean);
-  }, [query]);
+  }, [query, items]);
 
   useEffect(() => {
     if (focusedIndex >= filtered.length) {
       setFocusedIndex(0);
     }
-  }, [filtered, focusedIndex]);
+  }, [filtered, focusedIndex, category]);
 
   const getColumnCount = (width) => {
     if (width >= 1024) return 8;
@@ -90,13 +112,30 @@ export default function AppGrid({ openApp }) {
 
   return (
     <div className="flex flex-col items-center h-full">
+      <div className="mt-4 mb-2 flex space-x-2">
+        {Object.keys(categories).map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setCategory(cat)}
+            className={`px-3 py-1 rounded text-white focus:outline-none ${
+              cat === category ? 'bg-black bg-opacity-20' : 'bg-black bg-opacity-10'
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        className="mb-6 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <div
+        className="w-full flex-1 h-[70vh] outline-none"
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+      >
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -494,8 +494,8 @@ export class Window extends Component {
             else if (e.key === 'ArrowUp') dy = -step;
             else if (e.key === 'ArrowDown') dy = step;
             if (dx !== 0 || dy !== 0) {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 const node = document.getElementById(this.id);
                 if (node) {
                     const match = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(node.style.transform);
@@ -525,40 +525,40 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();


### PR DESCRIPTION
## Summary
- add run dialog page with run/finder toggle and keyboard navigation
- expand app grid to support categories and search filtering
- guard window key handlers against missing event methods

## Testing
- `npm test` *(fails: Unable to find role="alert" in __tests__/nmapNse.test.tsx; jsdom localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04f497a083289fc8dbc14b5dc9a6