### PR TITLE
feat: add Kali Tweaks app with persisted selections

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
+import { displayKaliTweaks } from './components/apps/kali-tweaks';
 
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
@@ -691,6 +692,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'kali-tweaks',
+    title: 'Kali Tweaks',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliTweaks,
   },
   {
     id: 'files',

--- a/components/apps/kali-tweaks.js
+++ b/components/apps/kali-tweaks.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import KaliTweaksPage from '../../pages/apps/kali-tweaks';
+
+export const displayKaliTweaks = () => <KaliTweaksPage />;
+
+export default KaliTweaksPage;
+

--- a/pages/apps/kali-tweaks/index.jsx
+++ b/pages/apps/kali-tweaks/index.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import Tabs from '../../../components/Tabs';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+const TAB_LIST = [
+  { id: 'shell', label: 'Shell' },
+  { id: 'mirrors', label: 'Mirrors' },
+  { id: 'metapackages', label: 'Metapackages' },
+  { id: 'hardening', label: 'Hardening' },
+  { id: 'virtualization', label: 'Virtualization' },
+  { id: 'kernel', label: 'Kernel' },
+];
+
+const OPTIONS = {
+  shell: ['Bash', 'Zsh', 'Fish'],
+  mirrors: ['Default', 'Cloudflare', 'Kali Rolling'],
+  metapackages: ['kali-linux-default', 'kali-linux-large', 'kali-linux-everything'],
+  hardening: ['Enable firewall', 'Install Lynis', 'Enable auditd'],
+  virtualization: ['VirtualBox Guest', 'VMware Tools'],
+  kernel: ['Install headers', 'Enable sources'],
+};
+
+export default function KaliTweaksPage() {
+  const [active, setActive] = useState('shell');
+  const [selections, setSelections] = usePersistentState('kaliTweaks', {
+    shell: [],
+    mirrors: [],
+    metapackages: [],
+    hardening: [],
+    virtualization: [],
+    kernel: [],
+  });
+
+  const toggleOption = (tab, option) => {
+    setSelections((prev) => {
+      const current = prev[tab] || [];
+      const next = current.includes(option)
+        ? current.filter((o) => o !== option)
+        : [...current, option];
+      return { ...prev, [tab]: next };
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <Tabs tabs={TAB_LIST} active={active} onChange={setActive} className="mb-4 border-b border-gray-600" />
+      <div className="space-y-2">
+        {OPTIONS[active].map((opt) => (
+          <label key={opt} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={selections[active]?.includes(opt)}
+              onChange={() => toggleOption(active, opt)}
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Kali Tweaks page with tabs for multiple tweak categories and store selections in localStorage
- expose Kali Tweaks in app launcher configuration

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48c32954832891848df98c6e4695