### PR TITLE
feat: track recent app launches

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import { getRecent } from '../../utils/recent';
 
 class AllApplications extends React.Component {
     constructor() {
@@ -8,6 +9,7 @@ class AllApplications extends React.Component {
             query: '',
             apps: [],
             unfilteredApps: [],
+            recent: [],
         };
     }
 
@@ -17,7 +19,11 @@ class AllApplications extends React.Component {
         games.forEach((game) => {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
-        this.setState({ apps: combined, unfilteredApps: combined });
+        const recentIds = getRecent();
+        const recent = recentIds
+            .map((id) => combined.find((app) => app.id === id))
+            .filter(Boolean);
+        this.setState({ apps: combined, unfilteredApps: combined, recent });
     }
 
     handleChange = (e) => {
@@ -53,6 +59,21 @@ class AllApplications extends React.Component {
         ));
     };
 
+    renderRecent = () => {
+        const apps = this.state.recent || [];
+        return apps.map((app) => (
+            <UbuntuApp
+                key={'recent-' + app.id}
+                name={app.title}
+                id={app.id}
+                icon={app.icon}
+                openApp={() => this.openApp(app.id)}
+                disabled={app.disabled}
+                prefetch={app.screen?.prefetch}
+            />
+        ));
+    };
+
     render() {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
@@ -62,6 +83,14 @@ class AllApplications extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
+                {this.state.recent.length > 0 && (
+                    <div className="mb-8 flex flex-col items-center w-full">
+                        <h2 className="mb-4 text-lg">Recently Used</h2>
+                        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-4 place-items-center">
+                            {this.renderRecent()}
+                        </div>
+                    </div>
+                )}
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,6 +22,7 @@ import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { addRecent } from '../../utils/recent';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 
 export class Desktop extends Component {
@@ -584,6 +585,8 @@ export class Desktop extends Component {
 
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
+
+        addRecent(objId);
 
         // if app is already open, focus it instead of spawning a new window
         if (this.state.closed_windows[objId] === false) {

--- a/utils/recent.ts
+++ b/utils/recent.ts
@@ -1,0 +1,24 @@
+import { safeLocalStorage } from './safeStorage';
+
+const KEY = 'recent-apps';
+const LIMIT = 10;
+
+export function getRecent(): string[] {
+  if (!safeLocalStorage) return [];
+  try {
+    const stored = safeLocalStorage.getItem(KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addRecent(id: string): void {
+  if (!safeLocalStorage) return;
+  const list = getRecent();
+  const idx = list.indexOf(id);
+  if (idx !== -1) list.splice(idx, 1);
+  list.unshift(id);
+  if (list.length > LIMIT) list.length = LIMIT;
+  safeLocalStorage.setItem(KEY, JSON.stringify(list));
+}


### PR DESCRIPTION
## Summary
- add LRU store for recent app IDs
- record app launches and surface them in Whisker menu

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a8a927c8328a2b13c49b1b52e19