### PR TITLE
test: add file manager search spec

### DIFF
--- a/tests/file-manager/search.spec.ts
+++ b/tests/file-manager/search.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('File Manager search', () => {
+  test('shows metadata and opens containing folder', async ({ page }) => {
+    // Navigate directly to the file manager application
+    await page.goto('/apps/file-explorer');
+
+    // Enter a query in the search box
+    await page.getByRole('textbox', { name: /search/i }).fill('README');
+    await page.keyboard.press('Enter');
+
+    // Ensure the first result displays path, size and modification time
+    const firstResult = page.locator('[data-testid="search-result"]').first();
+    await expect(firstResult.locator('[data-testid="path"]')).toBeVisible();
+    await expect(firstResult.locator('[data-testid="size"]')).toBeVisible();
+    await expect(firstResult.locator('[data-testid="mtime"]')).toBeVisible();
+
+    // Invoke "Open containing folder" on the result
+    await firstResult.getByRole('button', { name: /open containing folder/i }).click();
+
+    // Verify focus moves to the file list for that folder
+    await expect(page.locator('[data-testid="file-list"]')).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for file manager search to validate metadata and folder navigation

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fa8627c8328b823f0f4e6e48bad