### PR TITLE
feat: add window shade toggle and context menu

### DIFF
--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function WindowMenu(props) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, props.active);
+    useRovingTabIndex(menuRef, props.active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose();
+        }
+    };
+
+    const handleShade = () => {
+        props.onShade && props.onShade();
+        props.onClose && props.onClose();
+    };
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-hidden={!props.active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button
+                type="button"
+                onClick={handleShade}
+                role="menuitem"
+                aria-label={props.shaded ? 'Unshade Window' : 'Shade Window'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.shaded ? 'Unshade' : 'Shade'}</span>
+            </button>
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -19,6 +19,7 @@ import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
+import WindowMenu from '../context-menus/window-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -46,6 +47,7 @@ export class Desktop extends Component {
                 default: false,
                 app: false,
                 taskbar: false,
+                window: false,
             },
             context_app: null,
             showNameBar: false,
@@ -257,6 +259,13 @@ export class Desktop extends Component {
                 });
                 this.setState({ context_app: appId }, () => this.showContextMenu(e, "taskbar"));
                 break;
+            case "window":
+                ReactGA.event({
+                    category: `Context Menu`,
+                    action: `Opened Window Context Menu`
+                });
+                this.setState({ context_app: appId }, () => this.showContextMenu(e, "window"));
+                break;
             default:
                 ReactGA.event({
                     category: `Context Menu`,
@@ -287,6 +296,10 @@ export class Desktop extends Component {
             case "taskbar":
                 ReactGA.event({ category: `Context Menu`, action: `Opened Taskbar Context Menu` });
                 this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "taskbar"));
+                break;
+            case "window":
+                ReactGA.event({ category: `Context Menu`, action: `Opened Window Context Menu` });
+                this.setState({ context_app: appId }, () => this.showContextMenu(fakeEvent, "window"));
                 break;
             default:
                 ReactGA.event({ category: `Context Menu`, action: `Opened Default Context Menu` });
@@ -923,6 +936,16 @@ export class Desktop extends Component {
                         this.closeApp(id);
                     }}
                     onCloseMenu={this.hideAllContextMenu}
+                />
+                <WindowMenu
+                    active={this.state.context_menus.window}
+                    shaded={(this.state.context_app ? (document.getElementById(this.state.context_app)?.dataset.shaded === 'true') : false)}
+                    onShade={() => {
+                        const id = this.state.context_app;
+                        if (!id) return;
+                        document.getElementById(id)?.dispatchEvent(new CustomEvent('shade-toggle'));
+                    }}
+                    onClose={this.hideAllContextMenu}
                 />
 
                 {/* Folder Input Name Bar */}


### PR DESCRIPTION
## Summary
- add `shaded` window state and toggle logic
- support double-click titlebar to shade/unshade
- introduce window context menu with shade option

## Testing
- `npm test __tests__/window.test.tsx` *(fails: e.preventDefault is not a function)*
- `npm test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68ba1a9e34908328b4d474dccb94e1d2