### PR TITLE
feat: add tooltip for icon-only panel button

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { safeLocalStorage } from '../../utils/safeStorage';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -12,24 +13,36 @@ export default class Navbar extends Component {
 		};
 	}
 
-	render() {
-		return (
+        render() {
+                const menuTitle =
+                        this.props.menuTitle ||
+                        safeLocalStorage?.getItem('app:panel-menu-title') ||
+                        'Activities';
+                const iconOnly =
+                        this.props.iconOnly !== undefined
+                                ? this.props.iconOnly
+                                : safeLocalStorage?.getItem('app:panel-icon-only') === 'true';
+
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
-                                <div
+                                <button
+                                        type="button"
                                         className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
+                                        title={iconOnly ? menuTitle : undefined}
+                                        aria-label={menuTitle}
                                 >
                                         <Image
                                                 src="/themes/Yaru/status/decompiler-symbolic.svg"
                                                 alt="Decompiler"
                                                 width={16}
                                                 height={16}
-                                                className="inline mr-1"
+                                                className={`inline${iconOnly ? '' : ' mr-1'}`}
                                         />
-                                        Activities
-                                </div>
+                                        {iconOnly ? null : menuTitle}
+                                </button>
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
@@ -51,7 +64,7 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- detect icon-only mode in navbar panel button
- show menu title as tooltip and read from settings or props

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a8fa410832880606eee10bf0a5b