### PR TITLE
feat: add nmconnection previews

### DIFF
--- a/__tests__/nmconnection.test.ts
+++ b/__tests__/nmconnection.test.ts
@@ -1,0 +1,13 @@
+import { toKeyfile } from '../utils/nmconnection';
+
+describe('toKeyfile', () => {
+  it('converts connection objects to ini format', () => {
+    const conn = {
+      connection: { id: 'test', type: 'ethernet' },
+      ipv4: { method: 'auto' },
+    };
+
+    const ini = toKeyfile(conn);
+    expect(ini).toBe('[connection]\nid=test\ntype=ethernet\n\n[ipv4]\nmethod=auto');
+  });
+});

--- a/data/network-connections/ethernet.ini
+++ b/data/network-connections/ethernet.ini
@@ -1,0 +1,11 @@
+[connection]
+id=Wired connection 1
+type=ethernet
+interface-name=eth0
+autoconnect=true
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore

--- a/data/network-connections/ethernet.json
+++ b/data/network-connections/ethernet.json
@@ -1,0 +1,14 @@
+{
+  "connection": {
+    "id": "Wired connection 1",
+    "type": "ethernet",
+    "interface-name": "eth0",
+    "autoconnect": true
+  },
+  "ipv4": {
+    "method": "auto"
+  },
+  "ipv6": {
+    "method": "ignore"
+  }
+}

--- a/data/network-connections/wifi.ini
+++ b/data/network-connections/wifi.ini
@@ -1,0 +1,14 @@
+[connection]
+id=Home Wi-Fi
+type=wifi
+interface-name=wlan0
+
+[wifi]
+ssid=MyHomeNetwork
+mode=infrastructure
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto

--- a/data/network-connections/wifi.json
+++ b/data/network-connections/wifi.json
@@ -1,0 +1,17 @@
+{
+  "connection": {
+    "id": "Home Wi-Fi",
+    "type": "wifi",
+    "interface-name": "wlan0"
+  },
+  "wifi": {
+    "ssid": "MyHomeNetwork",
+    "mode": "infrastructure"
+  },
+  "ipv4": {
+    "method": "auto"
+  },
+  "ipv6": {
+    "method": "auto"
+  }
+}

--- a/scripts/generate-nmconnection-previews.ts
+++ b/scripts/generate-nmconnection-previews.ts
@@ -1,0 +1,16 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import { toKeyfile, NMConnection } from '../utils/nmconnection.ts';
+
+const dir = join(process.cwd(), 'data', 'network-connections');
+
+const files = (await readdir(dir)).filter((f) => f.endsWith('.json'));
+
+for (const file of files) {
+  const json = await readFile(join(dir, file), 'utf8');
+  const data: NMConnection = JSON.parse(json);
+  const ini = toKeyfile(data);
+  const outFile = join(dir, `${basename(file, '.json')}.ini`);
+  await writeFile(outFile, ini, 'utf8');
+  console.log(`Generated ${outFile}`);
+}

--- a/utils/nmconnection.ts
+++ b/utils/nmconnection.ts
@@ -1,0 +1,22 @@
+export interface NMSection {
+  [key: string]: string | number | boolean;
+}
+
+export interface NMConnection {
+  [section: string]: NMSection;
+}
+
+/**
+ * Converts a NetworkManager-style connection object into keyfile format.
+ */
+export function toKeyfile(connection: NMConnection): string {
+  const sections: string[] = [];
+  for (const [sectionName, entries] of Object.entries(connection)) {
+    const lines = [`[${sectionName}]`];
+    for (const [key, value] of Object.entries(entries)) {
+      lines.push(`${key}=${String(value)}`);
+    }
+    sections.push(lines.join('\n'));
+  }
+  return sections.join('\n\n');
+}


### PR DESCRIPTION
## Summary
- add converter to output NetworkManager-style keyfiles
- store example ethernet and wifi connections in JSON with INI previews

## Testing
- `yarn lint` *(fails: command not found)*
- `yarn test __tests__/nmconnection.test.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48dafc4483288e457711a6493a8a