### PR TITLE
Add system lid action settings

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import { handleLidAction, LidAction } from "@/src/lib/power/lid";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -31,6 +32,8 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    lidAction,
+    setLidAction,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -38,6 +41,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "system", label: "System" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -80,6 +84,8 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.lidAction !== undefined)
+        setLidAction(parsed.lidAction as LidAction);
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,6 +107,7 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setLidAction(defaults.lidAction as LidAction);
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -267,6 +274,28 @@ export default function Settings() {
             >
               Edit Shortcuts
             </button>
+          </div>
+        </>
+      )}
+      {activeTab === "system" && (
+        <>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Lid close action:</label>
+            <select
+              value={lidAction}
+              onChange={(e) => {
+                const action = e.target.value as LidAction;
+                setLidAction(action);
+                handleLidAction(action);
+              }}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="nothing">Nothing</option>
+              <option value="turn-off-display">Turn off display</option>
+              <option value="suspend">Suspend</option>
+              <option value="hibernate">Hibernate</option>
+              <option value="lock-screen">Lock screen</option>
+            </select>
           </div>
         </>
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,8 +20,11 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getLidAction as loadLidAction,
+  setLidAction as saveLidAction,
   defaults,
 } from '../utils/settingsStore';
+import type { LidAction } from '@/src/lib/power/lid';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
@@ -63,6 +66,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  lidAction: LidAction;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +78,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setLidAction: (value: LidAction) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +93,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  lidAction: defaults.lidAction as LidAction,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +105,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setLidAction: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +119,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [lidAction, setLidAction] = useState<LidAction>(defaults.lidAction as LidAction);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +135,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setLidAction((await loadLidAction()) as LidAction);
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +245,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveLidAction(lidAction);
+  }, [lidAction]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +262,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        lidAction,
         theme,
         setAccent,
         setWallpaper,
@@ -261,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setLidAction,
       }}
     >
       {children}

--- a/src/lib/power/lid.ts
+++ b/src/lib/power/lid.ts
@@ -1,0 +1,86 @@
+export type LidAction =
+  | 'nothing'
+  | 'turn-off-display'
+  | 'suspend'
+  | 'hibernate'
+  | 'lock-screen';
+
+let overlay: HTMLDivElement | null = null;
+
+function removeOverlay() {
+  if (!overlay) return;
+  overlay.style.opacity = '0';
+  overlay.addEventListener(
+    'transitionend',
+    () => {
+      overlay?.remove();
+      overlay = null;
+    },
+    { once: true }
+  );
+}
+
+export function turnOffDisplay() {
+  if (overlay) return;
+  overlay = document.createElement('div');
+  overlay.id = 'screen-off-overlay';
+  overlay.style.position = 'fixed';
+  overlay.style.inset = '0';
+  overlay.style.background = 'black';
+  overlay.style.opacity = '0';
+  overlay.style.transition = 'opacity 0.5s ease';
+  document.body.appendChild(overlay);
+  // trigger fade in
+  requestAnimationFrame(() => {
+    if (overlay) overlay.style.opacity = '1';
+  });
+  const restore = () => {
+    window.removeEventListener('keydown', restore);
+    window.removeEventListener('mousemove', restore);
+    window.removeEventListener('click', restore);
+    removeOverlay();
+  };
+  window.addEventListener('keydown', restore);
+  window.addEventListener('mousemove', restore);
+  window.addEventListener('click', restore);
+}
+
+export function suspend() {
+  // Placeholder for suspend functionality
+  console.log('Suspend requested');
+}
+
+export function hibernate() {
+  // Placeholder for hibernate functionality
+  console.log('Hibernate requested');
+}
+
+export function lockScreen() {
+  window.dispatchEvent(new CustomEvent('lock-screen'));
+}
+
+export function doNothing() {
+  // intentionally empty
+}
+
+export function handleLidAction(action: LidAction) {
+  switch (action) {
+    case 'nothing':
+      doNothing();
+      break;
+    case 'turn-off-display':
+      turnOffDisplay();
+      break;
+    case 'suspend':
+      suspend();
+      break;
+    case 'hibernate':
+      hibernate();
+      break;
+    case 'lock-screen':
+      lockScreen();
+      break;
+    default:
+      doNothing();
+  }
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  lidAction: 'nothing',
 };
 
 export async function getAccent() {
@@ -123,6 +124,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getLidAction() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lidAction;
+  return window.localStorage.getItem('lid-action') || DEFAULT_SETTINGS.lidAction;
+}
+
+export async function setLidAction(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lid-action', value);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('lid-action');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lidAction,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getLidAction(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lidAction,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    lidAction,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (lidAction !== undefined) await setLidAction(lidAction);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add System tab with lid action dropdown
- persist lid action in settings store and context
- implement power actions with screen-off animation for display off

## Testing
- `npx eslint apps/settings/index.tsx hooks/useSettings.tsx utils/settingsStore.js src/lib/power/lid.ts`
- `yarn test __tests__/ubuntu.test.tsx`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fa9d6248328b355d70f7ac60764