### PR TITLE
feat: add autostart manager

### DIFF
--- a/src/components/settings/AutostartManager.tsx
+++ b/src/components/settings/AutostartManager.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  readAutostart,
+  saveAutostartEntry,
+  AutostartEntry,
+} from "@/src/lib/autostart";
+
+const AutostartManager: React.FC = () => {
+  const [entries, setEntries] = useState<AutostartEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    readAutostart()
+      .then((items) => setEntries(items))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const updateEntry = (index: number, change: Partial<AutostartEntry>) => {
+    setEntries((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], ...change };
+      return next;
+    });
+  };
+
+  const handleSave = async (entry: AutostartEntry) => {
+    await saveAutostartEntry(entry);
+  };
+
+  if (loading) {
+    return <div>Loading autostart entries...</div>;
+  }
+
+  if (!entries.length) {
+    return <div>No autostart entries found.</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-2">Autostart Manager</h2>
+      <ul className="space-y-2">
+        {entries.map((entry, index) => (
+          <li key={entry.file} className="flex items-center gap-2">
+            <span className="flex-1">{entry.name}</span>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                aria-label="Enabled"
+                checked={entry.enabled}
+                onChange={(e) =>
+                  updateEntry(index, { enabled: e.target.checked })
+                }
+              />
+              <span>Enabled</span>
+            </label>
+            <label className="flex items-center gap-1">
+              <span>Delay</span>
+              <input
+                type="number"
+                aria-label="Delay"
+                min={0}
+                className="w-20 border rounded px-1"
+                value={entry.delay}
+                onChange={(e) =>
+                  updateEntry(index, { delay: Number(e.target.value) })
+                }
+              />
+            </label>
+            <button
+              className="px-2 py-1 border rounded"
+              onClick={() => handleSave(entry)}
+            >
+              Save
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AutostartManager;
+

--- a/src/lib/autostart.ts
+++ b/src/lib/autostart.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+
+export interface AutostartEntry {
+  /** Absolute path to the autostart file */
+  file: string;
+  /** Display name for the entry */
+  name: string;
+  /** Whether the entry is enabled */
+  enabled: boolean;
+  /** Delay in seconds before starting */
+  delay: number;
+  /** Raw data loaded from disk */
+  data: Record<string, any>;
+}
+
+const AUTOSTART_DIR = path.join(os.homedir(), ".config", "autostart");
+
+/**
+ * Read all autostart entries from ~/.config/autostart/*.desktop.json.
+ */
+export async function readAutostart(): Promise<AutostartEntry[]> {
+  let files: string[] = [];
+  try {
+    files = await fs.readdir(AUTOSTART_DIR);
+  } catch {
+    return [];
+  }
+
+  const entries: AutostartEntry[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".desktop.json")) continue;
+    const fullPath = path.join(AUTOSTART_DIR, file);
+    try {
+      const text = await fs.readFile(fullPath, "utf8");
+      const data = JSON.parse(text);
+      entries.push({
+        file: fullPath,
+        name: data.Name ?? path.basename(file, ".desktop.json"),
+        enabled: Boolean(
+          data["X-GNOME-Autostart-enabled"] ?? data.enabled ?? true
+        ),
+        delay: Number(data["X-GNOME-Autostart-Delay"] ?? data.delay ?? 0),
+        data,
+      });
+    } catch {
+      // ignore invalid files
+    }
+  }
+  return entries;
+}
+
+/**
+ * Persist an updated autostart entry back to its source file.
+ */
+export async function saveAutostartEntry(entry: AutostartEntry): Promise<void> {
+  const { file, data, name, enabled, delay } = entry;
+  const updated = { ...data, Name: name };
+  updated["X-GNOME-Autostart-enabled"] = enabled;
+  if (typeof delay === "number") {
+    updated["X-GNOME-Autostart-Delay"] = delay;
+  } else {
+    delete updated["X-GNOME-Autostart-Delay"];
+  }
+  await fs.writeFile(file, JSON.stringify(updated, null, 2), "utf8");
+}
+


### PR DESCRIPTION
## Summary
- parse autostart desktop json files and expose read/update helpers
- add AutostartManager settings component to toggle autostart entries and set launch delay

## Testing
- `yarn lint` *(fails: Unexpected global 'document', etc.)*
- `npx eslint src/lib/autostart.ts src/components/settings/AutostartManager.tsx`
- `yarn test __tests__/window.test.tsx` *(fails: releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f7b34f48328bb7d26ed2ea1a31e