### PR TITLE
feat: add logout dialog with session save option

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -956,7 +956,7 @@ export class Desktop extends Component {
     }
 }
 
-export default function DesktopWithSnap(props) {
+export default React.forwardRef(function DesktopWithSnap(props, ref) {
     const [snapEnabled] = useSnapSetting();
-    return <Desktop {...props} snapEnabled={snapEnabled} />;
-}
+    return <Desktop {...props} snapEnabled={snapEnabled} ref={ref} />;
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -49,9 +49,16 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings
+                                                open={this.state.status_card}
+                                                actions={[
+                                                        { label: 'Lock Screen', onClick: this.props.lockScreen },
+                                                        { label: 'Shut Down', onClick: this.props.shutDown },
+                                                ]}
+                                                saveSession={this.props.saveSession}
+                                        />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
@@ -9,15 +9,16 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor(props) {
+                super(props);
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+                this.desktopRef = createRef();
+        }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -85,10 +86,14 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('screen-locked', false);
 	};
 
-	changeBackgroundImage = (img_name) => {
-		this.setState({ bg_image_name: img_name });
+        changeBackgroundImage = (img_name) => {
+                this.setState({ bg_image_name: img_name });
                 safeLocalStorage?.setItem('bg-image', img_name);
-	};
+        };
+
+        saveSession = () => {
+                this.desktopRef.current?.saveSession?.();
+        };
 
 	shutDown = () => {
 		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
@@ -126,9 +131,16 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} saveSession={this.saveSession} />
+                                <Desktop
+                                        ref={this.desktopRef}
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        session={this.props.session}
+                                        setSession={this.props.setSession}
+                                        clearSession={this.props.resetSession}
+                                />
+                        </div>
+                );
+        }
 }

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import LogoutDialog, { SessionAction } from '@/src/components/session/LogoutDialog';
 
 interface Props {
   open: boolean;
+  actions?: SessionAction[];
+  saveSession?: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, actions = [], saveSession }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [showLogout, setShowLogout] = useState(false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -52,6 +56,19 @@ const QuickSettings = ({ open }: Props) => {
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>
+      {actions.length > 0 && (
+        <div className="px-4 pt-2">
+          <button className="w-full" onClick={() => setShowLogout(true)}>
+            Power
+          </button>
+        </div>
+      )}
+      <LogoutDialog
+        open={showLogout}
+        onClose={() => setShowLogout(false)}
+        actions={actions}
+        saveSession={saveSession}
+      />
     </div>
   );
 };

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import useSession from '../hooks/useSession';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +29,19 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { session, setSession, resetSession } = useSession();
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      <Ubuntu session={session} setSession={setSession} resetSession={resetSession} />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;

--- a/src/components/session/LogoutDialog.tsx
+++ b/src/components/session/LogoutDialog.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import Modal from '@/components/base/Modal';
+
+export interface SessionAction {
+  label: string;
+  onClick: () => void;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  actions: SessionAction[];
+  saveSession?: () => void;
+}
+
+const LogoutDialog: React.FC<Props> = ({ open, onClose, actions, saveSession }) => {
+  const [shouldSave, setShouldSave] = useState(false);
+
+  const handleAction = (action: () => void) => {
+    if (shouldSave && saveSession) {
+      try {
+        saveSession();
+      } catch {
+        // ignore save errors
+      }
+    }
+    action();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <div className="bg-ub-cool-grey text-white rounded-md p-4 w-64">
+        <h2 className="text-lg mb-4">Power options</h2>
+        <div className="space-y-2">
+          {actions.map((a) => (
+            <button
+              key={a.label}
+              className="w-full text-left px-4 py-2 rounded hover:bg-ub-warm-grey hover:bg-opacity-20"
+              onClick={() => handleAction(a.onClick)}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+        <label className="mt-4 flex items-center">
+          <input
+            type="checkbox"
+            className="mr-2"
+            checked={shouldSave}
+            onChange={() => setShouldSave(!shouldSave)}
+          />
+          Save session
+        </label>
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="px-4 py-1 border border-gray-700 rounded hover:bg-ub-warm-grey hover:bg-opacity-20"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default LogoutDialog;


### PR DESCRIPTION
## Summary
- add generic LogoutDialog component with power actions and optional session save
- wire QuickSettings and Navbar to launch dialog and execute lock or shutdown
- persist and manage desktop session through Ubuntu root and page

## Testing
- `yarn test` *(fails: window.snap behavior, NmapNSE output)*


------
https://chatgpt.com/codex/tasks/task_e_68ba2f821120832899eeefa58b25cdd2