### PR TITLE
feat: add toast slide-out and bubble theme vars

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 interface ToastProps {
   message: string;
@@ -15,29 +15,49 @@ const Toast: React.FC<ToastProps> = ({
   onClose,
   duration = 6000,
 }) => {
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+  }, []);
 
   useEffect(() => {
     setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
+    closeTimeoutRef.current = setTimeout(() => {
+      handleClose();
     }, duration);
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, handleClose]);
+
+  const handleTransitionEnd = () => {
+    if (!visible) {
+      onClose && onClose();
+    }
+  };
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform border px-4 py-3 shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      style={{
+        background: 'var(--bubble-bg)',
+        color: 'var(--bubble-text)',
+        borderColor: 'var(--bubble-border)',
+        borderRadius: 'var(--bubble-radius)',
+      }}
+      onTransitionEnd={handleTransitionEnd}
     >
       <span>{message}</span>
       {onAction && actionLabel && (
         <button
-          onClick={onAction}
+          onClick={() => {
+            onAction?.();
+            handleClose();
+          }}
           className="ml-4 underline focus:outline-none"
         >
           {actionLabel}

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -3,6 +3,9 @@ export const kaliTheme = {
   text: 'var(--color-text)',
   accent: 'var(--color-primary)',
   sidebar: 'var(--color-secondary)',
+  bubbleBg: 'var(--bubble-bg)',
+  bubbleText: 'var(--bubble-text)',
+  bubbleBorder: 'var(--bubble-border)',
 };
 
 export type KaliTheme = typeof kaliTheme;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -46,6 +46,12 @@
   --radius-lg: 8px;
   --radius-round: 9999px;
 
+  /* Bubble styling */
+  --bubble-bg: var(--color-ub-cool-grey);
+  --bubble-text: var(--color-text);
+  --bubble-border: var(--color-ub-border-orange);
+  --bubble-radius: var(--radius-md);
+
   /* Motion durations */
   --motion-fast: 150ms;
   --motion-medium: 300ms;


### PR DESCRIPTION
## Summary
- animate toast dismissal with slide-out transition
- add CSS variables for bubble styling and hook into theme

## Testing
- `yarn lint components/ui/Toast.tsx styles/themes/kali.ts styles/tokens.css` *(fails: many existing lint errors)*
- `npx eslint components/ui/Toast.tsx styles/themes/kali.ts styles/tokens.css`
- `yarn test components/ui/Toast.tsx` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1ab089f48328a8d8423330fe27ce