### PR TITLE
test: ensure layout reset disables per-window

### DIFF
--- a/tests/settings/layout-reset.spec.tsx
+++ b/tests/settings/layout-reset.spec.tsx
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies that switching back to system defaults resets any custom layouts
+// and automatically disables per-window mode until the user re-enables it.
+test('layout reset disables per-window mode', async ({ page }) => {
+  // Open the settings page that controls layout behaviour
+  await page.goto('/apps/settings');
+
+  // Enable per-window mode
+  const perWindowToggle = page.getByLabel('Per-window mode');
+  await perWindowToggle.check();
+  await expect(perWindowToggle).toBeChecked();
+
+  // Toggle "Use system defaults" which should reset layouts
+  await page.getByRole('button', { name: 'Use system defaults' }).click();
+
+  // Layouts should be reset and per-window mode disabled
+  await expect(perWindowToggle).not.toBeChecked();
+
+  // Re-enable per-window mode to confirm the toggle works again
+  await perWindowToggle.check();
+  await expect(perWindowToggle).toBeChecked();
+});


### PR DESCRIPTION
## Summary
- add Playwright test verifying layout reset disables per-window mode and can be re-enabled

## Testing
- `npm test` *(fails: TypeError in window.test.tsx, missing alert in nmapNse.test.tsx)*
- `npx playwright test` *(fails: unable to load app routes)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fc99dd0832895356cf527929249