### PR TITLE
feat: add Undercover theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ To send text or links directly into the Sticky Notes app:
 - Dynamic routes or API responses are not cached.
 - Future work may use `injectManifest` for finer control.
 
+### Undercover Theme
+
+A Windows-like appearance mode inspired by Kali's Undercover feature. Toggle **Undercover** in Settings → Appearance to swap icons and panels for a more discreet look.
+
 ---
 
 ## Environment Variables

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,7 +23,7 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(expect.arrayContaining(['default', 'undercover', 'neon', 'dark']));
     expect(unlocked).not.toContain('matrix');
   });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -129,6 +129,7 @@ export default function Settings() {
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>
+              <option value="undercover">Undercover</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,56 +1,42 @@
 import Image from 'next/image';
+import { useSettings } from '../hooks/useSettings';
+
+function useIconBase() {
+  const { theme } = useSettings();
+  return theme === 'undercover' ? '/themes/Undercover/window' : '/themes/Yaru/window';
+}
 
 export function CloseIcon() {
+  const base = useIconBase();
   return (
-    <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
-      alt="Close"
-      width={16}
-      height={16}
-    />
+    <Image src={`${base}/window-close-symbolic.svg`} alt="Close" width={16} height={16} />
   );
 }
 
 export function MinimizeIcon() {
+  const base = useIconBase();
   return (
-    <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
-      alt="Minimize"
-      width={16}
-      height={16}
-    />
+    <Image src={`${base}/window-minimize-symbolic.svg`} alt="Minimize" width={16} height={16} />
   );
 }
 
 export function MaximizeIcon() {
+  const base = useIconBase();
   return (
-    <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
-      alt="Maximize"
-      width={16}
-      height={16}
-    />
+    <Image src={`${base}/window-maximize-symbolic.svg`} alt="Maximize" width={16} height={16} />
   );
 }
 
 export function RestoreIcon() {
+  const base = useIconBase();
   return (
-    <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
-      alt="Restore"
-      width={16}
-      height={16}
-    />
+    <Image src={`${base}/window-restore-symbolic.svg`} alt="Restore" width={16} height={16} />
   );
 }
 
 export function PinIcon() {
+  const base = useIconBase();
   return (
-    <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
-      alt="Pin"
-      width={16}
-      height={16}
-    />
+    <Image src={`${base}/window-pin-symbolic.svg`} alt="Pin" width={16} height={16} />
   );
 }

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,57 +1,52 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { useSettings } from '../../hooks/useSettings';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
-
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <div
-                                        className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
-                                >
-                                        <Image
-                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
-                                                alt="Decompiler"
-                                                width={16}
-                                                height={16}
-                                                className="inline mr-1"
-                                        />
-                                        Activities
-                                </div>
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+export default function Navbar() {
+  const [statusCard, setStatusCard] = useState(false);
+  const { theme } = useSettings();
+  const iconTheme = theme === 'undercover' ? 'Undercover' : 'Yaru';
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <div className="pl-3 pr-1">
+        <Image
+          src={`/themes/${iconTheme}/status/network-wireless-signal-good-symbolic.svg`}
+          alt="network icon"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+      <div className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}>
+        <Image
+          src={`/themes/${iconTheme}/${theme === 'undercover' ? 'start-menu-symbolic.svg' : 'status/decompiler-symbolic.svg'}`}
+          alt={theme === 'undercover' ? 'Start' : 'Decompiler'}
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
+        {theme === 'undercover' ? 'Start' : 'Activities'}
+      </div>
+      <div
+        className={'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'}
+      >
+        <Clock />
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => {
+          setStatusCard(!statusCard);
+        }}
+        className={'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '}
+      >
+        <Status />
+        <QuickSettings open={statusCard} />
+      </button>
+    </div>
+  );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 taskbar" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -3,10 +3,9 @@ import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
-
 export default function Status() {
-  const { allowNetwork } = useSettings();
+  const { allowNetwork, theme } = useSettings();
+  const iconBase = theme === 'undercover' ? '/themes/Undercover/status' : '/themes/Yaru/status';
   const [online, setOnline] = useState(true);
 
   useEffect(() => {
@@ -47,7 +46,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={online ? `${iconBase}/network-wireless-signal-good-symbolic.svg` : `${iconBase}/network-wireless-signal-none-symbolic.svg`}
           alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
@@ -60,7 +59,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src={VOLUME_ICON}
+          src={`${iconBase}/audio-volume-medium-symbolic.svg`}
           alt="volume"
           className="inline status-symbol w-4 h-4"
           sizes="16px"
@@ -70,8 +69,8 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
+          src={`${iconBase}/battery-good-symbolic.svg`}
+          alt="battery"
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -60,6 +60,7 @@ export default function ThemeSettings() {
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="undercover">Undercover</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/public/themes/Undercover/status/audio-volume-medium-symbolic.svg
+++ b/public/themes/Undercover/status/audio-volume-medium-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M3 6v4h3l4 3V3L6 6H3z" fill="black"/>
+  <path d="M10 5a3 3 0 010 6" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/public/themes/Undercover/status/battery-good-symbolic.svg
+++ b/public/themes/Undercover/status/battery-good-symbolic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1" y="4" width="12" height="8" fill="none" stroke="black" stroke-width="1"/>
+  <rect x="13" y="6" width="2" height="4" fill="black"/>
+  <rect x="2" y="5" width="10" height="6" fill="black"/>
+</svg>

--- a/public/themes/Undercover/status/network-wireless-signal-good-symbolic.svg
+++ b/public/themes/Undercover/status/network-wireless-signal-good-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="2" y="11" width="2" height="3" fill="black"/>
+  <rect x="5" y="9" width="2" height="5" fill="black"/>
+  <rect x="8" y="7" width="2" height="7" fill="black"/>
+  <rect x="11" y="5" width="2" height="9" fill="black"/>
+</svg>

--- a/public/themes/Undercover/status/network-wireless-signal-none-symbolic.svg
+++ b/public/themes/Undercover/status/network-wireless-signal-none-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M4 4l8 8M12 4l-8 8" stroke="black" stroke-width="2"/>
+</svg>

--- a/public/themes/Undercover/status/start-menu-symbolic.svg
+++ b/public/themes/Undercover/status/start-menu-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1" y="1" width="6" height="6" fill="black"/>
+  <rect x="9" y="1" width="6" height="6" fill="black"/>
+  <rect x="1" y="9" width="6" height="6" fill="black"/>
+  <rect x="9" y="9" width="6" height="6" fill="black"/>
+</svg>

--- a/public/themes/Undercover/window/window-close-symbolic.svg
+++ b/public/themes/Undercover/window/window-close-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M4 4l8 8M12 4l-8 8" stroke="black" stroke-width="2"/>
+</svg>

--- a/public/themes/Undercover/window/window-maximize-symbolic.svg
+++ b/public/themes/Undercover/window/window-maximize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="3" y="3" width="10" height="10" fill="none" stroke="black" stroke-width="1"/>
+</svg>

--- a/public/themes/Undercover/window/window-minimize-symbolic.svg
+++ b/public/themes/Undercover/window/window-minimize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="3" y="8" width="10" height="2" fill="black"/>
+</svg>

--- a/public/themes/Undercover/window/window-pin-symbolic.svg
+++ b/public/themes/Undercover/window/window-pin-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M7 1v4H5l1 3v6l2-2 2 2V8l1-3H9V1z" fill="black"/>
+</svg>

--- a/public/themes/Undercover/window/window-restore-symbolic.svg
+++ b/public/themes/Undercover/window/window-restore-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="5" y="5" width="8" height="8" fill="none" stroke="black" stroke-width="1"/>
+  <rect x="3" y="3" width="8" height="8" fill="none" stroke="black" stroke-width="1"/>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,31 @@ html[data-theme='matrix'] {
 
 }
 
+/* Undercover (Windows-like) theme */
+html[data-theme='undercover'] {
+  --color-bg: #f0f0f0;
+  --color-text: #000000;
+  --color-primary: #0078d7;
+  --color-secondary: #f3f3f3;
+  --color-accent: #0078d7;
+  --color-muted: #e5e5e5;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d0d0d0;
+  --color-terminal: #008000;
+  --color-dark: #f0f0f0;
+}
+
+html[data-theme='undercover'] .main-navbar-vp,
+html[data-theme='undercover'] .taskbar {
+  background-color: #e5e5e5;
+  color: #000000;
+}
+
+html[data-theme='undercover'] .taskbar {
+  background-color: #c0c0c0;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  undercover: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add Windows-like Undercover theme option in Settings
- switch icons, panels and CSS variables when Undercover selected
- document Kali Undercover mode in README

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window snapping finalize and release, unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68ba04fac3a08328983f28ba4a52b151