### PR TITLE
feat: add Windows theme toggle

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,7 +23,7 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(expect.arrayContaining(['default', 'windows', 'neon', 'dark']));
     expect(unlocked).not.toContain('matrix');
   });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -129,10 +129,27 @@ export default function Settings() {
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>
+              <option value="windows">Windows</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>
             </select>
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Windows Theme:</span>
+            <ToggleSwitch
+              checked={theme === "windows"}
+              onChange={(val) => setTheme(val ? "windows" : "default")}
+              ariaLabel="Windows Theme"
+            />
+            {theme === "windows" && (
+              <button
+                onClick={() => setTheme("default")}
+                className="ml-4 px-4 py-2 rounded bg-ub-orange text-white"
+              >
+                Revert
+              </button>
+            )}
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -30,7 +30,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " sidebar absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="taskbar absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -60,6 +60,7 @@ export default function ThemeSettings() {
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="windows">Windows</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,44 @@ html[data-theme='matrix'] {
 
 }
 
+/* Windows theme */
+html[data-theme='windows'] {
+  --color-bg: #f3f3f3;
+  --color-text: #000000;
+  --color-primary: #0078d7;
+  --color-secondary: #ffffff;
+  --color-accent: #0078d7;
+  --color-muted: #e5e5e5;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #cccccc;
+  --color-terminal: #00ff00;
+  --color-dark: #f0f0f0;
+  --color-ub-grey: #e5e5e5;
+  --color-ub-cool-grey: #f3f3f3;
+  --color-ubt-grey: #000000;
+  --color-ubt-cool-grey: #000000;
+}
+
+/* Panel and launcher overrides for Windows theme */
+html[data-theme='windows'] .main-navbar-vp,
+html[data-theme='windows'] .taskbar,
+html[data-theme='windows'] nav.sidebar {
+  background-color: #e5e5e5 !important;
+  color: #000000 !important;
+}
+
+html[data-theme='windows'] .taskbar button span,
+html[data-theme='windows'] .taskbar span,
+html[data-theme='windows'] nav.sidebar span {
+  color: #000000 !important;
+}
+
+html[data-theme='windows'] .taskbar button:hover,
+html[data-theme='windows'] nav.sidebar button:hover {
+  background-color: #cccccc !important;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -38,7 +38,11 @@ export async function setWallpaper(wallpaper) {
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  try {
+    return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  } catch {
+    return DEFAULT_SETTINGS.density;
+  }
 }
 
 export async function setDensity(density) {
@@ -48,11 +52,15 @@ export async function setDensity(density) {
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
-  if (stored !== null) {
-    return stored === 'true';
+  try {
+    const stored = window.localStorage.getItem('reduced-motion');
+    if (stored !== null) {
+      return stored === 'true';
+    }
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return DEFAULT_SETTINGS.reducedMotion;
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 export async function setReducedMotion(value) {
@@ -62,8 +70,12 @@ export async function setReducedMotion(value) {
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
-  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+  try {
+    const stored = window.localStorage.getItem('font-scale');
+    return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+  } catch {
+    return DEFAULT_SETTINGS.fontScale;
+  }
 }
 
 export async function setFontScale(scale) {
@@ -73,7 +85,11 @@ export async function setFontScale(scale) {
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  try {
+    return window.localStorage.getItem('high-contrast') === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.highContrast;
+  }
 }
 
 export async function setHighContrast(value) {
@@ -83,7 +99,11 @@ export async function setHighContrast(value) {
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  try {
+    return window.localStorage.getItem('large-hit-areas') === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.largeHitAreas;
+  }
 }
 
 export async function setLargeHitAreas(value) {
@@ -93,8 +113,12 @@ export async function setLargeHitAreas(value) {
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
-  return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
+  try {
+    const val = window.localStorage.getItem('haptics');
+    return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.haptics;
+  }
 }
 
 export async function setHaptics(value) {
@@ -104,8 +128,12 @@ export async function setHaptics(value) {
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
-  return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
+  try {
+    const val = window.localStorage.getItem('pong-spin');
+    return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.pongSpin;
+  }
 }
 
 export async function setPongSpin(value) {
@@ -115,7 +143,11 @@ export async function setPongSpin(value) {
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  try {
+    return window.localStorage.getItem('allow-network') === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.allowNetwork;
+  }
 }
 
 export async function setAllowNetwork(value) {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  windows: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add global Windows theme toggle with revert option
- theme panels and launcher with Windows colors
- include Windows theme in settings and tests

## Testing
- `yarn test __tests__/themePersistence.test.ts`
- `yarn lint apps/settings/index.tsx components/screen/taskbar.js components/screen/side_bar.js pages/ui/settings/theme.tsx utils/theme.ts utils/settingsStore.js __tests__/themePersistence.test.ts styles/globals.css` *(fails: Unexpected global 'document')*


------
https://chatgpt.com/codex/tasks/task_e_68ba48ca91608328b2667e7effdea549