### PR TITLE
feat: add file interaction mode setting

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,11 +31,14 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    interactionMode,
+    setInteractionMode,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
+    { id: "behavior", label: "Behavior" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
   ] as const;
@@ -80,6 +83,8 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.interactionMode !== undefined)
+        setInteractionMode(parsed.interactionMode);
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,6 +106,7 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setInteractionMode(defaults.interactionMode as any);
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -208,6 +214,19 @@ export default function Settings() {
             </button>
           </div>
         </>
+      )}
+      {activeTab === "behavior" && (
+        <div className="flex justify-center my-4">
+          <label className="mr-2 text-ubt-grey">Click items:</label>
+          <select
+            value={interactionMode}
+            onChange={(e) => setInteractionMode(e.target.value as any)}
+            className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          >
+            <option value="single">Single-click to open (hover select)</option>
+            <option value="double">Double-click to open</option>
+          </select>
+        </div>
       )}
       {activeTab === "accessibility" && (
         <>

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import { useSettings } from '../../hooks/useSettings';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -104,6 +105,8 @@ export default function FileExplorer() {
   const [results, setResults] = useState([]);
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
+  const { interactionMode } = useSettings();
+  const [selected, setSelected] = useState(null);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -121,6 +124,10 @@ export default function FileExplorer() {
     setSupported(ok);
     if (ok) getRecentDirs().then(setRecent);
   }, []);
+
+  useEffect(() => {
+    setSelected(null);
+  }, [interactionMode]);
 
   useEffect(() => {
     if (!opfsSupported || !root) return;
@@ -319,8 +326,18 @@ export default function FileExplorer() {
           {recent.map((r, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openRecent(r)}
+              className={`px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 ${
+                selected?.type === 'recent' && selected.name === r.name
+                  ? 'bg-black bg-opacity-30'
+                  : ''
+              }`}
+              onClick={() => {
+                if (interactionMode === 'single') openRecent(r);
+                else setSelected({ type: 'recent', name: r.name });
+              }}
+              onDoubleClick={() => {
+                if (interactionMode === 'double') openRecent(r);
+              }}
             >
               {r.name}
             </div>
@@ -329,8 +346,18 @@ export default function FileExplorer() {
           {dirs.map((d, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
+              className={`px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 ${
+                selected?.type === 'dir' && selected.name === d.name
+                  ? 'bg-black bg-opacity-30'
+                  : ''
+              }`}
+              onClick={() => {
+                if (interactionMode === 'single') openDir(d);
+                else setSelected({ type: 'dir', name: d.name });
+              }}
+              onDoubleClick={() => {
+                if (interactionMode === 'double') openDir(d);
+              }}
             >
               {d.name}
             </div>
@@ -339,8 +366,18 @@ export default function FileExplorer() {
           {files.map((f, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
+              className={`px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 ${
+                selected?.type === 'file' && selected.name === f.name
+                  ? 'bg-black bg-opacity-30'
+                  : ''
+              }`}
+              onClick={() => {
+                if (interactionMode === 'single') openFile(f);
+                else setSelected({ type: 'file', name: f.name });
+              }}
+              onDoubleClick={() => {
+                if (interactionMode === 'double') openFile(f);
+              }}
             >
               {f.name}
             </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, interactionMode, setInteractionMode } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -97,6 +97,17 @@ export function Settings() {
                 >
                     <option value="regular">Regular</option>
                     <option value="compact">Compact</option>
+                </select>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">Click items:</label>
+                <select
+                    value={interactionMode}
+                    onChange={(e) => setInteractionMode(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="single">Single-click to open (hover select)</option>
+                    <option value="double">Double-click to open</option>
                 </select>
             </div>
             <div className="flex justify-center my-4">
@@ -252,6 +263,7 @@ export function Settings() {
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
+                        setInteractionMode(defaults.interactionMode);
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
@@ -276,6 +288,7 @@ export function Settings() {
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
+                        if (parsed.interactionMode !== undefined) setInteractionMode(parsed.interactionMode);
                     } catch (err) {
                         console.error('Invalid settings', err);
                     }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,10 +20,13 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getInteractionMode as loadInteractionMode,
+  setInteractionMode as saveInteractionMode,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+type InteractionMode = 'single' | 'double';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -63,6 +66,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  interactionMode: InteractionMode;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +78,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setInteractionMode: (mode: InteractionMode) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +93,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  interactionMode: defaults.interactionMode as InteractionMode,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +105,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setInteractionMode: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +120,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [interactionMode, setInteractionMode] = useState<InteractionMode>(
+    defaults.interactionMode as InteractionMode
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -127,6 +137,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setInteractionMode((await loadInteractionMode()) as InteractionMode);
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +247,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveInteractionMode(interactionMode);
+  }, [interactionMode]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +265,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        interactionMode,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +277,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setInteractionMode,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  interactionMode: 'double',
 };
 
 export async function getAccent() {
@@ -123,6 +124,19 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getInteractionMode() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.interactionMode;
+  return (
+    window.localStorage.getItem('interaction-mode') ||
+    DEFAULT_SETTINGS.interactionMode
+  );
+}
+
+export async function setInteractionMode(mode) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('interaction-mode', mode);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +151,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('interaction-mode');
 }
 
 export async function exportSettings() {
@@ -151,6 +166,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    interactionMode,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +178,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getInteractionMode(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +192,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    interactionMode,
     theme,
   });
 }
@@ -199,6 +217,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    interactionMode,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +230,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (interactionMode !== undefined) await setInteractionMode(interactionMode);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- support single- or double-click to open files
- persist file interaction mode across sessions
- expose interaction option in Settings

## Testing
- `npx eslint hooks/useSettings.tsx apps/settings/index.tsx components/apps/file-explorer.js components/apps/settings.js utils/settingsStore.js` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Window snapping finalize and release, NmapNSEApp copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1630b5d88328ac87bde269b64e34