### PR TITLE
feat: add thumbnail settings and cache controls

### DIFF
--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,14 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getThumbnailImages as loadThumbnailImages,
+  setThumbnailImages as saveThumbnailImages,
+  getThumbnailVideos as loadThumbnailVideos,
+  setThumbnailVideos as saveThumbnailVideos,
+  getThumbnailPDFs as loadThumbnailPDFs,
+  setThumbnailPDFs as saveThumbnailPDFs,
+  getThumbnailMaxFileSize as loadThumbnailMaxFileSize,
+  setThumbnailMaxFileSize as saveThumbnailMaxFileSize,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +70,10 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  thumbnailImages: boolean;
+  thumbnailVideos: boolean;
+  thumbnailPDFs: boolean;
+  thumbnailMaxFileSize: number;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +85,10 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setThumbnailImages: (value: boolean) => void;
+  setThumbnailVideos: (value: boolean) => void;
+  setThumbnailPDFs: (value: boolean) => void;
+  setThumbnailMaxFileSize: (value: number) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +103,10 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  thumbnailImages: defaults.thumbnailImages,
+  thumbnailVideos: defaults.thumbnailVideos,
+  thumbnailPDFs: defaults.thumbnailPDFs,
+  thumbnailMaxFileSize: defaults.thumbnailMaxFileSize,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +118,10 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setThumbnailImages: () => {},
+  setThumbnailVideos: () => {},
+  setThumbnailPDFs: () => {},
+  setThumbnailMaxFileSize: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +136,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [thumbnailImages, setThumbnailImages] = useState<boolean>(defaults.thumbnailImages);
+  const [thumbnailVideos, setThumbnailVideos] = useState<boolean>(defaults.thumbnailVideos);
+  const [thumbnailPDFs, setThumbnailPDFs] = useState<boolean>(defaults.thumbnailPDFs);
+  const [thumbnailMaxFileSize, setThumbnailMaxFileSize] = useState<number>(
+    defaults.thumbnailMaxFileSize,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +157,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setThumbnailImages(await loadThumbnailImages());
+      setThumbnailVideos(await loadThumbnailVideos());
+      setThumbnailPDFs(await loadThumbnailPDFs());
+      setThumbnailMaxFileSize(await loadThumbnailMaxFileSize());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +270,22 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveThumbnailImages(thumbnailImages);
+  }, [thumbnailImages]);
+
+  useEffect(() => {
+    saveThumbnailVideos(thumbnailVideos);
+  }, [thumbnailVideos]);
+
+  useEffect(() => {
+    saveThumbnailPDFs(thumbnailPDFs);
+  }, [thumbnailPDFs]);
+
+  useEffect(() => {
+    saveThumbnailMaxFileSize(thumbnailMaxFileSize);
+  }, [thumbnailMaxFileSize]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +299,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        thumbnailImages,
+        thumbnailVideos,
+        thumbnailPDFs,
+        thumbnailMaxFileSize,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +314,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setThumbnailImages,
+        setThumbnailVideos,
+        setThumbnailPDFs,
+        setThumbnailMaxFileSize,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,10 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  thumbnailImages: true,
+  thumbnailVideos: true,
+  thumbnailPDFs: true,
+  thumbnailMaxFileSize: 10,
 };
 
 export async function getAccent() {
@@ -123,6 +127,50 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getThumbnailImages() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.thumbnailImages;
+  const val = window.localStorage.getItem('thumb-images');
+  return val === null ? DEFAULT_SETTINGS.thumbnailImages : val === 'true';
+}
+
+export async function setThumbnailImages(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('thumb-images', value ? 'true' : 'false');
+}
+
+export async function getThumbnailVideos() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.thumbnailVideos;
+  const val = window.localStorage.getItem('thumb-videos');
+  return val === null ? DEFAULT_SETTINGS.thumbnailVideos : val === 'true';
+}
+
+export async function setThumbnailVideos(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('thumb-videos', value ? 'true' : 'false');
+}
+
+export async function getThumbnailPDFs() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.thumbnailPDFs;
+  const val = window.localStorage.getItem('thumb-pdfs');
+  return val === null ? DEFAULT_SETTINGS.thumbnailPDFs : val === 'true';
+}
+
+export async function setThumbnailPDFs(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('thumb-pdfs', value ? 'true' : 'false');
+}
+
+export async function getThumbnailMaxFileSize() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.thumbnailMaxFileSize;
+  const val = window.localStorage.getItem('thumb-max-file-size');
+  return val ? parseInt(val, 10) : DEFAULT_SETTINGS.thumbnailMaxFileSize;
+}
+
+export async function setThumbnailMaxFileSize(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('thumb-max-file-size', String(value));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +185,10 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('thumb-images');
+  window.localStorage.removeItem('thumb-videos');
+  window.localStorage.removeItem('thumb-pdfs');
+  window.localStorage.removeItem('thumb-max-file-size');
 }
 
 export async function exportSettings() {
@@ -162,6 +214,10 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getThumbnailImages(),
+    getThumbnailVideos(),
+    getThumbnailPDFs(),
+    getThumbnailMaxFileSize(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +231,10 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    thumbnailImages,
+    thumbnailVideos,
+    thumbnailPDFs,
+    thumbnailMaxFileSize,
     theme,
   });
 }
@@ -199,6 +259,10 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    thumbnailImages,
+    thumbnailVideos,
+    thumbnailPDFs,
+    thumbnailMaxFileSize,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +275,11 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (thumbnailImages !== undefined) await setThumbnailImages(thumbnailImages);
+  if (thumbnailVideos !== undefined) await setThumbnailVideos(thumbnailVideos);
+  if (thumbnailPDFs !== undefined) await setThumbnailPDFs(thumbnailPDFs);
+  if (thumbnailMaxFileSize !== undefined)
+    await setThumbnailMaxFileSize(thumbnailMaxFileSize);
   if (theme !== undefined) setTheme(theme);
 }
 

--- a/utils/thumbnailCache.ts
+++ b/utils/thumbnailCache.ts
@@ -1,0 +1,21 @@
+export const THUMBNAIL_CACHE = 'thumbnail-cache';
+
+export async function clearThumbnailCache() {
+  if (typeof caches === 'undefined') return;
+  await caches.delete(THUMBNAIL_CACHE);
+}
+
+export async function getThumbnailCacheSize(): Promise<number> {
+  if (typeof caches === 'undefined') return 0;
+  const cache = await caches.open(THUMBNAIL_CACHE);
+  const requests = await cache.keys();
+  let total = 0;
+  for (const request of requests) {
+    const response = await cache.match(request);
+    if (response) {
+      const blob = await response.clone().blob();
+      total += blob.size;
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary
- add thumbnail settings tab for image/video/PDF toggles
- support max file size and cache management for thumbnails
- persist new thumbnail preferences in settings store

## Testing
- `npx eslint apps/settings/index.tsx hooks/useSettings.tsx utils/settingsStore.js utils/thumbnailCache.ts`
- `yarn tsc` *(fails: Cannot write file because it would overwrite input file)*
- `yarn test` *(fails: __tests__/window.test.tsx, __tests__/game2048.test.tsx, __tests__/nmapNse.test.tsx, __tests__/Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48e2feb483289e6927238a08c859