### PR TITLE
feat: add dock edit mode and lock panel option

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -100,10 +100,18 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
+                draggable={this.props.draggable}
+                onDragStart={this.props.onDragStart}
+                onDragOver={this.props.onDragOver}
+                onDrop={this.props.onDrop}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                    (this.props.draggable ? " cursor-move pl-4 " : " ") +
                     " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
+                {this.props.editMode && (
+                    <span className="absolute left-0 top-1/2 -translate-y-1/2 text-ubt-grey select-none">☰</span>
+                )}
                 <Image
                     width={28}
                     height={28}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,19 +1,16 @@
-import React, { useState } from 'react'
-import Image from 'next/image'
+import React, { useState, useEffect } from 'react';
+import Image from 'next/image';
 import SideBarApp from '../base/side_bar_app';
+import usePersistentState from '../../hooks/usePersistentState';
 
-let renderApps = (props) => {
-    let sideBarAppsJsx = [];
-    props.apps.forEach((app, index) => {
-        if (props.favourite_apps[app.id] === false) return;
-        sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
-        );
-    });
-    return sideBarAppsJsx;
-}
+const PANEL_PREFIX = 'xfce.panel.';
 
 export default function SideBar(props) {
+
+    const [editMode, setEditMode] = useState(false);
+    const [dragId, setDragId] = useState(null);
+    const [order, setOrder] = usePersistentState(`${PANEL_PREFIX}order`, []);
+    const [locked, setLocked] = usePersistentState(`${PANEL_PREFIX}locked`, true);
 
     function showSideBar() {
         props.hideSideBar(null, false);
@@ -25,6 +22,39 @@ export default function SideBar(props) {
         }, 2000);
     }
 
+    const favourites = props.apps.filter(app => props.favourite_apps[app.id]);
+
+    useEffect(() => {
+        setOrder(prev => {
+            const ids = favourites.map(a => a.id);
+            const newOrder = prev.filter(id => ids.includes(id));
+            ids.forEach(id => { if (!newOrder.includes(id)) newOrder.push(id); });
+            return newOrder;
+        });
+    }, [favourites, setOrder]);
+
+    const getIndex = (id) => {
+        const i = order.indexOf(id);
+        return i === -1 ? order.length : i;
+    };
+    const orderedApps = favourites.sort((a, b) => getIndex(a.id) - getIndex(b.id));
+
+    const handleDragStart = (id) => {
+        setDragId(id);
+    };
+
+    const handleDrop = (id) => {
+        if (dragId === null || dragId === id) return;
+        setOrder(prev => {
+            const newOrder = [...prev];
+            const from = newOrder.indexOf(dragId);
+            const to = newOrder.indexOf(id);
+            if (from === -1 || to === -1) return prev;
+            newOrder.splice(to, 0, newOrder.splice(from, 1)[0]);
+            return newOrder;
+        });
+    };
+
     return (
         <>
             <nav
@@ -32,14 +62,45 @@ export default function SideBar(props) {
                 className={(props.hide ? " -translate-x-full " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
-                {
-                    (
-                        Object.keys(props.closed_windows).length !== 0
-                            ? renderApps(props)
-                            : null
-                    )
-                }
-                <AllApps showApps={props.showAllApps} />
+                {orderedApps.map(app => (
+                    <SideBarApp
+                        key={app.id}
+                        id={app.id}
+                        title={app.title}
+                        icon={app.icon}
+                        isClose={props.closed_windows}
+                        isFocus={props.focused_windows}
+                        openApp={props.openAppByAppId}
+                        isMinimized={props.isMinimized}
+                        openFromMinimised={props.openFromMinimised}
+                        draggable={editMode && !locked}
+                        editMode={editMode && !locked}
+                        onDragStart={() => handleDragStart(app.id)}
+                        onDragOver={(e) => { if (editMode && !locked) e.preventDefault(); }}
+                        onDrop={() => handleDrop(app.id)}
+                    />
+                ))}
+                <div className="mt-auto flex flex-col items-center">
+                    {!locked && (
+                        <button
+                            type="button"
+                            aria-label={editMode ? 'Exit Edit Mode' : 'Edit Panel'}
+                            onClick={() => setEditMode(!editMode)}
+                            className="w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center"
+                        >
+                            {editMode ? '✔️' : '✏️'}
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        aria-label={locked ? 'Unlock Panel' : 'Lock Panel'}
+                        onClick={() => { setLocked(!locked); if (!locked) setEditMode(false); }}
+                        className="w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center"
+                    >
+                        {locked ? '🔓' : '🔒'}
+                    </button>
+                    <AllApps showApps={props.showAllApps} />
+                </div>
             </nav>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
         </>
@@ -53,7 +114,6 @@ export function AllApps(props) {
     return (
         <div
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
-            style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);
             }}


### PR DESCRIPTION
## Summary
- allow rearranging dock apps via drag handles in edit mode
- persist dock item order and lock status in local storage
- add lock toggle to disable panel editing

## Testing
- `yarn test` *(fails: TypeError in window.test.tsx, missing alert role, etc.)*
- `yarn lint components/screen/side_bar.js components/base/side_bar_app.js` *(terminated after prolonged execution)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f8c8be08328bbae66afe10707f7