### PR TITLE
feat: add top-edge window maximize snapping

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -80,6 +80,43 @@ describe('Window snapping preview', () => {
     expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
   });
 
+  it('shows maximize preview when dragged near top edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Simulate being near the top edge
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: 5,
+      right: 300,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: 5,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+  });
+
   it('hides preview when away from edge', () => {
     const ref = React.createRef<Window>();
     render(
@@ -110,6 +147,59 @@ describe('Window snapping preview', () => {
       toJSON: () => {}
     });
 
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    expect(screen.queryByTestId('snap-preview')).toBeNull();
+  });
+
+  it('cancels preview when dragging away from edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Start near the left edge
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 10,
+      right: 105,
+      bottom: 110,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 10,
+      toJSON: () => {}
+    });
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
+
+    // Move away from edges
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: 200,
+      right: 300,
+      bottom: 300,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: 200,
+      toJSON: () => {}
+    });
     act(() => {
       ref.current!.handleDrag();
     });
@@ -160,6 +250,47 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.height).toBe(96.3);
   });
 
+  it('maximizes window on drag stop near top edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: 5,
+      right: 300,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: 5,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    act(() => {
+      ref.current!.handleStop();
+    });
+
+    expect(ref.current!.state.maximized).toBe(true);
+    expect(ref.current!.state.width).toBe(100.2);
+    expect(ref.current!.state.height).toBe(96.3);
+  });
+
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(
@@ -199,7 +330,7 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true, preventDefault: () => {}, stopPropagation: () => {} } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -269,10 +269,6 @@ export class Window extends Component {
             newWidth = 50;
             newHeight = 96.3;
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
-        } else if (position === 'top') {
-            newWidth = 100.2;
-            newHeight = 50;
-            transform = 'translate(-1pt,-2pt)';
         }
         const r = document.querySelector("#" + this.id);
         if (r && transform) {
@@ -328,7 +324,7 @@ export class Window extends Component {
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
         else if (rect.top <= threshold) {
-            snap = { left: '0', top: '0', width: '100%', height: '50%' };
+            snap = { left: '0', top: '0', width: '100%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
         }
         else {
@@ -369,7 +365,12 @@ export class Window extends Component {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
         if (snapPos) {
-            this.snapWindow(snapPos);
+            if (snapPos === 'top') {
+                this.maximizeWindow();
+                this.setState({ snapPreview: null, snapPosition: null, snapped: null });
+            } else {
+                this.snapWindow(snapPos);
+            }
         } else {
             this.setState({ snapPreview: null, snapPosition: null });
         }
@@ -539,7 +540,7 @@ export class Window extends Component {
             } else if (e.key === 'ArrowUp') {
                 e.preventDefault();
                 e.stopPropagation();
-                this.snapWindow('top');
+                this.maximizeWindow();
             }
             this.focusWindow();
         } else if (e.shiftKey) {


### PR DESCRIPTION
## Summary
- show full-screen preview when dragging window to top edge
- maximize window when dropped at top
- add cancellation and regression tests for snap previews

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1aa10e48832891b9a8e8047e92a9