### PR TITLE
feat: add panel profiles management

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -87,6 +87,7 @@ const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
+const PanelProfilesApp = createDynamicApp('panel-profiles', 'Panel Profiles');
 
 const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
@@ -170,6 +171,7 @@ const displayGhidra = createDisplay(GhidraApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
+const displayPanelProfiles = createDisplay(PanelProfilesApp);
 
 const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
@@ -827,17 +829,26 @@ const apps = [
     desktop_shortcut: false,
     screen: displayAutopsy,
   },
-  {
-    id: 'plugin-manager',
-    title: 'Plugin Manager',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
-    disabled: false,
-    favourite: false,
-    desktop_shortcut: false,
-    screen: displayPluginManager,
-  },
-  {    id: 'reaver',
-    title: 'Reaver',
+    {
+      id: 'plugin-manager',
+      title: 'Plugin Manager',
+      icon: '/themes/Yaru/apps/project-gallery.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayPluginManager,
+    },
+    {
+      id: 'panel-profiles',
+      title: 'Panel Profiles',
+      icon: '/themes/Yaru/apps/project-gallery.svg',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: displayPanelProfiles,
+    },
+    {    id: 'reaver',
+      title: 'Reaver',
     icon: '/themes/Yaru/apps/reaver.svg',
     disabled: false,
     favourite: false,

--- a/apps/panel-profiles/index.tsx
+++ b/apps/panel-profiles/index.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+interface Profile {
+  layout: string | null;
+  plugins: string | null;
+}
+
+const DEFAULT_PROFILES: Record<string, Profile> = {
+  'Kali default': { layout: null, plugins: null },
+};
+
+export default function PanelProfiles() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [profiles, setProfiles] = usePersistentState<Record<string, Profile>>(
+    'panel:profiles',
+    DEFAULT_PROFILES,
+  );
+  const [selected, setSelected] = useState<string>('Kali default');
+  const [name, setName] = useState('');
+
+  const saveProfile = () => {
+    if (!name.trim()) return;
+    const layout = window.localStorage.getItem('panelLayout');
+    const plugins = window.localStorage.getItem('pluginStates');
+    setProfiles({ ...profiles, [name]: { layout, plugins } });
+    setSelected(name);
+    setName('');
+  };
+
+  const restoreProfile = () => {
+    const p = profiles[selected];
+    if (!p) return;
+    if (p.layout !== null) window.localStorage.setItem('panelLayout', p.layout);
+    if (p.plugins !== null) window.localStorage.setItem('pluginStates', p.plugins);
+    window.location.reload();
+  };
+
+  const exportProfile = () => {
+    const p = profiles[selected];
+    if (!p) return;
+    const blob = new Blob(
+      [JSON.stringify({ name: selected, layout: p.layout, plugins: p.plugins })],
+      { type: 'application/json' },
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${selected}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importProfiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(String(reader.result));
+        const imported: Record<string, Profile> = { ...profiles };
+        if (Array.isArray(data)) {
+          data.forEach((item) => {
+            if (item && item.name) {
+              imported[item.name] = {
+                layout: item.layout ?? null,
+                plugins: item.plugins ?? null,
+              };
+            }
+          });
+        } else if (data && data.name) {
+          imported[data.name] = {
+            layout: data.layout ?? null,
+            plugins: data.plugins ?? null,
+          };
+        }
+        setProfiles(imported);
+      } catch {
+        // ignore invalid files
+      } finally {
+        if (fileRef.current) fileRef.current.value = '';
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const deleteProfile = (key: string) => {
+    const { [key]: _, ...rest } = profiles;
+    setProfiles(rest);
+    if (selected === key) setSelected('Kali default');
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-white">
+      <h1 className="text-xl">Panel Profiles</h1>
+      <div className="space-y-2">
+        <label htmlFor="profile-select" className="sr-only">
+          Profiles
+        </label>
+        <select
+          id="profile-select"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          className="bg-ub-cool-grey p-2 rounded w-full"
+        >
+          {Object.keys(profiles).map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-2">
+          <button
+            className="bg-ub-green text-black px-2 py-1 rounded"
+            onClick={restoreProfile}
+          >
+            Restore
+          </button>
+          <button
+            className="bg-ubt-blue px-2 py-1 rounded"
+            onClick={exportProfile}
+          >
+            Export
+          </button>
+          {selected !== 'Kali default' && (
+            <button
+              className="bg-ubt-red px-2 py-1 rounded"
+              onClick={() => deleteProfile(selected)}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <input
+          type="text"
+          placeholder="New profile name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="bg-ub-cool-grey p-2 rounded w-full"
+          aria-label="New profile name"
+        />
+        <button
+          className="bg-ub-orange px-2 py-1 rounded"
+          onClick={saveProfile}
+        >
+          Save Current Layout
+        </button>
+      </div>
+      <div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="application/json"
+          onChange={importProfiles}
+          aria-label="Import profiles"
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/panel-profiles.js
+++ b/components/apps/panel-profiles.js
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const PanelProfiles = dynamic(() => import('../../apps/panel-profiles'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default PanelProfiles;

--- a/pages/apps/panel-profiles/index.jsx
+++ b/pages/apps/panel-profiles/index.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const PanelProfiles = dynamic(() => import('../../../apps/panel-profiles'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function PanelProfilesPage() {
+  return <PanelProfiles />;
+}


### PR DESCRIPTION
## Summary
- add Panel Profiles app for saving, restoring, and sharing panel layouts and plugin states
- register Panel Profiles in app configuration and expose page route

## Testing
- `npx eslint apps/panel-profiles/index.tsx components/apps/panel-profiles.js pages/apps/panel-profiles/index.jsx apps.config.js`
- `yarn test apps/panel-profiles --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba48d4d5a0832882aa0570f2de07e6