### PR TITLE
feat(osd): add centralized overlay manager

### DIFF
--- a/components/osd/OSDManager.tsx
+++ b/components/osd/OSDManager.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef, useState } from "react";
+import Toast from "../ui/Toast";
+
+interface OSDPayload {
+  message: string;
+  duration?: number;
+}
+
+export function showOSD(message: string, duration?: number) {
+  window.dispatchEvent(
+    new CustomEvent<OSDPayload>("osd", { detail: { message, duration } })
+  );
+}
+
+export default function OSDManager() {
+  const [payload, setPayload] = useState<(OSDPayload & { key: number }) | null>(
+    null
+  );
+  const counter = useRef(0);
+
+  useEffect(() => {
+    const handler = (e: CustomEvent<OSDPayload>) => {
+      counter.current += 1;
+      setPayload({ ...e.detail, key: counter.current });
+    };
+    window.addEventListener("osd", handler as EventListener);
+    return () => {
+      window.removeEventListener("osd", handler as EventListener);
+    };
+  }, []);
+
+  if (!payload) return null;
+  return (
+    <Toast
+      key={payload.key}
+      message={payload.message}
+      duration={payload.duration}
+      onClose={() => setPayload(null)}
+    />
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import OSDManager from '../components/osd/OSDManager';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <OSDManager />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;


### PR DESCRIPTION
## Summary
- add OSDManager that listens for `osd` events and displays a single toast overlay
- wire OSDManager into `_app` so overlays don't stack when keys repeat

## Testing
- `yarn test components/osd/OSDManager.test.tsx --passWithNoTests`
- `yarn lint components/osd/OSDManager.tsx pages/_app.jsx` *(fails: A control must be associated with a text label ...)*
- `npx eslint --ext .jsx,.tsx components/osd/OSDManager.tsx pages/_app.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f6d752083288ee2b4d3c0386a00