### PR TITLE
feat: toggle applications submenu

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, showAppMenu, setShowAppMenu, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -164,6 +164,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     Haptics
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={showAppMenu}
+                        onChange={(e) => setShowAppMenu(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Show Applications submenu
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import { useSettings } from '../../hooks/useSettings'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const { showAppMenu } = useSettings()
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -76,38 +78,42 @@ function DesktopMenu(props) {
             <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
-            <button
-                onClick={openTerminal}
-                type="button"
-                role="menuitem"
-                aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Open in Terminal</span>
-            </button>
-            <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Change Background...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
-            </div>
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Settings</span>
-            </button>
+            {showAppMenu && (
+                <>
+                    <button
+                        onClick={openTerminal}
+                        type="button"
+                        role="menuitem"
+                        aria-label="Open in Terminal"
+                        className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                    >
+                        <span className="ml-5">Open in Terminal</span>
+                    </button>
+                    <Devider />
+                    <button
+                        onClick={openSettings}
+                        type="button"
+                        role="menuitem"
+                        aria-label="Change Background"
+                        className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                    >
+                        <span className="ml-5">Change Background...</span>
+                    </button>
+                    <Devider />
+                    <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+                        <span className="ml-5">Display Settings</span>
+                    </div>
+                    <button
+                        onClick={openSettings}
+                        type="button"
+                        role="menuitem"
+                        aria-label="Settings"
+                        className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                    >
+                        <span className="ml-5">Settings</span>
+                    </button>
+                </>
+            )}
             <Devider />
             <button
                 onClick={goFullScreen}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getShowAppMenu as loadShowAppMenu,
+  setShowAppMenu as saveShowAppMenu,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  showAppMenu: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setShowAppMenu: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  showAppMenu: defaults.showAppMenu,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setShowAppMenu: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [showAppMenu, setShowAppMenu] = useState<boolean>(defaults.showAppMenu);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setShowAppMenu(await loadShowAppMenu());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveShowAppMenu(showAppMenu);
+  }, [showAppMenu]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        showAppMenu,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setShowAppMenu,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  showAppMenu: true,
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getShowAppMenu() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.showAppMenu;
+  const val = window.localStorage.getItem('show-app-menu');
+  return val === null ? DEFAULT_SETTINGS.showAppMenu : val === 'true';
+}
+
+export async function setShowAppMenu(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('show-app-menu', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('show-app-menu');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showAppMenu,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getShowAppMenu(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    showAppMenu,
     theme,
   });
 }
@@ -199,6 +215,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    showAppMenu,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +228,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (showAppMenu !== undefined) await setShowAppMenu(showAppMenu);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add "Show Applications submenu" setting
- allow hiding app launch options from desktop context menu

## Testing
- `yarn lint` *(fails: Unexpected global 'document', Component definition is missing display name)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb162df0ac832894c98bec815f7a8a