### PR TITLE
feat: expand notification center with tabs and dnd toggle

### DIFF
--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,9 +1,19 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 
 export interface AppNotification {
   id: string;
   message: string;
   date: number;
+  closing?: boolean;
+}
+
+interface LogEntry extends AppNotification {
+  appId: string;
 }
 
 interface NotificationsContextValue {
@@ -12,28 +22,64 @@ interface NotificationsContextValue {
   clearNotifications: (appId?: string) => void;
 }
 
-export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+export const NotificationsContext = createContext<NotificationsContextValue | null>(
+  null
+);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+type Tab = 'general' | 'applications' | 'log';
+type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
-  const pushNotification = useCallback((appId: string, message: string) => {
-    setNotifications(prev => {
-      const list = prev[appId] ?? [];
-      const next = {
-        ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
-      };
-      return next;
-    });
-  }, []);
+export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const [notifications, setNotifications] = useState<
+    Record<string, AppNotification[]>
+  >({});
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [activeTab, setActiveTab] = useState<Tab>('general');
+  const [doNotDisturb, setDoNotDisturb] = useState(false);
+  const [position, setPosition] = useState<Position>('top-right');
+
+  const pushNotification = useCallback(
+    (appId: string, message: string) => {
+      const id = `${Date.now()}-${Math.random()}`;
+      const entry: LogEntry = { id, message, date: Date.now(), appId };
+      setLog(prev => [...prev, entry]);
+      if (doNotDisturb) return;
+      setNotifications(prev => {
+        const list = prev[appId] ?? [];
+        const next = {
+          ...prev,
+          [appId]: [...list, entry],
+        };
+        return next;
+      });
+      // schedule fade-out removal
+      setTimeout(() => {
+        setNotifications(prev => {
+          const list = prev[appId];
+          if (!list) return prev;
+          const idx = list.findIndex(n => n.id === id);
+          if (idx === -1) return prev;
+          const updated = [...list];
+          updated[idx] = { ...updated[idx], closing: true };
+          const next = { ...prev, [appId]: updated };
+          setTimeout(() => {
+            setNotifications(p2 => {
+              const l2 = p2[appId];
+              if (!l2) return p2;
+              const filtered = l2.filter(n => n.id !== id);
+              const final = { ...p2, [appId]: filtered };
+              if (filtered.length === 0) delete final[appId];
+              return final;
+            });
+          }, 500);
+          return next;
+        });
+      }, 5000);
+    },
+    [doNotDisturb]
+  );
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
@@ -57,22 +103,105 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     }
   }, [totalCount]);
 
+  const renderTab = () => {
+    if (activeTab === 'log') {
+      return (
+        <section className="notification-group">
+          <ul>
+            {log.map(n => (
+              <li key={n.id} className={n.closing ? 'fade' : ''}>
+                [{n.appId}] {n.message}
+              </li>
+            ))}
+          </ul>
+        </section>
+      );
+    }
+
+    if (activeTab === 'applications') {
+      return (
+        <>
+          {Object.entries(notifications)
+            .filter(([id]) => id !== 'general')
+            .map(([appId, list]) => (
+              <section key={appId} className="notification-group">
+                <h3>{appId}</h3>
+                <ul>
+                  {list.map(n => (
+                    <li key={n.id} className={n.closing ? 'fade' : ''}>
+                      {n.message}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+        </>
+      );
+    }
+
+    const list = notifications['general'] ?? [];
+    return (
+      <section className="notification-group">
+        <ul>
+          {list.map(n => (
+            <li key={n.id} className={n.closing ? 'fade' : ''}>
+              {n.message}
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+  };
+
   return (
     <NotificationsContext.Provider
       value={{ notifications, pushNotification, clearNotifications }}
     >
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
+      <div className={`notification-center ${position}`}>
+        <div className="notification-controls">
+          <div className="notification-tabs">
+            <button
+              type="button"
+              onClick={() => setActiveTab('general')}
+              className={activeTab === 'general' ? 'active' : ''}
+            >
+              General
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('applications')}
+              className={activeTab === 'applications' ? 'active' : ''}
+            >
+              Applications
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('log')}
+              className={activeTab === 'log' ? 'active' : ''}
+            >
+              Log
+            </button>
+          </div>
+          <label>
+            <input
+              type="checkbox"
+              checked={doNotDisturb}
+              onChange={e => setDoNotDisturb(e.target.checked)}
+            />
+            Do Not Disturb
+          </label>
+          <select
+            value={position}
+            onChange={e => setPosition(e.target.value as Position)}
+          >
+            <option value="top-left">Top Left</option>
+            <option value="top-right">Top Right</option>
+            <option value="bottom-left">Bottom Left</option>
+            <option value="bottom-right">Bottom Right</option>
+          </select>
+        </div>
+        {renderTab()}
       </div>
     </NotificationsContext.Provider>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,34 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.notification-center {
+  position: fixed;
+  z-index: 1000;
+  max-width: 20rem;
+  padding: 0.5rem;
+}
+.notification-center.top-left { top: 1rem; left: 1rem; }
+.notification-center.top-right { top: 1rem; right: 1rem; }
+.notification-center.bottom-left { bottom: 1rem; left: 1rem; }
+.notification-center.bottom-right { bottom: 1rem; right: 1rem; }
+
+.notification-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.notification-tabs button.active {
+  font-weight: bold;
+}
+.notification-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.notification-group li.fade {
+  animation: fadeOut 0.5s forwards;
+}
+@keyframes fadeOut {
+  to { opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- add tabbed notification center with General/Applications/Log views
- include Do Not Disturb toggle and position selector
- add fade-out animation styles

## Testing
- `yarn test` *(fails: Unable to find role="alert"; TypeError: e.preventDefault is not a function)*
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48eac3408328a2b281c69e4a5d95