### PR TITLE
Add reactive Whisker menu settings

### DIFF
--- a/src/components/menu/WhiskerMenu.tsx
+++ b/src/components/menu/WhiskerMenu.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useWhiskerPrefs } from './WhiskerSettings';
+
+const WhiskerMenu = () => {
+  const [prefs] = useWhiskerPrefs();
+
+  return (
+    <div>
+      {prefs.showFavorites && <div>Favorites Section</div>}
+      {prefs.showRecent && <div>Recent Section</div>}
+    </div>
+  );
+};
+
+export default WhiskerMenu;

--- a/src/components/menu/WhiskerSettings.tsx
+++ b/src/components/menu/WhiskerSettings.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type WhiskerPrefs = {
+  showFavorites: boolean;
+  showRecent: boolean;
+};
+
+const DEFAULT_PREFS: WhiskerPrefs = {
+  showFavorites: true,
+  showRecent: true,
+};
+
+const configPath = () => {
+  const path = require('path');
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  return path.join(home, '.config', 'whisker');
+};
+
+function readPrefs(): WhiskerPrefs {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const dir = configPath();
+    const file = path.join(dir, 'whisker.json');
+    if (fs.existsSync(file)) {
+      const data = fs.readFileSync(file, 'utf8');
+      return { ...DEFAULT_PREFS, ...JSON.parse(data) } as WhiskerPrefs;
+    }
+  } catch (err) {
+    console.error('Failed to read whisker prefs', err);
+  }
+  return DEFAULT_PREFS;
+}
+
+function writePrefs(prefs: WhiskerPrefs) {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const dir = configPath();
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'whisker.json');
+    fs.writeFileSync(file, JSON.stringify(prefs, null, 2));
+  } catch (err) {
+    console.error('Failed to write whisker prefs', err);
+  }
+}
+
+export function useWhiskerPrefs() {
+  const [prefs, setPrefs] = useState<WhiskerPrefs>(DEFAULT_PREFS);
+
+  useEffect(() => {
+    setPrefs(readPrefs());
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const file = path.join(configPath(), 'whisker.json');
+      fs.watchFile(file, () => {
+        setPrefs(readPrefs());
+      });
+      return () => fs.unwatchFile(file);
+    } catch (err) {
+      console.error('Failed to watch whisker prefs', err);
+    }
+  }, []);
+
+  const update = (next: WhiskerPrefs) => {
+    setPrefs(next);
+    writePrefs(next);
+  };
+
+  return [prefs, update] as const;
+}
+
+const WhiskerSettings = () => {
+  const [prefs, update] = useWhiskerPrefs();
+
+  return (
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          checked={prefs.showFavorites}
+          onChange={() => update({ ...prefs, showFavorites: !prefs.showFavorites })}
+        />
+        Show Favorites
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={prefs.showRecent}
+          onChange={() => update({ ...prefs, showRecent: !prefs.showRecent })}
+        />
+        Show Recent
+      </label>
+    </div>
+  );
+};
+
+export default WhiskerSettings;


### PR DESCRIPTION
## Summary
- add WhiskerSettings component to toggle favorites and recent sections
- persist user preferences in `~/.config/whisker/whisker.json`
- update WhiskerMenu to reactively read settings

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, localStorage origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f5377008328a967e795c82b00f7