### PR TITLE
feat: add simulated power actions panel plugin

### DIFF
--- a/components/ui/PowerMenu.tsx
+++ b/components/ui/PowerMenu.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useState } from 'react';
+
+interface Action {
+  id: string;
+  label: string;
+}
+
+const actions: Action[] = [
+  { id: 'Lock', label: 'Lock (simulation)' },
+  { id: 'Log Out', label: 'Log Out (simulation)' },
+  { id: 'Suspend', label: 'Suspend (simulation)' },
+  { id: 'Restart', label: 'Restart (simulation)' },
+  { id: 'Shutdown', label: 'Shutdown (simulation)' },
+];
+
+export default function PowerMenu() {
+  const [confirm, setConfirm] = useState<Action | null>(null);
+
+  return (
+    <div className="border-t border-ubt-cool-grey mt-2 pt-2">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          className="w-full flex justify-between px-4 py-1 hover:bg-ubt-grey hover:bg-opacity-10"
+          onClick={() => setConfirm(action)}
+        >
+          <span>{action.id}</span>
+          <span className="text-xs text-ubt-grey">simulation</span>
+        </button>
+      ))}
+      {confirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+        >
+          <div className="bg-ub-cool-grey p-4 rounded shadow text-center">
+            <p className="mb-4">{`Simulate ${confirm.id}?`}</p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="px-2 py-1 bg-gray-700 rounded"
+                onClick={() => setConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-2 py-1 bg-ub-orange rounded"
+                onClick={() => {
+                  setConfirm(null);
+                }}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import PowerMenu from './PowerMenu';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [powerVisible] = usePersistentState('qs-power-menu', false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -36,22 +38,40 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+      <div className="px-4 pb-2">
+        <label className="flex justify-between">
+          <span>Sound</span>
+          <input
+            aria-label="Sound"
+            type="checkbox"
+            checked={sound}
+            onChange={() => setSound(!sound)}
+          />
+        </label>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      <div className="px-4 pb-2">
+        <label className="flex justify-between">
+          <span>Network</span>
+          <input
+            aria-label="Network"
+            type="checkbox"
+            checked={online}
+            onChange={() => setOnline(!online)}
+          />
+        </label>
       </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+      <div className="px-4">
+        <label className="flex justify-between">
+          <span>Reduced motion</span>
+          <input
+            aria-label="Reduced motion"
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={() => setReduceMotion(!reduceMotion)}
+          />
+        </label>
       </div>
+      {powerVisible && <PowerMenu />}
     </div>
   );
 };

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -17,6 +17,7 @@ function Toggle({
       type="button"
       role="switch"
       aria-checked={checked}
+      aria-label="toggle"
       onClick={() => onChange(!checked)}
       className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
         checked ? 'bg-ubt-blue' : 'bg-ubt-grey'
@@ -35,6 +36,7 @@ export default function ThemeSettings() {
   const { theme, setTheme } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
+  const [showPower, setShowPower] = usePersistentState('qs-power-menu', false);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setTheme(e.target.value);
@@ -110,6 +112,20 @@ export default function ThemeSettings() {
               ></div>
             ))}
           </div>
+
+        <div className="mt-6">
+          <h2 className="text-lg mb-2">Panel</h2>
+          <label className="flex items-center gap-2">
+            <input
+              aria-label="Show power actions"
+              type="checkbox"
+              checked={showPower}
+              onChange={(e) => setShowPower(e.target.checked)}
+            />
+            <span>Show power actions</span>
+          </label>
+        </div>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add simulated lock/log-out/suspend/restart/shutdown panel plugin
- allow enabling power actions from settings
- wire power menu into quick settings panel

## Testing
- `npx eslint components/ui/PowerMenu.tsx components/ui/QuickSettings.tsx pages/ui/settings/theme.tsx`
- `yarn test` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard, modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04d787dc832890202cae6d8cdd81