### PR TITLE
feat: add image viewer with keyboard navigation

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -63,6 +63,7 @@ const NonogramApp = createDynamicApp('nonogram', 'Nonogram');
 const TetrisApp = createDynamicApp('tetris', 'Tetris');
 const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
+const RistrettoApp = createDynamicApp('ristretto', 'Image Viewer');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 const AboutAlexApp = createDynamicApp('alex', 'About Alex');
 
@@ -153,6 +154,7 @@ const displayNonogram = createDisplay(NonogramApp);
 const displayTetris = createDisplay(TetrisApp);
 const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayFileExplorer = createDisplay(FileExplorerApp);
+const displayRistretto = createDisplay(RistrettoApp);
 const displayRadare2 = createDisplay(Radare2App);
 const displayAboutAlex = createDisplay(AboutAlexApp);
 
@@ -700,6 +702,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFileExplorer,
+  },
+  {
+    id: 'ristretto',
+    title: 'Image Viewer',
+    icon: '/themes/Yaru/apps/ristretto.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayRistretto,
   },
   {
     id: 'resource-monitor',

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -91,7 +91,9 @@ async function addRecentDir(handle) {
   } catch {}
 }
 
-export default function FileExplorer() {
+const imageRegex = /\.(png|jpe?g|gif|webp|bmp)$/i;
+
+export default function FileExplorer({ openApp }) {
   const [supported, setSupported] = useState(true);
   const [dirHandle, setDirHandle] = useState(null);
   const [files, setFiles] = useState([]);
@@ -175,6 +177,14 @@ export default function FileExplorer() {
   };
 
   const openFile = async (file) => {
+    if (imageRegex.test(file.name)) {
+      const imageFiles = files.filter(f => imageRegex.test(f.name));
+      if (typeof window !== 'undefined') {
+        window.__ristretto = { files: imageFiles, index: imageFiles.findIndex(f => f.name === file.name) };
+      }
+      openApp && openApp('ristretto');
+      return;
+    }
     setCurrentFile(file);
     let text = '';
     if (opfsSupported) {

--- a/components/apps/ristretto/index.tsx
+++ b/components/apps/ristretto/index.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface ImageEntry {
+  name: string;
+  handle: FileSystemFileHandle;
+  url?: string;
+}
+
+export default function Ristretto() {
+  const [images, setImages] = useState<ImageEntry[]>([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const data = (window as any).__ristretto;
+    if (!data) return;
+    const load = async () => {
+      const items: ImageEntry[] = [];
+      for (const f of data.files as ImageEntry[]) {
+        try {
+          const file = await f.handle.getFile();
+          const url = URL.createObjectURL(file);
+          items.push({ ...f, url });
+        } catch {
+          // ignore errors loading individual images
+        }
+      }
+      setImages(items);
+      setIndex(data.index ?? 0);
+    };
+    load();
+  }, []);
+
+  const prev = () => setIndex(i => (i > 0 ? i - 1 : images.length - 1));
+  const next = () => setIndex(i => (i + 1) % images.length);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') prev();
+      if (e.key === 'ArrowRight') next();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      images.forEach(img => img.url && URL.revokeObjectURL(img.url));
+    };
+  }, [images]);
+
+  if (!images.length) {
+    return <div className="p-4 text-white">No images</div>;
+  }
+
+  return (
+    <div className="flex flex-col w-full h-full bg-black text-white">
+      <div className="flex-1 flex items-center justify-center overflow-hidden">
+        <img src={images[index].url} alt={images[index].name} className="max-w-full max-h-full" />
+      </div>
+      <div className="h-24 overflow-x-auto flex bg-gray-900">
+        {images.map((img, i) => (
+          <img
+            key={i}
+            src={img.url}
+            alt={img.name}
+            onClick={() => setIndex(i)}
+            className={`h-full cursor-pointer ${i === index ? 'ring-2 ring-blue-500' : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/public/themes/Yaru/apps/ristretto.svg
+++ b/public/themes/Yaru/apps/ristretto.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="8" ry="8" fill="#4B5563"/>
+  <rect x="8" y="8" width="48" height="48" fill="#9CA3AF"/>
+  <circle cx="24" cy="24" r="6" fill="#F9FAFB"/>
+  <path d="M8 48l12-16 10 8 6-8 12 16z" fill="#1F2937"/>
+</svg>


### PR DESCRIPTION
## Summary
- launch a new Ristretto image viewer with directory filmstrip and arrow-key navigation
- open images from the Files app in the new viewer
- add icon and configuration for the viewer

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/reconng.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f6d99f88328a1e4ad4d584603d6