### PR TITLE
feat(panel): support panel rows setting

### DIFF
--- a/__tests__/navbarLayout.test.tsx
+++ b/__tests__/navbarLayout.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Navbar from '../components/screen/navbar';
+
+describe('Navbar layout', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('applies grid rows from preferences', () => {
+    window.localStorage.setItem('app:panel-rows', '2');
+    const { container } = render(<Navbar />);
+    const nav = container.firstChild as HTMLElement;
+    expect(nav.style.gridTemplateRows).toBe('repeat(2, auto)');
+  });
+});
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,57 +1,74 @@
-import React, { Component } from 'react';
+"use client";
+
+import { useState } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import usePersistentState from '../../hooks/usePersistentState';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+/**
+ * Top panel showing network status, activities, clock and system menu.
+ *
+ * The layout previously relied on a single row flex container which made it
+ * difficult to support multi-row configurations or vertical orientations. This
+ * component now uses CSS grid so the number of rows and layout direction can be
+ * customised through persisted settings.
+ */
+export default function Navbar() {
+  const [statusCard, setStatusCard] = useState(false);
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <div
-                                        className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
-                                >
-                                        <Image
-                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
-                                                alt="Decompiler"
-                                                width={16}
-                                                height={16}
-                                                className="inline mr-1"
-                                        />
-                                        Activities
-                                </div>
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  // Persisted preference for number of panel rows. Defaults to a single row.
+  const [rows] = usePersistentState('app:panel-rows', 1);
+  // Orientation of the panel – 'horizontal' for top/bottom panels or 'vertical'
+  // for side panels. Currently only the horizontal orientation is exposed via
+  // the UI but the layout is prepared for future expansion.
+  const [orientation] = usePersistentState('app:panel-orientation', 'horizontal');
+
+  const gridClasses = orientation === 'vertical' ? 'grid grid-flow-row auto-cols-max' : 'grid grid-flow-col auto-rows-min';
+  const style =
+    orientation === 'vertical'
+      ? { gridTemplateColumns: `repeat(${rows}, minmax(0,1fr))` }
+      : { gridTemplateRows: `repeat(${rows}, auto)` };
+
+  return (
+    <div
+      className={`main-navbar-vp absolute top-0 right-0 w-screen shadow-md bg-ub-grey text-ubt-grey text-sm select-none z-50 ${gridClasses}`}
+      style={style}
+    >
+      <div className="pl-3 pr-1 place-self-center">
+        <Image
+          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+          alt="network icon"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+      <div className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 place-self-center">
+        <Image
+          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          alt="Decompiler"
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
+        Activities
+      </div>
+      <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 place-self-center">
+        <Clock />
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => setStatusCard(!statusCard)}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 place-self-center"
+      >
+        <Status />
+        <QuickSettings open={statusCard} />
+      </button>
+    </div>
+  );
 }
+

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -35,6 +35,7 @@ export default function ThemeSettings() {
   const { theme, setTheme } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
+  const [panelRows, setPanelRows] = usePersistentState('app:panel-rows', 1);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setTheme(e.target.value);
@@ -89,6 +90,18 @@ export default function ThemeSettings() {
               style={{ width: panelSize, height: panelSize }}
             ></div>
           </div>
+        </div>
+
+        <div className="mt-6">
+          <h2 className="text-lg mb-2">Panel Rows</h2>
+          <input
+            type="number"
+            min={1}
+            max={4}
+            value={panelRows}
+            onChange={(e) => setPanelRows(Number(e.target.value))}
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey w-20"
+          />
         </div>
 
         <div className="mt-6">


### PR DESCRIPTION
## Summary
- refactor top panel to use CSS grid with configurable rows and orientation
- add Panel Rows option to Preferences
- cover panel row preference with unit test

## Testing
- `npm test` *(fails: e.preventDefault is not a function in window.test.tsx, cannot read _origin in settingsStore.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a9bdb108328916ce3cc4bfbb16e