### PR TITLE
Add launcher editor for application entries

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -12,6 +12,7 @@ import { displayFiglet } from './components/apps/figlet';
 import { displayResourceMonitor } from './components/apps/resource_monitor';
 import { displayScreenRecorder } from './components/apps/screen-recorder';
 import { displayNikto } from './components/apps/nikto';
+import { displayLauncherEditor } from './components/apps/LauncherEditor';
 
 export const chromeDefaultTiles = [
   { title: 'MDN', url: 'https://developer.mozilla.org/' },
@@ -718,6 +719,16 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayScreenRecorder,
+  },
+  {
+    id: 'launcher-editor',
+    title: 'Launcher Editor',
+    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayLauncherEditor,
+    hidden: true,
   },
   {
     id: 'ettercap',

--- a/components/apps/LauncherEditor.tsx
+++ b/components/apps/LauncherEditor.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import apps from "../../apps.config";
+
+const LauncherEditor: React.FC = () => {
+    const [name, setName] = useState("");
+    const [comment, setComment] = useState("");
+    const [icon, setIcon] = useState("");
+    const [categories, setCategories] = useState("");
+
+    useEffect(() => {
+        const id = (window as any).launcherEditorTarget;
+        const app = apps.find(a => a.id === id);
+        if (app) {
+            setName(app.title || "");
+            setComment((app as any).comment || "");
+            setIcon(app.icon || "");
+            setCategories((app as any).categories || "");
+        }
+    }, []);
+
+    const handleSave = (e: React.FormEvent) => {
+        e.preventDefault();
+        const id = (window as any).launcherEditorTarget;
+        const app = apps.find(a => a.id === id);
+        if (app) {
+            app.title = name;
+            (app as any).comment = comment;
+            app.icon = icon;
+            (app as any).categories = categories;
+            window.dispatchEvent(new CustomEvent("launcher-updated", { detail: { id } }));
+        }
+    };
+
+    return (
+        <form onSubmit={handleSave} className="p-4 space-y-3 text-white bg-ub-cool-grey h-full overflow-auto">
+            <label className="block">
+                <span className="text-sm">Name</span>
+                <input className="w-full p-1 text-black" value={name} onChange={e => setName(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-sm">Comment</span>
+                <input className="w-full p-1 text-black" value={comment} onChange={e => setComment(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-sm">Icon</span>
+                <input className="w-full p-1 text-black" value={icon} onChange={e => setIcon(e.target.value)} />
+            </label>
+            <label className="block">
+                <span className="text-sm">Categories</span>
+                <input className="w-full p-1 text-black" value={categories} onChange={e => setCategories(e.target.value)} />
+            </label>
+            <button type="submit" className="px-2 py-1 bg-gray-700 hover:bg-gray-600">Save</button>
+        </form>
+    );
+};
+
+export const displayLauncherEditor = () => <LauncherEditor />;
+
+export default LauncherEditor;
+

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,11 @@ function AppMenu(props) {
         }
     }
 
+    const handleEdit = () => {
+        props.editLauncher && props.editLauncher()
+        props.onClose && props.onClose()
+    }
+
     return (
         <div
             id="app-menu"
@@ -38,6 +43,15 @@ function AppMenu(props) {
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleEdit}
+                role="menuitem"
+                aria-label="Edit Launcher"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Edit Launcher</span>
             </button>
         </div>
     )

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -12,24 +12,30 @@ class AllApplications extends React.Component {
     }
 
     componentDidMount() {
+        this.refreshApps();
+        window.addEventListener('launcher-updated', this.refreshApps);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('launcher-updated', this.refreshApps);
+    }
+
+    refreshApps = () => {
         const { apps = [], games = [] } = this.props;
-        const combined = [...apps];
+        const combined = [...apps.filter(app => !app.hidden)];
         games.forEach((game) => {
-            if (!combined.some((app) => app.id === game.id)) combined.push(game);
+            if (!game.hidden && !combined.some((app) => app.id === game.id)) combined.push(game);
         });
-        this.setState({ apps: combined, unfilteredApps: combined });
+        const { query } = this.state;
+        const filtered = query === ''
+            ? combined
+            : combined.filter((app) => app.title.toLowerCase().includes(query.toLowerCase()));
+        this.setState({ apps: filtered, unfilteredApps: combined });
     }
 
     handleChange = (e) => {
         const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
+        this.setState({ query: value }, this.refreshApps);
     };
 
     openApp = (id) => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -88,12 +88,14 @@ export class Desktop extends Component {
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
+        window.addEventListener('launcher-updated', this.handleLauncherUpdate);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        window.removeEventListener('launcher-updated', this.handleLauncherUpdate);
     }
 
     checkForNewFolders = () => {
@@ -142,6 +144,10 @@ export class Desktop extends Component {
         document.removeEventListener("contextmenu", this.checkContextMenu);
         document.removeEventListener("click", this.hideAllContextMenu);
         document.removeEventListener('keydown', this.handleContextKey);
+    }
+
+    handleLauncherUpdate = () => {
+        this.updateAppsData();
     }
 
     handleGlobalShortcut = (e) => {
@@ -318,6 +324,13 @@ export class Desktop extends Component {
             menus[key] = false;
         });
         this.setState({ context_menus: menus, context_app: null });
+    }
+
+    editLauncher = (id) => {
+        if (!id) return;
+        window.launcherEditorTarget = id;
+        this.hideAllContextMenu();
+        this.openApp('launcher-editor');
     }
 
     getMenuPosition = (e) => {
@@ -904,6 +917,7 @@ export class Desktop extends Component {
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
                     onClose={this.hideAllContextMenu}
+                    editLauncher={() => this.editLauncher(this.state.context_app)}
                 />
                 <TaskbarMenu
                     active={this.state.context_menus.taskbar}


### PR DESCRIPTION
## Summary
- add LauncherEditor app to edit menu item metadata
- allow editing a launcher from app context menu
- refresh application menu when launchers change

## Testing
- `yarn test` *(fails: e.preventDefault is not a function in window.test.tsx; Unable to find role="alert" in nmapNse.test.tsx; localStorage _origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f8676348328826a8fa86f8fc68b