### PR TITLE
Add FAQ page with mirror info and dropdown mock

### DIFF
--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const FaqPage: React.FC = () => {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">FAQ</h1>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">How does automatic mirror selection work?</h2>
+        <p>
+          We automatically redirect your downloads to the nearest and fastest mirror based on your
+          location. This ensures quicker downloads and a more reliable connection.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Are the mirrors up to date?</h2>
+        <p>
+          Yes. Mirrors are checked regularly and synced with the official Kali Linux repositories so
+          you always receive the latest packages and images.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Choose mirror</h2>
+        <select
+          disabled
+          className="border rounded p-2 bg-gray-100 text-gray-700"
+          defaultValue="automatic"
+        >
+          <option value="automatic">Automatic (recommended)</option>
+          <option value="mirror-1">Mirror 1</option>
+          <option value="mirror-2">Mirror 2</option>
+        </select>
+        <p className="text-sm text-gray-500 mt-1">Manual mirror selection coming soon.</p>
+      </section>
+    </div>
+  );
+};
+
+export default FaqPage;


### PR DESCRIPTION
## Summary
- add /faq page detailing automatic mirror redirection and mirror freshness
- include disabled “Choose mirror” dropdown placeholder

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js; component display name missing in utils/createDynamicApp.js)*
- `CI=true yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f49f5e08328a6391a966a5ec195