### PR TITLE
feat: add clipman plugin with history and regex actions

### DIFF
--- a/__tests__/Clipman.test.tsx
+++ b/__tests__/Clipman.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import fs from 'fs';
+import path from 'path';
+import Clipman from '../src/plugins/Clipman';
+
+const CONFIG_PATH = path.join(__dirname, '..', 'src', 'plugins', 'clipman.json');
+let original: string;
+
+beforeEach(() => {
+  original = fs.readFileSync(CONFIG_PATH, 'utf8');
+});
+
+afterEach(() => {
+  fs.writeFileSync(CONFIG_PATH, original);
+  cleanup();
+});
+
+test('triggers URL handler', () => {
+  const urlHandler = jest.fn();
+  render(<Clipman onUrl={urlHandler} />);
+  const input = screen.getByLabelText('clipboard input');
+  fireEvent.change(input, { target: { value: 'https://example.com' } });
+  fireEvent.click(screen.getByText('Add'));
+  expect(urlHandler).toHaveBeenCalledWith('https://example.com');
+});
+
+test('triggers email handler', () => {
+  const emailHandler = jest.fn();
+  render(<Clipman onEmail={emailHandler} />);
+  const input = screen.getByLabelText('clipboard input');
+  fireEvent.change(input, { target: { value: 'user@example.com' } });
+  fireEvent.click(screen.getByText('Add'));
+  expect(emailHandler).toHaveBeenCalledWith('user@example.com');
+});
+
+test('triggers hex handler', () => {
+  const hexHandler = jest.fn();
+  render(<Clipman onHex={hexHandler} />);
+  const input = screen.getByLabelText('clipboard input');
+  fireEvent.change(input, { target: { value: '0xdeadbeef' } });
+  fireEvent.click(screen.getByText('Add'));
+  expect(hexHandler).toHaveBeenCalledWith('0xdeadbeef');
+});
+
+test('updates settings and persists them', async () => {
+  render(<Clipman />);
+  const sync = screen.getByLabelText('Sync selections');
+  const persist = screen.getByLabelText('Persist on exit');
+  fireEvent.click(sync);
+  fireEvent.click(persist);
+  await waitFor(() => {
+    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    expect(data.settings.syncSelections).toBe(true);
+    expect(data.settings.persistOnExit).toBe(true);
+  });
+});
+
+test('persists history on exit when enabled', async () => {
+  const { unmount } = render(<Clipman />);
+  const persist = screen.getByLabelText('Persist on exit');
+  fireEvent.click(persist);
+  const input = screen.getByLabelText('clipboard input');
+  fireEvent.change(input, { target: { value: 'hello' } });
+  fireEvent.click(screen.getByText('Add'));
+  unmount();
+  await waitFor(() => {
+    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    expect(data.history[0]).toBe('hello');
+  });
+});

--- a/src/plugins/Clipman.tsx
+++ b/src/plugins/Clipman.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import fs from 'fs';
+import path from 'path';
+
+interface ClipmanSettings {
+  syncSelections: boolean;
+  persistOnExit: boolean;
+}
+
+interface ClipmanData {
+  history: string[];
+  settings: ClipmanSettings;
+}
+
+const CONFIG_PATH = path.join(__dirname, 'clipman.json');
+
+function loadData(): ClipmanData {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    return {
+      history: Array.isArray(data.history) ? data.history : [],
+      settings: {
+        syncSelections: Boolean(data.settings?.syncSelections),
+        persistOnExit: Boolean(data.settings?.persistOnExit),
+      },
+    };
+  } catch {
+    return {
+      history: [],
+      settings: { syncSelections: false, persistOnExit: false },
+    };
+  }
+}
+
+function saveData(data: ClipmanData) {
+  try {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2));
+  } catch {
+    /* ignore errors */
+  }
+}
+
+const urlRe = /^https?:\/\/\S+$/i;
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const hexRe = /^0x?[0-9a-f]+$/i;
+
+export interface ClipmanProps {
+  onUrl?: (url: string) => void;
+  onEmail?: (email: string) => void;
+  onHex?: (hex: string) => void;
+}
+
+export default function Clipman({
+  onUrl,
+  onEmail,
+  onHex,
+}: ClipmanProps) {
+  const [input, setInput] = useState('');
+  const [history, setHistory] = useState<string[]>(() => loadData().history);
+  const [settings, setSettings] = useState<ClipmanSettings>(() => loadData().settings);
+
+  const handleUrl = onUrl || ((url: string) => {
+    if (typeof window !== 'undefined') window.open(url, '_blank');
+  });
+  const handleEmail = onEmail || ((email: string) => {
+    if (typeof window !== 'undefined') window.location.href = `mailto:${email}`;
+  });
+  const handleHex = onHex || ((hex: string) => {
+    // default handler just logs
+    console.log('hex', hex);
+  });
+
+  useEffect(() => {
+    // persist settings whenever they change
+    const data: ClipmanData = {
+      history: settings.persistOnExit ? history : [],
+      settings,
+    };
+    saveData(data);
+  }, [settings]);
+
+  useEffect(() => {
+    if (settings.persistOnExit) {
+      saveData({ history, settings });
+    }
+  }, [history, settings.persistOnExit]);
+
+  const addClip = () => {
+    const text = input.trim();
+    if (!text) return;
+    setHistory((prev) => [text, ...prev]);
+    setInput('');
+    if (urlRe.test(text)) {
+      handleUrl(text);
+    } else if (emailRe.test(text)) {
+      handleEmail(text);
+    } else if (hexRe.test(text)) {
+      handleHex(text);
+    }
+  };
+
+  const toggleSyncSelections = () =>
+    setSettings((s) => ({ ...s, syncSelections: !s.syncSelections }));
+  const togglePersistOnExit = () =>
+    setSettings((s) => ({ ...s, persistOnExit: !s.persistOnExit }));
+
+  return (
+    <div>
+      <div>
+        <input
+          aria-label="clipboard input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button onClick={addClip}>Add</button>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.syncSelections}
+            onChange={toggleSyncSelections}
+          />
+          Sync selections
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.persistOnExit}
+            onChange={togglePersistOnExit}
+          />
+          Persist on exit
+        </label>
+      </div>
+      <ul>
+        {history.map((h, i) => (
+          <li key={i}>{h}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/plugins/clipman.json
+++ b/src/plugins/clipman.json
@@ -1,0 +1,7 @@
+{
+  "history": [],
+  "settings": {
+    "syncSelections": false,
+    "persistOnExit": false
+  }
+}


### PR DESCRIPTION
## Summary
- add Clipman plugin managing clipboard history and settings
- support URL, email, and hex regex handlers
- persist `syncSelections` and `persistOnExit` options in `clipman.json`

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, TypeError from localStorage)*


------
https://chatgpt.com/codex/tasks/task_e_68ba2fac7b008328847916a05f390cad