### PR TITLE
test: add panel sizing checks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/panel/sizing.spec.tsx
+++ b/tests/panel/sizing.spec.tsx
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+const SIZES = [24, 28, 32];
+
+test.describe('panel sizing', () => {
+  for (const size of SIZES) {
+    test(`icon size does not exceed row height at ${size}px`, async ({ page }) => {
+      await page.setContent(`
+        <style>
+          #panel { display:flex; height:${size}px; overflow:hidden; }
+          #panel .icon { width:${size}px; height:${size}px; flex:0 0 auto; }
+        </style>
+        <div id="panel">
+          <div class="icon"></div>
+          <div class="icon"></div>
+          <div class="icon"></div>
+        </div>
+      `);
+
+      const rowHeight = await page.locator('#panel').evaluate(el => el.clientHeight);
+      const iconHeights = await page.locator('#panel .icon').evaluateAll(nodes => nodes.map(n => n.clientHeight));
+      for (const h of iconHeights) {
+        expect(h).toBeLessThanOrEqual(rowHeight);
+      }
+    });
+  }
+
+  test('overflow reveals chevron menu', async ({ page }) => {
+    const size = SIZES[0];
+    await page.setContent(`
+      <style>
+        #panel { width:${size * 3}px; height:${size}px; display:flex; overflow:hidden; }
+        #panel .icon { width:${size}px; height:${size}px; flex:0 0 auto; }
+        #chevron { width:${size}px; height:${size}px; display:none; }
+      </style>
+      <div id="panel">
+        <div class="icon"></div>
+        <div class="icon"></div>
+        <div class="icon"></div>
+        <div class="icon"></div>
+        <div id="chevron">⌄</div>
+      </div>
+      <script>
+        const panel = document.getElementById('panel');
+        const chev = document.getElementById('chevron');
+        if (panel.scrollWidth > panel.clientWidth) {
+          chev.style.display = 'block';
+        }
+      </script>
+    `);
+
+    const panel = page.locator('#panel');
+    const overflow = await panel.evaluate(el => el.scrollWidth > el.clientWidth);
+    expect(overflow).toBeTruthy();
+    await expect(page.locator('#chevron')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests covering panel icon sizing and overflow
- allow Playwright to discover `.spec.tsx` files

## Testing
- `npx playwright test tests/panel/sizing.spec.tsx` *(fails: missing system dependencies for Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fbc29108328b0152b4b91d0568b