### PR TITLE
Add workspace name panel plugin

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, showWorkspaceName, setShowWorkspaceName, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -164,6 +164,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Haptics
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={showWorkspaceName}
+                        onChange={(e) => setShowWorkspaceName(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Show Workspace Name
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/panel/WorkspaceName.tsx
+++ b/components/panel/WorkspaceName.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSettings } from "../../hooks/useSettings";
+
+const WORKSPACE_NAME_KEY = "workspace-name";
+const WORKSPACE_EVENT = "workspace-change";
+
+export default function WorkspaceName() {
+  const { showWorkspaceName } = useSettings();
+  const [name, setName] = useState(() => {
+    if (typeof window === "undefined") return "";
+    return window.localStorage.getItem(WORKSPACE_NAME_KEY) || "";
+  });
+
+  useEffect(() => {
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      if (typeof detail === "string") {
+        setName(detail);
+        try {
+          window.localStorage.setItem(WORKSPACE_NAME_KEY, detail);
+        } catch {
+          // ignore write errors
+        }
+      }
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === WORKSPACE_NAME_KEY && e.newValue) {
+        setName(e.newValue);
+      }
+    };
+    window.addEventListener(WORKSPACE_EVENT, onChange as EventListener);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(WORKSPACE_EVENT, onChange as EventListener);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  if (!showWorkspaceName || !name) return null;
+
+  return (
+    <span className="px-2 text-white text-sm" aria-label="workspace-name">
+      {name}
+    </span>
+  );
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getShowWorkspaceName as loadShowWorkspaceName,
+  setShowWorkspaceName as saveShowWorkspaceName,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  showWorkspaceName: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setShowWorkspaceName: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  showWorkspaceName: defaults.showWorkspaceName,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setShowWorkspaceName: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [showWorkspaceName, setShowWorkspaceName] = useState<boolean>(
+    defaults.showWorkspaceName,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +136,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setShowWorkspaceName(await loadShowWorkspaceName());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +246,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveShowWorkspaceName(showWorkspaceName);
+  }, [showWorkspaceName]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        showWorkspaceName,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setShowWorkspaceName,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  showWorkspaceName: true,
 };
 
 export async function getAccent() {
@@ -123,6 +124,17 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getShowWorkspaceName() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.showWorkspaceName;
+  const val = window.localStorage.getItem('show-workspace-name');
+  return val === null ? DEFAULT_SETTINGS.showWorkspaceName : val === 'true';
+}
+
+export async function setShowWorkspaceName(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('show-workspace-name', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('show-workspace-name');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showWorkspaceName,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getShowWorkspaceName(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showWorkspaceName,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    showWorkspaceName,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (showWorkspaceName !== undefined)
+    await setShowWorkspaceName(showWorkspaceName);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- show current workspace name in panel via new WorkspaceName plugin
- add user setting to toggle workspace name visibility
- persist workspace name toggle in settings store

## Testing
- `yarn test` (fails: window snapping test, nmap NSE test)
- `yarn lint` (terminated due to time)


------
https://chatgpt.com/codex/tasks/task_e_68bb162074748328a0de30896877d4c0