### PR TITLE
feat: add settings change log overlay

### DIFF
--- a/__tests__/ChangeLog.test.tsx
+++ b/__tests__/ChangeLog.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import ChangeLog from '../components/settings/ChangeLog';
+import settingsBus from '../utils/settingsBus';
+
+describe('ChangeLog', () => {
+  it('logs settings changes', () => {
+    render(<ChangeLog />);
+    act(() => {
+      settingsBus.publish('ui', 'theme', 'dark');
+    });
+    expect(screen.getByRole('log')).toHaveTextContent('[ui] theme: dark');
+  });
+});

--- a/components/settings/ChangeLog.tsx
+++ b/components/settings/ChangeLog.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import settingsBus, { SettingsMessage } from '../../utils/settingsBus';
+
+const ChangeLog: React.FC = () => {
+  const [events, setEvents] = useState<SettingsMessage[]>([]);
+
+  useEffect(() => {
+    const unsub = settingsBus.subscribe((evt) => {
+      setEvents((prev) => [...prev, evt]);
+    });
+    return unsub;
+  }, []);
+
+  if (events.length === 0) return null;
+
+  const formatValue = (value: unknown) =>
+    typeof value === 'string' ? value : JSON.stringify(value);
+
+  return (
+    <div
+      className="fixed bottom-0 right-0 z-50 max-h-40 w-64 overflow-auto bg-black/80 p-2 text-xs text-white"
+      role="log"
+    >
+      <h2 className="mb-1 font-bold">Settings Change Log</h2>
+      <ul className="space-y-1">
+        {events.map((e, i) => (
+          <li key={i} className="font-mono">
+            [{e.channel}] {e.property}: {formatValue(e.value)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ChangeLog;

--- a/utils/settingsBus.ts
+++ b/utils/settingsBus.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { publish as pub, subscribe as sub } from './pubsub';
+
+export type SettingsMessage = {
+  channel: string;
+  property: string;
+  value: unknown;
+};
+
+const TOPIC = 'settings';
+
+export const publish = (channel: string, property: string, value: unknown): void => {
+  pub(TOPIC, { channel, property, value });
+};
+
+export const subscribe = (handler: (msg: SettingsMessage) => void): (() => void) =>
+  sub(TOPIC, handler);
+
+const settingsBus = { publish, subscribe };
+
+export default settingsBus;


### PR DESCRIPTION
## Summary
- add `settingsBus` utility for publishing and subscribing to settings updates
- implement developer overlay `ChangeLog` to list settings changes via `settingsBus`
- cover overlay with unit test

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, flappyBird.test.tsx)*
- `npx eslint components/settings/ChangeLog.tsx utils/settingsBus.ts __tests__/ChangeLog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f857d8c832895b0b59a254c9d1a