### PR TITLE
test: verify file manager open terminal context uses preference

### DIFF
--- a/tests/file-manager/open-terminal.spec.ts
+++ b/tests/file-manager/open-terminal.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('File manager - open terminal', () => {
+  test('launches preferred terminal from context menu', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('preferred-terminal', 'serial-terminal');
+    });
+
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Files' }).click();
+
+    const filesWindow = page.getByRole('dialog', { name: 'Files' });
+    await filesWindow.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Open in Terminal' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Serial Terminal' })).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright test verifying `Open in Terminal` respects the preferred terminal setting

## Testing
- `npx playwright test tests/file-manager/open-terminal.spec.ts --reporter=line` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc2e0588328838e35a5a0bba168