### PR TITLE
feat: add panel debug overlay

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -52,6 +52,7 @@ export class Desktop extends Component {
             showShortcutSelector: false,
             showWindowSwitcher: false,
             switcherWindows: [],
+            debugPanel: false,
         }
     }
 
@@ -145,7 +146,10 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
-        if (e.altKey && e.key === 'Tab') {
+        if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'd') {
+            e.preventDefault();
+            this.setState(prev => ({ debugPanel: !prev.debugPanel }));
+        } else if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
@@ -822,8 +826,16 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input
+                        className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5"
+                        id="folder-name-input"
+                        type="text"
+                        autoComplete="off"
+                        spellCheck="false"
+                        autoFocus={true}
+                        aria-label="Folder name"
+                    />
                 </div>
                 <div className="flex">
                     <button
@@ -874,7 +886,8 @@ export class Desktop extends Component {
                     closed_windows={this.state.closed_windows}
                     focused_windows={this.state.focused_windows}
                     isMinimized={this.state.minimized_windows}
-                    openAppByAppId={this.openApp} />
+                    openAppByAppId={this.openApp}
+                    debug={this.state.debugPanel} />
 
                 {/* Taskbar */}
                 <Taskbar
@@ -884,6 +897,7 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    debug={this.state.debugPanel}
                 />
 
                 {/* Desktop Apps */}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -7,7 +7,18 @@ let renderApps = (props) => {
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                debug={props.debug}
+            />
         );
     });
     return sideBarAppsJsx;

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,57 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+
+function TaskbarItem({ app, focused, minimized, onClick, debug }) {
+    const ref = useRef(null);
+    const [width, setWidth] = useState(0);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const update = () => setWidth(el.getBoundingClientRect().width);
+        update();
+        const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : null;
+        ro && ro.observe(el);
+        window.addEventListener('resize', update);
+        return () => {
+            ro && ro.disconnect();
+            window.removeEventListener('resize', update);
+        };
+    }, []);
+
+    return (
+        <button
+            ref={ref}
+            type="button"
+            aria-label={app.title}
+            data-context="taskbar"
+            data-app-id={app.id}
+            onClick={onClick}
+            className={(focused && !minimized ? ' bg-white bg-opacity-20 ' : ' ') +
+                'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+        >
+            <Image
+                width={24}
+                height={24}
+                className="w-5 h-5"
+                src={app.icon.replace('./', '/')}
+                alt=""
+                sizes="24px"
+            />
+            <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+            {!focused && !minimized && (
+                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+            )}
+            {debug && (
+                <div className="absolute inset-0 pointer-events-none border-2 border-red-500 text-red-500 text-[10px] flex flex-col">
+                    <span className="m-auto text-center">{app.title} ({Math.round(width)}px)</span>
+                    <div className="absolute left-0 top-0 bottom-0 border-l-2 border-red-500" />
+                    <div className="absolute right-0 top-0 bottom-0 border-r-2 border-red-500" />
+                </div>
+            )}
+        </button>
+    );
+}
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -18,29 +70,14 @@ export default function Taskbar(props) {
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
-                <button
+                <TaskbarItem
                     key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
+                    app={app}
+                    focused={props.focused_windows[app.id]}
+                    minimized={props.minimized_windows[app.id]}
                     onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
+                    debug={props.debug}
+                />
             ))}
         </div>
     );


### PR DESCRIPTION
## Summary
- add debugPanel toggle via Ctrl+Shift+D to show panel layout info
- overlay panel items with live name, width, and slot boundaries

## Testing
- `yarn lint components/base/side_bar_app.js components/screen/taskbar.js components/screen/side_bar.js components/screen/desktop.js` *(fails: Unexpected global 'document')*
- `yarn test components/base/side_bar_app.js components/screen/taskbar.js components/screen/side_bar.js components/screen/desktop.js` *(fails: No tests found)*
- `npx eslint components/base/side_bar_app.js components/screen/taskbar.js components/screen/side_bar.js components/screen/desktop.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb162ac7a88328bd3f0f705cdfef0b