### PR TITLE
feat: add apt update command with repo warning

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -1,4 +1,5 @@
 import type { CommandHandler, CommandContext } from './types';
+import { getExtraRepos } from '../../../utils/settingsStore';
 
 async function man(args: string, ctx: CommandContext) {
   const name = args.trim();
@@ -37,10 +38,27 @@ function alias(args: string, ctx: CommandContext) {
   }
 }
 
+async function apt(args: string, ctx: CommandContext) {
+  const sub = args.trim();
+  if (sub === 'update') {
+    ctx.writeLine('Hit:1 https://http.kali.org/kali kali-rolling InRelease');
+    const extra = await getExtraRepos();
+    if (extra) {
+      ctx.writeLine(
+        'WARNING: Extra repositories are enabled. Manage them in the APT sources panel: /apps/apt-sources',
+      );
+    }
+    ctx.writeLine('Reading package lists... Done');
+  } else {
+    ctx.writeLine('usage: apt update');
+  }
+}
+
 const registry: Record<string, CommandHandler> = {
   man,
   history,
   alias,
+  apt,
   cat: (args, ctx) => ctx.runWorker(`cat ${args}`),
   grep: (args, ctx) => ctx.runWorker(`grep ${args}`),
   jq: (args, ctx) => ctx.runWorker(`jq ${args}`),

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getExtraRepos as loadExtraRepos,
+  setExtraRepos as saveExtraRepos,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  extraRepos: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setExtraRepos: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  extraRepos: defaults.extraRepos,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setExtraRepos: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [extraRepos, setExtraRepos] = useState<boolean>(defaults.extraRepos);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setExtraRepos(await loadExtraRepos());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveExtraRepos(extraRepos);
+  }, [extraRepos]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        extraRepos,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setExtraRepos,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  extraRepos: false,
 };
 
 export async function getAccent() {
@@ -123,6 +124,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getExtraRepos() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.extraRepos;
+  return window.localStorage.getItem('extra-repos') === 'true';
+}
+
+export async function setExtraRepos(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('extra-repos', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('extra-repos');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    extraRepos,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getExtraRepos(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    extraRepos,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    extraRepos,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (extraRepos !== undefined) await setExtraRepos(extraRepos);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add `apt update` command simulating official repository line
- warn when extra repositories enabled and link to APT sources panel
- track `extraRepos` setting in settings store and context

## Testing
- `npx eslint apps/terminal/commands/index.ts hooks/useSettings.tsx utils/settingsStore.js`
- `yarn lint apps/terminal/commands/index.ts hooks/useSettings.tsx utils/settingsStore.js` *(fails: A control must be associated with a text label, etc.)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, localStorage origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f71cbc0832885244a0fa1754a54