### PR TITLE
feat(clipman): add search and pinning to history

### DIFF
--- a/apps/clipboard_manager/index.css
+++ b/apps/clipboard_manager/index.css
@@ -1,4 +1,5 @@
 body { font-family: Arial, sans-serif; margin: 2rem; }
-button { margin-bottom: 1rem; }
-li { cursor: pointer; margin: 0.25rem 0; }
+.controls { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
+li { cursor: pointer; margin: 0.25rem 0; display: flex; align-items: center; }
 li:hover { text-decoration: underline; }
+button.pin { margin-left: 0.5rem; cursor: pointer; }

--- a/apps/clipboard_manager/index.html
+++ b/apps/clipboard_manager/index.html
@@ -9,7 +9,16 @@
 </head>
 <body>
   <h1>Clipboard Manager</h1>
-  <button id="clear">Clear History</button>
+  <div class="controls">
+    <button id="clear">Clear History</button>
+    <input id="search" placeholder="Search" />
+    <select id="type-filter">
+      <option value="all">All</option>
+      <option value="text">Text</option>
+      <option value="url">URL</option>
+      <option value="hash">Hash</option>
+    </select>
+  </div>
   <ul id="history"></ul>
   <script src="main.js"></script>
 </body>

--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -1,7 +1,4 @@
 /* eslint-env browser */
-const historyKey = 'clipboardHistory';
-let history = JSON.parse(localStorage.getItem(historyKey)) || [];
-
 
 if (isBrowser) {
   const historyKey = 'clipboardHistory';
@@ -9,19 +6,59 @@ if (isBrowser) {
 
   const list = document.getElementById('history');
   const clearBtn = document.getElementById('clear');
+  const searchInput = document.getElementById('search');
+  const typeFilter = document.getElementById('type-filter');
+
+  const isUrl = (text) => {
+    try {
+      new URL(text);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const isHash = (text) => /^[a-fA-F0-9]{32,64}$/.test(text);
 
   function render() {
     list.innerHTML = '';
-    history.forEach((item) => {
+    const search = searchInput?.value.toLowerCase() || '';
+    const type = typeFilter?.value || 'all';
+
+    const filtered = history
+      .filter((item) => {
+        const matchesSearch = item.text.toLowerCase().includes(search);
+        let matchesType = true;
+        if (type === 'url') matchesType = isUrl(item.text);
+        else if (type === 'hash') matchesType = isHash(item.text);
+        else if (type === 'text') matchesType = !isUrl(item.text) && !isHash(item.text);
+        return matchesSearch && matchesType;
+      })
+      .sort((a, b) => {
+        if (a.pinned === b.pinned) return 0;
+        return a.pinned ? -1 : 1;
+      });
+
+    filtered.forEach((item) => {
       const li = document.createElement('li');
-      li.textContent = item;
+      li.textContent = item.text;
       li.addEventListener('click', async () => {
         try {
-          await navigator.clipboard.writeText(item);
+          await navigator.clipboard.writeText(item.text);
         } catch (err) {
           console.error('Failed to copy text:', err);
         }
       });
+      const pinBtn = document.createElement('button');
+      pinBtn.className = 'pin';
+      pinBtn.textContent = item.pinned ? '★' : '☆';
+      pinBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        item.pinned = !item.pinned;
+        save();
+        render();
+      });
+      li.appendChild(pinBtn);
       list.appendChild(li);
     });
   }
@@ -31,16 +68,19 @@ if (isBrowser) {
   }
 
   clearBtn?.addEventListener('click', () => {
-    history = [];
+    history = history.filter((item) => item.pinned);
     save();
     render();
   });
 
+  searchInput?.addEventListener('input', render);
+  typeFilter?.addEventListener('change', render);
+
   document.addEventListener('copy', async () => {
     try {
       const text = await navigator.clipboard.readText();
-      if (text && (history.length === 0 || history[0] !== text)) {
-        history.unshift(text);
+      if (text && (history.length === 0 || history[0].text !== text)) {
+        history.unshift({ text, pinned: false });
         save();
         render();
       }


### PR DESCRIPTION
## Summary
- add search box and type filter to Clipman history UI
- support pinning items with persistent storage so pinned clips survive reloads
- show pinned items at top and preserve them when clearing history

## Testing
- `npx eslint apps/clipboard_manager/main.js components/apps/ClipboardManager.tsx`
- `npx jest components/apps/ClipboardManager.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb1627ac888328bdee87c689ca3650