### PR TITLE
test: verify file manager highlight colors

### DIFF
--- a/tests/file-manager/highlight.spec.ts
+++ b/tests/file-manager/highlight.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+// Utility function to set color inputs and save
+async function setColors(page, foreground: string, background: string) {
+  await page.fill('input[name="foreground"]', foreground);
+  await page.fill('input[name="background"]', background);
+  await page.click('text=Save');
+}
+
+test('can highlight item with custom colors and clear them', async ({ page }) => {
+  await page.goto('/apps/file-explorer');
+
+  const item = page.locator('[data-testid="file-item"]').first();
+  const defaultColor = await item.evaluate((el) => getComputedStyle(el).color);
+  const defaultBg = await item.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+  await item.click({ button: 'right' });
+  await page.click('text=Properties');
+  await setColors(page, '#ff0000', '#00ff00');
+
+  await expect(item).toHaveCSS('color', 'rgb(255, 0, 0)');
+  await expect(item).toHaveCSS('background-color', 'rgb(0, 255, 0)');
+
+  await item.click({ button: 'right' });
+  await page.click('text=Properties');
+  await setColors(page, '', '');
+
+  await expect(item).toHaveCSS('color', defaultColor);
+  await expect(item).toHaveCSS('background-color', defaultBg);
+});


### PR DESCRIPTION
## Summary
- add Playwright test for custom file manager highlight colors

## Testing
- `npm test` *(fails: window snapping finalize and release > releases snap with Alt+ArrowDown restoring size, NmapNSEApp > copies example output to clipboard)*
- `npx playwright test tests/file-manager/highlight.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fa8bf4483289e9b833225bfde0e