### PR TITLE
test: add kali purple page test

### DIFF
--- a/tests/pages/kali-purple.spec.tsx
+++ b/tests/pages/kali-purple.spec.tsx
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('kali purple page has correct description and learn more link', async ({ page }) => {
+  await page.goto('/kali-purple');
+
+  await expect(page.locator('body')).toContainText(
+    'The dawn of a new era. Kali is not only Offense, but starting to be defense',
+  );
+
+  const learnMore = page.getByRole('link', { name: /learn more/i });
+  await expect(learnMore).toHaveAttribute(
+    'href',
+    'https://www.kali.org/blog/kali-linux-2023-1-release/',
+  );
+});


### PR DESCRIPTION
## Summary
- add Playwright test verifying Kali Purple description and external announcement link

## Testing
- `npx playwright test tests/pages/kali-purple.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fd1ae1c832881ee6c47cdacb924