### PR TITLE
feat: add assistive technology toggle

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -27,6 +27,8 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    assistiveTech,
+    setAssistiveTech,
     haptics,
     setHaptics,
     theme,
@@ -211,6 +213,21 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
+          <div className="mx-4 my-4 p-4 rounded border border-gray-900 bg-ub-cool-grey">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-white">Assistive technologies</h3>
+                <p className="text-sm text-ubt-grey mt-1">
+                  Enable screen reader support. Try Orca with <kbd>Super</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>.
+                </p>
+              </div>
+              <ToggleSwitch
+                checked={assistiveTech}
+                onChange={setAssistiveTech}
+                ariaLabel="Enable assistive technologies"
+              />
+            </div>
+          </div>
           <div className="flex justify-center my-4">
             <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
             <input

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getAssistiveTech as loadAssistiveTech,
+  setAssistiveTech as saveAssistiveTech,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  assistiveTech: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setAssistiveTech: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  assistiveTech: defaults.assistiveTech,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setAssistiveTech: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [assistiveTech, setAssistiveTech] = useState<boolean>(defaults.assistiveTech);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setAssistiveTech(await loadAssistiveTech());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveAssistiveTech(assistiveTech);
+  }, [assistiveTech]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        assistiveTech,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setAssistiveTech,
         setTheme,
       }}
     >

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import { useSettings } from '../hooks/useSettings';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +29,21 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { assistiveTech } = useSettings();
+  return (
+    <>
+      {assistiveTech && (
+        <a href="#window-area" className="sr-only focus:not-sr-only">
+          Skip to content
+        </a>
+      )}
+      <Meta />
+      <Ubuntu />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;

--- a/utils/announce.ts
+++ b/utils/announce.ts
@@ -1,0 +1,4 @@
+export function announce(message: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('announce', { detail: message }));
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  assistiveTech: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,16 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getAssistiveTech() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.assistiveTech;
+  return window.localStorage.getItem('assistive-tech') === 'true';
+}
+
+export async function setAssistiveTech(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('assistive-tech', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('assistive-tech');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    assistiveTech,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getAssistiveTech(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    assistiveTech,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    assistiveTech,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (assistiveTech !== undefined) await setAssistiveTech(assistiveTech);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add "Assistive technologies" card in Settings with Orca hint
- gate skip links and global live region behind new setting
- expose utility for app-wide ARIA announcements

## Testing
- `npx eslint --config eslint.config.mjs --ext .js,.jsx,.ts,.tsx pages/index.jsx pages/_app.jsx hooks/useSettings.tsx apps/settings/index.tsx utils/settingsStore.js utils/announce.ts`
- `yarn test __tests__/liveRegion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f7adae88328af7c6607071e5435