### PR TITLE
feat: add screenshooter app

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
+import { displayScreenshooter } from './src/apps/screenshooter/Screenshooter';
 
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
@@ -718,6 +719,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayScreenRecorder,
+  },
+  {
+    id: 'screenshooter',
+    title: 'Screenshooter',
+    icon: '/themes/Yaru/apps/screen-recorder.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayScreenshooter,
   },
   {
     id: 'ettercap',

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -87,6 +87,7 @@ export class Desktop extends Component {
         this.checkForAppShortcuts();
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
+        window.addEventListener('open-app', this.handleOpenApp);
         document.addEventListener('keydown', this.handleGlobalShortcut);
     }
 
@@ -94,6 +95,7 @@ export class Desktop extends Component {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        window.removeEventListener('open-app', this.handleOpenApp);
     }
 
     checkForNewFolders = () => {
@@ -162,6 +164,10 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if (e.key === 'PrintScreen') {
+            e.preventDefault();
+            this.openApp('screenshooter');
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
@@ -169,6 +175,13 @@ export class Desktop extends Component {
                 const event = new CustomEvent('super-arrow', { detail: e.key });
                 document.getElementById(id)?.dispatchEvent(event);
             }
+        }
+    }
+
+    handleOpenApp = (e) => {
+        const id = e.detail;
+        if (id) {
+            this.openApp(id);
         }
     }
 
@@ -822,8 +835,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -29,6 +29,18 @@ const QuickSettings = ({ open }: Props) => {
     >
       <div className="px-4 pb-2">
         <button
+          className="w-full flex justify-center"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent('open-app', { detail: 'screenshooter' })
+            )
+          }
+        >
+          Screenshot
+        </button>
+      </div>
+      <div className="px-4 pb-2">
+        <button
           className="w-full flex justify-between"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
@@ -36,20 +48,34 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <div className="px-4 pb-2 flex justify-between items-center">
+        <label htmlFor="qs-sound">Sound</label>
         <input
+          id="qs-sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Sound"
+        />
+      </div>
+      <div className="px-4 pb-2 flex justify-between items-center">
+        <label htmlFor="qs-network">Network</label>
+        <input
+          id="qs-network"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Network"
+        />
+      </div>
+      <div className="px-4 flex justify-between items-center">
+        <label htmlFor="qs-motion">Reduced motion</label>
+        <input
+          id="qs-motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Reduced motion"
         />
       </div>
     </div>

--- a/src/apps/screenshooter/Screenshooter.tsx
+++ b/src/apps/screenshooter/Screenshooter.tsx
@@ -1,0 +1,95 @@
+"use client";
+import React, { useState } from 'react';
+
+const Screenshooter = () => {
+  const [captureType, setCaptureType] = useState<'monitor' | 'window' | 'browser'>('monitor');
+  const [imgUrl, setImgUrl] = useState<string | null>(null);
+  const [blob, setBlob] = useState<Blob | null>(null);
+
+  const capture = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { displaySurface: captureType },
+      });
+      const track = stream.getVideoTracks()[0];
+      const imageCapture = new ImageCapture(track);
+      const bitmap = await imageCapture.grabFrame();
+      const canvas = document.createElement('canvas');
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+      const ctx = canvas.getContext('2d');
+      ctx?.drawImage(bitmap, 0, 0);
+      const b: Blob = await new Promise((resolve) =>
+        canvas.toBlob((bb) => resolve(bb || new Blob()), 'image/png')
+      );
+      setBlob(b);
+      setImgUrl(URL.createObjectURL(b));
+      stream.getTracks().forEach((t) => t.stop());
+    } catch {
+      // ignore
+    }
+  };
+
+  const copy = async () => {
+    if (!blob) return;
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({ [blob.type]: blob }),
+      ]);
+    } catch {
+      // ignore
+    }
+  };
+
+  const openWith = () => {
+    if (imgUrl) window.open(imgUrl);
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
+      <div className="space-x-2">
+        <label htmlFor="capture-type">Capture:</label>
+        <select
+          id="capture-type"
+          value={captureType}
+          onChange={(e) => setCaptureType(e.target.value as any)}
+          className="text-black px-2 py-1 rounded"
+        >
+          <option value="monitor">Screen</option>
+          <option value="window">Window</option>
+          <option value="browser">Browser Tab</option>
+        </select>
+        <button
+          onClick={capture}
+          className="ml-2 px-4 py-1 bg-ub-dracula rounded hover:bg-ub-dracula-dark"
+        >
+          Capture
+        </button>
+      </div>
+      {imgUrl && (
+        <>
+          <img src={imgUrl} alt="screenshot" className="max-w-full" />
+          <div className="space-x-2">
+            <button
+              onClick={copy}
+              className="px-3 py-1 bg-ub-dracula rounded hover:bg-ub-dracula-dark"
+            >
+              Copy
+            </button>
+            <button
+              onClick={openWith}
+              className="px-3 py-1 bg-ub-dracula rounded hover:bg-ub-dracula-dark"
+            >
+              Open With
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Screenshooter;
+
+export const displayScreenshooter = () => <Screenshooter />;
+


### PR DESCRIPTION
## Summary
- implement Screenshooter component with capture options, clipboard copy, and open-with action
- add panel shortcut and Print Screen hotkey to launch Screenshooter
- register Screenshooter in app config

## Testing
- `npx eslint src/apps/screenshooter/Screenshooter.tsx components/ui/QuickSettings.tsx components/screen/desktop.js apps.config.js`
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; TypeError: Cannot read properties of null)*
- `npx tsc src/apps/screenshooter/Screenshooter.tsx components/ui/QuickSettings.tsx --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fc7637483288b813de07ff300cc