### PR TITLE
feat(panel): add scroll volume option

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -39,6 +39,10 @@ export default function Preferences() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
+  const [scrollVolume, setScrollVolume] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(`${PANEL_PREFIX}scrollVolume`) === "true";
+  });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -59,6 +63,13 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PANEL_PREFIX}scrollVolume`,
+      scrollVolume ? "true" : "false",
+    );
+  }, [scrollVolume]);
 
   return (
     <div>
@@ -88,6 +99,16 @@ export default function Preferences() {
                 checked={autohide}
                 onChange={setAutohide}
                 ariaLabel="Autohide panel"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-ubt-grey">
+                Adjust volume when scrolling over panel
+              </span>
+              <ToggleSwitch
+                checked={scrollVolume}
+                onChange={setScrollVolume}
+                ariaLabel="Adjust volume when scrolling over panel"
               />
             </div>
           </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,31 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Image from 'next/image';
+import useGameAudio from '../../hooks/useGameAudio';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const { setVolume } = useGameAudio();
+    const barRef = useRef(null);
+
+    useEffect(() => {
+        const el = barRef.current;
+        if (!el) return;
+        const enabled = typeof window !== 'undefined' &&
+            localStorage.getItem('xfce.panel.scrollVolume') === 'true';
+        if (!enabled) return;
+        const handleWheel = (e) => {
+            e.preventDefault();
+            const delta = -e.deltaY / 100;
+            setVolume(prev => {
+                const next = Math.max(0, Math.min(1, prev + delta));
+                return next;
+            });
+        };
+        el.addEventListener('wheel', handleWheel);
+        return () => {
+            el.removeEventListener('wheel', handleWheel);
+        };
+    }, [setVolume]);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,7 +39,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div ref={barRef} className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
                 <button
                     key={app.id}


### PR DESCRIPTION
## Summary
- add panel preference to adjust volume when scrolling over panel
- taskbar forwards mouse wheel delta to global volume when enabled

## Testing
- `npx eslint components/panel/Preferences.tsx components/screen/taskbar.js && echo 'ESLint passed'`
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6ca55c8328aff5691a3d34ea9b