### PR TITLE
Add focus model options and focus stealing prevention

### DIFF
--- a/apps/settings/components/WindowManagerTweaks.tsx
+++ b/apps/settings/components/WindowManagerTweaks.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function WindowManagerTweaks() {
+  const {
+    focusModel,
+    setFocusModel,
+    preventFocusSteal,
+    setPreventFocusSteal,
+  } = useSettings();
+
+  return (
+    <>
+      <div className="flex justify-center my-4">
+        <label className="mr-2 text-ubt-grey">Focus Model:</label>
+        <select
+          value={focusModel}
+          onChange={(e) => setFocusModel(e.target.value as any)}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          <option value="click">Click to Focus</option>
+          <option value="sloppy">Focus Follows Mouse</option>
+        </select>
+      </div>
+      <div className="flex justify-center my-4 items-center">
+        <span className="mr-2 text-ubt-grey">Prevent Focus Stealing:</span>
+        <ToggleSwitch
+          checked={preventFocusSteal}
+          onChange={setPreventFocusSteal}
+          ariaLabel="Prevent Focus Stealing"
+        />
+      </div>
+    </>
+  );
+}
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import WindowManagerTweaks from "./components/WindowManagerTweaks";
 
 export default function Settings() {
   const {
@@ -260,6 +261,7 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
+          <WindowManagerTweaks />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={() => setShowKeymap(true)}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,10 +20,19 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getFocusModel as loadFocusModel,
+  setFocusModel as saveFocusModel,
+  getPreventFocusSteal as loadPreventFocusSteal,
+  setPreventFocusSteal as savePreventFocusSteal,
   defaults,
 } from '../utils/settingsStore';
+import {
+  setFocusModel as applyFocusModel,
+  setPreventFocusSteal as applyPreventFocusSteal,
+} from '../src/wm/focus';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+type FocusModel = 'click' | 'sloppy';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -62,6 +71,8 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  focusModel: FocusModel;
+  preventFocusSteal: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +84,8 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setFocusModel: (model: FocusModel) => void;
+  setPreventFocusSteal: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +100,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  focusModel: defaults.focusModel as FocusModel,
+  preventFocusSteal: defaults.preventFocusSteal,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +113,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setFocusModel: () => {},
+  setPreventFocusSteal: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +129,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [focusModel, setFocusModel] = useState<FocusModel>(defaults.focusModel as FocusModel);
+  const [preventFocusSteal, setPreventFocusSteal] = useState<boolean>(
+    defaults.preventFocusSteal,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +148,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setFocusModel((await loadFocusModel()) as FocusModel);
+      setPreventFocusSteal(await loadPreventFocusSteal());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +259,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveFocusModel(focusModel);
+    applyFocusModel(focusModel);
+  }, [focusModel]);
+
+  useEffect(() => {
+    savePreventFocusSteal(preventFocusSteal);
+    applyPreventFocusSteal(preventFocusSteal);
+  }, [preventFocusSteal]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +282,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        focusModel,
+        preventFocusSteal,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +295,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setFocusModel,
+        setPreventFocusSteal,
         setTheme,
       }}
     >

--- a/src/wm/focus.ts
+++ b/src/wm/focus.ts
@@ -1,0 +1,67 @@
+export type FocusModel = 'click' | 'sloppy';
+
+let currentModel: FocusModel = 'click';
+let preventSteal = false;
+let lastInteraction = 0;
+
+function recordInteraction() {
+  lastInteraction = Date.now();
+}
+
+function onMouseDown(e: MouseEvent) {
+  (e.target as HTMLElement)?.focus?.();
+}
+
+function onMouseMove(e: MouseEvent) {
+  (e.target as HTMLElement)?.focus?.();
+}
+
+function attachListeners() {
+  if (typeof window === 'undefined') return;
+  if (currentModel === 'click') {
+    window.addEventListener('mousedown', onMouseDown);
+  } else {
+    window.addEventListener('mousemove', onMouseMove);
+  }
+}
+
+function detachListeners() {
+  if (typeof window === 'undefined') return;
+  window.removeEventListener('mousedown', onMouseDown);
+  window.removeEventListener('mousemove', onMouseMove);
+}
+
+if (typeof window !== 'undefined') {
+  ['mousedown', 'keydown', 'touchstart'].forEach((evt) => {
+    window.addEventListener(evt, recordInteraction, true);
+  });
+  window.addEventListener(
+    'focusin',
+    (e) => {
+      if (!preventSteal) return;
+      if (Date.now() - lastInteraction > 100) {
+        (e.target as HTMLElement)?.blur?.();
+      }
+    },
+    true,
+  );
+}
+
+export function setFocusModel(model: FocusModel) {
+  if (model === currentModel) return;
+  detachListeners();
+  currentModel = model;
+  attachListeners();
+}
+
+export function setPreventFocusSteal(value: boolean) {
+  preventSteal = value;
+}
+
+export function initFocusHandling(model: FocusModel, prevent: boolean) {
+  currentModel = model;
+  preventSteal = prevent;
+  detachListeners();
+  attachListeners();
+}
+

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  focusModel: 'click',
+  preventFocusSteal: false,
 };
 
 export async function getAccent() {
@@ -123,6 +125,28 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getFocusModel() {
+  if (typeof window === 'undefined' || !window.localStorage)
+    return DEFAULT_SETTINGS.focusModel;
+  return window.localStorage.getItem('focus-model') || DEFAULT_SETTINGS.focusModel;
+}
+
+export async function setFocusModel(value) {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  window.localStorage.setItem('focus-model', value);
+}
+
+export async function getPreventFocusSteal() {
+  if (typeof window === 'undefined' || !window.localStorage)
+    return DEFAULT_SETTINGS.preventFocusSteal;
+  return window.localStorage.getItem('prevent-focus-steal') === 'true';
+}
+
+export async function setPreventFocusSteal(value) {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  window.localStorage.setItem('prevent-focus-steal', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +161,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('focus-model');
+  window.localStorage.removeItem('prevent-focus-steal');
 }
 
 export async function exportSettings() {
@@ -151,6 +177,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusModel,
+    preventFocusSteal,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +190,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getFocusModel(),
+    getPreventFocusSteal(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +205,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    focusModel,
+    preventFocusSteal,
     theme,
   });
 }
@@ -199,6 +231,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    focusModel,
+    preventFocusSteal,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +245,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (focusModel !== undefined) await setFocusModel(focusModel);
+  if (preventFocusSteal !== undefined) await setPreventFocusSteal(preventFocusSteal);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add window manager focus and focus-stealing settings in Accessibility tab
- store focus model in settings and apply via dynamic handler
- implement focus handler supporting click and sloppy modes with prevention logic

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f6929948328b17e7323f18405cd