### PR TITLE
feat: add thumbnail cache management

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -104,6 +104,37 @@ export default function Settings() {
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
+
+  const [thumbSize, setThumbSize] = useState<number | null>(null);
+
+  const formatBytes = (bytes: number) => {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB", "TB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+  };
+
+  const fetchThumbSize = async () => {
+    try {
+      const res = await fetch("/api/thumbnails");
+      if (res.ok) {
+        const data = await res.json();
+        setThumbSize(data.size);
+      }
+    } catch {
+      setThumbSize(0);
+    }
+  };
+
+  useEffect(() => {
+    if (activeTab === "privacy") void fetchThumbSize();
+  }, [activeTab]);
+
+  const handleClearThumbnails = async () => {
+    await fetch("/api/thumbnails", { method: "DELETE" });
+    void fetchThumbSize();
+  };
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -272,6 +303,17 @@ export default function Settings() {
       )}
       {activeTab === "privacy" && (
         <>
+          <div className="flex justify-center my-4 items-center space-x-4">
+            <span className="text-ubt-grey">
+              Thumbnail cache: {thumbSize === null ? "—" : formatBytes(thumbSize)}
+            </span>
+            <button
+              onClick={handleClearThumbnails}
+              className="px-4 py-2 rounded bg-ub-orange text-white"
+            >
+              Clear Thumbnails
+            </button>
+          </div>
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}

--- a/pages/api/thumbnails.ts
+++ b/pages/api/thumbnails.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+function getThumbDir() {
+  const cacheHome = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  return path.join(cacheHome, 'thumbnails');
+}
+
+async function dirSize(dir: string): Promise<number> {
+  let total = 0;
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        total += await dirSize(full);
+      } else {
+        const stat = await fs.stat(full);
+        total += stat.size;
+      }
+    }
+  } catch {
+    return 0;
+  }
+  return total;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const dir = getThumbDir();
+  if (req.method === 'GET') {
+    const size = await dirSize(dir);
+    res.status(200).json({ size });
+  } else if (req.method === 'DELETE') {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      await fs.mkdir(dir, { recursive: true });
+      res.status(200).json({ size: 0 });
+    } catch (err) {
+      res.status(500).json({ error: 'Failed to clear thumbnails' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'DELETE']);
+    res.status(405).end('Method Not Allowed');
+  }
+}
+


### PR DESCRIPTION
## Summary
- show thumbnail cache size and allow clearing from settings privacy tab
- add API endpoint to read and clear cached thumbnails

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint apps/settings/index.tsx pages/api/thumbnails.ts` *(fails: A control must be associated with a text label, Unexpected global 'document', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fc545e08328b615f0222ebd9194