### PR TITLE
test: add wsl prep page checks

### DIFF
--- a/tests/pages/wsl-prep.spec.tsx
+++ b/tests/pages/wsl-prep.spec.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('WSL prep page provides setup resources and WSL1/WSL2 note', async ({ page }) => {
+  await page.goto('/wsl-prep');
+
+  await expect(
+    page.locator('a[href*="learn.microsoft.com/windows/wsl"]')
+  ).toBeVisible();
+  await expect(
+    page.locator('a[href*="kali.org/docs/wsl"]')
+  ).toBeVisible();
+
+  await expect(page.getByText(/WSL1.*WSL2/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add playwright test for WSL prep page that checks setup resource links and WSL1/WSL2 note

## Testing
- `npx playwright test tests/pages/wsl-prep.spec.tsx --reporter=line` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fcae6608328b9fe17b957726454