### PR TITLE
feat(theme): add Kali presets

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,15 +23,21 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['default', 'neon', 'dark', 'kali-light', 'kali-dark'])
+    );
     expect(unlocked).not.toContain('matrix');
   });
 
-  test('dark class applied for neon and matrix themes', () => {
+  test('dark class applied for dark themes', () => {
     setTheme('neon');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     setTheme('matrix');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    setTheme('kali-dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    setTheme('kali-light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   test('updates CSS variables without reload', () => {

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -129,6 +129,8 @@ export default function Settings() {
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
               <option value="default">Default</option>
+              <option value="kali-dark">Kali Dark</option>
+              <option value="kali-light">Kali Light</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -67,6 +67,8 @@ export function Settings() {
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
                     <option value="default">Default</option>
+                    <option value="kali-dark">Kali Dark</option>
+                    <option value="kali-light">Kali Light</option>
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -60,6 +60,8 @@ export default function ThemeSettings() {
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="kali-dark">Kali Dark</option>
+          <option value="kali-light">Kali Light</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/public/theme.js
+++ b/public/theme.js
@@ -13,7 +13,7 @@
 
     var theme = stored || (prefersDark ? 'dark' : 'default');
     document.documentElement.dataset.theme = theme;
-    var darkThemes = ['dark', 'neon', 'matrix'];
+    var darkThemes = ['dark', 'neon', 'matrix', 'kali-dark'];
     document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
   } catch (e) {
     console.error('Failed to apply theme', e);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,10 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
+  /* Kali theme helpers */
+  --kali-bg: var(--color-bg);
+  --kali-panel: var(--color-surface);
+  --icon-spacing: var(--space-2);
 }
 
 /* Dark theme */
@@ -50,6 +54,36 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+}
+
+/* Kali dark theme */
+html[data-theme='kali-dark'] {
+  --color-bg: var(--color-ub-grey);
+  --color-text: var(--color-ubt-grey);
+  --color-primary: var(--color-ub-orange);
+  --color-secondary: var(--color-ub-cool-grey);
+  --color-accent: var(--color-ub-orange);
+  --color-muted: var(--color-ub-dark-grey);
+  --color-surface: var(--color-ub-lite-abrgn);
+  --color-inverse: var(--color-ubt-grey);
+  --color-border: var(--color-ub-dark-grey);
+  --color-terminal: #00ff00;
+  --color-dark: var(--color-ub-window-title);
+}
+
+/* Kali light theme */
+html[data-theme='kali-light'] {
+  --color-bg: var(--color-ubt-grey);
+  --color-text: var(--color-ub-grey);
+  --color-primary: var(--color-ubt-blue);
+  --color-secondary: var(--color-ubt-cool-grey);
+  --color-accent: var(--color-ubt-blue);
+  --color-muted: var(--color-ubt-warm-grey);
+  --color-surface: var(--color-ubt-grey);
+  --color-inverse: var(--color-ub-grey);
+  --color-border: var(--color-ubt-cool-grey);
+  --color-terminal: #00ff00;
+  --color-dark: var(--color-ubt-gedit-dark);
 }
 
 /* Matrix theme */

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,12 +3,14 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  'kali-light': 0,
+  'kali-dark': 0,
   neon: 100,
   dark: 500,
   matrix: 1000,
 };
 
-const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
+const DARK_THEMES = ['dark', 'neon', 'matrix', 'kali-dark'] as const;
 
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);


### PR DESCRIPTION
## Summary
- add Kali-Dark and Kali-Light theme definitions using existing CSS tokens
- expose Kali presets in settings menus
- include Kali presets in theme utilities and tests

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, pluginManager.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48f0e4308328935cd034d948efe5