### PR TITLE
Add Plymouth splash screen preview

### DIFF
--- a/pages/preview/plymouth.tsx
+++ b/pages/preview/plymouth.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const PlymouthPreview: React.FC = () => {
+  return (
+    <div className="flex min-h-screen w-screen flex-col items-center justify-center bg-black">
+      <div className="h-24 w-24 animate-spin rounded-full border-4 border-blue-400 border-t-transparent" />
+      <p className="mt-8 w-11/12 max-w-lg text-center text-sm text-gray-300">
+        This mock splash screen mimics a Plymouth animation. To change Plymouth
+        themes on a real system, run{' '}
+        <code className="rounded bg-gray-800 px-1 py-0.5 text-xs text-gray-100">
+          sudo update-alternatives --config default.plymouth
+        </code>{' '} 
+        and then rebuild your initramfs with{' '}
+        <code className="rounded bg-gray-800 px-1 py-0.5 text-xs text-gray-100">
+          sudo update-initramfs -u
+        </code>
+        .
+      </p>
+    </div>
+  );
+};
+
+export default PlymouthPreview;


### PR DESCRIPTION
## Summary
- add `/preview/plymouth` page with full-screen mock splash animation
- note `update-alternatives` and `update-initramfs` for changing Plymouth themes

## Testing
- `node_modules/.bin/eslint pages/preview/plymouth.tsx`
- `yarn test __tests__/window.test.tsx` *(fails: TypeError: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f86fb5c8328ab9eb2fb14050c03