### PR TITLE
test: verify kali-wallpapers package link

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/pages/wallpapers-info.spec.tsx
+++ b/tests/pages/wallpapers-info.spec.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('infobox mentions kali-wallpapers package with link', async ({ page }) => {
+  await page.goto('/tools/kali-wallpapers/');
+  const link = page.locator('aside #package-links a[href*="pkg.kali.org/pkg/kali-wallpapers"]');
+  await expect(link).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright spec to ensure kali-wallpapers infobox links to package tracker
- allow .tsx Playwright specs

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, reconng.test.tsx)*
- `BASE_URL=https://www.kali.org npx playwright test tests/pages/wallpapers-info.spec.tsx` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fd48c4083288ebfb2d9a4b3ea4c