### PR TITLE
feat: add custom DPI toggle to settings

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -31,6 +31,10 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    customDpi,
+    setCustomDpi,
+    dpi,
+    setDpi,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -54,6 +58,14 @@ export default function Settings() {
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
+
+  const [systemDpi, setSystemDpi] = useState(96);
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setSystemDpi(Math.round(window.devicePixelRatio * 96));
+    }
+  }, []);
+  const effectiveDpi = customDpi ? dpi : systemDpi;
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -79,6 +91,8 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.customDpi !== undefined) setCustomDpi(parsed.customDpi);
+      if (parsed.dpi !== undefined) setDpi(parsed.dpi);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -100,6 +114,8 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setCustomDpi(defaults.customDpi);
+    setDpi(defaults.dpi);
     setTheme("default");
   };
 
@@ -150,6 +166,31 @@ export default function Settings() {
               ))}
             </div>
           </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Custom DPI ({effectiveDpi})</span>
+            <ToggleSwitch
+              checked={customDpi}
+              onChange={setCustomDpi}
+              ariaLabel="Custom DPI"
+            />
+          </div>
+          {customDpi && (
+            <div className="flex justify-center my-4 items-center">
+              <label htmlFor="dpi-slider" className="mr-2 text-ubt-grey">DPI:</label>
+              <input
+                id="dpi-slider"
+                type="range"
+                min="72"
+                max="192"
+                step="1"
+                value={dpi}
+                onChange={(e) => setDpi(parseInt(e.target.value, 10))}
+                className="ubuntu-slider"
+                aria-label="DPI"
+              />
+              <span className="ml-2 text-ubt-grey">{dpi}</span>
+            </div>
+          )}
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
             <input

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getCustomDpi as loadCustomDpi,
+  setCustomDpi as saveCustomDpi,
+  getDpi as loadDpi,
+  setDpi as saveDpi,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +67,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  customDpi: boolean;
+  dpi: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +80,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setCustomDpi: (value: boolean) => void;
+  setDpi: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +96,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  customDpi: defaults.customDpi,
+  dpi: defaults.dpi,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +109,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setCustomDpi: () => {},
+  setDpi: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +124,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [customDpi, setCustomDpi] = useState<boolean>(defaults.customDpi);
+  const [dpi, setDpi] = useState<number>(defaults.dpi);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +141,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setCustomDpi(await loadCustomDpi());
+      setDpi(await loadDpi());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +252,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveCustomDpi(customDpi);
+    if (customDpi) {
+      const scale = dpi / 96;
+      document.documentElement.style.setProperty('font-size', `${16 * scale}px`);
+    } else {
+      document.documentElement.style.removeProperty('font-size');
+    }
+  }, [customDpi, dpi]);
+
+  useEffect(() => {
+    saveDpi(dpi);
+  }, [dpi]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +279,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        customDpi,
+        dpi,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +292,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setCustomDpi,
+        setDpi,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  customDpi: false,
+  dpi: 96,
 };
 
 export async function getAccent() {
@@ -38,12 +40,20 @@ export async function setWallpaper(wallpaper) {
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  try {
+    return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  } catch {
+    return DEFAULT_SETTINGS.density;
+  }
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  try {
+    window.localStorage.setItem('density', density);
+  } catch {
+    /* ignore */
+  }
 }
 
 export async function getReducedMotion() {
@@ -123,6 +133,43 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getCustomDpi() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.customDpi;
+  try {
+    return window.localStorage.getItem('custom-dpi') === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.customDpi;
+  }
+}
+
+export async function setCustomDpi(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('custom-dpi', value ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function getDpi() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.dpi;
+  try {
+    const val = window.localStorage.getItem('dpi');
+    return val ? parseFloat(val) : DEFAULT_SETTINGS.dpi;
+  } catch {
+    return DEFAULT_SETTINGS.dpi;
+  }
+}
+
+export async function setDpi(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('dpi', String(value));
+  } catch {
+    /* ignore */
+  }
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +184,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('custom-dpi');
+  window.localStorage.removeItem('dpi');
 }
 
 export async function exportSettings() {
@@ -151,6 +200,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    customDpi,
+    dpi,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +213,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getCustomDpi(),
+    getDpi(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +228,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    customDpi,
+    dpi,
     theme,
   });
 }
@@ -199,6 +254,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    customDpi,
+    dpi,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +268,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (customDpi !== undefined) await setCustomDpi(customDpi);
+  if (dpi !== undefined) await setDpi(dpi);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add Custom DPI option with adjustable slider in Settings Appearance
- persist DPI preferences in settings store and context
- apply custom DPI to document root when enabled

## Testing
- `npm test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48cc7fb8832883184c7618f20ab8