### PR TITLE
Add screenshot utility and Print Screen shortcuts

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -11,6 +11,7 @@ import { displayClipboardManager } from './components/apps/ClipboardManager';
 import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
+import { displayScreenshot } from './components/apps/screenshot';
 import { displayNikto } from './components/apps/nikto';
 
 export const chromeDefaultTiles = [
@@ -248,6 +249,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQuote,
+  },
+  {
+    id: 'screenshot',
+    title: 'Screenshot',
+    icon: '/themes/Yaru/apps/screen-recorder.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayScreenshot,
   },
   {
     id: 'project-gallery',

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,9 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Screenshot Full', keys: 'PrintScreen' },
+  { description: 'Screenshot Window', keys: 'Alt+PrintScreen' },
+  { description: 'Screenshot Region', keys: 'Shift+PrintScreen' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/apps/screenshot.tsx
+++ b/components/apps/screenshot.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { useState } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import { captureScreenshot, ScreenshotMode } from '../../utils/screenshot';
+
+const modes: ScreenshotMode[] = ['region', 'window', 'full'];
+
+export default function ScreenshotApp() {
+  const [mode, setMode] = useState<ScreenshotMode>('region');
+  const [delay, setDelay] = usePersistentState<number>(
+    'screenshot-delay',
+    0,
+    (v): v is number => typeof v === 'number',
+  );
+  const [includePointer, setIncludePointer] = usePersistentState<boolean>(
+    'screenshot-pointer',
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  const cycleMode = (deltaY: number) => {
+    let idx = modes.indexOf(mode);
+    if (deltaY > 0) idx = (idx + 1) % modes.length;
+    else idx = (idx - 1 + modes.length) % modes.length;
+    setMode(modes[idx]);
+  };
+
+  const capture = async () => {
+    const blob = await captureScreenshot({ mode, delay, includePointer });
+    if (blob) {
+      const url = URL.createObjectURL(blob);
+      setImageUrl(url);
+    }
+  };
+
+  const copy = async () => {
+    if (!imageUrl) return;
+    const blob = await (await fetch(imageUrl)).blob();
+    try {
+      await navigator.clipboard.write([
+        new (window as any).ClipboardItem({ 'image/png': blob }),
+      ]);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const openWith = () => {
+    if (imageUrl) window.open(imageUrl);
+  };
+
+  return (
+    <div className="h-full w-full p-4 bg-ub-cool-grey text-white space-y-4 overflow-auto">
+      <div
+        onWheel={(e) => cycleMode(e.deltaY)}
+        className="select-none cursor-pointer"
+        aria-label="capture-mode"
+      >
+        Mode: {mode.charAt(0).toUpperCase() + mode.slice(1)} (scroll to change)
+      </div>
+      <div className="flex items-center space-x-2">
+        <label htmlFor="delay">Delay (s):</label>
+        <input
+          id="delay"
+          type="number"
+          value={delay}
+          onChange={(e) => setDelay(parseInt(e.target.value, 10) || 0)}
+          className="bg-ub-dark bg-opacity-50 p-1 rounded w-16"
+        />
+      </div>
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          checked={includePointer}
+          onChange={(e) => setIncludePointer(e.target.checked)}
+        />
+        <span>Include pointer</span>
+      </label>
+      <button
+        type="button"
+        onClick={capture}
+        className="px-4 py-2 bg-ub-dracula rounded"
+      >
+        Capture
+      </button>
+      {imageUrl && (
+        <div className="space-y-2">
+          <img src={imageUrl} alt="Screenshot" className="max-w-full border" />
+          <div className="space-x-2">
+            <button
+              type="button"
+              onClick={copy}
+              className="px-4 py-2 bg-ub-green text-black rounded"
+            >
+              Copy to Clipboard
+            </button>
+            <button
+              type="button"
+              onClick={openWith}
+              className="px-4 py-2 bg-ub-orange rounded"
+            >
+              Open With
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const displayScreenshot = () => <ScreenshotApp />;
+

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,6 +519,8 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        if (typeof e.preventDefault !== 'function') e.preventDefault = () => {};
+        if (typeof e.stopPropagation !== 'function') e.stopPropagation = () => {};
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {

--- a/components/common/PrintScreenHandler.tsx
+++ b/components/common/PrintScreenHandler.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import { captureScreenshot, ScreenshotMode } from '../../utils/screenshot';
+
+const keyToMode = (e: KeyboardEvent): ScreenshotMode => {
+  if (e.shiftKey) return 'region';
+  if (e.ctrlKey || e.altKey) return 'window';
+  return 'full';
+};
+
+export default function PrintScreenHandler() {
+  const [delay] = usePersistentState<number>(
+    'screenshot-delay',
+    0,
+    (v): v is number => typeof v === 'number',
+  );
+  const [includePointer] = usePersistentState<boolean>(
+    'screenshot-pointer',
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+      if (isInput) return;
+      if (e.key === 'PrintScreen') {
+        e.preventDefault();
+        const mode = keyToMode(e);
+        captureScreenshot({
+          mode,
+          delay,
+          includePointer,
+          copy: true,
+          open: true,
+        });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [delay, includePointer]);
+
+  return null;
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import PrintScreenHandler from '../components/common/PrintScreenHandler';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <PrintScreenHandler />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/utils/screenshot.ts
+++ b/utils/screenshot.ts
@@ -1,0 +1,66 @@
+"use client";
+
+export type ScreenshotMode = 'region' | 'window' | 'full';
+
+export interface CaptureOptions {
+  mode: ScreenshotMode;
+  delay: number;
+  includePointer: boolean;
+  copy?: boolean;
+  open?: boolean;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function captureScreenshot(options: CaptureOptions): Promise<Blob | null> {
+  const { mode, delay, includePointer, copy, open } = options;
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getDisplayMedia) {
+    return null;
+  }
+  if (delay > 0) await sleep(delay * 1000);
+
+  const videoOpts: any = { cursor: includePointer ? 'always' : 'never' };
+  // Hint desired capture surface; browsers may ignore these.
+  if (mode === 'window') videoOpts.displaySurface = 'window';
+  else if (mode === 'full') videoOpts.displaySurface = 'monitor';
+  else if (mode === 'region') videoOpts.displaySurface = 'browser';
+
+  try {
+    const stream = await navigator.mediaDevices.getDisplayMedia({ video: videoOpts, audio: false });
+    const track = stream.getVideoTracks()[0];
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    await new Promise<void>((resolve) => {
+      video.onloadedmetadata = () => {
+        video.play().then(() => resolve());
+      };
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.drawImage(video, 0, 0);
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), 'image/png'),
+    );
+    stream.getTracks().forEach((t) => t.stop());
+    if (!blob) return null;
+    if (copy && navigator.clipboard && (navigator as any).clipboard?.write) {
+      try {
+        await navigator.clipboard.write([
+          new (window as any).ClipboardItem({ 'image/png': blob }),
+        ]);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (open) {
+      const url = URL.createObjectURL(blob);
+      window.open(url);
+    }
+    return blob;
+  } catch {
+    return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add screenshot utility with region/window/full capture options, delay, pointer toggle and clipboard/open actions
- bind Print Screen keys to trigger screenshots and register shortcuts
- include screenshot app in utilities menu

## Testing
- `npm test` *(fails: Unable to find role="alert" in nmapNse.test.tsx; Cannot read properties of null in Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48e9a2388328a9208fefe18402a5