### PR TITLE
Add session settings page with login/logout controls

### DIFF
--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,11 +7,17 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import {
+        SHOW_CHOOSER_KEY,
+        AUTO_SAVE_KEY,
+        PROMPT_LOGOUT_KEY,
+} from '../utils/sessionSettings';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
+        constructor() {
+                super();
+                this.desktopRef = React.createRef();
+                this.state = {
 			screen_locked: false,
 			bg_image_name: 'wall-2',
 			booting_screen: true,
@@ -19,9 +25,10 @@ export default class Ubuntu extends Component {
 		};
 	}
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+                this.maybeShowSessionChooser();
+        }
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {
@@ -29,7 +36,7 @@ export default class Ubuntu extends Component {
 		}, 2000);
 	};
 
-	getLocalData = () => {
+        getLocalData = () => {
 		// Get Previously selected Background Image
                 let bg_image_name = safeLocalStorage?.getItem('bg-image');
 		if (bg_image_name !== null && bg_image_name !== undefined) {
@@ -55,16 +62,34 @@ export default class Ubuntu extends Component {
 			if (screen_locked !== null && screen_locked !== undefined) {
 				this.setState({ screen_locked: screen_locked === 'true' ? true : false });
 			}
-		}
-	};
+                }
+        };
 
-	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Set Screen to Locked`
-		});
+        maybeShowSessionChooser = () => {
+                const show = safeLocalStorage?.getItem(SHOW_CHOOSER_KEY) === 'true';
+                const hasSession = safeLocalStorage?.getItem('desktop-session');
+                if (show && hasSession) {
+                        const restore = window.confirm('Restore previous session?');
+                        if (!restore) {
+                                this.props.resetSession && this.props.resetSession();
+                                window.location.reload();
+                        }
+                }
+        };
+
+        lockScreen = () => {
+                const promptLogout = safeLocalStorage?.getItem(PROMPT_LOGOUT_KEY) === 'true';
+                if (promptLogout && !window.confirm('Log out of this session?')) return;
+                const autoSave = safeLocalStorage?.getItem(AUTO_SAVE_KEY) === 'true';
+                if (autoSave) {
+                        this.desktopRef.current?.saveSession?.();
+                }
+                // google analytics
+                ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Set Screen to Locked`
+                });
 
                 const statusBar = document.getElementById('status-bar');
                 // Consider using a React ref if the status bar element lives within this component tree
@@ -75,23 +100,28 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('screen-locked', true);
 	};
 
-	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        unLockScreen = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		window.removeEventListener('click', this.unLockScreen);
 		window.removeEventListener('keypress', this.unLockScreen);
 
-		this.setState({ screen_locked: false });
+                this.setState({ screen_locked: false });
                 safeLocalStorage?.setItem('screen-locked', false);
-	};
+                this.maybeShowSessionChooser();
+        };
 
 	changeBackgroundImage = (img_name) => {
 		this.setState({ bg_image_name: img_name });
                 safeLocalStorage?.setItem('bg-image', img_name);
 	};
 
-	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+        shutDown = () => {
+                const autoSave = safeLocalStorage?.getItem(AUTO_SAVE_KEY) === 'true';
+                if (autoSave) {
+                        this.desktopRef.current?.saveSession?.();
+                }
+                ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
 		ReactGA.event({
 			category: `Screen Change`,
@@ -127,8 +157,14 @@ export default class Ubuntu extends Component {
 					turnOn={this.turnOn}
 				/>
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Desktop
+                                        ref={this.desktopRef}
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        session={this.props.session}
+                                        setSession={this.props.setSession}
+                                />
+                        </div>
+                );
+        }
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import useSession from '../hooks/useSession';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +29,19 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const { session, setSession, resetSession } = useSession();
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      <Ubuntu session={session} setSession={setSession} resetSession={resetSession} />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;

--- a/pages/settings/session.tsx
+++ b/pages/settings/session.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import ToggleSwitch from "../../components/ToggleSwitch";
+import usePersistentState from "../../hooks/usePersistentState";
+import {
+  SHOW_CHOOSER_KEY,
+  AUTO_SAVE_KEY,
+  PROMPT_LOGOUT_KEY,
+} from "../../utils/sessionSettings";
+
+export default function SessionSettings() {
+  const [showChooser, setShowChooser] = usePersistentState<boolean>(
+    SHOW_CHOOSER_KEY,
+    false,
+    (v): v is boolean => typeof v === "boolean"
+  );
+  const [autoSave, setAutoSave] = usePersistentState<boolean>(
+    AUTO_SAVE_KEY,
+    false,
+    (v): v is boolean => typeof v === "boolean"
+  );
+  const [prompt, setPrompt] = usePersistentState<boolean>(
+    PROMPT_LOGOUT_KEY,
+    true,
+    (v): v is boolean => typeof v === "boolean"
+  );
+
+  return (
+    <div className="p-4 space-y-4 text-ubt-grey">
+      <h1 className="text-xl mb-2">Session</h1>
+      <label className="flex items-center justify-between gap-4">
+        <span>Display session chooser on login</span>
+        <ToggleSwitch
+          checked={showChooser}
+          onChange={setShowChooser}
+          ariaLabel="Display session chooser on login"
+        />
+      </label>
+      <label className="flex items-center justify-between gap-4">
+        <span>Automatically save session on logout</span>
+        <ToggleSwitch
+          checked={autoSave}
+          onChange={setAutoSave}
+          ariaLabel="Automatically save session on logout"
+        />
+      </label>
+      <label className="flex items-center justify-between gap-4">
+        <span>Prompt on logout</span>
+        <ToggleSwitch
+          checked={prompt}
+          onChange={setPrompt}
+          ariaLabel="Prompt on logout"
+        />
+      </label>
+    </div>
+  );
+}

--- a/utils/sessionSettings.ts
+++ b/utils/sessionSettings.ts
@@ -1,0 +1,3 @@
+export const SHOW_CHOOSER_KEY = "session:show-chooser";
+export const AUTO_SAVE_KEY = "session:auto-save";
+export const PROMPT_LOGOUT_KEY = "session:prompt-logout";


### PR DESCRIPTION
## Summary
- add Session settings page with toggles for session chooser, auto-save, and logout prompt
- integrate session options with login flow and lock screen via Ubuntu component
- wire session persistence through index page and new utility constants

## Testing
- `npm test` (fails: Window snapping finalize and release, NmapNSEApp)
- `npm run lint` (fails: 576 problems)


------
https://chatgpt.com/codex/tasks/task_e_68bb161f22a08328bc9675474aaf49b5