### PR TITLE
feat(panel): add action buttons

### DIFF
--- a/components/panel/ActionButtons.tsx
+++ b/components/panel/ActionButtons.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSession from "../../hooks/useSession";
+import { safeLocalStorage } from "../../utils/safeStorage";
+
+const PLUGIN_PREFIX = "xfce.panel.plugin.";
+
+export default function ActionButtons() {
+  const { resetSession } = useSession();
+  const [order, setOrder] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem(`${PLUGIN_PREFIX}actionButtons`);
+    setOrder(stored ? parseInt(stored, 10) : 0);
+  }, []);
+
+  const lockScreen = () => {
+    safeLocalStorage?.setItem("screen-locked", "true");
+    window.location.reload();
+  };
+
+  const logOut = () => {
+    resetSession();
+    safeLocalStorage?.setItem("screen-locked", "true");
+    window.location.reload();
+  };
+
+  const restart = () => {
+    resetSession();
+    window.location.reload();
+  };
+
+  const disabledClasses =
+    "px-4 py-1 rounded bg-ubt-grey text-white text-sm opacity-50 cursor-not-allowed";
+  const activeClasses =
+    "px-4 py-1 rounded bg-ubt-blue text-white text-sm hover:bg-ubt-blue/80";
+
+  return (
+    <div className="flex flex-col space-y-2" style={{ order }}>
+      <button type="button" onClick={lockScreen} className={activeClasses}>
+        Lock Screen
+      </button>
+      <button
+        type="button"
+        disabled
+        title="Multiple users are not supported"
+        className={disabledClasses}
+      >
+        Switch User
+      </button>
+      <button type="button" onClick={logOut} className={activeClasses}>
+        Log Out
+      </button>
+      <button type="button" onClick={restart} className={activeClasses}>
+        Restart
+      </button>
+      <button
+        type="button"
+        disabled
+        title="Shutdown is not available"
+        className={disabledClasses}
+      >
+        Shut Down
+      </button>
+    </div>
+  );
+}
+

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -5,6 +5,7 @@ import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
 
 const PANEL_PREFIX = "xfce.panel.";
+const PLUGIN_PREFIX = "xfce.panel.plugin.";
 
 export default function Preferences() {
   type TabId = "display" | "measurements" | "appearance" | "opacity" | "items";
@@ -39,6 +40,11 @@ export default function Preferences() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
   });
+  const [actionButtonsPos, setActionButtonsPos] = useState(() => {
+    if (typeof window === "undefined") return 0;
+    const stored = localStorage.getItem(`${PLUGIN_PREFIX}actionButtons`);
+    return stored ? parseInt(stored, 10) : 0;
+  });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -59,6 +65,14 @@ export default function Preferences() {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PLUGIN_PREFIX}actionButtons`,
+      String(actionButtonsPos),
+    );
+  }, [actionButtonsPos]);
 
   return (
     <div>
@@ -133,7 +147,28 @@ export default function Preferences() {
           <p className="text-ubt-grey">Opacity settings are not available yet.</p>
         )}
         {active === "items" && (
-          <p className="text-ubt-grey">Item settings are not available yet.</p>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <label
+                htmlFor="action-buttons-pos"
+                className="text-ubt-grey"
+              >
+                Action Buttons position
+              </label>
+              <input
+                id="action-buttons-pos"
+                type="number"
+                min="0"
+                max="20"
+                value={actionButtonsPos}
+                onChange={(e) =>
+                  setActionButtonsPos(parseInt(e.target.value, 10))
+                }
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded w-20"
+                aria-label="Action Buttons position"
+              />
+            </div>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add panel action buttons for locking, logging out, and restarting
- support configuring action buttons placement via panel preferences

## Testing
- `npx eslint components/panel/ActionButtons.tsx components/panel/Preferences.tsx`
- `yarn test __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb161fc324832888b4aafd0dbb7491