### PR TITLE
feat: add whisker menu shortcuts

### DIFF
--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -55,10 +55,11 @@ class AllApplications extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div id="whisker-menu" className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
+                    aria-label="Search applications"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -94,6 +94,7 @@ export class Desktop extends Component {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        document.removeEventListener('click', this.handleWhiskerBlur);
     }
 
     checkForNewFolders = () => {
@@ -145,6 +146,10 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
+        if (e.key === 'Meta' && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+            e.preventDefault();
+            this.showAllApps();
+        }
         if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
@@ -807,7 +812,24 @@ export class Desktop extends Component {
         this.setState({ showNameBar: false }, this.updateAppsData);
     }
 
-    showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }) }
+    showAllApps = (force) => {
+        const next = typeof force === 'boolean' ? force : !this.state.allAppsView;
+        this.setState({ allAppsView: next }, () => {
+            if (this.state.allAppsView) {
+                document.addEventListener('click', this.handleWhiskerBlur);
+            } else {
+                document.removeEventListener('click', this.handleWhiskerBlur);
+            }
+        });
+    }
+
+    handleWhiskerBlur = (e) => {
+        if (!this.state.allAppsView) return;
+        const menu = document.getElementById('whisker-menu');
+        if (menu && !menu.contains(e.target)) {
+            this.showAllApps(false);
+        }
+    }
 
     renderNameBar = () => {
         let addFolder = () => {
@@ -823,7 +845,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button


### PR DESCRIPTION
## Summary
- toggle WhiskerMenu with the Super key
- close WhiskerMenu when clicking outside and clean up listeners

## Testing
- `npx eslint components/screen/desktop.js components/screen/all-applications.js`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a90d6308328a3afc42c01c8a359