### PR TITLE
feat: add metapackage toggles

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -108,6 +108,7 @@ const NmapNSEApp = createDynamicApp('nmap-nse', 'Nmap NSE');
 const OpenVASApp = createDynamicApp('openvas', 'OpenVAS');
 const ReconNGApp = createDynamicApp('reconng', 'Recon-ng');
 const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
+const KaliTweaksApp = createDynamicApp('kali-tweaks', 'Kali Tweaks');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
@@ -193,6 +194,7 @@ const displayNmapNSE = createDisplay(NmapNSEApp);
 const displayOpenVAS = createDisplay(OpenVASApp);
 const displayReconNG = createDisplay(ReconNGApp);
 const displaySecurityTools = createDisplay(SecurityToolsApp);
+const displayKaliTweaks = createDisplay(KaliTweaksApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
@@ -1050,6 +1052,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displaySecurityTools,
+  },
+  {
+    id: 'kali-tweaks',
+    title: 'Kali Tweaks',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayKaliTweaks,
   },
   // Utilities are grouped separately
   ...utilities,

--- a/apps/kali-tweaks/index.tsx
+++ b/apps/kali-tweaks/index.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+interface Metapackage {
+  id: string;
+  name: string;
+  dependencies: string[];
+}
+
+type Action = 'install' | 'remove';
+
+const METAPACKAGES: Metapackage[] = [
+  {
+    id: 'kali-linux-default',
+    name: 'kali-linux-default',
+    dependencies: ['kali-tools-top10'],
+  },
+  {
+    id: 'kali-linux-large',
+    name: 'kali-linux-large',
+    dependencies: ['kali-linux-default', 'kali-tools-everything'],
+  },
+  {
+    id: 'kali-tools-top10',
+    name: 'kali-tools-top10',
+    dependencies: ['nmap', 'hydra', 'john', 'sqlmap', 'aircrack-ng'],
+  },
+  {
+    id: 'kali-tools-wireless',
+    name: 'kali-tools-wireless',
+    dependencies: ['aircrack-ng', 'kismet', 'wireless-tools'],
+  },
+];
+
+const KaliTweaks: React.FC = () => {
+  const [actions, setActions] = usePersistentState<Record<string, Action>>(
+    'kaliTweaks.metapackages',
+    {},
+  );
+
+  const toggle = (id: string, action: Action) => {
+    setActions((prev) => {
+      const next = { ...prev };
+      if (next[id] === action) {
+        delete next[id];
+      } else {
+        next[id] = action;
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white text-sm">
+      <h1 className="mb-4 text-2xl">Kali Tweaks</h1>
+      <p className="mb-4 text-gray-300">
+        Select metapackages to install or remove. Selections are saved locally.
+      </p>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Metapackage</th>
+            <th className="p-2">Dependencies</th>
+            <th className="p-2 text-center">Install</th>
+            <th className="p-2 text-center">Remove</th>
+          </tr>
+        </thead>
+        <tbody>
+          {METAPACKAGES.map((pkg) => (
+            <tr key={pkg.id} className="border-t border-gray-700">
+              <td className="p-2 font-medium">{pkg.name}</td>
+              <td className="p-2">
+                <ul className="list-disc pl-4">
+                  {pkg.dependencies.map((dep) => (
+                    <li key={dep}>{dep}</li>
+                  ))}
+                </ul>
+              </td>
+              <td className="p-2 text-center">
+                <input
+                  type="checkbox"
+                  aria-label="Install"
+                  checked={actions[pkg.id] === 'install'}
+                  onChange={() => toggle(pkg.id, 'install')}
+                />
+              </td>
+              <td className="p-2 text-center">
+                <input
+                  type="checkbox"
+                  aria-label="Remove"
+                  checked={actions[pkg.id] === 'remove'}
+                  onChange={() => toggle(pkg.id, 'remove')}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default KaliTweaks;
+


### PR DESCRIPTION
## Summary
- add Kali Tweaks app to manage Kali metapackages
- list popular metapackages with dependencies and install/remove toggles
- persist selections under `localStorage.kaliTweaks.metapackages`

## Testing
- `npx eslint apps/kali-tweaks/index.tsx apps.config.js`
- `yarn test apps/kali-tweaks/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba48c67ccc8328bf113a8a2befaaf4