### PR TITLE
Suspend screen lock during fullscreen media playback

### DIFF
--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -4,6 +4,7 @@ import React, { useRef, useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 import useOPFS from '../hooks/useOPFS';
+import useWakeLockOnFullscreen from '../hooks/useWakeLockOnFullscreen';
 
 // Basic YouTube player with keyboard shortcuts, playback rate cycling,
 // chapter drawer and Picture-in-Picture helpers. The Doc-PiP window is a
@@ -11,6 +12,7 @@ import useOPFS from '../hooks/useOPFS';
 export default function YouTubePlayer({ videoId }) {
   const [activated, setActivated] = useState(false);
   const containerRef = useRef(null); // DOM node hosting the iframe
+  useWakeLockOnFullscreen(containerRef);
   const playerRef = useRef(null); // YT.Player instance
   const [isPlaying, setIsPlaying] = useState(false);
   const [chapters, setChapters] = useState([]); // [{title, startTime}]
@@ -308,6 +310,7 @@ export default function YouTubePlayer({ videoId }) {
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   className="mb-2 bg-black/80 border border-white/20 p-1"
+                  aria-label="Search notes"
                 />
                 {search && results.length > 0 && (
                   <ul className="mb-2 overflow-auto max-h-24 border border-white/20 p-1">
@@ -323,6 +326,7 @@ export default function YouTubePlayer({ videoId }) {
                   onChange={handleNoteChange}
                   className="flex-1 bg-black/80 border border-white/20 p-1"
                   placeholder="Write notes…"
+                  aria-label="Notes editor"
                 />
               </>
             ) : (

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
+import useWakeLockOnFullscreen from "../../hooks/useWakeLockOnFullscreen";
 
 interface VideoPlayerProps {
   src: string;
@@ -19,6 +20,8 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   const [pipSupported, setPipSupported] = useState(false);
   const [docPipSupported, setDocPipSupported] = useState(false);
   const [isPip, setIsPip] = useState(false);
+
+  useWakeLockOnFullscreen(videoRef);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -119,6 +122,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
               setVol(v);
               send({ type: "volume", value: v });
             }}
+            aria-label="Volume"
           />
         </div>
       );
@@ -129,7 +133,14 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
 
   return (
     <div className={`relative ${className}`.trim()}>
-      <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        controls
+        className="w-full h-auto"
+        aria-label="Video player"
+      />
       {pipSupported && (
         <button
           type="button"

--- a/hooks/useWakeLockOnFullscreen.ts
+++ b/hooks/useWakeLockOnFullscreen.ts
@@ -1,0 +1,39 @@
+import { useEffect, RefObject } from "react";
+
+export default function useWakeLockOnFullscreen(ref: RefObject<HTMLElement>) {
+  useEffect(() => {
+    let lock: any;
+
+    const requestLock = async () => {
+      try {
+        lock = await (navigator as any).wakeLock?.request?.("screen");
+      } catch {
+        lock = null;
+      }
+    };
+
+    const releaseLock = async () => {
+      try {
+        await lock?.release?.();
+      } catch {}
+      lock = null;
+    };
+
+    const handleChange = () => {
+      const el = ref.current;
+      const fsEl = document.fullscreenElement;
+      if (el && fsEl && (el === fsEl || el.contains(fsEl))) {
+        requestLock();
+      } else {
+        releaseLock();
+      }
+    };
+
+    document.addEventListener("fullscreenchange", handleChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleChange);
+      releaseLock();
+    };
+  }, [ref]);
+}
+


### PR DESCRIPTION
## Summary
- add `useWakeLockOnFullscreen` hook to request screen wake lock when media enters fullscreen
- integrate wake lock in VideoPlayer and YouTubePlayer components and label controls for accessibility

## Testing
- `yarn eslint hooks/useWakeLockOnFullscreen.ts components/ui/VideoPlayer.tsx components/YouTubePlayer.js`
- `yarn test ubuntu`


------
https://chatgpt.com/codex/tasks/task_e_68ba6f9914408328a4a12d9043c4bb70