### PR TITLE
feat: add directory menu panel plugin

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import DirectoryMenu from '../../src/plugins/DirectoryMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -17,6 +18,9 @@ export default class Navbar extends Component {
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                </div>
+                                <div className="pl-1 pr-1">
+                                        <DirectoryMenu path="~/Desktop" />
                                 </div>
                                 <div
                                         className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}

--- a/src/plugins/DirectoryMenu.tsx
+++ b/src/plugins/DirectoryMenu.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface DirectoryMenuProps {
+  /** Path to show within the menu */
+  path: string;
+  /** Whether hidden files should be included */
+  showHidden?: boolean;
+  /** Whether file type icons should be shown */
+  showIcons?: boolean;
+}
+
+interface Entry {
+  name: string;
+  icon?: string;
+}
+
+/**
+ * DirectoryMenu renders a simple list of files for a given path with
+ * optional toggles for hidden files and icons. An "Open in Thunar"
+ * button is provided for launching the native file manager.
+ */
+const DirectoryMenu: React.FC<DirectoryMenuProps> = ({
+  path,
+  showHidden = false,
+  showIcons = true,
+}) => {
+  const [includeHidden, setIncludeHidden] = useState(showHidden);
+  const [includeIcons, setIncludeIcons] = useState(showIcons);
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    // Attempt to fetch directory listing from an API route. Errors are ignored
+    // so the component still renders even if the route is missing.
+    fetch(`/api/files?path=${encodeURIComponent(path)}&hidden=${includeHidden}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setEntries(data);
+        } else if (Array.isArray(data?.files)) {
+          setEntries(data.files);
+        } else {
+          setEntries([]);
+        }
+      })
+      .catch(() => setEntries([]));
+  }, [path, includeHidden]);
+
+  const openInThunar = () => {
+    const encoded = encodeURIComponent(path);
+    // Using a custom scheme so systems with Thunar installed can handle it
+    window.open(`thunar://${encoded}`);
+  };
+
+  return (
+    <div className="relative" role="menu">
+      <ul className="bg-ub-cool-grey rounded p-2 text-white">
+        {entries.map((e) => (
+          <li key={e.name} className="flex items-center">
+            {includeIcons && e.icon && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={e.icon} alt="" className="w-4 h-4 mr-1" />
+            )}
+            {e.name}
+          </li>
+        ))}
+        {entries.length === 0 && (
+          <li className="text-gray-400">No files</li>
+        )}
+      </ul>
+      <div className="mt-2 flex flex-col text-xs text-white">
+        <label className="flex items-center mb-1">
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={includeHidden}
+            onChange={() => setIncludeHidden((v) => !v)}
+          />
+          Show hidden files
+        </label>
+        <label className="flex items-center mb-2">
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={includeIcons}
+            onChange={() => setIncludeIcons((v) => !v)}
+          />
+          Show icons
+        </label>
+        <button
+          type="button"
+          onClick={openInThunar}
+          className="bg-ub-orange text-black rounded px-2 py-1"
+        >
+          Open in Thunar
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DirectoryMenu;
+


### PR DESCRIPTION
## Summary
- add DirectoryMenu plugin component with hidden file & icon toggles and Thunar option
- register DirectoryMenu in navbar panel targeting ~/Desktop

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f589b8c832887d910061567906c