### PR TITLE
feat: add panel and desktop shortcut context menu options

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -34,10 +34,19 @@ function AppMenu(props) {
                 type="button"
                 onClick={handlePin}
                 role="menuitem"
-                aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                aria-label={props.pinned ? 'Remove from Panel' : 'Add to Panel'}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <span className="ml-5">{props.pinned ? 'Remove from Panel' : 'Add to Panel'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={props.addToDesktop}
+                role="menuitem"
+                aria-label="Add to Desktop"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"
+            >
+                <span className="ml-5">Add to Desktop</span>
             </button>
         </div>
     )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -752,6 +752,11 @@ export class Desktop extends Component {
         this.setState({ showShortcutSelector: false }, this.updateAppsData);
     }
 
+    addAppToDesktop = (app_id) => {
+        this.addShortcutToDesktop(app_id);
+        this.hideAllContextMenu();
+    }
+
     checkForAppShortcuts = () => {
         const shortcuts = safeLocalStorage?.getItem('app_shortcuts');
         if (!shortcuts) {
@@ -822,8 +827,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" aria-label="New folder name" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button
@@ -903,6 +908,7 @@ export class Desktop extends Component {
                     pinned={this.initFavourite[this.state.context_app]}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
+                    addToDesktop={() => this.addAppToDesktop(this.state.context_app)}
                     onClose={this.hideAllContextMenu}
                 />
                 <TaskbarMenu


### PR DESCRIPTION
## Summary
- allow adding apps to panel or desktop from app context menu
- create wrapper for desktop shortcut creation and close menu
- add label for new-folder input

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx` *(fails: window snapping finalize and release; NmapNSEApp copies example output to clipboard)*
- `npx eslint components/context-menus/app-menu.js components/screen/desktop.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb1637326c83289312e36d12aa1f3b