### PR TITLE
Add wavelan panel Playwright spec

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/panel/wavelan.spec.tsx
+++ b/tests/panel/wavelan.spec.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// Simulate fluctuating RSSI and SSID, ensure bars animate and tooltip shows percent.
+// Clicking the widget should navigate to the network editor.
+
+test.describe('wavelan panel plugin', () => {
+  test('updates signal bars and opens editor', async ({ page }) => {
+    // Navigate to the panel page that contains the wavelan widget
+    await page.goto('/panel');
+
+    const widget = page.locator('[data-testid="panel-wavelan"]');
+
+    // Simulate network changes
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('wavelan-update', { detail: { rssi: -30, ssid: 'CafeWifi' } })
+      );
+    });
+
+    // Verify tooltip shows signal percentage
+    await widget.hover();
+    await expect(page.locator('[role="tooltip"]')).toContainText('93%');
+
+    // Update with weaker signal to trigger animation
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('wavelan-update', { detail: { rssi: -75, ssid: 'CafeWifi' } })
+      );
+    });
+
+    const bars = widget.locator('[data-testid="signal-bar"]');
+    await expect(bars.first()).toBeVisible();
+
+    // Clicking the widget should open the network editor
+    await widget.click();
+    await expect(page).toHaveURL(/network-editor/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright E2E spec for panel wavelan plugin
- allow Playwright to discover `.tsx` specs

## Testing
- `npx playwright test tests/panel/wavelan.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fb51fc083289ab7ac5b226f7725