### PR TITLE
test: check pi imager page instructions

### DIFF
--- a/tests/pages/pi-imager.spec.tsx
+++ b/tests/pages/pi-imager.spec.tsx
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Pi Imager page', () => {
+  test('shows step-by-step instructions', async ({ page }) => {
+    await page.goto('/pi-imager');
+    await expect(page.getByText(/step-by-step instructions/i)).toBeVisible();
+  });
+
+  test('mentions advanced menu unsupported', async ({ page }) => {
+    await page.goto('/pi-imager');
+    await expect(page.getByText(/advanced menu.*not supported/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright spec for the Pi Imager page verifying step-by-step instructions and absence of advanced menu

## Testing
- `npx playwright test tests/pages/pi-imager.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fcfbb148328a1c7beeea4da556b