### PR TITLE
feat: add taskbar grouping and sorting preferences

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -7,6 +7,9 @@ jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
 
 describe('Taskbar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
   it('minimizes focused window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
@@ -18,6 +21,7 @@ describe('Taskbar', () => {
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        window_timestamps={{ app1: 1 }}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -37,10 +41,58 @@ describe('Taskbar', () => {
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        window_timestamps={{ app1: 1 }}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('sorts alphabetically when preference set', () => {
+    localStorage.setItem('xfce.panel.sort', 'alphabetical');
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    const testApps = [
+      { id: 'b', title: 'Beta', icon: '/icon.png' },
+      { id: 'a', title: 'Alpha', icon: '/icon.png' },
+    ];
+    render(
+      <Taskbar
+        apps={testApps}
+        closed_windows={{ a: false, b: false }}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={openApp}
+        minimize={minimize}
+        window_timestamps={{ a: 2, b: 1 }}
+      />
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveAttribute('aria-label', 'Alpha');
+  });
+
+  it('groups windows when preference is always', () => {
+    localStorage.setItem('xfce.panel.group', 'always');
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    const testApps = [
+      { id: 'dup', title: 'Dup', icon: '/icon.png' },
+      { id: 'dup', title: 'Dup', icon: '/icon.png' },
+    ];
+    render(
+      <Taskbar
+        apps={testApps}
+        closed_windows={{ dup: false }}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={openApp}
+        minimize={minimize}
+        window_timestamps={{ dup: 1 }}
+      />
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 });

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -39,6 +39,25 @@ export default function Preferences() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
+  const [group, setGroup] = useState<"never" | "auto" | "always">(() => {
+    if (typeof window === "undefined") return "auto";
+    return (
+      (localStorage.getItem(`${PANEL_PREFIX}group`) as
+        | "never"
+        | "auto"
+        | "always"
+        | null) || "auto"
+    );
+  });
+  const [sort, setSort] = useState<"timestamp" | "alphabetical">(() => {
+    if (typeof window === "undefined") return "timestamp";
+    return (
+      (localStorage.getItem(`${PANEL_PREFIX}sort`) as
+        | "timestamp"
+        | "alphabetical"
+        | null) || "timestamp"
+    );
+  });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -59,6 +78,14 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}group`, group);
+  }, [group]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}sort`, sort);
+  }, [sort]);
 
   return (
     <div>
@@ -89,6 +116,41 @@ export default function Preferences() {
                 onChange={setAutohide}
                 ariaLabel="Autohide panel"
               />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="group-windows" className="text-ubt-grey">
+                Group windows
+              </label>
+              <select
+                id="group-windows"
+                value={group}
+                onChange={(e) =>
+                  setGroup(e.target.value as "never" | "auto" | "always")
+                }
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+              >
+                <option value="never">Never</option>
+                <option value="auto">Auto</option>
+                <option value="always">Always</option>
+              </select>
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="sort-windows" className="text-ubt-grey">
+                Sorting
+              </label>
+              <select
+                id="sort-windows"
+                value={sort}
+                onChange={(e) =>
+                  setSort(
+                    e.target.value as "timestamp" | "alphabetical"
+                  )
+                }
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+              >
+                <option value="timestamp">Timestamp</option>
+                <option value="alphabetical">Alphabetical</option>
+              </select>
             </div>
           </div>
         )}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -40,6 +40,7 @@ export class Desktop extends Component {
             hideSideBar: false,
             minimized_windows: {},
             window_positions: {},
+            window_timestamps: {},
             desktop_apps: [],
             context_menus: {
                 desktop: false,
@@ -631,7 +632,9 @@ export class Desktop extends Component {
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
+                let window_timestamps = { ...this.state.window_timestamps };
+                window_timestamps[objId] = Date.now();
+                this.setState({ closed_windows, favourite_apps, allAppsView: false, window_timestamps }, () => {
                     this.focus(objId);
                     this.saveSession();
                 });
@@ -681,11 +684,13 @@ export class Desktop extends Component {
         // close window
         let closed_windows = this.state.closed_windows;
         let favourite_apps = this.state.favourite_apps;
+        let window_timestamps = { ...this.state.window_timestamps };
 
         if (this.initFavourite[objId] === false) favourite_apps[objId] = false; // if user default app is not favourite, remove from sidebar
         closed_windows[objId] = true; // closes the app's window
+        delete window_timestamps[objId];
 
-        this.setState({ closed_windows, favourite_apps }, this.saveSession);
+        this.setState({ closed_windows, favourite_apps, window_timestamps }, this.saveSession);
     }
 
     pinApp = (id) => {
@@ -823,7 +828,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="Folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -884,6 +889,7 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    window_timestamps={this.state.window_timestamps}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,46 @@
-import React from 'react';
+"use client";
+
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 
+const PANEL_PREFIX = "xfce.panel.";
+
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const [group, setGroup] = useState("auto");
+    const [sort, setSort] = useState("timestamp");
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        setGroup(localStorage.getItem(`${PANEL_PREFIX}group`) || "auto");
+        setSort(localStorage.getItem(`${PANEL_PREFIX}sort`) || "timestamp");
+    }, []);
+
+    let runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+
+    if (group !== "never") {
+        const groups = {};
+        runningApps.forEach(app => {
+            const key = app.id;
+            const ts = props.window_timestamps[app.id] || 0;
+            if (!groups[key]) groups[key] = { ...app, count: 0, timestamp: ts };
+            groups[key].count += 1;
+            groups[key].timestamp = Math.min(groups[key].timestamp, ts);
+        });
+        const hasDup = Object.values(groups).some(g => g.count > 1);
+        if (group === "always" || (group === "auto" && hasDup)) {
+            runningApps = Object.values(groups);
+        }
+    }
+
+    if (sort === "alphabetical") {
+        runningApps.sort((a, b) => a.title.localeCompare(b.title));
+    } else {
+        runningApps.sort((a, b) => {
+            const tA = a.timestamp !== undefined ? a.timestamp : (props.window_timestamps[a.id] || 0);
+            const tB = b.timestamp !== undefined ? b.timestamp : (props.window_timestamps[b.id] || 0);
+            return tA - tB;
+        });
+    }
 
     const handleClick = (app) => {
         const id = app.id;
@@ -37,6 +75,11 @@ export default function Taskbar(props) {
                         sizes="24px"
                     />
                     <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                    {app.count > 1 && (
+                        <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full px-1">
+                            {app.count}
+                        </span>
+                    )}
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}


### PR DESCRIPTION
## Summary
- add group and sorting controls to panel preferences
- track window timestamps and update taskbar to group and sort
- cover grouping and sorting in taskbar tests

## Testing
- `yarn test __tests__/taskbar.test.tsx`
- `npx eslint components/screen/taskbar.js components/panel/Preferences.tsx components/screen/desktop.js __tests__/taskbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f8844808328bdefa85dad5f767a