### PR TITLE
feat: add volume icon interactivity

### DIFF
--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,13 +1,41 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
+import Image from "next/image";
 import SmallArrow from "./small_arrow";
-import { useSettings } from '../../hooks/useSettings';
+import { useSettings } from "../../hooks/useSettings";
+import useGameAudio from "../../hooks/useGameAudio";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
+  const { muted, setMuted, volume, setVolume } = useGameAudio();
   const [online, setOnline] = useState(true);
+  const [showSlider, setShowSlider] = useState(false);
+
+  const sliderValue = muted ? 0 : volume;
+
+  const handleMiddleClick = (e) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      e.stopPropagation();
+      setMuted(!muted);
+    }
+  };
+
+  const handleWheel = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const delta = e.deltaY < 0 ? 0.05 : -0.05;
+    const newVol = Math.max(0, Math.min(1, sliderValue + delta));
+    setVolume(newVol);
+    setMuted(newVol === 0);
+  };
+
+  const handleSliderChange = (e) => {
+    const val = parseFloat(e.target.value);
+    setVolume(val);
+    setMuted(val === 0);
+  };
 
   useEffect(() => {
     const pingServer = async () => {
@@ -56,7 +84,13 @@ export default function Status() {
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
-      <span className="mx-1.5">
+      <span
+        className="mx-1.5 relative"
+        onMouseDown={handleMiddleClick}
+        onWheel={handleWheel}
+        onMouseEnter={() => setShowSlider(true)}
+        onMouseLeave={() => setShowSlider(false)}
+      >
         <Image
           width={16}
           height={16}
@@ -65,6 +99,19 @@ export default function Status() {
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />
+        {showSlider && (
+          <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 bg-ub-cool-grey p-2 rounded shadow-md">
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={sliderValue}
+              onChange={handleSliderChange}
+              className="w-24"
+            />
+          </div>
+        )}
       </span>
       <span className="mx-1.5">
         <Image


### PR DESCRIPTION
## Summary
- allow middle-click to toggle mute and mouse wheel to adjust volume
- show volume slider popover synced with mute/volume state

## Testing
- `yarn test` *(fails: window, nmapNse, installButton)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6c495c8328bb42985067366d60