### PR TITLE
Add window context menu and Alt+Space shortcut

### DIFF
--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function WindowMenu(props) {
+    const {
+        active,
+        onCloseMenu,
+        pos,
+        onMove,
+        onResize,
+        onTop,
+        onShade,
+        onStick,
+        onMaximize,
+        onClose,
+    } = props;
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, active);
+    useRovingTabIndex(menuRef, active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            onCloseMenu && onCloseMenu();
+        }
+    };
+
+    const wrap = (fn) => () => {
+        fn && fn();
+        onCloseMenu && onCloseMenu();
+    };
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-hidden={!active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            style={{ left: pos?.x, top: pos?.y }}
+            className={(active ? ' block ' : ' hidden ') +
+                ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+        >
+            <button type="button" onClick={wrap(onMove)} role="menuitem" aria-label="Move Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Move</span>
+            </button>
+            <button type="button" onClick={wrap(onResize)} role="menuitem" aria-label="Resize Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Resize</span>
+            </button>
+            <button type="button" onClick={wrap(onTop)} role="menuitem" aria-label="Always on top" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Always on top</span>
+            </button>
+            <button type="button" onClick={wrap(onShade)} role="menuitem" aria-label="Shade Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Shade</span>
+            </button>
+            <button type="button" onClick={wrap(onStick)} role="menuitem" aria-label="Stick Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Stick</span>
+            </button>
+            <button type="button" onClick={wrap(onMaximize)} role="menuitem" aria-label="Maximize Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Maximize</span>
+            </button>
+            <button type="button" onClick={wrap(onClose)} role="menuitem" aria-label="Close Window" className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5">
+                <span className="ml-5">Close</span>
+            </button>
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -162,6 +162,14 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if (e.altKey && e.key === ' ') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const evt = new CustomEvent('open-window-menu');
+                document.getElementById(id)?.dispatchEvent(evt);
+            }
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();


### PR DESCRIPTION
## Summary
- add window context menu with Move/Resize/Always on top/Shade/Stick/Maximize/Close
- open window menu with Alt+Space on focused window
- connect menu actions to window behavior and top-most state

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert" in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a9cd4c483289b4f773aaa14d08c