### PR TITLE
feat: add official wallpaper gallery

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
+import Appearance from "../settings/Appearance";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -126,9 +127,7 @@ export default function Preferences() {
             </div>
           </div>
         )}
-        {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
-        )}
+        {active === "appearance" && <Appearance />}
         {active === "opacity" && (
           <p className="text-ubt-grey">Opacity settings are not available yet.</p>
         )}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperUrl } from '../../utils/wallpapers';
 
 export default function LockScreen(props) {
 
@@ -17,7 +18,7 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={getWallpaperUrl(wallpaper)}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />

--- a/components/settings/Appearance.tsx
+++ b/components/settings/Appearance.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { useSettings } from "../../hooks/useSettings";
+import { OFFICIAL_WALLPAPERS, getWallpaperUrl } from "../../utils/wallpapers";
+
+export default function Appearance() {
+  const { wallpaper, setWallpaper } = useSettings();
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+      {OFFICIAL_WALLPAPERS.map((id) => {
+        const src = getWallpaperUrl(id);
+        const selected = wallpaper === id;
+        return (
+          <button
+            key={id}
+            onClick={() => setWallpaper(id)}
+            className={`relative overflow-hidden rounded focus:outline-none border-4 ${
+              selected ? "border-yellow-700" : "border-transparent"
+            }`}
+          >
+            <img src={src} alt={`Kali Linux ${id}`} className="w-full h-full object-cover" />
+            <span className="absolute bottom-1 right-1 bg-black/60 text-white text-xs px-2 py-0.5 rounded">
+              {id}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -2,44 +2,51 @@
 
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperUrl } from '../../utils/wallpapers';
 
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
+        const src = getWallpaperUrl(wallpaper);
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        if (src.startsWith('http')) img.crossOrigin = 'anonymous';
+        img.src = src;
         img.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = img.width;
-            canvas.height = img.height;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) return;
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-            const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-            let r = 0, g = 0, b = 0, count = 0;
-            for (let i = 0; i < data.length; i += 40) {
-                r += data[i];
-                g += data[i + 1];
-                b += data[i + 2];
-                count++;
+            try {
+                const canvas = document.createElement('canvas');
+                canvas.width = img.width;
+                canvas.height = img.height;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) return;
+                ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+                const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+                let r = 0, g = 0, b = 0, count = 0;
+                for (let i = 0; i < data.length; i += 40) {
+                    r += data[i];
+                    g += data[i + 1];
+                    b += data[i + 2];
+                    count++;
+                }
+                const avgR = r / count, avgG = g / count, avgB = b / count;
+                const toLinear = (c) => {
+                    c /= 255;
+                    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+                };
+                const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
+                const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
+                setNeedsOverlay(contrast < 4.5);
+            } catch {
+                setNeedsOverlay(false);
             }
-            const avgR = r / count, avgG = g / count, avgB = b / count;
-            const toLinear = (c) => {
-                c /= 255;
-                return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-            };
-            const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
-            const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
-            setNeedsOverlay(contrast < 4.5);
         };
     }, [wallpaper]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={getWallpaperUrl(wallpaper)}
                 alt=""
                 className="w-full h-full object-cover"
             />

--- a/utils/wallpapers.ts
+++ b/utils/wallpapers.ts
@@ -1,0 +1,18 @@
+export const OFFICIAL_WALLPAPERS = [
+  '2019.4',
+  '2020.1','2020.2','2020.3','2020.4',
+  '2021.1','2021.2','2021.3','2021.4',
+  '2022.1','2022.2','2022.3','2022.4',
+  '2023.1','2023.2','2023.3','2023.4',
+  '2024.1','2024.2','2024.3','2024.4',
+  '2025.1','2025.2'
+] as const;
+
+export type WallpaperId = typeof OFFICIAL_WALLPAPERS[number] | string;
+
+export function getWallpaperUrl(id: WallpaperId): string {
+  if (/^\d{4}\.\d/.test(id)) {
+    return `https://images.kali.org/wallpapers/kali-linux-${id}.png`;
+  }
+  return `/wallpapers/${id}.webp`;
+}


### PR DESCRIPTION
## Summary
- add `Appearance` settings component with Kali's official wallpapers from 2019.4–2025
- allow selecting wallpapers and show release badge
- support remote wallpaper URLs across background and lock screen

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6fae34d8832891c747f97f060997