### PR TITLE
feat: add desktop icon arrangement options

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -11,8 +11,16 @@ export class UbuntuApp extends Component {
         this.setState({ dragging: true });
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (e) => {
         this.setState({ dragging: false });
+        if (this.props.onMove && !this.props.autoArrange) {
+            const desktop = document.getElementById('desktop');
+            const rect = e.target.getBoundingClientRect();
+            const drect = desktop ? desktop.getBoundingClientRect() : { left: 0, top: 0 };
+            const x = rect.left - drect.left;
+            const y = rect.top - drect.top;
+            this.props.onMove(this.props.id, x, y);
+        }
     }
 
     openApp = () => {
@@ -38,7 +46,7 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
+                draggable={!this.props.autoArrange}
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
@@ -49,6 +57,7 @@ export class UbuntuApp extends Component {
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
+                style={this.props.position ? { position: 'absolute', left: this.props.position.x, top: this.props.position.y } : {}}
             >
                 <Image
                     width={40}

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -68,6 +68,24 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
+            <button
+                onClick={props.arrangeIcons}
+                type="button"
+                role="menuitem"
+                aria-label="Arrange Desktop Icons"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Arrange Desktop Icons</span>
+            </button>
+            <button
+                onClick={props.toggleAutoArrange}
+                type="button"
+                role="menuitem"
+                aria-label="Toggle Auto Arrange"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">{props.autoArrange ? "Disable" : "Enable"} Auto Arrange</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>


### PR DESCRIPTION
## Summary
- add "Arrange Desktop Icons" and auto-arrange toggle to desktop context menu
- persist desktop icon positions and allow manual drag when auto-arrange is disabled

## Testing
- `npm test` *(fails: window snapping finalize and release → TypeError: e.preventDefault is not a function; copies example output to clipboard → Unable to find role="alert"; modal closes when Escape pressed globally → Cannot read properties of null)*
- `npm run lint` *(terminated after running with no output)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1aa6569c83288d24a7dc77528da0