### PR TITLE
feat(panel): add workspace pager

### DIFF
--- a/__tests__/pager.test.tsx
+++ b/__tests__/pager.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, fireEvent, within } from '@testing-library/react';
+import Pager from '../components/panel/Pager';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('switches workspace on click', () => {
+  const { getByLabelText } = render(<Pager miniatureView={false} />);
+  const ws2 = getByLabelText('Workspace 2');
+  fireEvent.click(ws2);
+  expect(ws2).toHaveAttribute('aria-selected', 'true');
+});
+
+test('dragging window moves it to another workspace', () => {
+  const { getByTestId } = render(<Pager miniatureView />);
+  const ws1 = getByTestId('workspace-0');
+  const ws2 = getByTestId('workspace-1');
+  const win = within(ws1).getAllByTestId('window-thumbnail')[0];
+  expect(within(ws1).getAllByTestId('window-thumbnail')).toHaveLength(2);
+  expect(within(ws2).getAllByTestId('window-thumbnail')).toHaveLength(1);
+  const data = {
+    data: {} as Record<string, string>,
+    setData(type: string, val: string) { this.data[type] = val; },
+    getData(type: string) { return this.data[type]; },
+  };
+  fireEvent.dragStart(win, { dataTransfer: data });
+  fireEvent.dragOver(ws2, { dataTransfer: data });
+  fireEvent.drop(ws2, { dataTransfer: data });
+  expect(within(ws1).getAllByTestId('window-thumbnail')).toHaveLength(1);
+  expect(within(ws2).getAllByTestId('window-thumbnail')).toHaveLength(2);
+});

--- a/components/panel/Pager.tsx
+++ b/components/panel/Pager.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import React, { useState } from "react";
+import usePersistentState from "../../hooks/usePersistentState";
+
+type Workspace = {
+  id: number;
+  name: string;
+  windows: string[];
+};
+
+interface PagerProps {
+  rows?: number;
+  miniatureView?: boolean;
+  initialWorkspaces?: Workspace[];
+}
+
+const PAGER_PREFIX = "xfce.pager.";
+
+export default function Pager({
+  rows: rowsProp,
+  miniatureView: miniatureProp,
+  initialWorkspaces,
+}: PagerProps) {
+  const [rows] = usePersistentState<number>(
+    `${PAGER_PREFIX}rows`,
+    rowsProp ?? 1,
+    (v): v is number => typeof v === "number"
+  );
+  const [miniature] = usePersistentState<boolean>(
+    `${PAGER_PREFIX}miniature`,
+    miniatureProp ?? true,
+    (v): v is boolean => typeof v === "boolean"
+  );
+
+  const [workspaces, setWorkspaces] = useState<Workspace[]>(
+    () =>
+      initialWorkspaces || [
+        { id: 0, name: "Workspace 1", windows: ["win-1", "win-2"] },
+        { id: 1, name: "Workspace 2", windows: ["win-3"] },
+        { id: 2, name: "Workspace 3", windows: [] },
+        { id: 3, name: "Workspace 4", windows: [] },
+      ]
+  );
+  const [active, setActive] = useState(0);
+
+  const columns = Math.ceil(workspaces.length / rows);
+
+  const onDragStart = (
+    e: React.DragEvent<HTMLDivElement>,
+    wsIndex: number,
+    winId: string
+  ) => {
+    e.dataTransfer.setData(
+      "text/plain",
+      JSON.stringify({ wsIndex, winId })
+    );
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>, target: number) => {
+    e.preventDefault();
+    try {
+      const data = JSON.parse(e.dataTransfer.getData("text/plain"));
+      setWorkspaces((prev) => {
+        const copy = prev.map((ws) => ({ ...ws, windows: [...ws.windows] }));
+        const srcWs = copy[data.wsIndex];
+        const winIdx = srcWs.windows.indexOf(data.winId);
+        if (winIdx === -1) return prev;
+        const [moved] = srcWs.windows.splice(winIdx, 1);
+        copy[target].windows.push(moved);
+        return copy;
+      });
+    } catch {
+      /* ignore malformed drops */
+    }
+  };
+
+  const onDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
+
+  return (
+    <div className="space-y-2">
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      >
+        {workspaces.map((ws, i) => (
+          <div
+            key={ws.id}
+            data-testid={`workspace-${i}`}
+            aria-label={`Workspace ${i + 1}`}
+            aria-selected={active === i}
+            onClick={() => setActive(i)}
+            onDrop={(e) => onDrop(e, i)}
+            onDragOver={onDragOver}
+            className={`border p-1 rounded cursor-pointer ${
+              active === i ? "border-blue-400" : "border-gray-600"
+            }`}
+          >
+            {miniature ? (
+              <div className="flex flex-wrap gap-1">
+                {ws.windows.map((win) => (
+                  <div
+                    key={win}
+                    data-testid="window-thumbnail"
+                    draggable
+                    onDragStart={(e) => onDragStart(e, i, win)}
+                    className="w-4 h-4 bg-gray-500"
+                  />
+                ))}
+              </div>
+            ) : (
+              <span>{ws.name}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      <a
+        href="https://github.com/unnippillil/kali-linux-portfolio/issues/485"
+        className="text-blue-400 hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Open Workspace Settings
+      </a>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add panel Pager for switching workspaces with thumbnails or names
- support persisted rows and miniature view settings
- simulate moving windows between workspaces via drag and drop

## Testing
- `yarn test __tests__/pager.test.tsx`
- `yarn eslint components/panel/Pager.tsx __tests__/pager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb16194e848328a5ca0c91ef4a807c