### PR TITLE
Add desktop launcher and URL link creation

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -68,6 +68,24 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
+            <button
+                onClick={props.openLauncherDialog}
+                type="button"
+                role="menuitem"
+                aria-label="Create Launcher"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Create Launcher...</span>
+            </button>
+            <button
+                onClick={props.openUrlLinkDialog}
+                type="button"
+                role="menuitem"
+                aria-label="Create URL Link"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Create URL Link...</span>
+            </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>


### PR DESCRIPTION
## Summary
- Add context menu options to create custom launchers and URL links on the desktop
- Persist launcher and link metadata in local storage and load them as desktop shortcuts
- Open .desktop entries by executing commands or opening URLs in default apps

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb162c02f48328b3442878c430cbdb