### PR TITLE
feat: add per-workspace wallpaper picker

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -19,6 +19,10 @@ export default function Settings() {
     setAccent,
     wallpaper,
     setWallpaper,
+    wallpaperMode,
+    setWallpaperMode,
+    workspace,
+    setWorkspace,
     density,
     setDensity,
     reducedMotion,
@@ -42,16 +46,25 @@ export default function Settings() {
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
+  const collections = {
+    all: [
+      "wall-1",
+      "wall-2",
+      "wall-3",
+      "wall-4",
+      "wall-5",
+      "wall-6",
+      "wall-7",
+      "wall-8",
+    ],
+    "2022": ["wall-1", "wall-2"],
+    "2023": ["wall-3", "wall-4"],
+    "2024": ["wall-5", "wall-6"],
+    "2025": ["wall-7", "wall-8"],
+  } as const;
+  type CollectionId = keyof typeof collections;
+  const [collection, setCollection] = useState<CollectionId>("all");
+  const wallpapers = collections[collection];
 
   const changeBackground = (name: string) => setWallpaper(name);
 
@@ -72,7 +85,11 @@ export default function Settings() {
     try {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
-      if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+      if (parsed.wallpapers && parsed.wallpapers[workspace] !== undefined)
+        setWallpaper(parsed.wallpapers[workspace]);
+      else if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+      if (parsed.wallpaperModes && parsed.wallpaperModes[workspace] !== undefined)
+        setWallpaperMode(parsed.wallpaperModes[workspace]);
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
@@ -96,6 +113,7 @@ export default function Settings() {
     window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
+    setWallpaperMode(defaults.wallpaperMode as any);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
@@ -116,11 +134,30 @@ export default function Settings() {
             className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
             style={{
               backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
+              backgroundSize:
+                wallpaperMode === "fit"
+                  ? "contain"
+                  : wallpaperMode === "center"
+                    ? "auto"
+                    : "cover",
               backgroundRepeat: "no-repeat",
               backgroundPosition: "center center",
             }}
           ></div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Workspace:</label>
+            <select
+              value={workspace}
+              onChange={(e) => setWorkspace(parseInt(e.target.value, 10))}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              {[0, 1, 2].map((w) => (
+                <option key={w} value={w}>
+                  {w + 1}
+                </option>
+              ))}
+            </select>
+          </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Theme:</label>
             <select
@@ -149,6 +186,32 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Wallpaper Mode:</label>
+            <select
+              value={wallpaperMode}
+              onChange={(e) => setWallpaperMode(e.target.value as any)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="fill">Fill</option>
+              <option value="fit">Fit</option>
+              <option value="center">Center</option>
+            </select>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Collection:</label>
+            <select
+              value={collection}
+              onChange={(e) => setCollection(e.target.value as CollectionId)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="all">All wallpapers</option>
+              <option value="2022">2022</option>
+              <option value="2023">2023</option>
+              <option value="2024">2024</option>
+              <option value="2025">2025</option>
+            </select>
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -4,7 +4,7 @@ import { useSettings } from '../../hooks/useSettings';
 
 export default function LockScreen(props) {
 
-    const { wallpaper } = useSettings();
+    const { wallpaper, wallpaperMode } = useSettings();
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -19,7 +19,7 @@ export default function LockScreen(props) {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                className={`absolute top-0 left-0 w-full h-full ${wallpaperMode === 'fit' ? 'object-contain' : wallpaperMode === 'center' ? 'object-none' : 'object-cover'} object-center transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
+    const { wallpaper, wallpaperMode } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
@@ -41,7 +41,7 @@ export default function BackgroundImage() {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
-                className="w-full h-full object-cover"
+                className={`w-full h-full ${wallpaperMode === 'fit' ? 'object-contain' : wallpaperMode === 'center' ? 'object-none' : 'object-cover'} object-center`}
             />
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,6 +4,8 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getWallpaperMode as loadWallpaperMode,
+  setWallpaperMode as saveWallpaperMode,
   getDensity as loadDensity,
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
@@ -54,6 +56,8 @@ const shadeColor = (color: string, percent: number): string => {
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
+  wallpaperMode: 'fill' | 'fit' | 'center';
+  workspace: number;
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
@@ -65,6 +69,8 @@ interface SettingsContextValue {
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setWallpaperMode: (mode: 'fill' | 'fit' | 'center') => void;
+  setWorkspace: (ws: number) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
@@ -79,6 +85,8 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  wallpaperMode: defaults.wallpaperMode as 'fill',
+  workspace: 0,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
@@ -90,6 +98,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
+  setWallpaperMode: () => {},
+  setWorkspace: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
@@ -103,7 +113,11 @@ export const SettingsContext = createContext<SettingsContextValue>({
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
+  const [workspace, setWorkspace] = useState<number>(0);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [wallpaperMode, setWallpaperMode] = useState<'fill' | 'fit' | 'center'>(
+    defaults.wallpaperMode as 'fill',
+  );
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -119,6 +133,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setWallpaperMode(await loadWallpaperMode());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -130,6 +145,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setTheme(loadTheme());
     })();
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      setWallpaper(await loadWallpaper(workspace));
+      setWallpaperMode(await loadWallpaperMode(workspace));
+    })();
+  }, [workspace]);
 
   useEffect(() => {
     saveTheme(theme);
@@ -153,8 +175,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [accent]);
 
   useEffect(() => {
-    saveWallpaper(wallpaper);
-  }, [wallpaper]);
+    saveWallpaper(workspace, wallpaper);
+  }, [wallpaper, workspace]);
+
+  useEffect(() => {
+    saveWallpaperMode(workspace, wallpaperMode);
+  }, [wallpaperMode, workspace]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -241,6 +267,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         accent,
         wallpaper,
+        wallpaperMode,
+        workspace,
         density,
         reducedMotion,
         fontScale,
@@ -252,6 +280,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
+        setWallpaperMode,
+        setWorkspace,
         setDensity,
         setReducedMotion,
         setFontScale,


### PR DESCRIPTION
## Summary
- add wallpaper collections for 2022–2025 and an All wallpapers option
- support Fit/Fill/Center modes and per-workspace wallpaper selection
- persist wallpaper image path and mode across workspaces

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `yarn lint` *(fails: lint errors in public/apps/tetris/main.js and utils/createDynamicApp.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48cdc2a4832894edea1c357758ed