### PR TITLE
feat: add terminal run option and keyboard tab

### DIFF
--- a/__tests__/CommandBuilder.test.tsx
+++ b/__tests__/CommandBuilder.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import CommandBuilder from '../components/CommandBuilder';
+
+jest.useFakeTimers();
+
+it('opens terminal and dispatches command when run in terminal is checked', async () => {
+  const openApp = jest.fn();
+  const listener = jest.fn();
+  window.addEventListener('run-terminal-command', listener as any);
+  const { getByLabelText } = render(
+    <CommandBuilder doc="" build={({ target = '' }) => `echo ${target}`.trim()} openApp={openApp} />
+  );
+  fireEvent.change(getByLabelText('target'), { target: { value: 'hi' } });
+  await act(async () => {
+    fireEvent.click(getByLabelText('Run in terminal'));
+    jest.runAllTimers();
+  });
+  expect(openApp).toHaveBeenCalledWith('terminal');
+  expect(listener).toHaveBeenCalled();
+  const event = listener.mock.calls[0][0] as CustomEvent<string>;
+  expect(event.detail).toBe('echo hi');
+  window.removeEventListener('run-terminal-command', listener as any);
+});

--- a/apps/settings/components/KeymapEditor.tsx
+++ b/apps/settings/components/KeymapEditor.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useKeymap from '../keymapRegistry';
+
+const formatEvent = (e: KeyboardEvent) => {
+  const parts = [
+    e.ctrlKey ? 'Ctrl' : '',
+    e.altKey ? 'Alt' : '',
+    e.shiftKey ? 'Shift' : '',
+    e.metaKey ? 'Meta' : '',
+    e.key.length === 1 ? e.key.toUpperCase() : e.key,
+  ];
+  return parts.filter(Boolean).join('+');
+};
+
+export default function KeymapEditor() {
+  const { shortcuts, updateShortcut } = useKeymap();
+  const [rebinding, setRebinding] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!rebinding) return;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      const combo = formatEvent(e);
+      updateShortcut(rebinding, combo);
+      setRebinding(null);
+    };
+    window.addEventListener('keydown', handler, { once: true });
+    return () => window.removeEventListener('keydown', handler);
+  }, [rebinding, updateShortcut]);
+
+  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
+    map.set(s.keys, (map.get(s.keys) || 0) + 1);
+    return map;
+  }, new Map());
+  const conflicts = new Set(
+    Array.from(keyCounts.entries())
+      .filter(([, count]) => count > 1)
+      .map(([key]) => key)
+  );
+
+  return (
+    <ul className="space-y-1">
+      {shortcuts.map((s) => (
+        <li
+          key={s.description}
+          data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
+          className={
+            conflicts.has(s.keys)
+              ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
+              : 'flex justify-between px-2 py-1'
+          }
+        >
+          <span className="flex-1">{s.description}</span>
+          <span className="font-mono mr-2">{s.keys}</span>
+          <button
+            type="button"
+            onClick={() => setRebinding(s.description)}
+            className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+          >
+            {rebinding === s.description ? 'Press keys...' : 'Rebind'}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -1,51 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import useKeymap from '../keymapRegistry';
+import KeymapEditor from './KeymapEditor';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
-
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
-  const { shortcuts, updateShortcut } = useKeymap();
-  const [rebinding, setRebinding] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!rebinding) return;
-    const handler = (e: KeyboardEvent) => {
-      e.preventDefault();
-      const combo = formatEvent(e);
-      updateShortcut(rebinding, combo);
-      setRebinding(null);
-    };
-    window.addEventListener('keydown', handler, { once: true });
-    return () => window.removeEventListener('keydown', handler);
-  }, [rebinding, updateShortcut]);
-
   if (!open) return null;
-
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
-  );
 
   return (
     <div
@@ -58,38 +21,13 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
           <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
           <button
             type="button"
-            onClick={() => {
-              setRebinding(null);
-              onClose();
-            }}
+            onClick={onClose}
             className="text-sm underline"
           >
             Close
           </button>
         </div>
-        <ul className="space-y-1">
-          {shortcuts.map((s) => (
-            <li
-              key={s.description}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
-                conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
-              }
-            >
-              <span className="flex-1">{s.description}</span>
-              <span className="font-mono mr-2">{s.keys}</span>
-              <button
-                type="button"
-                onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
-              >
-                {rebinding === s.description ? 'Press keys...' : 'Rebind'}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <KeymapEditor />
       </div>
     </div>
   );

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -9,9 +9,9 @@ import {
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
-import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import KeymapEditor from "./components/KeymapEditor";
 
 export default function Settings() {
   const {
@@ -37,6 +37,7 @@ export default function Settings() {
   const tabs = [
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
+    { id: "keyboard", label: "Keyboard" },
     { id: "privacy", label: "Privacy" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
@@ -102,8 +103,6 @@ export default function Settings() {
     setHighContrast(defaults.highContrast);
     setTheme("default");
   };
-
-  const [showKeymap, setShowKeymap] = useState(false);
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -260,15 +259,13 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
         </>
+      )}
+      {activeTab === "keyboard" && (
+        <div className="p-4 space-y-4">
+          <h2 className="text-lg font-bold">Keyboard Shortcuts</h2>
+          <KeymapEditor />
+        </div>
       )}
       {activeTab === "privacy" && (
         <>
@@ -300,7 +297,6 @@ export default function Settings() {
           }}
           className="hidden"
         />
-      <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );
 }

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -290,6 +290,16 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   }));
 
   useEffect(() => {
+    const handler = (e: Event) => {
+      const cmd = (e as CustomEvent<string>).detail;
+      runCommand(cmd);
+    };
+    window.addEventListener('run-terminal-command', handler as EventListener);
+    return () =>
+      window.removeEventListener('run-terminal-command', handler as EventListener);
+  }, [runCommand]);
+
+  useEffect(() => {
     let disposed = false;
     (async () => {
       const [{ Terminal: XTerm }, { FitAddon }, { SearchAddon }] = await Promise.all([

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,18 +1,30 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import TerminalOutput from './TerminalOutput';
 
 interface BuilderProps {
   doc: string;
   build: (params: Record<string, string>) => string;
+  openApp?: (id: string) => void;
 }
 
-export default function CommandBuilder({ doc, build }: BuilderProps) {
+export default function CommandBuilder({ doc, build, openApp }: BuilderProps) {
   const [params, setParams] = useState<Record<string, string>>({});
+  const [runInTerminal, setRunInTerminal] = useState(false);
   const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
     setParams({ ...params, [key]: e.target.value });
   };
 
   const command = build(params);
+
+  useEffect(() => {
+    if (!runInTerminal || !command) return;
+    openApp?.('terminal');
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('run-terminal-command', { detail: command })
+      );
+    }, 0);
+  }, [runInTerminal, command, openApp]);
 
   return (
     <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
@@ -34,6 +46,15 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
           onChange={update('opts')}
           className="border p-1 text-black w-full"
         />
+      </label>
+      <label className="inline-flex items-center mt-2">
+        <input
+          type="checkbox"
+          checked={runInTerminal}
+          onChange={(e) => setRunInTerminal(e.target.checked)}
+          className="mr-1"
+        />
+        <span>Run in terminal</span>
       </label>
       <div className="mt-2">
         <TerminalOutput text={command} ariaLabel="command output" />

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -15,7 +15,7 @@ const tabs = [
   { id: 'fixtures', label: 'Fixtures' },
 ];
 
-export default function SecurityTools() {
+export default function SecurityTools({ openApp }) {
   const [active, setActive] = useState('repeater');
   const [query, setQuery] = useState('');
   const [authorized, setAuthorized] = useState(false);
@@ -201,6 +201,7 @@ export default function SecurityTools() {
                 <CommandBuilder
                   doc="Build a curl command. Output is copy-only and not executed."
                   build={({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim()}
+                  openApp={openApp}
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary
- add "Run in terminal" option to command builder that opens Terminal with the command
- listen for custom `run-terminal-command` events in Terminal
- expose keyboard shortcut editor under new Settings → Keyboard tab

## Testing
- `yarn test __tests__/CommandBuilder.test.tsx __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(window.test.tsx and nmapNse.test.tsx failed: TypeError: e.preventDefault is not a function; Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68ba1aae4e708328b43dc20b0ea9c270