### PR TITLE
feat: add compositor toggle

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    compositorEnabled,
+    setCompositorEnabled,
     theme,
     setTheme,
   } = useSettings();
@@ -168,6 +170,14 @@ export default function Settings() {
           </div>
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Compositor:</span>
+            <ToggleSwitch
+              checked={compositorEnabled}
+              onChange={setCompositorEnabled}
+              ariaLabel="Compositor"
+            />
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
             {wallpapers.map((name) => (

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getCompositorEnabled as loadCompositorEnabled,
+  setCompositorEnabled as saveCompositorEnabled,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  compositorEnabled: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setCompositorEnabled: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  compositorEnabled: defaults.compositorEnabled,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setCompositorEnabled: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [compositorEnabled, setCompositorEnabled] = useState<boolean>(
+    defaults.compositorEnabled,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setCompositorEnabled(await loadCompositorEnabled());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    document.documentElement.classList.toggle(
+      'compositor-disabled',
+      !compositorEnabled,
+    );
+    saveCompositorEnabled(compositorEnabled);
+  }, [compositorEnabled]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +267,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        compositorEnabled,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +279,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setCompositorEnabled,
         setTheme,
       }}
     >

--- a/styles/index.css
+++ b/styles/index.css
@@ -110,6 +110,12 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 }
 
+.compositor-disabled .window-shadow {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+
 .closed-window {
     animation: closeWindow 200ms 1 forwards;
 }
@@ -377,6 +383,13 @@ dialog {
         backdrop-filter: blur(10px);
         background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
     }
+}
+
+.compositor-disabled .context-menu-bg,
+.compositor-disabled .windowMainScreen {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    background-color: var(--color-bg);
 }
 
 .emoji-list>li {

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  compositorEnabled: true,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getCompositorEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.compositorEnabled;
+  const val = window.localStorage.getItem('compositor-enabled');
+  return val === null ? DEFAULT_SETTINGS.compositorEnabled : val === 'true';
+}
+
+export async function setCompositorEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('compositor-enabled', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('compositor-enabled');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    compositorEnabled,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getCompositorEnabled(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    compositorEnabled,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    compositorEnabled,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (compositorEnabled !== undefined) await setCompositorEnabled(compositorEnabled);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add compositorEnabled setting to control window shadows and panel opacity
- expose compositor toggle in settings UI
- adjust styles to disable shadows and transparency when compositor is off

## Testing
- `npm test` *(fails: __tests__/window.test.tsx, __tests__/nmapNse.test.tsx, __tests__/Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1aa51b9c8328b04a0768f4740991