### PR TITLE
feat: show battery estimate in status bar

### DIFF
--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,31 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import useBattery from '../../hooks/useBattery';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const { level, charging, timeLeft } = useBattery();
+
+  const formatTime = (secs) => {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    return `${h}h ${m}m`;
+  };
+
+  const batteryTitle =
+    level !== null
+      ? `${Math.round(level * 100)}%${
+          timeLeft != null
+            ? ` — about ${formatTime(timeLeft)} ${
+                charging ? 'charging' : 'remaining'
+              }`
+            : ''
+        }`
+      : 'Battery status unavailable';
 
   useEffect(() => {
     const pingServer = async () => {
@@ -66,7 +85,7 @@ export default function Status() {
           sizes="16px"
         />
       </span>
-      <span className="mx-1.5">
+      <span className="mx-1.5" title={batteryTitle}>
         <Image
           width={16}
           height={16}

--- a/hooks/useBattery.js
+++ b/hooks/useBattery.js
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export default function useBattery() {
+  const [level, setLevel] = useState(null);
+  const [charging, setCharging] = useState(null);
+  const [timeLeft, setTimeLeft] = useState(null);
+  const historyRef = useRef([]);
+
+  useEffect(() => {
+    let battery;
+    let interval;
+
+    const update = () => {
+      const now = Date.now();
+      const lvl = battery.level;
+      const chg = battery.charging;
+      setLevel(lvl);
+      setCharging(chg);
+
+      const history = historyRef.current;
+      history.push({ time: now, level: lvl });
+      const cutoff = now - 60000;
+      while (history.length && history[0].time < cutoff) history.shift();
+
+      if (history.length >= 2) {
+        const first = history[0];
+        const last = history[history.length - 1];
+        const dt = (last.time - first.time) / 1000;
+        const dl = last.level - first.level;
+        const rate = dl / dt;
+        if (rate !== 0) {
+          let est = chg ? (1 - last.level) / rate : last.level / -rate;
+          if (est > 0 && isFinite(est)) {
+            setTimeLeft(est);
+            return;
+          }
+        }
+      }
+      setTimeLeft(null);
+    };
+
+    navigator.getBattery?.().then((b) => {
+      battery = b;
+      update();
+      battery.addEventListener('levelchange', update);
+      battery.addEventListener('chargingchange', update);
+      interval = setInterval(update, 1000);
+    }).catch(() => {});
+
+    return () => {
+      if (battery) {
+        battery.removeEventListener('levelchange', update);
+        battery.removeEventListener('chargingchange', update);
+      }
+      if (interval) clearInterval(interval);
+    };
+  }, []);
+
+  return { level, charging, timeLeft };
+}
+


### PR DESCRIPTION
## Summary
- track battery history and estimate time remaining/charging
- display dynamic tooltip on battery icon with percent and time

## Testing
- `npx eslint components/util-components/status.js hooks/useBattery.js`
- `yarn test` *(fails: TypeError: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bb162516f88328acf438f02a5e0e17