### PR TITLE
test: add ARM images table checks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/, 
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/pages/arm-images.spec.tsx
+++ b/tests/pages/arm-images.spec.tsx
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ARM images table', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/arm-images');
+  });
+
+  const cases = [
+    { model: 'Pi 4', href: 'https://www.kali.org/docs/arm/raspberry-pi-4/' },
+    { model: 'Pi 5', href: 'https://www.kali.org/docs/arm/raspberry-pi-5/' },
+  ];
+
+  for (const { model, href } of cases) {
+    test(`contains ${model} row with docs link`, async ({ page }) => {
+      const row = page.locator('table tbody tr', { hasText: model });
+      await expect(row).toBeVisible();
+      await expect(row.locator(`a[href="${href}"]`)).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright spec for ARM images page verifying Pi 4 and Pi 5 rows and docs links
- support `.tsx` Playwright specs

## Testing
- `npx playwright test tests/pages/arm-images.spec.tsx` *(fails: missing browser dependencies)*
- `npx playwright install-deps` *(fails: 503 fetching packages)*
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: 2 failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fcf35cc832889cea2264d07e9ee