### PR TITLE
feat: track recent files

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from 'react';
+import { addRecentFile } from '../../utils/recentFiles';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
@@ -185,6 +186,8 @@ export default function FileExplorer() {
       const f = await file.handle.getFile();
       text = await f.text();
     }
+    const filePath = `${path.map((p) => p.name).join('/')}/${file.name}`;
+    addRecentFile({ path: filePath, name: file.name });
     setContent(text);
   };
 

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
+import { onRecentFilesChange } from '../../utils/recentFiles';
 
 class AllApplications extends React.Component {
     constructor() {
@@ -8,7 +9,9 @@ class AllApplications extends React.Component {
             query: '',
             apps: [],
             unfilteredApps: [],
+            recentFiles: [],
         };
+        this.unsubscribeRecent = null;
     }
 
     componentDidMount() {
@@ -18,6 +21,13 @@ class AllApplications extends React.Component {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
         this.setState({ apps: combined, unfilteredApps: combined });
+        this.unsubscribeRecent = onRecentFilesChange((files) =>
+            this.setState({ recentFiles: files }),
+        );
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribeRecent) this.unsubscribeRecent();
     }
 
     handleChange = (e) => {
@@ -53,6 +63,23 @@ class AllApplications extends React.Component {
         ));
     };
 
+    renderRecent = () => {
+        const recent = this.state.recentFiles || [];
+        if (!recent.length) return null;
+        return (
+            <div className="mb-8 w-2/3 md:w-1/3">
+                <h2 className="mb-2 text-center text-white">Recently Used</h2>
+                <ul className="max-h-40 overflow-y-auto rounded bg-black bg-opacity-20 p-2 text-white">
+                    {recent.map((f) => (
+                        <li key={f.path} className="truncate py-1 text-sm">
+                            {f.name}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        );
+    };
+
     render() {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
@@ -62,6 +89,7 @@ class AllApplications extends React.Component {
                     value={this.state.query}
                     onChange={this.handleChange}
                 />
+                {this.renderRecent()}
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
                     {this.renderApps()}
                 </div>

--- a/utils/recentFiles.ts
+++ b/utils/recentFiles.ts
@@ -1,0 +1,67 @@
+import { safeLocalStorage } from './safeStorage';
+import { publish, subscribe } from './pubsub';
+
+export interface RecentFile {
+  path: string;
+  name: string;
+  lastOpened: number;
+}
+
+const STORAGE_KEY = 'recent-files';
+const MAX_ITEMS = 20;
+
+function read(): RecentFile[] {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as RecentFile[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(list: RecentFile[]): void {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {}
+}
+
+export function getRecentFiles(): RecentFile[] {
+  return read();
+}
+
+export function addRecentFile(file: { path: string; name: string }): void {
+  const list = read().filter((f) => f.path !== file.path);
+  list.unshift({ ...file, lastOpened: Date.now() });
+  if (list.length > MAX_ITEMS) list.length = MAX_ITEMS;
+  write(list);
+  publish('recent-files:update', list);
+}
+
+export function clearRecentFiles(): void {
+  write([]);
+  publish('recent-files:update', []);
+}
+
+export function onRecentFilesChange(
+  cb: (files: RecentFile[]) => void,
+): () => void {
+  cb(read());
+  return subscribe('recent-files:update', (files) => {
+    cb(files as RecentFile[]);
+  });
+}
+
+const api = {
+  getRecentFiles,
+  addRecentFile,
+  clearRecentFiles,
+  onRecentFilesChange,
+};
+
+if (typeof globalThis !== 'undefined') {
+  (globalThis as any).recentFiles = api;
+}
+
+export default api;


### PR DESCRIPTION
## Summary
- add recentFiles service for storing recently opened documents
- log file explorer opens to central list
- surface recent files in application menu

## Testing
- `yarn test` *(fails: window snapping test, NmapNSEApp copy test, localStorage access error)*
- `yarn lint` *(fails: command terminated without output)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f92b2848328b03e73130af68a5d