### PR TITLE
feat: add mouse and touchpad settings

### DIFF
--- a/components/settings/MouseTouchpad.tsx
+++ b/components/settings/MouseTouchpad.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import ToggleSwitch from "../ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+export default function MouseTouchpad() {
+  const {
+    tapToClick,
+    setTapToClick,
+    disableWhileTyping,
+    setDisableWhileTyping,
+    naturalScroll,
+    setNaturalScroll,
+    mouseSpeed,
+    setMouseSpeed,
+    touchpadSpeed,
+    setTouchpadSpeed,
+  } = useSettings();
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-lg font-bold mb-2">Mouse</h2>
+        <label htmlFor="mouse-speed" className="block mb-2 text-ubt-grey">
+          Pointer Speed
+        </label>
+        <input
+          id="mouse-speed"
+          type="range"
+          min="0"
+          max="100"
+          value={mouseSpeed}
+          onChange={(e) => setMouseSpeed(parseInt(e.target.value, 10))}
+          className="ubuntu-slider w-full"
+          aria-label="Mouse pointer speed"
+        />
+        <div className="mt-2 h-4 w-full bg-ubt-cool-grey">
+          <div
+            className="h-full bg-ub-orange transition-all"
+            style={{ width: `${mouseSpeed}%` }}
+          />
+        </div>
+      </section>
+      <section>
+        <h2 className="text-lg font-bold mb-2">Touchpad</h2>
+        <div className="flex items-center mb-2">
+          <span className="mr-2 text-ubt-grey">Tap to Click</span>
+          <ToggleSwitch
+            checked={tapToClick}
+            onChange={setTapToClick}
+            ariaLabel="Tap to click"
+          />
+        </div>
+        <div className="flex items-center mb-2">
+          <span className="mr-2 text-ubt-grey">Disable While Typing</span>
+          <ToggleSwitch
+            checked={disableWhileTyping}
+            onChange={setDisableWhileTyping}
+            ariaLabel="Disable while typing"
+          />
+        </div>
+        <div className="flex items-center mb-4">
+          <span className="mr-2 text-ubt-grey">Natural Scrolling</span>
+          <ToggleSwitch
+            checked={naturalScroll}
+            onChange={setNaturalScroll}
+            ariaLabel="Natural scrolling"
+          />
+        </div>
+        <label htmlFor="touchpad-speed" className="block mb-2 text-ubt-grey">
+          Pointer Speed
+        </label>
+        <input
+          id="touchpad-speed"
+          type="range"
+          min="0"
+          max="100"
+          value={touchpadSpeed}
+          onChange={(e) => setTouchpadSpeed(parseInt(e.target.value, 10))}
+          className="ubuntu-slider w-full"
+          aria-label="Touchpad pointer speed"
+        />
+        <div className="mt-2 h-4 w-full bg-ubt-cool-grey">
+          <div
+            className="h-full bg-ub-orange transition-all"
+            style={{ width: `${touchpadSpeed}%` }}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,16 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getTapToClick as loadTapToClick,
+  setTapToClick as saveTapToClick,
+  getDisableWhileTyping as loadDisableWhileTyping,
+  setDisableWhileTyping as saveDisableWhileTyping,
+  getNaturalScroll as loadNaturalScroll,
+  setNaturalScroll as saveNaturalScroll,
+  getMouseSpeed as loadMouseSpeed,
+  setMouseSpeed as saveMouseSpeed,
+  getTouchpadSpeed as loadTouchpadSpeed,
+  setTouchpadSpeed as saveTouchpadSpeed,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +73,11 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  tapToClick: boolean;
+  disableWhileTyping: boolean;
+  naturalScroll: boolean;
+  mouseSpeed: number;
+  touchpadSpeed: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +89,11 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setTapToClick: (value: boolean) => void;
+  setDisableWhileTyping: (value: boolean) => void;
+  setNaturalScroll: (value: boolean) => void;
+  setMouseSpeed: (value: number) => void;
+  setTouchpadSpeed: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +108,11 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  tapToClick: defaults.tapToClick,
+  disableWhileTyping: defaults.disableWhileTyping,
+  naturalScroll: defaults.naturalScroll,
+  mouseSpeed: defaults.mouseSpeed,
+  touchpadSpeed: defaults.touchpadSpeed,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +124,11 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setTapToClick: () => {},
+  setDisableWhileTyping: () => {},
+  setNaturalScroll: () => {},
+  setMouseSpeed: () => {},
+  setTouchpadSpeed: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +143,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [tapToClick, setTapToClick] = useState<boolean>(defaults.tapToClick);
+  const [disableWhileTyping, setDisableWhileTyping] = useState<boolean>(
+    defaults.disableWhileTyping
+  );
+  const [naturalScroll, setNaturalScroll] = useState<boolean>(
+    defaults.naturalScroll
+  );
+  const [mouseSpeed, setMouseSpeed] = useState<number>(defaults.mouseSpeed);
+  const [touchpadSpeed, setTouchpadSpeed] = useState<number>(
+    defaults.touchpadSpeed
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -127,6 +168,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setTapToClick(await loadTapToClick());
+      setDisableWhileTyping(await loadDisableWhileTyping());
+      setNaturalScroll(await loadNaturalScroll());
+      setMouseSpeed(await loadMouseSpeed());
+      setTouchpadSpeed(await loadTouchpadSpeed());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +282,26 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveTapToClick(tapToClick);
+  }, [tapToClick]);
+
+  useEffect(() => {
+    saveDisableWhileTyping(disableWhileTyping);
+  }, [disableWhileTyping]);
+
+  useEffect(() => {
+    saveNaturalScroll(naturalScroll);
+  }, [naturalScroll]);
+
+  useEffect(() => {
+    saveMouseSpeed(mouseSpeed);
+  }, [mouseSpeed]);
+
+  useEffect(() => {
+    saveTouchpadSpeed(touchpadSpeed);
+  }, [touchpadSpeed]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +316,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        tapToClick,
+        disableWhileTyping,
+        naturalScroll,
+        mouseSpeed,
+        touchpadSpeed,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +332,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setTapToClick,
+        setDisableWhileTyping,
+        setNaturalScroll,
+        setMouseSpeed,
+        setTouchpadSpeed,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,11 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  tapToClick: false,
+  disableWhileTyping: true,
+  naturalScroll: false,
+  mouseSpeed: 50,
+  touchpadSpeed: 50,
 };
 
 export async function getAccent() {
@@ -123,6 +128,61 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getTapToClick() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.tapToClick;
+  const val = window.localStorage.getItem('tap-to-click');
+  return val === null ? DEFAULT_SETTINGS.tapToClick : val === 'true';
+}
+
+export async function setTapToClick(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('tap-to-click', value ? 'true' : 'false');
+}
+
+export async function getDisableWhileTyping() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.disableWhileTyping;
+  const val = window.localStorage.getItem('disable-while-typing');
+  return val === null ? DEFAULT_SETTINGS.disableWhileTyping : val === 'true';
+}
+
+export async function setDisableWhileTyping(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('disable-while-typing', value ? 'true' : 'false');
+}
+
+export async function getNaturalScroll() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.naturalScroll;
+  const val = window.localStorage.getItem('natural-scroll');
+  return val === null ? DEFAULT_SETTINGS.naturalScroll : val === 'true';
+}
+
+export async function setNaturalScroll(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('natural-scroll', value ? 'true' : 'false');
+}
+
+export async function getMouseSpeed() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.mouseSpeed;
+  const val = window.localStorage.getItem('mouse-speed');
+  return val === null ? DEFAULT_SETTINGS.mouseSpeed : parseInt(val, 10);
+}
+
+export async function setMouseSpeed(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('mouse-speed', String(value));
+}
+
+export async function getTouchpadSpeed() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.touchpadSpeed;
+  const val = window.localStorage.getItem('touchpad-speed');
+  return val === null ? DEFAULT_SETTINGS.touchpadSpeed : parseInt(val, 10);
+}
+
+export async function setTouchpadSpeed(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('touchpad-speed', String(value));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +197,11 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('tap-to-click');
+  window.localStorage.removeItem('disable-while-typing');
+  window.localStorage.removeItem('natural-scroll');
+  window.localStorage.removeItem('mouse-speed');
+  window.localStorage.removeItem('touchpad-speed');
 }
 
 export async function exportSettings() {
@@ -151,6 +216,11 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    tapToClick,
+    disableWhileTyping,
+    naturalScroll,
+    mouseSpeed,
+    touchpadSpeed,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +232,11 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getTapToClick(),
+    getDisableWhileTyping(),
+    getNaturalScroll(),
+    getMouseSpeed(),
+    getTouchpadSpeed(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +250,11 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    tapToClick,
+    disableWhileTyping,
+    naturalScroll,
+    mouseSpeed,
+    touchpadSpeed,
     theme,
   });
 }
@@ -199,6 +279,11 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    tapToClick,
+    disableWhileTyping,
+    naturalScroll,
+    mouseSpeed,
+    touchpadSpeed,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +296,12 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (tapToClick !== undefined) await setTapToClick(tapToClick);
+  if (disableWhileTyping !== undefined)
+    await setDisableWhileTyping(disableWhileTyping);
+  if (naturalScroll !== undefined) await setNaturalScroll(naturalScroll);
+  if (mouseSpeed !== undefined) await setMouseSpeed(mouseSpeed);
+  if (touchpadSpeed !== undefined) await setTouchpadSpeed(touchpadSpeed);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add Mouse & Touchpad settings component with tap-to-click, typing disable, natural scroll toggles and pointer speed sliders
- persist new settings in context and settings store

## Testing
- `yarn lint`
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*
- `yarn tsc -p tsconfig.json` *(fails: Cannot write file ... overwrite input file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f7320b48328b3134938479b2454