### PR TITLE
Add minimal Parole player and Ristretto viewer apps

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -112,6 +112,8 @@ const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
 const ContactApp = createDynamicApp('contact', 'Contact');
+const ParoleApp = createDynamicApp('parole', 'Parole');
+const RistrettoApp = createDynamicApp('ristretto', 'Ristretto');
 
 
 
@@ -197,6 +199,8 @@ const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
 const displayContact = createDisplay(ContactApp);
+const displayParole = createDisplay(ParoleApp);
+const displayRistretto = createDisplay(RistrettoApp);
 
 const displayHashcat = createDisplay(HashcatApp);
 
@@ -239,6 +243,24 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFiglet,
+  },
+  {
+    id: 'parole',
+    title: 'Parole',
+    icon: '/themes/Yaru/apps/parole.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayParole,
+  },
+  {
+    id: 'ristretto',
+    title: 'Ristretto',
+    icon: '/themes/Yaru/apps/ristretto.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayRistretto,
   },
   {
     id: 'quote',

--- a/components/apps/parole.tsx
+++ b/components/apps/parole.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+// Lightweight wrapper that dynamically loads the Parole player
+// implemented in src/apps/parole. This keeps initial bundle size small.
+const ParoleApp = dynamic(() => import('../../src/apps/parole'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default ParoleApp;

--- a/components/apps/ristretto.tsx
+++ b/components/apps/ristretto.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+// Wrapper that lazy-loads the Ristretto image viewer from src/apps/ristretto.
+const RistrettoApp = dynamic(() => import('../../src/apps/ristretto'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default RistrettoApp;

--- a/public/themes/Yaru/apps/parole.svg
+++ b/public/themes/Yaru/apps/parole.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#4a86e8" />
+  <polygon points="40,30 70,50 40,70" fill="#fff" />
+</svg>

--- a/public/themes/Yaru/apps/ristretto.svg
+++ b/public/themes/Yaru/apps/ristretto.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="8" y="20" width="84" height="60" rx="4" fill="#4a86e8" />
+  <polygon points="25,60 35,45 45,60" fill="#fff" />
+  <circle cx="70" cy="45" r="8" fill="#fff" />
+</svg>

--- a/src/apps/parole/config.ts
+++ b/src/apps/parole/config.ts
@@ -1,0 +1,26 @@
+export interface ParoleConfig {
+  autoplay: boolean;
+}
+
+const defaultParoleConfig: ParoleConfig = {
+  autoplay: false,
+};
+
+const KEY = 'parole-config';
+
+export function loadParoleConfig(): ParoleConfig {
+  if (typeof window === 'undefined') return defaultParoleConfig;
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? { ...defaultParoleConfig, ...JSON.parse(raw) } : defaultParoleConfig;
+  } catch {
+    return defaultParoleConfig;
+  }
+}
+
+export function saveParoleConfig(config: ParoleConfig) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(KEY, JSON.stringify(config));
+}
+
+export { defaultParoleConfig };

--- a/src/apps/parole/index.tsx
+++ b/src/apps/parole/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import {
+  loadParoleConfig,
+  saveParoleConfig,
+  ParoleConfig,
+} from './config';
+
+export default function Parole() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [source, setSource] = useState('');
+  const [showPrefs, setShowPrefs] = useState(false);
+  const [config, setConfig] = useState<ParoleConfig>(loadParoleConfig());
+
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSource(URL.createObjectURL(file));
+    }
+  };
+
+  const togglePlay = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      void audio.play();
+    } else {
+      audio.pause();
+    }
+  };
+
+  const savePrefs = () => {
+    saveParoleConfig(config);
+    setShowPrefs(false);
+  };
+
+  return (
+    <div className="p-2 text-sm">
+      <input
+        aria-label="Open audio file"
+        type="file"
+        accept="audio/*"
+        onChange={onFile}
+      />
+      <div className="mt-2">
+        <audio
+          aria-label="Audio player"
+          ref={audioRef}
+          src={source}
+          autoPlay={config.autoplay}
+        />
+      </div>
+      <div className="mt-2 space-x-2">
+        <button onClick={togglePlay} className="px-2 py-1 bg-blue-600 text-white">
+          Play/Pause
+        </button>
+        <button
+          onClick={() => setShowPrefs(true)}
+          className="px-2 py-1 bg-gray-600 text-white"
+        >
+          Preferences
+        </button>
+      </div>
+      {showPrefs && (
+        <div role="dialog" className="mt-4 border p-2 bg-white text-black">
+          <div className="flex items-center space-x-2">
+            <input
+              id="parole-autoplay"
+              aria-label="Autoplay"
+              type="checkbox"
+              checked={config.autoplay}
+              onChange={(e) =>
+                setConfig({ ...config, autoplay: e.target.checked })
+              }
+            />
+            <label htmlFor="parole-autoplay">Autoplay</label>
+          </div>
+          <button
+            onClick={savePrefs}
+            className="mt-2 px-2 py-1 bg-blue-600 text-white"
+          >
+            Save
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/apps/ristretto/config.ts
+++ b/src/apps/ristretto/config.ts
@@ -1,0 +1,26 @@
+export interface RistrettoConfig {
+  loop: boolean;
+}
+
+const defaultRistrettoConfig: RistrettoConfig = {
+  loop: false,
+};
+
+const KEY = 'ristretto-config';
+
+export function loadRistrettoConfig(): RistrettoConfig {
+  if (typeof window === 'undefined') return defaultRistrettoConfig;
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? { ...defaultRistrettoConfig, ...JSON.parse(raw) } : defaultRistrettoConfig;
+  } catch {
+    return defaultRistrettoConfig;
+  }
+}
+
+export function saveRistrettoConfig(config: RistrettoConfig) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(KEY, JSON.stringify(config));
+}
+
+export { defaultRistrettoConfig };

--- a/src/apps/ristretto/index.tsx
+++ b/src/apps/ristretto/index.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  loadRistrettoConfig,
+  saveRistrettoConfig,
+  RistrettoConfig,
+} from './config';
+
+export default function Ristretto() {
+  const [images, setImages] = useState<string[]>([]);
+  const [index, setIndex] = useState(0);
+  const [showPrefs, setShowPrefs] = useState(false);
+  const [config, setConfig] = useState<RistrettoConfig>(loadRistrettoConfig());
+
+  const onFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    const urls = files.map((f) => URL.createObjectURL(f));
+    setImages(urls);
+    setIndex(0);
+  };
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (images.length === 0) return;
+      if (e.key === 'ArrowRight') {
+        setIndex((i) => {
+          const next = i + 1;
+          if (next < images.length) return next;
+          return config.loop ? 0 : i;
+        });
+      } else if (e.key === 'ArrowLeft') {
+        setIndex((i) => {
+          const prev = i - 1;
+          if (prev >= 0) return prev;
+          return config.loop ? images.length - 1 : i;
+        });
+      }
+    },
+    [images, config.loop],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [handleKey]);
+
+  const savePrefs = () => {
+    saveRistrettoConfig(config);
+    setShowPrefs(false);
+  };
+
+  return (
+    <div className="p-2 text-sm">
+      <input
+        aria-label="Open images"
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={onFiles}
+      />
+      {images.length > 0 && (
+        <div className="mt-2 flex items-center justify-center">
+          <img
+            src={images[index]}
+            alt={`image ${index + 1}`}
+            className="max-w-full max-h-[70vh] object-contain"
+          />
+        </div>
+      )}
+      <div className="mt-2">
+        <button
+          onClick={() => setShowPrefs(true)}
+          className="px-2 py-1 bg-gray-600 text-white"
+        >
+          Preferences
+        </button>
+      </div>
+      {showPrefs && (
+        <div role="dialog" className="mt-4 border p-2 bg-white text-black">
+          <div className="flex items-center space-x-2">
+            <input
+              id="ristretto-loop"
+              aria-label="Loop images"
+              type="checkbox"
+              checked={config.loop}
+              onChange={(e) =>
+                setConfig({ ...config, loop: e.target.checked })
+              }
+            />
+            <label htmlFor="ristretto-loop">Loop images</label>
+          </div>
+          <button
+            onClick={savePrefs}
+            className="mt-2 px-2 py-1 bg-blue-600 text-white"
+          >
+            Save
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Parole audio player with play/pause controls and configurable autoplay
- add Ristretto image viewer with arrow key navigation and looping preference
- register new apps in configuration and include simple icons

## Testing
- `npx eslint src/apps/parole src/apps/ristretto components/apps/parole.tsx components/apps/ristretto.tsx apps.config.js`
- `yarn test src/apps/parole src/apps/ristretto --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fc8c86483289d07574570b1e478