### PR TITLE
Add VM tweak settings with persistent model

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -3,6 +3,7 @@ import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';
 import { displaySettings } from './components/apps/settings';
+import { displayTweaks } from './components/apps/tweaks';
 import { displayChrome } from './components/apps/chrome';
 import { displayGedit } from './components/apps/gedit';
 import { displayTodoist } from './components/apps/todoist';
@@ -691,6 +692,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'tweaks',
+    title: 'VM Tweaks',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayTweaks,
   },
   {
     id: 'files',

--- a/apps/tweaks/index.tsx
+++ b/apps/tweaks/index.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTweaks } from "../../hooks/useTweaks";
+
+export default function Tweaks() {
+  const {
+    clipboard,
+    timeSync,
+    sharedFolders,
+    setClipboard,
+    setTimeSync,
+    setSharedFolders,
+  } = useTweaks();
+
+  const options = [
+    {
+      key: "clipboard",
+      label: "Shared Clipboard",
+      description: "Allows copy and paste between host and virtual machine.",
+      checked: clipboard,
+      onChange: setClipboard,
+    },
+    {
+      key: "timeSync",
+      label: "Sync Host Time",
+      description: "Keep the VM clock synchronized with the host system.",
+      checked: timeSync,
+      onChange: setTimeSync,
+    },
+    {
+      key: "sharedFolders",
+      label: "Auto-Mount Shared Folders",
+      description: "Mount shared folders from the host at startup.",
+      checked: sharedFolders,
+      onChange: setSharedFolders,
+    },
+  ];
+
+  return (
+    <div className="p-4 space-y-4 text-ubt-grey">
+      <h1 className="text-2xl font-bold">VM Tweaks</h1>
+      {options.map((opt) => (
+        <label key={opt.key} className="flex items-start space-x-2">
+          <input
+            type="checkbox"
+            checked={opt.checked}
+            onChange={(e) => opt.onChange(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            <span className="font-medium">{opt.label}</span> - {opt.description}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/components/apps/tweaks.tsx
+++ b/components/apps/tweaks.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+
+const Tweaks = dynamic(() => import("../../apps/tweaks"), {
+  ssr: false,
+});
+
+export const displayTweaks = () => <Tweaks />;
+
+export default Tweaks;

--- a/hooks/useTweaks.tsx
+++ b/hooks/useTweaks.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import {
+  getClipboard,
+  setClipboard,
+  getTimeSync,
+  setTimeSync,
+  getSharedFolders,
+  setSharedFolders,
+  defaults,
+} from "../utils/tweaksStore";
+
+interface TweaksContextValue {
+  clipboard: boolean;
+  timeSync: boolean;
+  sharedFolders: boolean;
+  setClipboard: (v: boolean) => void;
+  setTimeSync: (v: boolean) => void;
+  setSharedFolders: (v: boolean) => void;
+}
+
+export const TweaksContext = createContext<TweaksContextValue>({
+  clipboard: defaults.clipboard,
+  timeSync: defaults.timeSync,
+  sharedFolders: defaults.sharedFolders,
+  setClipboard: () => {},
+  setTimeSync: () => {},
+  setSharedFolders: () => {},
+});
+
+export function TweaksProvider({ children }: { children: ReactNode }) {
+  const [clipboard, setClipboardState] = useState(defaults.clipboard);
+  const [timeSync, setTimeSyncState] = useState(defaults.timeSync);
+  const [sharedFolders, setSharedFoldersState] = useState(defaults.sharedFolders);
+
+  useEffect(() => {
+    (async () => {
+      setClipboardState(await getClipboard());
+      setTimeSyncState(await getTimeSync());
+      setSharedFoldersState(await getSharedFolders());
+    })();
+  }, []);
+
+  useEffect(() => {
+    setClipboard(clipboard);
+  }, [clipboard]);
+
+  useEffect(() => {
+    setTimeSync(timeSync);
+  }, [timeSync]);
+
+  useEffect(() => {
+    setSharedFolders(sharedFolders);
+  }, [sharedFolders]);
+
+  return (
+    <TweaksContext.Provider
+      value={{
+        clipboard,
+        timeSync,
+        sharedFolders,
+        setClipboard: setClipboardState,
+        setTimeSync: setTimeSyncState,
+        setSharedFolders: setSharedFoldersState,
+      }}
+    >
+      {children}
+    </TweaksContext.Provider>
+  );
+}
+
+export const useTweaks = () => useContext(TweaksContext);

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { TweaksProvider } from '../hooks/useTweaks';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <TweaksProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </TweaksProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/pages/apps/tweaks.jsx
+++ b/pages/apps/tweaks.jsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const TweaksApp = dynamic(() => import('../../apps/tweaks'), { ssr: false });
+
+export default function TweaksPage() {
+  return <TweaksApp />;
+}

--- a/utils/tweaksStore.ts
+++ b/utils/tweaksStore.ts
@@ -1,0 +1,60 @@
+"use client";
+
+interface TweaksSettings {
+  clipboard: boolean;
+  timeSync: boolean;
+  sharedFolders: boolean;
+}
+
+export const defaults: TweaksSettings = {
+  clipboard: true,
+  timeSync: true,
+  sharedFolders: false,
+};
+
+const STORAGE_KEY = "vm-tweaks";
+
+async function load(): Promise<TweaksSettings> {
+  if (typeof window === "undefined") return defaults;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? { ...defaults, ...JSON.parse(raw) } : defaults;
+  } catch {
+    return defaults;
+  }
+}
+
+async function save(values: Partial<TweaksSettings>): Promise<void> {
+  if (typeof window === "undefined") return;
+  const current = await load();
+  const updated = { ...current, ...values };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch {
+    // ignore write errors
+  }
+}
+
+export async function getClipboard(): Promise<boolean> {
+  return (await load()).clipboard;
+}
+
+export async function setClipboard(value: boolean): Promise<void> {
+  await save({ clipboard: value });
+}
+
+export async function getTimeSync(): Promise<boolean> {
+  return (await load()).timeSync;
+}
+
+export async function setTimeSync(value: boolean): Promise<void> {
+  await save({ timeSync: value });
+}
+
+export async function getSharedFolders(): Promise<boolean> {
+  return (await load()).sharedFolders;
+}
+
+export async function setSharedFolders(value: boolean): Promise<void> {
+  await save({ sharedFolders: value });
+}


### PR DESCRIPTION
## Summary
- add VM Tweaks app with checkboxes for clipboard, time sync and shared folders
- persist VM tweak preferences via new tweaks model and context
- integrate Tweaks provider and app into system config

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba48c7bfc48328959ae69b641d5e18