### PR TITLE
feat(panel): add profiles dialog

### DIFF
--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
+import PanelProfilesDialog from '@/src/components/panel/PanelProfilesDialog';
+import {
+  DEFAULT_PANEL_LAYOUT,
+  PANEL_LAYOUT_KEY,
+  PanelLayout,
+} from '@/src/components/panel/types';
 
 /** Simple Adwaita-like toggle switch */
 function Toggle({
@@ -16,6 +22,7 @@ function Toggle({
     <button
       type="button"
       role="switch"
+      aria-label="Toggle setting"
       aria-checked={checked}
       onClick={() => onChange(!checked)}
       className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
@@ -35,12 +42,28 @@ export default function ThemeSettings() {
   const { theme, setTheme } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
+  const [panelLayout, setPanelLayout] = useState<PanelLayout>(
+    DEFAULT_PANEL_LAYOUT,
+  );
+  const [profilesOpen, setProfilesOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(PANEL_LAYOUT_KEY);
+      if (stored) {
+        setPanelLayout(JSON.parse(stored));
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setTheme(e.target.value);
   };
 
   return (
+    <>
     <div className="flex h-full">
       <nav className="w-48 p-4 border-r border-ubt-cool-grey text-sm">
         <ul className="space-y-1.5">
@@ -91,28 +114,48 @@ export default function ThemeSettings() {
           </div>
         </div>
 
-        <div className="mt-6">
-          <h2 className="text-lg mb-2">Grid Icons</h2>
-          <div className="flex items-center gap-2 mb-2">
-            <span className="w-6 h-6 bg-ubt-grey rounded"></span>
-            <Toggle
-              checked={gridSize === 96}
-              onChange={(val) => setGridSize(val ? 96 : 64)}
-            />
-            <span className="w-6 h-6 bg-ubt-grey rounded"></span>
+          <div className="mt-6">
+            <h2 className="text-lg mb-2">Grid Icons</h2>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="w-6 h-6 bg-ubt-grey rounded"></span>
+              <Toggle
+                checked={gridSize === 96}
+                onChange={(val) => setGridSize(val ? 96 : 64)}
+              />
+              <span className="w-6 h-6 bg-ubt-grey rounded"></span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 p-2 bg-ub-cool-grey rounded">
+              {[1, 2, 3, 4].map((n) => (
+                <div
+                  key={n}
+                  className="bg-ubt-grey rounded"
+                  style={{ width: gridSize, height: gridSize }}
+                ></div>
+              ))}
+            </div>
           </div>
-          <div className="grid grid-cols-2 gap-2 p-2 bg-ub-cool-grey rounded">
-            {[1, 2, 3, 4].map((n) => (
-              <div
-                key={n}
-                className="bg-ubt-grey rounded"
-                style={{ width: gridSize, height: gridSize }}
-              ></div>
-            ))}
+
+          <div className="mt-6">
+            <h2 className="text-lg mb-2">Panel Profiles</h2>
+            <button
+              type="button"
+              onClick={() => setProfilesOpen(true)}
+              className="px-3 py-1 bg-ubt-blue text-white rounded"
+            >
+              Manage Profiles
+            </button>
           </div>
         </div>
       </div>
-    </div>
+
+      <PanelProfilesDialog
+        isOpen={profilesOpen}
+        onClose={() => setProfilesOpen(false)}
+        layout={panelLayout}
+        onLayoutChange={setPanelLayout}
+        defaultLayout={DEFAULT_PANEL_LAYOUT}
+      />
+    </>
   );
 }
 

--- a/src/components/panel/PanelProfilesDialog.tsx
+++ b/src/components/panel/PanelProfilesDialog.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Modal from '../../../components/base/Modal';
+import { PanelLayout, PANEL_LAYOUT_KEY } from './types';
+import React from 'react';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  layout: PanelLayout;
+  onLayoutChange: (layout: PanelLayout) => void;
+  defaultLayout: PanelLayout;
+}
+
+function safeParse(json: string | null): PanelLayout | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export default function PanelProfilesDialog({
+  isOpen,
+  onClose,
+  layout,
+  onLayoutChange,
+  defaultLayout,
+}: Props) {
+  const handleSave = () => {
+    try {
+      localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify(layout));
+    } catch (err) {
+      console.error('Failed to save panel layout', err);
+    }
+    onClose();
+  };
+
+  const handleLoad = () => {
+    const stored = safeParse(localStorage.getItem(PANEL_LAYOUT_KEY));
+    if (stored) {
+      onLayoutChange(stored);
+    }
+    onClose();
+  };
+
+  const handleReset = () => {
+    try {
+      localStorage.removeItem(PANEL_LAYOUT_KEY);
+    } catch {}
+    onLayoutChange(defaultLayout);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="bg-ub-cool-grey text-ubt-grey p-4 rounded shadow w-72">
+        <h2 className="text-lg mb-4">Panel Profiles</h2>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="px-3 py-1 rounded bg-ubt-red text-white"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={handleLoad}
+            className="px-3 py-1 rounded bg-ubt-blue text-white"
+          >
+            Load
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="px-3 py-1 rounded bg-ubt-green text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/panel/types.ts
+++ b/src/components/panel/types.ts
@@ -1,0 +1,18 @@
+export interface PanelPlugin {
+  id: string;
+  settings?: Record<string, unknown>;
+}
+
+export interface PanelLayout {
+  position: 'top' | 'bottom';
+  size: number;
+  plugins: PanelPlugin[];
+}
+
+export const DEFAULT_PANEL_LAYOUT: PanelLayout = {
+  position: 'bottom',
+  size: 40,
+  plugins: [],
+};
+
+export const PANEL_LAYOUT_KEY = '~/.config/xfce4/panel.json';


### PR DESCRIPTION
## Summary
- add PanelProfilesDialog component with Save/Load/Reset options
- integrate panel profile management into theme settings
- define panel layout types and defaults

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn eslint src/components/panel pages/ui/settings/theme.tsx`
- `yarn tsc` *(fails: TS5055 cannot write file because it would overwrite input file)*
- `yarn test` *(fails: some tests such as __tests__/game2048.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f4cb19c8328975c7e11ae74230f