### PR TITLE
feat(trash): add metadata and context actions

### DIFF
--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -7,6 +7,8 @@ export interface TrashItem {
   icon?: string;
   image?: string;
   closedAt: number;
+  /** Original location of the window when it was trashed. */
+  path?: string;
 }
 
 const ITEMS_KEY = 'window-trash';

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -8,6 +8,7 @@ interface TrashItem {
   icon?: string;
   image?: string;
   closedAt: number;
+  path?: string;
 }
 
 const formatAge = (closedAt: number): string => {

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,18 @@ function AppMenu(props) {
         }
     }
 
+    const handleRestore = () => {
+        props.restoreTrash && props.restoreTrash();
+        props.onClose && props.onClose();
+    };
+
+    const handleEmpty = () => {
+        props.emptyTrash && props.emptyTrash();
+        props.onClose && props.onClose();
+    };
+
+    const isTrash = props.appId === 'trash';
+
     return (
         <div
             id="app-menu"
@@ -30,6 +42,26 @@ function AppMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
+            {isTrash && (
+                <>
+                    <button
+                        type="button"
+                        onClick={handleRestore}
+                        role="menuitem"
+                        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                    >
+                        <span className="ml-5">Restore</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleEmpty}
+                        role="menuitem"
+                        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                    >
+                        <span className="ml-5">Empty</span>
+                    </button>
+                </>
+            )}
             <button
                 type="button"
                 onClick={handlePin}


### PR DESCRIPTION
## Summary
- track original path when trashing windows
- add restore and empty actions for trash icon
- show trash item count and keep icon in sync

## Testing
- `yarn test __tests__/trashState.test.ts`
- `npx eslint apps/trash/state.ts components/apps/trash/index.tsx components/context-menus/app-menu.js components/screen/desktop.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba1aa95cb083289592bd6e50990d5a