### PR TITLE
feat: add session manager with UI

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import SessionManager from "../../src/components/settings/SessionManager";
 
 export default function Settings() {
   const {
@@ -285,6 +286,9 @@ export default function Settings() {
             >
               Import Settings
             </button>
+          </div>
+          <div className="flex justify-center my-4">
+            <SessionManager />
           </div>
         </>
       )}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,17 +7,23 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import {
+        loadSession,
+        updateSession,
+        clearSession as clearSavedSession,
+} from '../src/lib/session/manager';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false,
+                        session: loadSession()
+                };
+        }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -126,9 +132,15 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        session={this.state.session}
+                                        setSession={updateSession}
+                                        clearSession={clearSavedSession}
+                                />
+                        </div>
+                );
+        }
 }

--- a/src/components/settings/SessionManager.tsx
+++ b/src/components/settings/SessionManager.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  saveSession,
+  clearSession,
+  isAutoSaveEnabled,
+  setAutoSave,
+} from "../../lib/session/manager";
+
+const SessionManager = () => {
+  const [autoSave, setAuto] = useState(false);
+
+  useEffect(() => {
+    setAuto(isAutoSaveEnabled());
+  }, []);
+
+  const handleSave = () => {
+    saveSession();
+  };
+
+  const handleClear = () => {
+    if (window.confirm("Clear saved session?")) {
+      clearSession();
+    }
+  };
+
+  const toggleAuto = () => {
+    const next = !autoSave;
+    setAuto(next);
+    setAutoSave(next);
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <button
+        onClick={handleSave}
+        className="px-4 py-2 rounded bg-ub-orange text-white"
+      >
+        Save Session
+      </button>
+      <label className="flex items-center space-x-2 text-ubt-grey">
+        <input
+          type="checkbox"
+          checked={autoSave}
+          onChange={toggleAuto}
+          aria-label="Toggle auto-save"
+        />
+        <span>Auto-save</span>
+      </label>
+      <button
+        onClick={handleClear}
+        className="px-4 py-2 rounded bg-ub-orange text-white"
+      >
+        Clear Session
+      </button>
+    </div>
+  );
+};
+
+export default SessionManager;
+

--- a/src/lib/session/manager.ts
+++ b/src/lib/session/manager.ts
@@ -1,0 +1,110 @@
+export interface SessionWindow {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export interface DesktopSession {
+  windows: SessionWindow[];
+  dock: string[];
+}
+
+const SESSION_KEY = 'desktop-session';
+const AUTO_KEY = 'desktop-session-auto';
+
+let currentSession: DesktopSession | null = null;
+
+function isSession(value: unknown): value is DesktopSession {
+  if (!value || typeof value !== 'object') return false;
+  const s = value as DesktopSession;
+  return (
+    Array.isArray(s.windows) &&
+    s.windows.every(
+      (w) =>
+        w &&
+        typeof w.id === 'string' &&
+        typeof w.x === 'number' &&
+        typeof w.y === 'number',
+    ) &&
+    Array.isArray(s.dock)
+  );
+}
+
+export const loadSession = (): DesktopSession | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(SESSION_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (isSession(parsed)) {
+        currentSession = parsed;
+        return parsed;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+};
+
+export const getCurrentSession = () => currentSession;
+
+const persist = () => {
+  if (typeof window === 'undefined' || !currentSession) return;
+  try {
+    window.localStorage.setItem(SESSION_KEY, JSON.stringify(currentSession));
+  } catch {
+    // ignore
+  }
+};
+
+export const updateSession = (session: DesktopSession) => {
+  currentSession = session;
+  if (isAutoSaveEnabled()) persist();
+};
+
+export const saveSession = () => {
+  persist();
+};
+
+export const clearSession = () => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(SESSION_KEY);
+  } catch {
+    // ignore
+  }
+  currentSession = null;
+};
+
+export const isAutoSaveEnabled = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(AUTO_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const setAutoSave = (enabled: boolean) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(AUTO_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // ignore
+  }
+  if (enabled && currentSession) persist();
+};
+
+const sessionManager = {
+  loadSession,
+  updateSession,
+  saveSession,
+  clearSession,
+  isAutoSaveEnabled,
+  setAutoSave,
+  getCurrentSession,
+};
+
+export default sessionManager;
+


### PR DESCRIPTION
## Summary
- add session manager to persist open app geometry with optional auto-save
- expose session management controls in Settings
- load saved sessions on startup

## Testing
- `./node_modules/.bin/eslint src/lib/session/manager.ts src/components/settings/SessionManager.tsx apps/settings/index.tsx components/ubuntu.js`
- `yarn test __tests__/metadata.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f77e7748328a375d5cd27464f85