### PR TITLE
feat: add disk mount selector

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,12 +5,12 @@ import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor(props) {
+                super(props);
+                this.state = {
+                        status_card: false
+                };
+        }
 
 	render() {
 		return (
@@ -49,7 +49,7 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings open={this.state.status_card} openApp={this.props.openApp} />
                                 </button>
 			</div>
 		);

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -9,15 +9,16 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.desktopRef = React.createRef();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+        }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -105,8 +106,12 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', true);
 	};
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        openApp = (id) => {
+                this.desktopRef.current?.openApp(id);
+        };
+
+        turnOn = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		this.setState({ shutDownScreen: false, booting_screen: true });
 		this.setTimeOutBootScreen();
@@ -126,9 +131,9 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Navbar openApp={this.openApp} lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop ref={this.desktopRef} bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                        </div>
+                );
+        }
 }

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -5,13 +5,36 @@ import { useEffect } from 'react';
 
 interface Props {
   open: boolean;
+  openApp?: (id: string) => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const DiskIcon = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    width="16"
+    height="16"
+    className={className}
+  >
+    <path d="M2 0h12l2 2v14H0V0h2zm5 3v4h2V3H7zm5-1H4v5h8V2z" />
+  </svg>
+);
+
+const QuickSettings = ({ open, openApp }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [mount, setMount] = usePersistentState<'/' | '/home'>('qs-mount', '/');
+
+  const usage = mount === '/' ? 82 : 95; // simulate usage for mounts
+  const level = usage >= 90 ? 'urgent' : usage >= 80 ? 'warning' : 'normal';
+  const color =
+    level === 'urgent'
+      ? 'text-red-500'
+      : level === 'warning'
+      ? 'text-yellow-400'
+      : 'text-green-400';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -43,6 +66,26 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      </div>
+      <div className="px-4 pb-2 flex justify-between items-center">
+        <div className="flex items-center">
+          <DiskIcon className={`w-4 h-4 ${color}`} />
+          <select
+            aria-label="Select mount"
+            className="ml-2 bg-ub-grey text-white"
+            value={mount}
+            onChange={(e) => setMount(e.target.value as '/' | '/home')}
+          >
+            <option value="/">/</option>
+            <option value="/home">/home</option>
+          </select>
+        </div>
+        <button
+          className="text-ubt-blue underline"
+          onClick={() => openApp?.('file-explorer')}
+        >
+          Open
+        </button>
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>


### PR DESCRIPTION
## Summary
- add QuickSettings mount dropdown with simulated disk usage color thresholds
- allow opening Files app from QuickSettings
- wire Navbar and Ubuntu to pass openApp into QuickSettings

## Testing
- `yarn test QuickSettings --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f53b8788328b122a4b053d4aff6