### PR TITLE
feat: add terminal ps1 presets

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -34,6 +34,7 @@ jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
 
 import React, { createRef, act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import { Terminal as XTerm } from '@xterm/xterm';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
 
@@ -75,5 +76,14 @@ describe('Terminal component', () => {
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
     expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);
+  });
+
+  it('applies PS1 preset for new sessions', async () => {
+    (XTerm as jest.Mock).mockClear();
+    window.localStorage.setItem('terminal-ps1-preset', JSON.stringify('classic'));
+    render(<Terminal openApp={openApp} />);
+    await act(async () => {});
+    const instance = (XTerm as jest.Mock).mock.results[0].value;
+    expect(instance.write).toHaveBeenCalledWith(expect.stringContaining('user@kali:~$ '));
   });
 });


### PR DESCRIPTION
## Summary
- add configurable PS1 presets (Kali Minimal, Powerline, Classic)
- persist selected preset and use for new terminal sessions
- test PS1 preset loading

## Testing
- `yarn test __tests__/terminal.test.tsx`
- `yarn lint apps/terminal/index.tsx __tests__/terminal.test.tsx` *(fails: A control must be associated with a text label, Unexpected global 'document')*


------
https://chatgpt.com/codex/tasks/task_e_68ba5f7116e4832884b610e65b04ba83