### PR TITLE
feat: add window switcher grid navigation

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -145,7 +145,7 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
-        if (e.altKey && e.key === 'Tab') {
+        if (e.metaKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
@@ -153,10 +153,6 @@ export class Desktop extends Component {
         } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
             e.preventDefault();
             this.openApp('clipboard-manager');
-        }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
         }
         else if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
@@ -823,7 +819,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input aria-label="Folder name" className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -4,6 +4,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
+  const columns = 3;
 
   const filtered = windows.filter((w) =>
     w.title.toLowerCase().includes(query.toLowerCase())
@@ -13,38 +14,32 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     inputRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const handleKeyUp = (e) => {
-      if (e.key === 'Alt') {
-        const win = filtered[selected];
-        if (win && typeof onSelect === 'function') {
-          onSelect(win.id);
-        } else if (typeof onClose === 'function') {
-          onClose();
-        }
-      }
-    };
-    window.addEventListener('keyup', handleKeyUp);
-    return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
-
   const handleKeyDown = (e) => {
+    const len = filtered.length;
+    if (!len) return;
+
     if (e.key === 'Tab') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
       const dir = e.shiftKey ? -1 : 1;
       setSelected((selected + dir + len) % len);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setSelected((selected + 1) % len);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setSelected((selected - 1 + len) % len);
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected + 1) % len);
+      setSelected((selected + columns) % len);
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected - 1 + len) % len);
+      setSelected((selected - columns + len) % len);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const win = filtered[selected];
+      if (win && typeof onSelect === 'function') {
+        onSelect(win.id);
+      }
     } else if (e.key === 'Escape') {
       e.preventDefault();
       if (typeof onClose === 'function') onClose();
@@ -58,7 +53,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
-      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/2 lg:w-1/3">
         <input
           ref={inputRef}
           value={query}
@@ -66,12 +61,13 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           onKeyDown={handleKeyDown}
           className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
           placeholder="Search windows"
+          aria-label="Search windows"
         />
-        <ul>
+        <ul className="grid grid-cols-3 gap-2">
           {filtered.map((w, i) => (
             <li
               key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
+              className={`px-2 py-1 rounded text-center ${i === selected ? 'bg-ub-orange text-black' : 'bg-black bg-opacity-20'}`}
             >
               {w.title}
             </li>


### PR DESCRIPTION
## Summary
- open window switcher with Super+Tab
- navigate window switcher grid with arrow keys and activate with Enter

## Testing
- `npx eslint components/screen/desktop.js components/screen/window-switcher.js`
- `yarn test` *(fails: window.test.tsx TypeError e.preventDefault is not a function; nmapNse.test.tsx missing role="alert"; jsdom Window localStorage TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f6e2fec83288604f1f64bb5ae80