### PR TITLE
feat(whisker): add preference for generic app names

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -598,6 +598,7 @@ const apps = [
   {
     id: 'chrome',
     title: 'Google Chrome',
+    genericName: 'Web Browser',
     icon: '/themes/Yaru/apps/chrome.png',
     disabled: false,
     favourite: true,
@@ -620,6 +621,7 @@ const apps = [
   {
     id: 'terminal',
     title: 'Terminal',
+    genericName: 'Terminal Emulator',
     icon: '/themes/Yaru/apps/bash.png',
     disabled: false,
     favourite: true,
@@ -630,6 +632,7 @@ const apps = [
     // VSCode app uses a Stack iframe, so no editor dependencies are required
     id: 'vscode',
     title: 'Visual Studio Code',
+    genericName: 'Code Editor',
     icon: '/themes/Yaru/apps/vscode.png',
     disabled: false,
     favourite: true,


### PR DESCRIPTION
## Summary
- add gear menu in Whisker to toggle generic application names
- store generic name preference in localStorage
- support generic names for Chrome, Terminal, and VS Code

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and other lint errors)*
- `yarn test` *(fails: window snapping finalize test, NmapNSE output copy test, Modal focus test)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04ce8b308328948bff70489ab5e0