### PR TITLE
feat: add customizable clock plugin

### DIFF
--- a/src/plugins/Clock.tsx
+++ b/src/plugins/Clock.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import usePersistentState from '@/hooks/usePersistentState';
+
+export type ClockStyle = 'time' | 'date' | 'datetime' | 'custom';
+
+const STYLE_FORMATS: Record<Exclude<ClockStyle, 'custom'>, string> = {
+  time: '%H:%M',
+  date: '%a %b %-d',
+  datetime: '%a %b %-d %H:%M',
+};
+
+function pad(num: number, len = 2) {
+  return num.toString().padStart(len, '0');
+}
+
+function formatDate(date: Date, fmt: string) {
+  const map: Record<string, string> = {
+    '%a': date.toLocaleDateString(undefined, { weekday: 'short' }),
+    '%A': date.toLocaleDateString(undefined, { weekday: 'long' }),
+    '%b': date.toLocaleDateString(undefined, { month: 'short' }),
+    '%B': date.toLocaleDateString(undefined, { month: 'long' }),
+    '%d': pad(date.getDate()),
+    '%-d': date.getDate().toString(),
+    '%H': pad(date.getHours()),
+    '%-H': date.getHours().toString(),
+    '%I': pad((date.getHours() % 12) || 12),
+    '%-I': ((date.getHours() % 12) || 12).toString(),
+    '%M': pad(date.getMinutes()),
+    '%S': pad(date.getSeconds()),
+    '%p': date.getHours() < 12 ? 'AM' : 'PM',
+    '%Y': date.getFullYear().toString(),
+    '%m': pad(date.getMonth() + 1),
+  };
+  return fmt.replace(/%[-]?[aAbBdHImMpSYm]/g, (m) => map[m] ?? m);
+}
+
+export default function Clock() {
+  const [now, setNow] = useState<Date>(new Date());
+  const [style, setStyle] = usePersistentState<ClockStyle>('clock:style', 'datetime');
+  const [customFormat, setCustomFormat] = usePersistentState<string>('clock:format', STYLE_FORMATS.datetime);
+  const [tooltipFormat, setTooltipFormat] = usePersistentState<string>('clock:tooltip', '%A %B %-d, %Y');
+  const [calendarEnabled, setCalendarEnabled] = usePersistentState<boolean>('clock:calendar', false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // sync with settings events
+  useEffect(() => {
+    const onStyle = (e: Event) => setStyle((e as CustomEvent<ClockStyle>).detail);
+    const onFormat = (e: Event) => setCustomFormat((e as CustomEvent<string>).detail);
+    const onTooltip = (e: Event) => setTooltipFormat((e as CustomEvent<string>).detail);
+    const onCalendar = (e: Event) => setCalendarEnabled((e as CustomEvent<boolean>).detail);
+    window.addEventListener('clock-style', onStyle);
+    window.addEventListener('clock-format', onFormat);
+    window.addEventListener('clock-tooltip', onTooltip);
+    window.addEventListener('clock-calendar', onCalendar);
+    return () => {
+      window.removeEventListener('clock-style', onStyle);
+      window.removeEventListener('clock-format', onFormat);
+      window.removeEventListener('clock-tooltip', onTooltip);
+      window.removeEventListener('clock-calendar', onCalendar);
+    };
+  }, [setStyle, setCustomFormat, setTooltipFormat, setCalendarEnabled]);
+
+  const format = style === 'custom' ? customFormat : STYLE_FORMATS[style];
+  const label = formatDate(now, format);
+  const tooltip = tooltipFormat ? formatDate(now, tooltipFormat) : undefined;
+
+  const handleClick = () => {
+    if (calendarEnabled) setOpen((o) => !o);
+  };
+
+  return (
+    <div className="relative inline-block" onClick={handleClick}>
+      <span dangerouslySetInnerHTML={{ __html: label }} title={tooltip}></span>
+      {calendarEnabled && open && (
+        <div className="absolute mt-1 p-2 bg-white text-black rounded shadow">
+          {now.toDateString()}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/plugins/settings/ClockSettings.tsx
+++ b/src/plugins/settings/ClockSettings.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { ChangeEvent } from 'react';
+import usePersistentState from '@/hooks/usePersistentState';
+import type { ClockStyle } from '../Clock';
+
+const STYLES: { value: ClockStyle; label: string }[] = [
+  { value: 'time', label: 'Time only' },
+  { value: 'date', label: 'Date only' },
+  { value: 'datetime', label: 'Date & Time' },
+  { value: 'custom', label: 'Custom' },
+];
+
+export default function ClockSettings() {
+  const [style, setStyle] = usePersistentState<ClockStyle>('clock:style', 'datetime');
+  const [format, setFormat] = usePersistentState<string>('clock:format', '%a %b %-d %H:%M');
+  const [tooltip, setTooltip] = usePersistentState<string>('clock:tooltip', '%A %B %-d, %Y');
+  const [calendar, setCalendar] = usePersistentState<boolean>('clock:calendar', false);
+
+  const handleStyle = (e: ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as ClockStyle;
+    setStyle(value);
+    window.dispatchEvent(new CustomEvent('clock-style', { detail: value }));
+  };
+
+  const handleFormat = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setFormat(value);
+    window.dispatchEvent(new CustomEvent('clock-format', { detail: value }));
+  };
+
+  const handleTooltip = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setTooltip(value);
+    window.dispatchEvent(new CustomEvent('clock-tooltip', { detail: value }));
+  };
+
+  const handleCalendar = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.checked;
+    setCalendar(value);
+    window.dispatchEvent(new CustomEvent('clock-calendar', { detail: value }));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-center space-x-2">
+        <span>Style</span>
+        <select
+          className="text-black px-1 py-0.5 rounded"
+          value={style}
+          onChange={handleStyle}
+        >
+          {STYLES.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {style === 'custom' && (
+        <label className="flex items-center space-x-2">
+          <span>Format</span>
+          <input
+            type="text"
+            className="text-black px-1 py-0.5 rounded flex-1"
+            value={format}
+            onChange={handleFormat}
+            aria-label="Clock format"
+          />
+        </label>
+      )}
+      <label className="flex items-center space-x-2">
+        <span>Tooltip</span>
+        <input
+          type="text"
+          className="text-black px-1 py-0.5 rounded flex-1"
+          value={tooltip}
+          onChange={handleTooltip}
+          aria-label="Clock tooltip"
+        />
+      </label>
+      <label className="flex items-center space-x-2">
+        <span>Calendar</span>
+        <input
+          type="checkbox"
+          checked={calendar}
+          onChange={handleCalendar}
+          aria-label="Toggle calendar"
+        />
+      </label>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add configurable Clock plugin with style presets and custom Pango-like format
- include settings UI for clock style, tooltip text, and calendar toggle
- update clock display live when custom format changes

## Testing
- `npx eslint src/plugins/Clock.tsx src/plugins/settings/ClockSettings.tsx`
- `yarn test src/plugins/Clock.tsx src/plugins/settings/ClockSettings.tsx --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ba2f5ae900832891ac5835b5af37d2