### PR TITLE
feat: customize login screen visuals

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -19,6 +19,10 @@ export default function Settings() {
     setAccent,
     wallpaper,
     setWallpaper,
+    loginBackground,
+    setLoginBackground,
+    loginLogo,
+    setLoginLogo,
     density,
     setDensity,
     reducedMotion,
@@ -36,6 +40,7 @@ export default function Settings() {
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
+    { id: "login", label: "Login Screen" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
   ] as const;
@@ -51,6 +56,12 @@ export default function Settings() {
     "wall-6",
     "wall-7",
     "wall-8",
+  ];
+
+  const logos = [
+    "logo.png",
+    "logo_1024.png",
+    "logo_1200.png",
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
@@ -73,6 +84,9 @@ export default function Settings() {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
       if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+      if (parsed.loginBackground !== undefined)
+        setLoginBackground(parsed.loginBackground);
+      if (parsed.loginLogo !== undefined) setLoginLogo(parsed.loginLogo);
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
@@ -96,6 +110,8 @@ export default function Settings() {
     window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
+    setLoginBackground(defaults.loginBackground);
+    setLoginLogo(defaults.loginLogo);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
@@ -206,6 +222,60 @@ export default function Settings() {
             >
               Reset Desktop
             </button>
+          </div>
+        </>
+      )}
+      {activeTab === "login" && (
+        <>
+          <div
+            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4 flex items-center justify-center"
+            style={{
+              backgroundImage: `url(/wallpapers/${loginBackground}.webp)`,
+              backgroundSize: "cover",
+              backgroundRepeat: "no-repeat",
+              backgroundPosition: "center center",
+            }}
+          >
+            <img
+              src={`/images/logos/${loginLogo}`}
+              alt="Login Logo"
+              className="w-24 h-24 object-contain"
+            />
+          </div>
+          <div className="flex justify-center my-4">
+            <label htmlFor="login-bg-slider" className="mr-2 text-ubt-grey">
+              Background:
+            </label>
+            <input
+              id="login-bg-slider"
+              type="range"
+              min="0"
+              max={wallpapers.length - 1}
+              step="1"
+              value={wallpapers.indexOf(loginBackground)}
+              onChange={(e) =>
+                setLoginBackground(wallpapers[parseInt(e.target.value, 10)])
+              }
+              className="ubuntu-slider"
+              aria-label="Login background"
+            />
+          </div>
+          <div className="flex justify-center my-4">
+            <label htmlFor="login-logo-select" className="mr-2 text-ubt-grey">
+              Logo:
+            </label>
+            <select
+              id="login-logo-select"
+              value={loginLogo}
+              onChange={(e) => setLoginLogo(e.target.value)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              {logos.map((l) => (
+                <option key={l} value={l}>
+                  {l}
+                </option>
+              ))}
+            </select>
           </div>
         </>
       )}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -4,7 +4,7 @@ import { useSettings } from '../../hooks/useSettings';
 
 export default function LockScreen(props) {
 
-    const { wallpaper } = useSettings();
+    const { loginBackground, loginLogo } = useSettings();
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -17,11 +17,16 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={`/wallpapers/${loginBackground}.webp`}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
+                <img
+                    src={`/images/logos/${loginLogo}`}
+                    alt="Login Logo"
+                    className="w-24 h-24 mb-8 object-contain"
+                />
                 <div className=" text-7xl">
                     <Clock onlyTime={true} />
                 </div>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,6 +4,10 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getLoginBackground as loadLoginBackground,
+  setLoginBackground as saveLoginBackground,
+  getLoginLogo as loadLoginLogo,
+  setLoginLogo as saveLoginLogo,
   getDensity as loadDensity,
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
@@ -54,6 +58,8 @@ const shadeColor = (color: string, percent: number): string => {
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
+  loginBackground: string;
+  loginLogo: string;
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
@@ -65,6 +71,8 @@ interface SettingsContextValue {
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setLoginBackground: (bg: string) => void;
+  setLoginLogo: (logo: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
@@ -79,6 +87,8 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  loginBackground: defaults.loginBackground,
+  loginLogo: defaults.loginLogo,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
@@ -90,6 +100,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
+  setLoginBackground: () => {},
+  setLoginLogo: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
@@ -104,6 +116,10 @@ export const SettingsContext = createContext<SettingsContextValue>({
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [loginBackground, setLoginBackground] = useState<string>(
+    defaults.loginBackground
+  );
+  const [loginLogo, setLoginLogo] = useState<string>(defaults.loginLogo);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -119,6 +135,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setLoginBackground(await loadLoginBackground());
+      setLoginLogo(await loadLoginLogo());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -155,6 +173,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  useEffect(() => {
+    saveLoginBackground(loginBackground);
+  }, [loginBackground]);
+
+  useEffect(() => {
+    saveLoginLogo(loginLogo);
+  }, [loginLogo]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -241,6 +267,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         accent,
         wallpaper,
+        loginBackground,
+        loginLogo,
         density,
         reducedMotion,
         fontScale,
@@ -252,6 +280,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
+        setLoginBackground,
+        setLoginLogo,
         setDensity,
         setReducedMotion,
         setFontScale,

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,6 +6,8 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
+  loginBackground: 'wall-2',
+  loginLogo: 'logo.png',
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
@@ -34,6 +36,26 @@ export async function getWallpaper() {
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
   await set('bg-image', wallpaper);
+}
+
+export async function getLoginBackground() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.loginBackground;
+  return (await get('login-bg')) || DEFAULT_SETTINGS.loginBackground;
+}
+
+export async function setLoginBackground(bg) {
+  if (typeof window === 'undefined') return;
+  await set('login-bg', bg);
+}
+
+export async function getLoginLogo() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.loginLogo;
+  return (await get('login-logo')) || DEFAULT_SETTINGS.loginLogo;
+}
+
+export async function setLoginLogo(logo) {
+  if (typeof window === 'undefined') return;
+  await set('login-logo', logo);
 }
 
 export async function getDensity() {
@@ -128,6 +150,8 @@ export async function resetSettings() {
   await Promise.all([
     del('accent'),
     del('bg-image'),
+    del('login-bg'),
+    del('login-logo'),
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
@@ -143,6 +167,8 @@ export async function exportSettings() {
   const [
     accent,
     wallpaper,
+    loginBackground,
+    loginLogo,
     density,
     reducedMotion,
     fontScale,
@@ -154,6 +180,8 @@ export async function exportSettings() {
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
+    getLoginBackground(),
+    getLoginLogo(),
     getDensity(),
     getReducedMotion(),
     getFontScale(),
@@ -175,6 +203,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    loginBackground,
+    loginLogo,
     theme,
   });
 }
@@ -199,10 +229,14 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    loginBackground,
+    loginLogo,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
+  if (loginBackground !== undefined) await setLoginBackground(loginBackground);
+  if (loginLogo !== undefined) await setLoginLogo(loginLogo);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);


### PR DESCRIPTION
## Summary
- add login screen tab to settings with background and logo controls
- persist login background and logo in settings store
- lock screen renders configurable logo and background

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js)*
- `npx eslint apps/settings/index.tsx components/screen/lock_screen.js hooks/useSettings.tsx utils/settingsStore.js`
- `yarn test` *(fails: e.preventDefault is not a function in __tests__/window.test.tsx; Unable to find role="alert" in __tests__/nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48eea40c8328851dd07753110bca