### PR TITLE
feat: add file permission controls

### DIFF
--- a/components/apps/FilePropertiesDialog.js
+++ b/components/apps/FilePropertiesDialog.js
@@ -1,0 +1,82 @@
+import React from 'react';
+
+export default function FilePropertiesDialog({ file, permissions, onChange, onClose }) {
+  const categories = ['owner', 'group', 'other'];
+  const perms = ['read', 'write', 'execute'];
+
+  const toggle = (cat, perm) => {
+    const updated = {
+      ...permissions,
+      [cat]: { ...permissions[cat], [perm]: !permissions[cat][perm] },
+    };
+    onChange(updated);
+  };
+
+  const makeExecutable = () => {
+    const updated = {
+      owner: { ...permissions.owner, execute: true },
+      group: { ...permissions.group, execute: true },
+      other: { ...permissions.other, execute: true },
+    };
+    onChange(updated);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="bg-ub-cool-grey text-white p-4 rounded shadow min-w-[300px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="font-bold mb-2">{file?.name || 'Properties'}</div>
+        <table className="w-full text-sm mb-4">
+          <thead>
+            <tr>
+              <th className="text-left">&nbsp;</th>
+              {perms.map((p) => (
+                <th key={p} className="text-left capitalize">
+                  {p}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((cat) => (
+              <tr key={cat}>
+                <td className="capitalize">{cat}</td>
+                {perms.map((perm) => (
+                  <td key={perm}>
+                    <input
+                      type="checkbox"
+                      checked={permissions[cat][perm]}
+                      onChange={() => toggle(cat, perm)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex justify-end space-x-2">
+          <button
+            className="px-2 py-1 bg-black bg-opacity-50 rounded"
+            onClick={makeExecutable}
+          >
+            Make executable
+          </button>
+          <button
+            className="px-2 py-1 bg-black bg-opacity-50 rounded"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import ContextMenu from '../common/ContextMenu';
+import FilePropertiesDialog from './FilePropertiesDialog';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -104,6 +106,7 @@ export default function FileExplorer() {
   const [results, setResults] = useState([]);
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
+  const fileRefs = useRef([]);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -115,6 +118,28 @@ export default function FileExplorer() {
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+  const [permissions, setPermissions] = useState({});
+  const [propsFile, setPropsFile] = useState(null);
+
+  const DEFAULT_PERMS = {
+    owner: { read: true, write: true, execute: false },
+    group: { read: true, write: false, execute: false },
+    other: { read: true, write: false, execute: false },
+  };
+
+  const getPerms = (name) => permissions[name] || DEFAULT_PERMS;
+  const setPerms = (name, perms) =>
+    setPermissions((p) => ({ ...p, [name]: perms }));
+  const makeExecutable = (file) => {
+    const perms = getPerms(file.name);
+    const updated = {
+      owner: { ...perms.owner, execute: true },
+      group: { ...perms.group, execute: true },
+      other: { ...perms.other, execute: true },
+    };
+    setPerms(file.name, updated);
+  };
+  const openProperties = (file) => setPropsFile(file);
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -296,7 +321,8 @@ export default function FileExplorer() {
   }
 
   return (
-    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
+    <>
+      <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
       <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
         <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
           Open Folder
@@ -336,15 +362,41 @@ export default function FileExplorer() {
             </div>
           ))}
           <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
-            </div>
-          ))}
+          {files.map((f, i) => {
+            const ref = fileRefs.current[i] || React.createRef();
+            fileRefs.current[i] = ref;
+            const perms = getPerms(f.name);
+            const isExec =
+              perms.owner.execute || perms.group.execute || perms.other.execute;
+            const items = [
+              {
+                label: isExec ? 'Run' : 'Open',
+                onSelect: () => openFile(f),
+              },
+            ];
+            if (!isExec) {
+              items.push({
+                label: 'Make executable',
+                onSelect: () => makeExecutable(f),
+              });
+            }
+            items.push({
+              label: 'Properties',
+              onSelect: () => openProperties(f),
+            });
+            return (
+              <div key={i} className="relative">
+                <div
+                  ref={ref}
+                  className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                  onClick={() => openFile(f)}
+                >
+                  {f.name}
+                </div>
+                <ContextMenu targetRef={ref} items={items} />
+              </div>
+            );
+          })}
         </div>
         <div className="flex-1 flex flex-col">
           {currentFile && (
@@ -370,6 +422,14 @@ export default function FileExplorer() {
           </div>
         </div>
       </div>
-    </div>
+      {propsFile && (
+        <FilePropertiesDialog
+          file={propsFile}
+          permissions={getPerms(propsFile.name)}
+          onChange={(perms) => setPerms(propsFile.name, perms)}
+          onClose={() => setPropsFile(null)}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add file properties dialog with owner/group/other read/write/execute checkboxes
- allow marking files executable and reflect in context menu

## Testing
- `yarn lint components/apps/file-explorer.js components/apps/FilePropertiesDialog.js` *(fails: 576 problems)*
- `yarn test --passWithNoTests components/apps/file-explorer.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f933a688328ad571910088645cd