### PR TITLE
feat(settings): add display scale options

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -23,8 +23,8 @@ export default function Settings() {
     setDensity,
     reducedMotion,
     setReducedMotion,
-    fontScale,
-    setFontScale,
+    scale,
+    setScale,
     highContrast,
     setHighContrast,
     haptics,
@@ -76,7 +76,7 @@ export default function Settings() {
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
-      if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
+      if (parsed.scale !== undefined) setScale(parsed.scale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
@@ -98,12 +98,20 @@ export default function Settings() {
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
-    setFontScale(defaults.fontScale);
+    setScale(defaults.scale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
+  const initialScale = useRef(scale);
+  const [showRestart, setShowRestart] = useState(false);
+
+  useEffect(() => {
+    if (scale !== initialScale.current) {
+      setShowRestart(true);
+    }
+  }, [scale]);
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
@@ -134,6 +142,45 @@ export default function Settings() {
               <option value="matrix">Matrix</option>
             </select>
           </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Scale:</label>
+            <select
+              value={scale}
+              onChange={(e) => setScale(parseFloat(e.target.value))}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value={1}>100%</option>
+              <option value={1.25}>125%</option>
+              <option value={1.5}>150%</option>
+              <option value={2}>200%</option>
+            </select>
+          </div>
+          {showRestart && (
+            <div className="flex items-center justify-center bg-amber-100 text-amber-900 p-2" role="alert">
+              <button
+                onClick={() => window.location.reload()}
+                className="px-2 py-1 rounded bg-ub-orange text-white"
+              >
+                Apply & Restart shell
+              </button>
+              <span className="relative group ml-2">
+                <span aria-label="HiDPI help" tabIndex={0} className="cursor-help">ℹ️</span>
+                <div
+                  role="tooltip"
+                  className="absolute hidden group-hover:block group-focus-within:block bg-gray-700 text-white text-xs p-2 rounded bottom-full left-1/2 transform -translate-x-1/2 mb-2 whitespace-nowrap"
+                >
+                  <a
+                    href="https://www.kali.org/docs/general-use/hidpi/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    Kali HiDPI docs
+                  </a>
+                </div>
+              </span>
+            </div>
+          )}
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
             <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
@@ -211,20 +258,6 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Density:</label>
             <select

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, scale, setScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -54,6 +54,13 @@ export function Settings() {
         });
         return () => cancelAnimationFrame(raf);
     }, [accent, accentText, contrastRatio]);
+    const initialScale = useRef(scale);
+    const [showRestart, setShowRestart] = useState(false);
+    useEffect(() => {
+        if (scale !== initialScale.current) {
+            setShowRestart(true);
+        }
+    }, [scale]);
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
@@ -100,17 +107,29 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
-                <input
-                    type="range"
-                    min="0.75"
-                    max="1.5"
-                    step="0.05"
-                    value={fontScale}
-                    onChange={(e) => setFontScale(parseFloat(e.target.value))}
-                    className="ubuntu-slider"
-                />
+                <label className="mr-2 text-ubt-grey">Scale:</label>
+                <select
+                    value={scale}
+                    onChange={(e) => setScale(parseFloat(e.target.value))}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value={1}>100%</option>
+                    <option value={1.25}>125%</option>
+                    <option value={1.5}>150%</option>
+                    <option value={2}>200%</option>
+                </select>
             </div>
+            {showRestart && (
+                <div className="flex items-center justify-center bg-amber-100 text-amber-900 p-2" role="alert">
+                    <button onClick={() => window.location.reload()} className="px-2 py-1 rounded bg-ub-orange text-white">Apply & Restart shell</button>
+                    <span className="relative group ml-2">
+                        <span aria-label="HiDPI help" tabIndex={0} className="cursor-help">ℹ️</span>
+                        <div role="tooltip" className="absolute hidden group-hover:block group-focus-within:block bg-gray-700 text-white text-xs p-2 rounded bottom-full left-1/2 transform -translate-x-1/2 mb-2 whitespace-nowrap">
+                            <a href="https://www.kali.org/docs/general-use/hidpi/" target="_blank" rel="noopener noreferrer" className="underline">Kali HiDPI docs</a>
+                        </div>
+                    </span>
+                </div>
+            )}
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
@@ -249,7 +268,7 @@ export function Settings() {
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
                         setLargeHitAreas(defaults.largeHitAreas);
-                        setFontScale(defaults.fontScale);
+                        setScale(defaults.scale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
                     }}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -8,8 +8,8 @@ import {
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
-  getFontScale as loadFontScale,
-  setFontScale as saveFontScale,
+  getScale as loadScale,
+  setScale as saveScale,
   getHighContrast as loadHighContrast,
   setHighContrast as saveHighContrast,
   getLargeHitAreas as loadLargeHitAreas,
@@ -56,7 +56,7 @@ interface SettingsContextValue {
   wallpaper: string;
   density: Density;
   reducedMotion: boolean;
-  fontScale: number;
+  scale: number;
   highContrast: boolean;
   largeHitAreas: boolean;
   pongSpin: boolean;
@@ -67,7 +67,7 @@ interface SettingsContextValue {
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
-  setFontScale: (value: number) => void;
+  setScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
@@ -81,7 +81,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   wallpaper: defaults.wallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
-  fontScale: defaults.fontScale,
+  scale: defaults.scale,
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
@@ -92,7 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
-  setFontScale: () => {},
+  setScale: () => {},
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
@@ -106,7 +106,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
-  const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
+  const [scale, setScale] = useState<number>(defaults.scale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
@@ -121,7 +121,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
-      setFontScale(await loadFontScale());
+      setScale(await loadScale());
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
@@ -188,9 +188,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [reducedMotion]);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
-    saveFontScale(fontScale);
-  }, [fontScale]);
+    document.documentElement.style.setProperty('--scale', scale.toString());
+    document.documentElement.style.setProperty('--font-multiplier', scale.toString());
+    document.documentElement.style.setProperty('--font-size', `calc(16px * ${scale})`);
+    saveScale(scale);
+  }, [scale]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('high-contrast', highContrast);
@@ -243,7 +245,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         wallpaper,
         density,
         reducedMotion,
-        fontScale,
+        scale,
         highContrast,
         largeHitAreas,
         pongSpin,
@@ -254,7 +256,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setWallpaper,
         setDensity,
         setReducedMotion,
-        setFontScale,
+        setScale,
         setHighContrast,
         setLargeHitAreas,
         setPongSpin,

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,7 @@
 @import './globals.css';
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: clamp(12px, var(--font-size), 32px);
 }
 
 body{

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -53,7 +53,9 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+  --scale: 1;
   --font-multiplier: 1;
+  --font-size: calc(16px * var(--font-multiplier));
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -8,7 +8,7 @@ const DEFAULT_SETTINGS = {
   wallpaper: 'wall-2',
   density: 'regular',
   reducedMotion: false,
-  fontScale: 1,
+  scale: 1,
   highContrast: false,
   largeHitAreas: false,
   pongSpin: true,
@@ -60,15 +60,15 @@ export async function setReducedMotion(value) {
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
-export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
-  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+export async function getScale() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.scale;
+  const stored = window.localStorage.getItem('scale');
+  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.scale;
 }
 
-export async function setFontScale(scale) {
+export async function setScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  window.localStorage.setItem('scale', String(scale));
 }
 
 export async function getHighContrast() {
@@ -131,7 +131,7 @@ export async function resetSettings() {
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
+  window.localStorage.removeItem('scale');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
@@ -145,7 +145,7 @@ export async function exportSettings() {
     wallpaper,
     density,
     reducedMotion,
-    fontScale,
+    scale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -156,7 +156,7 @@ export async function exportSettings() {
     getWallpaper(),
     getDensity(),
     getReducedMotion(),
-    getFontScale(),
+    getScale(),
     getHighContrast(),
     getLargeHitAreas(),
     getPongSpin(),
@@ -169,7 +169,7 @@ export async function exportSettings() {
     wallpaper,
     density,
     reducedMotion,
-    fontScale,
+    scale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -193,7 +193,7 @@ export async function importSettings(json) {
     wallpaper,
     density,
     reducedMotion,
-    fontScale,
+    scale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -205,7 +205,7 @@ export async function importSettings(json) {
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
-  if (fontScale !== undefined) await setFontScale(fontScale);
+  if (scale !== undefined) await setScale(scale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);


### PR DESCRIPTION
## Summary
- add display scale setting with 100–200% options
- persist scale and font size tokens
- show Apply & Restart shell banner with HiDPI docs tooltip

## Testing
- `yarn lint` (fails: Unexpected global 'document' etc.)
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/reconng.test.tsx` (fails: window snapping finalize and release, NmapNSEApp copies example output to clipboard)


------
https://chatgpt.com/codex/tasks/task_e_68ba48cbdcac8328b3cf5b10580455a2