### PR TITLE
feat: add separator plugin with adjustable mode

### DIFF
--- a/src/plugins/Separator.tsx
+++ b/src/plugins/Separator.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export type SeparatorMode = 'line' | 'expand';
+
+export interface SeparatorProps {
+  /**
+   * Determines the visual style of the separator.
+   * - `line`: renders a thin divider line.
+   * - `expand`: flex item that grows to push adjacent items apart.
+   */
+  mode?: SeparatorMode;
+}
+
+export interface SeparatorSettingsProps {
+  mode: SeparatorMode;
+  onChange: (mode: SeparatorMode) => void;
+}
+
+const Separator: React.FC<SeparatorProps> & {
+  Settings?: React.FC<SeparatorSettingsProps>;
+} = ({ mode = 'line' }) => {
+  return mode === 'expand' ? (
+    <div className="flex-grow" />
+  ) : (
+    <div className="mx-2 border-l border-current opacity-25" />
+  );
+};
+
+const Settings: React.FC<SeparatorSettingsProps> = ({ mode, onChange }) => (
+  <label className="block text-xs">
+    Mode:
+    <select
+      className="ml-2 bg-black border border-gray-600 rounded px-1 py-0.5"
+      value={mode}
+      onChange={(e) => onChange(e.target.value as SeparatorMode)}
+    >
+      <option value="line">Line</option>
+      <option value="expand">Expand</option>
+    </select>
+  </label>
+);
+
+Separator.Settings = Settings;
+
+export default Separator;
+export { Settings as SeparatorSettings };


### PR DESCRIPTION
## Summary
- add Separator plugin supporting `line` and `expand` modes
- include settings UI to select separator mode

## Testing
- `npx eslint src/plugins/Separator.tsx`
- `yarn typecheck`
- `yarn test src/plugins/Separator.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f60f8f88328b6d18fc4c3503305