### PR TITLE
feat(settings): add kernel tab

### DIFF
--- a/__tests__/kernelTab.test.tsx
+++ b/__tests__/kernelTab.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import KernelTab from '../apps/settings/components/KernelTab';
+
+describe('KernelTab', () => {
+  it('shows preview after apply without editing', async () => {
+    const user = userEvent.setup();
+    render(<KernelTab />);
+
+    const textarea = screen.getByLabelText('kernel-settings');
+    await user.clear(textarea);
+    await user.type(textarea, 'net.ipv4.ip_forward = 1');
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+    const preview = screen.getByLabelText('kernel-preview');
+    expect(preview).toHaveTextContent('net.ipv4.ip_forward = 1');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});
+

--- a/apps/settings/components/KernelTab.tsx
+++ b/apps/settings/components/KernelTab.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+
+const DEFAULT_SYSCTL = `kernel.domainname = localdomain
+kernel.hostname = kali
+net.ipv4.ip_forward = 0`;
+
+export default function KernelTab() {
+  const [input, setInput] = useState(DEFAULT_SYSCTL);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const handleApply = () => {
+    setPreview(input);
+  };
+
+  if (preview !== null) {
+    return (
+      <div className="p-4 space-y-4">
+        <pre
+          aria-label="kernel-preview"
+          className="bg-ub-cool-grey text-ubt-grey p-2 rounded overflow-auto"
+        >
+          {preview}
+        </pre>
+        <div className="flex justify-center">
+          <button
+            onClick={() => setPreview(null)}
+            className="px-4 py-2 rounded bg-ub-orange text-white"
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <textarea
+        aria-label="kernel-settings"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        className="w-full h-64 bg-ub-cool-grey text-ubt-grey p-2 rounded border border-ubt-cool-grey"
+      />
+      <div className="flex justify-center">
+        <button
+          onClick={handleApply}
+          className="px-4 py-2 rounded bg-ub-orange text-white"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import KernelTab from "./components/KernelTab";
 import {
   resetSettings,
   defaults,
@@ -38,6 +39,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "kernel", label: "Kernel" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -288,6 +290,7 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "kernel" && <KernelTab />}
         <input
           type="file"
           accept="application/json"


### PR DESCRIPTION
## Summary
- add Kernel tab in settings with editable sysctl-style text
- show read-only preview after applying changes
- test KernelTab apply behavior

## Testing
- `npx eslint apps/settings/index.tsx apps/settings/components/KernelTab.tsx __tests__/kernelTab.test.tsx`
- `npx tsc --noEmit -p tsconfig.json` *(fails: command aborted due to long runtime)*
- `yarn test __tests__/kernelTab.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba48c855888328a02a7f69eb80d60a