### PR TITLE
feat: add channels inspector component

### DIFF
--- a/components/settings/ChannelsInspector.tsx
+++ b/components/settings/ChannelsInspector.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+/**
+ * Read-only view of all stored settings grouped by channel.
+ * Updates automatically when settings change.
+ */
+export default function ChannelsInspector() {
+  const {
+    accent,
+    wallpaper,
+    density,
+    reducedMotion,
+    fontScale,
+    highContrast,
+    largeHitAreas,
+    pongSpin,
+    allowNetwork,
+    haptics,
+    theme,
+  } = useSettings();
+
+  // Group settings into logical channels
+  const channels = useMemo(
+    () => ({
+      appearance: { accent, wallpaper, density, fontScale, theme },
+      accessibility: { reducedMotion, highContrast, largeHitAreas, haptics },
+      gameplay: { pongSpin },
+      privacy: { allowNetwork },
+    }),
+    [
+      accent,
+      wallpaper,
+      density,
+      fontScale,
+      theme,
+      reducedMotion,
+      highContrast,
+      largeHitAreas,
+      haptics,
+      pongSpin,
+      allowNetwork,
+    ]
+  );
+
+  return (
+    <div className="text-sm">
+      {Object.entries(channels).map(([channel, props]) => (
+        <div key={channel} className="mb-4">
+          <h3 className="font-bold capitalize">{channel}</h3>
+          <ul className="pl-4">
+            {Object.entries(props).map(([key, value]) => (
+              <li key={key}>
+                <span className="text-ubt-grey">{key}</span>: <span>{String(value)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add read-only ChannelsInspector component to display settings grouped by channel and update live

## Testing
- `npx eslint components/settings/ChannelsInspector.tsx`
- `yarn test __tests__/window.test.tsx` *(fails: TypeError e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f7580008328a371311f33038b20