### PR TITLE
feat(terminal): add kali tools modal

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -33,7 +33,8 @@ jest.mock(
 jest.mock('@xterm/xterm/css/xterm.css', () => ({}), { virtual: true });
 
 import React, { createRef, act } from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
 
@@ -75,5 +76,24 @@ describe('Terminal component', () => {
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
     expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);
+  });
+
+  it('shows kali tools modal for apt install', async () => {
+    const root = document.createElement('div');
+    root.setAttribute('id', '__next');
+    document.body.appendChild(root);
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} />, { container: root });
+    await act(async () => {});
+    act(() => {
+      ref.current.runCommand('sudo apt install kali-tools-top10');
+    });
+    const heading = await screen.findByText('kali-tools-top10');
+    expect(heading).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Close'));
+    await waitFor(() => {
+      expect(screen.queryByText('kali-tools-top10')).toBeNull();
+    });
+    document.body.removeChild(root);
   });
 });

--- a/apps/terminal/components/KaliToolsModal.tsx
+++ b/apps/terminal/components/KaliToolsModal.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Modal from '../../../components/base/Modal';
+
+interface Info {
+  description: string;
+  tools: string[];
+}
+
+interface Props {
+  category: string;
+  info: Info;
+  onClose: () => void;
+}
+
+const KaliToolsModal: React.FC<Props> = ({ category, info, onClose }) => {
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <div className="bg-gray-800 text-white p-4 rounded max-w-md">
+        <h2 className="text-xl mb-2">{`kali-tools-${category}`}</h2>
+        <p className="mb-2">{info.description}</p>
+        <ul className="list-disc pl-5 max-h-60 overflow-y-auto text-sm">
+          {info.tools.map((t) => (
+            <li key={t}>{t}</li>
+          ))}
+        </ul>
+        <div className="mt-4 text-right">
+          <button
+            className="px-3 py-1 bg-blue-600 rounded"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default KaliToolsModal;

--- a/data/kali-tools.json
+++ b/data/kali-tools.json
@@ -1,0 +1,36 @@
+{
+  "top10": {
+    "description": "Top 10 security tools",
+    "tools": [
+      "nmap",
+      "hydra",
+      "john",
+      "metasploit-framework",
+      "sqlmap",
+      "aircrack-ng",
+      "burpsuite",
+      "wireshark",
+      "maltego",
+      "zenmap"
+    ]
+  },
+  "passwords": {
+    "description": "Password attack tools",
+    "tools": [
+      "hashcat",
+      "john",
+      "hydra",
+      "medusa",
+      "smbmap"
+    ]
+  },
+  "forensics": {
+    "description": "Digital forensics tools",
+    "tools": [
+      "autopsy",
+      "sleuthkit",
+      "volatility",
+      "binwalk"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- show kali-tools category details when running `sudo apt install`
- add KaliToolsModal component and tool metadata
- test apt install modal appearance and dismissal

## Testing
- `npx eslint apps/terminal/index.tsx apps/terminal/components/KaliToolsModal.tsx __tests__/terminal.test.tsx`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f7416d483289a68260848c10c1a