### PR TITLE
Add keyboard layout indicator

### DIFF
--- a/__tests__/keyboardLayoutIndicator.test.tsx
+++ b/__tests__/keyboardLayoutIndicator.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import KeyboardLayoutIndicator from '../components/util-components/keyboard-layout';
+
+describe('KeyboardLayoutIndicator', () => {
+  test('allows selecting different layout', async () => {
+    render(<KeyboardLayoutIndicator />);
+    await userEvent.click(screen.getByRole('button', { name: /keyboard layout/i }));
+    await userEvent.click(await screen.findByRole('button', { name: 'DE' }));
+    await screen.findByText('DE');
+    expect(screen.getByRole('button', { name: /keyboard layout/i })).toHaveTextContent('DE');
+  });
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import KeyboardLayoutIndicator from '../util-components/keyboard-layout';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -36,6 +37,9 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Clock />
+                                </div>
+                                <div className="pl-2 pr-2 text-xs md:text-sm outline-none border-b-2 border-transparent py-1">
+                                        <KeyboardLayoutIndicator />
                                 </div>
                                 <button
                                         type="button"

--- a/components/util-components/keyboard-layout.tsx
+++ b/components/util-components/keyboard-layout.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const LAYOUTS = ['EN', 'DE', 'FR'];
+
+export default function KeyboardLayoutIndicator() {
+  const [layout, setLayout] = usePersistentState('keyboard-layout', LAYOUTS[0]);
+  const [perWindow, setPerWindow] = usePersistentState('keyboard-layout-per-window', false);
+  const [open, setOpen] = useState(false);
+
+  const cycleLayout = useCallback(() => {
+    const currentIndex = LAYOUTS.indexOf(layout);
+    const nextLayout = LAYOUTS[(currentIndex + 1) % LAYOUTS.length];
+    setLayout(nextLayout);
+  }, [layout, setLayout]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.altKey && e.shiftKey && e.code === 'Space') {
+        e.preventDefault();
+        cycleLayout();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [cycleLayout]);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        aria-label={`Keyboard layout: ${layout}`}
+        className="px-2 py-1 text-xs text-white focus:outline-none"
+        onClick={() => setOpen(!open)}
+      >
+        {layout}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 bg-ub-cool-grey rounded-md shadow border border-black border-opacity-20 z-50">
+          {LAYOUTS.map((l) => (
+            <button
+              key={l}
+              type="button"
+              className={`block w-full text-left px-4 py-2 hover:bg-white hover:bg-opacity-10 ${l === layout ? 'font-bold' : ''}`}
+              onClick={() => {
+                setLayout(l);
+                setOpen(false);
+              }}
+            >
+              {l}
+            </button>
+          ))}
+          <div className="px-4 py-2 border-t border-black border-opacity-20 flex justify-between items-center">
+            <span>Per-window</span>
+            <input
+              type="checkbox"
+              aria-label="Per-window"
+              checked={perWindow}
+              onChange={() => setPerWindow(!perWindow)}
+            />
+          </div>
+          <button
+            type="button"
+            className="block w-full text-left px-4 py-2 border-t border-black border-opacity-20 hover:bg-white hover:bg-opacity-10"
+            onClick={() => {
+              cycleLayout();
+              setOpen(false);
+            }}
+          >
+            Cycle Layout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- show keyboard layout in the navbar with a dropdown of available layouts
- allow cycling layouts with Alt+Shift+Space and a dropdown button
- persist layout and per-window mode settings
- add unit test for layout selection

## Testing
- `npx eslint components/util-components/keyboard-layout.tsx components/screen/navbar.js __tests__/keyboardLayoutIndicator.test.tsx --max-warnings=0`
- `npx jest __tests__/keyboardLayoutIndicator.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f79cd888328a8b65392fda45be1