### PR TITLE
feat(wm): add adjustable snap threshold

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import WindowManagerTweaks from "../../src/components/settings/WindowManagerTweaks";
 import {
   resetSettings,
   defaults,
@@ -260,6 +261,7 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
+          <WindowManagerTweaks />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={() => setShowKeymap(true)}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,8 +7,11 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import { getSnap } from '@/src/wm/snap';
+import { SettingsContext } from '../../hooks/useSettings';
 
 export class Window extends Component {
+    static contextType = SettingsContext;
     constructor(props) {
         super(props);
         this.id = null;
@@ -317,28 +320,18 @@ export class Window extends Component {
         var r = document.querySelector("#" + this.id);
         if (!r) return;
         var rect = r.getBoundingClientRect();
-        const threshold = 30;
-        let snap = null;
-        if (rect.left <= threshold) {
-            snap = { left: '0', top: '0', width: '50%', height: '100%' };
-            this.setState({ snapPreview: snap, snapPosition: 'left' });
-        }
-        else if (rect.right >= window.innerWidth - threshold) {
-            snap = { left: '50%', top: '0', width: '50%', height: '100%' };
-            this.setState({ snapPreview: snap, snapPosition: 'right' });
-        }
-        else if (rect.top <= threshold) {
-            snap = { left: '0', top: '0', width: '100%', height: '50%' };
-            this.setState({ snapPreview: snap, snapPosition: 'top' });
-        }
-        else {
-            if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
+        const threshold = this.context?.snapThreshold ?? 30;
+        const { preview, position } = getSnap(rect, threshold);
+        if (position && preview) {
+            this.setState({ snapPreview: preview, snapPosition: position });
+        } else if (this.state.snapPreview) {
+            this.setState({ snapPreview: null, snapPosition: null });
         }
     }
 
     applyEdgeResistance = (node, data) => {
         if (!node || !data) return;
-        const threshold = 30;
+        const threshold = this.context?.snapThreshold ?? 30;
         const resistance = 0.35; // how much to slow near edges
         let { x, y } = data;
         const maxX = this.state.parentSize.width;
@@ -525,20 +518,20 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getSnapThreshold as loadSnapThreshold,
+  setSnapThreshold as saveSnapThreshold,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +65,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  snapThreshold: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +77,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setSnapThreshold: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  snapThreshold: defaults.snapThreshold,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setSnapThreshold: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [snapThreshold, setSnapThreshold] = useState<number>(defaults.snapThreshold);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setSnapThreshold(await loadSnapThreshold());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveSnapThreshold(snapThreshold);
+  }, [snapThreshold]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +262,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        snapThreshold,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +274,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setSnapThreshold,
       }}
     >
       {children}

--- a/src/components/settings/WindowManagerTweaks.tsx
+++ b/src/components/settings/WindowManagerTweaks.tsx
@@ -1,0 +1,24 @@
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function WindowManagerTweaks() {
+  const { snapThreshold, setSnapThreshold } = useSettings();
+  return (
+    <div className="flex justify-center my-4 items-center">
+      <label htmlFor="snap-threshold" className="mr-2 text-ubt-grey">
+        Snap Threshold:
+      </label>
+      <input
+        id="snap-threshold"
+        type="range"
+        min="0"
+        max="200"
+        step="5"
+        value={snapThreshold}
+        onChange={(e) => setSnapThreshold(parseInt(e.target.value, 10))}
+        className="ubuntu-slider"
+        aria-label="Snap Threshold"
+      />
+      <span className="ml-2 text-ubt-grey">{snapThreshold}px</span>
+    </div>
+  );
+}

--- a/src/wm/snap.ts
+++ b/src/wm/snap.ts
@@ -1,0 +1,42 @@
+export type SnapPosition = 'left' | 'right' | 'top';
+
+export interface SnapPreview {
+  left: string;
+  top: string;
+  width: string;
+  height: string;
+}
+
+export interface SnapResult {
+  preview: SnapPreview | null;
+  position: SnapPosition | null;
+}
+
+/**
+ * Calculate snap preview and position for a window.
+ *
+ * @param rect - Bounding rectangle of the draggable window
+ * @param threshold - Distance from viewport edge in pixels to trigger snap
+ * @param viewportWidth - Width of the viewport (window.innerWidth)
+ */
+export function getSnap(
+  rect: DOMRect,
+  threshold: number,
+  viewportWidth: number = typeof window !== 'undefined' ? window.innerWidth : 0
+): SnapResult {
+  let preview: SnapPreview | null = null;
+  let position: SnapPosition | null = null;
+
+  if (rect.left <= threshold) {
+    preview = { left: '0', top: '0', width: '50%', height: '100%' };
+    position = 'left';
+  } else if (rect.right >= viewportWidth - threshold) {
+    preview = { left: '50%', top: '0', width: '50%', height: '100%' };
+    position = 'right';
+  } else if (rect.top <= threshold) {
+    preview = { left: '0', top: '0', width: '100%', height: '50%' };
+    position = 'top';
+  }
+
+  return { preview, position };
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  snapThreshold: 30,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getSnapThreshold() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.snapThreshold;
+  const val = window.localStorage.getItem('snap-threshold');
+  return val ? parseInt(val, 10) : DEFAULT_SETTINGS.snapThreshold;
+}
+
+export async function setSnapThreshold(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('snap-threshold', String(value));
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('snap-threshold');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    snapThreshold,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getSnapThreshold(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    snapThreshold,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    snapThreshold,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (snapThreshold !== undefined) await setSnapThreshold(snapThreshold);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add window edge snapping helper with configurable threshold
- expose snap threshold setting in UI and settings store
- apply threshold when dragging windows to edges and during keyboard snapping

## Testing
- `npm test __tests__/window.test.tsx`
- `npm test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68ba2f6896d08328bd45c63d0b38f17c