### PR TITLE
feat: add terminal banner

### DIFF
--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import dynamic from 'next/dynamic';
 import HelpPanel from '../HelpPanel';
+import usePersistentState from '../../hooks/usePersistentState';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
 const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
@@ -17,8 +20,29 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
  * app, this wrapper just provides the necessary container styles.
  */
 export default function Terminal() {
+  const [dismissed, setDismissed] = usePersistentState<boolean>(
+    'terminal-banner-dismissed',
+    false,
+  );
+
   return (
     <div className="h-full w-full overflow-y-auto">
+      {!dismissed && (
+        <div
+          className="bg-ub-yellow text-black p-2 text-xs flex justify-between items-center"
+          role="alert"
+        >
+          <span>zsh (default in current Kali) – press ? for shortcuts</span>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={() => setDismissed(true)}
+            className="ml-2 px-2"
+          >
+            ×
+          </button>
+        </div>
+      )}
       <HelpPanel appId="terminal" />
       <TerminalApp />
     </div>


### PR DESCRIPTION
## Summary
- show first-launch banner in Terminal app
- remember dismissal to avoid re-showing

## Testing
- `yarn eslint components/apps/terminal.tsx`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f6fe1dc8328a497da0d9efdb811