### PR TITLE
Add live regions and reduced-motion overlay option

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -237,11 +237,11 @@ export default function Settings() {
             </select>
           </div>
           <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
+            <span className="mr-2 text-ubt-grey">Reduce Motion:</span>
             <ToggleSwitch
               checked={reducedMotion}
               onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
+              ariaLabel="Reduce Motion"
             />
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/apps/Games/common/Overlay.tsx
+++ b/components/apps/Games/common/Overlay.tsx
@@ -23,6 +23,7 @@ export default function Overlay({
   const count = useRef(0);
   const [toast, setToast] = useState('');
   const pausedByDisconnect = useRef(false);
+  const [liveMessage, setLiveMessage] = useState('');
 
   // track fps using requestAnimationFrame
   useEffect(() => {
@@ -43,6 +44,7 @@ export default function Overlay({
   const togglePause = useCallback(() => {
     setPaused((p) => {
       const np = !p;
+      setLiveMessage(np ? 'Paused' : 'Resumed');
       np ? onPause?.() : onResume?.();
       return np;
     });
@@ -52,6 +54,7 @@ export default function Overlay({
     setMuted((m) => {
       const nm = !m;
       onToggleSound?.(nm);
+      setLiveMessage(nm ? 'Muted' : 'Sound on');
       return nm;
     });
   }, [onToggleSound]);
@@ -96,6 +99,9 @@ export default function Overlay({
         </button>
         <span className="fps">{fps} FPS</span>
       </div>
+      <span aria-live="polite" className="sr-only">
+        {liveMessage}
+      </span>
       {toast && (
         <Toast
           message={toast}

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -119,7 +119,7 @@ export function Settings() {
                         onChange={(e) => setReducedMotion(e.target.checked)}
                         className="mr-2"
                     />
-                    Reduced Motion
+                    Reduce Motion
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
 class AllApplications extends React.Component {
     constructor() {
@@ -9,6 +10,7 @@ class AllApplications extends React.Component {
             apps: [],
             unfilteredApps: [],
         };
+        this.liveRegion = React.createRef();
     }
 
     componentDidMount() {
@@ -30,6 +32,10 @@ class AllApplications extends React.Component {
                       app.title.toLowerCase().includes(value.toLowerCase())
                   );
         this.setState({ query: value, apps });
+        if (this.liveRegion.current) {
+            const msg = `${apps.length} result${apps.length === 1 ? '' : 's'} found`;
+            this.liveRegion.current.textContent = msg;
+        }
     };
 
     openApp = (id) => {
@@ -54,14 +60,16 @@ class AllApplications extends React.Component {
     };
 
     render() {
+        const prefersReducedMotion = usePrefersReducedMotion();
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div className={`fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 ${prefersReducedMotion ? 'all-apps-fade' : 'all-apps-anim'}`}>
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
+                <span ref={this.liveRegion} aria-live="polite" className="sr-only"></span>
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
 interface ToastProps {
   message: string;
@@ -17,6 +18,7 @@ const Toast: React.FC<ToastProps> = ({
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     setVisible(true);
@@ -32,7 +34,11 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center ${
+        prefersReducedMotion
+          ? `transition-opacity duration-150 ease-in-out ${visible ? 'opacity-100' : 'opacity-0'}`
+          : `transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`
+      }`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/styles/index.css
+++ b/styles/index.css
@@ -222,6 +222,10 @@ dialog {
     animation: allAppsScale 200ms ease-out;
 }
 
+.all-apps-fade {
+    animation: allAppsFade 200ms ease-out;
+}
+
 @keyframes allAppsScale {
     from {
         opacity: 0;
@@ -231,6 +235,15 @@ dialog {
     to {
         opacity: 1;
         transform: scale(1);
+    }
+}
+
+@keyframes allAppsFade {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
     }
 }
 


### PR DESCRIPTION
## Summary
- Announce game HUD updates via aria-live regions
- Respect reduce-motion setting to fade overlays instead of sliding
- Label settings toggle as "Reduce Motion" and adjust styles

## Testing
- `npm test` *(fails: TypeError e.preventDefault is not a function; Unable to find role="alert"; jsdom localStorage origin null)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f6eca808328889c37f46ed3acc4