### PR TITLE
feat(panel): add height presets and rows

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -19,9 +19,14 @@ export default function Preferences() {
   const [active, setActive] = useState<TabId>("display");
 
   const [size, setSize] = useState(() => {
-    if (typeof window === "undefined") return 24;
+    if (typeof window === "undefined") return 40;
     const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
-    return stored ? parseInt(stored, 10) : 24;
+    return stored ? parseInt(stored, 10) : 40;
+  });
+  const [rows, setRows] = useState(() => {
+    if (typeof window === "undefined") return 1;
+    const stored = localStorage.getItem(`${PANEL_PREFIX}rows`);
+    return stored ? parseInt(stored, 10) : 1;
   });
   const [length, setLength] = useState(() => {
     if (typeof window === "undefined") return 100;
@@ -43,7 +48,14 @@ export default function Preferences() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
+    window.dispatchEvent(new Event("storage"));
   }, [size]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}rows`, String(rows));
+    window.dispatchEvent(new Event("storage"));
+  }, [rows]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -95,19 +107,35 @@ export default function Preferences() {
         {active === "measurements" && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <label htmlFor="panel-size" className="text-ubt-grey">
-                Size: {size}px
+              <label htmlFor="panel-height" className="text-ubt-grey">
+                Height
               </label>
-              <input
-                id="panel-size"
-                type="range"
-                min="16"
-                max="128"
+              <select
+                id="panel-height"
                 value={size}
                 onChange={(e) => setSize(parseInt(e.target.value, 10))}
-                className="ubuntu-slider"
-                aria-label="Panel size"
-              />
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+              >
+                {[24, 28, 32, 40].map((h) => (
+                  <option key={h} value={h}>
+                    {h}px
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="panel-rows" className="text-ubt-grey">
+                Rows
+              </label>
+              <select
+                id="panel-rows"
+                value={rows}
+                onChange={(e) => setRows(parseInt(e.target.value, 10))}
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+              >
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+              </select>
             </div>
             <div className="flex items-center justify-between">
               <label htmlFor="panel-length" className="text-ubt-grey">

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+
+const PANEL_PREFIX = 'xfce.panel.';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+
+    const [rowHeight, setRowHeight] = useState(() => {
+        if (typeof window === 'undefined') return 40;
+        const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
+        return stored ? parseInt(stored, 10) : 40;
+    });
+
+    const [rows, setRows] = useState(() => {
+        if (typeof window === 'undefined') return 1;
+        const stored = localStorage.getItem(`${PANEL_PREFIX}rows`);
+        return stored ? parseInt(stored, 10) : 1;
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const handler = () => {
+            const h = localStorage.getItem(`${PANEL_PREFIX}size`);
+            const r = localStorage.getItem(`${PANEL_PREFIX}rows`);
+            setRowHeight(h ? parseInt(h, 10) : 40);
+            setRows(r ? parseInt(r, 10) : 1);
+        };
+        window.addEventListener('storage', handler);
+        handler();
+        return () => window.removeEventListener('storage', handler);
+    }, []);
+
+    const totalHeight = rowHeight * rows;
+    const iconSize = rowHeight;
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,7 +46,11 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex flex-wrap items-center content-start overflow-hidden z-40"
+            role="toolbar"
+            style={{ height: totalHeight }}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -26,15 +60,16 @@ export default function Taskbar(props) {
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                        'relative flex items-center mx-1 px-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    style={{ height: rowHeight }}
                 >
                     <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
+                        width={iconSize}
+                        height={iconSize}
+                        style={{ width: iconSize, height: iconSize, maxWidth: rowHeight, maxHeight: rowHeight }}
                         src={app.icon.replace('./', '/')}
                         alt=""
-                        sizes="24px"
+                        sizes={`${iconSize}px`}
                     />
                     <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (


### PR DESCRIPTION
## Summary
- add panel height presets and row count controls
- size changes trigger taskbar reflow with icon size matching row height

## Testing
- `yarn lint` *(fails: Unexpected global 'document' in public/apps/tetris/main.js, Component definition missing display name in utils/createDynamicApp.js)*
- `yarn test` *(fails: window.test.tsx TypeError e.preventDefault is not a function; nmapNse.test.tsx Unable to find role="alert"; TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68bb16228bf48328a64353d7207f9b14