### PR TITLE
Add panel separator plugin

### DIFF
--- a/components/panel/items.ts
+++ b/components/panel/items.ts
@@ -1,0 +1,7 @@
+import Separator from "./plugins/Separator";
+
+export const panelItems = [
+  { id: "separator", component: Separator },
+];
+
+export default panelItems;

--- a/components/panel/plugins/Separator.tsx
+++ b/components/panel/plugins/Separator.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+export type SeparatorStyle = "transparent" | "line" | "handle" | "dots";
+
+interface SeparatorProps {
+  style?: SeparatorStyle;
+  expand?: boolean;
+}
+
+export default function Separator({ style = "transparent", expand = false }: SeparatorProps) {
+  const grow = expand ? "flex-grow" : "";
+
+  switch (style) {
+    case "line":
+      return <div className={`mx-1 w-px h-6 bg-gray-600 ${grow}`} />;
+    case "handle":
+      return (
+        <div className={`flex items-center mx-1 ${grow}`}>
+          <div className="w-0.5 h-4 bg-gray-500 rounded-sm" />
+          <div className="w-0.5 h-4 bg-gray-500 rounded-sm ml-0.5" />
+        </div>
+      );
+    case "dots":
+      return (
+        <div className={`flex items-center mx-1 space-x-0.5 ${grow}`}>
+          <span className="w-1 h-1 bg-gray-500 rounded-full" />
+          <span className="w-1 h-1 bg-gray-500 rounded-full" />
+          <span className="w-1 h-1 bg-gray-500 rounded-full" />
+        </div>
+      );
+    case "transparent":
+    default:
+      return <div className={`mx-1 ${grow}`} />;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add separator panel plugin with transparent, line, handle, and dots styles
- support optional expand to push items apart
- register separator in panel item list

## Testing
- `yarn test` *(fails: Window snapping finalize and release; NmapNSEApp; Modal)*
- `yarn lint` *(fails: 576 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a94745483289b4db830a324a1be