### PR TITLE
Add keyboard tiling shortcuts

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -36,6 +36,7 @@ export default function Settings() {
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
+    { id: "keyboard", label: "Keyboard" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
   ] as const;
@@ -260,7 +261,17 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+        </>
+      )}
+      {activeTab === "keyboard" && (
+        <>
+          <ul className="list-disc pl-6 my-4 text-ubt-grey">
+            <li>Tile window left: Meta+ArrowLeft</li>
+            <li>Tile window right: Meta+ArrowRight</li>
+            <li>Tile window top: Ctrl+Meta+ArrowUp</li>
+            <li>Tile window bottom: Ctrl+Meta+ArrowDown</li>
+          </ul>
+          <div className="flex justify-center mt-4">
             <button
               onClick={() => setShowKeymap(true)}
               className="px-4 py-2 rounded bg-ub-orange text-white"

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,10 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Tile window left', keys: 'Meta+ArrowLeft' },
+  { description: 'Tile window right', keys: 'Meta+ArrowRight' },
+  { description: 'Tile window top', keys: 'Ctrl+Meta+ArrowUp' },
+  { description: 'Tile window bottom', keys: 'Ctrl+Meta+ArrowDown' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -53,6 +53,7 @@ export class Window extends Component {
         window.addEventListener('context-menu-close', this.removeInertBackground);
         const root = document.getElementById(this.id);
         root?.addEventListener('super-arrow', this.handleSuperArrow);
+        root?.addEventListener('super-ctrl-arrow', this.handleSuperCtrlArrow);
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
@@ -66,6 +67,7 @@ export class Window extends Component {
         window.removeEventListener('context-menu-close', this.removeInertBackground);
         const root = document.getElementById(this.id);
         root?.removeEventListener('super-arrow', this.handleSuperArrow);
+        root?.removeEventListener('super-ctrl-arrow', this.handleSuperCtrlArrow);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
         }
@@ -273,6 +275,10 @@ export class Window extends Component {
             newWidth = 100.2;
             newHeight = 50;
             transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'bottom') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = `translate(-1pt, ${window.innerHeight / 2}px)`;
         }
         const r = document.querySelector("#" + this.id);
         if (r && transform) {
@@ -330,6 +336,10 @@ export class Window extends Component {
         else if (rect.top <= threshold) {
             snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (rect.bottom >= window.innerHeight - threshold) {
+            snap = { left: '0', top: '50%', width: '100%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -584,6 +594,19 @@ export class Window extends Component {
         }
     }
 
+    handleSuperCtrlArrow = (e) => {
+        const key = e.detail;
+        if (key === 'ArrowUp') {
+            this.snapWindow('top');
+        } else if (key === 'ArrowDown') {
+            this.snapWindow('bottom');
+        } else if (key === 'ArrowLeft') {
+            this.snapWindow('left');
+        } else if (key === 'ArrowRight') {
+            this.snapWindow('right');
+        }
+    }
+
     snapWindow = (pos) => {
         this.focusWindow();
         const { width, height } = this.state;
@@ -598,6 +621,14 @@ export class Window extends Component {
             newWidth = 50;
             newHeight = 96.3;
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (pos === 'top') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (pos === 'bottom') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = `translate(-1pt, ${window.innerHeight / 2}px)`;
         }
         const node = document.getElementById(this.id);
         if (node && transform) {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -162,6 +162,14 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if (e.metaKey && e.ctrlKey && ['ArrowUp', 'ArrowDown'].includes(e.key)) {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const event = new CustomEvent('super-ctrl-arrow', { detail: e.key });
+                document.getElementById(id)?.dispatchEvent(event);
+            }
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();


### PR DESCRIPTION
## Summary
- List window tiling shortcuts in new Keyboard tab
- Support Meta+Ctrl+Arrow shortcuts for top and bottom tiling
- Snap windows to bottom and show previews

## Testing
- `yarn test` *(fails: window.snap, nmap NSE, modal escape)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f78649083288c68105f976d6fd3