### PR TITLE
Add launcher search modal with dock drag‑and‑drop pinning

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,7 +7,13 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (e) => {
+        try {
+            e.dataTransfer.setData('app-id', this.props.id);
+            e.dataTransfer.effectAllowed = 'copy';
+        } catch (err) {
+            // ignore drag errors
+        }
         this.setState({ dragging: true });
     }
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -19,6 +19,7 @@ import DefaultMenu from '../context-menus/default';
 import AppMenu from '../context-menus/app-menu';
 import Taskbar from './taskbar';
 import TaskbarMenu from '../context-menus/taskbar-menu';
+import SearchModal from '../screen/search-modal';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
@@ -51,6 +52,7 @@ export class Desktop extends Component {
             showNameBar: false,
             showShortcutSelector: false,
             showWindowSwitcher: false,
+            showSearchModal: false,
             switcherWindows: [],
         }
     }
@@ -162,6 +164,10 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if ((e.ctrlKey || e.metaKey) && e.key === ' ') {
+            e.preventDefault();
+            this.openSearchModal();
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
@@ -207,6 +213,14 @@ export class Desktop extends Component {
         let index = windows.indexOf(currentId);
         let next = (index + direction + windows.length) % windows.length;
         this.focus(windows[next]);
+    }
+
+    openSearchModal = () => {
+        this.setState({ showSearchModal: true });
+    }
+
+    closeSearchModal = () => {
+        this.setState({ showSearchModal: false });
     }
 
     openWindowSwitcher = () => {
@@ -823,7 +837,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -874,7 +888,8 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     focused_windows={this.state.focused_windows}
                     isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
+                    openAppByAppId={this.openApp}
+                    pinApp={this.pinApp} />
 
                 {/* Taskbar */}
                 <Taskbar
@@ -950,6 +965,11 @@ export class Desktop extends Component {
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                { this.state.showSearchModal ?
+                    <SearchModal registry={apps}
+                        openApp={this.openApp}
+                        close={this.closeSearchModal} /> : null}
 
             </main>
         )

--- a/components/screen/search-modal.js
+++ b/components/screen/search-modal.js
@@ -1,0 +1,63 @@
+import React, { useState, useEffect, useRef } from 'react';
+import UbuntuApp from '../base/ubuntu_app';
+
+export default function SearchModal({ registry = [], openApp, close }) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState(registry);
+    const inputRef = useRef(null);
+
+    useEffect(() => {
+        inputRef.current?.focus();
+        const onKey = (e) => {
+            if (e.key === 'Escape') {
+                close();
+            }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [close]);
+
+    useEffect(() => {
+        const lower = query.toLowerCase();
+        setResults(
+            registry.filter((app) => app.title.toLowerCase().includes(lower))
+        );
+    }, [query, registry]);
+
+    const handleBackground = (e) => {
+        if (e.target === e.currentTarget) close();
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95"
+            onClick={handleBackground}
+        >
+            <input
+                ref={inputRef}
+                className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                placeholder="Search"
+                aria-label="Search applications"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+            />
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
+                {results.map((app) => (
+                    <UbuntuApp
+                        key={app.id}
+                        name={app.title}
+                        id={app.id}
+                        icon={app.icon}
+                        disabled={app.disabled}
+                        prefetch={app.screen?.prefetch}
+                        openApp={(id) => {
+                            if (typeof openApp === 'function') openApp(id);
+                            close();
+                        }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -25,12 +25,26 @@ export default function SideBar(props) {
         }, 2000);
     }
 
+    const handleDragOver = (e) => {
+        e.preventDefault();
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        const id = e.dataTransfer.getData('app-id');
+        if (id && typeof props.pinApp === 'function') {
+            props.pinApp(id);
+        }
+    };
+
     return (
         <>
             <nav
                 aria-label="Dock"
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-60 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (


### PR DESCRIPTION
## Summary
- add modal to search menu registry entries and open apps
- enable dragging search results onto dock to pin new launchers
- wire ctrl+space shortcut and dock drop handler into desktop

## Testing
- `npx eslint components/base/ubuntu_app.js components/screen/side_bar.js components/screen/search-modal.js components/screen/desktop.js`
- `yarn test __tests__/desktopNameBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f61f4c883289e6ac5ed1ecc778c