### PR TITLE
feat: add panel customization settings

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -7,6 +7,9 @@ jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
 
 describe('Taskbar', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
   it('minimizes focused window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
@@ -42,5 +45,25 @@ describe('Taskbar', () => {
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('applies stored panel settings', () => {
+    window.localStorage.setItem(
+      'app:panel-settings',
+      JSON.stringify({ size: 50, mode: 'top', autohide: false, background: '#123456' }),
+    );
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{}}
+        openApp={() => {}}
+        minimize={() => {}}
+      />,
+    );
+    const toolbar = screen.getByRole('toolbar');
+    expect(toolbar).toHaveStyle({ height: '50px', background: '#123456' });
+    expect(toolbar.className).toContain('top-0');
   });
 });

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
+import usePanelSettings from '../../hooks/usePanelSettings';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const [panelSettings] = usePanelSettings();
+    const { size, mode, autohide, background } = panelSettings;
+    const [hover, setHover] = useState(false);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -15,8 +19,15 @@ export default function Taskbar(props) {
         }
     };
 
+    const hiddenClass = autohide && !hover ? (mode === 'top' ? '-translate-y-full' : 'translate-y-full') : '';
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            role="toolbar"
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}
+            className={`absolute ${mode === 'top' ? 'top-0' : 'bottom-0'} left-0 w-full flex items-center z-40 transition-transform duration-300 ${hiddenClass}`}
+            style={{ height: size, background }}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/hooks/usePanelSettings.ts
+++ b/hooks/usePanelSettings.ts
@@ -1,0 +1,34 @@
+import usePersistentState from './usePersistentState';
+
+export interface PanelSettings {
+  size: number; // height in px
+  mode: 'bottom' | 'top';
+  autohide: boolean;
+  background: string; // hex with alpha
+}
+
+export const defaultPanelSettings: PanelSettings = {
+  size: 40,
+  mode: 'bottom',
+  autohide: false,
+  background: '#00000080',
+};
+
+function isPanelSettings(value: unknown): value is PanelSettings {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as any;
+  return (
+    typeof v.size === 'number' &&
+    (v.mode === 'bottom' || v.mode === 'top') &&
+    typeof v.autohide === 'boolean' &&
+    typeof v.background === 'string'
+  );
+}
+
+export default function usePanelSettings() {
+  return usePersistentState<PanelSettings>(
+    'app:panel-settings',
+    defaultPanelSettings,
+    isPanelSettings,
+  );
+}

--- a/pages/ui/settings/panel.tsx
+++ b/pages/ui/settings/panel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from 'react';
+import usePanelSettings, { PanelSettings } from '../../../hooks/usePanelSettings';
+
+function SandboxPanel({ settings }: { settings: PanelSettings }) {
+  return (
+    <div
+      className={`w-full flex items-center ${settings.mode === 'top' ? '' : 'mt-4'}`}
+      style={{ height: settings.size, background: settings.background }}
+    >
+      {[1,2,3].map(n => (
+        <div key={n} className="w-5 h-5 bg-white rounded mx-1" />
+      ))}
+    </div>
+  );
+}
+
+export default function PanelSettingsPage() {
+  const [settings, setSettings] = usePanelSettings();
+  const [preview, setPreview] = useState<PanelSettings>(settings);
+
+  const handleChange = (field: keyof PanelSettings, value: any) => {
+    setPreview(prev => ({ ...prev, [field]: value }));
+  };
+
+  const apply = () => setSettings(preview);
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-48 p-4 border-r border-ubt-cool-grey text-sm">
+        <ul className="space-y-1.5">
+          <li>
+            <a className="flex items-center gap-2 p-2 rounded-l-md border-l-2 border-ubt-blue bg-ub-cool-grey">
+              <span className="w-6 h-6 bg-ubt-grey rounded"></span>
+              <span>Panel</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div className="flex-1 p-4 overflow-y-auto">
+        <h1 className="text-xl mb-4">Panel</h1>
+
+        <div className="mb-4">
+          <label className="block mb-1">Size</label>
+          <input
+            type="range"
+            min={24}
+            max={80}
+            value={preview.size}
+            onChange={e => handleChange('size', parseInt(e.target.value))}
+            className="w-full"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="block mb-1">Mode</label>
+          <select
+            value={preview.mode}
+            onChange={e => handleChange('mode', e.target.value as PanelSettings['mode'])}
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          >
+            <option value="bottom">Bottom</option>
+            <option value="top">Top</option>
+          </select>
+        </div>
+
+        <div className="mb-4 flex items-center gap-2">
+          <label>Autohide</label>
+          <input
+            type="checkbox"
+            checked={preview.autohide}
+            onChange={e => handleChange('autohide', e.target.checked)}
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="block mb-1">Background</label>
+          <input
+            type="color"
+            value={preview.background.slice(0,7)}
+            onChange={e => handleChange('background', e.target.value + '80')}
+          />
+        </div>
+
+        <SandboxPanel settings={preview} />
+
+        <button
+          onClick={apply}
+          className="mt-4 px-4 py-2 rounded bg-ub-orange text-white"
+        >
+          Apply
+        </button>
+
+        <h2 className="text-lg mt-6 mb-2">Current Config</h2>
+        <pre className="bg-ub-cool-grey p-2 rounded text-xs overflow-x-auto">
+          {JSON.stringify(settings, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add panel settings hook for size, mode, autohide and background
- implement settings UI with sandbox preview
- apply panel settings to taskbar and test persistence

## Testing
- `yarn test __tests__/taskbar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f6ec528832896ac2f1e6a348b38