### PR TITLE
feat(thunar): add bulk rename dialog and numbering

### DIFF
--- a/src/components/thunar/BulkRenameDialog.tsx
+++ b/src/components/thunar/BulkRenameDialog.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import bulkRename from '../../lib/bulkRename';
+
+export interface BulkRenameDialogProps {
+  /** Original file names that will be renamed */
+  files: string[];
+  /** Called with the new names when the user confirms */
+  onRename: (names: string[]) => void;
+  /** Called when the dialog should be closed without renaming */
+  onCancel?: () => void;
+}
+
+/**
+ * Dialog used by the Thunar file manager for performing bulk rename
+ * operations. Users can provide a template string containing `#`
+ * characters as placeholders for incrementing numbers. A preview of
+ * the resulting file names is shown while typing.
+ */
+const BulkRenameDialog: React.FC<BulkRenameDialogProps> = ({
+  files,
+  onRename,
+  onCancel,
+}) => {
+  const [template, setTemplate] = useState('');
+
+  const preview = template ? bulkRename(files, { template }) : files;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onRename(preview);
+  };
+
+  return (
+    <div className="p-4 bg-gray-800 text-white rounded shadow-lg w-96">
+      <form onSubmit={handleSubmit}>
+        <h2 className="text-lg font-bold mb-3">Bulk Rename</h2>
+        <label htmlFor="bulk-rename-template" className="block text-sm mb-2">
+          Template
+        </label>
+        <input
+          id="bulk-rename-template"
+          type="text"
+          aria-label="Template"
+          value={template}
+          onChange={(e) => setTemplate(e.target.value)}
+          placeholder="e.g. file_##.txt"
+          className="w-full mb-2 p-1 text-black rounded"
+        />
+        <ul className="max-h-40 overflow-auto mb-3 text-sm">
+          {preview.map((name, i) => (
+            <li key={i} className="flex justify-between">
+              <span>{files[i]}</span>
+              <span className="text-green-400">{name}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-2 py-1 rounded bg-gray-700 hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-2 py-1 rounded bg-blue-600 hover:bg-blue-500"
+          >
+            Rename
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default BulkRenameDialog;

--- a/src/components/thunar/SelectionContextMenu.tsx
+++ b/src/components/thunar/SelectionContextMenu.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import ContextMenu, { MenuItem } from '@/components/common/ContextMenu';
+import BulkRenameDialog from './BulkRenameDialog';
+
+export interface SelectionContextMenuProps {
+  /** Reference to the element that triggers the menu */
+  targetRef: React.RefObject<HTMLElement>;
+  /** Names of currently selected files */
+  selected: string[];
+  /** Called when a rename operation is confirmed */
+  onRename: (names: string[]) => void;
+}
+
+/**
+ * Context menu used within the Thunar file manager when files are selected.
+ * Currently only exposes a "Bulk Rename" action which opens the
+ * `BulkRenameDialog`.
+ */
+const SelectionContextMenu: React.FC<SelectionContextMenuProps> = ({
+  targetRef,
+  selected,
+  onRename,
+}) => {
+  const [showRename, setShowRename] = useState(false);
+
+  const items: MenuItem[] = [
+    {
+      label: 'Bulk Rename…',
+      onSelect: () => setShowRename(true),
+    },
+  ];
+
+  return (
+    <>
+      <ContextMenu targetRef={targetRef} items={items} />
+      {showRename && (
+        <BulkRenameDialog
+          files={selected}
+          onRename={(names) => {
+            onRename(names);
+            setShowRename(false);
+          }}
+          onCancel={() => setShowRename(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default SelectionContextMenu;

--- a/src/lib/bulkRename.ts
+++ b/src/lib/bulkRename.ts
@@ -1,0 +1,42 @@
+export interface BulkRenameOptions {
+  /**
+   * Template containing one or more `#` characters which will be replaced
+   * with incrementing numbers. The amount of `#` characters controls the
+   * zero padding. For example `file_##.txt` will generate `file_01.txt`,
+   * `file_02.txt`, ...
+   */
+  template: string;
+  /** Starting number for the sequence (default: 1) */
+  start?: number;
+}
+
+/**
+ * Apply a bulk rename pattern to a list of filenames. Only numbering logic is
+ * handled here – the caller is responsible for actually renaming files on disk.
+ *
+ * @param files - Array of original file names
+ * @param options - Rename options including the template and starting number
+ * @returns Array of new file names generated from the template
+ */
+export function bulkRename(
+  files: string[],
+  options: BulkRenameOptions | string,
+): string[] {
+  const opts: BulkRenameOptions =
+    typeof options === 'string' ? { template: options } : options;
+  const start = opts.start ?? 1;
+
+  const match = opts.template.match(/#+/);
+  const padLength = match ? match[0].length : 0;
+
+  return files.map((_, i) => {
+    const num = String(start + i).padStart(padLength, '0');
+    if (match) {
+      return opts.template.replace(/#+/, num);
+    }
+    // If no placeholder provided simply append the number at the end
+    return opts.template + num;
+  });
+}
+
+export default bulkRename;


### PR DESCRIPTION
## Summary
- add bulk renamer utility with template-based numbering
- introduce BulkRename dialog that previews new filenames
- expose Bulk Rename action in Thunar selection context menu

## Testing
- `yarn test src/lib/bulkRename.ts --passWithNoTests`
- `npx eslint src/lib/bulkRename.ts src/components/thunar/BulkRenameDialog.tsx src/components/thunar/SelectionContextMenu.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fc295e08328b03bcbf5eda6d101