### PR TITLE
feat: add bluetooth tray toggle

### DIFF
--- a/components/util-components/BluetoothTray.tsx
+++ b/components/util-components/BluetoothTray.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const ICON = '/themes/Yaru/status/bluetooth-symbolic.svg';
+
+const BluetoothTray: React.FC = () => {
+  const [enabled, setEnabled] = usePersistentState<boolean>('tray-bluetooth', false);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative mx-1.5">
+      <button
+        type="button"
+        className="relative flex items-center focus:outline-none"
+        onClick={() => setOpen(!open)}
+        title={enabled ? 'Bluetooth on' : 'Bluetooth off'}
+        aria-label="Bluetooth status"
+      >
+        <Image
+          width={16}
+          height={16}
+          src={ICON}
+          alt={enabled ? 'Bluetooth on' : 'Bluetooth off'}
+          className={`inline status-symbol w-4 h-4 ${enabled ? '' : 'opacity-40'}`}
+          sizes="16px"
+        />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 bg-ub-cool-grey rounded-md shadow border border-black border-opacity-20 z-50 p-3">
+          <div className="flex justify-between items-center mb-2">
+            <span>Bluetooth</span>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={() => setEnabled(!enabled)}
+              aria-label="Toggle Bluetooth"
+            />
+          </div>
+          <div className="text-center text-xs text-ubt-grey">Devices…</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BluetoothTray;

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
+import BluetoothTray from './BluetoothTray';
 import { useSettings } from '../../hooks/useSettings';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
@@ -56,6 +57,7 @@ export default function Status() {
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
+      <BluetoothTray />
       <span className="mx-1.5">
         <Image
           width={16}


### PR DESCRIPTION
## Summary
- add Bluetooth tray icon with persistent on/off toggle
- show stub popover listing "Devices…"
- update icon and tooltip based on Bluetooth state

## Testing
- `npx eslint components/util-components/BluetoothTray.tsx components/util-components/status.js`
- `npx jest __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*
- `npx tsc --noEmit -p tsconfig.json` *(errors: Module can only be default-imported; Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04db836c8328981fbd9aef661428