### PR TITLE
feat(notifications): add configurable timeout and position

### DIFF
--- a/src/components/notifications/Notifier.tsx
+++ b/src/components/notifications/Notifier.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import type { NotificationCorner } from './SettingsDialog';
+
+interface NotifierContextValue {
+  notify: (message: string) => void;
+}
+
+const NotifierContext = createContext<NotifierContextValue>({ notify: () => {} });
+
+export const useNotifier = () => useContext(NotifierContext);
+
+const cornerClass = (corner: NotificationCorner) => {
+  switch (corner) {
+    case 'top-left':
+      return 'top-2 left-2';
+    case 'top-right':
+      return 'top-2 right-2';
+    case 'bottom-left':
+      return 'bottom-2 left-2';
+    case 'bottom-right':
+    default:
+      return 'bottom-2 right-2';
+  }
+};
+
+export const Notifier: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [queue, setQueue] = useState<string[]>([]);
+  const [current, setCurrent] = useState<string | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const [timeoutMs] = usePersistentState<number>('notification-timeout', 3000);
+  const [corner] = usePersistentState<NotificationCorner>('notification-corner', 'top-right');
+
+  const notify = useCallback((message: string) => {
+    setQueue(q => [...q, message]);
+  }, []);
+
+  useEffect(() => {
+    if (!current && queue.length > 0) {
+      setCurrent(queue[0]);
+      setQueue(q => q.slice(1));
+    }
+  }, [queue, current]);
+
+  useEffect(() => {
+    if (current) {
+      timerRef.current = setTimeout(() => {
+        setCurrent(null);
+      }, timeoutMs);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [current, timeoutMs]);
+
+  return (
+    <NotifierContext.Provider value={{ notify }}>
+      {children}
+      {current && (
+        <div className={`fixed z-50 ${cornerClass(corner)}`} role="alert">
+          <div className="bg-black text-white px-4 py-2 rounded shadow">{current}</div>
+        </div>
+      )}
+    </NotifierContext.Provider>
+  );
+};
+
+export default Notifier;

--- a/src/components/notifications/SettingsDialog.tsx
+++ b/src/components/notifications/SettingsDialog.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+export type NotificationCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+const SettingsDialog: React.FC = () => {
+  const [timeout, setTimeoutMs] = usePersistentState<number>('notification-timeout', 3000);
+  const [corner, setCorner] = usePersistentState<NotificationCorner>('notification-corner', 'top-right');
+
+  return (
+    <div>
+      <label htmlFor="notification-timeout" className="block mb-2">
+        Notification timeout (ms)
+      </label>
+      <input
+        id="notification-timeout"
+        name="notification-timeout"
+        type="number"
+        value={timeout}
+        aria-label="Notification timeout (ms)"
+        onChange={(e) => setTimeoutMs(Number(e.target.value))}
+        className="border rounded px-2 py-1 mb-4"
+      />
+      <label htmlFor="notification-corner" className="block mb-2">
+        Screen corner
+      </label>
+      <select
+        id="notification-corner"
+        name="notification-corner"
+        value={corner}
+        aria-label="Screen corner"
+        onChange={(e) => setCorner(e.target.value as NotificationCorner)}
+        className="border rounded px-2 py-1"
+      >
+        <option value="top-left">Top-left</option>
+        <option value="top-right">Top-right</option>
+        <option value="bottom-left">Bottom-left</option>
+        <option value="bottom-right">Bottom-right</option>
+      </select>
+    </div>
+  );
+};
+
+export default SettingsDialog;


### PR DESCRIPTION
## Summary
- add settings dialog fields for notification timeout and corner
- queue notifications and position based on settings

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `npx eslint src/components/notifications/SettingsDialog.tsx src/components/notifications/Notifier.tsx`
- `yarn test` *(fails: TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fa057b48328aa10e86701908a39