### PR TITLE
feat: add removable device mount controls

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -43,6 +43,12 @@ function DesktopMenu(props) {
         }
     }
 
+    const handleMountToggle = () => {
+        if (props.mounted) props.unmountDevice && props.unmountDevice();
+        else props.mountDevice && props.mountDevice();
+        props.onClose && props.onClose();
+    };
+
     return (
         <div
             id="desktop-menu"
@@ -50,6 +56,16 @@ function DesktopMenu(props) {
             aria-label="Desktop context menu"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
+            <button
+                onClick={handleMountToggle}
+                type="button"
+                role="menuitem"
+                aria-label={props.mounted ? 'Unmount Removable Device' : 'Mount Removable Device'}
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">{props.mounted ? 'Unmount Removable Device' : 'Mount Removable Device'}</span>
+            </button>
+            <Devider />
             <button
                 onClick={props.addNewFolder}
                 type="button"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,8 +23,11 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import RemovableDeviceIcon from './removable-device';
+import { NotificationsContext } from '../common/NotificationCenter';
 
 export class Desktop extends Component {
+    static contextType = NotificationsContext;
     constructor() {
         super();
         this.app_stack = [];
@@ -52,6 +55,7 @@ export class Desktop extends Component {
             showShortcutSelector: false,
             showWindowSwitcher: false,
             switcherWindows: [],
+            mounted: false,
         }
     }
 
@@ -142,6 +146,16 @@ export class Desktop extends Component {
         document.removeEventListener("contextmenu", this.checkContextMenu);
         document.removeEventListener("click", this.hideAllContextMenu);
         document.removeEventListener('keydown', this.handleContextKey);
+    }
+
+    mountDevice = () => {
+        this.setState({ mounted: true });
+        this.context?.pushNotification?.('System', 'Device mounted');
+    }
+
+    unmountDevice = () => {
+        this.setState({ mounted: false });
+        this.context?.pushNotification?.('System', 'Device unmounted');
     }
 
     handleGlobalShortcut = (e) => {
@@ -449,6 +463,9 @@ export class Desktop extends Component {
                 );
             }
         });
+        if (this.state.mounted) {
+            appsJsx.push(<RemovableDeviceIcon key="removable-device" />);
+        }
         return appsJsx;
     }
 
@@ -896,6 +913,10 @@ export class Desktop extends Component {
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                    mounted={this.state.mounted}
+                    mountDevice={this.mountDevice}
+                    unmountDevice={this.unmountDevice}
+                    onClose={this.hideAllContextMenu}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu

--- a/components/screen/removable-device.js
+++ b/components/screen/removable-device.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Image from 'next/image';
+
+export default function RemovableDeviceIcon() {
+  return (
+    <div
+      role="button"
+      aria-label="Removable Device"
+      data-context="desktop-area"
+      tabIndex={0}
+      className="p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active"
+    >
+      <Image
+        width={40}
+        height={40}
+        className="mb-1 w-10"
+        src="/themes/Yaru/status/drive-removable-media.svg"
+        alt="Removable Device"
+        sizes="40px"
+      />
+      Removable
+    </div>
+  );
+}

--- a/public/themes/Yaru/status/drive-removable-media.svg
+++ b/public/themes/Yaru/status/drive-removable-media.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M7 2h10v6H7V2zm0 8h10a2 2 0 0 1 2 2v8H5v-8a2 2 0 0 1 2-2z"/>
+  <circle cx="12" cy="17" r="1" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Summary
- show removable drive icon when mounted
- add mount/unmount options to desktop context menu with notifications

## Testing
- `yarn test` *(fails: TypeError in window.snap tests, NmapNSE missing alert, localStorage origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1aaa43dc8328b47003f8f5c151db