### PR TITLE
feat: open terminal at path

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -104,6 +104,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   const { supported: opfsSupported, getDir, readFile, writeFile, deleteFile } =
     useOPFS();
   const dirRef = useRef<FileSystemDirectoryHandle | null>(null);
+  const cwdRef = useRef<string>((window as any).__TERMINAL_CWD || '~');
+  if (typeof window !== 'undefined') delete (window as any).__TERMINAL_CWD;
   const [overflow, setOverflow] = useState({ top: false, bottom: false });
   const ansiColors = [
     '#000000',
@@ -146,7 +148,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   contextRef.current.writeLine = writeLine;
 
   const prompt = useCallback(() => {
-    if (termRef.current) termRef.current.write('$ ');
+    if (termRef.current) termRef.current.write(`${cwdRef.current} $ `);
   }, []);
 
   const handleCopy = () => {
@@ -234,6 +236,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
     const runCommand = useCallback(
       async (cmd: string) => {
         const [name, ...rest] = cmd.trim().split(/\s+/);
+        if (name === 'cd') {
+          cwdRef.current = rest[0] || '~';
+          return;
+        }
         const expanded =
           aliasesRef.current[name]
             ? `${aliasesRef.current[name]} ${rest.join(' ')}`.trim()

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -14,6 +14,9 @@ function DesktopMenu(props) {
 
 
     const openTerminal = () => {
+        if (typeof window !== 'undefined') {
+            window.__TERMINAL_CWD = props.cwd || '~';
+        }
         props.openApp("terminal");
     }
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -895,6 +895,7 @@ export class Desktop extends Component {
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
+                    cwd="~/Desktop"
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />


### PR DESCRIPTION
## Summary
- launch Terminal from desktop context menu with a preset working directory
- show current path in the Terminal prompt and support basic `cd`

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and other lint errors)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1aa953dc83289ec8536a55bf82b6