### PR TITLE
feat(settings): add reset buttons

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import Toast from "../../components/ui/Toast";
 
 export default function Settings() {
   const {
@@ -33,6 +34,7 @@ export default function Settings() {
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [toast, setToast] = useState("");
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
@@ -100,7 +102,9 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setHaptics(defaults.haptics);
     setTheme("default");
+    setToast("Settings reset to defaults");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -301,6 +305,7 @@ export default function Settings() {
           className="hidden"
         />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </div>
   );
 }

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import { resetSettings, defaults } from '../utils/settingsStore';
+import Toast from './ui/Toast';
 
 interface Props {
   highScore?: number;
@@ -8,8 +10,16 @@ interface Props {
 
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
+  const [toast, setToast] = useState('');
   const unlocked = getUnlockedThemes(highScore);
   const { accent, setAccent, theme, setTheme } = useSettings();
+
+  const handleReset = async () => {
+    await resetSettings();
+    setAccent(defaults.accent);
+    setTheme('default');
+    setToast('Settings reset to defaults');
+  };
 
   return (
     <div>
@@ -52,8 +62,10 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </div>
           </label>
+          <button onClick={handleReset}>Reset</button>
         </div>
       )}
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add toast-enhanced reset action in desktop settings dialog
- add reset option to reusable SettingsDrawer

## Testing
- `npx eslint apps/settings/index.tsx components/SettingsDrawer.tsx`
- `yarn test apps/settings/index.tsx components/SettingsDrawer.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f769e2c8328ae9cf6e6944d7e97