### PR TITLE
feat(panel): add volume plugin toggle

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -39,6 +39,10 @@ export default function Preferences() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
+  const [volumePlugin, setVolumePlugin] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return localStorage.getItem(`${PANEL_PREFIX}volume-plugin`) !== "false";
+  });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -59,6 +63,13 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PANEL_PREFIX}volume-plugin`,
+      volumePlugin ? "true" : "false",
+    );
+  }, [volumePlugin]);
 
   return (
     <div>
@@ -133,7 +144,22 @@ export default function Preferences() {
           <p className="text-ubt-grey">Opacity settings are not available yet.</p>
         )}
         {active === "items" && (
-          <p className="text-ubt-grey">Item settings are not available yet.</p>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-ubt-grey">
+                Volume plugin
+                <span className="block text-xs">
+                  Disable to stop media-key handling and hide the on-screen
+                  overlay.
+                </span>
+              </span>
+              <ToggleSwitch
+                checked={volumePlugin}
+                onChange={setVolumePlugin}
+                ariaLabel="Enable volume plugin"
+              />
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/components/panel/VolumePlugin.tsx
+++ b/components/panel/VolumePlugin.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+
+const PANEL_KEY = "xfce.panel.volume-plugin";
+
+export default function VolumePlugin() {
+  const [enabled, setEnabled] = useState(true);
+  const [level, setLevel] = useState(50);
+  const [visible, setVisible] = useState(false);
+
+  // Sync enabled state with localStorage and storage events
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(PANEL_KEY);
+    setEnabled(stored !== "false");
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === PANEL_KEY) {
+        setEnabled(e.newValue !== "false");
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  // Register media-key listeners when enabled
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      switch (e.code) {
+        case "AudioVolumeUp":
+          setLevel((l) => Math.min(l + 5, 100));
+          break;
+        case "AudioVolumeDown":
+          setLevel((l) => Math.max(l - 5, 0));
+          break;
+        case "AudioVolumeMute":
+          setLevel(0);
+          break;
+        default:
+          return;
+      }
+      setVisible(true);
+      setTimeout(() => setVisible(false), 1000);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled]);
+
+  if (!enabled || !visible) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-[1000]">
+      <div className="bg-black bg-opacity-75 text-white px-4 py-2 rounded">
+        Volume: {level}
+      </div>
+    </div>
+  );
+}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import VolumePlugin from '../panel/VolumePlugin';
 
 export class Desktop extends Component {
     constructor() {
@@ -950,6 +951,8 @@ export class Desktop extends Component {
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                <VolumePlugin />
 
             </main>
         )


### PR DESCRIPTION
## Summary
- add `VolumePlugin` component that listens for media keys and shows on-screen volume
- integrate volume plugin toggle in panel preferences
- mount volume plugin on desktop and document behavior in settings

## Testing
- `yarn test components/panel/Preferences.tsx components/panel/VolumePlugin.tsx components/screen/desktop.js --passWithNoTests`
- `yarn lint components/panel/Preferences.tsx components/panel/VolumePlugin.tsx components/screen/desktop.js` *(fails: Unexpected global 'document' in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68ba6f6f0de48328bc74e5ca264b23a4