### PR TITLE
feat: enhance App Finder with categories and favorites

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -269,7 +269,10 @@ const utilityList = [
   },
 ];
 
-export const utilities = utilityList;
+export const utilities = utilityList.map((app) => ({
+  ...app,
+  category: 'Utilities',
+}));
 
 // Default window sizing for games to prevent oversized frames
 export const gameDefaults = {
@@ -592,9 +595,13 @@ const gameList = [
   },
 ];
 
-export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
+export const games = gameList.map((game) => ({
+  ...gameDefaults,
+  ...game,
+  category: 'Games',
+}));
 
-const apps = [
+const mainApps = [
   {
     id: 'chrome',
     title: 'Google Chrome',
@@ -1051,9 +1058,11 @@ const apps = [
     desktop_shortcut: false,
     screen: displaySecurityTools,
   },
-  // Utilities are grouped separately
+];
+
+const apps = [
+  ...mainApps.map((app) => ({ ...app, category: 'Applications' })),
   ...utilities,
-  // Games are included so they appear alongside apps
   ...games,
 ];
 

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,10 +1,14 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
+import usePersistedState from '../../hooks/usePersistedState';
 
 const AppsPage = () => {
   const [apps, setApps] = useState([]);
   const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('All');
+  const [favorites, setFavorites] = usePersistedState('app-favorites', []);
+  const [history, setHistory] = usePersistedState('app-history', []);
 
   useEffect(() => {
     let isMounted = true;
@@ -18,12 +22,58 @@ const AppsPage = () => {
     };
   }, []);
 
-  const filteredApps = apps.filter(
+  const categories = useMemo(
+    () => ['All', 'Favorites', 'History', ...Array.from(new Set(apps.map((a) => a.category)))],
+    [apps],
+  );
+
+  const handleOpen = (id) => {
+    setHistory((prev) => {
+      const updated = [id, ...prev.filter((h) => h !== id)];
+      return updated.slice(0, 20);
+    });
+  };
+
+  const toggleFavorite = (id) => {
+    setFavorites((prev) =>
+      prev.includes(id) ? prev.filter((f) => f !== id) : [...prev, id],
+    );
+  };
+
+  let catFiltered;
+  if (category === 'Favorites') {
+    catFiltered = apps.filter((app) => favorites.includes(app.id));
+  } else if (category === 'History') {
+    catFiltered = history
+      .map((id) => apps.find((app) => app.id === id))
+      .filter(Boolean);
+  } else if (category === 'All') {
+    catFiltered = apps;
+  } else {
+    catFiltered = apps.filter((app) => app.category === category);
+  }
+
+  const filteredApps = catFiltered.filter(
     (app) => !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
   );
 
   return (
     <div className="p-4">
+      <label htmlFor="app-category" className="sr-only">
+        Filter by category
+      </label>
+      <select
+        id="app-category"
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        className="mb-4 w-full rounded border p-2"
+      >
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
       <label htmlFor="app-search" className="sr-only">
         Search apps
       </label>
@@ -41,24 +91,37 @@ const AppsPage = () => {
         className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
         {filteredApps.map((app) => (
-          <Link
-            key={app.id}
-            href={`/apps/${app.id}`}
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-            aria-label={app.title}
-          >
-            {app.icon && (
-              <Image
-                src={app.icon}
-                alt=""
-                width={64}
-                height={64}
-                sizes="64px"
-                className="h-16 w-16"
-              />
-            )}
-            <span className="mt-2">{app.title}</span>
-          </Link>
+          <div key={app.id} className="relative">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleFavorite(app.id);
+              }}
+              aria-label="Toggle favorite"
+              className="absolute right-1 top-1"
+            >
+              {favorites.includes(app.id) ? '★' : '☆'}
+            </button>
+            <Link
+              href={`/apps/${app.id}`}
+              onClick={() => handleOpen(app.id)}
+              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+              aria-label={app.title}
+            >
+              {app.icon && (
+                <Image
+                  src={app.icon}
+                  alt=""
+                  width={64}
+                  height={64}
+                  sizes="64px"
+                  className="h-16 w-16"
+                />
+              )}
+              <span className="mt-2">{app.title}</span>
+            </Link>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- categorize apps and link finder to registry
- add favorites and history filters to App Finder

## Testing
- `yarn lint` *(fails: Unexpected global 'document', missing display name)*
- `yarn test` *(fails: Window snapping finalize, NmapNSEApp copies output)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48e89738832893888e64a626b909