### PR TITLE
feat(xdg): add desktop and menu parsers

### DIFF
--- a/lib/xdg/desktop.ts
+++ b/lib/xdg/desktop.ts
@@ -1,0 +1,40 @@
+export interface DesktopEntry {
+  name: string;
+  exec: string;
+  icon: string;
+  categories: string[];
+}
+
+export interface DesktopLikeJSON {
+  Name: string;
+  Exec: string;
+  Icon?: string;
+  Categories?: string[] | string;
+}
+
+/**
+ * Parse a .desktop-like JSON object into a normalized DesktopEntry.
+ * Accepts both array or semicolon-separated string for Categories.
+ */
+export function parseDesktopEntry(data: DesktopLikeJSON): DesktopEntry {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid desktop entry');
+  }
+
+  const name = String(data.Name ?? '').trim();
+  const exec = String(data.Exec ?? '').trim();
+  const icon = String(data.Icon ?? '').trim();
+  let categories: string[] = [];
+
+  if (Array.isArray(data.Categories)) {
+    categories = data.Categories.map((c) => String(c).trim()).filter(Boolean);
+  } else if (typeof data.Categories === 'string') {
+    categories = data.Categories.split(';').map((c) => c.trim()).filter(Boolean);
+  }
+
+  if (!name || !exec) {
+    throw new Error('Desktop entry must include Name and Exec');
+  }
+
+  return { name, exec, icon, categories };
+}

--- a/lib/xdg/menu.ts
+++ b/lib/xdg/menu.ts
@@ -1,0 +1,32 @@
+import { DesktopEntry } from './desktop';
+
+// Primary categories defined by the XDG menu specification
+export const PRIMARY_CATEGORIES = [
+  'AudioVideo',
+  'Development',
+  'Education',
+  'Game',
+  'Graphics',
+  'Network',
+  'Office',
+  'Settings',
+  'System',
+  'Utility',
+];
+
+export type Menu<T extends DesktopEntry = DesktopEntry> = Record<string, T[]>;
+
+/**
+ * Group desktop entries by their primary category. If no primary
+ * category is present, entries are grouped under "Other".
+ */
+export function buildMenu<T extends DesktopEntry>(entries: T[]): Menu<T> {
+  const menu: Menu<T> = {};
+  for (const entry of entries) {
+    const category =
+      entry.categories.find((c) => PRIMARY_CATEGORIES.includes(c)) || 'Other';
+    if (!menu[category]) menu[category] = [];
+    menu[category].push(entry);
+  }
+  return menu;
+}


### PR DESCRIPTION
## Summary
- parse .desktop style JSON entries and normalize fields
- group desktop entries by primary XDG categories
- use XDG parsers to build categorized All Applications menu

## Testing
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert")*
- `yarn lint components/screen/all-applications.js lib/xdg/desktop.ts lib/xdg/menu.ts` *(fails: Unexpected global 'document'; Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a8cbf2c8328ad3e4aab3981ece7