### PR TITLE
feat: add session action buttons

### DIFF
--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  message: React.ReactNode;
+  title?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  message,
+  title,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}) => {
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="bg-gray-800 text-white p-4 rounded shadow-lg w-80 max-w-full">
+        {title && <h2 className="text-lg mb-2">{title}</h2>}
+        <div className="mb-4 text-sm">{message}</div>
+        <div className="flex justify-end space-x-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-3 py-1 rounded bg-red-600 hover:bg-red-500"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/src/lib/session/actions.ts
+++ b/src/lib/session/actions.ts
@@ -1,0 +1,32 @@
+export interface SessionAction {
+  id: string;
+  label: string;
+  /** Optional confirmation message */
+  confirm?: string;
+}
+
+/**
+ * Fetch available session actions from the API.
+ */
+export async function listSessionActions(): Promise<SessionAction[]> {
+  try {
+    const res = await fetch('/api/session/actions');
+    if (!res.ok) throw new Error('Failed to fetch actions');
+    const data = await res.json();
+    // Support either array response or {actions: []}
+    return Array.isArray(data) ? data : data.actions || [];
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+}
+
+/**
+ * Execute a specific session action by id.
+ */
+export async function executeSessionAction(id: string): Promise<void> {
+  const res = await fetch(`/api/session/actions/${id}`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error('Failed to execute action');
+  }
+}

--- a/src/plugins/ActionButtons.tsx
+++ b/src/plugins/ActionButtons.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import ConfirmDialog from '../components/common/ConfirmDialog';
+import {
+  SessionAction,
+  listSessionActions,
+  executeSessionAction,
+} from '../lib/session/actions';
+
+/**
+ * Renders a set of buttons for performing session actions.
+ * Actions are fetched from the session actions API.
+ */
+const ActionButtons: React.FC = () => {
+  const [actions, setActions] = useState<SessionAction[]>([]);
+  const [pending, setPending] = useState<SessionAction | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const list = await listSessionActions();
+      setActions(list);
+    })();
+  }, []);
+
+  const triggerAction = async (action: SessionAction) => {
+    if (action.confirm) {
+      setPending(action);
+    } else {
+      await executeSessionAction(action.id);
+    }
+  };
+
+  const confirm = async () => {
+    if (pending) {
+      await executeSessionAction(pending.id);
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-gray-700"
+          onClick={() => triggerAction(action)}
+        >
+          {action.label}
+        </button>
+      ))}
+      <ConfirmDialog
+        open={!!pending}
+        message={pending?.confirm || ''}
+        onConfirm={confirm}
+        onCancel={() => setPending(null)}
+      />
+    </div>
+  );
+};
+
+export default ActionButtons;


### PR DESCRIPTION
## Summary
- add confirmation dialog component
- add session action helpers and action buttons plugin

## Testing
- `yarn eslint --format json src/components/common/ConfirmDialog.tsx src/lib/session/actions.ts src/plugins/ActionButtons.tsx`
- `yarn tsc --noEmit src/components/common/ConfirmDialog.tsx src/lib/session/actions.ts src/plugins/ActionButtons.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided, etc.)*
- `yarn test --passWithNoTests src/plugins/ActionButtons.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f59e9088328a2833006e8d4321f