### PR TITLE
feat: add bridge and VLAN presets to network manager

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -84,6 +84,7 @@ const BleSensorApp = createDynamicApp('ble-sensor', 'BLE Sensor');
 const DsniffApp = createDynamicApp('dsniff', 'dsniff');
 const BeefApp = createDynamicApp('beef', 'BeEF');
 const MetasploitApp = createDynamicApp('metasploit', 'Metasploit');
+const NetworkManagerApp = createDynamicApp('network-manager', 'Network Manager');
 
 const AutopsyApp = createDynamicApp('autopsy', 'Autopsy');
 const PluginManagerApp = createDynamicApp('plugin-manager', 'Plugin Manager');
@@ -175,6 +176,7 @@ const displayWireshark = createDisplay(WiresharkApp);
 const displayBleSensor = createDisplay(BleSensorApp);
 const displayBeef = createDisplay(BeefApp);
 const displayMetasploit = createDisplay(MetasploitApp);
+const displayNetworkManager = createDisplay(NetworkManagerApp);
 const displayDsniff = createDisplay(DsniffApp);
 const displayGomoku = createDisplay(GomokuApp);
 const displayPinball = createDisplay(PinballApp);
@@ -1014,6 +1016,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayDsniff,
+  },
+  {
+    id: 'network-manager',
+    title: 'Network Manager',
+    icon: '/themes/Yaru/apps/resource-monitor.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNetworkManager,
   },
   {
     id: 'john',

--- a/apps/network-manager/components/AddConnectionDialog.tsx
+++ b/apps/network-manager/components/AddConnectionDialog.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import React, { useState } from 'react';
+
+export interface NetworkConnection {
+  type: 'Ethernet' | 'Bridge' | 'VLAN';
+  name: string;
+  interface?: string;
+  interfaces?: string;
+  parent?: string;
+  vlanId?: string;
+}
+
+interface Props {
+  onSave: (conn: NetworkConnection) => void;
+  onCancel: () => void;
+}
+
+const AddConnectionDialog: React.FC<Props> = ({ onSave, onCancel }) => {
+  const [type, setType] = useState<'Ethernet' | 'Bridge' | 'VLAN'>('Ethernet');
+  const [name, setName] = useState('');
+  const [iface, setIface] = useState('');
+  const [bridgeIfaces, setBridgeIfaces] = useState('');
+  const [parent, setParent] = useState('');
+  const [vlanId, setVlanId] = useState('');
+
+  const save = () => {
+    const base = { type, name };
+    let conn: NetworkConnection;
+    if (type === 'Bridge') {
+      conn = { ...base, interfaces: bridgeIfaces };
+    } else if (type === 'VLAN') {
+      conn = { ...base, parent, vlanId };
+    } else {
+      conn = { ...base, interface: iface };
+    }
+    onSave(conn);
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/70">
+      <div className="w-72 rounded bg-ub-cool-grey p-4 text-white">
+        <h2 className="mb-2 text-lg font-bold">Add Connection</h2>
+        <div className="mb-2">
+          <label className="block text-sm">Type</label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as any)}
+            className="w-full rounded bg-gray-800 p-1"
+          >
+            <option value="Ethernet">Ethernet</option>
+            <option value="Bridge">Bridge</option>
+            <option value="VLAN">VLAN</option>
+          </select>
+        </div>
+        <div className="mb-2">
+          <label className="block text-sm">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded bg-gray-800 p-1"
+          />
+        </div>
+        {type === 'Ethernet' && (
+          <div className="mb-2">
+            <label className="block text-sm">Interface</label>
+            <input
+              value={iface}
+              onChange={(e) => setIface(e.target.value)}
+              className="w-full rounded bg-gray-800 p-1"
+            />
+          </div>
+        )}
+        {type === 'Bridge' && (
+          <div className="mb-2">
+            <label className="block text-sm">Interfaces</label>
+            <input
+              value={bridgeIfaces}
+              onChange={(e) => setBridgeIfaces(e.target.value)}
+              className="w-full rounded bg-gray-800 p-1"
+              placeholder="e.g. eth0,eth1"
+            />
+          </div>
+        )}
+        {type === 'VLAN' && (
+          <>
+            <div className="mb-2">
+              <label className="block text-sm">Parent Interface</label>
+              <input
+                value={parent}
+                onChange={(e) => setParent(e.target.value)}
+                className="w-full rounded bg-gray-800 p-1"
+              />
+            </div>
+            <div className="mb-2">
+              <label className="block text-sm">VLAN ID</label>
+              <input
+                value={vlanId}
+                onChange={(e) => setVlanId(e.target.value)}
+                className="w-full rounded bg-gray-800 p-1"
+              />
+            </div>
+          </>
+        )}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="rounded bg-gray-700 px-2 py-1"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={save}
+            className="rounded bg-ubt-blue px-2 py-1"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddConnectionDialog;
+

--- a/apps/network-manager/index.tsx
+++ b/apps/network-manager/index.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React, { useState } from 'react';
+import AddConnectionDialog, { NetworkConnection } from './components/AddConnectionDialog';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const CONNECTIONS_KEY = 'network-manager-connections';
+
+export default function NetworkManagerApp() {
+  const [connections, setConnections] = usePersistentState<NetworkConnection[]>(CONNECTIONS_KEY, []);
+  const [showDialog, setShowDialog] = useState(false);
+
+  const handleSave = (conn: NetworkConnection) => {
+    setConnections([...connections, conn]);
+    setShowDialog(false);
+  };
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey p-4 text-white">
+      <h1 className="mb-4 text-lg font-bold">Connections</h1>
+      <ul className="mb-4 space-y-2">
+        {connections.length === 0 && <li className="text-gray-400">No connections</li>}
+        {connections.map((c, i) => (
+          <li key={i} className="rounded border border-gray-700 p-2">
+            <div className="font-semibold">{c.name}</div>
+            <div className="text-xs text-gray-400">Type: {c.type}</div>
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={() => setShowDialog(true)}
+        className="rounded bg-ubt-blue px-3 py-1"
+      >
+        Add Connection
+      </button>
+      {showDialog && (
+        <AddConnectionDialog
+          onSave={handleSave}
+          onCancel={() => setShowDialog(false)}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/pages/apps/network-manager.jsx
+++ b/pages/apps/network-manager.jsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const NetworkManager = dynamic(() => import('../../apps/network-manager'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function NetworkManagerPage() {
+  return <NetworkManager />;
+}
+


### PR DESCRIPTION
## Summary
- add Network Manager app for managing simulated connections
- support Bridge and VLAN presets with appropriate fields
- persist connection configs in local storage

## Testing
- `yarn lint` *(fails: command timed out)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, settingsStore related)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48dc28208328a1c75058f36fb896