### PR TITLE
test: verify get-kali download options

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/, 
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    ignoreHTTPSErrors: true,
   },
 });

--- a/tests/pages/get-kali.spec.tsx
+++ b/tests/pages/get-kali.spec.tsx
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+const options = ['Live', 'Cloud', 'Containers', 'WSL', 'ARM', 'NetHunter'];
+
+test('get-kali grid shows options with pros and cons', async ({ page }) => {
+  await page.goto('/get-kali');
+  for (const option of options) {
+    const card = page.locator('a.card', { hasText: option }).first();
+    await expect(card, `${option} card should be visible`).toBeVisible();
+    await expect(card.locator('ul.positives'), `${option} should list pros`).toBeVisible();
+    const negatives = card.locator('ul.negatives');
+    if (option !== 'NetHunter') {
+      await expect(negatives, `${option} should list cons`).toBeVisible();
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- expand Playwright config to pick up `.spec.tsx` files and ignore TLS errors
- add Get Kali page test ensuring download options show pros and cons

## Testing
- `BASE_URL=https://www.kali.org npx playwright test tests/pages/get-kali.spec.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ba7fd03c7c832887dc8f5ca6febf82