### PR TITLE
Add resource stacked bars with uptime tooltips

### DIFF
--- a/components/apps/resource_bars.tsx
+++ b/components/apps/resource_bars.tsx
@@ -1,0 +1,78 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+interface Info {
+  cpuPercent: number;
+  ramPercent: number;
+  swapPercent: number;
+  uptime: number;
+  descriptions: Record<string, string>;
+}
+
+const formatUptime = (secs: number) => {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = Math.floor(secs % 60);
+  return `${h}h ${m}m ${s}s`;
+};
+
+const Bar = ({ label, percent, color, desc, uptime }: { label: string; percent: number; color: string; desc: string; uptime: number; }) => (
+  <div className="w-full mb-4">
+    <div className="flex justify-between mb-1">
+      <span>{label}</span>
+      <span>{percent.toFixed(1)}%</span>
+    </div>
+    <div
+      className="h-4 w-full flex bg-ub-dark-grey"
+      title={`Uptime: ${formatUptime(uptime)}\n${desc}`}
+    >
+      <div
+        className="h-full"
+        style={{
+          width: `${percent}%`,
+          backgroundColor: color,
+          transition: 'width 2s',
+        }}
+      />
+      <div className="h-full flex-1" />
+    </div>
+  </div>
+);
+
+export default function ResourceBars() {
+  const [info, setInfo] = useState<Info>({
+    cpuPercent: 0,
+    ramPercent: 0,
+    swapPercent: 0,
+    uptime: 0,
+    descriptions: { cpu: '', ram: '', swap: '' },
+  });
+
+  useEffect(() => {
+    let handle: NodeJS.Timeout;
+    const fetchInfo = async () => {
+      try {
+        const res = await fetch('/api/system');
+        const json = await res.json();
+        setInfo(json);
+      } catch {
+        /* ignore */
+      }
+    };
+    fetchInfo();
+    handle = setInterval(fetchInfo, 2000);
+    return () => clearInterval(handle);
+  }, []);
+
+  return (
+    <div className="p-4 text-white font-ubuntu">
+      <Bar label="CPU" percent={info.cpuPercent} color="#00ff00" desc={info.descriptions.cpu} uptime={info.uptime} />
+      <Bar label="RAM" percent={info.ramPercent} color="#ffd700" desc={info.descriptions.ram} uptime={info.uptime} />
+      <Bar label="Swap" percent={info.swapPercent} color="#ff00ff" desc={info.descriptions.swap} uptime={info.uptime} />
+    </div>
+  );
+}
+
+export const displayResourceBars = (addFolder: any, openApp: any) => (
+  <ResourceBars addFolder={addFolder} openApp={openApp} />
+);

--- a/pages/api/system.js
+++ b/pages/api/system.js
@@ -1,0 +1,38 @@
+import os from 'os';
+import fs from 'fs';
+
+export default function handler(req, res) {
+  const uptime = os.uptime();
+  const totalMem = os.totalmem();
+  const freeMem = os.freemem();
+  const usedMem = totalMem - freeMem;
+
+  let swapTotal = 0;
+  let swapFree = 0;
+  try {
+    const meminfo = fs.readFileSync('/proc/meminfo', 'utf8');
+    const totalMatch = meminfo.match(/SwapTotal:\s+(\d+) kB/);
+    const freeMatch = meminfo.match(/SwapFree:\s+(\d+) kB/);
+    if (totalMatch) swapTotal = parseInt(totalMatch[1], 10) * 1024;
+    if (freeMatch) swapFree = parseInt(freeMatch[1], 10) * 1024;
+  } catch {
+    /* ignore */
+  }
+  const swapUsed = swapTotal - swapFree;
+
+  const load = os.loadavg()[0];
+  const cpuCount = os.cpus().length || 1;
+  const cpuPercent = Math.min(100, (load / cpuCount) * 100);
+
+  res.status(200).json({
+    uptime,
+    cpuPercent,
+    ramPercent: (usedMem / totalMem) * 100,
+    swapPercent: swapTotal ? (swapUsed / swapTotal) * 100 : 0,
+    descriptions: {
+      cpu: 'Plugin: CPU monitor - displays server load',
+      ram: 'Plugin: RAM monitor - tracks memory usage',
+      swap: 'Plugin: Swap monitor - tracks swap usage',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- expose system API returning CPU, RAM, swap percentages with uptime and plugin-style descriptions
- add ResourceBars component rendering animated stacked bars with descriptive tooltips

## Testing
- `npx eslint components/apps/resource_bars.tsx pages/api/system.js`
- `npx jest resource_bars`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f4f74308328b221b36806480cc8