### PR TITLE
feat: add desktop context menu and grid arrangement

### DIFF
--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import DesktopContextMenu from './DesktopContextMenu';
+
+export interface DesktopIcon {
+  id: string;
+  title: string;
+  x: number;
+  y: number;
+}
+
+/** Arrange icons into a grid based on container width. */
+export function arrangeIconsToGrid(
+  icons: DesktopIcon[],
+  width: number,
+  grid = 80
+): DesktopIcon[] {
+  if (width <= 0) return icons;
+  const cols = Math.max(1, Math.floor(width / grid));
+  return icons.map((icon, idx) => {
+    const col = idx % cols;
+    const row = Math.floor(idx / cols);
+    return { ...icon, x: col * grid, y: row * grid };
+  });
+}
+
+/**
+ * Minimal desktop implementation that demonstrates context menu support and
+ * grid-based icon arrangement.
+ */
+export const Desktop: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [icons, setIcons] = useState<DesktopIcon[]>([]);
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  // Example icons for demonstration
+  useEffect(() => {
+    setIcons([
+      { id: 'about', title: 'About', x: 0, y: 0 },
+      { id: 'settings', title: 'Settings', x: 100, y: 0 },
+      { id: 'terminal', title: 'Terminal', x: 200, y: 0 },
+    ]);
+  }, []);
+
+  const closeMenu = () => setMenuPos(null);
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleArrange = useCallback(() => {
+    const width = containerRef.current?.clientWidth || window.innerWidth;
+    setIcons((prev) => arrangeIconsToGrid(prev, width));
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full h-full overflow-hidden"
+      onContextMenu={handleContextMenu}
+      onClick={closeMenu}
+    >
+      {icons.map((icon) => (
+        <div
+          key={icon.id}
+          className="absolute text-center text-xs text-white"
+          style={{ left: icon.x, top: icon.y, width: 80 }}
+        >
+          <div className="h-16 w-16 rounded bg-black bg-opacity-20" />
+          <div>{icon.title}</div>
+        </div>
+      ))}
+      <DesktopContextMenu
+        position={menuPos}
+        onClose={closeMenu}
+        onArrange={handleArrange}
+      />
+    </div>
+  );
+};
+
+export default Desktop;

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+
+export interface DesktopContextMenuProps {
+  /** Position where the menu should appear. `null` hides the menu. */
+  position: { x: number; y: number } | null;
+  /** Closes the menu */
+  onClose: () => void;
+  /** Create a new folder */
+  onNewFolder?: () => void;
+  /** Create a new shortcut */
+  onCreateShortcut?: () => void;
+  /** Arrange icons to grid */
+  onArrange?: () => void;
+  /** Change background */
+  onChangeBackground?: () => void;
+  /** Open terminal */
+  onOpenTerminal?: () => void;
+  /** Open settings */
+  onOpenSettings?: () => void;
+  /** Toggle full screen */
+  onToggleFullScreen?: () => void;
+  /** Clear session */
+  onClearSession?: () => void;
+}
+
+/**
+ * Simple desktop context menu.
+ *
+ * The component renders nothing when `position` is `null`. Consumers should
+ * control the visibility through the `position` prop and call `onClose` to hide
+ * the menu when an action is invoked or the user clicks elsewhere.
+ */
+export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
+  position,
+  onClose,
+  onNewFolder,
+  onCreateShortcut,
+  onArrange,
+  onChangeBackground,
+  onOpenTerminal,
+  onOpenSettings,
+  onToggleFullScreen,
+  onClearSession,
+}) => {
+  if (!position) return null;
+
+  const handle = (cb?: () => void) => () => {
+    cb?.();
+    onClose();
+  };
+
+  return (
+    <div
+      role="menu"
+      className="absolute z-50 w-52 cursor-default select-none rounded border border-gray-700 bg-gray-800 text-sm text-white shadow-lg"
+      style={{ top: position.y, left: position.x }}
+    >
+      <ul className="py-2">
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onNewFolder)}
+          >
+            New Folder
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onCreateShortcut)}
+          >
+            Create Shortcut...
+          </button>
+        </li>
+        <li className="border-t border-gray-700 mt-1" />
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onArrange)}
+          >
+            Arrange Icons
+          </button>
+        </li>
+        <li className="border-t border-gray-700 mt-1" />
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onOpenTerminal)}
+          >
+            Open in Terminal
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onChangeBackground)}
+          >
+            Change Background...
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onOpenSettings)}
+          >
+            Settings
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onToggleFullScreen)}
+          >
+            Toggle Full Screen
+          </button>
+        </li>
+        <li className="border-t border-gray-700 mt-1" />
+        <li>
+          <button
+            type="button"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            onClick={handle(onClearSession)}
+          >
+            Clear Session
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default DesktopContextMenu;


### PR DESCRIPTION
## Summary
- add React-based DesktopContextMenu with common actions
- implement grid-based icon arrangement and context menu support in Desktop

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, TypeError in jsdom Window localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f5477688328b4b4d16f9dcaf59d