### PR TITLE
feat: add DPMS timers and display settings

### DIFF
--- a/pages/ui/settings/display.tsx
+++ b/pages/ui/settings/display.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { ChangeEvent } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+interface Durations {
+  standby: number;
+  suspend: number;
+  off: number;
+}
+
+const defaults: Durations = {
+  standby: 5,
+  suspend: 10,
+  off: 30,
+};
+
+export default function DisplaySettings() {
+  const [durations, setDurations] = usePersistentState<Durations>(
+    'dpms-durations',
+    defaults,
+    (v): v is Durations =>
+      typeof v === 'object' && v !== null &&
+      typeof (v as any).standby === 'number' &&
+      typeof (v as any).suspend === 'number' &&
+      typeof (v as any).off === 'number',
+  );
+
+  const update = (key: keyof Durations) => (e: ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10) || 0;
+    setDurations({ ...durations, [key]: value });
+  };
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-48 p-4 border-r border-ubt-cool-grey text-sm">
+        <ul className="space-y-1.5">
+          <li>
+            <a
+              href="/ui/settings/theme"
+              className="flex items-center gap-2 p-2 rounded-l-md hover:bg-ub-cool-grey"
+            >
+              <span className="w-6 h-6 bg-ubt-grey rounded" />
+              <span>Theme</span>
+            </a>
+          </li>
+          <li>
+            <a
+              className="flex items-center gap-2 p-2 rounded-l-md border-l-2 border-ubt-blue bg-ub-cool-grey"
+            >
+              <span className="w-6 h-6 bg-ubt-grey rounded" />
+              <span>Display</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div className="flex-1 p-4 overflow-y-auto">
+        <h1 className="text-xl mb-4">Display</h1>
+        <div className="space-y-4">
+          <label className="flex items-center gap-2">
+            <span className="w-32">Standby (min)</span>
+            <input
+              type="number"
+              min={0}
+              value={durations.standby}
+              onChange={update('standby')}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="w-32">Suspend (min)</span>
+            <input
+              type="number"
+              min={0}
+              value={durations.suspend}
+              onChange={update('suspend')}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="w-32">Off (min)</span>
+            <input
+              type="number"
+              min={0}
+              value={durations.off}
+              onChange={update('off')}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -45,9 +45,20 @@ export default function ThemeSettings() {
       <nav className="w-48 p-4 border-r border-ubt-cool-grey text-sm">
         <ul className="space-y-1.5">
           <li>
-            <a className="flex items-center gap-2 p-2 rounded-l-md border-l-2 border-ubt-blue bg-ub-cool-grey">
+            <a
+              className="flex items-center gap-2 p-2 rounded-l-md border-l-2 border-ubt-blue bg-ub-cool-grey"
+            >
               <span className="w-6 h-6 bg-ubt-grey rounded"></span>
               <span>Theme</span>
+            </a>
+          </li>
+          <li>
+            <a
+              href="/ui/settings/display"
+              className="flex items-center gap-2 p-2 rounded-l-md hover:bg-ub-cool-grey"
+            >
+              <span className="w-6 h-6 bg-ubt-grey rounded"></span>
+              <span>Display</span>
             </a>
           </li>
         </ul>

--- a/src/lib/power/dpms.ts
+++ b/src/lib/power/dpms.ts
@@ -1,0 +1,69 @@
+export type DPMSStage = 'standby' | 'suspend' | 'off';
+
+export interface DPMSTimers {
+  standby: number; // milliseconds until standby
+  suspend: number; // milliseconds after standby until suspend
+  off: number; // milliseconds after suspend until off
+}
+
+export interface DPMSOptions extends DPMSTimers {
+  /** Callback fired when a stage is reached */
+  onStage?: (stage: DPMSStage) => void;
+}
+
+/**
+ * Simple DPMS (Display Power Management Signaling) helper.
+ * Tracks three power saving stages and cancels when user activity is detected.
+ */
+export function createDPMS({ standby, suspend, off, onStage }: DPMSOptions) {
+  let timers: ReturnType<typeof setTimeout>[] = [];
+
+  const schedule = () => {
+    let total = 0;
+    const stages: [DPMSStage, number][] = [
+      ['standby', standby],
+      ['suspend', suspend],
+      ['off', off],
+    ];
+    stages.forEach(([stage, delay]) => {
+      total += delay;
+      timers.push(
+        setTimeout(() => {
+          onStage?.(stage);
+        }, total),
+      );
+    });
+  };
+
+  const clear = () => {
+    timers.forEach(clearTimeout);
+    timers = [];
+  };
+
+  const handleInput = () => {
+    cancel();
+  };
+
+  const start = () => {
+    clear();
+    schedule();
+    window.addEventListener('keydown', handleInput);
+    window.addEventListener('pointerdown', handleInput);
+    window.addEventListener('mousemove', handleInput);
+    window.addEventListener('touchstart', handleInput);
+    window.addEventListener('wheel', handleInput, { passive: true });
+  };
+
+  const cancel = () => {
+    clear();
+    window.removeEventListener('keydown', handleInput);
+    window.removeEventListener('pointerdown', handleInput);
+    window.removeEventListener('mousemove', handleInput);
+    window.removeEventListener('touchstart', handleInput);
+    window.removeEventListener('wheel', handleInput);
+  };
+
+  return { start, cancel };
+}
+
+export default createDPMS;


### PR DESCRIPTION
## Summary
- add DPMS helper tracking standby, suspend and off stages
- expose DPMS durations in new Display settings page
- link Theme settings to new Display tab

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; jsdom localStorage origin null)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fab014c832884c366911802c67b