### PR TITLE
Add blog feed component with cached Kali posts

### DIFF
--- a/components/kali/BlogFeed.tsx
+++ b/components/kali/BlogFeed.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import posts from '../../data/kali-blog.json';
+
+interface Post {
+  title: string;
+  link: string;
+  date: string;
+}
+
+const BlogFeed: React.FC = () => {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {posts.slice(0, 6).map((post: Post) => (
+        <div
+          key={post.link}
+          className="flex flex-col p-4 rounded bg-gray-800 text-white"
+        >
+          <h3 className="text-lg font-semibold">{post.title}</h3>
+          <p className="text-sm text-gray-400">
+            {new Date(post.date).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
+          </p>
+          <a
+            href={post.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-auto text-sm text-blue-400 hover:underline"
+          >
+            Read on kali.org ↗
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BlogFeed;

--- a/data/kali-blog.json
+++ b/data/kali-blog.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Kali Vagrant Rebuilt: Out With Packer, In With DebOS",
+    "link": "https://www.kali.org/blog/kali-vagrant-rebuilt/",
+    "date": "2025-08-21"
+  },
+  {
+    "title": "Kali Linux & Containerization (Apple's Container)",
+    "link": "https://www.kali.org/blog/kali-apple-container-containerization/",
+    "date": "2025-07-29"
+  },
+  {
+    "title": "The Raspberry Pi's Wi-Fi Glow-Up",
+    "link": "https://www.kali.org/blog/raspberry-pi-wi-fi-glow-up/",
+    "date": "2025-07-22"
+  },
+  {
+    "title": "Kali Linux 2025.2 Release (Kali Menu Refresh, BloodHound CE & CARsenal)",
+    "link": "https://www.kali.org/blog/kali-linux-2025-2-release/",
+    "date": "2025-06-13"
+  },
+  {
+    "title": "A New Kali Linux Archive Signing Key",
+    "link": "https://www.kali.org/blog/new-kali-archive-signing-key/",
+    "date": "2025-04-28"
+  },
+  {
+    "title": "Kali Linux 2025.1a Release (2025 Theme, & Raspberry Pi)",
+    "link": "https://www.kali.org/blog/kali-linux-2025-1-release/",
+    "date": "2025-03-19"
+  }
+]


### PR DESCRIPTION
## Summary
- add cached JSON for recent Kali blog posts
- implement `BlogFeed` component to render six post cards with links to kali.org

## Testing
- `yarn lint components/kali/BlogFeed.tsx data/kali-blog.json` (fails: Unexpected global 'document' etc.)
- `yarn test` (fails: `window.test.tsx`, `nmapNse.test.tsx`)


------
https://chatgpt.com/codex/tasks/task_e_68ba5f48823883288b539c587eb6b6d6