### PR TITLE
test: add input method settings test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/settings/input-method.spec.tsx
+++ b/tests/settings/input-method.spec.tsx
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Input method settings', () => {
+  test('toggles input method and shows tray icon and shortcut hint', async ({ page }) => {
+    await page.goto('/apps/settings');
+
+    const toggle = page.getByRole('switch', { name: /input method/i });
+    await toggle.click();
+
+    const trayIcon = page.locator('[aria-label="Input Method Tray Icon"]');
+    await expect(trayIcon).toBeVisible();
+
+    const hint = page.getByText(/ctrl\+space/i);
+    await expect(hint).toBeVisible();
+
+    await toggle.click();
+    await expect(trayIcon).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for input method toggle behavior and icon/hint visibility
- allow `.tsx` spec files in Playwright config

## Testing
- `npx playwright test tests/settings/input-method.spec.tsx` *(fails: waiting for input method toggle to appear)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc4e3a88328bbd7566694120b49