### PR TITLE
Add compositor settings and tweaks UI

### DIFF
--- a/apps/window-manager-tweaks/WindowManagerTweaks.tsx
+++ b/apps/window-manager-tweaks/WindowManagerTweaks.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import Tabs from '../../components/Tabs';
+import ToggleSwitch from '../../components/ToggleSwitch';
+import {
+  CompositorSettings,
+  loadCompositor,
+  updateCompositor,
+} from '../../src/wm/compositor';
+
+export default function WindowManagerTweaks() {
+  const tabs = [
+    { id: 'general', label: 'General' },
+    { id: 'compositor', label: 'Compositor' },
+  ] as const;
+  type TabId = (typeof tabs)[number]['id'];
+  const [active, setActive] = useState<TabId>('compositor');
+
+  const [settings, setSettings] = useState<CompositorSettings>(() => loadCompositor());
+
+  useEffect(() => {
+    setSettings(loadCompositor());
+  }, []);
+
+  const handleToggle = (key: keyof CompositorSettings) => (val: boolean) => {
+    const next = { ...settings, [key]: val };
+    setSettings(next);
+    updateCompositor({ [key]: val });
+  };
+
+  return (
+    <div className="p-4 text-ubt-grey">
+      <Tabs tabs={tabs} active={active} onChange={setActive} />
+      {active === 'compositor' && (
+        <div className="space-y-4 mt-4">
+          <div className="flex items-center space-x-2">
+            <span>CSS Effects</span>
+            <ToggleSwitch
+              ariaLabel="CSS Effects"
+              checked={settings.css}
+              onChange={handleToggle('css')}
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <span>WebGL Effects</span>
+            <ToggleSwitch
+              ariaLabel="WebGL Effects"
+              checked={settings.webgl}
+              onChange={handleToggle('webgl')}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/window-manager-tweaks/index.tsx
+++ b/apps/window-manager-tweaks/index.tsx
@@ -1,0 +1,2 @@
+import WindowManagerTweaks from './WindowManagerTweaks';
+export default WindowManagerTweaks;

--- a/src/wm/compositor.ts
+++ b/src/wm/compositor.ts
@@ -1,0 +1,72 @@
+export interface CompositorSettings {
+  css: boolean;
+  webgl: boolean;
+}
+
+const DEFAULT_SETTINGS: CompositorSettings = {
+  css: true,
+  webgl: true,
+};
+
+const STORAGE_KEY = 'wm-compositor-settings';
+
+let current: CompositorSettings = { ...DEFAULT_SETTINGS };
+
+export function loadCompositor(): CompositorSettings {
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        current = { ...current, ...JSON.parse(stored) };
+      }
+    } catch {
+      // ignore parse errors
+    }
+    applySettings();
+  }
+  return current;
+}
+
+export function updateCompositor(partial: Partial<CompositorSettings>) {
+  current = { ...current, ...partial };
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+    } catch {
+      // ignore storage errors
+    }
+    applySettings();
+  }
+}
+
+function applySettings() {
+  if (typeof window === 'undefined') return;
+  document.documentElement.classList.toggle('compositor-css-disabled', !current.css);
+  const id = 'wm-compositor-canvas';
+  let canvas = document.getElementById(id) as HTMLCanvasElement | null;
+  if (current.webgl) {
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = id;
+      canvas.style.position = 'fixed';
+      canvas.style.top = '0';
+      canvas.style.left = '0';
+      canvas.style.width = '100vw';
+      canvas.style.height = '100vh';
+      canvas.style.pointerEvents = 'none';
+      document.body.appendChild(canvas);
+    }
+    const gl = canvas.getContext('webgl');
+    if (gl) {
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+  } else if (canvas) {
+    canvas.remove();
+  }
+}
+
+export function getCompositor(): CompositorSettings {
+  return current;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,11 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+/* When CSS compositor effects are disabled */
+.compositor-css-disabled *,
+.compositor-css-disabled *::before,
+.compositor-css-disabled *::after {
+  animation: none !important;
+  transition: none !important;
+}


### PR DESCRIPTION
## Summary
- add compositor state manager with persistent CSS and WebGL toggles
- expose compositor settings in new WindowManagerTweaks app
- disable transitions when compositor effects are off

## Testing
- `yarn lint src/wm/compositor.ts apps/window-manager-tweaks/WindowManagerTweaks.tsx apps/window-manager-tweaks/index.tsx` *(fails: A control must be associated with a text label)*
- `yarn eslint src/wm/compositor.ts apps/window-manager-tweaks/WindowManagerTweaks.tsx apps/window-manager-tweaks/index.tsx`
- `yarn tsc --noEmit`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f6a51c4832885fce5b55989719d