### PR TITLE
feat(wm): add focus settings

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -525,40 +525,40 @@ export class Window extends Component {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                e.preventDefault?.();
+                e.stopPropagation?.();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();
@@ -635,12 +635,14 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? (this.props.raiseOnFocus === false ? " z-20 " : " z-30 ") : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onMouseEnter={this.props.focusMode === 'sloppy' ? this.focusWindow : undefined}
+                        onMouseDown={this.focusWindow}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,7 +22,7 @@ import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
-import { useSnapSetting } from '../../hooks/usePersistentState';
+import { useSnapSetting, useFocusModeSetting, useRaiseOnFocusSetting } from '../../hooks/usePersistentState';
 
 export class Desktop extends Component {
     constructor() {
@@ -478,6 +478,8 @@ export class Desktop extends Component {
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
+                    focusMode: this.props.focusMode,
+                    raiseOnFocus: this.props.raiseOnFocus,
                 }
 
                 windowsJsx.push(
@@ -958,5 +960,7 @@ export class Desktop extends Component {
 
 export default function DesktopWithSnap(props) {
     const [snapEnabled] = useSnapSetting();
-    return <Desktop {...props} snapEnabled={snapEnabled} />;
+    const [focusMode] = useFocusModeSetting();
+    const [raiseOnFocus] = useRaiseOnFocusSetting();
+    return <Desktop {...props} snapEnabled={snapEnabled} focusMode={focusMode} raiseOnFocus={raiseOnFocus} />;
 }

--- a/hooks/usePersistentState.js
+++ b/hooks/usePersistentState.js
@@ -49,3 +49,17 @@ export const useSnapSetting = () =>
     true,
     (value) => typeof value === "boolean",
   );
+
+export const useFocusModeSetting = () =>
+  usePersistentState(
+    "wm-focus-mode",
+    "click",
+    (value) => value === "click" || value === "sloppy",
+  );
+
+export const useRaiseOnFocusSetting = () =>
+  usePersistentState(
+    "wm-raise-on-focus",
+    true,
+    (value) => typeof value === "boolean",
+  );

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -60,3 +60,17 @@ export const useSnapSetting = () =>
     true,
     (v): v is boolean => typeof v === 'boolean',
   );
+
+export const useFocusModeSetting = () =>
+  usePersistentState<'click' | 'sloppy'>(
+    'wm-focus-mode',
+    'click',
+    (v): v is 'click' | 'sloppy' => v === 'click' || v === 'sloppy',
+  );
+
+export const useRaiseOnFocusSetting = () =>
+  usePersistentState<boolean>(
+    'wm-raise-on-focus',
+    true,
+    (v): v is boolean => typeof v === 'boolean',
+  );

--- a/pages/settings/window-manager/focus.tsx
+++ b/pages/settings/window-manager/focus.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useFocusModeSetting, useRaiseOnFocusSetting } from '../../../hooks/usePersistentState';
+
+export default function FocusSettings() {
+  const [mode, setMode] = useFocusModeSetting();
+  const [raise, setRaise] = useRaiseOnFocusSetting();
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Focus</h1>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="focus-mode"
+            value="click"
+            checked={mode === 'click'}
+            onChange={() => setMode('click')}
+          />
+          <span>Click to focus</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="focus-mode"
+            value="sloppy"
+            checked={mode === 'sloppy'}
+            onChange={() => setMode('sloppy')}
+          />
+          <span>Focus follows mouse (sloppy)</span>
+        </label>
+        <label className="flex items-center gap-2 pt-2">
+          <input
+            type="checkbox"
+            checked={raise}
+            onChange={(e) => setRaise(e.target.checked)}
+          />
+          <span>Raise on focus</span>
+        </label>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add window manager focus settings page
- persist focus mode and raise-on-focus preference
- route focus and raising behavior based on settings

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint hooks/usePersistentState.ts hooks/usePersistentState.js components/base/window.js components/screen/desktop.js pages/settings/window-manager/focus.tsx` *(fails: Unexpected global 'document' in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bb161c83948328949cf69b046f434b