### PR TITLE
feat: save project gallery searches

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -108,6 +108,18 @@ interface Project {
   demo?: string;
 }
 
+interface SavedSearch {
+  name: string;
+  params: {
+    tech: string[];
+    year: string;
+    type: string;
+    tags: string[];
+    search: string;
+    demoOnly: boolean;
+  };
+}
+
 export default function ProjectGalleryPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
@@ -119,6 +131,26 @@ export default function ProjectGalleryPage() {
   const [tags, setTags] = usePersistentState<string[]>('pg-tags', []);
   const [search, setSearch] = usePersistentState<string>('pg-search', '');
   const [demoOnly, setDemoOnly] = usePersistentState<boolean>('pg-demo', false);
+  const [savedSearches, setSavedSearches] = usePersistentState<SavedSearch[]>(
+    'pg-saved',
+    [],
+  );
+
+  const handleSaveSearch = () => {
+    const name = window.prompt('Save search as:');
+    if (!name) return;
+    const params = { tech, year, type, tags, search, demoOnly };
+    setSavedSearches([...savedSearches, { name, params }]);
+  };
+
+  const applySavedSearch = (s: SavedSearch) => {
+    setTech(s.params.tech);
+    setYear(s.params.year);
+    setType(s.params.type);
+    setTags(s.params.tags);
+    setSearch(s.params.search);
+    setDemoOnly(s.params.demoOnly);
+  };
 
   // load projects
   useEffect(() => {
@@ -204,112 +236,152 @@ export default function ProjectGalleryPage() {
   );
 
   return (
-    <div className="p-4 space-y-4 text-black">
-      <div className="flex flex-wrap gap-2 items-center">
-        <input
-          type="text"
-          placeholder="Search..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="px-2 py-1 border rounded"
-        />
-        <FilterChip
-          label="Playable"
-          active={demoOnly}
-          onClick={() => setDemoOnly(!demoOnly)}
-          icon={<PlayIcon />}
-        />
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {tagList.map((t) => (
-          <FilterChip
-            key={t}
-            label={t}
-            active={tags.includes(t)}
-            onClick={() =>
-              setTags(tags.includes(t) ? tags.filter((tag) => tag !== t) : [...tags, t])
-            }
-            icon={<TagIcon />}
-          />
-        ))}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {stacks.map((s) => (
-          <FilterChip
-            key={s}
-            label={s}
-            active={tech.includes(s)}
-            onClick={() =>
-              setTech(tech.includes(s) ? tech.filter((t) => t !== s) : [...tech, s])
-            }
-            icon={<StackIcon />}
-          />
-        ))}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {years.map((y) => (
-          <FilterChip
-            key={y}
-            label={String(y)}
-            active={year === String(y)}
-            onClick={() => setYear(year === String(y) ? '' : String(y))}
-            icon={<CalendarIcon />}
-          />
-        ))}
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {types.map((t) => (
-          <FilterChip
-            key={t}
-            label={t}
-            active={type === t}
-            onClick={() => setType(type === t ? '' : t)}
-            icon={<TypeIcon />}
-          />
-        ))}
-      </div>
-      <div className="grid gap-3 min-[320px]:grid-cols-2 md:grid-cols-3">
-        {loading
-          ? Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-72 flex flex-col border rounded overflow-hidden animate-pulse"
-              >
-                <div className="w-full h-40 bg-gray-300" />
-                <div className="p-2 space-y-2 flex-1">
-                  <div className="h-4 bg-gray-300 rounded w-3/4" />
-                  <div className="h-3 bg-gray-300 rounded w-1/2" />
-                </div>
-              </div>
+    <div className="flex text-black">
+      <aside className="w-64 p-4 border-r">
+        <h2 className="font-semibold mb-2">Saved Searches</h2>
+        <ul className="space-y-1">
+          {savedSearches.length ? (
+            savedSearches.map((s, i) => (
+              <li key={i}>
+                <button
+                  className="underline"
+                  onClick={() => applySavedSearch(s)}
+                >
+                  {s.name}
+                </button>
+              </li>
             ))
-          : filtered.map((p) => (
-              <div
-                key={p.id}
-                tabIndex={0}
-                className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
-                aria-label={`${p.title}: ${p.description}`}
-              >
-                <div className="w-full aspect-video overflow-hidden">
-                  <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
-                </div>
-                <div className="p-2 flex-1">
-                  <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>
-                  <p className="text-sm">{p.description}</p>
-                </div>
-                <div className="absolute inset-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity bg-black/60 text-white flex flex-col">
-                  <div className="p-2 flex flex-wrap gap-1">
-                    {p.tags.map((t) => (
-                      <span key={t} className="bg-white text-black rounded px-1 text-xs">
-                        {t}
-                      </span>
-                    ))}
+          ) : (
+            <li className="text-sm text-gray-500">None</li>
+          )}
+        </ul>
+      </aside>
+      <div className="p-4 space-y-4 flex-1">
+        <div className="flex flex-wrap gap-2 items-center">
+          <input
+            type="text"
+            placeholder="Search..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="px-2 py-1 border rounded"
+          />
+          <FilterChip
+            label="Playable"
+            active={demoOnly}
+            onClick={() => setDemoOnly(!demoOnly)}
+            icon={<PlayIcon />}
+          />
+          <button
+            onClick={handleSaveSearch}
+            className="px-2 py-1 border rounded"
+          >
+            Save Search
+          </button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {tagList.map((t) => (
+            <FilterChip
+              key={t}
+              label={t}
+              active={tags.includes(t)}
+              onClick={() =>
+                setTags(
+                  tags.includes(t) ? tags.filter((tag) => tag !== t) : [...tags, t],
+                )
+              }
+              icon={<TagIcon />}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {stacks.map((s) => (
+            <FilterChip
+              key={s}
+              label={s}
+              active={tech.includes(s)}
+              onClick={() =>
+                setTech(
+                  tech.includes(s) ? tech.filter((t) => t !== s) : [...tech, s],
+                )
+              }
+              icon={<StackIcon />}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {years.map((y) => (
+            <FilterChip
+              key={y}
+              label={String(y)}
+              active={year === String(y)}
+              onClick={() => setYear(year === String(y) ? '' : String(y))}
+              icon={<CalendarIcon />}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {types.map((t) => (
+            <FilterChip
+              key={t}
+              label={t}
+              active={type === t}
+              onClick={() => setType(type === t ? '' : t)}
+              icon={<TypeIcon />}
+            />
+          ))}
+        </div>
+        <div className="grid gap-3 min-[320px]:grid-cols-2 md:grid-cols-3">
+          {loading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-72 flex flex-col border rounded overflow-hidden animate-pulse"
+                >
+                  <div className="w-full h-40 bg-gray-300" />
+                  <div className="p-2 space-y-2 flex-1">
+                    <div className="h-4 bg-gray-300 rounded w-3/4" />
+                    <div className="h-3 bg-gray-300 rounded w-1/2" />
                   </div>
-                  <div className="mt-auto p-2 text-right">
-                    <button className="bg-blue-600 text-white px-4 h-10 rounded">Launch</button>
+                </div>
+              ))
+            : filtered.map((p) => (
+                <div
+                  key={p.id}
+                  tabIndex={0}
+                  className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
+                  aria-label={`${p.title}: ${p.description}`}
+                >
+                  <div className="w-full aspect-video overflow-hidden">
+                    <img
+                      src={p.thumbnail}
+                      alt={p.title}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                  <div className="p-2 flex-1">
+                    <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>
+                    <p className="text-sm">{p.description}</p>
+                  </div>
+                  <div className="absolute inset-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity bg-black/60 text-white flex flex-col">
+                    <div className="p-2 flex flex-wrap gap-1">
+                      {p.tags.map((t) => (
+                        <span
+                          key={t}
+                          className="bg-white text-black rounded px-1 text-xs"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="mt-auto p-2 text-right">
+                      <button className="bg-blue-600 text-white px-4 h-10 rounded">
+                        Launch
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow naming and saving project gallery search/filter combinations
- show saved searches in a sidebar for quick reuse

## Testing
- `yarn test projectGallery.test.tsx`
- `yarn lint apps/project-gallery/pages/index.tsx` *(fails: many existing "A control must be associated with a text label" errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68bb163bf4d083288f4cbbee21992a08