### PR TITLE
feat: add session clearing

### DIFF
--- a/components/SessionManager.tsx
+++ b/components/SessionManager.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React, { useState } from 'react';
+import Toast from "./ui/Toast";
+
+const SessionManager: React.FC = () => {
+  const [toast, setToast] = useState("");
+
+  const handleClear = async () => {
+    try {
+      const res = await fetch("/api/clear-sessions", { method: "POST" });
+      if (!res.ok) throw new Error("Failed");
+      setToast("Sessions cleared");
+    } catch {
+      setToast("Failed to clear sessions");
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full">
+      <button
+        type="button"
+        onClick={handleClear}
+        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
+      >
+        Clear saved sessions
+      </button>
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
+    </div>
+  );
+};
+
+export default SessionManager;

--- a/pages/api/clear-sessions.ts
+++ b/pages/api/clear-sessions.ts
@@ -1,0 +1,19 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const sessionDir = path.join(os.homedir(), '.cache', 'xfce4-session');
+  try {
+    await fs.rm(sessionDir, { recursive: true, force: true });
+    await fs.mkdir(sessionDir, { recursive: true });
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to clear sessions' });
+  }
+}


### PR DESCRIPTION
## Summary
- add SessionManager with "Clear saved sessions" button and confirmation toast
- add API route to remove XFCE session cache files

## Testing
- `npm test -- __tests__/window.test.tsx __tests__/nmapNse.test.tsx`
- `npx eslint components/SessionManager.tsx pages/api/clear-sessions.ts && echo 'lint complete'`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f81e5b483289e7da3aff2a5226e