### PR TITLE
feat(power): add lock on sleep preference

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -73,6 +73,7 @@ const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery')
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
+const PowerApp = createDynamicApp('power', 'Power');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displayPower = createDisplay(PowerApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -691,6 +693,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'power',
+    title: 'Power',
+    icon: '/themes/Yaru/status/power-button.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPower,
   },
   {
     id: 'files',

--- a/apps/power/index.tsx
+++ b/apps/power/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSettings } from "../../hooks/useSettings";
+import ToggleSwitch from "../../components/ToggleSwitch";
+
+export default function Power() {
+  const { lockOnSleep, setLockOnSleep } = useSettings();
+
+  const handleSleep = () => {
+    const event = new Event("simulate-sleep");
+    window.dispatchEvent(event);
+  };
+
+  return (
+    <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey text-white p-4">
+      <h1 className="text-xl mb-4">Power</h1>
+      <div className="flex items-center justify-between mb-4">
+        <span>Lock screen when sleeping</span>
+        <ToggleSwitch
+          checked={lockOnSleep}
+          onChange={setLockOnSleep}
+          ariaLabel="Lock screen when sleeping"
+        />
+      </div>
+      <button
+        onClick={handleSleep}
+        className="px-4 py-2 bg-ub-grey rounded"
+      >
+        Sleep
+      </button>
+    </div>
+  );
+}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -19,9 +19,14 @@ export default class Ubuntu extends Component {
 		};
 	}
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+                window.addEventListener('simulate-sleep', this.handleSimulatedSleep);
+        }
+
+        componentWillUnmount() {
+                window.removeEventListener('simulate-sleep', this.handleSimulatedSleep);
+        }
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {
@@ -90,7 +95,7 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('bg-image', img_name);
 	};
 
-	shutDown = () => {
+        shutDown = () => {
 		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
 		ReactGA.event({
@@ -105,13 +110,27 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', true);
 	};
 
-	turnOn = () => {
+        turnOn = () => {
 		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		this.setState({ shutDownScreen: false, booting_screen: true });
 		this.setTimeOutBootScreen();
                 safeLocalStorage?.setItem('shut-down', false);
-	};
+        };
+
+        handleSimulatedSleep = () => {
+                const lockOnSleep = safeLocalStorage?.getItem('lock-on-sleep') === 'true';
+                const proceed = () => {
+                        // Placeholder for additional sleep handling
+                        console.log('Simulated sleep');
+                };
+                if (lockOnSleep) {
+                        this.lockScreen();
+                        setTimeout(proceed, 100);
+                } else {
+                        proceed();
+                }
+        };
 
 	render() {
 		return (

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getLockOnSleep as loadLockOnSleep,
+  setLockOnSleep as saveLockOnSleep,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +65,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  lockOnSleep: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +77,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setLockOnSleep: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  lockOnSleep: defaults.lockOnSleep,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setLockOnSleep: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [lockOnSleep, setLockOnSleep] = useState<boolean>(defaults.lockOnSleep);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setLockOnSleep(await loadLockOnSleep());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveLockOnSleep(lockOnSleep);
+  }, [lockOnSleep]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +262,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        lockOnSleep,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +274,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setLockOnSleep,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  lockOnSleep: false,
 };
 
 export async function getAccent() {
@@ -123,6 +124,17 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getLockOnSleep() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockOnSleep;
+  const val = window.localStorage.getItem('lock-on-sleep');
+  return val === null ? DEFAULT_SETTINGS.lockOnSleep : val === 'true';
+}
+
+export async function setLockOnSleep(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-on-sleep', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('lock-on-sleep');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lockOnSleep,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getLockOnSleep(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lockOnSleep,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    lockOnSleep,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (lockOnSleep !== undefined) await setLockOnSleep(lockOnSleep);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add Power preferences app with 'Lock screen when sleeping' option
- persist lock-on-sleep setting in settings store and context
- trigger lock screen on simulated sleep when enabled

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f7e05188328b9b3af18cf161ffe