### PR TITLE
feat: add wallpaper style settings

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -19,6 +19,8 @@ export default function Settings() {
     setAccent,
     wallpaper,
     setWallpaper,
+    wallpaperStyle,
+    setWallpaperStyle,
     density,
     setDensity,
     reducedMotion,
@@ -52,6 +54,13 @@ export default function Settings() {
     "wall-7",
     "wall-8",
   ];
+  const wallpaperStyles: Record<string, any> = {
+    fill: { backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" },
+    fit: { backgroundSize: "contain", backgroundRepeat: "no-repeat", backgroundPosition: "center center" },
+    stretch: { backgroundSize: "100% 100%", backgroundRepeat: "no-repeat", backgroundPosition: "center center" },
+    center: { backgroundSize: "auto", backgroundRepeat: "no-repeat", backgroundPosition: "center center" },
+    tile: { backgroundSize: "auto", backgroundRepeat: "repeat", backgroundPosition: "top left" },
+  };
 
   const changeBackground = (name: string) => setWallpaper(name);
 
@@ -73,6 +82,7 @@ export default function Settings() {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
       if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+      if (parsed.wallpaperStyle !== undefined) setWallpaperStyle(parsed.wallpaperStyle);
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
@@ -96,6 +106,7 @@ export default function Settings() {
     window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
+    setWallpaperStyle(defaults.wallpaperStyle);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
@@ -116,9 +127,7 @@ export default function Settings() {
             className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
             style={{
               backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
+              ...wallpaperStyles[wallpaperStyle],
             }}
           ></div>
           <div className="flex justify-center my-4">
@@ -132,6 +141,20 @@ export default function Settings() {
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>
+            </select>
+          </div>
+          <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey">Style:</label>
+            <select
+              value={wallpaperStyle}
+              onChange={(e) => setWallpaperStyle(e.target.value)}
+              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+            >
+              <option value="fill">Fill</option>
+              <option value="fit">Fit</option>
+              <option value="stretch">Stretch</option>
+              <option value="center">Center</option>
+              <option value="tile">Tile</option>
             </select>
           </div>
           <div className="flex justify-center my-4">

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,12 +3,19 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, wallpaperStyle, setWallpaperStyle, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+    const wallpaperStyles = {
+        fill: { backgroundSize: 'cover', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        fit: { backgroundSize: 'contain', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        stretch: { backgroundSize: '100% 100%', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        center: { backgroundSize: 'auto', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        tile: { backgroundSize: 'auto', backgroundRepeat: 'repeat', backgroundPosition: 'top left' },
+    };
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
@@ -57,7 +64,7 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, ...wallpaperStyles[wallpaperStyle] }}>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Theme:</label>
@@ -70,6 +77,20 @@ export function Settings() {
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>
+                </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Style:</label>
+                <select
+                    value={wallpaperStyle}
+                    onChange={(e) => setWallpaperStyle(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="fill">Fill</option>
+                    <option value="fit">Fit</option>
+                    <option value="stretch">Stretch</option>
+                    <option value="center">Center</option>
+                    <option value="tile">Tile</option>
                 </select>
             </div>
             <div className="flex justify-center my-4">
@@ -246,6 +267,7 @@ export function Settings() {
                         await resetSettings();
                         setAccent(defaults.accent);
                         setWallpaper(defaults.wallpaper);
+                        setWallpaperStyle(defaults.wallpaperStyle);
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
                         setLargeHitAreas(defaults.largeHitAreas);
@@ -271,6 +293,7 @@ export function Settings() {
                         const parsed = JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
+                        if (parsed.wallpaperStyle !== undefined) setWallpaperStyle(parsed.wallpaperStyle);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -4,7 +4,14 @@ import { useSettings } from '../../hooks/useSettings';
 
 export default function LockScreen(props) {
 
-    const { wallpaper } = useSettings();
+    const { wallpaper, wallpaperStyle } = useSettings();
+    const styleMap = {
+        fill: { backgroundSize: 'cover', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        fit: { backgroundSize: 'contain', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        stretch: { backgroundSize: '100% 100%', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        center: { backgroundSize: 'auto', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        tile: { backgroundSize: 'auto', backgroundRepeat: 'repeat', backgroundPosition: 'top left' },
+    };
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -16,10 +23,9 @@ export default function LockScreen(props) {
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+            <div
+                className={`absolute top-0 left-0 w-full h-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, ...styleMap[wallpaperStyle] }}
             />
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -4,8 +4,15 @@ import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
+    const { wallpaper, wallpaperStyle } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
+    const styleMap = {
+        fill: { backgroundSize: 'cover', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        fit: { backgroundSize: 'contain', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        stretch: { backgroundSize: '100% 100%', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        center: { backgroundSize: 'auto', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center' },
+        tile: { backgroundSize: 'auto', backgroundRepeat: 'repeat', backgroundPosition: 'top left' },
+    };
 
     useEffect(() => {
         const img = new Image();
@@ -37,12 +44,10 @@ export default function BackgroundImage() {
     }, [wallpaper]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className="w-full h-full object-cover"
-            />
+        <div
+            className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
+            style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, ...styleMap[wallpaperStyle] }}
+        >
             {needsOverlay && (
                 <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
             )}

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -10,12 +10,14 @@ export interface SessionWindow {
 export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
+  wallpaperStyle?: string;
   dock: string[];
 }
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
+  wallpaperStyle: defaults.wallpaperStyle,
   dock: [],
 };
 
@@ -25,6 +27,7 @@ function isSession(value: unknown): value is DesktopSession {
   return (
     Array.isArray(s.windows) &&
     typeof s.wallpaper === 'string' &&
+    (typeof s.wallpaperStyle === 'string' || s.wallpaperStyle === undefined) &&
     Array.isArray(s.dock)
   );
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,6 +4,8 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getWallpaperStyle as loadWallpaperStyle,
+  setWallpaperStyle as saveWallpaperStyle,
   getDensity as loadDensity,
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
@@ -54,6 +56,7 @@ const shadeColor = (color: string, percent: number): string => {
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
+  wallpaperStyle: string;
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
@@ -65,6 +68,7 @@ interface SettingsContextValue {
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setWallpaperStyle: (style: string) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
@@ -79,6 +83,7 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  wallpaperStyle: defaults.wallpaperStyle,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
@@ -90,6 +95,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
+  setWallpaperStyle: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
@@ -104,6 +110,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [wallpaperStyle, setWallpaperStyle] = useState<string>(defaults.wallpaperStyle);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -119,6 +126,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setWallpaperStyle(await loadWallpaperStyle());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -155,6 +163,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  useEffect(() => {
+    saveWallpaperStyle(wallpaperStyle);
+  }, [wallpaperStyle]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -241,6 +253,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         accent,
         wallpaper,
+        wallpaperStyle,
         density,
         reducedMotion,
         fontScale,
@@ -252,6 +265,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
+        setWallpaperStyle,
         setDensity,
         setReducedMotion,
         setFontScale,

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,6 +6,7 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
+  wallpaperStyle: 'fill',
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
@@ -34,6 +35,16 @@ export async function getWallpaper() {
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
   await set('bg-image', wallpaper);
+}
+
+export async function getWallpaperStyle() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaperStyle;
+  return (await get('bg-style')) || DEFAULT_SETTINGS.wallpaperStyle;
+}
+
+export async function setWallpaperStyle(style) {
+  if (typeof window === 'undefined') return;
+  await set('bg-style', style);
 }
 
 export async function getDensity() {
@@ -128,6 +139,7 @@ export async function resetSettings() {
   await Promise.all([
     del('accent'),
     del('bg-image'),
+    del('bg-style'),
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
@@ -143,6 +155,7 @@ export async function exportSettings() {
   const [
     accent,
     wallpaper,
+    wallpaperStyle,
     density,
     reducedMotion,
     fontScale,
@@ -154,6 +167,7 @@ export async function exportSettings() {
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
+    getWallpaperStyle(),
     getDensity(),
     getReducedMotion(),
     getFontScale(),
@@ -167,6 +181,7 @@ export async function exportSettings() {
   return JSON.stringify({
     accent,
     wallpaper,
+    wallpaperStyle,
     density,
     reducedMotion,
     fontScale,
@@ -191,6 +206,7 @@ export async function importSettings(json) {
   const {
     accent,
     wallpaper,
+    wallpaperStyle,
     density,
     reducedMotion,
     fontScale,
@@ -203,6 +219,7 @@ export async function importSettings(json) {
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
+  if (wallpaperStyle !== undefined) await setWallpaperStyle(wallpaperStyle);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);


### PR DESCRIPTION
## Summary
- add wallpaper style preference with fill, fit, stretch, center or tile options
- persist wallpaper style and expose through settings context
- render selected style on background and lock screen

## Testing
- `npm test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; TypeError: Cannot read properties of null)*
- `npx eslint hooks/useSettings.tsx components/util-components/background-image.js components/apps/settings.js apps/settings/index.tsx components/screen/lock_screen.js hooks/useSession.ts utils/settingsStore.js` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68bb162ec2e083289dfd7ef0ca68dc34