### PR TITLE
feat: add notification settings dialog

### DIFF
--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -8,32 +8,49 @@ export interface AppNotification {
 
 interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
+  /** Do not disturb mode prevents any notifications from being added */
+  dnd: boolean;
+  /** Map of appId to whether notifications are muted */
+  muted: Record<string, boolean>;
   pushNotification: (appId: string, message: string) => void;
   clearNotifications: (appId?: string) => void;
+  toggleDnd: () => void;
+  toggleApp: (appId: string) => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const [dnd, setDnd] = useState(false);
+  const [muted, setMuted] = useState<Record<string, boolean>>({});
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
-      };
-      return next;
-    });
+  const toggleDnd = useCallback(() => setDnd(v => !v), []);
+  const toggleApp = useCallback((appId: string) => {
+    setMuted(prev => ({ ...prev, [appId]: !prev[appId] }));
   }, []);
+
+  const pushNotification = useCallback(
+    (appId: string, message: string) => {
+      setNotifications(prev => {
+        if (dnd || muted[appId]) return prev;
+        const list = prev[appId] ?? [];
+        const next = {
+          ...prev,
+          [appId]: [
+            ...list,
+            {
+              id: `${Date.now()}-${Math.random()}`,
+              message,
+              date: Date.now(),
+            },
+          ],
+        };
+        return next;
+      });
+    },
+    [dnd, muted]
+  );
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
@@ -59,7 +76,7 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+      value={{ notifications, dnd, muted, pushNotification, clearNotifications, toggleDnd, toggleApp }}
     >
       {children}
       <div className="notification-center">

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,32 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import useNotifications from '../../hooks/useNotifications';
+import SettingsDialog from '../../src/components/notifications/SettingsDialog';
+
+function NotificationsButton() {
+  const { dnd, toggleDnd } = useNotifications();
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Notifications"
+        onClick={toggleDnd}
+        onContextMenu={e => {
+          e.preventDefault();
+          setOpen(true);
+        }}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1"
+      >
+        <span role="img" aria-label={dnd ? 'Do not disturb' : 'Notifications'}>
+          {dnd ? '🔕' : '🔔'}
+        </span>
+      </button>
+      <SettingsDialog open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}
 
 export default class Navbar extends Component {
 	constructor() {
@@ -37,6 +63,7 @@ export default class Navbar extends Component {
                                 >
                                         <Clock />
                                 </div>
+                                <NotificationsButton />
                                 <button
                                         type="button"
                                         id="status-bar"

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import NotificationCenter from '../components/common/NotificationCenter';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -158,19 +159,21 @@ function MyApp(props) {
         </a>
         <SettingsProvider>
           <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+            <NotificationCenter>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </NotificationCenter>
           </PipPortalProvider>
         </SettingsProvider>
       </div>

--- a/src/components/notifications/SettingsDialog.tsx
+++ b/src/components/notifications/SettingsDialog.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import useNotifications from '../../../hooks/useNotifications';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SettingsDialog: React.FC<Props> = ({ open, onClose }) => {
+  const { notifications, dnd, toggleDnd, muted, toggleApp } = useNotifications();
+  const [tab, setTab] = useState<'settings' | 'log'>('settings');
+
+  if (!open) return null;
+
+  const appIds = Array.from(
+    new Set([...Object.keys(notifications), ...Object.keys(muted)])
+  );
+
+  return (
+    <div
+      role="dialog"
+      className="absolute bg-ub-cool-grey rounded-md py-4 top-9 right-0 shadow border-black border border-opacity-20 w-64 z-50"
+    >
+      <div className="flex mb-3 border-b border-gray-500">
+        <button
+          className={`flex-1 pb-1 ${tab === 'settings' ? 'font-bold border-b-2 border-white' : ''}`}
+          onClick={() => setTab('settings')}
+        >
+          Settings
+        </button>
+        <button
+          className={`flex-1 pb-1 ${tab === 'log' ? 'font-bold border-b-2 border-white' : ''}`}
+          onClick={() => setTab('log')}
+        >
+          Log
+        </button>
+      </div>
+      {tab === 'settings' ? (
+        <div className="px-4 max-h-60 overflow-y-auto">
+          <div className="flex justify-between items-center mb-2">
+            <span>Do Not Disturb</span>
+            <input type="checkbox" checked={dnd} onChange={toggleDnd} />
+          </div>
+          {appIds.map(id => (
+            <div key={id} className="flex justify-between items-center mb-1">
+              <span>{id}</span>
+              <input
+                type="checkbox"
+                checked={!muted[id]}
+                onChange={() => toggleApp(id)}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="px-4 max-h-60 overflow-y-auto">
+          {appIds.map(id => (
+            <section key={id} className="mb-2">
+              <h4 className="font-bold">{id}</h4>
+              <ul className="pl-4 text-sm list-disc">
+                {(notifications[id] ?? []).map(n => (
+                  <li key={n.id}>{n.message}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+      <div className="mt-3 flex justify-end px-4">
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsDialog;


### PR DESCRIPTION
## Summary
- add notification center provider with DND and per-app muting
- create notification settings dialog with tabs for settings and log
- add panel bell icon to toggle DND and open settings

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `npm run lint` *(fails: no-top-level-window, jsx-a11y/control-has-associated-label, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ba2f861d708328a66e694033aeb331