### PR TITLE
feat(panel): add microphone tray icon with mute toggle

### DIFF
--- a/components/util-components/Microphone.tsx
+++ b/components/util-components/Microphone.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Toast from '../ui/Toast';
+import usePersistentState from '../../hooks/usePersistentState';
+
+const EVENT_NAME = 'micmutechange';
+
+const MicOnIcon = () => (
+  <svg
+    className="inline status-symbol w-4 h-4"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M8.25 4.5a3.75 3.75 0 1 1 7.5 0v8.25a3.75 3.75 0 1 1-7.5 0V4.5Z" />
+    <path d="M6 10.5a.75.75 0 0 1 .75.75v1.5a5.25 5.25 0 1 0 10.5 0v-1.5a.75.75 0 0 1 1.5 0v1.5a6.751 6.751 0 0 1-6 6.709v2.291h3a.75.75 0 0 1 0 1.5h-7.5a.75.75 0 0 1 0-1.5h3v-2.291a6.751 6.751 0 0 1-6-6.709v-1.5A.75.75 0 0 1 6 10.5Z" />
+  </svg>
+);
+
+const MicOffIcon = () => (
+  <svg
+    className="inline status-symbol w-4 h-4"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M8.25 4.5a3.75 3.75 0 1 1 7.5 0v8.25a3.75 3.75 0 1 1-7.5 0V4.5Z" />
+    <path d="M6 10.5a.75.75 0 0 1 .75.75v1.5a5.25 5.25 0 1 0 10.5 0v-1.5a.75.75 0 0 1 1.5 0v1.5a6.751 6.751 0 0 1-6 6.709v2.291h3a.75.75 0 0 1 0 1.5h-7.5a.75.75 0 0 1 0-1.5h3v-2.291a6.751 6.751 0 0 1-6-6.709v-1.5A.75.75 0 0 1 6 10.5Z" />
+    <path
+      d="M5 5l14 14"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      fill="none"
+    />
+  </svg>
+);
+
+export default function Microphone() {
+  const [muted, setMuted] = usePersistentState('settings:micMuted', false);
+  const [toast, setToast] = useState('');
+  const first = useRef(true);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ muted: boolean }>).detail;
+      if (detail && typeof detail.muted === 'boolean') {
+        setMuted(detail.muted);
+      }
+    };
+    window.addEventListener(EVENT_NAME, handler as EventListener);
+    return () => window.removeEventListener(EVENT_NAME, handler as EventListener);
+  }, [setMuted]);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    setToast(muted ? 'Microphone Muted' : 'Microphone On');
+    window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { muted } }));
+  }, [muted]);
+
+  const toggle = () => setMuted(m => !m);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      toggle();
+    }
+  };
+
+  return (
+    <>
+      <span
+        className="mx-1.5"
+        onMouseDown={handleMouseDown}
+        title={muted ? 'Microphone muted' : 'Microphone on'}
+      >
+        {muted ? <MicOffIcon /> : <MicOnIcon />}
+      </span>
+      {toast && (
+        <Toast
+          message={toast}
+          onClose={() => setToast('')}
+          duration={2000}
+        />
+      )}
+    </>
+  );
+}
+

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import Microphone from './Microphone';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
@@ -56,6 +57,7 @@ export default function Status() {
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
+      <Microphone />
       <span className="mx-1.5">
         <Image
           width={16}


### PR DESCRIPTION
## Summary
- add microphone tray icon that syncs with a simulated system audio state
- middle-click toggles mic mute and triggers toast OSD

## Testing
- `yarn test` *(fails: TypeError e.preventDefault is not a function, and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16258be88328a52cb9c558135968