### PR TITLE
feat: add tumbler settings pane and plugin-aware thumbnail generation

### DIFF
--- a/src/components/tumbler/SettingsPane.tsx
+++ b/src/components/tumbler/SettingsPane.tsx
@@ -1,0 +1,68 @@
+'use client';
+import React from 'react';
+
+export interface TumblerSettings {
+  maxSize: number;
+  disabledPlugins: Record<string, boolean>;
+}
+
+export interface SettingsPaneProps {
+  availablePlugins: string[];
+  settings: TumblerSettings;
+  onChange: (settings: TumblerSettings) => void;
+}
+
+export default function SettingsPane({
+  availablePlugins,
+  settings,
+  onChange,
+}: SettingsPaneProps) {
+  const togglePlugin = (id: string) => {
+    const disabled = { ...settings.disabledPlugins, [id]: !settings.disabledPlugins[id] };
+    onChange({ ...settings, disabledPlugins: disabled });
+  };
+
+  const updateMaxSize = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value) || 0;
+    onChange({ ...settings, maxSize: value });
+  };
+
+  return (
+    <div className="space-y-4 text-white">
+      <div>
+        <label htmlFor="tumbler-max-size" className="block text-sm mb-1">
+          Max thumbnail size (px)
+        </label>
+        <input
+          id="tumbler-max-size"
+          type="number"
+          className="w-full rounded p-1 text-black"
+          value={settings.maxSize}
+          onChange={updateMaxSize}
+          min={0}
+          aria-label="Max thumbnail size"
+        />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium mb-2">Plugins</h3>
+        <ul className="space-y-1">
+          {availablePlugins.map((id) => (
+            <li key={id}>
+              <label className="flex items-center">
+                <input
+                  type="checkbox"
+                  className="mr-2"
+                  checked={!settings.disabledPlugins[id]}
+                  onChange={() => togglePlugin(id)}
+                  aria-label={`${id} plugin toggle`}
+                />
+                <span className="text-sm">{id}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/src/tumbler/cache.ts
+++ b/src/tumbler/cache.ts
@@ -1,0 +1,13 @@
+import os from 'os';
+import path from 'path';
+
+/**
+ * Resolve the directory used for caching generated thumbnails.
+ * Uses the XDG_CACHE_HOME environment variable if provided, falling back
+ * to the standard ~/.cache location.
+ */
+export function getCacheDir(): string {
+  const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  return path.join(base, 'tumbler');
+}
+

--- a/src/tumbler/generate.ts
+++ b/src/tumbler/generate.ts
@@ -1,0 +1,30 @@
+export interface TumblerPlugin {
+  id: string;
+  generate: (file: string) => Promise<Buffer | null>;
+}
+
+export interface GenerateOptions {
+  plugins: TumblerPlugin[];
+  disabledPlugins?: Record<string, boolean>;
+}
+
+/**
+ * Run through available plugins until one returns a thumbnail.
+ * Disabled plugins are skipped.
+ */
+export async function generateThumbnail(
+  file: string,
+  { plugins, disabledPlugins = {} }: GenerateOptions
+): Promise<Buffer | null> {
+  for (const plugin of plugins) {
+    if (disabledPlugins[plugin.id]) continue;
+    try {
+      const result = await plugin.generate(file);
+      if (result) return result;
+    } catch {
+      // ignore plugin errors and try next
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add tumbler settings pane with plugin toggles and max-size control
- allow cache directory override via XDG_CACHE_HOME
- skip disabled plugins when generating thumbnails

## Testing
- `yarn test` *(fails: TypeError e.preventDefault is not a function; Unable to find role="alert"; jsdom localStorage origin error)*
- `npx eslint src/components/tumbler/SettingsPane.tsx src/tumbler/cache.ts src/tumbler/generate.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fc442f08328981d6ef7f6342ebd