### PR TITLE
feat(settings): add cursor theme picker

### DIFF
--- a/apps/settings/components/MouseSettings.tsx
+++ b/apps/settings/components/MouseSettings.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useSettings } from "../../../hooks/useSettings";
+
+const CURSOR_THEMES = [
+  { value: "white", label: "White" },
+  { value: "black", label: "Black" },
+];
+
+const CURSOR_SIZES = [24, 32, 48];
+
+export default function MouseSettings() {
+  const { cursor, setCursor, cursorSize, setCursorSize } = useSettings();
+  const url = `/cursors/${cursor}/${cursorSize}/left_ptr.png`;
+  const previewStyle: React.CSSProperties = {
+    cursor: `url(${url}) ${cursorSize / 2} ${cursorSize / 2}, auto`,
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex items-center gap-2">
+        <label className="text-ubt-grey">Cursor Theme:</label>
+        <select
+          value={cursor}
+          onChange={(e) => setCursor(e.target.value)}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          {CURSOR_THEMES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-ubt-grey">Size:</label>
+        <div className="flex gap-2">
+          {CURSOR_SIZES.map((s) => (
+            <button
+              key={s}
+              onClick={() => setCursorSize(s)}
+              className={`px-3 py-1 rounded ${
+                cursorSize === s
+                  ? "bg-ub-orange text-white"
+                  : "bg-ub-cool-grey text-ubt-grey"
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div
+        className="mt-4 p-4 border border-ubt-cool-grey rounded bg-ub-cool-grey"
+        style={previewStyle}
+        aria-label="Cursor preview"
+      >
+        Hover to preview
+      </div>
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import MouseSettings from "./components/MouseSettings";
 
 export default function Settings() {
   const {
@@ -36,6 +37,7 @@ export default function Settings() {
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
+    { id: "mouse", label: "Mouse & Touchpad" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
   ] as const;
@@ -88,7 +90,7 @@ export default function Settings() {
   const handleReset = async () => {
     if (
       !window.confirm(
-        "Reset desktop to default settings? This will clear all saved data."
+        "Reset desktop to default settings? This will clear all saved data.",
       )
     )
       return;
@@ -136,7 +138,11 @@ export default function Settings() {
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+            <div
+              aria-label="Accent color picker"
+              role="radiogroup"
+              className="flex gap-2"
+            >
               {ACCENT_OPTIONS.map((c) => (
                 <button
                   key={c}
@@ -144,14 +150,16 @@ export default function Settings() {
                   role="radio"
                   aria-checked={accent === c}
                   onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? "border-white" : "border-transparent"}`}
                   style={{ backgroundColor: c }}
                 />
               ))}
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
+            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">
+              Wallpaper:
+            </label>
             <input
               id="wallpaper-slider"
               type="range"
@@ -209,10 +217,13 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "mouse" && <MouseSettings />}
       {activeTab === "accessibility" && (
         <>
           <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">
+              Icon Size:
+            </label>
             <input
               id="font-scale"
               type="range"
@@ -288,18 +299,18 @@ export default function Settings() {
           </div>
         </>
       )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+  useRef,
+} from "react";
 import {
   getAccent as loadAccent,
   setAccent as saveAccent,
@@ -20,19 +27,23 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getCursor as loadCursor,
+  setCursor as saveCursor,
+  getCursorSize as loadCursorSize,
+  setCursorSize as saveCursorSize,
   defaults,
-} from '../utils/settingsStore';
-import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
-type Density = 'regular' | 'compact';
+} from "../utils/settingsStore";
+import { getTheme as loadTheme, setTheme as saveTheme } from "../utils/theme";
+type Density = "regular" | "compact";
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
-  '#1793d1', // kali blue (default)
-  '#e53e3e', // red
-  '#d97706', // orange
-  '#38a169', // green
-  '#805ad5', // purple
-  '#ed64a6', // pink
+  "#1793d1", // kali blue (default)
+  "#e53e3e", // red
+  "#d97706", // orange
+  "#38a169", // green
+  "#805ad5", // purple
+  "#ed64a6", // pink
 ];
 
 // Utility to lighten or darken a hex color by a percentage
@@ -63,6 +74,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  cursor: string;
+  cursorSize: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +87,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setCursor: (value: string) => void;
+  setCursorSize: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -87,7 +102,9 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
-  theme: 'default',
+  theme: "default",
+  cursor: defaults.cursor,
+  cursorSize: defaults.cursorSize,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,19 +116,31 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setCursor: () => {},
+  setCursorSize: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
-  const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
+  const [reducedMotion, setReducedMotion] = useState<boolean>(
+    defaults.reducedMotion,
+  );
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
-  const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
-  const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
+  const [highContrast, setHighContrast] = useState<boolean>(
+    defaults.highContrast,
+  );
+  const [largeHitAreas, setLargeHitAreas] = useState<boolean>(
+    defaults.largeHitAreas,
+  );
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
-  const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [allowNetwork, setAllowNetwork] = useState<boolean>(
+    defaults.allowNetwork,
+  );
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [cursor, setCursor] = useState<string>(defaults.cursor);
+  const [cursorSize, setCursorSize] = useState<number>(defaults.cursorSize);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +156,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setCursor(await loadCursor());
+      setCursorSize(await loadCursorSize());
       setTheme(loadTheme());
     })();
   }, []);
