### PR TITLE
test: add split view keyboard spec placeholder

### DIFF
--- a/tests/file-manager/split-keyboard.spec.ts
+++ b/tests/file-manager/split-keyboard.spec.ts
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test';
+
+test.describe.skip('File manager split view keyboard navigation', () => {
+  test('cycles focus and copies/moves between panes', async ({ page }) => {
+    // Navigate to the file manager app
+    await page.goto('/apps/file-manager');
+
+    // TODO: Open split view
+
+    // TODO: Use F6, Tab, and Shift+F6 to cycle focus and swap panes
+
+    // TODO: Confirm copy/move shortcuts operate between panes
+  });
+});


### PR DESCRIPTION
## Summary
- add placeholder test for file manager split view keyboard navigation

## Testing
- `npx playwright test tests/file-manager/split-keyboard.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ba7fb112a483289fdcebe73528dbc1