### PR TITLE
feat: add xflock4 lock screen shortcut

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Lock screen', keys: 'Ctrl+Alt+L' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -162,6 +162,10 @@ export class Desktop extends Component {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
         }
+        else if (e.ctrlKey && e.altKey && e.key.toLowerCase() === 'l') {
+            e.preventDefault();
+            import('../../utils/xflock4').then(m => m.default());
+        }
         else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,21 +7,24 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { subscribe } from '../utils/pubsub';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+                this.unsubscribeLock = null;
+        }
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+                this.unsubscribeLock = subscribe('session:lock', () => this.lockScreen());
+        }
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {
@@ -105,13 +108,17 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', true);
 	};
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        turnOn = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		this.setState({ shutDownScreen: false, booting_screen: true });
 		this.setTimeOutBootScreen();
                 safeLocalStorage?.setItem('shut-down', false);
-	};
+        };
+
+        componentWillUnmount() {
+                this.unsubscribeLock && this.unsubscribeLock();
+        }
 
 	render() {
 		return (

--- a/utils/xflock4.ts
+++ b/utils/xflock4.ts
@@ -1,0 +1,15 @@
+import { publish } from './pubsub';
+
+/**
+ * Shim for the `xflock4` command used in XFCE to lock the session.
+ * When invoked, publishes a `session:lock` event that components can
+ * listen for to display the lock screen.
+ */
+export default function xflock4(): void {
+  publish('session:lock', null);
+}
+
+// Expose globally for shell/console access in the browser
+if (typeof globalThis !== 'undefined') {
+  (globalThis as any).xflock4 = xflock4;
+}


### PR DESCRIPTION
## Summary
- add xflock4 utility that publishes a session lock event
- wire Ctrl+Alt+L to invoke xflock4 and display lock screen
- expose lock screen shortcut in keymap registry

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: window snapping finalize and release; copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f9669ec83288af00a56c7a1d1af