### PR TITLE
feat: add high contrast theme option

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,8 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, highContrast, setHighContrast } =
+    useSettings();
 
   return (
     <div>
@@ -31,6 +32,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 </option>
               ))}
             </select>
+          </label>
+          <label className="mt-2 flex items-center gap-2">
+            <input
+              id="settings-high-contrast"
+              type="checkbox"
+              checked={highContrast}
+              onChange={(e) => setHighContrast(e.target.checked)}
+            />
+            <span>High Contrast</span>
           </label>
           <label>
             Accent

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -18,7 +18,7 @@ function Toggle({
       role="switch"
       aria-checked={checked}
       onClick={() => onChange(!checked)}
-      className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
+      className={`relative w-12 h-6 rounded-full transition-colors duration-200 ${
         checked ? 'bg-ubt-blue' : 'bg-ubt-grey'
       }`}
     >
@@ -32,7 +32,7 @@ function Toggle({
 }
 
 export default function ThemeSettings() {
-  const { theme, setTheme } = useSettings();
+  const { theme, setTheme, highContrast, setHighContrast } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
 
@@ -64,6 +64,15 @@ export default function ThemeSettings() {
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>
         </select>
+        <label className="mt-4 flex items-center gap-2">
+          <input
+            id="theme-high-contrast"
+            type="checkbox"
+            checked={highContrast}
+            onChange={(e) => setHighContrast(e.target.checked)}
+          />
+          <span>High Contrast</span>
+        </label>
 
         <div className="mt-6">
           <h2 className="text-lg mb-2">Panel Icons</h2>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -74,6 +74,6 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: var(--focus-outline-width) solid var(--focus-outline-color);
   outline-offset: 2px;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -72,6 +72,7 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --focus-outline-color: #ffff00;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;


### PR DESCRIPTION
## Summary
- add a High Contrast toggle to theme settings and settings drawer
- expose focus outline variables for accessible contrast
- adjust tokens for high contrast focus color

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and missing display name)*
- `yarn test` *(fails: Window snapping finalize and NmapNSEApp tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f7b8e2c8328b2af88dbd7a4ff54