### PR TITLE
feat: add audio controls and pavucontrol link

### DIFF
--- a/apps/pavucontrol/index.tsx
+++ b/apps/pavucontrol/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Pavucontrol: React.FC = () => (
+  <div className="p-4 text-center">
+    <h1 className="text-xl mb-2">pavucontrol</h1>
+    <p className="text-sm">PulseAudio Volume Control placeholder.</p>
+  </div>
+);
+
+export default Pavucontrol;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import Link from 'next/link';
 
 interface Props {
   open: boolean;
@@ -9,7 +10,10 @@ interface Props {
 
 const QuickSettings = ({ open }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
-  const [sound, setSound] = usePersistentState('qs-sound', true);
+  const [volume, setVolume] = usePersistentState('qs-volume', 1);
+  const [muted, setMuted] = usePersistentState('qs-muted', false);
+  const [device, setDevice] = usePersistentState('qs-device', 'speakers');
+  const [profile, setProfile] = usePersistentState('qs-profile', 'Stereo');
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
 
@@ -20,6 +24,22 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'AudioVolumeUp') {
+        setMuted(false);
+        setVolume((v) => Math.min(1, v + 0.05));
+      } else if (e.key === 'AudioVolumeDown') {
+        setMuted(false);
+        setVolume((v) => Math.max(0, v - 0.05));
+      } else if (e.key === 'AudioVolumeMute') {
+        setMuted((m) => !m);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [setVolume, setMuted]);
 
   return (
     <div
@@ -36,13 +56,87 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+      <div className="px-4 pb-2">
+        <div className="flex items-center mb-2">
+          <button
+            aria-label={muted ? 'Unmute' : 'Mute'}
+            className="mr-2 px-2 py-1 border rounded"
+            onClick={() => setMuted(!muted)}
+          >
+            {muted ? 'Unmute' : 'Mute'}
+          </button>
+          <div className="flex-1">
+            <label htmlFor="qs-volume" className="sr-only">
+              Volume
+            </label>
+            <input
+              id="qs-volume"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={muted ? 0 : volume}
+              onChange={(e) => {
+                setMuted(false);
+                setVolume(parseFloat(e.target.value));
+              }}
+              className="w-full"
+              aria-label="Volume"
+            />
+          </div>
+        </div>
+        <div className="mb-2">
+          <label htmlFor="qs-device" className="block text-sm mb-1">
+            Output device
+          </label>
+          <select
+            id="qs-device"
+            value={device}
+            onChange={(e) => {
+              const d = e.target.value;
+              setDevice(d);
+              setProfile(d === 'headphones' ? 'Bass Boost' : 'Stereo');
+            }}
+            className="w-full mb-1"
+          >
+            <option value="speakers">Speakers</option>
+            <option value="headphones">Headphones</option>
+            <option value="hdmi">HDMI Output</option>
+          </select>
+          <label htmlFor="qs-profile" className="sr-only">
+            Profile
+          </label>
+          <select
+            id="qs-profile"
+            value={profile}
+            onChange={(e) => setProfile(e.target.value)}
+            className="w-full"
+          >
+            {device === 'headphones' ? (
+              <>
+                <option value="Bass Boost">Bass Boost</option>
+                <option value="Stereo">Stereo</option>
+              </>
+            ) : (
+              <>
+                <option value="Stereo">Stereo</option>
+                <option value="Surround">Surround</option>
+              </>
+            )}
+          </select>
+        </div>
+        <Link href="/apps/pavucontrol" className="text-blue-400 underline">
+          Sound settings
+        </Link>
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={() => setOnline(!online)}
+            aria-label="Network"
+          />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
@@ -50,6 +144,7 @@ const QuickSettings = ({ open }: Props) => {
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Reduced motion"
         />
       </div>
     </div>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,15 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import usePersistentState from '../../hooks/usePersistentState';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const [muted] = usePersistentState('qs-muted', false);
+  const [volume] = usePersistentState('qs-volume', 1);
 
   useEffect(() => {
     const pingServer = async () => {
@@ -56,15 +59,20 @@ export default function Status() {
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
-      <span className="mx-1.5">
+      <span className="mx-1.5 relative" title={muted ? 'Muted' : `Volume ${(volume * 100).toFixed(0)}%`}>
         <Image
           width={16}
           height={16}
           src={VOLUME_ICON}
-          alt="volume"
+          alt={muted ? 'muted' : 'volume'}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />
+        {muted && (
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="block w-full h-px bg-red-500 rotate-45" />
+          </span>
+        )}
       </span>
       <span className="mx-1.5">
         <Image

--- a/pages/apps/pavucontrol.jsx
+++ b/pages/apps/pavucontrol.jsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const Pavucontrol = dynamic(() => import('../../apps/pavucontrol'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default Pavucontrol;


### PR DESCRIPTION
## Summary
- add volume slider, mute toggle, device selector, and multimedia key handling to quick settings
- show mute overlay and volume tooltip in status bar
- add pavucontrol placeholder page and link

## Testing
- `npx eslint components/ui/QuickSettings.tsx components/util-components/status.js apps/pavucontrol/index.tsx pages/apps/pavucontrol.jsx`
- `yarn test QuickSettings --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba48ea3c6083289ba6cceed2d0c420