### PR TITLE
Add notification manager with bell icon and DND mode

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
 import OpenVASApp from '../components/apps/openvas';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 describe('OpenVASApp', () => {
   beforeEach(() => {
@@ -27,7 +28,11 @@ describe('OpenVASApp', () => {
   });
 
   it('includes group and profile in scan request', async () => {
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     fireEvent.change(
       screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
       { target: { value: '1.2.3.4' } }
@@ -45,7 +50,11 @@ describe('OpenVASApp', () => {
   });
 
   it('triggers notification on scan completion', async () => {
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     fireEvent.change(
       screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
       { target: { value: '1.2.3.4' } }
@@ -62,7 +71,11 @@ describe('OpenVASApp', () => {
     (fetch as jest.Mock).mockImplementationOnce(() =>
       Promise.reject(new Error('fail'))
     );
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     fireEvent.change(
       screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
       { target: { value: '1.2.3.4' } }
@@ -76,13 +89,21 @@ describe('OpenVASApp', () => {
   });
 
   it('displays sample policy settings', () => {
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     expect(screen.getByText('Policy Settings')).toBeInTheDocument();
     expect(screen.getByText('PCI DSS')).toBeInTheDocument();
   });
 
   it('allows saving and loading a custom policy', () => {
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     fireEvent.change(screen.getByLabelText('Policy Name'), {
       target: { value: 'Custom Policy' },
     });
@@ -95,8 +116,14 @@ describe('OpenVASApp', () => {
   });
 
   it('opens issue detail panel with remediation info', () => {
-    render(<OpenVASApp />);
-    fireEvent.click(screen.getByText('Outdated banner exposes software version'));
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
+    fireEvent.click(
+      screen.getByText('Outdated banner exposes software version')
+    );
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Remediation/)).toBeInTheDocument();
     fireEvent.click(screen.getByText('Close'));
@@ -114,7 +141,11 @@ describe('OpenVASApp', () => {
         })
     ) as any;
 
-    const { unmount } = render(<OpenVASApp />);
+    const { unmount } = render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
     fireEvent.change(
       screen.getByPlaceholderText('Target (e.g. 192.168.1.1)'),
       { target: { value: '1.2.3.4' } }
@@ -123,7 +154,11 @@ describe('OpenVASApp', () => {
     expect(localStorage.getItem('openvas/session')).toBeTruthy();
 
     unmount();
-    render(<OpenVASApp />);
+    render(
+      <NotificationCenter>
+        <OpenVASApp />
+      </NotificationCenter>
+    );
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
     expect(fetch).toHaveBeenLastCalledWith(

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import NotificationBell from '../util-components/NotificationBell';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -35,8 +36,9 @@ export default class Navbar extends Component {
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
-                                        <Clock />
+                                <Clock />
                                 </div>
+                                <NotificationBell />
                                 <button
                                         type="button"
                                         id="status-bar"
@@ -51,7 +53,7 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }

--- a/components/util-components/NotificationBell.tsx
+++ b/components/util-components/NotificationBell.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo, useState } from 'react';
+import useNotifications from '../../hooks/useNotifications';
+
+const BellIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-4 h-4"
+    aria-hidden="true"
+  >
+    <path d="M12 24a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2zm6.364-6V11a6.364 6.364 0 1 0-12.728 0v7L3 20h18l-2.636-2z" />
+  </svg>
+);
+
+const NotificationBell: React.FC = () => {
+  const { notifications, doNotDisturb, toggleDoNotDisturb } = useNotifications();
+  const [open, setOpen] = useState(false);
+
+  const totalCount = useMemo(
+    () => Object.values(notifications).reduce((sum, list) => sum + list.length, 0),
+    [notifications]
+  );
+
+  const allNotifications = useMemo(
+    () =>
+      Object.entries(notifications)
+        .flatMap(([appId, list]) =>
+          list.map(n => ({ ...n, appId }))
+        )
+        .sort((a, b) => b.date - a.date),
+    [notifications]
+  );
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="Notifications"
+        onClick={() => setOpen(o => !o)}
+        className="relative px-2 py-1 hover:bg-black hover:bg-opacity-20 rounded"
+      >
+        <BellIcon />
+        {totalCount > 0 && (
+          <span className="absolute -top-0 -right-0 bg-red-600 rounded-full text-[10px] w-4 h-4 flex items-center justify-center">
+            {totalCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-64 bg-ub-grey text-white rounded shadow-lg z-50 p-2 text-sm">
+          <div className="flex items-center justify-between mb-2">
+            <span className="font-semibold">Notifications</span>
+            <label className="flex items-center gap-1 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={doNotDisturb}
+                onChange={toggleDoNotDisturb}
+              />
+              DND
+            </label>
+          </div>
+          <ul className="max-h-60 overflow-y-auto">
+            {allNotifications.length === 0 && (
+              <li className="text-center text-ubt-grey py-2">No notifications</li>
+            )}
+            {allNotifications.map(n => (
+              <li
+                key={n.id}
+                className="border-b border-ubt-grey border-opacity-20 py-1 last:border-0"
+              >
+                <div className="text-ubt-grey text-[10px]">{n.appId}</div>
+                {n.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 const Ubuntu = dynamic(
   () =>
@@ -34,9 +35,11 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
+    <NotificationCenter>
+      <Ubuntu />
+      <BetaBadge />
+      <InstallButton />
+    </NotificationCenter>
   </>
 );
 


### PR DESCRIPTION
## Summary
- add NotificationCenter with toast support and do-not-disturb toggle
- provide NotificationBell navbar plugin to review log
- integrate notification provider and OpenVAS alerts

## Testing
- `yarn test` (fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)
- `yarn test __tests__/openvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1aafaffc8328aac80678d5f4bea4