### PR TITLE
feat: add session notifications

### DIFF
--- a/session/manager.ts
+++ b/session/manager.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import useNotifications from '../hooks/useNotifications';
+import { getDoNotDisturb } from '../utils/notificationSettings';
+
+/**
+ * Hook returning utilities for working with desktop sessions.
+ * Emits toast notifications through the central NotificationCenter
+ * while respecting the user's Do Not Disturb preference.
+ */
+export default function useSessionManager() {
+  const { pushNotification } = useNotifications();
+
+  /**
+   * Notify the user that windows are being restored.
+   * The message is suppressed when Do Not Disturb is enabled.
+   *
+   * @param count Number of windows that will be restored.
+   */
+  const notifyRestore = useCallback(
+    (count: number) => {
+      if (getDoNotDisturb()) return;
+      pushNotification('session', `Restoring ${count} windows`);
+    },
+    [pushNotification],
+  );
+
+  return { notifyRestore };
+}

--- a/utils/notificationSettings.ts
+++ b/utils/notificationSettings.ts
@@ -1,0 +1,18 @@
+const DND_KEY = 'notifications-dnd';
+
+/**
+ * Returns the current Do Not Disturb flag from notification settings.
+ * Defaults to false when running server-side or when no preference is stored.
+ */
+export function getDoNotDisturb(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(DND_KEY) === 'true';
+}
+
+/**
+ * Persists the Do Not Disturb flag in notification settings.
+ */
+export function setDoNotDisturb(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(DND_KEY, value ? 'true' : 'false');
+}


### PR DESCRIPTION
## Summary
- add session manager hook that uses notification service to announce window restoration
- introduce notification settings helper with Do Not Disturb flag

## Testing
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; modal closes when Escape pressed globally)*


------
https://chatgpt.com/codex/tasks/task_e_68ba2f8479f083289de8793c365faa25