### PR TITLE
test: add layout indicator e2e spec

### DIFF
--- a/tests/panel/layout-indicator.spec.tsx
+++ b/tests/panel/layout-indicator.spec.tsx
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('layout indicator', () => {
+  test('cycles layouts and toggles IME badge', async ({ page }) => {
+    await page.goto('/');
+
+    const indicator = page.locator('[data-testid="layout-indicator"]');
+    const indicatorCount = await indicator.count();
+    test.skip(indicatorCount === 0, 'layout indicator not available');
+
+    const badge = indicator.locator('[data-testid="ime-badge"]');
+
+    const initial = await indicator.textContent();
+    await indicator.click();
+    await expect(indicator).not.toHaveText(initial || '');
+
+    await page.keyboard.press('Control+Space');
+    await expect(badge).toBeVisible();
+
+    await page.keyboard.press('Control+Space');
+    await expect(badge).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- add end-to-end test for layout indicator to cycle layouts and toggle IME badge

## Testing
- `npx playwright test tests/panel/layout-indicator.spec.tsx` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc5ad048328be442e50390e313c