### PR TITLE
feat: add desktop icon auto-arrange and refresh

### DIFF
--- a/components/DesktopIcons.tsx
+++ b/components/DesktopIcons.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+/**
+ * Utility functions for managing desktop icons.
+ */
+export function autoArrange(): void {
+  const container = document.getElementById('desktop');
+  if (!container) return;
+  const icons = Array.from(
+    container.querySelectorAll<HTMLElement>('#desktop [data-context="app"]')
+  );
+  icons
+    .sort((a, b) => {
+      const aLabel = (a.getAttribute('aria-label') || '').toLowerCase();
+      const bLabel = (b.getAttribute('aria-label') || '').toLowerCase();
+      return aLabel.localeCompare(bLabel);
+    })
+    .forEach((icon, index) => {
+      icon.style.order = String(index);
+    });
+}
+
+export function refreshIcons(): void {
+  const icons = document.querySelectorAll<HTMLElement>(
+    '#desktop [data-context="app"]'
+  );
+  icons.forEach((icon) => {
+    icon.classList.add('icon-refresh');
+    setTimeout(() => {
+      icon.classList.remove('icon-refresh');
+    }, 300);
+  });
+}
+
+// Placeholder React component (not used directly but helps TypeScript treat file as TSX)
+export default function DesktopIcons(): React.JSX.Element | null {
+  return null;
+}

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -68,6 +68,24 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
+            <button
+                onClick={props.refreshIcons}
+                type="button"
+                role="menuitem"
+                aria-label="Refresh Icons"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Refresh Icons</span>
+            </button>
+            <button
+                onClick={props.autoArrange}
+                type="button"
+                role="menuitem"
+                aria-label="Auto Arrange Icons"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Auto Arrange Icons</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -15,6 +15,7 @@ import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
 import DesktopMenu from '../context-menus/desktop-menu';
+import { autoArrange, refreshIcons } from '../DesktopIcons';
 import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
@@ -161,6 +162,14 @@ export class Desktop extends Component {
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
+        }
+        else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'a') {
+            e.preventDefault();
+            autoArrange();
+        }
+        else if ((e.key === 'F5') || (e.ctrlKey && e.key.toLowerCase() === 'r')) {
+            e.preventDefault();
+            refreshIcons();
         }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
@@ -896,6 +905,8 @@ export class Desktop extends Component {
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                    autoArrange={autoArrange}
+                    refreshIcons={refreshIcons}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,11 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+#desktop [data-context="app"] {
+  transition: opacity 0.3s ease-in-out;
+}
+
+#desktop [data-context="app"].icon-refresh {
+  opacity: 0;
+}


### PR DESCRIPTION
## Summary
- add utilities to auto-arrange icons and refresh icon display
- expose auto-arrange and refresh via desktop context menu and shortcuts
- animate icon redraw using CSS transitions

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: Window snapping finalize and release releases snap with Alt+ArrowDown restoring size, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f569e588328992ca3364813d1a9