### PR TITLE
feat: add configurable world clocks

### DIFF
--- a/apps/settings/components/ClockSettings.tsx
+++ b/apps/settings/components/ClockSettings.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useClocks, ClockConfig } from '../../../hooks/useClocks';
+
+const timezones =
+  typeof Intl !== 'undefined' && 'supportedValuesOf' in Intl
+    ? Intl.supportedValuesOf('timeZone')
+    : [
+        'UTC',
+      ];
+
+export default function ClockSettings() {
+  const [clocks, setClocks] = useClocks();
+
+  const updateClock = (idx: number, data: Partial<ClockConfig>) => {
+    setClocks(clocks.map((c, i) => (i === idx ? { ...c, ...data } : c)));
+  };
+
+  const removeClock = (idx: number) => {
+    setClocks(clocks.filter((_, i) => i !== idx));
+  };
+
+  const addClock = () => {
+    setClocks([
+      ...clocks,
+      {
+        label: 'Clock',
+        timezone:
+          typeof Intl !== 'undefined'
+            ? Intl.DateTimeFormat().resolvedOptions().timeZone
+            : 'UTC',
+        format: '%a %b %d %I:%M %p',
+      },
+    ]);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      {clocks.map((clock, idx) => (
+          <div key={idx} className="flex gap-2 items-center">
+          <input
+            value={clock.label}
+            onChange={(e) => updateClock(idx, { label: e.target.value })}
+            placeholder="Label"
+            aria-label="Clock label"
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          />
+          <select
+            value={clock.timezone}
+            onChange={(e) => updateClock(idx, { timezone: e.target.value })}
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            aria-label="Clock timezone"
+          >
+            {timezones.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+          <input
+            value={clock.format}
+            onChange={(e) => updateClock(idx, { format: e.target.value })}
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            placeholder="%a %b %d %I:%M %p"
+            aria-label="Clock format"
+          />
+          <button
+            type="button"
+            onClick={() => removeClock(idx)}
+            className="px-2 py-1 bg-red-700 text-white rounded"
+            aria-label="Remove clock"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addClock}
+        className="px-3 py-1 bg-ub-grey text-ubt-grey rounded border border-ubt-cool-grey"
+      >
+        Add Clock
+      </button>
+    </div>
+  );
+}
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import ClockSettings from "./components/ClockSettings";
 import {
   resetSettings,
   defaults,
@@ -38,6 +39,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "clocks", label: "Clocks" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -288,6 +290,7 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "clocks" && <ClockSettings />}
         <input
           type="file"
           accept="application/json"

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -23,10 +23,10 @@ export default function LockScreen(props) {
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">
-                    <Clock onlyTime={true} />
+                    <Clock format="%I:%M %p" />
                 </div>
                 <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
+                    <Clock format="%a %b %d" />
                 </div>
                 <div className=" mt-16 text-base">
                     Click or Press a key to unlock

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,6 +3,18 @@ import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import { useClocks } from '../../hooks/useClocks';
+
+function NavbarClockDisplay() {
+        const [clocks] = useClocks();
+        return (
+                <div className="flex gap-2">
+                        {clocks.map((c, i) => (
+                                <Clock key={i} timezone={c.timezone} format={c.format} label={c.label} />
+                        ))}
+                </div>
+        );
+}
 
 export default class Navbar extends Component {
 	constructor() {
@@ -35,7 +47,7 @@ export default class Navbar extends Component {
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
-                                        <Clock />
+                                        <NavbarClockDisplay />
                                 </div>
                                 <button
                                         type="button"

--- a/hooks/useClocks.ts
+++ b/hooks/useClocks.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import usePersistentState from './usePersistentState';
+
+export interface ClockConfig {
+  label: string;
+  timezone: string;
+  format: string;
+}
+
+const defaultTimezone =
+  typeof Intl === 'undefined'
+    ? 'UTC'
+    : Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const defaultClocks: ClockConfig[] = [
+  { label: 'Local', timezone: defaultTimezone, format: '%a %b %d %I:%M %p' },
+];
+
+export function useClocks() {
+  return usePersistentState<ClockConfig[]>(
+    'clocks',
+    defaultClocks,
+    (v): v is ClockConfig[] => Array.isArray(v),
+  );
+}
+


### PR DESCRIPTION
## Summary
- support timezone-aware strftime clock formatting
- add hook and settings UI for managing multiple clocks
- show configurable clocks in navbar and lock screen

## Testing
- `npx eslint components/util-components/clock.js hooks/useClocks.ts components/screen/navbar.js components/screen/lock_screen.js apps/settings/index.tsx apps/settings/components/ClockSettings.tsx`
- `yarn test` *(failed: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; InstallButton › shows install prompt when beforeinstallprompt fires)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f8eb78c8328a08fff77ec9a2278