### PR TITLE
feat(session): add profile manager and chooser

### DIFF
--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,21 +7,27 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { getDefaultSession } from '../session/manager';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false,
+                        session: null
+                };
+        }
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+                const profile = getDefaultSession();
+                if (profile) {
+                        this.setState({ session: profile.session });
+                }
+        }
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {
@@ -127,8 +133,12 @@ export default class Ubuntu extends Component {
 					turnOn={this.turnOn}
 				/>
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Desktop
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        session={this.state.session}
+                                />
+                        </div>
+                );
+        }
 }

--- a/session/manager.ts
+++ b/session/manager.ts
@@ -1,0 +1,63 @@
+import type { DesktopSession } from '../hooks/useSession';
+
+export interface SessionProfile {
+  id: string;
+  name: string;
+  session: DesktopSession;
+}
+
+const STORAGE_KEY = 'session-profiles';
+const DEFAULT_KEY = 'default-session';
+
+function readProfiles(): SessionProfile[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SessionProfile[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeProfiles(list: SessionProfile[]): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+}
+
+export function listSessions(): SessionProfile[] {
+  return readProfiles();
+}
+
+export function saveSession(profile: SessionProfile): void {
+  const sessions = readProfiles();
+  const idx = sessions.findIndex((s) => s.id === profile.id);
+  if (idx >= 0) {
+    sessions[idx] = profile;
+  } else {
+    sessions.push(profile);
+  }
+  writeProfiles(sessions);
+}
+
+export function setDefaultSession(id: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(DEFAULT_KEY, id);
+}
+
+export function getDefaultSession(): SessionProfile | null {
+  if (typeof window === 'undefined') return null;
+  const id = window.localStorage.getItem(DEFAULT_KEY);
+  return readProfiles().find((p) => p.id === id) || null;
+}
+
+export function removeSession(id: string): void {
+  const sessions = readProfiles().filter((s) => s.id !== id);
+  writeProfiles(sessions);
+  const current = typeof window === 'undefined' ? null : window.localStorage.getItem(DEFAULT_KEY);
+  if (current === id) {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(DEFAULT_KEY);
+    }
+  }
+}
+

--- a/src/components/session/SessionChooser.tsx
+++ b/src/components/session/SessionChooser.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import type { SessionProfile } from '../../../session/manager';
+import { listSessions, getDefaultSession, setDefaultSession } from '../../../session/manager';
+
+export default function SessionChooser() {
+  const [sessions, setSessions] = useState<SessionProfile[]>([]);
+  const [defaultId, setDefaultId] = useState<string>('');
+
+  useEffect(() => {
+    const list = listSessions();
+    setSessions(list);
+    const def = getDefaultSession();
+    if (def) setDefaultId(def.id);
+  }, []);
+
+  const handleChange = (id: string) => {
+    setDefaultId(id);
+    setDefaultSession(id);
+  };
+
+  return (
+    <div className="space-y-2">
+      {sessions.map((profile) => (
+        <div key={profile.id} className="flex items-center justify-between">
+          <span>{profile.name}</span>
+          <div className="flex items-center space-x-1">
+            <input
+              id={`default-${profile.id}`}
+              type="radio"
+              name="default-session"
+              checked={defaultId === profile.id}
+              onChange={() => handleChange(profile.id)}
+            />
+            <label htmlFor={`default-${profile.id}`}>Set as default</label>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add session profile manager using localStorage
- allow selecting a default session via new SessionChooser component
- load saved default session when Ubuntu desktop starts

## Testing
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/nmapNse.test.tsx, __tests__/reconng.test.tsx)*
- `yarn lint` *(fails: numerous lint errors including control label warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f82eff88328913fc06e87b13e7a