### PR TITLE
Add slide-out toast animation and bubble theme variables

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { kaliTheme } from '../../styles/themes/kali';
 
 interface ToastProps {
   message: string;
@@ -16,15 +17,20 @@ const Toast: React.FC<ToastProps> = ({
   duration = 6000,
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const closeRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
+      setVisible(false);
+      closeRef.current = setTimeout(() => {
+        onClose && onClose();
+      }, 300);
     }, duration);
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (closeRef.current) clearTimeout(closeRef.current);
     };
   }, [duration, onClose]);
 
@@ -32,7 +38,13 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 shadow-md flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      style={{
+        background: kaliTheme.bubble.background,
+        color: kaliTheme.bubble.text,
+        border: `1px solid ${kaliTheme.bubble.border}`,
+        borderRadius: 'var(--radius-md)',
+      }}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,10 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  /* Toast bubble theme variables */
+  --toast-bg: var(--color-surface);
+  --toast-text: var(--color-text);
+  --toast-border: var(--color-border);
   accent-color: var(--color-control-accent);
 }
 

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -3,6 +3,11 @@ export const kaliTheme = {
   text: 'var(--color-text)',
   accent: 'var(--color-primary)',
   sidebar: 'var(--color-secondary)',
+  bubble: {
+    background: 'var(--toast-bg)',
+    text: 'var(--toast-text)',
+    border: 'var(--toast-border)',
+  },
 };
 
 export type KaliTheme = typeof kaliTheme;


### PR DESCRIPTION
## Summary
- animate toasts with a slide-out transition and delay removal
- expose bubble styling via theme variables
- make slide-out the default toast animation

## Testing
- `yarn test` *(fails: __tests__/window.test.tsx TypeError: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04f81f848328946cc1371d1499df