### PR TITLE
test: add nethunter page checks

### DIFF
--- a/tests/pages/nethunter.spec.tsx
+++ b/tests/pages/nethunter.spec.tsx
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('NetHunter page', () => {
+  test('shows edition cards and app store link', async ({ page }) => {
+    await page.goto('/nethunter');
+
+    await expect(page.getByText('Rootless')).toBeVisible();
+    await expect(page.getByText('Lite')).toBeVisible();
+    await expect(page.getByText('Full')).toBeVisible();
+
+    await expect(
+      page.getByRole('link', { name: /app store/i })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test verifying NetHunter editions (Rootless, Lite, Full) and App Store link

## Testing
- `npx playwright test tests/pages/nethunter.spec.tsx` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fcd8b4483289b959cef37914d90