### PR TITLE
feat: add plain text clipboard paste action

### DIFF
--- a/__tests__/clipboard.test.ts
+++ b/__tests__/clipboard.test.ts
@@ -1,0 +1,8 @@
+import { stripFormatting } from '@/src/lib/clipboard';
+
+describe('stripFormatting', () => {
+  it('removes HTML tags', () => {
+    const html = '<b>Hello</b> <i>world</i>';
+    expect(stripFormatting(html)).toBe('Hello world');
+  });
+});

--- a/__tests__/clipman.test.tsx
+++ b/__tests__/clipman.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import Clipman from '../components/Clipman';
+import { pastePlainText } from '@/src/lib/clipboard';
+
+jest.mock('@/src/lib/clipboard', () => ({
+  pastePlainText: jest.fn().mockResolvedValue('hello'),
+}));
+
+describe('Clipman context menu', () => {
+  it('pastes plain text into input', async () => {
+    const { getByPlaceholderText, getByText } = render(<Clipman />);
+    const input = getByPlaceholderText('Sample input') as HTMLInputElement;
+    fireEvent.contextMenu(input);
+    fireEvent.click(getByText('Paste Plain Text'));
+    await waitFor(() => expect(input).toHaveValue('hello'));
+    expect(pastePlainText).toHaveBeenCalled();
+  });
+});

--- a/components/Clipman.tsx
+++ b/components/Clipman.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { useState } from 'react';
+import { pastePlainText } from '@/src/lib/clipboard';
+
+interface MenuState {
+  x: number;
+  y: number;
+  target: HTMLInputElement | HTMLTextAreaElement | null;
+}
+
+const Clipman: React.FC = () => {
+  const [menu, setMenu] = useState<MenuState | null>(null);
+
+  const openMenu = (
+    e: React.MouseEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY, target: e.currentTarget });
+  };
+
+  const paste = async () => {
+    if (!menu?.target) return;
+    const text = await pastePlainText();
+    const el = menu.target;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? 0;
+    const before = el.value.slice(0, start);
+    const after = el.value.slice(end);
+    el.value = before + text + after;
+    const pos = start + text.length;
+    el.setSelectionRange(pos, pos);
+    el.focus();
+    setMenu(null);
+  };
+
+  const closeMenu = () => setMenu(null);
+
+  return (
+    <div className="p-4 space-y-2" onClick={closeMenu}>
+      <input
+        type="text"
+        placeholder="Sample input"
+        aria-label="sample input"
+        onContextMenu={openMenu}
+        className="border p-1 w-full"
+      />
+      <textarea
+        placeholder="Another field"
+        aria-label="another field"
+        onContextMenu={openMenu}
+        className="border p-1 w-full"
+      />
+      {menu && (
+        <ul
+          data-testid="context-menu"
+          className="absolute bg-gray-800 text-white p-2 z-50"
+          style={{ top: menu.y, left: menu.x }}
+        >
+          <li
+            className="cursor-pointer px-2 py-1 hover:bg-gray-700"
+            onClick={paste}
+          >
+            Paste Plain Text
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Clipman;

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,31 @@
+export function stripFormatting(html: string): string {
+  if (!html) return '';
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
+}
+
+export async function pastePlainText(): Promise<string> {
+  try {
+    if (navigator.clipboard && (navigator.clipboard as any).read) {
+      const items = await (navigator.clipboard as any).read();
+      for (const item of items) {
+        if (item.types.includes('text/plain')) {
+          const blob = await item.getType('text/plain');
+          return await blob.text();
+        }
+        if (item.types.includes('text/html')) {
+          const blob = await item.getType('text/html');
+          const html = await blob.text();
+          return stripFormatting(html);
+        }
+      }
+    }
+    const text = await navigator.clipboard.readText();
+    return stripFormatting(text);
+  } catch {
+    return '';
+  }
+}
+
+export default pastePlainText;


### PR DESCRIPTION
## Summary
- add clipboard helper to strip formatting and read plain text
- create Clipman sample with context menu for pasting plain text
- test plain text pasting and formatting stripping

## Testing
- `npx eslint components/Clipman.tsx src/lib/clipboard.ts __tests__/clipman.test.tsx __tests__/clipboard.test.ts`
- `npx jest --runTestsByPath __tests__/clipman.test.tsx __tests__/clipboard.test.ts --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fa4b73083288c9f9b11f7595279