### PR TITLE
feat: add configurable fonts

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -25,6 +25,8 @@ export default function Settings() {
     setReducedMotion,
     fontScale,
     setFontScale,
+    fontHinting,
+    setFontHinting,
     highContrast,
     setHighContrast,
     haptics,
@@ -151,6 +153,28 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Font Size:</label>
+            <input
+              id="font-scale"
+              type="range"
+              min="0.75"
+              max="1.5"
+              step="0.05"
+              value={fontScale}
+              onChange={(e) => setFontScale(parseFloat(e.target.value))}
+              className="ubuntu-slider"
+              aria-label="Font size"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Hinting:</span>
+            <ToggleSwitch
+              checked={fontHinting}
+              onChange={setFontHinting}
+              ariaLabel="Font hinting"
+            />
+          </div>
+          <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
             <input
               id="wallpaper-slider"
@@ -211,20 +235,6 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Density:</label>
             <select

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -12,7 +12,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       className={`text-white ${className}`}
       style={{
         background: 'var(--kali-bg)',
-        fontFamily: 'monospace',
+        fontFamily: 'var(--font-family-mono)',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -304,6 +304,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         scrollback: 1000,
         cols: 80,
         rows: 24,
+        fontFamily:
+          'Fira Code, Fira Mono, Source Code Pro, monospace, Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji',
       });
       const fit = new FitAddon();
       const search = new SearchAddon();

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
   setFontScale as saveFontScale,
+  getFontHinting as loadFontHinting,
+  setFontHinting as saveFontHinting,
   getHighContrast as loadHighContrast,
   setHighContrast as saveHighContrast,
   getLargeHitAreas as loadLargeHitAreas,
@@ -57,6 +59,7 @@ interface SettingsContextValue {
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
+  fontHinting: boolean;
   highContrast: boolean;
   largeHitAreas: boolean;
   pongSpin: boolean;
@@ -68,6 +71,7 @@ interface SettingsContextValue {
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
+  setFontHinting: (value: boolean) => void;
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
@@ -82,6 +86,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
+  fontHinting: defaults.fontHinting,
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
@@ -93,6 +98,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
+  setFontHinting: () => {},
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
@@ -107,6 +113,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
+  const [fontHinting, setFontHinting] = useState<boolean>(defaults.fontHinting);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
@@ -122,6 +129,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
+      setFontHinting(await loadFontHinting());
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
@@ -193,6 +201,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [fontScale]);
 
   useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--font-smoothing',
+      fontHinting ? 'auto' : 'antialiased',
+    );
+    saveFontHinting(fontHinting);
+  }, [fontHinting]);
+
+  useEffect(() => {
     document.documentElement.classList.toggle('high-contrast', highContrast);
     saveHighContrast(highContrast);
   }, [highContrast]);
@@ -244,6 +260,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         density,
         reducedMotion,
         fontScale,
+        fontHinting,
         highContrast,
         largeHitAreas,
         pongSpin,
@@ -255,6 +272,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setDensity,
         setReducedMotion,
         setFontScale,
+        setFontHinting,
         setHighContrast,
         setLargeHitAreas,
         setPongSpin,

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,10 @@
 @import './globals.css';
+@import url('https://fonts.googleapis.com/css2?family=Cantarell:wght@400;700&family=Fira+Code:wght@400;700&display=swap');
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    -webkit-font-smoothing: var(--font-smoothing);
+    font-smooth: var(--font-smoothing);
 }
 
 body{
@@ -9,6 +12,10 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+}
+
+code, pre, kbd, samp, .font-mono {
+    font-family: var(--font-family-mono);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,7 +52,9 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: 'Cantarell', 'Ubuntu', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji';
+  --font-family-mono: 'Fira Code', 'Fira Mono', 'Source Code Pro', monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji';
+  --font-smoothing: auto;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const plugin = require('tailwindcss/plugin');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   darkMode: 'class',
@@ -39,6 +40,15 @@ module.exports = {
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
+        sans: ['Cantarell', 'Ubuntu', ...defaultTheme.fontFamily.sans],
+        mono: [
+          'Fira Code',
+          'Fira Mono',
+          ...defaultTheme.fontFamily.mono,
+          'Apple Color Emoji',
+          'Segoe UI Emoji',
+          'Noto Color Emoji',
+        ],
       },
       minWidth: {
         '0': '0',

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
+  fontHinting: true,
   highContrast: false,
   largeHitAreas: false,
   pongSpin: true,
@@ -69,6 +70,17 @@ export async function getFontScale() {
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('font-scale', String(scale));
+}
+
+export async function getFontHinting() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontHinting;
+  const stored = window.localStorage.getItem('font-hinting');
+  return stored === null ? DEFAULT_SETTINGS.fontHinting : stored === 'true';
+}
+
+export async function setFontHinting(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('font-hinting', value ? 'true' : 'false');
 }
 
 export async function getHighContrast() {
@@ -132,6 +144,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
+  window.localStorage.removeItem('font-hinting');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
@@ -146,6 +159,7 @@ export async function exportSettings() {
     density,
     reducedMotion,
     fontScale,
+    fontHinting,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -157,6 +171,7 @@ export async function exportSettings() {
     getDensity(),
     getReducedMotion(),
     getFontScale(),
+    getFontHinting(),
     getHighContrast(),
     getLargeHitAreas(),
     getPongSpin(),
@@ -170,6 +185,7 @@ export async function exportSettings() {
     density,
     reducedMotion,
     fontScale,
+    fontHinting,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -194,6 +210,7 @@ export async function importSettings(json) {
     density,
     reducedMotion,
     fontScale,
+    fontHinting,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -206,6 +223,7 @@ export async function importSettings(json) {
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
+  if (fontHinting !== undefined) await setFontHinting(fontHinting);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);


### PR DESCRIPTION
## Summary
- add Cantarell UI and Fira Code terminal fonts with emoji fallback
- allow adjusting font size and toggling hinting in appearance settings
- persist font hinting in settings store and apply via CSS variables

## Testing
- `yarn lint` *(fails: Unexpected global 'document', missing display name)*
- `yarn test` *(fails: window snapping, nmapNSE, modal focus tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48f48cc883289e994cf0a39454df