### PR TITLE
Fix keyboard snap/unsnap restoring window position

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +257,57 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+});
+
+describe('Window keyboard snapping', () => {
+  it('restores position after snap and unsnap via keyboard', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+
+    act(() => {
+      ref.current!.handleKeyDown({
+        key: 'ArrowLeft',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
+    });
+
+    const x = parseFloat(
+      winEl.style.getPropertyValue('--window-transform-x')
+    );
+    const y = parseFloat(
+      winEl.style.getPropertyValue('--window-transform-y')
+    );
+
+    expect(ref.current!.state.snapped).toBe('left');
+
+    act(() => {
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
+    });
+
+    expect(ref.current!.state.snapped).toBeNull();
+    expect(winEl.style.transform).toBe(`translate(${x}px,${y}px)`);
   });
 });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -236,12 +236,15 @@ export class Window extends Component {
 
     unsnapWindow = () => {
         if (!this.state.snapped) return;
-        var r = document.querySelector("#" + this.id);
+        const r = document.querySelector("#" + this.id);
         if (r) {
-            const x = r.style.getPropertyValue('--window-transform-x');
-            const y = r.style.getPropertyValue('--window-transform-y');
-            if (x && y) {
-                r.style.transform = `translate(${x},${y})`;
+            const x = parseFloat(r.style.getPropertyValue('--window-transform-x'));
+            const y = parseFloat(r.style.getPropertyValue('--window-transform-y'));
+            if (!Number.isNaN(x) && !Number.isNaN(y)) {
+                r.style.transform = `translate(${x}px,${y}px)`;
+                if (this.props.onPositionChange) {
+                    this.props.onPositionChange(x, y);
+                }
             }
         }
         if (this.state.lastSize) {
@@ -586,6 +589,7 @@ export class Window extends Component {
 
     snapWindow = (pos) => {
         this.focusWindow();
+        this.setWinowsPosition();
         const { width, height } = this.state;
         let newWidth = width;
         let newHeight = height;


### PR DESCRIPTION
## Summary
- preserve window coordinates before keyboard snapping and restore them on unsnap
- add regression test for snap/unsnap via keyboard

## Testing
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb161611fc83289c770d16d5f0d607