### PR TITLE
feat(panel): add edit mode and drag persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "react-activity-calendar": "^2.7.13",
     "react-bootstrap": "^2.10.4",
     "react-cytoscapejs": "^2.0.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "19.1.1",
     "react-draggable": "^4.4.5",
     "react-force-graph": "^1.45.0",

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { useDrag, useDrop } from 'react-dnd';
+import layoutData from './layout.json';
+import { usePanelPreferences } from './PanelPreferences';
+
+interface PluginItem {
+  id: string;
+  title: string;
+}
+
+interface DraggableProps {
+  plugin: PluginItem;
+  index: number;
+  move: (from: number, to: number) => void;
+}
+
+const type = 'PLUGIN_ITEM';
+
+function DraggablePlugin({ plugin, index, move }: DraggableProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { editMode, locked } = usePanelPreferences();
+
+  const [, drop] = useDrop<{ index: number }>({
+    accept: type,
+    hover(item) {
+      if (!ref.current || item.index === index) return;
+      move(item.index, index);
+      item.index = index;
+    },
+  }, [index]);
+
+  const [{ isDragging }, drag] = useDrag({
+    type,
+    item: { index },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+    canDrag: editMode && !locked,
+  }, [index, editMode, locked]);
+
+  drag(drop(ref));
+
+  return (
+    <div
+      ref={ref}
+      className={`flex items-center p-2 border mb-1 bg-black/20 text-white ${
+        editMode && !locked ? 'cursor-move' : ''
+      }`}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      {editMode && !locked && <span className="mr-2">⋮⋮</span>}
+      {plugin.title}
+    </div>
+  );
+}
+
+export default function Panel() {
+  const [plugins, setPlugins] = useState<PluginItem[]>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem('panel-layout');
+        if (stored) return JSON.parse(stored) as PluginItem[];
+      } catch {
+        /* ignore */
+      }
+    }
+    return layoutData as PluginItem[];
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('panel-layout', JSON.stringify(plugins));
+    } catch {
+      /* ignore */
+    }
+  }, [plugins]);
+
+  const move = (from: number, to: number) => {
+    setPlugins((prev) => {
+      const updated = [...prev];
+      const [item] = updated.splice(from, 1);
+      updated.splice(to, 0, item);
+      return updated;
+    });
+  };
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div>
+        {plugins.map((p, i) => (
+          <DraggablePlugin key={p.id} plugin={p} index={i} move={move} />
+        ))}
+      </div>
+    </DndProvider>
+  );
+}

--- a/src/components/panel/PanelPreferences.tsx
+++ b/src/components/panel/PanelPreferences.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface PanelPreferencesContextValue {
+  editMode: boolean;
+  locked: boolean;
+  toggleEdit: () => void;
+  toggleLock: () => void;
+}
+
+const PanelPreferencesContext = createContext<PanelPreferencesContextValue | undefined>(
+  undefined
+);
+
+export function PanelPreferencesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [editMode, setEditMode] = useState(false);
+  const [locked, setLocked] = useState(false);
+
+  const toggleEdit = () => setEditMode((v) => !v);
+  const toggleLock = () => setLocked((v) => !v);
+
+  return (
+    <PanelPreferencesContext.Provider
+      value={{ editMode, locked, toggleEdit, toggleLock }}
+    >
+      {children}
+    </PanelPreferencesContext.Provider>
+  );
+}
+
+export function usePanelPreferences() {
+  const ctx = useContext(PanelPreferencesContext);
+  if (!ctx) throw new Error('usePanelPreferences must be used within provider');
+  return ctx;
+}
+
+export default function PanelPreferences() {
+  const { editMode, toggleEdit, locked, toggleLock } = usePanelPreferences();
+  return (
+    <div className="flex items-center gap-4 p-2">
+      <label className="flex items-center gap-1">
+        <input type="checkbox" checked={editMode} onChange={toggleEdit} />
+        Edit mode
+      </label>
+      <label className="flex items-center gap-1">
+        <input type="checkbox" checked={locked} onChange={toggleLock} />
+        Lock
+      </label>
+    </div>
+  );
+}

