### PR TITLE
feat: add undercover theme

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -23,7 +23,9 @@ describe('theme persistence and unlocking', () => {
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['default', 'undercover', 'neon', 'dark'])
+    );
     expect(unlocked).not.toContain('matrix');
   });
 

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,9 +1,16 @@
 import Image from 'next/image';
+import { useSettings } from '../hooks/useSettings';
+
+const iconPath = (theme: string, name: string) =>
+  theme === 'undercover'
+    ? `/themes/Undercover/window/${name}.svg`
+    : `/themes/Yaru/window/${name}-symbolic.svg`;
 
 export function CloseIcon() {
+  const { theme } = useSettings();
   return (
     <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
+      src={iconPath(theme, 'window-close')}
       alt="Close"
       width={16}
       height={16}
@@ -12,9 +19,10 @@ export function CloseIcon() {
 }
 
 export function MinimizeIcon() {
+  const { theme } = useSettings();
   return (
     <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
+      src={iconPath(theme, 'window-minimize')}
       alt="Minimize"
       width={16}
       height={16}
@@ -23,9 +31,10 @@ export function MinimizeIcon() {
 }
 
 export function MaximizeIcon() {
+  const { theme } = useSettings();
   return (
     <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
+      src={iconPath(theme, 'window-maximize')}
       alt="Maximize"
       width={16}
       height={16}
@@ -34,9 +43,10 @@ export function MaximizeIcon() {
 }
 
 export function RestoreIcon() {
+  const { theme } = useSettings();
   return (
     <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
+      src={iconPath(theme, 'window-restore')}
       alt="Restore"
       width={16}
       height={16}
@@ -45,9 +55,10 @@ export function RestoreIcon() {
 }
 
 export function PinIcon() {
+  const { theme } = useSettings();
   return (
     <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
+      src={iconPath(theme, 'window-pin')}
       alt="Pin"
       width={16}
       height={16}

--- a/components/UndercoverToggle.tsx
+++ b/components/UndercoverToggle.tsx
@@ -1,0 +1,21 @@
+"use client";
+import Image from 'next/image';
+import { useSettings } from '../hooks/useSettings';
+
+export default function UndercoverToggle() {
+  const { theme, setTheme } = useSettings();
+  const active = theme === 'undercover';
+  const icon = '/themes/Undercover/windows-logo.svg';
+
+  return (
+    <button
+      type="button"
+      title="Undercover mode disguises the desktop to look like Windows"
+      aria-label="Undercover mode"
+      onClick={() => setTheme(active ? 'default' : 'undercover')}
+      className="focus:outline-none"
+    >
+      <Image src={icon} alt="Undercover" width={16} height={16} />
+    </button>
+  );
+}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import UndercoverToggle from '../UndercoverToggle';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -15,6 +16,9 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <div className="pl-3 pr-1">
+                                        <UndercoverToggle />
+                                </div>
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -15,7 +15,7 @@ class MyDocument extends Document {
     return (
       <Html lang="en" data-csp-nonce={nonce}>
         <Head>
-          <link rel="icon" href="/favicon.ico" />
+          <link rel="icon" href="/favicon.svg" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -16,6 +16,7 @@ function Toggle({
     <button
       type="button"
       role="switch"
+      aria-label="toggle"
       aria-checked={checked}
       onClick={() => onChange(!checked)}
       className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
@@ -55,11 +56,13 @@ export default function ThemeSettings() {
       <div className="flex-1 p-4 overflow-y-auto">
         <h1 className="text-xl mb-4">Theme</h1>
         <select
+          aria-label="Theme"
           value={theme}
           onChange={handleChange}
           className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
         >
           <option value="default">Default</option>
+          <option value="undercover">Undercover</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/public/favicon-undercover.svg
+++ b/public/favicon-undercover.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect x="0" y="0" width="30" height="30" fill="#0078d7"/>
+  <rect x="34" y="0" width="30" height="30" fill="#0078d7"/>
+  <rect x="0" y="34" width="30" height="30" fill="#0078d7"/>
+  <rect x="34" y="34" width="30" height="30" fill="#0078d7"/>
+</svg>

--- a/public/themes/Undercover/window/window-close.svg
+++ b/public/themes/Undercover/window/window-close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path stroke="#000" stroke-width="2" d="M4 4l8 8m0-8l-8 8"/>
+</svg>

--- a/public/themes/Undercover/window/window-maximize.svg
+++ b/public/themes/Undercover/window/window-maximize.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect x="3" y="3" width="10" height="10" fill="none" stroke="#000" stroke-width="2"/>
+</svg>

--- a/public/themes/Undercover/window/window-minimize.svg
+++ b/public/themes/Undercover/window/window-minimize.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path stroke="#000" stroke-width="2" d="M3 8h10"/>
+</svg>

--- a/public/themes/Undercover/window/window-pin.svg
+++ b/public/themes/Undercover/window/window-pin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="#000">
+  <path d="M16 9V4h-1V2H9v2H8v5L5 12v2h6v7l1 1 1-1v-7h6v-2l-3-3Z"/>
+</svg>

--- a/public/themes/Undercover/window/window-restore.svg
+++ b/public/themes/Undercover/window/window-restore.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path fill="none" stroke="#000" stroke-width="2" d="M5 5h8v6h-8z"/>
+  <path fill="none" stroke="#000" stroke-width="2" d="M3 7v6h8"/>
+</svg>

--- a/public/themes/Undercover/windows-logo.svg
+++ b/public/themes/Undercover/windows-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect x="0" y="0" width="7" height="7" fill="#0078d7"/>
+  <rect x="9" y="0" width="7" height="7" fill="#0078d7"/>
+  <rect x="0" y="9" width="7" height="7" fill="#0078d7"/>
+  <rect x="9" y="9" width="7" height="7" fill="#0078d7"/>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,21 @@ html[data-theme='matrix'] {
 
 }
 
+/* Undercover theme mimicking Windows colors */
+html[data-theme='undercover'] {
+  --color-bg: #f3f3f3;
+  --color-text: #000000;
+  --color-primary: #0078d7;
+  --color-secondary: #e5e5e5;
+  --color-accent: #0078d7;
+  --color-muted: #cccccc;
+  --color-surface: #ffffff;
+  --color-inverse: #ffffff;
+  --color-border: #d0d0d0;
+  --color-terminal: #00ff00;
+  --color-dark: #e5e5e5;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,6 +3,7 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  undercover: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,
@@ -33,6 +34,13 @@ export const setTheme = (theme: string): void => {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    const link = document.querySelector("link[rel='icon']");
+    if (link) {
+      link.setAttribute(
+        'href',
+        theme === 'undercover' ? '/favicon-undercover.svg' : '/favicon.svg'
+      );
+    }
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- add Windows-style Undercover theme and favicon
- include Undercover toggle with tooltip and Windows-like toolbar icons
- allow selecting Undercover theme in settings and update favicon on switch

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*
- `npx eslint components/UndercoverToggle.tsx components/screen/navbar.js components/ToolbarIcons.tsx styles/globals.css pages/ui/settings/theme.tsx utils/theme.ts __tests__/themePersistence.test.ts pages/_document.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f4b342c83289ea6aa41de3bb3b5