### PR TITLE
feat: add file manager status bar

### DIFF
--- a/__tests__/fileManagerStatusBar.test.tsx
+++ b/__tests__/fileManagerStatusBar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import StatusBar, { FileItem } from '../components/file-manager/StatusBar';
+
+const file: FileItem = { name: 'file.txt', kind: 'file', size: 1024 };
+const folder: FileItem = {
+  name: 'folder',
+  kind: 'directory',
+  children: [
+    { name: 'a', kind: 'file', size: 2048 },
+    { name: 'b', kind: 'file', size: 4096 },
+  ],
+};
+
+describe('StatusBar', () => {
+  test('updates count and size when selection changes', async () => {
+    const { rerender } = render(<StatusBar selectedItems={[]} />);
+    expect(screen.getByText('0 items selected')).toBeInTheDocument();
+    expect(screen.getByText('0 B')).toBeInTheDocument();
+
+    rerender(<StatusBar selectedItems={[file]} />);
+    await waitFor(() => {
+      expect(screen.getByText('1 item selected')).toBeInTheDocument();
+      expect(screen.getByText('1 KB')).toBeInTheDocument();
+    });
+
+    rerender(<StatusBar selectedItems={[folder]} />);
+    await waitFor(() => {
+      expect(screen.getByText('1 item selected')).toBeInTheDocument();
+      expect(screen.getByText('6 KB')).toBeInTheDocument();
+    });
+
+    rerender(<StatusBar selectedItems={[file, folder]} />);
+    await waitFor(() => {
+      expect(screen.getByText('2 items selected')).toBeInTheDocument();
+      expect(screen.getByText('7 KB')).toBeInTheDocument();
+    });
+  });
+});
+

--- a/components/file-manager/StatusBar.tsx
+++ b/components/file-manager/StatusBar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface FileItem {
+  name: string;
+  kind: 'file' | 'directory';
+  size?: number;
+  children?: FileItem[];
+}
+
+interface StatusBarProps {
+  selectedItems: FileItem[];
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / Math.pow(k, i);
+  const fixed = Number.isInteger(value) ? value.toString() : value.toFixed(2);
+  return `${fixed} ${sizes[i]}`;
+}
+
+async function calculateSize(item: FileItem): Promise<number> {
+  if (item.kind === 'file') {
+    return item.size || 0;
+  }
+  // Simulate async folder size calculation
+  let total = 0;
+  if (item.children && item.children.length > 0) {
+    for (const child of item.children) {
+      total += await calculateSize(child);
+    }
+  }
+  // Simulate delay to mimic disk access
+  await new Promise((res) => setTimeout(res, 0));
+  return total;
+}
+
+async function calculateTotal(items: FileItem[]): Promise<number> {
+  let total = 0;
+  for (const item of items) {
+    total += await calculateSize(item);
+  }
+  return total;
+}
+
+export default function StatusBar({ selectedItems }: StatusBarProps) {
+  const [size, setSize] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    calculateTotal(selectedItems).then((s) => {
+      if (!cancelled) setSize(s);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedItems]);
+
+  const count = selectedItems.length;
+  return (
+    <div className="w-full px-2 py-1 border-t border-gray-600 flex justify-between text-xs text-white bg-ub-warm-grey bg-opacity-40">
+      <span>{count} item{count === 1 ? '' : 's'} selected</span>
+      <span>{formatBytes(size)}</span>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add file manager status bar to show selected item count and total size
- include unit test for status bar behavior

## Testing
- `npx eslint components/file-manager/StatusBar.tsx __tests__/fileManagerStatusBar.test.tsx`
- `yarn test __tests__/fileManagerStatusBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb16301c308328a0a1e6718517ebd9