### PR TITLE
feat: add media key step settings

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -40,6 +40,18 @@ export default function Preferences() {
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
 
+  const [volumeStep, setVolumeStep] = useState(() => {
+    if (typeof window === "undefined") return 5;
+    const stored = localStorage.getItem(`${PANEL_PREFIX}volume-step`);
+    return stored ? parseInt(stored, 10) : 5;
+  });
+
+  const [brightnessStep, setBrightnessStep] = useState(() => {
+    if (typeof window === "undefined") return 10;
+    const stored = localStorage.getItem(`${PANEL_PREFIX}brightness-step`);
+    return stored ? parseInt(stored, 10) : 10;
+  });
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
@@ -59,6 +71,16 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}volume-step`, String(volumeStep));
+  }, [volumeStep]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}brightness-step`, String(brightnessStep));
+  }, [brightnessStep]);
 
   return (
     <div>
@@ -88,6 +110,34 @@ export default function Preferences() {
                 checked={autohide}
                 onChange={setAutohide}
                 ariaLabel="Autohide panel"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="volume-step" className="text-ubt-grey">
+                Volume step
+              </label>
+              <input
+                id="volume-step"
+                type="number"
+                min="1"
+                max="100"
+                value={volumeStep}
+                onChange={(e) => setVolumeStep(parseInt(e.target.value, 10))}
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded w-16 text-right"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="brightness-step" className="text-ubt-grey">
+                Brightness step
+              </label>
+              <input
+                id="brightness-step"
+                type="number"
+                min="1"
+                max="100"
+                value={brightnessStep}
+                onChange={(e) => setBrightnessStep(parseInt(e.target.value, 10))}
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded w-16 text-right"
               />
             </div>
           </div>

--- a/hooks/useMediaKeys.ts
+++ b/hooks/useMediaKeys.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const PANEL_PREFIX = "xfce.panel.";
+
+const getStep = (key: string, fallback: number) => {
+  if (typeof window === "undefined") return fallback;
+  const stored = window.localStorage.getItem(`${PANEL_PREFIX}${key}`);
+  const parsed = stored ? parseInt(stored, 10) : NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export default function useMediaKeys() {
+  const [volumeStep, setVolumeStep] = useState(() => getStep("volume-step", 5));
+  const [brightnessStep, setBrightnessStep] = useState(() => getStep("brightness-step", 10));
+  const [volume, setVolume] = useState(100);
+  const [brightness, setBrightness] = useState(100);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === `${PANEL_PREFIX}volume-step`) setVolumeStep(getStep("volume-step", 5));
+      if (e.key === `${PANEL_PREFIX}brightness-step`) setBrightnessStep(getStep("brightness-step", 10));
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "AudioVolumeUp":
+          e.preventDefault();
+          setVolume((v) => {
+            const next = Math.min(100, v + volumeStep);
+            document.documentElement.style.setProperty("--system-volume", String(next));
+            return next;
+          });
+          break;
+        case "AudioVolumeDown":
+          e.preventDefault();
+          setVolume((v) => {
+            const next = Math.max(0, v - volumeStep);
+            document.documentElement.style.setProperty("--system-volume", String(next));
+            return next;
+          });
+          break;
+        case "BrightnessUp":
+          e.preventDefault();
+          setBrightness((b) => {
+            const next = Math.min(100, b + brightnessStep);
+            document.documentElement.style.setProperty("--system-brightness", String(next));
+            document.documentElement.style.setProperty("filter", `brightness(${next}%)`);
+            return next;
+          });
+          break;
+        case "BrightnessDown":
+          e.preventDefault();
+          setBrightness((b) => {
+            const next = Math.max(0, b - brightnessStep);
+            document.documentElement.style.setProperty("--system-brightness", String(next));
+            document.documentElement.style.setProperty("filter", `brightness(${next}%)`);
+            return next;
+          });
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [volumeStep, brightnessStep]);
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import useMediaKeys from '../hooks/useMediaKeys';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -27,8 +28,7 @@ const ubuntu = Ubuntu({
 
 function MyApp(props) {
   const { Component, pageProps } = props;
-
-
+  useMediaKeys();
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
       window.initA2HS();


### PR DESCRIPTION
## Summary
- add volume and brightness step controls to panel preferences
- handle media key presses using configurable step values
- wire media key hook into application

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6e36e083288a0b29554c62cac8