### PR TITLE
feat(trash): add move, restore, empty actions with full tray alert

### DIFF
--- a/__tests__/trashState.test.ts
+++ b/__tests__/trashState.test.ts
@@ -1,5 +1,7 @@
+import React from 'react';
 import { act, renderHook } from '@testing-library/react';
-import useTrashState, { TrashItem } from '../apps/trash/state';
+import useTrashState, { TrashItem, TRASH_FULL_THRESHOLD } from '../apps/trash/state';
+import { NotificationsContext } from '../components/common/NotificationCenter';
 
 describe('useTrashState restoreFromHistory', () => {
   beforeEach(() => {
@@ -53,6 +55,67 @@ describe('useTrashState restoreFromHistory', () => {
     expect(result.current.items).toEqual([{ ...fromHistory }]);
 
     confirm.mockRestore();
+  });
+});
+
+describe('useTrashState actions', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('moveToTrash and restore remove item', () => {
+    const { result } = renderHook(() => useTrashState());
+    const item: TrashItem = { id: '1', title: 'App1', closedAt: Date.now() };
+    act(() => {
+      result.current.moveToTrash(item);
+    });
+    expect(result.current.items).toEqual([item]);
+    let restored: TrashItem | null = null;
+    act(() => {
+      restored = result.current.restore(0);
+    });
+    expect(restored).toEqual(item);
+    expect(result.current.items).toEqual([]);
+  });
+
+  test('empty moves all items to history', () => {
+    const { result } = renderHook(() => useTrashState());
+    const a: TrashItem = { id: '1', title: 'A', closedAt: Date.now() };
+    const b: TrashItem = { id: '2', title: 'B', closedAt: Date.now() };
+    act(() => {
+      result.current.moveToTrash(a);
+      result.current.moveToTrash(b);
+    });
+    act(() => {
+      result.current.empty();
+    });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.history).toEqual([a, b]);
+  });
+
+  test('notifies when trash is full', () => {
+    const pushNotification = jest.fn();
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        NotificationsContext.Provider,
+        { value: { notifications: {}, pushNotification, clearNotifications: () => {} } },
+        children,
+      );
+    const { result } = renderHook(() => useTrashState(), { wrapper });
+    for (let i = 0; i < TRASH_FULL_THRESHOLD; i += 1) {
+      act(() => {
+        result.current.moveToTrash({
+          id: `${i}`,
+          title: `App${i}`,
+          closedAt: Date.now(),
+        });
+      });
+    }
+    expect(pushNotification).not.toHaveBeenCalled();
+    act(() => {
+      result.current.moveToTrash({ id: 'x', title: 'AppX', closedAt: Date.now() });
+    });
+    expect(pushNotification).toHaveBeenCalledWith('trash', 'Trash is full');
   });
 });
 

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -16,6 +16,8 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     pushHistory,
     restoreFromHistory,
     restoreAllFromHistory,
+    restore: restoreItem,
+    empty: emptyTrash,
   } = useTrashState();
   const [selected, setSelected] = useState<number | null>(null);
   const [purgeDays, setPurgeDays] = useState(30);
@@ -48,10 +50,9 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     const item = items[selected];
     if (!window.confirm(`Restore ${item.title}?`)) return;
     openApp(item.id);
-    setItems(items => items.filter((_, i) => i !== selected));
+    restoreItem(selected);
     setSelected(null);
-    notifyChange();
-  }, [items, selected, openApp, setItems]);
+  }, [items, selected, openApp, restoreItem]);
 
   const remove = useCallback(() => {
     if (selected === null) return;
@@ -96,11 +97,9 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
       count -= 1;
       if (count <= 0) {
         clearInterval(timer);
-        pushHistory(items);
-        setItems([]);
+        emptyTrash();
         setSelected(null);
         setEmptyCountdown(null);
-        notifyChange();
       } else {
         setEmptyCountdown(count);
       }


### PR DESCRIPTION
## Summary
- add reusable moveToTrash, restore, and empty helpers to trash state
- wire Trash app to new helpers
- notify via tray when trash item count exceeds threshold

## Testing
- `yarn test __tests__/trashState.test.ts`
- `yarn lint apps/trash/state.ts apps/trash/index.tsx __tests__/trashState.test.ts` *(fails: Unexpected global 'document' in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48e507b88328a88384bfdcc62ade