### PR TITLE
feat: add volume overlay and media key handling

### DIFF
--- a/components/osd/VolumeOverlay.tsx
+++ b/components/osd/VolumeOverlay.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import Image from 'next/image';
+
+interface Props {
+  volume: number;
+  visible: boolean;
+}
+
+const ICON = '/themes/Yaru/status/audio-volume-medium-symbolic.svg';
+
+export default function VolumeOverlay({ volume, visible }: Props) {
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-50">
+      <div className="flex flex-col items-center bg-black/60 text-white p-4 rounded">
+        <Image src={ICON} alt="volume" width={48} height={48} />
+        <span className="mt-2 text-xl">{volume}%</span>
+      </div>
+    </div>
+  );
+}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { MediaKeysProvider } from '../../hooks/useMediaKeys';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -48,8 +49,10 @@ export default class Navbar extends Component {
                                                 'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <MediaKeysProvider>
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </MediaKeysProvider>
                                 </button>
 			</div>
 		);

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,8 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import ToggleSwitch from '../ToggleSwitch';
+import { useMediaKeys } from '../../hooks/useMediaKeys';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,8 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [showNotifications, setShowNotifications] = usePersistentState('qs-show-notifications', false);
+  const { volume, setVolume, enabled, setEnabled } = useMediaKeys();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -22,6 +26,7 @@ const QuickSettings = ({ open }: Props) => {
   }, [reduceMotion]);
 
   return (
+    <>
     <div
       className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
@@ -36,15 +41,26 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+      <div className="px-4 pb-2">
+        <div className="flex justify-between mb-2">
+          <span>Sound</span>
+          <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        </div>
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={volume}
+          onChange={(e) => setVolume(parseInt(e.target.value, 10))}
+          className="ubuntu-slider w-full"
+          aria-label="Volume"
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
       </div>
-      <div className="px-4 flex justify-between">
+      <div className="px-4 pb-2 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
@@ -52,7 +68,24 @@ const QuickSettings = ({ open }: Props) => {
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Show notifications</span>
+        <ToggleSwitch
+          checked={showNotifications}
+          onChange={setShowNotifications}
+          ariaLabel="Show notifications"
+        />
+      </div>
+      <div className="px-4 flex justify-between">
+        <span>Handle multimedia keys</span>
+        <ToggleSwitch
+          checked={enabled}
+          onChange={setEnabled}
+          ariaLabel="Handle multimedia keys"
+        />
+      </div>
     </div>
+    </>
   );
 };
 

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,18 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import NotificationCenter from '../common/NotificationCenter';
+import VolumeOverlay from '../osd/VolumeOverlay';
+import usePersistentState from '../../hooks/usePersistentState';
+import { useMediaKeys } from '../../hooks/useMediaKeys';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const [showNotifications] = usePersistentState('qs-show-notifications', false);
+  const { volume, visible, enabled } = useMediaKeys();
 
   useEffect(() => {
     const pingServer = async () => {
@@ -79,6 +85,8 @@ export default function Status() {
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>
+      {showNotifications && <NotificationCenter />}
+      <VolumeOverlay volume={volume} visible={enabled && visible} />
     </div>
   );
 }

--- a/hooks/useMediaKeys.ts
+++ b/hooks/useMediaKeys.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import usePersistentState from './usePersistentState';
+
+interface MediaKeysContextValue {
+  volume: number;
+  setVolume: (v: number) => void;
+  enabled: boolean;
+  setEnabled: (v: boolean) => void;
+  visible: boolean;
+}
+
+const MediaKeysContext = createContext<MediaKeysContextValue | null>(null);
+
+export const MediaKeysProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [volume, setVolumeState] = usePersistentState('media-volume', 50, (v: any) => typeof v === 'number' && v >= 0 && v <= 100);
+  const [enabled, setEnabled] = usePersistentState('media-keys-enabled', false, (v: any) => typeof v === 'boolean');
+  const [visible, setVisible] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const setVolume = (v: number) => {
+    const value = Math.max(0, Math.min(100, v));
+    setVolumeState(value);
+    setVisible(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setVisible(false), 1000);
+  };
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'XF86AudioRaiseVolume') {
+        e.preventDefault();
+        setVolume(volume + 5);
+      } else if (e.key === 'XF86AudioLowerVolume') {
+        e.preventDefault();
+        setVolume(volume - 5);
+      } else if (e.key === 'XF86AudioMute') {
+        e.preventDefault();
+        setVolume(0);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [enabled, volume]);
+
+  return (
+    <MediaKeysContext.Provider value={{ volume, setVolume, enabled, setEnabled, visible }}>
+      {children}
+    </MediaKeysContext.Provider>
+  );
+};
+
+export const useMediaKeys = () => {
+  const ctx = useContext(MediaKeysContext);
+  if (!ctx) throw new Error('useMediaKeys must be used within MediaKeysProvider');
+  return ctx;
+};
+
+export default useMediaKeys;


### PR DESCRIPTION
## Summary
- add context and overlay to show current volume
- bind XF86Audio keys and expose volume slider
- include notification and media key toggles in quick settings

## Testing
- `npm test` *(fails: e.preventDefault is not a function, Unable to find role="alert", Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6a1e088328bc458ec1fe5faf4f