### PR TITLE
feat(panel): add profile previews and confirm switch

### DIFF
--- a/components/panel/profiles.tsx
+++ b/components/panel/profiles.tsx
@@ -1,0 +1,53 @@
+import type { SVGProps } from "react";
+
+export interface PanelProfile {
+  id: string;
+  name: string;
+  description: string;
+  Preview: (props: SVGProps<SVGSVGElement>) => JSX.Element;
+  settings: {
+    orientation: "horizontal" | "vertical";
+    length: number;
+    size: number;
+    autohide: boolean;
+  };
+}
+
+const bar = "#666";
+
+export const PANEL_PROFILES: readonly PanelProfile[] = [
+  {
+    id: "default",
+    name: "Default",
+    description: "Top panel with full width.",
+    Preview: (props) => (
+      <svg viewBox="0 0 100 50" {...props}>
+        <rect x="0" y="0" width="100" height="10" fill={bar} />
+      </svg>
+    ),
+    settings: { orientation: "horizontal", length: 100, size: 24, autohide: false },
+  },
+  {
+    id: "bottom",
+    name: "Bottom Dock",
+    description: "Bottom panel that autohides.",
+    Preview: (props) => (
+      <svg viewBox="0 0 100 50" {...props}>
+        <rect x="0" y="40" width="100" height="10" fill={bar} />
+      </svg>
+    ),
+    settings: { orientation: "horizontal", length: 100, size: 32, autohide: true },
+  },
+  {
+    id: "vertical",
+    name: "Vertical",
+    description: "Left side vertical panel.",
+    Preview: (props) => (
+      <svg viewBox="0 0 100 50" {...props}>
+        <rect x="0" y="0" width="10" height="50" fill={bar} />
+      </svg>
+    ),
+    settings: { orientation: "vertical", length: 100, size: 24, autohide: false },
+  },
+];
+


### PR DESCRIPTION
## Summary
- add panel profile metadata with inline SVG previews
- add Profiles tab with preview thumbnails and descriptions
- require user confirmation before applying a panel profile

## Testing
- `yarn lint components/panel/Preferences.tsx components/panel/profiles.tsx` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16283f448328a6992ba543e81e89