### PR TITLE
feat(terminal): add man drawer

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -15,8 +15,12 @@ async function man(args: string, ctx: CommandContext) {
     man: () => fetch(new URL('../man/man.txt', import.meta.url)).then((r) => r.text()),
   };
   const loader = loaders[name];
-  if (loader) ctx.writeLine(await loader());
-  else ctx.writeLine(`No manual entry for ${name}`);
+  if (loader) {
+    const text = await loader();
+    const [synopsis, ...rest] = text.split('\n');
+    const description = rest.join('\n').trim();
+    ctx.openManPage(name, { synopsis, description });
+  } else ctx.writeLine(`No manual entry for ${name}`);
 }
 
 function history(_args: string, ctx: CommandContext) {

--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -5,6 +5,10 @@ export interface CommandContext {
   aliases: Record<string, string>;
   setAlias: (name: string, value: string) => void;
   runWorker: (command: string) => Promise<void>;
+  openManPage: (
+    name: string,
+    sections: { synopsis: string; description: string },
+  ) => void;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/components/ManDrawer.tsx
+++ b/apps/terminal/components/ManDrawer.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  name: string;
+  synopsis: string;
+  description: string;
+}
+
+export default function ManDrawer({
+  open,
+  onClose,
+  name,
+  synopsis,
+  description,
+}: Props) {
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      onClick={onClose}
+    >
+      <div
+        className={`absolute right-0 top-0 h-full w-80 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <section id="name" className="mb-4">
+          <h2 className="text-lg font-bold mb-1">NAME</h2>
+          <p>{name}</p>
+        </section>
+        <section id="synopsis" className="mb-4">
+          <h2 className="text-lg font-bold mb-1">SYNOPSIS</h2>
+          <pre className="whitespace-pre-wrap">{synopsis}</pre>
+        </section>
+        <section id="description">
+          <h2 className="text-lg font-bold mb-1">DESCRIPTION</h2>
+          <p className="whitespace-pre-wrap">{description}</p>
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -11,6 +11,7 @@ import React, {
 import useOPFS from '../../hooks/useOPFS';
 import commandRegistry, { CommandContext } from './commands';
 import TerminalContainer from './components/Terminal';
+import ManDrawer from './components/ManDrawer';
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -88,6 +89,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   const filesRef = useRef<Record<string, string>>(files);
   const aliasesRef = useRef<Record<string, string>>({});
   const historyRef = useRef<string[]>([]);
+  const [manPage, setManPage] = useState<{
+    name: string;
+    synopsis: string;
+    description: string;
+  } | null>(null);
   const contextRef = useRef<CommandContext>({
     writeLine: () => {},
     files: filesRef.current,
@@ -97,6 +103,9 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       aliasesRef.current[n] = v;
     },
     runWorker: async () => {},
+    openManPage: (name, sections) => {
+      setManPage({ name, ...sections });
+    },
   });
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteInput, setPaletteInput] = useState('');
@@ -407,6 +416,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
           <div className="mt-10 w-80 bg-gray-800 p-4 rounded">
             <input
               autoFocus
+              aria-label="command-palette"
               className="w-full mb-2 bg-black text-white p-2"
               value={paletteInput}
               onChange={(e) => setPaletteInput(e.target.value)}
@@ -469,6 +479,15 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
             </div>
           </div>
         </div>
+      )}
+      {manPage && (
+        <ManDrawer
+          open={!!manPage}
+          onClose={() => setManPage(null)}
+          name={manPage.name}
+          synopsis={manPage.synopsis}
+          description={manPage.description}
+        />
       )}
       <div className="flex flex-col h-full">
         <div className="flex items-center gap-2 bg-gray-800 p-1">


### PR DESCRIPTION
## Summary
- open manual pages in a right-side drawer with NAME, SYNOPSIS and DESCRIPTION sections
- extend terminal context and man command to populate the drawer
- add aria label to command palette input

## Testing
- `npx eslint apps/terminal/index.tsx apps/terminal/commands/index.ts apps/terminal/commands/types.ts apps/terminal/components/ManDrawer.tsx`
- `npx jest apps/terminal/commands/index.ts apps/terminal/index.tsx apps/terminal/components/ManDrawer.tsx --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f715d0c8328ba05173c6c384708