### PR TITLE
feat: add logout session selection

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -49,7 +49,7 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings open={this.state.status_card} onLogout={this.props.lockScreen} />
                                 </button>
 			</div>
 		);

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { setTheme as applyTheme } from '../../utils/theme';
+import { setAllowNetwork } from '../../utils/settingsStore';
 
 interface Props {
   open: boolean;
+  onLogout?: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, onLogout }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [showLogout, setShowLogout] = useState(false);
+  const [session, setSession] = useState<'xfce' | 'undercover' | 'safe'>('xfce');
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +25,25 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  const handleLogout = async () => {
+    switch (session) {
+      case 'xfce':
+        applyTheme('default');
+        await setAllowNetwork(true);
+        break;
+      case 'undercover':
+        applyTheme('dark');
+        await setAllowNetwork(true);
+        break;
+      case 'safe':
+        applyTheme('dark');
+        await setAllowNetwork(false);
+        break;
+    }
+    window.localStorage.setItem('session', session);
+    onLogout?.();
+  };
 
   return (
     <div
@@ -51,6 +75,53 @@ const QuickSettings = ({ open }: Props) => {
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
+      </div>
+      <div className="px-4 pt-2 border-t border-gray-600 mt-2">
+        {showLogout ? (
+          <div>
+            <p className="mb-2">Session</p>
+            <label className="block mb-1">
+              <input
+                type="radio"
+                name="session"
+                value="xfce"
+                checked={session === 'xfce'}
+                onChange={() => setSession('xfce')}
+              />{' '}
+              Xfce
+            </label>
+            <label className="block mb-1">
+              <input
+                type="radio"
+                name="session"
+                value="undercover"
+                checked={session === 'undercover'}
+                onChange={() => setSession('undercover')}
+              />{' '}
+              Undercover
+            </label>
+            <label className="block mb-2">
+              <input
+                type="radio"
+                name="session"
+                value="safe"
+                checked={session === 'safe'}
+                onChange={() => setSession('safe')}
+              />{' '}
+              Safe mode
+            </label>
+            <button
+              className="w-full bg-red-600 text-white rounded px-2 py-1"
+              onClick={handleLogout}
+            >
+              Log out
+            </button>
+          </div>
+        ) : (
+          <button className="w-full text-left" onClick={() => setShowLogout(true)}>
+            Log out...
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow choosing Xfce, Undercover, or Safe mode at logout
- store session choice and adjust theme/network for next login
- hook navbar quick settings logout to lock screen

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48f00dd483288170e4b3c72a27a2