@@ -138,13 +169,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const border = shadeColor(accent, -0.2);
     const vars: Record<string, string> = {
-      '--color-ub-orange': accent,
-      '--color-ub-border-orange': border,
-      '--color-primary': accent,
-      '--color-accent': accent,
-      '--color-focus-ring': accent,
-      '--color-selection': accent,
-      '--color-control-accent': accent,
+      "--color-ub-orange": accent,
+      "--color-ub-border-orange": border,
+      "--color-primary": accent,
+      "--color-accent": accent,
+      "--color-focus-ring": accent,
+      "--color-selection": accent,
+      "--color-control-accent": accent,
     };
     Object.entries(vars).forEach(([key, value]) => {
       document.documentElement.style.setProperty(key, value);
@@ -159,20 +190,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
       regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
+        "--space-1": "0.25rem",
+        "--space-2": "0.5rem",
+        "--space-3": "0.75rem",
+        "--space-4": "1rem",
+        "--space-5": "1.5rem",
+        "--space-6": "2rem",
       },
       compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
+        "--space-1": "0.125rem",
+        "--space-2": "0.25rem",
+        "--space-3": "0.5rem",
+        "--space-4": "0.75rem",
+        "--space-5": "1rem",
+        "--space-6": "1.5rem",
       },
     };
     const vars = spacing[density];
@@ -183,22 +214,25 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [density]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('reduced-motion', reducedMotion);
+    document.documentElement.classList.toggle("reduced-motion", reducedMotion);
     saveReducedMotion(reducedMotion);
   }, [reducedMotion]);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
+    document.documentElement.style.setProperty(
+      "--font-multiplier",
+      fontScale.toString(),
+    );
     saveFontScale(fontScale);
   }, [fontScale]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('high-contrast', highContrast);
+    document.documentElement.classList.toggle("high-contrast", highContrast);
     saveHighContrast(highContrast);
   }, [highContrast]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('large-hit-area', largeHitAreas);
+    document.documentElement.classList.toggle("large-hit-area", largeHitAreas);
     saveLargeHitAreas(largeHitAreas);
   }, [largeHitAreas]);
 
@@ -208,22 +242,22 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     saveAllowNetwork(allowNetwork);
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
     if (!fetchRef.current) fetchRef.current = window.fetch.bind(window);
     if (!allowNetwork) {
       window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
         const url =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
-            : 'url' in input
+            : "url" in input
               ? input.url
               : input.href;
         if (
           /^https?:/i.test(url) &&
           !url.startsWith(window.location.origin) &&
-          !url.startsWith('/')
+          !url.startsWith("/")
         ) {
-          return Promise.reject(new Error('Network requests disabled'));
+          return Promise.reject(new Error("Network requests disabled"));
         }
         return fetchRef.current!(input, init);
       };
@@ -235,6 +269,19 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveHaptics(haptics);
   }, [haptics]);
+
+  useEffect(() => {
+    saveCursor(cursor);
+  }, [cursor]);
+
+  useEffect(() => {
+    saveCursorSize(cursorSize);
+  }, [cursorSize]);
+
+  useEffect(() => {
+    const url = `/cursors/${cursor}/${cursorSize}/left_ptr.png`;
+    document.documentElement.style.cursor = `url(${url}) ${cursorSize / 2} ${cursorSize / 2}, auto`;
+  }, [cursor, cursorSize]);
 
   return (
     <SettingsContext.Provider
@@ -250,6 +297,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        cursor,
+        cursorSize,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +310,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setCursor,
+        setCursorSize,
       }}
     >
       {children}
@@ -269,4 +320,3 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 }
 
 export const useSettings = () => useContext(SettingsContext);
