### PR TITLE
feat(power): add power profile schema and source simulation

### DIFF
--- a/apps/settings/components/PowerProfilesDialog.tsx
+++ b/apps/settings/components/PowerProfilesDialog.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import Modal from '../../../components/base/Modal';
+import type { PowerSettings, PowerProfile } from '@/src/lib/power/schema';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  settings: PowerSettings;
+  onChange: (settings: PowerSettings) => void;
+}
+
+const ProfileEditor = ({ profile, onChange }: { profile: PowerProfile; onChange: (p: PowerProfile) => void }) => (
+  <div className="flex flex-col gap-2">
+    <label>
+      CPU
+      <input
+        type="number"
+        min={0}
+        max={100}
+        value={profile.cpu}
+        onChange={(e) => onChange({ ...profile, cpu: Number(e.target.value) })}
+      />
+    </label>
+    <label>
+      GPU
+      <input
+        type="number"
+        min={0}
+        max={100}
+        value={profile.gpu}
+        onChange={(e) => onChange({ ...profile, gpu: Number(e.target.value) })}
+      />
+    </label>
+  </div>
+);
+
+const PowerProfilesDialog = ({ open, onClose, settings, onChange }: Props) => {
+  const [tab, setTab] = useState<'ac' | 'battery'>('ac');
+
+  const updateProfile = (key: 'ac' | 'battery', profile: PowerProfile) => {
+    onChange({ ...settings, [key]: profile });
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <div className="p-4 bg-black text-white">
+        <div className="flex gap-2 mb-4">
+          <button onClick={() => setTab('ac')} aria-selected={tab === 'ac'}>AC</button>
+          <button onClick={() => setTab('battery')} aria-selected={tab === 'battery'}>Battery</button>
+        </div>
+        {tab === 'ac' && <ProfileEditor profile={settings.ac} onChange={(p) => updateProfile('ac', p)} />}
+        {tab === 'battery' && <ProfileEditor profile={settings.battery} onChange={(p) => updateProfile('battery', p)} />}
+      </div>
+    </Modal>
+  );
+};
+
+export default PowerProfilesDialog;

--- a/src/lib/power/schema.ts
+++ b/src/lib/power/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const PowerProfileSchema = z.object({
+  cpu: z.number().min(0).max(100).default(100),
+  gpu: z.number().min(0).max(100).default(100),
+});
+
+export const PowerSettingsSchema = z.object({
+  ac: PowerProfileSchema,
+  battery: PowerProfileSchema,
+});
+
+export type PowerProfile = z.infer<typeof PowerProfileSchema>;
+export type PowerSettings = z.infer<typeof PowerSettingsSchema>;
+
+export const defaultPowerSettings: PowerSettings = {
+  ac: { cpu: 100, gpu: 100 },
+  battery: { cpu: 100, gpu: 100 },
+};

--- a/src/lib/power/source.ts
+++ b/src/lib/power/source.ts
@@ -1,0 +1,17 @@
+import { PowerSettings, PowerProfile } from './schema';
+
+export type PowerSource = keyof PowerSettings; // 'ac' | 'battery'
+
+let simulatedSource: PowerSource = 'ac';
+
+export function setSimulatedSource(source: PowerSource) {
+  simulatedSource = source;
+}
+
+export function getSimulatedSource(): PowerSource {
+  return simulatedSource;
+}
+
+export function getActiveProfile(settings: PowerSettings): PowerProfile {
+  return settings[simulatedSource];
+}


### PR DESCRIPTION
## Summary
- define PowerProfile schema with separate AC and battery profiles
- simulate power source and return active profile
- add dialog tabs to edit power profiles

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fa7ed80832899debcf9b62bce12