### PR TITLE
feat: support quiet hours for notifications

### DIFF
--- a/__tests__/openvas.test.tsx
+++ b/__tests__/openvas.test.tsx
@@ -54,6 +54,7 @@ describe('OpenVASApp', () => {
     await waitFor(() =>
       expect(Notification).toHaveBeenCalledWith('OpenVAS Scan Complete', {
         body: expect.any(String),
+        data: { critical: true },
       })
     );
   });
@@ -71,6 +72,7 @@ describe('OpenVASApp', () => {
     await waitFor(() =>
       expect(Notification).toHaveBeenCalledWith('OpenVAS Scan Failed', {
         body: 'fail',
+        data: { critical: true },
       })
     );
   });

--- a/__tests__/quietHours.test.ts
+++ b/__tests__/quietHours.test.ts
@@ -1,0 +1,23 @@
+import { isWithinQuietHours } from '../utils/quietHours';
+
+describe('isWithinQuietHours', () => {
+  it('handles same-day range', () => {
+    const now = new Date('2023-01-01T10:00:00');
+    expect(isWithinQuietHours(now, '09:00', '17:00')).toBe(true);
+    expect(isWithinQuietHours(new Date('2023-01-01T18:00:00'), '09:00', '17:00')).toBe(
+      false
+    );
+  });
+
+  it('handles overnight range', () => {
+    expect(
+      isWithinQuietHours(new Date('2023-01-01T23:00:00'), '22:00', '06:00')
+    ).toBe(true);
+    expect(
+      isWithinQuietHours(new Date('2023-01-02T05:00:00'), '22:00', '06:00')
+    ).toBe(true);
+    expect(
+      isWithinQuietHours(new Date('2023-01-01T20:00:00'), '22:00', '06:00')
+    ).toBe(false);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,10 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    quietHoursStart,
+    setQuietHoursStart,
+    quietHoursEnd,
+    setQuietHoursEnd,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -38,6 +42,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "notifications", label: "Notifications" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -287,6 +292,34 @@ export default function Settings() {
             </button>
           </div>
         </>
+      )}
+      {activeTab === "notifications" && (
+        <div className="flex flex-col items-center my-4 gap-4">
+          <div className="flex items-center gap-2">
+            <label htmlFor="quiet-start" className="text-ubt-grey">
+              Quiet Hours Start:
+            </label>
+            <input
+              id="quiet-start"
+              type="time"
+              value={quietHoursStart}
+              onChange={(e) => setQuietHoursStart(e.target.value)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="quiet-end" className="text-ubt-grey">
+              Quiet Hours End:
+            </label>
+            <input
+              id="quiet-end"
+              type="time"
+              value={quietHoursEnd}
+              onChange={(e) => setQuietHoursEnd(e.target.value)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            />
+          </div>
+        </div>
       )}
         <input
           type="file"

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -28,7 +28,7 @@ const profileTabs = [
 const notify = (title, body) => {
   if (typeof window === 'undefined') return;
   if ('Notification' in window && Notification.permission === 'granted') {
-    new Notification(title, { body });
+    new Notification(title, { body, data: { critical: true } });
   } else {
     alert(`${title}: ${body}`);
   }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getQuietHoursStart as loadQuietHoursStart,
+  setQuietHoursStart as saveQuietHoursStart,
+  getQuietHoursEnd as loadQuietHoursEnd,
+  setQuietHoursEnd as saveQuietHoursEnd,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +67,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  quietHoursStart: string;
+  quietHoursEnd: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +80,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setQuietHoursStart: (value: string) => void;
+  setQuietHoursEnd: (value: string) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +96,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  quietHoursStart: defaults.quietHoursStart,
+  quietHoursEnd: defaults.quietHoursEnd,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +109,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setQuietHoursStart: () => {},
+  setQuietHoursEnd: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +125,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [quietHoursStart, setQuietHoursStart] = useState<string>(
+    defaults.quietHoursStart
+  );
+  const [quietHoursEnd, setQuietHoursEnd] = useState<string>(
+    defaults.quietHoursEnd
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -127,6 +145,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setQuietHoursStart(await loadQuietHoursStart());
+      setQuietHoursEnd(await loadQuietHoursEnd());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +256,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveQuietHoursStart(quietHoursStart);
+  }, [quietHoursStart]);
+
+  useEffect(() => {
+    saveQuietHoursEnd(quietHoursEnd);
+  }, [quietHoursEnd]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +278,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        quietHoursStart,
+        quietHoursEnd,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +291,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setQuietHoursStart,
+        setQuietHoursEnd,
       }}
     >
       {children}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { isWithinQuietHours } from '../utils/quietHours';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -118,7 +119,15 @@ function MyApp(props) {
 
     const OriginalNotification = window.Notification;
     if (OriginalNotification) {
-      const WrappedNotification = function (title, options) {
+      const WrappedNotification = function (title, options = {}) {
+        const start =
+          window.localStorage.getItem('quiet-hours-start') || '';
+        const end = window.localStorage.getItem('quiet-hours-end') || '';
+        const quiet = isWithinQuietHours(new Date(), start, end);
+        const critical = options?.data?.critical;
+        if (quiet && !critical) {
+          return { close: () => {} };
+        }
         update(`${title}${options?.body ? ' ' + options.body : ''}`);
         return new OriginalNotification(title, options);
       };

--- a/utils/quietHours.ts
+++ b/utils/quietHours.ts
@@ -1,0 +1,18 @@
+export function isWithinQuietHours(
+  now: Date,
+  start: string,
+  end: string
+): boolean {
+  if (!start || !end) return false;
+  const [sH, sM] = start.split(':').map(Number);
+  const [eH, eM] = end.split(':').map(Number);
+  const startDate = new Date(now);
+  startDate.setHours(sH, sM, 0, 0);
+  const endDate = new Date(now);
+  endDate.setHours(eH, eM, 0, 0);
+  if (start === end) return false;
+  if (startDate < endDate) {
+    return now >= startDate && now < endDate;
+  }
+  return now >= startDate || now < endDate;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  quietHoursStart: '',
+  quietHoursEnd: '',
 };
 
 export async function getAccent() {
@@ -123,20 +125,61 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getQuietHoursStart() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.quietHoursStart;
+  try {
+    return (
+      window.localStorage?.getItem('quiet-hours-start') ||
+      DEFAULT_SETTINGS.quietHoursStart
+    );
+  } catch {
+    return DEFAULT_SETTINGS.quietHoursStart;
+  }
+}
+
+export async function setQuietHoursStart(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage?.setItem('quiet-hours-start', value);
+  } catch {}
+}
+
+export async function getQuietHoursEnd() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.quietHoursEnd;
+  try {
+    return (
+      window.localStorage?.getItem('quiet-hours-end') ||
+      DEFAULT_SETTINGS.quietHoursEnd
+    );
+  } catch {
+    return DEFAULT_SETTINGS.quietHoursEnd;
+  }
+}
+
+export async function setQuietHoursEnd(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage?.setItem('quiet-hours-end', value);
+  } catch {}
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  const ls = window.localStorage;
+  ls?.removeItem('density');
+  ls?.removeItem('reduced-motion');
+  ls?.removeItem('font-scale');
+  ls?.removeItem('high-contrast');
+  ls?.removeItem('large-hit-areas');
+  ls?.removeItem('pong-spin');
+  ls?.removeItem('allow-network');
+  ls?.removeItem('haptics');
+  ls?.removeItem('quiet-hours-start');
+  ls?.removeItem('quiet-hours-end');
 }
 
 export async function exportSettings() {
@@ -151,6 +194,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    quietHoursStart,
+    quietHoursEnd,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +207,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getQuietHoursStart(),
+    getQuietHoursEnd(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +222,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    quietHoursStart,
+    quietHoursEnd,
     theme,
   });
 }
@@ -199,6 +248,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    quietHoursStart,
+    quietHoursEnd,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +262,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (quietHoursStart !== undefined) await setQuietHoursStart(quietHoursStart);
+  if (quietHoursEnd !== undefined) await setQuietHoursEnd(quietHoursEnd);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add notifications tab with quiet-hour schedule
- persist quiet hours in settings and notification wrapper
- mark OpenVAS notifications as critical and add tests

## Testing
- `npm test __tests__/openvas.test.tsx __tests__/quietHours.test.ts`
- `npm test __tests__/openvas.test.tsx __tests__/quietHours.test.ts __tests__/Modal.test.tsx __tests__/nmapNse.test.tsx __tests__/window.test.tsx` *(fails: Window snapping finalize and release / NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68bb162430548328a804fde8e84b3add