### PR TITLE
Add power mode selection to status menu

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -12,6 +12,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [mode, setMode] = usePersistentState('qs-mode', 'balanced');
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -43,6 +44,21 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      </div>
+      <div className="px-4 pb-2 flex items-center justify-between">
+        <span>Mode</span>
+        <div className="flex items-center gap-1">
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+            className="bg-ub-dark-grey text-white text-sm rounded"
+          >
+            <option value="performance">Performance</option>
+            <option value="balanced">Balanced</option>
+            <option value="powersave">Powersave</option>
+          </select>
+          <span className="text-xs text-ubt-grey">MHz</span>
+        </div>
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import usePersistentState from '../../hooks/usePersistentState';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const [mode] = usePersistentState('qs-mode', 'balanced');
 
   useEffect(() => {
     const pingServer = async () => {
@@ -38,6 +40,12 @@ export default function Status() {
     };
   }, []);
 
+  const modeIcon = {
+    performance: '/themes/Yaru/status/power-profile-performance-symbolic.svg',
+    balanced: '/themes/Yaru/status/power-profile-balanced-symbolic.svg',
+    powersave: '/themes/Yaru/status/power-profile-power-save-symbolic.svg',
+  }[mode];
+
   return (
     <div className="flex justify-center items-center">
       <span
@@ -55,6 +63,16 @@ export default function Status() {
         {!allowNetwork && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
+      </span>
+      <span className="mx-1.5">
+        <Image
+          width={16}
+          height={16}
+          src={modeIcon}
+          alt={mode}
+          className="inline status-symbol w-4 h-4"
+          sizes="16px"
+        />
       </span>
       <span className="mx-1.5">
         <Image

--- a/public/themes/Yaru/status/power-profile-balanced-symbolic.svg
+++ b/public/themes/Yaru/status/power-profile-balanced-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <rect x="2" y="7" width="12" height="2"/>
+</svg>

--- a/public/themes/Yaru/status/power-profile-performance-symbolic.svg
+++ b/public/themes/Yaru/status/power-profile-performance-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <path d="M8 2L14 14H2L8 2z"/>
+</svg>

--- a/public/themes/Yaru/status/power-profile-power-save-symbolic.svg
+++ b/public/themes/Yaru/status/power-profile-power-save-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <path d="M2 2h12L8 14 2 2z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add persistent power mode selector with Performance/Balanced/Powersave options and MHz label
- show current power mode with corresponding icon in status bar

## Testing
- `yarn lint components/ui/QuickSettings.tsx components/util-components/status.js` *(fails: unexpected global 'document' etc.)*
- `yarn test` *(fails: window.snap test and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f4f0d8c832886f8127b0f2dcbc5