### PR TITLE
Add preferred app settings and exo-open helper

### DIFF
--- a/__tests__/exo-open.test.ts
+++ b/__tests__/exo-open.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exo-open-test-'));
+const originalHome = process.env.HOME;
+process.env.HOME = tmpDir;
+jest.spyOn(os, 'homedir').mockReturnValue(tmpDir);
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('exo-open helpers.rc handling', () => {
+  it('reads defaults and persists selections', async () => {
+    const exo = await import('../src/lib/exo-open');
+    const { getPreferredApp, setPreferredApp } = exo;
+    const rcPath = path.join(tmpDir, '.config', 'xfce4', 'helpers.rc');
+
+    expect(fs.existsSync(rcPath)).toBe(false);
+    const def = await getPreferredApp('TerminalEmulator');
+    expect(def).toBe('terminal');
+    expect(fs.existsSync(rcPath)).toBe(false);
+
+    await setPreferredApp('TerminalEmulator', 'serial-terminal');
+    const updated = await getPreferredApp('TerminalEmulator');
+    expect(updated).toBe('serial-terminal');
+
+    expect(fs.existsSync(rcPath)).toBe(true);
+    const content = fs.readFileSync(rcPath, 'utf-8');
+    expect(content).toContain('TerminalEmulator=serial-terminal');
+  });
+});

--- a/src/components/settings/PreferredApps.tsx
+++ b/src/components/settings/PreferredApps.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { HelperType } from '../../lib/exo-open';
+
+interface Option {
+  id: string;
+  name: string;
+}
+
+const TERMINAL_OPTIONS: Option[] = [
+  { id: 'terminal', name: 'Terminal' },
+  { id: 'serial-terminal', name: 'Serial Terminal' },
+];
+
+const BROWSER_OPTIONS: Option[] = [
+  { id: 'chrome', name: 'Chrome' },
+];
+
+const FILE_OPTIONS: Option[] = [
+  { id: 'file-explorer', name: 'Files' },
+];
+
+export default function PreferredApps() {
+  const [values, setValues] = useState<Record<HelperType, string>>({
+    TerminalEmulator: 'terminal',
+    WebBrowser: 'chrome',
+    FileManager: 'file-explorer',
+  });
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { getPreferredApp } = await import('../../lib/exo-open');
+      const [t, b, f] = await Promise.all([
+        getPreferredApp('TerminalEmulator'),
+        getPreferredApp('WebBrowser'),
+        getPreferredApp('FileManager'),
+      ]);
+      if (mounted) {
+        setValues({
+          TerminalEmulator: t,
+          WebBrowser: b,
+          FileManager: f,
+        });
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleChange = (type: HelperType) =>
+    async (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value;
+      setValues((prev) => ({ ...prev, [type]: value }));
+      const { setPreferredApp } = await import('../../lib/exo-open');
+      await setPreferredApp(type, value);
+    };
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center space-x-2">
+        <label className="w-40 text-right">Terminal:</label>
+        <select
+          value={values.TerminalEmulator}
+          onChange={handleChange('TerminalEmulator')}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          {TERMINAL_OPTIONS.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center space-x-2">
+        <label className="w-40 text-right">File Manager:</label>
+        <select
+          value={values.FileManager}
+          onChange={handleChange('FileManager')}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          {FILE_OPTIONS.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center space-x-2">
+        <label className="w-40 text-right">Web Browser:</label>
+        <select
+          value={values.WebBrowser}
+          onChange={handleChange('WebBrowser')}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          {BROWSER_OPTIONS.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/exo-open.ts
+++ b/src/lib/exo-open.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export type HelperType = 'TerminalEmulator' | 'WebBrowser' | 'FileManager';
+
+const DEFAULT_APPS: Record<HelperType, string> = {
+  TerminalEmulator: 'terminal',
+  WebBrowser: 'chrome',
+  FileManager: 'file-explorer',
+};
+
+const rcPath = path.join(os.homedir(), '.config', 'xfce4', 'helpers.rc');
+
+async function readRc(): Promise<Record<string, string>> {
+  try {
+    const data = await fs.readFile(rcPath, 'utf-8');
+    const lines = data.split(/\r?\n/);
+    const map: Record<string, string> = {};
+    for (const line of lines) {
+      const m = /^([^=]+)=(.*)$/.exec(line.trim());
+      if (m) {
+        map[m[1]] = m[2];
+      }
+    }
+    return map;
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+async function writeRc(data: Record<string, string>): Promise<void> {
+  const dir = path.dirname(rcPath);
+  await fs.mkdir(dir, { recursive: true });
+  const content = Object.entries(data)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+  await fs.writeFile(rcPath, content + '\n', 'utf-8');
+}
+
+export async function getPreferredApp(type: HelperType): Promise<string> {
+  const rc = await readRc();
+  return rc[type] || DEFAULT_APPS[type];
+}
+
+export async function setPreferredApp(
+  type: HelperType,
+  appId: string,
+): Promise<void> {
+  const rc = await readRc();
+  rc[type] = appId;
+  await writeRc(rc);
+}
+
+export async function exoOpen(
+  type: HelperType,
+  openApp: (id: string, arg?: string) => void,
+  arg?: string,
+): Promise<void> {
+  const appId = await getPreferredApp(type);
+  if (!appId) {
+    throw new Error(`No preferred application configured for ${type}`);
+  }
+  openApp(appId, arg);
+}


### PR DESCRIPTION
## Summary
- add PreferredApps settings component to select default terminal, file manager and web browser
- persist selections to `~/.config/xfce4/helpers.rc`
- implement `exo-open` utility for reading config and launching preferred apps
- test helpers.rc read/write behavior

## Testing
- `npx eslint src/lib/exo-open.ts src/components/settings/PreferredApps.tsx __tests__/exo-open.test.ts`
- `yarn test __tests__/exo-open.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fbefb1883289a645d52c803c1a6