### PR TITLE
feat(panel): add status tray plugin

### DIFF
--- a/components/panel/plugins/StatusTray.tsx
+++ b/components/panel/plugins/StatusTray.tsx
@@ -1,0 +1,49 @@
+'use client';
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type TrayContext = {
+  /** Register a tray icon. */
+  registerIcon: (id: string, icon: ReactNode) => void;
+  /** Remove a tray icon. */
+  unregisterIcon: (id: string) => void;
+};
+
+const StatusTrayContext = createContext<TrayContext | null>(null);
+
+export function useStatusTray(): TrayContext {
+  const ctx = useContext(StatusTrayContext);
+  if (!ctx) {
+    throw new Error('useStatusTray must be used within <StatusTray>');
+  }
+  return ctx;
+}
+
+export default function StatusTray({ children }: { children?: ReactNode }) {
+  const [icons, setIcons] = useState<Record<string, ReactNode>>({});
+
+  const registerIcon = (id: string, icon: ReactNode) => {
+    setIcons((prev) => ({ ...prev, [id]: icon }));
+  };
+
+  const unregisterIcon = (id: string) => {
+    setIcons((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  return (
+    <StatusTrayContext.Provider value={{ registerIcon, unregisterIcon }}>
+      <div className="flex items-center gap-1 px-2 bg-ub-cool-grey border border-ubt-cool-grey rounded-sm">
+        {Object.entries(icons).map(([id, icon]) => (
+          <div key={id} className="w-tray-icon h-tray-icon flex items-center justify-center">
+            {icon}
+          </div>
+        ))}
+        {children}
+      </div>
+    </StatusTrayContext.Provider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add StatusTray plugin for panel that hosts app icons
- expose context API to register/unregister tray icons
- style tray to mimic Xfce's notifier area

## Testing
- `npx eslint components/panel/plugins/StatusTray.tsx`
- `yarn test __tests__/openvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a981cb8832894adabaa7badeb1d