### PR TITLE
feat: add workspace margin controls

### DIFF
--- a/apps/settings/components/WindowManagerTweaks.tsx
+++ b/apps/settings/components/WindowManagerTweaks.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useWorkspaceMargins } from '@/src/state/workspace';
+
+export default function WindowManagerTweaks() {
+  const [margins, setMargins] = useWorkspaceMargins();
+
+  const handleChange = (side: keyof typeof margins, value: number) => {
+    setMargins((prev) => ({ ...prev, [side]: value }));
+  };
+
+  return (
+    <div className="p-4 space-y-2 text-ubt-grey">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <div key={side} className="flex items-center space-x-2">
+          <label htmlFor={`wm-margin-${side}`} className="capitalize">
+            {side}:
+          </label>
+          <input
+            id={`wm-margin-${side}`}
+            type="number"
+            min={0}
+            value={margins[side]}
+            onChange={(e) => handleChange(side, Number(e.target.value))}
+            className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/state/workspace.ts
+++ b/src/state/workspace.ts
@@ -1,0 +1,25 @@
+import usePersistentState from '@/hooks/usePersistentState';
+
+export interface WorkspaceMargins {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+const DEFAULT_MARGINS: WorkspaceMargins = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+const isMargins = (v: unknown): v is WorkspaceMargins =>
+  typeof v === 'object' && v !== null &&
+  ['top', 'right', 'bottom', 'left'].every(
+    (key) => typeof (v as Record<string, unknown>)[key] === 'number'
+  );
+
+export const useWorkspaceMargins = () =>
+  usePersistentState<WorkspaceMargins>('workspace:margins', DEFAULT_MARGINS, isMargins);
+

--- a/src/wm/placement.ts
+++ b/src/wm/placement.ts
@@ -1,0 +1,20 @@
+import type { WorkspaceMargins } from '@/src/state/workspace';
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function getMaximizedRect(margins: WorkspaceMargins): Rect {
+  const width = window.innerWidth - margins.left - margins.right;
+  const height = window.innerHeight - margins.top - margins.bottom;
+  return {
+    x: margins.left,
+    y: margins.top,
+    width,
+    height,
+  };
+}
+


### PR DESCRIPTION
## Summary
- store workspace margin preferences
- add placement helper to compute maximized window bounds using margins
- expose margin settings UI via WindowManagerTweaks component

## Testing
- `yarn test __tests__/window.test.tsx` (fails: e.preventDefault is not a function)
- `yarn test __tests__/nmapNse.test.tsx` (fails: Unable to find role="alert")
- `yarn test __tests__/Modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f705b14832886e4d3179c2e92ca