### PR TITLE
test: verify helpers pane links open docs in new tabs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/settings/helpers-pane.spec.tsx
+++ b/tests/settings/helpers-pane.spec.tsx
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('helpers pane shows documentation links', async ({ page }) => {
+  await page.goto('/apps/settings');
+  const pane = page.getByLabel('explainer pane');
+  await expect(pane).toBeVisible();
+
+  const links = pane.locator('a');
+  const count = await links.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    await expect(links.nth(i)).toHaveAttribute('target', '_blank');
+    const href = await links.nth(i).getAttribute('href');
+    expect(href).toMatch(/^https?:/);
+  }
+});


### PR DESCRIPTION
## Summary
- extend Playwright config to pick up `.spec.tsx` tests
- add helpers pane test verifying info card links open documentation in new tabs

## Testing
- `npx playwright test tests/settings/helpers-pane.spec.tsx` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc3fe408328a2792af3be4ed583