### PR TITLE
feat: add OSD visibility preferences

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,16 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const {
+    accent,
+    setAccent,
+    theme,
+    setTheme,
+    showVolumeOSD,
+    setShowVolumeOSD,
+    showBrightnessOSD,
+    setShowBrightnessOSD,
+  } = useSettings();
 
   return (
     <div>
@@ -51,6 +60,24 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="flex items-center gap-2 mt-2">
+            <input
+              type="checkbox"
+              aria-label="toggle-volume-osd"
+              checked={showVolumeOSD}
+              onChange={(e) => setShowVolumeOSD(e.target.checked)}
+            />
+            <span>Show volume OSD</span>
+          </label>
+          <label className="flex items-center gap-2 mt-2">
+            <input
+              type="checkbox"
+              aria-label="toggle-brightness-osd"
+              checked={showBrightnessOSD}
+              onChange={(e) => setShowBrightnessOSD(e.target.checked)}
+            />
+            <span>Show brightness OSD</span>
           </label>
         </div>
       )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getShowVolumeOSD as loadShowVolumeOSD,
+  setShowVolumeOSD as saveShowVolumeOSD,
+  getShowBrightnessOSD as loadShowBrightnessOSD,
+  setShowBrightnessOSD as saveShowBrightnessOSD,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +67,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  showVolumeOSD: boolean;
+  showBrightnessOSD: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +80,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setShowVolumeOSD: (value: boolean) => void;
+  setShowBrightnessOSD: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +96,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  showVolumeOSD: defaults.showVolumeOSD,
+  showBrightnessOSD: defaults.showBrightnessOSD,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +109,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setShowVolumeOSD: () => {},
+  setShowBrightnessOSD: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +124,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [showVolumeOSD, setShowVolumeOSD] = useState<boolean>(defaults.showVolumeOSD);
+  const [showBrightnessOSD, setShowBrightnessOSD] = useState<boolean>(
+    defaults.showBrightnessOSD,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +143,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setShowVolumeOSD(await loadShowVolumeOSD());
+      setShowBrightnessOSD(await loadShowBrightnessOSD());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +254,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveShowVolumeOSD(showVolumeOSD);
+  }, [showVolumeOSD]);
+
+  useEffect(() => {
+    saveShowBrightnessOSD(showBrightnessOSD);
+  }, [showBrightnessOSD]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +275,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        showVolumeOSD,
+        showBrightnessOSD,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +288,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setShowVolumeOSD,
+        setShowBrightnessOSD,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  showVolumeOSD: true,
+  showBrightnessOSD: true,
 };
 
 export async function getAccent() {
@@ -38,7 +40,11 @@ export async function setWallpaper(wallpaper) {
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  try {
+    return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  } catch {
+    return DEFAULT_SETTINGS.density;
+  }
 }
 
 export async function setDensity(density) {
@@ -123,6 +129,45 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getShowVolumeOSD() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.showVolumeOSD;
+  try {
+    const val = window.localStorage.getItem('show-volume-osd');
+    return val === null ? DEFAULT_SETTINGS.showVolumeOSD : val === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.showVolumeOSD;
+  }
+}
+
+export async function setShowVolumeOSD(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('show-volume-osd', value ? 'true' : 'false');
+  } catch {
+    // ignore
+  }
+}
+
+export async function getShowBrightnessOSD() {
+  if (typeof window === 'undefined')
+    return DEFAULT_SETTINGS.showBrightnessOSD;
+  try {
+    const val = window.localStorage.getItem('show-brightness-osd');
+    return val === null ? DEFAULT_SETTINGS.showBrightnessOSD : val === 'true';
+  } catch {
+    return DEFAULT_SETTINGS.showBrightnessOSD;
+  }
+}
+
+export async function setShowBrightnessOSD(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('show-brightness-osd', value ? 'true' : 'false');
+  } catch {
+    // ignore
+  }
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +182,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('show-volume-osd');
+  window.localStorage.removeItem('show-brightness-osd');
 }
 
 export async function exportSettings() {
@@ -151,6 +198,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showVolumeOSD,
+    showBrightnessOSD,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +211,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getShowVolumeOSD(),
+    getShowBrightnessOSD(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +226,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showVolumeOSD,
+    showBrightnessOSD,
     theme,
   });
 }
@@ -199,6 +252,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    showVolumeOSD,
+    showBrightnessOSD,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +266,9 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (showVolumeOSD !== undefined) await setShowVolumeOSD(showVolumeOSD);
+  if (showBrightnessOSD !== undefined)
+    await setShowBrightnessOSD(showBrightnessOSD);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add volume/brightness OSD visibility toggles to settings drawer
- persist OSD preferences through useSettings and settingsStore

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx, getReducedMotion localStorage error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6b36e08328b4909fdbd7301cc5