### PR TITLE
test: add preferred apps settings checks

### DIFF
--- a/tests/settings/preferred-apps.spec.tsx
+++ b/tests/settings/preferred-apps.spec.tsx
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Preferred Applications', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/settings/preferred-apps');
+  });
+
+  test('changing default browser updates URL handlers', async ({ page }) => {
+    await page.selectOption('select#default-browser', { label: 'Chromium' });
+    await expect(page.locator('[data-testid="url-handler-http"]')).toHaveText('Chromium');
+    await expect(page.locator('[data-testid="url-handler-https"]')).toHaveText('Chromium');
+  });
+
+  test('changing default terminal updates Open With list', async ({ page }) => {
+    await page.selectOption('select#default-terminal', { label: 'TTY' });
+    await page.click('button#open-with');
+    await expect(page.locator('[data-testid="open-with-terminal"]')).toHaveText('TTY');
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests that change default browser and terminal
- assert URL handlers and Open With menu update when preferences change

## Testing
- `npx playwright test tests/settings/preferred-apps.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fbdca2c8328aaf2b9642606f471