### PR TITLE
feat: add network connections editor

### DIFF
--- a/components/apps/NetworkEditor.tsx
+++ b/components/apps/NetworkEditor.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import Modal from "../base/Modal";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const NetworkEditor: React.FC<Props> = ({ open, onClose }) => (
+  <Modal isOpen={open} onClose={onClose}>
+    <div className="fixed inset-0 flex items-center justify-center">
+      <div className="bg-ub-cool-grey text-white w-80 rounded shadow border border-black border-opacity-20">
+        <div className="flex justify-between items-center border-b border-black border-opacity-20 px-4 py-2">
+          <h2 className="text-lg">Network Connections</h2>
+          <button
+            aria-label="Close"
+            className="text-white hover:text-ubt-grey"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="p-4 text-sm">
+          <p>No network connections configured.</p>
+        </div>
+      </div>
+    </div>
+  </Modal>
+);
+
+export default NetworkEditor;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,20 +3,39 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import NetworkEditor from '../apps/NetworkEditor';
 
 export default class Navbar extends Component {
 	constructor() {
 		super();
-		this.state = {
-			status_card: false
-		};
+                this.state = {
+                        status_card: false,
+                        network_menu: false,
+                        show_network_editor: false
+                };
 	}
 
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                <div className="pl-3 pr-1 relative">
+                                        <button
+                                                type="button"
+                                                aria-label="Network"
+                                                onClick={() => this.setState({ network_menu: !this.state.network_menu })}
+                                        >
+                                                <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                        </button>
+                                        {this.state.network_menu ? (
+                                                <div className="absolute bg-ub-cool-grey rounded-md py-1 top-8 left-0 shadow border-black border border-opacity-20 text-white">
+                                                        <button
+                                                                className="px-4 py-1 text-left hover:bg-gray-50 hover:bg-opacity-5 w-full"
+                                                                onClick={() => this.setState({ show_network_editor: true, network_menu: false })}
+                                                        >
+                                                                Edit Connections...
+                                                        </button>
+                                                </div>
+                                        ) : null}
                                 </div>
                                 <div
                                         className={'pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 '}
@@ -51,7 +70,13 @@ export default class Navbar extends Component {
                                         <Status />
                                         <QuickSettings open={this.state.status_card} />
                                 </button>
-			</div>
-		);
-	}
+                                {this.state.show_network_editor ? (
+                                        <NetworkEditor
+                                                open={this.state.show_network_editor}
+                                                onClose={() => this.setState({ show_network_editor: false })}
+                                        />
+                                ) : null}
+                        </div>
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- add "Edit Connections..." menu to network panel icon
- implement basic connections editor modal

## Testing
- `npx eslint components/screen/navbar.js components/apps/NetworkEditor.tsx`
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js and missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: Window snapping finalize and release and NmapNSEApp copies example output tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f8cc4b883289147d71e956ae895