### PR TITLE
feat: add tour carousel

### DIFF
--- a/components/welcome/TourCarousel.tsx
+++ b/components/welcome/TourCarousel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import slidesData from "@/content/kali-tour.json";
+
+interface Slide {
+  title: string;
+  description: string;
+}
+
+const slides: Slide[] = slidesData as Slide[];
+
+export default function TourCarousel() {
+  const [index, setIndex] = useState(0);
+  const liveRef = useRef<HTMLDivElement>(null);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowRight") {
+      setIndex((i) => (i + 1) % slides.length);
+    } else if (e.key === "ArrowLeft") {
+      setIndex((i) => (i - 1 + slides.length) % slides.length);
+    }
+  };
+
+  useEffect(() => {
+    if (liveRef.current) {
+      liveRef.current.textContent = slides[index].title;
+    }
+  }, [index]);
+
+  return (
+    <div
+      tabIndex={0}
+      onKeyDown={handleKey}
+      aria-roledescription="carousel"
+      aria-label="Kali Linux tour"
+      className="flex flex-col items-center"
+    >
+      <div ref={liveRef} aria-live="polite" className="sr-only" />
+      <h2 className="text-xl font-bold">{slides[index].title}</h2>
+      <p className="mt-2 text-center max-w-lg">{slides[index].description}</p>
+      <div className="mt-4 text-sm text-gray-500">
+        {index + 1} / {slides.length}
+      </div>
+    </div>
+  );
+}

--- a/content/kali-tour.json
+++ b/content/kali-tour.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "Xfce Desktop",
+    "description": "Explore Kali Linux's default Xfce desktop environment."
+  },
+  {
+    "title": "Undercover Mode",
+    "description": "Blend in by switching to the Windows-like undercover mode."
+  },
+  {
+    "title": "Tools Library",
+    "description": "Access the extensive collection of security tools." 
+  },
+  {
+    "title": "Metapackages",
+    "description": "Install predefined sets of tools via metapackages." 
+  },
+  {
+    "title": "Mirrors",
+    "description": "Select mirrors for efficient package downloads." 
+  }
+]


### PR DESCRIPTION
## Summary
- add kali tour slide data
- introduce TourCarousel component with keyboard and screen reader support

## Testing
- `npx eslint components/welcome/TourCarousel.tsx`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f4837c08328be07253fcd5536ad