### PR TITLE
feat: simulate root option in desktop context menu

### DIFF
--- a/components/common/PolicyKitPrompt.tsx
+++ b/components/common/PolicyKitPrompt.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import Modal from '../base/Modal';
+
+interface PolicyKitPromptProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const PolicyKitPrompt: React.FC<PolicyKitPromptProps> = ({ open, onClose }) => {
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleAuth = () => {
+    setMessage('Not supported in demo');
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70">
+        <div className="w-80 rounded bg-gray-800 p-4 text-white">
+          <h2 className="mb-2 text-lg font-bold">Authentication Required</h2>
+          {message ? (
+            <>
+              <p className="mb-4 text-sm">{message}</p>
+              <div className="flex justify-end">
+                <button
+                  onClick={onClose}
+                  className="rounded bg-gray-600 px-3 py-1"
+                >
+                  Close
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="mb-4 text-sm">
+                Enter your password to perform administrative tasks.
+              </p>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="mb-4 w-full rounded bg-black p-2 text-white"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={onClose}
+                  className="rounded bg-gray-600 px-3 py-1"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleAuth}
+                  className="rounded bg-blue-600 px-3 py-1"
+                >
+                  Authenticate
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PolicyKitPrompt;
+

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import PolicyKitPrompt from '../common/PolicyKitPrompt'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const [showRootPrompt, setShowRootPrompt] = useState(false)
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -19,6 +21,10 @@ function DesktopMenu(props) {
 
     const openSettings = () => {
         props.openApp("settings");
+    }
+
+    const openRootPrompt = () => {
+        setShowRootPrompt(true)
     }
 
     const checkFullScreen = () => {
@@ -44,6 +50,7 @@ function DesktopMenu(props) {
     }
 
     return (
+        <>
         <div
             id="desktop-menu"
             role="menu"
@@ -76,6 +83,17 @@ function DesktopMenu(props) {
             <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
+            <button
+                onClick={openRootPrompt}
+                type="button"
+                role="menuitem"
+                aria-label="Open as root"
+                title="Demo only: root access is not available"
+                aria-disabled="true"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400 cursor-not-allowed"
+            >
+                <span className="ml-5">Open as root</span>
+            </button>
             <button
                 onClick={openTerminal}
                 type="button"
@@ -129,6 +147,8 @@ function DesktopMenu(props) {
                 <span className="ml-5">Clear Session</span>
             </button>
         </div>
+        <PolicyKitPrompt open={showRootPrompt} onClose={() => setShowRootPrompt(false)} />
+        </>
     )
 }
 


### PR DESCRIPTION
## Summary
- add disabled "Open as root" entry to desktop context menu with simulation tooltip
- clicking shows PolicyKit-style prompt that ends with "Not supported in demo"

## Testing
- `yarn test` (fails: Window snapping finalize and release, NmapNSEApp)
- `yarn test __tests__/Modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb163a06bc8328b1a1f9aa0fa48658