### PR TITLE
feat: enhance lock screen greeter

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,14 +1,23 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
 export default function LockScreen(props) {
 
     const { wallpaper } = useSettings();
+    const [password, setPassword] = useState('');
+    const inputRef = useRef(null);
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
+    useEffect(() => {
+        if (props.isLocked) {
+            inputRef.current?.focus();
+        }
+    }, [props.isLocked]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setPassword('');
+        props.unLockScreen();
     };
 
     return (
@@ -19,18 +28,30 @@ export default function LockScreen(props) {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-md' : 'blur-none'}`}
             />
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
+            <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
+                <div className="absolute top-10 text-center">
+                    <div className="text-7xl">
+                        <Clock onlyTime={true} />
+                    </div>
+                    <div className="mt-2 text-xl font-medium">
+                        <Clock onlyDay={true} />
+                    </div>
                 </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
-                </div>
+                <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
+                    <img src="/images/logos/bitmoji.png" alt="avatar" className="w-24 h-24 rounded-full mb-4 border-2 border-white" />
+                    <div className="text-2xl mb-4">kali</div>
+                    <input
+                        ref={inputRef}
+                        type="password"
+                        className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
+                        placeholder="Password"
+                        aria-label="Password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                    />
+                </form>
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary
- add centered login panel with avatar, username, and password field
- blur wallpaper and show clock above login panel similar to Xfce
- unlock desktop immediately on password submit without backend auth

## Testing
- `npx eslint components/screen/lock_screen.js`
- `yarn test` *(fails: window and NmapNSE tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba05002c7c8328b1abde2812284bb5