### PR TITLE
feat: add volume control plugin

### DIFF
--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
+import Volume from "./volume";
 import { useSettings } from '../../hooks/useSettings';
-
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
@@ -56,16 +55,7 @@ export default function Status() {
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
+      <Volume />
       <span className="mx-1.5">
         <Image
           width={16}

--- a/components/util-components/volume.js
+++ b/components/util-components/volume.js
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import useGameAudio from "../../hooks/useGameAudio";
+
+// Small volume control used in the top status bar.  Scrolling adjusts the
+// volume in 5% increments.  Clicking the icon opens a popover with a range
+// slider as well as a stub "Open Mixer" link.  The volume value itself is
+// persisted via the `useGameAudio` hook so changes are shared across apps.
+
+export default function Volume() {
+  const { volume, setVolume } = useGameAudio();
+  const [open, setOpen] = useState(false);
+
+  const handleWheel = (e) => {
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? 0.05 : -0.05;
+    setVolume((v) => Math.max(0, Math.min(1, Math.round((v + delta) * 100) / 100)));
+  };
+
+  const icon =
+    volume === 0
+      ? "/themes/Yaru/status/audio-volume-muted-symbolic.svg"
+      : volume < 0.33
+      ? "/themes/Yaru/status/audio-volume-low-symbolic.svg"
+      : volume < 0.66
+      ? "/themes/Yaru/status/audio-volume-medium-symbolic.svg"
+      : "/themes/Yaru/status/audio-volume-high-symbolic.svg";
+
+  return (
+    <span className="mx-1.5 relative inline-block" onWheel={handleWheel}>
+      <button type="button" onClick={() => setOpen(!open)} aria-label="Volume">
+        <Image
+          width={16}
+          height={16}
+          src={icon}
+          alt="volume"
+          className="inline status-symbol w-4 h-4"
+          sizes="16px"
+        />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-40 p-2 bg-ub-cool-grey rounded shadow border border-black border-opacity-20 z-50">
+          <div className="mb-2 text-xs text-center">Speakers</div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={Math.round(volume * 100)}
+            onChange={(e) => setVolume(Number(e.target.value) / 100)}
+            className="w-full"
+          />
+          <a
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            className="block mt-2 text-xs text-center text-ubt-grey underline"
+          >
+            Open Mixer
+          </a>
+        </div>
+      )}
+    </span>
+  );
+}
+

--- a/hooks/useGameAudio.js
+++ b/hooks/useGameAudio.js
@@ -20,10 +20,13 @@ export default function useGameAudio() {
   const sfxBuffersRef = useRef({});
   const musicLayersRef = useRef({});
 
-  // Global mute is persisted across the portfolio, but per‑game volume lives
-  // only for the lifetime of the hook instance.
+  // Global mute and volume are persisted across the portfolio so different
+  // apps share the same audio levels.
   const [muted, setMuted] = usePersistedState('settings:audioMuted', false);
-  const [gameVolume, setGameVolume] = useState(1);
+  const [gameVolume, setGameVolume] = usePersistedState(
+    'settings:audioVolume',
+    1,
+  );
   const [ready, setReady] = useState(false);
 
   // Create the audio graph after the first user interaction to comply with


### PR DESCRIPTION
## Summary
- add volume plugin with scroll wheel volume control and popover slider
- integrate volume plugin into status bar
- persist audio volume across sessions

## Testing
- `npm test` *(fails: window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*
- `npm run lint` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04d84c5c8328b94e9db63033f49f