### PR TITLE
Add expression evaluation to Input Lab

### DIFF
--- a/__tests__/inputLab.test.tsx
+++ b/__tests__/inputLab.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InputLab from '../apps/input-lab';
+
+describe('InputLab expression evaluation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('evaluates expressions with functions and operators', () => {
+    render(<InputLab />);
+    const input = screen.getByLabelText('Text');
+    fireEvent.change(input, { target: { value: 'sqrt(9) + sin(pi / 2)' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(input).toHaveValue('4');
+    expect(screen.queryByText('Invalid expression')).toBeNull();
+  });
+
+  test('shows error for invalid input', () => {
+    render(<InputLab />);
+    const input = screen.getByLabelText('Text');
+    fireEvent.change(input, { target: { value: '2++' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(screen.getByText('Invalid expression')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- evaluate expressions with + - * / ^, sqrt(), sin(), and pi
- show calculation result on Enter and inline error for invalid input

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `yarn test __tests__/inputLab.test.tsx`
- `npx eslint apps/input-lab/index.tsx __tests__/inputLab.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f576ce883288aa4dec26b17cc23