### PR TITLE
feat: add send-to context options

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,11 @@ function AppMenu(props) {
         }
     }
 
+    const handleSend = (fn) => {
+        fn && fn()
+        props.onClose && props.onClose()
+    }
+
     return (
         <div
             id="app-menu"
@@ -30,6 +35,46 @@ function AppMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
+            <div className="w-full text-left py-0.5 mb-1.5 text-gray-400">
+                <span className="ml-5">Send To</span>
+            </div>
+            <button
+                type="button"
+                onClick={() => handleSend(props.sendToDesktop)}
+                role="menuitem"
+                aria-label="Send to Desktop"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Desktop (Create Link)</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => handleSend(props.sendToEmail)}
+                role="menuitem"
+                aria-label="Send via Email"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Email (mock)</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => handleSend(props.sendToArchive)}
+                role="menuitem"
+                aria-label="Send to Archive"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Archive</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => handleSend(props.sendToTrash)}
+                role="menuitem"
+                aria-label="Send to Trash"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Trash</span>
+            </button>
+            <Devider />
             <button
                 type="button"
                 onClick={handlePin}
@@ -41,6 +86,14 @@ function AppMenu(props) {
             </button>
         </div>
     )
+}
+
+function Devider() {
+    return (
+        <div className="flex justify-center w-full">
+            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        </div>
+    );
 }
 
 export default AppMenu

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -752,6 +752,32 @@ export class Desktop extends Component {
         this.setState({ showShortcutSelector: false }, this.updateAppsData);
     }
 
+    sendToEmail = (app_id) => {
+        const app = apps.find(app => app.id === app_id);
+        if (app) {
+            window.alert(`Mock email sent for ${app.title}`);
+        }
+    }
+
+    sendToArchive = (app_id) => {
+        const app = apps.find(app => app.id === app_id);
+        if (!app) return;
+        let archive = [];
+        try { archive = JSON.parse(safeLocalStorage?.getItem('window-archive') || '[]'); } catch (e) { archive = []; }
+        archive.unshift({ id: app.id, title: app.title, icon: app.icon?.replace('./', '/'), archivedAt: Date.now() });
+        safeLocalStorage?.setItem('window-archive', JSON.stringify(archive));
+    }
+
+    sendToTrash = (app_id) => {
+        const app = apps.find(app => app.id === app_id);
+        if (!app) return;
+        let trash = [];
+        try { trash = JSON.parse(safeLocalStorage?.getItem('window-trash') || '[]'); } catch (e) { trash = []; }
+        trash.unshift({ id: app.id, title: app.title, icon: app.icon?.replace('./', '/'), closedAt: Date.now() });
+        safeLocalStorage?.setItem('window-trash', JSON.stringify(trash));
+        this.updateTrashIcon();
+    }
+
     checkForAppShortcuts = () => {
         const shortcuts = safeLocalStorage?.getItem('app_shortcuts');
         if (!shortcuts) {
@@ -903,6 +929,10 @@ export class Desktop extends Component {
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
+                    sendToDesktop={() => this.addShortcutToDesktop(this.state.context_app)}
+                    sendToEmail={() => this.sendToEmail(this.state.context_app)}
+                    sendToArchive={() => this.sendToArchive(this.state.context_app)}
+                    sendToTrash={() => this.sendToTrash(this.state.context_app)}
                     onClose={this.hideAllContextMenu}
                 />
                 <TaskbarMenu


### PR DESCRIPTION
## Summary
- add "Send To" section in app context menu with Desktop link, mock Email, Archive, and Trash options
- implement handlers on desktop for email, archive, and trash actions and wire them to the menu

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48e487f88328b1b2c4b3f1554288