### PR TITLE
feat(panel): add show desktop toggle

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -18,6 +18,7 @@ describe('Taskbar', () => {
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        toggleMinimizeAll={() => {}}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -37,10 +38,29 @@ describe('Taskbar', () => {
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        toggleMinimizeAll={() => {}}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('toggles all windows when show desktop button is clicked', () => {
+    const toggle = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={() => {}}
+        minimize={() => {}}
+        toggleMinimizeAll={toggle}
+      />
+    );
+    const button = screen.getByRole('button', { name: /show desktop/i });
+    fireEvent.click(button);
+    expect(toggle).toHaveBeenCalledWith('workspace');
   });
 });

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -53,6 +53,8 @@ export class Desktop extends Component {
             showWindowSwitcher: false,
             switcherWindows: [],
         }
+        this._toggledWindows = [];
+        this._desktopShown = false;
     }
 
     componentDidMount() {
@@ -552,6 +554,36 @@ export class Desktop extends Component {
         this.giveFocusToLastApp();
     }
 
+    toggleMinimizeAll = (scope = 'workspace') => {
+        // For now, scope is reserved for future multi-workspace support
+        const minimized_windows = { ...this.state.minimized_windows };
+        const focused_windows = { ...this.state.focused_windows };
+
+        if (this._desktopShown) {
+            this._toggledWindows.forEach(id => {
+                minimized_windows[id] = false;
+            });
+            this._toggledWindows = [];
+            this._desktopShown = false;
+            this.setState({ minimized_windows }, () => this.giveFocusToLastApp());
+            return;
+        }
+
+        this._toggledWindows = [];
+        for (const id in this.state.closed_windows) {
+            if (this.state.closed_windows[id]) continue;
+            if (!minimized_windows[id]) {
+                minimized_windows[id] = true;
+                focused_windows[id] = false;
+                this._toggledWindows.push(id);
+            }
+        }
+
+        this._desktopShown = true;
+        this.setState({ minimized_windows, focused_windows });
+        this.hideSideBar(null, false);
+    }
+
     giveFocusToLastApp = () => {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {
@@ -884,6 +916,8 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    toggleMinimizeAll={this.toggleMinimizeAll}
+                    toggleScope={this.props?.toggleScope}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -17,6 +17,21 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+            <button
+                type="button"
+                aria-label="Show Desktop"
+                onClick={() => props.toggleMinimizeAll && props.toggleMinimizeAll(props.toggleScope || 'workspace')}
+                className="relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10"
+            >
+                <Image
+                    width={24}
+                    height={24}
+                    className="w-5 h-5"
+                    src="/themes/Yaru/system/user-desktop.png"
+                    alt=""
+                    sizes="24px"
+                />
+            </button>
             {runningApps.map(app => (
                 <button
                     key={app.id}


### PR DESCRIPTION
## Summary
- add show desktop button to panel taskbar
- toggle minimization of all windows and restore on second click
- test taskbar show desktop behaviour

## Testing
- `npm test` *(fails: e.preventDefault is not a function in window.test.tsx; Unable to find role="alert" in nmapNse.test.tsx)*
- `npm test __tests__/taskbar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb16215eac8328bdaedc29620e658c