-

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,12 +1,12 @@
 "use client";
 
-import { get, set, del } from 'idb-keyval';
-import { getTheme, setTheme } from './theme';
+import { get, set, del } from "idb-keyval";
+import { getTheme, setTheme } from "./theme";
 
 const DEFAULT_SETTINGS = {
-  accent: '#1793d1',
-  wallpaper: 'wall-2',
-  density: 'regular',
+  accent: "#1793d1",
+  wallpaper: "wall-2",
+  density: "regular",
   reducedMotion: false,
   fontScale: 1,
   highContrast: false,
@@ -14,129 +14,151 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  cursor: "white",
+  cursorSize: 24,
 };
 
 export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.accent;
+  return (await get("accent")) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  if (typeof window === "undefined") return;
+  await set("accent", accent);
 }
 
 export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.wallpaper;
+  return (await get("bg-image")) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  if (typeof window === "undefined") return;
+  await set("bg-image", wallpaper);
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.density;
+  return window.localStorage.getItem("density") || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("density", density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.reducedMotion;
+  const stored = window.localStorage.getItem("reduced-motion");
   if (stored !== null) {
-    return stored === 'true';
+    return stored === "true";
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("reduced-motion", value ? "true" : "false");
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.fontScale;
+  const stored = window.localStorage.getItem("font-scale");
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("font-scale", String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.highContrast;
+  return window.localStorage.getItem("high-contrast") === "true";
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("high-contrast", value ? "true" : "false");
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.largeHitAreas;
+  return window.localStorage.getItem("large-hit-areas") === "true";
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("large-hit-areas", value ? "true" : "false");
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
-  return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.haptics;
+  const val = window.localStorage.getItem("haptics");
+  return val === null ? DEFAULT_SETTINGS.haptics : val === "true";
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("haptics", value ? "true" : "false");
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
-  return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.pongSpin;
+  const val = window.localStorage.getItem("pong-spin");
+  return val === null ? DEFAULT_SETTINGS.pongSpin : val === "true";
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("pong-spin", value ? "true" : "false");
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.allowNetwork;
+  return window.localStorage.getItem("allow-network") === "true";
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("allow-network", value ? "true" : "false");
+}
+
+export async function getCursor() {
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.cursor;
+  return window.localStorage.getItem("cursor-theme") || DEFAULT_SETTINGS.cursor;
+}
+
+export async function setCursor(value) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("cursor-theme", value);
+}
+
+export async function getCursorSize() {
+  if (typeof window === "undefined") return DEFAULT_SETTINGS.cursorSize;
+  const val = window.localStorage.getItem("cursor-size");
+  return val ? parseInt(val, 10) : DEFAULT_SETTINGS.cursorSize;
+}
+
+export async function setCursorSize(value) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("cursor-size", String(value));
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
-  await Promise.all([
-    del('accent'),
-    del('bg-image'),
-  ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  if (typeof window === "undefined") return;
+  await Promise.all([del("accent"), del("bg-image")]);
+  window.localStorage.removeItem("density");
+  window.localStorage.removeItem("reduced-motion");
+  window.localStorage.removeItem("font-scale");
+  window.localStorage.removeItem("high-contrast");
+  window.localStorage.removeItem("large-hit-areas");
+  window.localStorage.removeItem("pong-spin");
+  window.localStorage.removeItem("allow-network");
+  window.localStorage.removeItem("haptics");
+  window.localStorage.removeItem("cursor-theme");
+  window.localStorage.removeItem("cursor-size");
 }
 
 export async function exportSettings() {
@@ -151,6 +173,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    cursor,
+    cursorSize,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +186,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getCursor(),
+    getCursorSize(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,16 +202,18 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    cursor,
+    cursorSize,
   });
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
   let settings;
   try {
-    settings = typeof json === 'string' ? JSON.parse(json) : json;
+    settings = typeof json === "string" ? JSON.parse(json) : json;
   } catch (e) {
-    console.error('Invalid settings', e);
+    console.error("Invalid settings", e);
     return;
   }
   const {
@@ -200,6 +228,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    cursor,
+    cursorSize,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +242,8 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (cursor !== undefined) await setCursor(cursor);
+  if (cursorSize !== undefined) await setCursorSize(cursorSize);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add Mouse & Touchpad tab with cursor theme and size picker
- persist cursor preferences via useSettings and settingsStore
- preview selected cursor in settings

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in tetris etc)*
- `yarn test __tests__/themePersistence.test.ts` *(fails: TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f7d91e08328aca5c458290daa9f