### PR TITLE
feat: support prefixed commands in terminal

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -61,6 +61,22 @@ describe('Terminal component', () => {
     expect(openApp).toHaveBeenCalledWith('calculator');
   });
 
+  it('transforms prefixed commands', async () => {
+    const ref = createRef<any>();
+    const open = jest.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+    act(() => {
+      ref.current.runCommand('#notes');
+    });
+    expect(openApp).toHaveBeenCalledWith('notes');
+    act(() => {
+      ref.current.runCommand('!kali linux');
+    });
+    expect(open).toHaveBeenCalled();
+    open.mockRestore();
+  });
+
   it('supports tab management shortcuts', async () => {
     const { container } = render(<TerminalTabs openApp={openApp} />);
     await act(async () => {});


### PR DESCRIPTION
## Summary
- allow `!` and `#` prefixes to transform terminal commands
- add help tooltip documenting prefix usage
- test prefix handling

## Testing
- `yarn test __tests__/terminal.test.tsx`
- `npx eslint apps/terminal/index.tsx __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1aad22e88328a6466eeb39b0d83b