### PR TITLE
fix: remove hidden menu items from tab order

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -35,6 +35,7 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -30,6 +30,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
@@ -40,6 +41,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
@@ -50,6 +52,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
@@ -60,6 +63,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -37,6 +37,7 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
@@ -46,6 +47,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
+                tabIndex={props.active ? 0 : -1}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">Close</span>


### PR DESCRIPTION
## Summary
- ensure context menu items are not focusable when hidden by adding conditional `tabIndex`

## Testing
- `yarn lint components/context-menus/app-menu.js components/context-menus/default.js components/context-menus/taskbar-menu.js` *(fails: Unexpected global 'document')*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ba187d696083288c6531d4db621485