### PR TITLE
feat: add show desktop plugin and shortcut

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Show desktop', keys: 'Meta+D' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/src/plugins/ShowDesktop.tsx
+++ b/src/plugins/ShowDesktop.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import showDesktop from '../wm/showDesktop';
+
+const DEFAULT_SHORTCUT = 'Meta+D';
+
+/**
+ * Panel button plugin which toggles the "show desktop" state.
+ * It also listens for the default keyboard shortcut (Meta+D).
+ */
+export default function ShowDesktop() {
+  const onClick = () => showDesktop();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key.toUpperCase();
+      if (e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey && key === 'D') {
+        e.preventDefault();
+        showDesktop();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <button type="button" aria-label="Show Desktop" onClick={onClick}>
+      ☐
+    </button>
+  );
+}
+
+export { DEFAULT_SHORTCUT };

--- a/src/wm/showDesktop.ts
+++ b/src/wm/showDesktop.ts
@@ -1,0 +1,89 @@
+/**
+ * Minimal window manager helper to toggle the "show desktop" behaviour.
+ *
+ * The function hides every element with the attribute `data-window-id`
+ * (or, as a fallback, every element with the class `window`).  A record of
+ * the previous minimised state is stored so that a subsequent invocation
+ * will restore only those windows that were visible when the desktop was
+ * shown.
+ *
+ * In addition to minimising windows the function will also toggle the
+ * visibility of an element representing the task list.  By default the
+ * element with `[data-tasklist]` is used, but a specific element can be
+ * provided via the `tasklist` option.
+ */
+
+export interface ShowDesktopOptions {
+  /**
+   * Optional list of window elements.  When omitted all elements matching
+   * `[data-window-id]` or the `.window` class are used.
+   */
+  windows?: HTMLElement[];
+
+  /** Element representing the task list. */
+  tasklist?: HTMLElement | null;
+}
+
+// Internal cache of window visibility so we can restore them on the next run.
+let previousState: Record<string, boolean> | null = null;
+
+/**
+ * Toggle the desktop view. The first call minimises all windows and hides the
+ * task list, while the second call restores any windows that were previously
+ * visible and shows the task list again.
+ */
+export default function showDesktop(options: ShowDesktopOptions = {}): void {
+  const tasklist =
+    options.tasklist ??
+    (document.querySelector('[data-tasklist]') as HTMLElement | null);
+
+  const windows =
+    options.windows ??
+    Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-window-id], .window'
+      )
+    );
+
+  if (previousState === null) {
+    // Save current minimised state and hide every window.
+    previousState = {};
+    windows.forEach((w) => {
+      const id = w.dataset.windowId || w.id;
+      previousState![id] = w.classList.contains('minimized');
+      if (!previousState![id]) {
+        w.classList.add('minimized');
+        // `display: none` keeps things simple for tests and DOM.
+        w.style.display = 'none';
+      }
+    });
+    if (tasklist) {
+      tasklist.style.display = 'none';
+    }
+    return;
+  }
+
+  // Restore windows that we minimised previously
+  windows.forEach((w) => {
+    const id = w.dataset.windowId || w.id;
+    const wasMinimized = previousState![id];
+    if (!wasMinimized) {
+      w.classList.remove('minimized');
+      w.style.display = '';
+    }
+  });
+
+  if (tasklist) {
+    tasklist.style.display = '';
+  }
+
+  previousState = null;
+}
+
+/**
+ * Helper primarily for tests to reset the internal cached state.
+ */
+export function resetShowDesktopState() {
+  previousState = null;
+}
+


### PR DESCRIPTION
## Summary
- implement window manager helper to toggle show desktop and restore windows
- add panel button plugin with Meta+D shortcut
- register default shortcut in settings keymap

## Testing
- `yarn test src/wm/showDesktop.ts --passWithNoTests`
- `yarn lint src/wm/showDesktop.ts src/plugins/ShowDesktop.tsx apps/settings/keymapRegistry.ts` *(fails: Unexpected global 'document', Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f73c4a48328b38d1f861305c737