### PR TITLE
feat: add power settings link

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,12 +1,15 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+    const [sleep, setSleep] = usePersistentState('power-sleep', 'never');
+    const [blank, setBlank] = usePersistentState('power-blank', 'never');
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -37,6 +40,14 @@ export function Settings() {
         let l1 = luminance(hexToRgb(hex1)) + 0.05;
         let l2 = luminance(hexToRgb(hex2)) + 0.05;
         return l1 > l2 ? l1 / l2 : l2 / l1;
+    }, []);
+
+    useEffect(() => {
+        const tab = window.localStorage.getItem('settings-open-tab');
+        if (tab === 'power') {
+            document.getElementById('power-section')?.scrollIntoView();
+            window.localStorage.removeItem('settings-open-tab');
+        }
     }, []);
 
     const accentText = useCallback(() => {
@@ -196,7 +207,7 @@ export function Settings() {
                 </div>
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
-                {
+                { 
                     wallpapers.map((name, index) => (
                         <div
                             key={name}
@@ -218,6 +229,33 @@ export function Settings() {
                         ></div>
                     ))
                 }
+            </div>
+            <div id="power-section" className="border-t border-gray-900 mt-4 pt-4">
+                <h2 className="text-center mb-4">Power</h2>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Sleep after:</label>
+                    <select
+                        value={sleep}
+                        onChange={(e) => setSleep(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        <option value="never">Never</option>
+                        <option value="5">5 minutes</option>
+                        <option value="15">15 minutes</option>
+                    </select>
+                </div>
+                <div className="flex justify-center my-4">
+                    <label className="mr-2 text-ubt-grey">Blank screen after:</label>
+                    <select
+                        value={blank}
+                        onChange={(e) => setBlank(e.target.value)}
+                        className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                        <option value="never">Never</option>
+                        <option value="1">1 minute</option>
+                        <option value="5">5 minutes</option>
+                    </select>
+                </div>
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
                 <button

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -128,6 +128,13 @@ export class Desktop extends Component {
                 this.openApp("settings");
             });
         }
+        document.addEventListener('open-settings', (e) => {
+            const tab = e.detail && e.detail.tab;
+            if (tab) {
+                window.localStorage.setItem('settings-open-tab', tab);
+            }
+            this.openApp('settings');
+        });
     }
 
     setContextListeners = () => {

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -52,6 +52,19 @@ const QuickSettings = ({ open }: Props) => {
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>
+      <div className="px-4 pt-2 border-t border-black border-opacity-20 mt-2">
+        <button
+          className="w-full text-left text-blue-300 hover:underline"
+          onClick={() => {
+            window.localStorage.setItem('settings-open-tab', 'power');
+            document.dispatchEvent(
+              new CustomEvent('open-settings', { detail: { tab: 'power' } }),
+            );
+          }}
+        >
+          Power Manager Settings…
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add power management link to quick settings popover
- allow navigation from panel to Settings power section
- stub sleep and blank screen options with persistence

## Testing
- `npm test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; NiktoPage › builds command preview and shows fix suggestion)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04fd571c8328bc55009ce5b7508c