### PR TITLE
feat: add apt sources help component

### DIFF
--- a/components/kali/AptSourcesHelp.tsx
+++ b/components/kali/AptSourcesHelp.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import WarningBanner from '../WarningBanner';
+
+export default function AptSourcesHelp() {
+  return (
+    <div className="space-y-2 text-sm">
+      <p>
+        Add the official Kali repository to{' '}
+        <code>/etc/apt/sources.list</code>:
+      </p>
+      <pre className="bg-gray-800 text-green-400 p-2 rounded font-mono overflow-x-auto">
+        deb http://http.kali.org/kali kali-rolling main contrib non-free non-free-firmware
+      </pre>
+      <WarningBanner>
+        Adding unofficial, Debian, or third-party repositories can break your
+        system or introduce security risks. Only use official Kali Linux
+        sources.
+      </WarningBanner>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add AptSourcesHelp component showing official Kali repo entry
- warn against adding unofficial repositories

## Testing
- `npx eslint components/kali/AptSourcesHelp.tsx`
- `yarn test components/kali/AptSourcesHelp.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f49b58c832885b99cb92618cc39