### PR TITLE
feat: add tool category filters

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -735,6 +735,7 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
+    categories: ['bluetooth'],
     screen: displayBleSensor,
   },
   {
@@ -807,6 +808,7 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
+    categories: ['802-11'],
     screen: displayKismet,
   },
   {
@@ -860,6 +862,7 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
+    categories: ['reverse-engineering'],
     screen: displayGhidra,
   },
   {
@@ -968,6 +971,7 @@ const apps = [
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
+    categories: ['reverse-engineering'],
     screen: displayRadare2,
   },
   {

--- a/data/metapackages.json
+++ b/data/metapackages.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "802-11",
+    "title": "802.11",
+    "description": "Wireless 802.11 assessment tools",
+    "link": "https://www.kali.org/tools/?kali-tools-802-11"
+  },
+  {
+    "id": "bluetooth",
+    "title": "Bluetooth",
+    "description": "Tools for Bluetooth exploration and testing",
+    "link": "https://www.kali.org/tools/?kali-tools-bluetooth"
+  },
+  {
+    "id": "reverse-engineering",
+    "title": "Reverse Engineering",
+    "description": "Utilities for reverse engineering binaries and software",
+    "link": "https://www.kali.org/tools/?kali-tools-reverse-engineering"
+  }
+]
+

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,10 +1,22 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
 
 const AppsPage = () => {
   const [apps, setApps] = useState([]);
   const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('');
+
+  const CATEGORY_LABELS = {
+    '802-11': '802.11',
+    bluetooth: 'Bluetooth',
+    'reverse-engineering': 'Reverse Engineering',
+  };
+
+  const categories = useMemo(
+    () => Array.from(new Set(apps.flatMap((a) => a.categories || []))),
+    [apps],
+  );
 
   useEffect(() => {
     let isMounted = true;
@@ -19,7 +31,10 @@ const AppsPage = () => {
   }, []);
 
   const filteredApps = apps.filter(
-    (app) => !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
+    (app) =>
+      !app.disabled &&
+      app.title.toLowerCase().includes(query.toLowerCase()) &&
+      (!category || (app.categories || []).includes(category)),
   );
 
   return (
@@ -35,6 +50,27 @@ const AppsPage = () => {
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
       />
+      <div className="mb-4 flex flex-wrap gap-2">
+        <button
+          onClick={() => setCategory('')}
+          className={`px-2 py-1 rounded ${
+            category === '' ? 'bg-blue-600 text-white' : 'bg-gray-200'
+          }`}
+        >
+          All
+        </button>
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setCategory(cat)}
+            className={`px-2 py-1 rounded ${
+              category === cat ? 'bg-blue-600 text-white' : 'bg-gray-200'
+            }`}
+          >
+            {CATEGORY_LABELS[cat] || cat}
+          </button>
+        ))}
+      </div>
       <div
         id="app-grid"
         tabIndex="-1"
@@ -58,6 +94,21 @@ const AppsPage = () => {
               />
             )}
             <span className="mt-2">{app.title}</span>
+            {app.categories && (
+              <div className="mt-2 flex flex-wrap justify-center gap-1">
+                {app.categories.map((cat) => (
+                  <Link
+                    key={cat}
+                    href={`/metapackages/${cat}`}
+                    className={`px-2 py-0.5 text-xs rounded ${
+                      category === cat ? 'bg-blue-600 text-white' : 'bg-gray-200'
+                    }`}
+                  >
+                    {CATEGORY_LABELS[cat] || cat}
+                  </Link>
+                ))}
+              </div>
+            )}
           </Link>
         ))}
       </div>

--- a/pages/metapackages/[id].tsx
+++ b/pages/metapackages/[id].tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import meta from '../../data/metapackages.json';
+
+const MetapackageInfo = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  if (!id || Array.isArray(id)) return null;
+  const pack = (meta as any[]).find((m) => m.id === id);
+  if (!pack) {
+    return <p className="p-4">Metapackage not found.</p>;
+  }
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">{pack.title}</h1>
+      <p>{pack.description}</p>
+      <Link
+        href={pack.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline text-blue-500"
+      >
+        Official package list
+      </Link>
+    </div>
+  );
+};
+
+export default MetapackageInfo;
+


### PR DESCRIPTION
## Summary
- add category filters and legends to app listings
- include Bluetooth, 802.11 and reverse engineering metapackage data
- create metapackage info page for category links

## Testing
- `./node_modules/.bin/eslint pages/apps/index.jsx "pages/metapackages/[id].tsx" apps.config.js`
- `yarn test pages/apps/index.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f4a5f288328b3d094bf7f756140