### PR TITLE
test: add desktop launcher creation test

### DIFF
--- a/tests/desktop/launcher-creation.spec.tsx
+++ b/tests/desktop/launcher-creation.spec.tsx
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Drag an application from the app finder to the desktop and ensure a
+ * corresponding `.desktop` launcher file is created. Finally verify that the
+ * launcher can be edited from its context menu.
+ */
+test('create desktop launcher from app finder', async ({ page }) => {
+  // Open the desktop and reveal the App Finder ("Show Applications" button).
+  await page.goto('/');
+  await page.locator('nav [aria-label="Show Applications"]').click();
+
+  const appId = 'gedit';
+  const appTile = page.locator(`#app-${appId}`);
+  const desktopArea = page.locator('#desktop');
+
+  // Drag the application tile onto the desktop area.
+  await appTile.dragTo(desktopArea);
+
+  // Expect a .desktop file to be created for the dragged application.
+  const desktopFile = path.join(process.env.HOME || '', 'Desktop', `${appId}.desktop`);
+  await expect
+    .poll(() => fs.existsSync(desktopFile), {
+      message: `${desktopFile} should exist`,
+    })
+    .toBe(true);
+
+  // Open the context menu on the newly created desktop icon and choose Edit.
+  const desktopIcon = desktopArea.locator(`#app-${appId}`);
+  await desktopIcon.click({ button: 'right' });
+  await page.locator('text=Edit').click();
+
+  // The editor should open; assert an editor window is visible.
+  await expect(page.locator('[data-app-id="gedit"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- cover dragging an app from the App Finder to the desktop, verifying a `.desktop` launcher file appears and the context menu Edit option opens the editor

## Testing
- `npx playwright test tests/desktop/launcher-creation.spec.tsx` *(fails: missing system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc04a3c8328a25180d905afc7e3