### PR TITLE
feat: add network manager banner

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import { useNetworkManager } from '../../hooks/useNetworkManager';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { running } = useNetworkManager();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -145,12 +147,13 @@ export function Settings() {
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label className={`mr-2 text-ubt-grey flex items-center ${running ? '' : 'opacity-50'}`}> 
                     <input
                         type="checkbox"
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
+                        disabled={!running}
                     />
                     Allow Network Requests
                 </label>

--- a/components/common/NetworkManagerBanner.tsx
+++ b/components/common/NetworkManagerBanner.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from 'react';
+import { useNetworkManager } from '../../hooks/useNetworkManager';
+
+const NetworkManagerBanner: React.FC = () => {
+  const { running, setRunning } = useNetworkManager();
+
+  if (running) return null;
+
+  return (
+    <div className="bg-yellow-300 text-black text-center py-2">
+      Network Manager not running.{' '}
+      <button
+        type="button"
+        className="underline"
+        onClick={() => setRunning(true)}
+      >
+        Start service
+      </button>
+    </div>
+  );
+};
+
+export default NetworkManagerBanner;
+

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useNetworkManager } from '../../hooks/useNetworkManager';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { running } = useNetworkManager();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -40,10 +42,17 @@ const QuickSettings = ({ open }: Props) => {
         <span>Sound</span>
         <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
+        <div
+          className={`px-4 pb-2 flex justify-between ${running ? '' : 'opacity-50 pointer-events-none'}`}
+        >
+          <span>Network</span>
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={() => setOnline(!online)}
+            disabled={!running}
+          />
+        </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input

--- a/hooks/useNetworkManager.tsx
+++ b/hooks/useNetworkManager.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React, { createContext, useContext, ReactNode } from 'react';
+import usePersistentState from './usePersistentState';
+
+interface NetworkManagerContextValue {
+  running: boolean;
+  setRunning: (value: boolean) => void;
+}
+
+const NetworkManagerContext = createContext<NetworkManagerContextValue>({
+  running: false,
+  setRunning: () => {},
+});
+
+export function NetworkManagerProvider({ children }: { children: ReactNode }) {
+  const [running, setRunning] = usePersistentState<boolean>('network-manager-running', false);
+  return (
+    <NetworkManagerContext.Provider value={{ running, setRunning }}>
+      {children}
+    </NetworkManagerContext.Provider>
+  );
+}
+
+export const useNetworkManager = () => useContext(NetworkManagerContext);
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,8 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { NetworkManagerProvider } from '../hooks/useNetworkManager';
+import NetworkManagerBanner from '../components/common/NetworkManagerBanner';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,23 +158,26 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <SettingsProvider>
+            <NetworkManagerProvider>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <NetworkManagerBanner />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NetworkManagerProvider>
+          </SettingsProvider>
       </div>
     </ErrorBoundary>
 


### PR DESCRIPTION
## Summary
- show a banner prompting to start Network Manager when service is stopped
- disable network controls in Quick Settings and Settings until Network Manager starts
- provide shared NetworkManager context for service state

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68ba48dec0608328b1b71aec1de70f5b