### PR TITLE
feat(search): integrate fuse.js weighted search

### DIFF
--- a/__tests__/whiskerMenuSearch.test.tsx
+++ b/__tests__/whiskerMenuSearch.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AllApplications from "../components/screen/all-applications";
+
+test('Terminal ranks highest when searching "ter"', async () => {
+  const apps = [
+    {
+      id: "terminal",
+      title: "Terminal",
+      icon: "",
+      disabled: false,
+      favourite: true,
+    },
+    {
+      id: "serial-terminal",
+      title: "Serial Terminal",
+      icon: "",
+      disabled: false,
+      favourite: false,
+    },
+    {
+      id: "tetris",
+      title: "Tetris",
+      icon: "",
+      disabled: false,
+      favourite: false,
+    },
+  ];
+  const { container } = render(
+    <AllApplications apps={apps} games={[]} openApp={() => {}} />,
+  );
+  await screen.findByLabelText("Terminal");
+  const input = screen.getByPlaceholderText("Search");
+  await userEvent.type(input, "ter");
+  await new Promise((r) => setTimeout(r, 100));
+  const appNodes = container.querySelectorAll("[data-app-id]");
+  expect(appNodes[0].getAttribute("data-app-id")).toBe("terminal");
+});

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,74 +1,104 @@
-import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import React from "react";
+import UbuntuApp from "../base/ubuntu_app";
+import Fuse from "fuse.js";
 
 class AllApplications extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            query: '',
-            apps: [],
-            unfilteredApps: [],
-        };
-    }
-
-    componentDidMount() {
-        const { apps = [], games = [] } = this.props;
-        const combined = [...apps];
-        games.forEach((game) => {
-            if (!combined.some((app) => app.id === game.id)) combined.push(game);
-        });
-        this.setState({ apps: combined, unfilteredApps: combined });
-    }
-
-    handleChange = (e) => {
-        const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
+  constructor() {
+    super();
+    this.state = {
+      query: "",
+      apps: [],
+      unfilteredApps: [],
     };
+    this.searchTimer = null;
+    this.fuse = null;
+  }
 
-    openApp = (id) => {
-        if (typeof this.props.openApp === 'function') {
-            this.props.openApp(id);
-        }
-    };
+  componentDidMount() {
+    const { apps = [], games = [] } = this.props;
+    const combined = [...apps];
+    games.forEach((game) => {
+      if (!combined.some((app) => app.id === game.id)) combined.push(game);
+    });
+    this.fuse = new Fuse(combined, {
+      keys: ["title"],
+      includeScore: true,
+      ignoreLocation: true,
+      threshold: 0.4,
+    });
+    this.setState({ apps: combined, unfilteredApps: combined });
+  }
 
-    renderApps = () => {
-        const apps = this.state.apps || [];
-        return apps.map((app) => (
-            <UbuntuApp
-                key={app.id}
-                name={app.title}
-                id={app.id}
-                icon={app.icon}
-                openApp={() => this.openApp(app.id)}
-                disabled={app.disabled}
-                prefetch={app.screen?.prefetch}
-            />
-        ));
-    };
+  componentWillUnmount() {
+    clearTimeout(this.searchTimer);
+  }
 
-    render() {
-        return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
-                </div>
-            </div>
-        );
+  handleChange = (e) => {
+    const value = e.target.value;
+    this.setState({ query: value });
+    clearTimeout(this.searchTimer);
+    this.searchTimer = setTimeout(() => {
+      this.runSearch(value);
+    }, 75);
+  };
+
+  runSearch = (value) => {
+    const { unfilteredApps } = this.state;
+    if (!value) {
+      this.setState({ apps: unfilteredApps });
+      return;
     }
+    const lower = value.toLowerCase();
+    const results = this.fuse.search(lower, { limit: unfilteredApps.length });
+    const ranked = results
+      .map(({ item, score }) => {
+        let bonus = 0;
+        if (item.favourite) bonus += 3;
+        if (item.title.toLowerCase().startsWith(lower)) bonus += 2;
+        return { item, rank: bonus - (score ?? 0) };
+      })
+      .sort((a, b) => b.rank - a.rank)
+      .map((r) => r.item);
+    this.setState({ apps: ranked });
+  };
+
+  openApp = (id) => {
+    if (typeof this.props.openApp === "function") {
+      this.props.openApp(id);
+    }
+  };
+
+  renderApps = () => {
+    const apps = this.state.apps || [];
+    return apps.map((app) => (
+      <UbuntuApp
+        key={app.id}
+        name={app.title}
+        id={app.id}
+        icon={app.icon}
+        openApp={() => this.openApp(app.id)}
+        disabled={app.disabled}
+        prefetch={app.screen?.prefetch}
+      />
+    ));
+  };
+
+  render() {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+        <input
+          className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+          placeholder="Search"
+          aria-label="Search"
+          value={this.state.query}
+          onChange={this.handleChange}
+        />
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+          {this.renderApps()}
+        </div>
+      </div>
+    );
+  }
 }
 
 export default AllApplications;
-

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "fuse.js": "^7.1.0",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,6 +7640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "fuse.js@npm:7.1.0"
+  checksum: 10c0/c0d1b1d192a4bdf3eade897453ddd28aff96b70bf3e49161a45880f9845ebaee97265595db633776700a5bcf8942223c752754a848d70c508c3c9fd997faad1e
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -13911,6 +13918,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    fuse.js: "npm:^7.1.0"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- use fuse.js for application search
- debounce search input ~75ms
- weight favorites and prefix matches so Terminal ranks first for "ter"

## Testing
- `npx eslint components/screen/all-applications.js __tests__/whiskerMenuSearch.test.tsx`
- `yarn test __tests__/whiskerMenuSearch.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a8d676c8328883341d4821ecaea