### PR TITLE
feat: add toast notifications with log and DND

### DIFF
--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
-import Toast from '../../components/ui/Toast';
+import { useToast } from '../../hooks/useToast';
 
 interface Module {
   name: string;
@@ -47,9 +47,9 @@ const MetasploitPage: React.FC = () => {
   const [split, setSplit] = useState(60);
   const splitRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
-  const [toast, setToast] = useState('');
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('');
+  const { notify } = useToast();
 
   const allTags = useMemo(
     () =>
@@ -99,7 +99,7 @@ const MetasploitPage: React.FC = () => {
     };
   }, []);
 
-  const handleGenerate = () => setToast('Payload generated');
+  const handleGenerate = () => notify('Payload generated');
 
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
@@ -209,7 +209,6 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import NotificationBell from '../ui/NotificationBell';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -37,6 +38,7 @@ export default class Navbar extends Component {
                                 >
                                         <Clock />
                                 </div>
+                                <NotificationBell />
                                 <button
                                         type="button"
                                         id="status-bar"

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, type SVGProps } from 'react';
+import { useToast } from '../../hooks/useToast';
+
+const BellIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+    />
+  </svg>
+);
+
+const NotificationBell = () => {
+  const { log, dnd, setDnd } = useToast();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Notifications"
+        onClick={() => setOpen(!open)}
+        className="pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1"
+      >
+        <BellIcon className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-64 bg-ub-cool-grey text-ubt-grey rounded-md shadow border-black border border-opacity-20 z-50">
+          <div className="flex items-center justify-between px-2 py-1 border-b border-black border-opacity-20">
+            <span className="font-semibold">Notifications</span>
+            <label className="flex items-center gap-1 text-xs">
+              <input
+                type="checkbox"
+                checked={dnd}
+                onChange={() => setDnd(!dnd)}
+              />
+              DND
+            </label>
+          </div>
+          <ul className="max-h-60 overflow-auto">
+            {log.length ? (
+              [...log].reverse().map((t) => (
+                <li
+                  key={t.id}
+                  className="px-2 py-1 border-b border-black border-opacity-10 last:border-0"
+                >
+                  {t.message}
+                </li>
+              ))
+            ) : (
+              <li className="px-2 py-1 text-sm">No notifications</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;
+

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -6,6 +6,7 @@ interface ToastProps {
   onAction?: () => void;
   onClose?: () => void;
   duration?: number;
+  offset?: number;
 }
 
 const Toast: React.FC<ToastProps> = ({
@@ -14,6 +15,7 @@ const Toast: React.FC<ToastProps> = ({
   onAction,
   onClose,
   duration = 6000,
+  offset = 16,
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
@@ -32,7 +34,8 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      style={{ top: offset }}
+      className={`fixed left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/hooks/useToast.tsx
+++ b/hooks/useToast.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React, { createContext, useContext, useState } from 'react';
+import Toast from '../components/ui/Toast';
+import usePersistentState from './usePersistentState';
+
+interface ToastItem {
+  id: number;
+  message: string;
+}
+
+interface ToastContextType {
+  notify: (msg: string) => void;
+  log: ToastItem[];
+  dnd: boolean;
+  setDnd: (value: boolean) => void;
+}
+
+const ToastContext = createContext<ToastContextType>({
+  notify: () => {},
+  log: [],
+  dnd: false,
+  setDnd: () => {},
+});
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [log, setLog] = usePersistentState<ToastItem[]>("toast-log", []);
+  const [dnd, setDnd] = usePersistentState<boolean>("toast-dnd", false);
+  const [visible, setVisible] = useState<ToastItem[]>([]);
+
+  const notify = (message: string) => {
+    const item = { id: Date.now(), message };
+    setLog((prev) => [...prev, item]);
+    if (!dnd) {
+      setVisible((prev) => [...prev, item]);
+    }
+  };
+
+  const remove = (id: number) => {
+    setVisible((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return (
+    <ToastContext.Provider value={{ notify, log, dnd, setDnd }}>
+      {children}
+      {visible.map((t, i) => (
+        <Toast key={t.id} message={t.message} onClose={() => remove(t.id)} offset={16 + i * 56} />
+      ))}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { ToastProvider } from '../hooks/useToast';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <ToastProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </ToastProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add global toast context with log and Do Not Disturb toggle
- show toast history and DND control via bell icon in navbar
- integrate toast provider and update Metasploit to use it

## Testing
- `yarn lint apps/metasploit/index.tsx components/ui/Toast.tsx components/ui/NotificationBell.tsx components/screen/navbar.js pages/_app.jsx hooks/useToast.tsx` (fails: Unexpected global 'document' and others)
- `yarn tsc` (fails: Cannot write file ... because it would overwrite input file)
- `yarn test` (fails: e.g., FAIL __tests__/window.test.tsx, FAIL __tests__/game2048.test.tsx, FAIL __tests__/nmapNse.test.tsx, FAIL __tests__/reconng.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ba04f8d444832887bc4d2ce05b2e30