--- a/src/components/panel/layout.json
+++ b/src/components/panel/layout.json
@@ -1,0 +1,5 @@
+[
+  { "id": "plugin-a", "title": "Plugin A" },
+  { "id": "plugin-b", "title": "Plugin B" },
+  { "id": "plugin-c", "title": "Plugin C" }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.26.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.26.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.28.3
   resolution: "@babel/runtime@npm:7.28.3"
   checksum: 10c0/b360f82c2c5114f2a062d4d143d7b4ec690094764853937110585a9497977aed66c102166d0e404766c274e02a50ffb8f6d77fef7251ecf3f607f0e03e6397bc
@@ -2815,6 +2815,27 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10c0/44acb4c441d9c5d65aab94aa81fd8368413cf2958ab458582296dd78f6ba4783583f2311fa986120060e5c26b54b1f01e8910ffd17e4f41ccc5fc8c357d84089
+  languageName: node
+  linkType: hard
+
+"@react-dnd/asap@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "@react-dnd/asap@npm:5.0.2"
+  checksum: 10c0/0063db616db9801c9be18f11a912c3e214f87e714b1e4bf9462952af7ead65cba0b43e1f7c34bc8748811b6926e74d929e5e126f85ebb91b870faf809ceb5177
+  languageName: node
+  linkType: hard
+
+"@react-dnd/invariant@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@react-dnd/invariant@npm:4.0.2"
+  checksum: 10c0/b303cc53fc5074cefb2a76b45b9c73ebb5d35630b18f5dc282ed9a9ac9b0287b9da1f6ac63acfdea2341b8f8187f615afc12d5eb14ec6015964f5c1b167332e2
+  languageName: node
+  linkType: hard
+
+"@react-dnd/shallowequal@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@react-dnd/shallowequal@npm:4.0.2"
+  checksum: 10c0/9a352fd176752e5d9c2797d598aca034b7829111ae0c992d80f40d5f068fcd6a039b1841c741dfa1ab67a36a00664310aec4f0ce216e4112f80875c9fe6fd8dc
   languageName: node
   linkType: hard
 
@@ -6353,6 +6374,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dnd-core@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "dnd-core@npm:16.0.1"
+  dependencies:
+    "@react-dnd/asap": "npm:^5.0.1"
+    "@react-dnd/invariant": "npm:^4.0.1"
+    redux: "npm:^4.2.0"
+  checksum: 10c0/6b852c576c88b0a42e618efb37e046334f5e9914b8d38ad139933dd9595b6caf2a484953a6301094d23119c17479549553d71e92fd77fa37318122ea1e579f65
+  languageName: node
+  linkType: hard
+
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
@@ -7949,6 +7981,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
   languageName: node
   linkType: hard
 
@@ -11848,6 +11889,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dnd-html5-backend@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "react-dnd-html5-backend@npm:16.0.1"
+  dependencies:
+    dnd-core: "npm:^16.0.1"
+  checksum: 10c0/6e4b632a11e20211d71f5f3bedadf13ecec2fa73372fde388619838294b1375f15b717d1ce128e12c872ff7b15c32d26761d2026b33c14fc55e4fd5477c15289
+  languageName: node
+  linkType: hard
+
+"react-dnd@npm:^16.0.1":
+  version: 16.0.1
+  resolution: "react-dnd@npm:16.0.1"
+  dependencies:
+    "@react-dnd/invariant": "npm:^4.0.1"
+    "@react-dnd/shallowequal": "npm:^4.0.1"
+    dnd-core: "npm:^16.0.1"
+    fast-deep-equal: "npm:^3.1.3"
+    hoist-non-react-statics: "npm:^3.3.2"
+  peerDependencies:
+    "@types/hoist-non-react-statics": ">= 3.3.1"
+    "@types/node": ">= 12"
+    "@types/react": ">= 16"
+    react: ">= 16.14"
+  peerDependenciesMeta:
+    "@types/hoist-non-react-statics":
+      optional: true
+    "@types/node":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/d069435750f0d6653cfa2b951cac8abb3583fb144ff134a20176608877d9c5964c63384ebbacaa0fdeef819b592a103de0d8e06f3b742311d64a029ffed0baa3
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:19.1.1":
   version: 19.1.1
   resolution: "react-dom@npm:19.1.1"
@@ -11906,7 +11981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.3.2":
+"react-is@npm:^16.13.1, react-is@npm:^16.3.2, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -12025,6 +12100,15 @@ __metadata:
     indent-string: "npm:^4.0.0"
     strip-indent: "npm:^3.0.0"
   checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.9.2"
+  checksum: 10c0/136d98b3d5dbed1cd6279c8c18a6a74c416db98b8a432a46836bdd668475de6279a2d4fd9d1363f63904e00f0678a8a3e7fa532c897163340baf1e71bb42c742
   languageName: node
   linkType: hard
 
@@ -13944,6 +14028,8 @@ __metadata:
     react-activity-calendar: "npm:^2.7.13"
     react-bootstrap: "npm:^2.10.4"
     react-cytoscapejs: "npm:^2.0.0"
+    react-dnd: "npm:^16.0.1"
+    react-dnd-html5-backend: "npm:^16.0.1"
     react-dom: "npm:19.1.1"
     react-draggable: "npm:^4.4.5"
     react-force-graph: "npm:^1.45.0"


### PR DESCRIPTION
## Summary
- add `PanelPreferences` component for toggling edit mode and lock
- implement draggable `Panel` with react-dnd and persistent order
- seed panel layout with default plugin list

## Testing
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp copies example output to clipboard, modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f61a95083288e5a24a55cd5ee77