### PR TITLE
feat: add lock screen settings toggles

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,12 +31,23 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    lockClock,
+    setLockClock,
+    lockDate,
+    setLockDate,
+    lockBlur,
+    setLockBlur,
+    lockPasswordFocus,
+    setLockPasswordFocus,
+    lockCapsLock,
+    setLockCapsLock,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
+    { id: "lock", label: "Lock Screen" },
     { id: "privacy", label: "Privacy" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
@@ -267,6 +278,50 @@ export default function Settings() {
             >
               Edit Shortcuts
             </button>
+          </div>
+        </>
+      )}
+      {activeTab === "lock" && (
+        <>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Show Clock:</span>
+            <ToggleSwitch
+              checked={lockClock}
+              onChange={setLockClock}
+              ariaLabel="Show Clock"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Show Date:</span>
+            <ToggleSwitch
+              checked={lockDate}
+              onChange={setLockDate}
+              ariaLabel="Show Date"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Blur Wallpaper:</span>
+            <ToggleSwitch
+              checked={lockBlur}
+              onChange={setLockBlur}
+              ariaLabel="Blur Wallpaper"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Auto-Focus Password:</span>
+            <ToggleSwitch
+              checked={lockPasswordFocus}
+              onChange={setLockPasswordFocus}
+              ariaLabel="Auto-Focus Password"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Caps Lock Indicator:</span>
+            <ToggleSwitch
+              checked={lockCapsLock}
+              onChange={setLockCapsLock}
+              ariaLabel="Caps Lock Indicator"
+            />
           </div>
         </>
       )}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,37 +1,76 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
 export default function LockScreen(props) {
+    const {
+        wallpaper,
+        lockClock,
+        lockDate,
+        lockBlur,
+        lockPasswordFocus,
+        lockCapsLock,
+    } = useSettings();
 
-    const { wallpaper } = useSettings();
+    const passwordRef = useRef(null);
+    const [caps, setCaps] = useState(false);
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
+    useEffect(() => {
+        if (props.isLocked) {
+            window.addEventListener('click', props.unLockScreen);
+            return () => window.removeEventListener('click', props.unLockScreen);
+        }
+    }, [props.isLocked, props.unLockScreen]);
+
+    useEffect(() => {
+        if (props.isLocked && lockPasswordFocus) {
+            passwordRef.current?.focus();
+        }
+    }, [props.isLocked, lockPasswordFocus]);
+
+    const handleKey = (e) => {
+        setCaps(e.getModifierState && e.getModifierState('CapsLock'));
+        if (e.key === 'Enter') {
+            props.unLockScreen();
+        }
     };
 
     return (
         <div
             id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
+            style={{ zIndex: '100', contentVisibility: 'auto' }}
+            className={(props.isLocked ? ' visible translate-y-0 ' : ' invisible -translate-y-full ') + ' absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen'}>
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked && lockBlur ? 'blur-sm' : 'blur-none'}`}
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
-                </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
+                {lockClock && (
+                    <div className=" text-7xl">
+                        <Clock onlyTime={true} />
+                    </div>
+                )}
+                {lockDate && (
+                    <div className="mt-4 text-xl font-medium">
+                        <Clock onlyDay={true} />
+                    </div>
+                )}
+                <input
+                    ref={passwordRef}
+                    type="password"
+                    onKeyUp={handleKey}
+                    className="mt-8 bg-black bg-opacity-50 text-white px-4 py-2 rounded"
+                    aria-label="Password"
+                />
+                {lockCapsLock && caps && (
+                    <div className="mt-2 text-sm text-red-500">Caps Lock is on</div>
+                )}
                 <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
+                    Click or Press Enter to unlock
                 </div>
             </div>
         </div>
-    )
+    );
 }
+

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,16 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getLockClock as loadLockClock,
+  setLockClock as saveLockClock,
+  getLockDate as loadLockDate,
+  setLockDate as saveLockDate,
+  getLockBlur as loadLockBlur,
+  setLockBlur as saveLockBlur,
+  getLockPasswordFocus as loadLockPasswordFocus,
+  setLockPasswordFocus as saveLockPasswordFocus,
+  getLockCapsLock as loadLockCapsLock,
+  setLockCapsLock as saveLockCapsLock,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +73,11 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  lockClock: boolean;
+  lockDate: boolean;
+  lockBlur: boolean;
+  lockPasswordFocus: boolean;
+  lockCapsLock: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +89,11 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setLockClock: (value: boolean) => void;
+  setLockDate: (value: boolean) => void;
+  setLockBlur: (value: boolean) => void;
+  setLockPasswordFocus: (value: boolean) => void;
+  setLockCapsLock: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +108,11 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  lockClock: defaults.lockClock,
+  lockDate: defaults.lockDate,
+  lockBlur: defaults.lockBlur,
+  lockPasswordFocus: defaults.lockPasswordFocus,
+  lockCapsLock: defaults.lockCapsLock,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +124,11 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setLockClock: () => {},
+  setLockDate: () => {},
+  setLockBlur: () => {},
+  setLockPasswordFocus: () => {},
+  setLockCapsLock: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -112,6 +142,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [lockClock, setLockClock] = useState<boolean>(defaults.lockClock);
+  const [lockDate, setLockDate] = useState<boolean>(defaults.lockDate);
+  const [lockBlur, setLockBlur] = useState<boolean>(defaults.lockBlur);
+  const [lockPasswordFocus, setLockPasswordFocus] = useState<boolean>(defaults.lockPasswordFocus);
+  const [lockCapsLock, setLockCapsLock] = useState<boolean>(defaults.lockCapsLock);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +162,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setLockClock(await loadLockClock());
+      setLockDate(await loadLockDate());
+      setLockBlur(await loadLockBlur());
+      setLockPasswordFocus(await loadLockPasswordFocus());
+      setLockCapsLock(await loadLockCapsLock());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +276,26 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveLockClock(lockClock);
+  }, [lockClock]);
+
+  useEffect(() => {
+    saveLockDate(lockDate);
+  }, [lockDate]);
+
+  useEffect(() => {
+    saveLockBlur(lockBlur);
+  }, [lockBlur]);
+
+  useEffect(() => {
+    saveLockPasswordFocus(lockPasswordFocus);
+  }, [lockPasswordFocus]);
+
+  useEffect(() => {
+    saveLockCapsLock(lockCapsLock);
+  }, [lockCapsLock]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +310,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        lockClock,
+        lockDate,
+        lockBlur,
+        lockPasswordFocus,
+        lockCapsLock,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +326,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setLockClock,
+        setLockDate,
+        setLockBlur,
+        setLockPasswordFocus,
+        setLockCapsLock,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,11 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  lockClock: true,
+  lockDate: true,
+  lockBlur: true,
+  lockPasswordFocus: true,
+  lockCapsLock: true,
 };
 
 export async function getAccent() {
@@ -123,6 +128,61 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getLockClock() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockClock;
+  const val = window.localStorage.getItem('lock-clock');
+  return val === null ? DEFAULT_SETTINGS.lockClock : val === 'true';
+}
+
+export async function setLockClock(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-clock', value ? 'true' : 'false');
+}
+
+export async function getLockDate() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockDate;
+  const val = window.localStorage.getItem('lock-date');
+  return val === null ? DEFAULT_SETTINGS.lockDate : val === 'true';
+}
+
+export async function setLockDate(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-date', value ? 'true' : 'false');
+}
+
+export async function getLockBlur() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockBlur;
+  const val = window.localStorage.getItem('lock-blur');
+  return val === null ? DEFAULT_SETTINGS.lockBlur : val === 'true';
+}
+
+export async function setLockBlur(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-blur', value ? 'true' : 'false');
+}
+
+export async function getLockPasswordFocus() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockPasswordFocus;
+  const val = window.localStorage.getItem('lock-password-focus');
+  return val === null ? DEFAULT_SETTINGS.lockPasswordFocus : val === 'true';
+}
+
+export async function setLockPasswordFocus(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-password-focus', value ? 'true' : 'false');
+}
+
+export async function getLockCapsLock() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.lockCapsLock;
+  const val = window.localStorage.getItem('lock-capslock');
+  return val === null ? DEFAULT_SETTINGS.lockCapsLock : val === 'true';
+}
+
+export async function setLockCapsLock(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('lock-capslock', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +197,11 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('lock-clock');
+  window.localStorage.removeItem('lock-date');
+  window.localStorage.removeItem('lock-blur');
+  window.localStorage.removeItem('lock-password-focus');
+  window.localStorage.removeItem('lock-capslock');
 }
 
 export async function exportSettings() {
@@ -151,6 +216,11 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lockClock,
+    lockDate,
+    lockBlur,
+    lockPasswordFocus,
+    lockCapsLock,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +232,11 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getLockClock(),
+    getLockDate(),
+    getLockBlur(),
+    getLockPasswordFocus(),
+    getLockCapsLock(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +250,11 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    lockClock,
+    lockDate,
+    lockBlur,
+    lockPasswordFocus,
+    lockCapsLock,
     theme,
   });
 }
@@ -199,6 +279,11 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    lockClock,
+    lockDate,
+    lockBlur,
+    lockPasswordFocus,
+    lockCapsLock,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +296,12 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (lockClock !== undefined) await setLockClock(lockClock);
+  if (lockDate !== undefined) await setLockDate(lockDate);
+  if (lockBlur !== undefined) await setLockBlur(lockBlur);
+  if (lockPasswordFocus !== undefined)
+    await setLockPasswordFocus(lockPasswordFocus);
+  if (lockCapsLock !== undefined) await setLockCapsLock(lockCapsLock);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add persistent settings for clock, date, wallpaper blur, password focus, and caps indicator
- expose new lock screen preferences in Settings app
- respect lock screen toggles live in lock screen UI

## Testing
- `yarn lint components/screen/lock_screen.js hooks/useSettings.tsx utils/settingsStore.js apps/settings/index.tsx` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f96dc6483288539a9a5e3a49a59