### PR TITLE
feat: add monitor filtering to taskbar

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -7,6 +7,9 @@ jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
 
 describe('Taskbar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
   it('minimizes focused window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
@@ -42,5 +45,28 @@ describe('Taskbar', () => {
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('filters windows by monitor when enabled', () => {
+    localStorage.setItem('xfce.panel.currentMonitorOnly', 'true');
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    const multiApps = [
+      { id: 'app1', title: 'App One', icon: '/icon.png', screenId: 0 },
+      { id: 'app2', title: 'App Two', icon: '/icon.png', screenId: 1 },
+    ];
+    render(
+      <Taskbar
+        apps={multiApps}
+        closed_windows={{ app1: false, app2: false }}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={openApp}
+        minimize={minimize}
+        monitorId={0}
+      />
+    );
+    expect(screen.getByRole('button', { name: /app one/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /app two/i })).toBeNull();
   });
 });

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -39,6 +39,12 @@ export default function Preferences() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
+  const [currentMonitorOnly, setCurrentMonitorOnly] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return (
+      localStorage.getItem(`${PANEL_PREFIX}currentMonitorOnly`) === "true"
+    );
+  });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -59,6 +65,13 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PANEL_PREFIX}currentMonitorOnly`,
+      currentMonitorOnly ? "true" : "false"
+    );
+  }, [currentMonitorOnly]);
 
   return (
     <div>
@@ -88,6 +101,16 @@ export default function Preferences() {
                 checked={autohide}
                 onChange={setAutohide}
                 ariaLabel="Autohide panel"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-ubt-grey">
+                Show windows from current monitor only
+              </span>
+              <ToggleSwitch
+                checked={currentMonitorOnly}
+                onChange={setCurrentMonitorOnly}
+                ariaLabel="Show windows from current monitor only"
               />
             </div>
           </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,22 @@
 import React from 'react';
 import Image from 'next/image';
 
+const PANEL_PREFIX = 'xfce.panel.';
+
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const showCurrentMonitorOnly = typeof window !== 'undefined' &&
+        localStorage.getItem(`${PANEL_PREFIX}currentMonitorOnly`) === 'true';
+    const currentMonitor = props.monitorId || 0;
+    const runningApps = props.apps.filter(app => {
+        if (props.closed_windows[app.id] === false) {
+            if (showCurrentMonitorOnly) {
+                const appMonitor = app.screenId || 0;
+                return appMonitor === currentMonitor;
+            }
+            return true;
+        }
+        return false;
+    });
 
     const handleClick = (app) => {
         const id = app.id;


### PR DESCRIPTION
## Summary
- add panel setting to limit taskbar to current monitor
- filter taskbar windows by monitor id when setting is enabled
- test taskbar monitor filtering

## Testing
- `npm test __tests__/taskbar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ba6f8942f083288017125b96b40a1a