### PR TITLE
feat: export settings as xfce xml

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -56,12 +56,12 @@ export default function Settings() {
   const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
-    const data = await exportSettingsData();
-    const blob = new Blob([data], { type: "application/json" });
+    const data = await exportSettingsData("appearance");
+    const blob = new Blob([data], { type: "application/xml" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "settings.json";
+    a.download = "xsettings.xml";
     a.click();
     URL.revokeObjectURL(url);
   };

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -222,12 +222,12 @@ export function Settings() {
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
                 <button
                     onClick={async () => {
-                        const data = await exportSettingsData();
-                        const blob = new Blob([data], { type: 'application/json' });
+                        const data = await exportSettingsData('appearance');
+                        const blob = new Blob([data], { type: 'application/xml' });
                         const url = URL.createObjectURL(blob);
                         const a = document.createElement('a');
                         a.href = url;
-                        a.download = 'settings.json';
+                        a.download = 'xsettings.xml';
                         a.click();
                         URL.revokeObjectURL(url);
                     }}

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
+import { exportSettings as exportSettingsData } from "../../utils/settingsStore";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -135,6 +136,24 @@ export default function Preferences() {
         {active === "items" && (
           <p className="text-ubt-grey">Item settings are not available yet.</p>
         )}
+      </div>
+      </div>
+      <div className="border-t border-gray-900 mt-4 pt-4 flex justify-end px-4">
+        <button
+          onClick={async () => {
+            const data = await exportSettingsData("panel");
+            const blob = new Blob([data], { type: "application/xml" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "xfce4-panel.xml";
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
+          className="px-4 py-2 rounded bg-ub-orange text-white"
+        >
+          Export
+        </button>
       </div>
     </div>
   );

--- a/utils/settingsStore.ts
+++ b/utils/settingsStore.ts
@@ -3,7 +3,20 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 
-const DEFAULT_SETTINGS = {
+interface Settings {
+  accent: string;
+  wallpaper: string;
+  density: string;
+  reducedMotion: boolean;
+  fontScale: number;
+  highContrast: boolean;
+  largeHitAreas: boolean;
+  pongSpin: boolean;
+  allowNetwork: boolean;
+  haptics: boolean;
+}
+
+const DEFAULT_SETTINGS: Settings = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
   density: 'regular',
@@ -16,37 +29,37 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
-export async function getAccent() {
+export async function getAccent(): Promise<string> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
-export async function setAccent(accent) {
+export async function setAccent(accent: string): Promise<void> {
   if (typeof window === 'undefined') return;
   await set('accent', accent);
 }
 
-export async function getWallpaper() {
+export async function getWallpaper(): Promise<string> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
-export async function setWallpaper(wallpaper) {
+export async function setWallpaper(wallpaper: string): Promise<void> {
   if (typeof window === 'undefined') return;
   await set('bg-image', wallpaper);
 }
 
-export async function getDensity() {
+export async function getDensity(): Promise<string> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
   return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
-export async function setDensity(density) {
+export async function setDensity(density: string): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('density', density);
 }
 
-export async function getReducedMotion() {
+export async function getReducedMotion(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
   const stored = window.localStorage.getItem('reduced-motion');
   if (stored !== null) {
@@ -55,75 +68,75 @@ export async function getReducedMotion() {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-export async function setReducedMotion(value) {
+export async function setReducedMotion(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
-export async function getFontScale() {
+export async function getFontScale(): Promise<number> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
   const stored = window.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
-export async function setFontScale(scale) {
+export async function setFontScale(scale: number): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('font-scale', String(scale));
 }
 
-export async function getHighContrast() {
+export async function getHighContrast(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
   return window.localStorage.getItem('high-contrast') === 'true';
 }
 
-export async function setHighContrast(value) {
+export async function setHighContrast(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
-export async function getLargeHitAreas() {
+export async function getLargeHitAreas(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
   return window.localStorage.getItem('large-hit-areas') === 'true';
 }
 
-export async function setLargeHitAreas(value) {
+export async function setLargeHitAreas(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
-export async function getHaptics() {
+export async function getHaptics(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
   const val = window.localStorage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
-export async function setHaptics(value) {
+export async function setHaptics(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
-export async function getPongSpin() {
+export async function getPongSpin(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
-export async function setPongSpin(value) {
+export async function setPongSpin(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
-export async function getAllowNetwork() {
+export async function getAllowNetwork(): Promise<boolean> {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
   return window.localStorage.getItem('allow-network') === 'true';
 }
 
-export async function setAllowNetwork(value) {
+export async function setAllowNetwork(value: boolean): Promise<void> {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
-export async function resetSettings() {
+export async function resetSettings(): Promise<void> {
   if (typeof window === 'undefined') return;
   await Promise.all([
     del('accent'),
@@ -139,7 +152,30 @@ export async function resetSettings() {
   window.localStorage.removeItem('haptics');
 }
 
-export async function exportSettings() {
+export type ExportChannel = 'appearance' | 'panel';
+
+export async function exportSettings(channel: ExportChannel = 'appearance'): Promise<string> {
+  if (channel === 'panel') {
+    if (typeof window === 'undefined') {
+      return '<?xml version="1.0" encoding="UTF-8"?>\n<channel name="xfce4-panel" version="1.0"></channel>';
+    }
+    const size = window.localStorage.getItem('xfce.panel.size') || '24';
+    const length = window.localStorage.getItem('xfce.panel.length') || '100';
+    const orientation =
+      window.localStorage.getItem('xfce.panel.orientation') || 'horizontal';
+    const autohide = window.localStorage.getItem('xfce.panel.autohide') === 'true';
+    const lines = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<channel name="xfce4-panel" version="1.0">',
+      `  <property name="size" type="int" value="${size}"/>`,
+      `  <property name="length" type="int" value="${length}"/>`,
+      `  <property name="orientation" type="string" value="${orientation}"/>`,
+      `  <property name="autohide" type="bool" value="${autohide}"/>`,
+      '</channel>',
+    ];
+    return lines.join('\n');
+  }
+
   const [
     accent,
     wallpaper,
@@ -164,24 +200,28 @@ export async function exportSettings() {
     getHaptics(),
   ]);
   const theme = getTheme();
-  return JSON.stringify({
-    accent,
-    wallpaper,
-    density,
-    reducedMotion,
-    fontScale,
-    highContrast,
-    largeHitAreas,
-    pongSpin,
-    allowNetwork,
-    haptics,
-    theme,
-  });
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<channel name="xsettings" version="1.0">',
+    `  <property name="theme" type="string" value="${theme}"/>`,
+    `  <property name="accent" type="string" value="${accent}"/>`,
+    `  <property name="wallpaper" type="string" value="${wallpaper}"/>`,
+    `  <property name="density" type="string" value="${density}"/>`,
+    `  <property name="reducedMotion" type="bool" value="${reducedMotion}"/>`,
+    `  <property name="fontScale" type="double" value="${fontScale}"/>`,
+    `  <property name="highContrast" type="bool" value="${highContrast}"/>`,
+    `  <property name="largeHitAreas" type="bool" value="${largeHitAreas}"/>`,
+    `  <property name="pongSpin" type="bool" value="${pongSpin}"/>`,
+    `  <property name="allowNetwork" type="bool" value="${allowNetwork}"/>`,
+    `  <property name="haptics" type="bool" value="${haptics}"/>`,
+    '</channel>',
+  ];
+  return lines.join('\n');
 }
 
-export async function importSettings(json) {
+export async function importSettings(json: string | object): Promise<void> {
   if (typeof window === 'undefined') return;
-  let settings;
+  let settings: any;
   try {
     settings = typeof json === 'string' ? JSON.parse(json) : json;
   } catch (e) {
@@ -200,7 +240,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
-  } = settings;
+  } = settings as Partial<Settings> & { theme?: string };
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
   if (density !== undefined) await setDensity(density);
@@ -215,3 +255,4 @@ export async function importSettings(json) {
 }
 
 export const defaults = DEFAULT_SETTINGS;
+


### PR DESCRIPTION
## Summary
- add XFCE-style XML export to settings store for appearance and panel data
- allow Settings and Panel dialogs to download exported XML

## Testing
- `yarn test utils/settingsStore apps/settings/index.tsx components/panel/Preferences.tsx components/apps/settings.js --passWithNoTests`
- `npx tsc utils/settingsStore.ts --noEmit` *(fails: 'cytoscape' has no exported member 'Stylesheet')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6f762b3c8328912031ff814cfafb