### PR TITLE
feat: add desktop icon visibility settings

### DIFF
--- a/src/components/desktop/DesktopIcons.tsx
+++ b/src/components/desktop/DesktopIcons.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import {
+  loadPreferences,
+  subscribe,
+  DesktopIconPreferences,
+} from '../../utils/desktopIconSettings';
+
+export default function DesktopIcons() {
+  const [prefs, setPrefs] = useState<DesktopIconPreferences>(() => loadPreferences());
+
+  useEffect(() => {
+    return subscribe(setPrefs);
+  }, []);
+
+  return (
+    <div>
+      {prefs.showHome && <div data-testid="desktop-icon-home">Home</div>}
+      {prefs.showTrash && <div data-testid="desktop-icon-trash">Trash</div>}
+    </div>
+  );
+}

--- a/src/components/settings/DesktopSettings.tsx
+++ b/src/components/settings/DesktopSettings.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import {
+  loadPreferences,
+  savePreferences,
+  subscribe,
+  DesktopIconPreferences,
+} from '../../utils/desktopIconSettings';
+
+export default function DesktopSettings() {
+  const [activeTab, setActiveTab] = useState<'icons'>('icons');
+  const [prefs, setPrefs] = useState<DesktopIconPreferences>(() => loadPreferences());
+
+  useEffect(() => {
+    return subscribe(setPrefs);
+  }, []);
+
+  const handleChange = (key: keyof DesktopIconPreferences) => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const next = { ...prefs, [key]: e.target.checked };
+    savePreferences(next);
+  };
+
+  return (
+    <div>
+      <div role="tablist">
+        <button
+          role="tab"
+          aria-selected={activeTab === 'icons'}
+          onClick={() => setActiveTab('icons')}
+        >
+          Icons
+        </button>
+      </div>
+      {activeTab === 'icons' && (
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={prefs.showHome}
+              onChange={handleChange('showHome')}
+            />
+            Show Home icon
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={prefs.showTrash}
+              onChange={handleChange('showTrash')}
+            />
+            Show Trash icon
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/utils/desktopIconSettings.ts
+++ b/src/utils/desktopIconSettings.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { EventEmitter } from 'events';
+
+export interface DesktopIconPreferences {
+  showHome: boolean;
+  showTrash: boolean;
+}
+
+const defaultPrefs: DesktopIconPreferences = {
+  showHome: true,
+  showTrash: true,
+};
+
+const configPath = path.join(
+  os.homedir(),
+  '.config',
+  'xfce4',
+  'desktop-icons.json'
+);
+
+let current: DesktopIconPreferences = loadFromFile();
+const emitter = new EventEmitter();
+
+function loadFromFile(): DesktopIconPreferences {
+  try {
+    const data = fs.readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(data);
+    return { ...defaultPrefs, ...parsed };
+  } catch {
+    return { ...defaultPrefs };
+  }
+}
+
+export function loadPreferences(): DesktopIconPreferences {
+  return current;
+}
+
+export function savePreferences(prefs: DesktopIconPreferences): void {
+  current = { ...defaultPrefs, ...prefs };
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(current, null, 2));
+  emitter.emit('change', current);
+}
+
+export function subscribe(
+  listener: (prefs: DesktopIconPreferences) => void
+): () => void {
+  emitter.on('change', listener);
+  return () => emitter.off('change', listener);
+}
+
+// Ensure current is initialized
+current = loadFromFile();


### PR DESCRIPTION
## Summary
- add desktop settings with Icon tab to show/hide Home and Trash
- persist icon preferences under `~/.config/xfce4/desktop-icons.json`
- render desktop icons based on saved preferences

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f5582608328b2a886a78302129f