### PR TITLE
feat: add docs topic page and markdown seeds

### DIFF
--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { marked } from 'marked';
+import { useEffect } from 'react';
+
+interface TocItem {
+  id: string;
+  text: string;
+  depth: number;
+}
+
+interface DocProps {
+  html: string;
+  toc: TocItem[];
+}
+
+export default function DocPage({ html, toc }: DocProps) {
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash) {
+      const el = document.getElementById(window.location.hash.slice(1));
+      el?.scrollIntoView();
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col md:flex-row p-4">
+      <nav className="md:w-1/4 md:pr-4">
+        <ul>
+          {toc.map(({ id, text, depth }) => (
+            <li key={id} className={depth === 3 ? 'ml-4' : ''}>
+              <a href={`#${id}`}>{text}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const dir = path.join(process.cwd(), 'public', 'docs', 'seed');
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
+  return {
+    paths: files.map((name) => ({ params: { topic: name.replace(/\.md$/, '') } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<DocProps> = async ({ params }) => {
+  const topic = params?.topic as string;
+  const filePath = path.join(process.cwd(), 'public', 'docs', 'seed', `${topic}.md`);
+  const md = fs.readFileSync(filePath, 'utf8');
+  const tokens = marked.lexer(md);
+
+  const tocSlugger = new marked.Slugger();
+  const toc: TocItem[] = tokens
+    .filter((t) => t.type === 'heading' && (t as any).depth && ((t as any).depth === 2 || (t as any).depth === 3))
+    .map((t) => ({
+      id: tocSlugger.slug((t as any).text),
+      text: (t as any).text,
+      depth: (t as any).depth,
+    }));
+
+  const renderer = new marked.Renderer();
+  const renderSlugger = new marked.Slugger();
+  renderer.heading = (text, level) => {
+    const id = renderSlugger.slug(text);
+    return `<h${level} id="${id}">${text}</h${level}>`;
+  };
+
+  const html = marked.parse(md, { renderer }) as string;
+  return { props: { html, toc } };
+};

--- a/public/docs/seed/branches.md
+++ b/public/docs/seed/branches.md
@@ -1,0 +1,16 @@
+# Branches
+
+Working with Git branches.
+
+## Creating a Branch
+
+```bash
+git checkout -b feature
+```
+
+## Merging
+
+```bash
+git checkout main
+git merge feature
+```

--- a/public/docs/seed/installation.md
+++ b/public/docs/seed/installation.md
@@ -1,0 +1,15 @@
+# Installation
+
+Set up the environment and install dependencies.
+
+## Requirements
+
+- Node.js
+- Yarn
+
+## Steps
+
+```bash
+yarn install
+yarn dev
+```

--- a/public/docs/seed/introduction.md
+++ b/public/docs/seed/introduction.md
@@ -1,0 +1,12 @@
+# Introduction
+
+Welcome to the documentation.
+
+## Getting Started
+
+This section introduces the project and how to begin.
+
+## Features
+
+- Simple examples
+- Clear explanations

--- a/public/docs/seed/repos.md
+++ b/public/docs/seed/repos.md
@@ -1,0 +1,15 @@
+# Repos
+
+Managing repositories.
+
+## Cloning
+
+```bash
+git clone https://example.com/repo.git
+```
+
+## Updating
+
+```bash
+git pull
+```

--- a/public/docs/seed/virtualization.md
+++ b/public/docs/seed/virtualization.md
@@ -1,0 +1,12 @@
+# Virtualization
+
+An overview of virtualization concepts.
+
+## What is Virtualization?
+
+Virtualization allows multiple systems to run on a single physical machine.
+
+## Tools
+
+- VirtualBox
+- VMware


### PR DESCRIPTION
## Summary
- add markdown seeds for intro, installation, virtualization, branches and repos
- implement dynamic docs topic page with TOC and anchors

## Testing
- `npx eslint pages/docs/[topic].tsx`
- `yarn test` *(fails: Test Suites: 3 failed, 3 skipped, 46 passed, 49 of 147 total)*


------
https://chatgpt.com/codex/tasks/task_e_68ba5f4804cc8328ae409e878219a7d6