### PR TITLE
feat: add window system menu

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -252,6 +257,36 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBeNull();
     expect(ref.current!.state.width).toBe(60);
     expect(ref.current!.state.height).toBe(85);
+  });
+});
+
+describe('Window system menu', () => {
+  it('toggles always on top with Alt+Space menu', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+
+    fireEvent.keyDown(winEl, { altKey: true, code: 'Space', key: ' ' });
+    const menuItem = screen.getByRole('menuitemcheckbox', { name: /Always on Top/i });
+    expect(menuItem).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(menuItem);
+
+    fireEvent.keyDown(winEl, { altKey: true, code: 'Space', key: ' ' });
+    const menuItem2 = screen.getByRole('menuitemcheckbox', { name: /Always on Top/i });
+    expect(menuItem2).toHaveAttribute('aria-checked', 'true');
   });
 });
 

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,79 @@
+import React, { useRef, useEffect } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+function WindowMenu({ active, flags, onToggle, onClose, onMoveWorkspace }) {
+  const menuRef = useRef(null);
+  useFocusTrap(menuRef, active);
+  useRovingTabIndex(menuRef, active, 'vertical');
+
+  useEffect(() => {
+    if (!active) return;
+    const handleClick = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        onClose && onClose();
+      }
+    };
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        onClose && onClose();
+      }
+    };
+    const handleBlur = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.relatedTarget)) {
+        onClose && onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    menuRef.current && menuRef.current.addEventListener('blur', handleBlur, true);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+      menuRef.current && menuRef.current.removeEventListener('blur', handleBlur, true);
+    };
+  }, [active, onClose]);
+
+  const renderItem = (label, key, action) => (
+    <button
+      type="button"
+      role="menuitemcheckbox"
+      aria-checked={flags[key] ? 'true' : 'false'}
+      onClick={() => {
+        action();
+        onClose && onClose();
+      }}
+      className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+    >
+      <span className="ml-5">{flags[key] ? '✔' : ''}</span> <span className="ml-2">{label}</span>
+    </button>
+  );
+
+  return (
+    <div
+      role="menu"
+      aria-hidden={!active}
+      ref={menuRef}
+      className={(active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm left-0 top-0'}
+    >
+      {renderItem('Move', 'movable', () => onToggle('movable'))}
+      {renderItem('Resize', 'resizable', () => onToggle('resizable'))}
+      {renderItem('Always on Top', 'alwaysOnTop', () => onToggle('alwaysOnTop'))}
+      {renderItem('Sticky', 'sticky', () => onToggle('sticky'))}
+      {renderItem('Fullscreen', 'fullscreen', () => onToggle('fullscreen'))}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onMoveWorkspace && onMoveWorkspace();
+          onClose && onClose();
+        }}
+        className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+      >
+        <span className="ml-5">Move to Workspace →</span>
+      </button>
+    </div>
+  );
+}
+
+export default WindowMenu;


### PR DESCRIPTION
## Summary
- add `WindowMenu` with Move, Resize, Always on Top, Sticky, Fullscreen and workspace options
- capture Alt+Space to open menu and toggle window flags
- test Alt+Space menu toggling behavior

## Testing
- `yarn lint` (fails: Unexpected global 'document')
- `yarn test __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb161d715c8328bc30fdd7d5cc1a2f