### PR TITLE
test: add file manager advanced settings spec

### DIFF
--- a/tests/file-manager/advanced-settings.spec.ts
+++ b/tests/file-manager/advanced-settings.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+// Test advanced settings for the file manager.
+// Toggles the "Vertical split" option and verifies panes rotate
+// and a restart requirement is indicated.
+
+test.describe('File manager advanced settings', () => {
+  test('toggle vertical split and verify restart label', async ({ page }) => {
+    // Navigate to the file manager application
+    await page.goto('/apps/file-explorer');
+
+    // Open the Advanced settings tab
+    await page.click('text=Advanced');
+
+    const panes = page.locator('[data-testid="file-manager-panes"]');
+    const initialDirection = await panes.evaluate((el) => getComputedStyle(el).flexDirection);
+
+    const verticalSplitToggle = page.getByLabel('Vertical split');
+    await verticalSplitToggle.click();
+
+    const restartLabel = page.locator('label:has-text("Vertical split") >> text=/restart/i');
+    const needsRestart = await restartLabel.isVisible();
+
+    // Restart if the UI indicates it is required
+    if (needsRestart) {
+      await page.reload();
+    }
+
+    const newDirection = await panes.evaluate((el) => getComputedStyle(el).flexDirection);
+
+    // Panes should rotate orientation after the change
+    expect(newDirection).not.toBe(initialDirection);
+
+    // The label should indicate a restart requirement
+    await expect(restartLabel).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for file manager vertical split restart behavior

## Testing
- `npx playwright test tests/file-manager/advanced-settings.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fb1fa1c83288c58ff3deb20d333