### PR TITLE
feat: add brightness overlay and slider

### DIFF
--- a/components/osd/BrightnessOverlay.tsx
+++ b/components/osd/BrightnessOverlay.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+
+interface BrightnessOverlayProps {
+  /** Brightness level from 0-100 */
+  value: number;
+}
+
+const BrightnessOverlay: React.FC<BrightnessOverlayProps> = ({ value }) => {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+      <div className="bg-gray-800/90 text-white rounded-lg px-4 py-3 flex flex-col items-center w-40">
+        <Image
+          src="/themes/Yaru/status/display-brightness-symbolic.svg"
+          alt="brightness"
+          width={32}
+          height={32}
+          className="mb-2"
+          sizes="32px"
+        />
+        <div className="w-full h-1.5 bg-gray-600 rounded">
+          <div
+            className="h-full bg-white rounded"
+            style={{ width: `${clamped}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BrightnessOverlay;
+

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,13 +1,47 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import BrightnessOverlay from "../osd/BrightnessOverlay";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+
+  // Local brightness state (0-100)
+  const [brightness, setBrightness] = useState(100);
+  const [showMenu, setShowMenu] = useState(false);
+  const [showOsd, setShowOsd] = useState(false);
+
+  const changeBrightness = useCallback((val) => {
+    setBrightness((prev) => {
+      const next = Math.max(0, Math.min(100, typeof val === 'function' ? val(prev) : val));
+      return next;
+    });
+    setShowOsd(true);
+  }, []);
+
+  useEffect(() => {
+    if (!showOsd) return;
+    const id = setTimeout(() => setShowOsd(false), 1000);
+    return () => clearTimeout(id);
+  }, [showOsd]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'XF86MonBrightnessUp') {
+        e.preventDefault();
+        changeBrightness((b) => Math.min(100, b + 10));
+      } else if (e.key === 'XF86MonBrightnessDown') {
+        e.preventDefault();
+        changeBrightness((b) => Math.max(0, b - 10));
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [changeBrightness]);
 
   useEffect(() => {
     const pingServer = async () => {
@@ -39,7 +73,7 @@ export default function Status() {
   }, []);
 
   return (
-    <div className="flex justify-center items-center">
+    <div className="flex justify-center items-center relative">
       <span
         className="mx-1.5 relative"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
@@ -74,11 +108,28 @@ export default function Status() {
           alt="ubuntu battry"
           className="inline status-symbol w-4 h-4"
           sizes="16px"
+          title={`${brightness}%`}
         />
       </span>
-      <span className="mx-1">
+      <span className="mx-1" onClick={() => setShowMenu((o) => !o)}>
         <SmallArrow angle="down" className=" status-symbol" />
       </span>
+      {showMenu && (
+        <div className="absolute right-0 mt-2 w-48 bg-gray-800 text-white rounded p-3 space-y-2 z-40">
+          <div>
+            <label className="text-xs">Brightness: {brightness}%</label>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={brightness}
+              onChange={(e) => changeBrightness(Number(e.target.value))}
+              className="w-full"
+            />
+          </div>
+        </div>
+      )}
+      {showOsd && <BrightnessOverlay value={brightness} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add BrightnessOverlay component mirroring volume overlay
- integrate brightness slider and OSD in status popover
- handle XF86MonBrightness keys to adjust brightness state

## Testing
- `yarn lint` *(fails: Unexpected global 'document' and component display name issues)*
- `yarn test` *(fails: window snapping finalize and release, NmapNSEApp copies output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6ab1c08328baf1bd24aa407f7f