### PR TITLE
feat(youtube): add preferences modal and mini player

### DIFF
--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -113,5 +113,66 @@ describe('YouTube search app', () => {
       name: 'My Clip',
     });
   });
+
+  it('opens preferences modal with tabs', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeApp initialResults={mockVideos} />);
+    await user.click(screen.getByAltText('Video A'));
+    await user.click(screen.getByTestId('prefs-button'));
+    expect(screen.getByText('Video')).toBeInTheDocument();
+    expect(screen.getByText('Audio')).toBeInTheDocument();
+    expect(screen.getByText('Subtitles')).toBeInTheDocument();
+    expect(screen.getByText('Plugins')).toBeInTheDocument();
+  });
+
+  it('toggles mini player mode', async () => {
+    const user = userEvent.setup();
+    render(<YouTubeApp initialResults={mockVideos} />);
+    await user.click(screen.getByAltText('Video A'));
+    const toggle = screen.getByTestId('mini-player-toggle');
+    await user.click(toggle);
+    expect(screen.getByTestId('player-container').className).toContain('fixed');
+  });
+
+  it('handles J/K/L and space shortcuts', async () => {
+    const user = userEvent.setup();
+    let curTime = 50;
+    let state = 1;
+    const seekTo = jest.fn((t: number) => {
+      curTime = t;
+    });
+    const pauseVideo = jest.fn(() => {
+      state = 0;
+    });
+    const playVideo = jest.fn(() => {
+      state = 1;
+    });
+    (window as any).YT = {
+      Player: function (_el: any, { events }: any) {
+        const obj = {
+          getCurrentTime: () => curTime,
+          getPlayerState: () => state,
+          loadVideoById: jest.fn(),
+          pauseVideo,
+          playVideo,
+          seekTo,
+          getPlaybackRate: () => 1,
+        };
+        events?.onReady?.({ target: obj });
+        return obj;
+      },
+      PlayerState: { PLAYING: 1 },
+    };
+    render(<YouTubeApp initialResults={mockVideos} />);
+    await user.click(screen.getByAltText('Video A'));
+    fireEvent.keyDown(window, { key: 'j' });
+    expect(seekTo).toHaveBeenNthCalledWith(1, 40, true);
+    fireEvent.keyDown(window, { key: 'l' });
+    expect(seekTo).toHaveBeenNthCalledWith(2, 50, true);
+    fireEvent.keyDown(window, { key: 'k' });
+    expect(pauseVideo).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: ' ' });
+    expect(playVideo).toHaveBeenCalled();
+  });
 });
 

--- a/components/apps/youtube/Preferences.tsx
+++ b/components/apps/youtube/Preferences.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const TABS = ['Video', 'Audio', 'Subtitles', 'Plugins'] as const;
+
+type Tab = typeof TABS[number];
+
+export default function Preferences({ open, onClose }: Props) {
+  const [active, setActive] = useState<Tab>('Video');
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-96 rounded bg-ub-cool-grey p-4 text-ubt-grey shadow-lg">
+        <div className="mb-4 flex border-b border-ubt-cool-grey">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              className={`flex-1 p-2 text-sm ${active === tab ? 'border-b-2 border-ubt-green text-ubt-green' : ''}`}
+              onClick={() => setActive(tab)}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="text-sm">
+          Preferences for {active} coming soon.
+        </div>
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="rounded border border-ubt-cool-grey px-2 py-1 hover:text-ubt-green"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add preferences modal with Video/Audio/Subtitles/Plugins tabs
- support playlist sidebar and mini-player toggle
- implement J/K/L and space keyboard shortcuts with tests

## Testing
- `npm test __tests__/youtube.test.tsx`
- `npx eslint components/apps/youtube/index.tsx components/apps/youtube/Preferences.tsx __tests__/youtube.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba48e5e49c8328b620edcf0d6e2fcd