### PR TITLE
feat: improve tray icon behavior

### DIFF
--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -4,8 +4,57 @@ import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+const MAX_VISIBLE = 3;
 
-export default function Status() {
+function TrayIcon({ src, alt, title }) {
+  return (
+    <span
+      className="mx-0.5 flex items-center justify-center"
+      style={{ width: 'var(--hit-area)', height: 'var(--hit-area)' }}
+      title={title}
+    >
+      <Image
+        width={16}
+        height={16}
+        src={src}
+        alt={alt}
+        className="max-w-full max-h-full"
+        sizes="16px"
+      />
+    </span>
+  );
+}
+
+function OverflowMenu({ icons }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+        className="mx-0.5 flex items-center justify-center"
+        style={{ width: 'var(--hit-area)', height: 'var(--hit-area)' }}
+        title="More indicators"
+      >
+        &#8230;
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 p-1 bg-ub-cool-grey border border-black border-opacity-20 rounded shadow flex"
+        >
+          {icons.map((icon, i) => (
+            <TrayIcon key={i} {...icon} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Status({ icons = [] }) {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
 
@@ -38,46 +87,39 @@ export default function Status() {
     };
   }, []);
 
+  const baseIcons = [
+    {
+      src: online
+        ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+        : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg",
+      alt: online ? "online" : "offline",
+      title: online
+        ? (allowNetwork ? 'Online' : 'Online (requests blocked)')
+        : 'Offline',
+    },
+    { src: VOLUME_ICON, alt: 'volume', title: 'Volume' },
+    {
+      src: "/themes/Yaru/status/battery-good-symbolic.svg",
+      alt: 'battery',
+      title: 'Battery level',
+    },
+  ];
+
+  const allIcons = [...baseIcons, ...icons];
+  const visible = allIcons.slice(0, MAX_VISIBLE);
+  const overflow = allIcons.slice(MAX_VISIBLE);
+
   return (
     <div className="flex justify-center items-center">
+      {visible.map((icon, i) => (
+        <TrayIcon key={i} {...icon} />
+      ))}
+      {overflow.length > 0 && <OverflowMenu icons={overflow} />}
       <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+        className="mx-0.5 flex items-center justify-center"
+        style={{ width: 'var(--hit-area)', height: 'var(--hit-area)' }}
       >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-        {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
-        )}
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src={VOLUME_ICON}
-          alt="volume"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-      </span>
-      <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+        <SmallArrow angle="down" className="status-symbol" />
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- clamp tray icons to panel row height
- add overflow ellipsis for extra icons

## Testing
- `npx eslint components/util-components/status.js -f json`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function, Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68ba48d8fa148328bf73a513fd7e08b1