### PR TITLE
feat(wm): add window switcher overlay

### DIFF
--- a/__tests__/WindowSwitcher.test.tsx
+++ b/__tests__/WindowSwitcher.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, act } from '@testing-library/react';
+import WindowSwitcher, { WindowInfo } from '../src/wm/WindowSwitcher';
+
+describe('WindowSwitcher', () => {
+  it('shows overlay when Alt+Tab is pressed', () => {
+    const windows: WindowInfo[] = [{ id: '1', title: 'Window 1', icon: '/icon.png' }];
+    render(<WindowSwitcher windows={windows} />);
+    expect(screen.queryByText('Window 1')).toBeNull();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', altKey: true }));
+    });
+    expect(screen.getByText('Window 1')).toBeInTheDocument();
+  });
+});

--- a/src/wm/WindowSwitcher.tsx
+++ b/src/wm/WindowSwitcher.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from 'react';
+import keybindingManager from './keybindingManager';
+
+export interface WindowInfo {
+  id: string;
+  title: string;
+  icon: string;
+  preview?: string;
+}
+
+interface Props {
+  windows: WindowInfo[];
+  onSelect?: (id: string) => void;
+}
+
+export default function WindowSwitcher({ windows, onSelect }: Props) {
+  const [visible, setVisible] = useState(false);
+  const [index, setIndex] = useState(0);
+  const [cycleAll, setCycleAll] = useState(false);
+
+  useEffect(() => {
+    const handleAltTab = () => {
+      setVisible(true);
+      setIndex((i) => (i + 1) % windows.length);
+    };
+
+    keybindingManager.register('Alt+Tab', handleAltTab);
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (visible && e.key === 'Alt') {
+        setVisible(false);
+        onSelect?.(windows[index]?.id);
+        setIndex(0);
+      }
+    };
+
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      keybindingManager.unregister('Alt+Tab', handleAltTab);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [visible, windows, index, onSelect]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="window-switcher-overlay"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        className="window-switcher-list"
+        style={{ display: 'flex', gap: '1rem' }}
+      >
+        {windows.map((win, i) => (
+          <div
+            key={win.id}
+            className={
+              i === index ? 'window-switcher-item active' : 'window-switcher-item'
+            }
+            style={{
+              padding: '0.5rem',
+              border: i === index ? '2px solid #fff' : '2px solid transparent',
+              background: '#222',
+              color: '#fff',
+              width: '200px',
+              textAlign: 'center',
+            }}
+          >
+            <img src={win.icon} alt="" style={{ width: '32px', height: '32px' }} />
+            <div>{win.title}</div>
+            {win.preview && (
+              <img
+                src={win.preview}
+                alt="preview"
+                style={{ width: '100%', marginTop: '0.5rem' }}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <label
+        className="cycle-all"
+        style={{ marginTop: '1rem', color: '#fff' }}
+      >
+        <input
+          type="checkbox"
+          aria-label="Cycle through all workspaces"
+          checked={cycleAll}
+          onChange={() => setCycleAll((v) => !v)}
+        />{' '}
+        Cycle through all workspaces
+      </label>
+    </div>
+  );
+}

--- a/src/wm/keybindingManager.ts
+++ b/src/wm/keybindingManager.ts
@@ -1,0 +1,44 @@
+export type KeyComboHandler = (event: KeyboardEvent) => void;
+
+class KeybindingManager {
+  private bindings = new Map<string, Set<KeyComboHandler>>();
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', this.handleKeyDown);
+    }
+  }
+
+  register(combo: string, handler: KeyComboHandler): void {
+    if (!this.bindings.has(combo)) {
+      this.bindings.set(combo, new Set());
+    }
+    this.bindings.get(combo)!.add(handler);
+  }
+
+  unregister(combo: string, handler: KeyComboHandler): void {
+    const handlers = this.bindings.get(combo);
+    if (handlers) {
+      handlers.delete(handler);
+      if (handlers.size === 0) this.bindings.delete(combo);
+    }
+  }
+
+  private handleKeyDown = (event: KeyboardEvent): void => {
+    const comboParts: string[] = [];
+    if (event.altKey) comboParts.push('Alt');
+    if (event.ctrlKey) comboParts.push('Ctrl');
+    if (event.metaKey) comboParts.push('Meta');
+    if (event.shiftKey) comboParts.push('Shift');
+    comboParts.push(event.key);
+    const combo = comboParts.join('+');
+    const handlers = this.bindings.get(combo);
+    if (handlers && handlers.size > 0) {
+      event.preventDefault();
+      handlers.forEach((cb) => cb(event));
+    }
+  };
+}
+
+const keybindingManager = new KeybindingManager();
+export default keybindingManager;


### PR DESCRIPTION
## Summary
- add keybinding manager to handle keyboard shortcuts
- implement Alt+Tab window switcher overlay with window previews
- test Alt+Tab window switcher behavior

## Testing
- `npx eslint src/wm/WindowSwitcher.tsx src/wm/keybindingManager.ts __tests__/WindowSwitcher.test.tsx`
- `yarn test __tests__/WindowSwitcher.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f737cc48328becb7d1148a0f653