### PR TITLE
feat(settings): add dpi scaling controls

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,10 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    dpi,
+    setDpi,
+    scale,
+    setScale,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -100,6 +104,8 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setDpi(defaults.dpi);
+    setScale(defaults.scale);
     setTheme("default");
   };
 
@@ -149,6 +155,31 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex justify-center my-4" title="Dots per inch controls base pixel density.">
+            <label htmlFor="custom-dpi" className="mr-2 text-ubt-grey">Custom DPI:</label>
+            <input
+              id="custom-dpi"
+              type="number"
+              min="50"
+              max="400"
+              value={dpi}
+              onChange={(e) => setDpi(parseInt(e.target.value, 10) || 0)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </div>
+          <div className="flex justify-center my-4" title="Scaling factor multiplies UI size based on DPI.">
+            <label htmlFor="scaling-factor" className="mr-2 text-ubt-grey">Scaling factor:</label>
+            <select
+              id="scaling-factor"
+              value={scale}
+              onChange={(e) => setScale(parseFloat(e.target.value))}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              {[1, 1.25, 1.5, 1.75, 2].map((f) => (
+                <option key={f} value={f}>{f}x</option>
+              ))}
+            </select>
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getDpi as loadDpi,
+  setDpi as saveDpi,
+  getScale as loadScale,
+  setScale as saveScale,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +67,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  dpi: number;
+  scale: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +80,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setDpi: (value: number) => void;
+  setScale: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +96,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  dpi: defaults.dpi,
+  scale: defaults.scale,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +109,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setDpi: () => {},
+  setScale: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +125,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [dpi, setDpi] = useState<number>(defaults.dpi);
+  const [scale, setScale] = useState<number>(defaults.scale);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +142,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setDpi(await loadDpi());
+      setScale(await loadScale());
     })();
   }, []);
 
@@ -236,6 +252,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    const finalScale = (dpi / 96) * scale;
+    document.documentElement.style.setProperty('--ui-scale', finalScale.toString());
+    saveDpi(dpi);
+    saveScale(scale);
+  }, [dpi, scale]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +273,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        dpi,
+        scale,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +286,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setDpi,
+        setScale,
       }}
     >
       {children}

--- a/styles/index.css
+++ b/styles/index.css
@@ -2,6 +2,7 @@
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    zoom: var(--ui-scale, 1);
 }
 
 body{

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  dpi: 96,
+  scale: 1,
 };
 
 export async function getAccent() {
@@ -123,6 +125,46 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getDpi() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.dpi;
+  try {
+    const ls = window.localStorage;
+    if (!ls) return DEFAULT_SETTINGS.dpi;
+    const stored = ls.getItem('custom-dpi');
+    return stored ? parseInt(stored, 10) : DEFAULT_SETTINGS.dpi;
+  } catch {
+    return DEFAULT_SETTINGS.dpi;
+  }
+}
+
+export async function setDpi(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    const ls = window.localStorage;
+    ls && ls.setItem('custom-dpi', String(value));
+  } catch {}
+}
+
+export async function getScale() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.scale;
+  try {
+    const ls = window.localStorage;
+    if (!ls) return DEFAULT_SETTINGS.scale;
+    const stored = ls.getItem('scale-factor');
+    return stored ? parseFloat(stored) : DEFAULT_SETTINGS.scale;
+  } catch {
+    return DEFAULT_SETTINGS.scale;
+  }
+}
+
+export async function setScale(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    const ls = window.localStorage;
+    ls && ls.setItem('scale-factor', String(value));
+  } catch {}
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +179,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('custom-dpi');
+  window.localStorage.removeItem('scale-factor');
 }
 
 export async function exportSettings() {
@@ -151,6 +195,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    scale,
+    dpi,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +208,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getScale(),
+    getDpi(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +223,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    scale,
+    dpi,
     theme,
   });
 }
@@ -199,6 +249,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    scale,
+    dpi,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +263,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (scale !== undefined) await setScale(scale);
+  if (dpi !== undefined) await setDpi(dpi);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add custom DPI input and scaling factor dropdown to appearance settings
- persist DPI and scale in settings store and apply scale to root element
- document UI scale via `zoom` CSS variable

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: window snapping finalize, NmapNSEApp copies example output to clipboard, modal traps focus)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f77b7508328879008af47320b6b