### PR TITLE
feat: add panel profile save/load and docs

### DIFF
--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -9,15 +9,15 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor(props) {
+                super(props);
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+       }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -126,8 +126,8 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop session={this.props.session} setSession={this.props.setSession} bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
 			</div>
 		);
 	}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
+import { useEffect } from 'react';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import useSession from '../hooks/useSession';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +30,51 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { session, setSession } = useSession();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.panelProfiles = {
+      save(name) {
+        try {
+          localStorage.setItem(
+            `panel-profile:${name}`,
+            JSON.stringify(session),
+          );
+          return true;
+        } catch (err) {
+          console.error('Failed to save panel profile', err);
+          return false;
+        }
+      },
+      load(name) {
+        try {
+          const data = localStorage.getItem(`panel-profile:${name}`);
+          if (!data) return false;
+          const profile = JSON.parse(data);
+          setSession(profile);
+          window.location.reload();
+          return true;
+        } catch (err) {
+          console.error('Failed to load panel profile', err);
+          return false;
+        }
+      },
+    };
+  }, [session, setSession]);
+
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      <Ubuntu session={session} setSession={setSession} />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;

--- a/public/docs/apps/terminal.md
+++ b/public/docs/apps/terminal.md
@@ -5,3 +5,17 @@ This terminal emulates basic shell commands. Type commands and press Enter to ex
 - Use arrow keys to navigate history.
 - Press `Ctrl+C` to cancel a running command.
 - The `help` command lists available commands.
+
+## Panel profiles
+
+For automated testing or personalized layouts, the desktop session can be
+saved and restored from the browser's developer console:
+
+```js
+window.panelProfiles.save('work');
+window.panelProfiles.load('work');
+```
+
+The `save` method stores the current window positions and dock icons under a
+named profile. `load` applies a saved profile and reloads the page to restore
+the layout.


### PR DESCRIPTION
## Summary
- expose `window.panelProfiles` with `save` and `load` for desktop sessions
- document how to save/load panel profiles via developer console

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68ba48d5f6988328b227de54653acb3a