### PR TITLE
feat(clock): add timezone option

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import panelLayout from '../../data/panel-layout.json';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -30,13 +31,16 @@ export default class Navbar extends Component {
                                         />
                                         Activities
                                 </div>
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
+                                {panelLayout.items.filter((item) => item.type === 'clock').map((clock) => (
+                                        <div
+                                                key={clock.id}
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
+                                        >
+                                                <Clock timezone={clock.timezone} useSystemTimezone={clock.useSystemTimezone} />
+                                        </div>
+                                ))}
                                 <button
                                         type="button"
                                         id="status-bar"

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -1,8 +1,8 @@
 import { Component } from 'react'
 
 export default class Clock extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.month_list = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
         this.day_list = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         this.state = {
@@ -11,8 +11,15 @@ export default class Clock extends Component {
         };
     }
 
+    getCurrentTime() {
+        if (this.props.useSystemTimezone === false && this.props.timezone) {
+            return new Date(new Date().toLocaleString('en-US', { timeZone: this.props.timezone }));
+        }
+        return new Date();
+    }
+
     componentDidMount() {
-        const update = () => this.setState({ current_time: new Date() });
+        const update = () => this.setState({ current_time: this.getCurrentTime() });
         update();
         if (typeof window !== 'undefined' && typeof Worker === 'function') {
             this.worker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
@@ -59,3 +66,7 @@ export default class Clock extends Component {
         return <span suppressHydrationWarning>{display_time}</span>;
     }
 }
+
+Clock.defaultProps = {
+    useSystemTimezone: true
+};

--- a/data/panel-layout.json
+++ b/data/panel-layout.json
@@ -1,0 +1,6 @@
+{
+  "items": [
+    { "type": "clock", "id": "clock-local", "useSystemTimezone": true },
+    { "type": "clock", "id": "clock-utc", "useSystemTimezone": false, "timezone": "UTC" }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow clocks to render in specified or system time zones
- drive panel clocks from new layout JSON

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `node -e "const now=new Date(); console.log('local', now.toTimeString()); console.log('tokyo', new Date(now.toLocaleString('en-US',{timeZone:'Asia/Tokyo'})).toTimeString());"`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f5dc9f88328abb7684cb6ee2a5b