### PR TITLE
test: add file manager view settings test

### DIFF
--- a/tests/file-manager/view-settings.spec.ts
+++ b/tests/file-manager/view-settings.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('file manager view settings', () => {
+  test('remembers folder-specific view preferences', async ({ page }) => {
+    await page.goto('/apps/files');
+
+    // open a folder and change its view
+    await page.locator('text=Documents').click();
+    await page.locator('[aria-label="List view"]').click();
+
+    // navigate away
+    await page.locator('[aria-label="Back"]').click();
+
+    // open a different folder to ensure it retains default view
+    await page.locator('text=Downloads').click();
+    await expect(page.locator('[aria-label="Icon view"].active')).toBeVisible();
+    await page.locator('[aria-label="Back"]').click();
+
+    // return to the original folder and verify the custom view persists
+    await page.locator('text=Documents').click();
+    await expect(page.locator('[aria-label="List view"].active')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test covering file manager view setting persistence

## Testing
- `npx playwright test tests/file-manager/view-settings.spec.ts` *(fails: missing system dependencies)*
- `npx playwright install-deps` *(fails: missing apt packages)*


------
https://chatgpt.com/codex/tasks/task_e_68ba7fac34548328819f92c6d0c427f7