### PR TITLE
feat: add battery status plugin

### DIFF
--- a/__tests__/presentationMode.test.tsx
+++ b/__tests__/presentationMode.test.tsx
@@ -1,0 +1,11 @@
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+
+test('presentation mode toggles brightness', () => {
+  const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+  act(() => result.current.setBrightness(0.7));
+  act(() => result.current.setPresentationMode(true));
+  expect(result.current.brightness).toBe(1);
+  act(() => result.current.setPresentationMode(false));
+  expect(result.current.brightness).toBe(0.7);
+});

--- a/components/util-components/battery.tsx
+++ b/components/util-components/battery.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { useSettings } from '../../hooks/useSettings';
+
+const icon = {
+  good: '/themes/Yaru/status/battery-good-symbolic.svg',
+  low: '/themes/Yaru/status/battery-low-symbolic.svg',
+  charging: '/themes/Yaru/status/battery-good-charging-symbolic.svg',
+};
+
+export default function Battery() {
+  const { brightness, setBrightness, presentationMode, setPresentationMode } = useSettings();
+  const [open, setOpen] = useState(false);
+  const [level, setLevel] = useState(1);
+  const [charging, setCharging] = useState(false);
+
+  useEffect(() => {
+    let battery: any;
+    const handler = () => {
+      setLevel(battery.level);
+      setCharging(battery.charging);
+    };
+    if ('getBattery' in navigator) {
+      // @ts-ignore
+      navigator.getBattery().then((b) => {
+        battery = b;
+        handler();
+        b.addEventListener('levelchange', handler);
+        b.addEventListener('chargingchange', handler);
+      });
+    }
+    return () => {
+      if (battery) {
+        battery.removeEventListener('levelchange', handler);
+        battery.removeEventListener('chargingchange', handler);
+      }
+    };
+  }, []);
+
+  const pct = Math.round(level * 100);
+  let src = icon.good;
+  if (charging) {
+    src = icon.charging;
+  } else if (pct < 20) {
+    src = icon.low;
+  }
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="battery"
+        className="mx-1.5"
+        onClick={() => setOpen(!open)}
+      >
+        <span className="relative inline-block">
+          <Image
+            width={16}
+            height={16}
+            src={src}
+            alt="battery"
+            className="inline status-symbol w-4 h-4"
+            sizes="16px"
+          />
+          {presentationMode && (
+            <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full" />
+          )}
+        </span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-48 p-2 rounded bg-[var(--color-surface)] text-sm shadow">
+          <div className="mb-2">
+            Battery: {pct}% {charging && '⚡'}
+          </div>
+          <label className="flex items-center gap-2 mb-2">
+            <span className="whitespace-nowrap">Brightness</span>
+            <input
+              type="range"
+              min={0.5}
+              max={1}
+              step={0.01}
+              value={brightness}
+              onChange={(e) => setBrightness(parseFloat(e.target.value))}
+              className="ubuntu-slider flex-1"
+              disabled={presentationMode}
+            />
+          </label>
+          <label className="flex items-center justify-between">
+            <span>Presentation Mode</span>
+            <input
+              type="checkbox"
+              checked={presentationMode}
+              onChange={(e) => setPresentationMode(e.target.checked)}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import Battery from './battery';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
@@ -66,16 +67,7 @@ export default function Status() {
           sizes="16px"
         />
       </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
+      <Battery />
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getBrightness as loadBrightness,
+  setBrightness as saveBrightness,
+  getPresentationMode as loadPresentationMode,
+  setPresentationMode as savePresentationMode,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +67,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  brightness: number;
+  presentationMode: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +80,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setBrightness: (value: number) => void;
+  setPresentationMode: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +96,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  brightness: defaults.brightness,
+  presentationMode: defaults.presentationMode,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +109,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setBrightness: () => {},
+  setPresentationMode: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,7 +125,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [brightness, setBrightness] = useState<number>(defaults.brightness);
+  const [presentationMode, setPresentationMode] = useState<boolean>(defaults.presentationMode);
   const fetchRef = useRef<typeof fetch | null>(null);
+  const prevBrightness = useRef<number>(defaults.brightness);
 
   useEffect(() => {
     (async () => {
@@ -127,6 +142,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setBrightness(await loadBrightness());
+      setPresentationMode(await loadPresentationMode());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +253,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    document.documentElement.style.setProperty('--screen-brightness', String(brightness));
+    saveBrightness(brightness);
+  }, [brightness]);
+
+  useEffect(() => {
+    savePresentationMode(presentationMode);
+    if (presentationMode) {
+      prevBrightness.current = brightness;
+      setBrightness(1);
+    } else {
+      setBrightness(prevBrightness.current);
+    }
+  }, [presentationMode]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +282,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        brightness,
+        presentationMode,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +295,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setBrightness,
+        setPresentationMode,
       }}
     >
       {children}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,7 +19,12 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --screen-brightness: 1;
   accent-color: var(--color-control-accent);
+}
+
+body {
+  filter: brightness(var(--screen-brightness));
 }
 
 /* Dark theme */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  brightness: 1,
+  presentationMode: false,
 };
 
 export async function getAccent() {
@@ -123,6 +125,27 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getBrightness() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.brightness;
+  const stored = window.localStorage.getItem('brightness');
+  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.brightness;
+}
+
+export async function setBrightness(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('brightness', String(value));
+}
+
+export async function getPresentationMode() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.presentationMode;
+  return window.localStorage.getItem('presentation-mode') === 'true';
+}
+
+export async function setPresentationMode(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('presentation-mode', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +160,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('brightness');
+  window.localStorage.removeItem('presentation-mode');
 }
 
 export async function exportSettings() {
@@ -151,6 +176,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    brightness,
+    presentationMode,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +189,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getBrightness(),
+    getPresentationMode(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +204,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    brightness,
+    presentationMode,
     theme,
   });
 }
@@ -199,6 +230,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    brightness,
+    presentationMode,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +244,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (brightness !== undefined) await setBrightness(brightness);
+  if (presentationMode !== undefined) await setPresentationMode(presentationMode);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add interactive battery plugin with brightness slider and presentation mode toggle
- store brightness and presentation mode settings and apply screen brightness
- include presentation mode test coverage

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx; TypeError after run)*
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test __tests__/presentationMode.test.tsx` *(fails: TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68ba04f8a11c8328ac55783e062bbf35