### PR TITLE
feat: add settings bus for live theme updates

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,11 +1,22 @@
-import React, { useRef } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import { useSettings, settingsBus } from '../../hooks/useSettings'
 
 function AppMenu(props) {
     const menuRef = useRef(null)
+    const { theme: initialTheme } = useSettings()
+    const [theme, setTheme] = useState(initialTheme)
     useFocusTrap(menuRef, props.active)
     useRovingTabIndex(menuRef, props.active, 'vertical')
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.detail?.key === 'theme') setTheme(e.detail.value)
+        }
+        settingsBus.addEventListener('change', handler)
+        return () => settingsBus.removeEventListener('change', handler)
+    }, [])
 
     const handleKeyDown = (e) => {
         if (e.key === 'Escape') {
@@ -29,6 +40,7 @@ function AppMenu(props) {
             ref={menuRef}
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            data-theme={theme}
         >
             <button
                 type="button"

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,26 +3,46 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { settingsBus, SettingsContext } from '../../hooks/useSettings';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        static contextType = SettingsContext;
 
-	render() {
-		return (
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false,
+                        theme: 'default'
+                };
+        }
+
+        componentDidMount() {
+                this.setState({ theme: this.context.theme });
+                settingsBus.addEventListener('change', this.handleSettings);
+        }
+
+        componentWillUnmount() {
+                settingsBus.removeEventListener('change', this.handleSettings);
+        }
+
+        handleSettings = (e) => {
+                if (e.detail?.key === 'theme') {
+                        this.setState({ theme: e.detail.value });
+                }
+        };
+
+        render() {
+                const iconTheme = this.state.theme === 'default' ? 'Yaru' : this.state.theme;
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                        <Image src={`/themes/${iconTheme}/status/network-wireless-signal-good-symbolic.svg`} alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <div
                                         className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
                                 >
                                         <Image
-                                                src="/themes/Yaru/status/decompiler-symbolic.svg"
+                                                src={`/themes/${iconTheme}/status/decompiler-symbolic.svg`}
                                                 alt="Decompiler"
                                                 width={16}
                                                 height={16}

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,13 +1,23 @@
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
-import { useSettings } from '../../hooks/useSettings';
-
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+import { useSettings, settingsBus } from '../../hooks/useSettings';
 
 export default function Status() {
-  const { allowNetwork } = useSettings();
+  const { allowNetwork, theme: initialTheme } = useSettings();
   const [online, setOnline] = useState(true);
+  const [theme, setTheme] = useState(initialTheme);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.detail?.key === 'theme') setTheme(e.detail.value);
+    };
+    settingsBus.addEventListener('change', handler);
+    return () => settingsBus.removeEventListener('change', handler);
+  }, []);
+
+  const iconTheme = theme === 'default' ? 'Yaru' : theme;
+  const volumeIcon = `/themes/${iconTheme}/status/audio-volume-medium-symbolic.svg`;
 
   useEffect(() => {
     const pingServer = async () => {
@@ -47,7 +57,11 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={
+            online
+              ? `/themes/${iconTheme}/status/network-wireless-signal-good-symbolic.svg`
+              : `/themes/${iconTheme}/status/network-wireless-signal-none-symbolic.svg`
+          }
           alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
@@ -60,7 +74,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src={VOLUME_ICON}
+          src={volumeIcon}
           alt="volume"
           className="inline status-symbol w-4 h-4"
           sizes="16px"
@@ -70,7 +84,7 @@ export default function Status() {
         <Image
           width={16}
           height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
+          src={`/themes/${iconTheme}/status/battery-good-symbolic.svg`}
           alt="ubuntu battry"
           className="inline status-symbol w-4 h-4"
           sizes="16px"

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -23,6 +23,15 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+
+// Simple event bus used to notify parts of the UI when a setting changes. It is
+// exported as a singleton so every module receives the same instance.  Using a
+// property on `window` avoids creating multiple emitters during hot reloads in
+// development.
+export const settingsBus: EventTarget =
+  typeof window !== 'undefined'
+    ? (window as any).__settingsBus || ((window as any).__settingsBus = new EventTarget())
+    : new EventTarget();
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -133,6 +142,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     saveTheme(theme);
+    settingsBus.dispatchEvent(
+      new CustomEvent('change', { detail: { key: 'theme', value: theme } })
+    );
   }, [theme]);
 
   useEffect(() => {
@@ -150,6 +162,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       document.documentElement.style.setProperty(key, value);
     });
     saveAccent(accent);
+    settingsBus.dispatchEvent(
+      new CustomEvent('change', { detail: { key: 'accent', value: accent } })
+    );
   }, [accent]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- implement global settingsBus and emit change events
- subscribe panel, menus, and OSD components to bus for immediate icon/theme updates

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f7472dc832883e796d90e0792b7