### PR TITLE
test: verify file manager session persistence

### DIFF
--- a/tests/file-manager/session.spec.ts
+++ b/tests/file-manager/session.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('file manager session', () => {
+  test('restores tabs after restart', async ({ page }) => {
+    // Open the root of the application
+    await page.goto('/');
+
+    // Simulate opening multiple tabs with different paths
+    const tabs = [
+      { path: '/tmp', title: 'tmp' },
+      { path: '/etc', title: 'etc' },
+      { path: '/usr', title: 'usr' },
+    ];
+    const active = 1; // second tab active
+
+    await page.evaluate(([tabs, active]) => {
+      localStorage.setItem('file-manager-session', JSON.stringify({ tabs, active }));
+    }, [tabs, active]);
+
+    // Reload the application to simulate a restart
+    await page.reload();
+
+    // Verify the same tabs and active tab were restored
+    const session = await page.evaluate(() => {
+      const raw = localStorage.getItem('file-manager-session');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(session).not.toBeNull();
+    expect(session.tabs).toHaveLength(3);
+    expect(session.tabs.map((t: any) => t.path)).toEqual(['/tmp', '/etc', '/usr']);
+    expect(session.active).toBe(active);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test checking file manager tabs and active tab persist across reload

## Testing
- `npx playwright test tests/file-manager/session.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fab1bcc8328a7dc41af1bdd684d