### PR TITLE
feat: add randomized IOPS bar

### DIFF
--- a/apps/resource-monitor/components/IOPSBar.tsx
+++ b/apps/resource-monitor/components/IOPSBar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+export default function IOPSBar() {
+  const [read, setRead] = useState(0);
+  const [write, setWrite] = useState(0);
+
+  useEffect(() => {
+    const update = () => {
+      setRead(Math.floor(Math.random() * 1000));
+      setWrite(Math.floor(Math.random() * 1000));
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const total = read + write || 1;
+  const readPct = (read / total) * 100;
+  const writePct = (write / total) * 100;
+
+  return (
+    <div className="w-full max-w-sm" title="Read/Write last 10s">
+      <div className="flex h-4 w-full bg-gray-700">
+        <div
+          className="bg-green-500"
+          style={{ width: `${readPct}%` }}
+        />
+        <div
+          className="bg-blue-500"
+          style={{ width: `${writePct}%` }}
+        />
+      </div>
+      <div className="mt-1 flex justify-between text-xs text-white">
+        <span>Read: {read} IOPS</span>
+        <span>Write: {write} IOPS</span>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -2,10 +2,14 @@
 
 import React from 'react';
 import NetworkInsights from './components/NetworkInsights';
+import IOPSBar from './components/IOPSBar';
 
 export default function ResourceMonitorApp() {
   return (
-    <div className="h-full w-full bg-ub-cool-grey overflow-auto">
+    <div className="h-full w-full bg-ub-cool-grey overflow-auto p-2">
+      <div className="mb-4 flex justify-center">
+        <IOPSBar />
+      </div>
       <NetworkInsights />
     </div>
   );


### PR DESCRIPTION
## Summary
- add client-side IOPSBar with random read/write stats and tooltip
- integrate IOPSBar into resource monitor app

## Testing
- `npx eslint apps/resource-monitor/index.tsx apps/resource-monitor/components/IOPSBar.tsx`
- `yarn test apps/resource-monitor` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f54377c8328a243d3dda472299e