### PR TITLE
feat: add terminal preferences dialog

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import { getDefaultTerminal } from '../../utils/preferredApps'
 
 function DesktopMenu(props) {
 
@@ -14,7 +15,7 @@ function DesktopMenu(props) {
 
 
     const openTerminal = () => {
-        props.openApp("terminal");
+        props.openApp(getDefaultTerminal());
     }
 
     const openSettings = () => {

--- a/src/apps/terminal/PreferencesDialog.tsx
+++ b/src/apps/terminal/PreferencesDialog.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+
+export interface PreferencesDialogProps {
+  open: boolean;
+  onClose: () => void;
+  colors: { background: string; foreground: string };
+  onColorsChange: (c: { background: string; foreground: string }) => void;
+}
+
+const tabs = [
+  'General',
+  'Appearance',
+  'Colors',
+  'Compatibility',
+  'Advanced',
+  'Shortcuts',
+];
+
+export default function PreferencesDialog({
+  open,
+  onClose,
+  colors,
+  onColorsChange,
+}: PreferencesDialogProps) {
+  const [active, setActive] = useState('General');
+  if (!open) return null;
+  return (
+    <div className="absolute inset-0 bg-black bg-opacity-75 flex items-center justify-center z-10">
+      <div className="bg-gray-900 p-4 rounded w-96">
+        <div className="flex border-b mb-4 overflow-x-auto">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              className={`px-2 py-1 text-sm whitespace-nowrap ${
+                active === t ? 'border-b-2 border-blue-500 text-white' : 'text-gray-400'
+              }`}
+              onClick={() => setActive(t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        {active === 'Colors' && (
+          <div className="space-y-4">
+            <label className="flex items-center justify-between text-sm">
+              <span>Background</span>
+              <input
+                type="color"
+                value={colors.background}
+                onChange={(e) =>
+                  onColorsChange({ ...colors, background: e.target.value })
+                }
+              />
+            </label>
+            <label className="flex items-center justify-between text-sm">
+              <span>Text</span>
+              <input
+                type="color"
+                value={colors.foreground}
+                onChange={(e) =>
+                  onColorsChange({ ...colors, foreground: e.target.value })
+                }
+              />
+            </label>
+          </div>
+        )}
+        {active !== 'Colors' && (
+          <p className="text-gray-400 text-sm">No settings available.</p>
+        )}
+        <div className="flex justify-end mt-4">
+          <button
+            className="px-2 py-1 bg-blue-600 rounded"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/utils/preferredApps.ts
+++ b/utils/preferredApps.ts
@@ -1,0 +1,9 @@
+export function getDefaultTerminal(): string {
+  if (typeof window === 'undefined') return 'terminal';
+  return window.localStorage.getItem('default-terminal') || 'terminal';
+}
+
+export function setDefaultTerminal(id: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('default-terminal', id);
+}


### PR DESCRIPTION
## Summary
- add reusable preferences dialog with tabs and color scheme picker
- apply terminal color changes live
- honor preferred default terminal setting

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, installButton.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fcba28c8328a3d8383645ba58d3