### PR TITLE
fix: prevent focus on hidden screen elements

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -9,6 +9,7 @@ function BootingScreen(props) {
                 ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
                 contentVisibility: 'auto',
             }}
+            aria-hidden={!(props.visible || props.isShutDown)}
             className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
             <Image
                 width={400}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -15,6 +15,7 @@ export default function LockScreen(props) {
         <div
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
+            aria-hidden={!props.isLocked}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
                 src={`/wallpapers/${wallpaper}.webp`}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -113,22 +113,32 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', false);
 	};
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+        render() {
+                const screenInactive = this.state.screen_locked || this.state.booting_screen || this.state.shutDownScreen;
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
+                                        unLockScreen={this.unLockScreen}
+                                />
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
+                                <div
+                                        aria-hidden={screenInactive}
+                                        tabIndex={screenInactive ? -1 : undefined}
+                                        inert={screenInactive || undefined}
+                                >
+                                        <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                        <Desktop
+                                                bg_image_name={this.state.bg_image_name}
+                                                changeBackgroundImage={this.changeBackgroundImage}
+                                        />
+                                </div>
+                        </div>
+                );
+        }
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -152,6 +152,7 @@ function MyApp(props) {
       <div className={ubuntu.className}>
         <a
           href="#app-grid"
+          tabIndex={-1}
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
         >
           Skip to app grid

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -30,7 +30,7 @@ const InstallButton = dynamic(
  */
 const App = () => (
   <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
+    <a href="#window-area" tabIndex={-1} className="sr-only focus:not-sr-only">
       Skip to content
     </a>
     <Meta />


### PR DESCRIPTION
## Summary
- hide locked or booting desktop sections using `inert` and `aria-hidden`
- ensure skip links are removed from tab order
- mark lock and boot screens as hidden when inactive

## Testing
- `npx eslint pages/_app.jsx pages/index.jsx components/ubuntu.js components/screen/lock_screen.js components/screen/booting_screen.js --ext .js,.jsx,.ts,.tsx`
- `npx jest` *(fails: e.preventDefault is not a function; unable to find role="alert"; cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68ba18e1dbac83288a11ed717fdf024c