### PR TITLE
test: verify KEX mode cards link to docs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/pages/kex.spec.tsx
+++ b/tests/pages/kex.spec.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('/kex', () => {
+  test('cards describe Window & Seamless modes and link to docs', async ({ page }) => {
+    await page.goto('/kex');
+
+    const modes = ['Window Mode', 'Seamless Mode'];
+    for (const mode of modes) {
+      const card = page.locator('a', { has: page.locator('h2', { hasText: mode }) });
+      await expect(card.locator('p')).toHaveText(/.+/);
+      await expect(card).toHaveAttribute('href', /https:\/\/www\.kali\.org\/docs\/wsl\/win-kex/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for /kex ensuring Window and Seamless Mode cards describe features and link to Win-KeX docs
- allow Playwright to pick up `.spec.tsx` files

## Testing
- `BASE_URL=https://www.kali.org npx playwright test tests/pages/kex.spec.tsx` *(fails: Executable doesn't exist at chromium_headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fca0d248328bbfb854432ed8d6b