### PR TITLE
Add power manager settings integration and persistence

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import usePersistentState from "../../hooks/usePersistentState";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -38,9 +39,27 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "power", label: "Power" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const [blankAfter, setBlankAfter] = usePersistentState<number>(
+    "power-blank-after",
+    5
+  );
+  const [sleepAfter, setSleepAfter] = usePersistentState<number>(
+    "power-sleep-after",
+    30
+  );
+
+  useEffect(() => {
+    const id = rootRef.current?.closest(".window")?.id;
+    if (id && id.includes("#power")) {
+      setActiveTab("power");
+    }
+  }, []);
 
   const wallpapers = [
     "wall-1",
@@ -106,7 +125,10 @@ export default function Settings() {
   const [showKeymap, setShowKeymap] = useState(false);
 
   return (
-    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
+    <div
+      ref={rootRef}
+      className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"
+    >
       <div className="flex justify-center border-b border-gray-900">
         <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
       </div>
@@ -285,6 +307,40 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+        </>
+      )}
+      {activeTab === "power" && (
+        <>
+          <div className="flex flex-col p-4 space-y-4">
+            <div className="flex items-center justify-center">
+              <label className="mr-2 text-ubt-grey">Blank screen after:</label>
+              <select
+                value={blankAfter}
+                onChange={(e) => setBlankAfter(parseInt(e.target.value))}
+                className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value={1}>1 min</option>
+                <option value={5}>5 min</option>
+                <option value={15}>15 min</option>
+                <option value={30}>30 min</option>
+                <option value={0}>Never</option>
+              </select>
+            </div>
+            <div className="flex items-center justify-center">
+              <label className="mr-2 text-ubt-grey">Automatic suspend:</label>
+              <select
+                value={sleepAfter}
+                onChange={(e) => setSleepAfter(parseInt(e.target.value))}
+                className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value={15}>15 min</option>
+                <option value={30}>30 min</option>
+                <option value={60}>1 hour</option>
+                <option value={120}>2 hours</option>
+                <option value={0}>Never</option>
+              </select>
+            </div>
           </div>
         </>
       )}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -128,6 +128,12 @@ export class Desktop extends Component {
                 this.openApp("settings");
             });
         }
+        const openPowerSettings = document.getElementById("open-power-settings");
+        if (openPowerSettings) {
+            openPowerSettings.addEventListener("click", () => {
+                this.openApp("settings#power");
+            });
+        }
     }
 
     setContextListeners = () => {
@@ -823,7 +829,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -38,19 +38,38 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle sound"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          aria-label="Toggle network"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
+          aria-label="Toggle reduced motion"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
+      </div>
+      <div className="px-4 mt-2">
+        <button
+          id="open-power-settings"
+          className="w-full text-left text-ubt-blue hover:underline"
+        >
+          Power Manager Settings…
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add Power Manager Settings button to quick settings popover
- Open settings app directly to new power tab from desktop
- Introduce power tab with blank screen and suspend preferences persisted via `usePersistentState`

## Testing
- `npx eslint components/ui/QuickSettings.tsx apps/settings/index.tsx components/screen/desktop.js`
- `yarn test __tests__/nonogram.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba1ab29adc83289606679a709accd0