### PR TITLE
feat: add LightDM explainer pane

### DIFF
--- a/components/LightDMPane.tsx
+++ b/components/LightDMPane.tsx
@@ -1,0 +1,16 @@
+import ExplainerPane from './ExplainerPane';
+
+export default function LightDMPane() {
+  return (
+    <ExplainerPane
+      lines={[
+        'Select LightDM when prompted to choose a display manager.',
+        'LightDM offers a lightweight login screen and integrates well with Xfce.'
+      ]}
+      resources={[
+        { label: 'Xfce FAQ', url: 'https://docs.xfce.org/faq' }
+      ]}
+    />
+  );
+}
+

--- a/pages/lightdm.tsx
+++ b/pages/lightdm.tsx
@@ -1,0 +1,10 @@
+import LightDMPane from '../components/LightDMPane';
+
+export default function LightDMPage() {
+  return (
+    <div className="min-h-screen flex">
+      <LightDMPane />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LightDMPane component to explain choosing LightDM and link to Xfce FAQ
- expose LightDM page rendering the explainer pane

## Testing
- `npm run lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npm test` *(fails: TypeError: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48ef0bb08328a4623e5489ee65ea