### PR TITLE
feat(menu): add desktop entry loader and menu rendering

### DIFF
--- a/src/components/menu/ApplicationsMenu.tsx
+++ b/src/components/menu/ApplicationsMenu.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import loadMenu, { MenuCategory } from '../../lib/menu/garcon';
+
+const ApplicationsMenu: React.FC = () => {
+  const [categories, setCategories] = useState<MenuCategory[]>([]);
+
+  useEffect(() => {
+    loadMenu()
+      .then((cats) => setCategories(cats))
+      .catch((err) => console.error('Failed to load menu', err));
+  }, []);
+
+  return (
+    <nav>
+      {categories.map((category) => (
+        <div key={category.id} className="mb-4">
+          <h3 className="font-bold mb-2">{category.name}</h3>
+          <ul className="ml-4 list-disc">
+            {category.items.map((item) => (
+              <li key={item.id}>{item.name}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+};
+
+export default ApplicationsMenu;

--- a/src/lib/menu/desktopEntry.ts
+++ b/src/lib/menu/desktopEntry.ts
@@ -1,0 +1,90 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+export interface DesktopEntry {
+  type?: string;
+  name: string;
+  exec?: string;
+  icon?: string;
+  categories?: string[];
+  terminal?: boolean;
+  noDisplay?: boolean;
+}
+
+// Simple INI parser tailored for .desktop files
+const parseIni = (text: string): Record<string, Record<string, string>> => {
+  const result: Record<string, Record<string, string>> = {};
+  let current: Record<string, string> | null = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const section = line.match(/^\[(.+)]$/);
+    if (section) {
+      current = result[section[1]] = {};
+      continue;
+    }
+    if (!current) continue;
+    const idx = line.indexOf('=');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    current[key] = value;
+  }
+  return result;
+};
+
+/**
+ * Parse a single .desktop file into a DesktopEntry.
+ * Returns null if the file cannot be read or lacks a Desktop Entry group.
+ */
+export const parseDesktopEntry = async (file: string): Promise<DesktopEntry | null> => {
+  try {
+    const text = await fs.readFile(file, 'utf8');
+    const data = parseIni(text)['Desktop Entry'];
+    if (!data) return null;
+    return {
+      type: data.Type,
+      name: data.Name || path.basename(file),
+      exec: data.Exec,
+      icon: data.Icon,
+      categories: data.Categories ? data.Categories.split(';').filter(Boolean) : undefined,
+      terminal: data.Terminal === 'true',
+      noDisplay: data.NoDisplay === 'true',
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Load desktop entries according to XDG merge semantics.
+ * Earlier directories in the search path have precedence.
+ */
+export const loadDesktopEntries = async (
+  dirs: string[] = [
+    path.join(os.homedir(), '.local/share/applications'),
+    '/usr/local/share/applications',
+    '/usr/share/applications',
+  ],
+): Promise<Record<string, DesktopEntry>> => {
+  const entries = new Map<string, DesktopEntry>();
+  for (const dir of dirs) {
+    try {
+      const files = await fs.readdir(dir);
+      for (const file of files) {
+        if (!file.endsWith('.desktop')) continue;
+        const abs = path.join(dir, file);
+        const parsed = await parseDesktopEntry(abs);
+        if (parsed) {
+          // According to XDG spec, earlier directories override later ones
+          entries.set(file, parsed);
+        }
+      }
+    } catch {
+      // ignore missing directories
+    }
+  }
+  return Object.fromEntries(entries);
+};
+

--- a/src/lib/menu/garcon.ts
+++ b/src/lib/menu/garcon.ts
@@ -1,0 +1,91 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { DesktopEntry, parseDesktopEntry } from './desktopEntry';
+
+export interface MenuItem {
+  id: string;
+  name: string;
+  desktop?: string;
+  icon?: string;
+  exec?: string;
+  categories?: string[];
+}
+
+export interface MenuCategory {
+  id: string;
+  name: string;
+  items: MenuItem[];
+}
+
+export interface MenuJson {
+  categories?: MenuCategory[];
+}
+
+const readJson = async (file: string): Promise<MenuJson> => {
+  try {
+    const text = await fs.readFile(file, 'utf8');
+    return JSON.parse(text);
+  } catch {
+    return { categories: [] };
+  }
+};
+
+const mergeCategories = (
+  base: MenuCategory[] = [],
+  extra: MenuCategory[] = [],
+): MenuCategory[] => {
+  const map = new Map<string, MenuCategory>();
+  for (const cat of base) map.set(cat.id, { ...cat, items: [...(cat.items || [])] });
+  for (const cat of extra) {
+    if (!map.has(cat.id)) {
+      map.set(cat.id, { ...cat, items: [...(cat.items || [])] });
+      continue;
+    }
+    const existing = map.get(cat.id)!;
+    const itemMap = new Map(existing.items.map((i) => [i.id, i]));
+    for (const item of cat.items) itemMap.set(item.id, item);
+    existing.items = Array.from(itemMap.values());
+  }
+  return Array.from(map.values());
+};
+
+/**
+ * Load menu data by merging system and user menu files and parsing .desktop entries
+ */
+export const loadMenu = async (): Promise<MenuCategory[]> => {
+  const systemPath = '/data/applications.menu.json';
+  const userPath = path.join(
+    os.homedir(),
+    '.config/menus/xfce-applications.menu.json',
+  );
+
+  const system = await readJson(systemPath);
+  const user = await readJson(userPath);
+  const categories = mergeCategories(system.categories, user.categories);
+
+  for (const cat of categories) {
+    const parsedItems: MenuItem[] = [];
+    for (const item of cat.items || []) {
+      if (item.desktop) {
+        const entry: DesktopEntry | null = await parseDesktopEntry(item.desktop);
+        if (entry && !entry.noDisplay) {
+          parsedItems.push({
+            id: item.id || entry.name,
+            name: entry.name,
+            icon: entry.icon,
+            exec: entry.exec,
+            categories: entry.categories,
+          });
+        }
+      } else {
+        parsedItems.push(item);
+      }
+    }
+    cat.items = parsedItems;
+  }
+
+  return categories;
+};
+
+export default loadMenu;


### PR DESCRIPTION
## Summary
- load system/user XFCE menus and parse .desktop files
- render application categories and items
- add desktop entry parsing with XDG merge semantics

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f50fe908328a5b8ac831593b64b