### PR TITLE
test: add undercover tooltip ui test

### DIFF
--- a/tests/ui/undercover-tooltip.spec.tsx
+++ b/tests/ui/undercover-tooltip.spec.tsx
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Undercover tooltip', () => {
+  test('mentions Windows-like theme and docs link', async ({ page }) => {
+    await page.goto('/');
+    const trigger = page.getByLabel(/undercover/i);
+    await trigger.hover();
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toContainText('Windows-like theme');
+    const docLink = tooltip.locator('a');
+    await expect(docLink).toHaveAttribute('href', /undercover/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for Undercover tooltip

## Testing
- `npx playwright test tests/ui/undercover-tooltip.spec.tsx` *(fails: browser executable doesn't exist)*
- `npx playwright install-deps chromium` *(fails: apt repositories unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fd82f10832882daf51fbb67ea51