### PR TITLE
Add test for Win-KeX troubleshooting message

### DIFF
--- a/tests/pages/kex-troubleshoot.spec.tsx
+++ b/tests/pages/kex-troubleshoot.spec.tsx
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('kex troubleshooting displays error message after expanding card', async ({ page }) => {
+  await page.goto('https://www.kali.org/docs/wsl/win-kex/#troubleshooting');
+  await page.locator('summary', { hasText: 'Error connecting to the Win-KeX server' }).click();
+  await expect(
+    page.locator('text=Error connecting to the Win-KeX server… try kex start')
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright test expanding Win-KeX troubleshooting card and checking error message

## Testing
- `npx playwright test tests/pages/kex-troubleshoot.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fcbaec48328966193553a13c4d7