### PR TITLE
feat: add urgent window blink preference

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -7,6 +7,10 @@ jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
 
 describe('Taskbar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('minimizes focused window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
@@ -42,5 +46,42 @@ describe('Taskbar', () => {
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('applies blink animation when window is urgent', () => {
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={openApp}
+        minimize={minimize}
+        window_data={{ app1: { urgent: true } }}
+      />
+    );
+    const button = screen.getByRole('button', { name: /app one/i });
+    expect(button.className).toMatch(/animate-pulse/);
+  });
+
+  it('keeps blinking for focused urgent window when preference enabled', () => {
+    localStorage.setItem('xfce.panel.keep-urgent', 'true');
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: true }}
+        openApp={openApp}
+        minimize={minimize}
+        window_data={{ app1: { urgent: true } }}
+      />
+    );
+    const button = screen.getByRole('button', { name: /app one/i });
+    expect(button.className).toMatch(/animate-pulse/);
   });
 });

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -40,6 +40,11 @@ export default function Preferences() {
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
 
+  const [keepUrgent, setKeepUrgent] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(`${PANEL_PREFIX}keep-urgent`) === "true";
+  });
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
@@ -59,6 +64,14 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PANEL_PREFIX}keep-urgent`,
+      keepUrgent ? "true" : "false"
+    );
+  }, [keepUrgent]);
 
   return (
     <div>
@@ -88,6 +101,14 @@ export default function Preferences() {
                 checked={autohide}
                 onChange={setAutohide}
                 ariaLabel="Autohide panel"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-ubt-grey">Keep urgent windows blinking</span>
+              <ToggleSwitch
+                checked={keepUrgent}
+                onChange={setKeepUrgent}
+                ariaLabel="Keep urgent windows blinking"
               />
             </div>
           </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,19 @@
 import React from 'react';
 import Image from 'next/image';
 
+const PANEL_PREFIX = 'xfce.panel.';
+
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+
+    const keepBlinking = typeof window !== 'undefined' &&
+        localStorage.getItem(`${PANEL_PREFIX}keep-urgent`) === 'true';
+
+    const isUrgent = (id) => {
+        if (!props.window_data) return false;
+        const win = props.window_data[id];
+        return win && win.urgent;
+    };
 
     const handleClick = (app) => {
         const id = app.id;
@@ -26,6 +37,7 @@ export default function Taskbar(props) {
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                        (isUrgent(app.id) && (!props.focused_windows[app.id] || keepBlinking) ? ' animate-pulse ' : '') +
                         'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
                 >
                     <Image


### PR DESCRIPTION
## Summary
- blink taskbar items when window data marks them urgent
- add user setting to keep urgent windows blinking
- test taskbar urgent behavior

## Testing
- `npx eslint components/screen/taskbar.js components/panel/Preferences.tsx __tests__/taskbar.test.tsx`
- `yarn test __tests__/taskbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f88dd8c8328bcead7cf661f5733