### PR TITLE
feat: enable terminal buffer export

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -48,7 +48,9 @@ describe('Terminal component', () => {
     act(() => {
       ref.current.runCommand('help');
     });
-    expect(ref.current.getContent()).toContain('help');
+    expect(ref.current.getContent()).toContain('Available commands');
+    const buffer = ref.current.getBuffer();
+    expect(buffer.some((e: any) => e.text.includes('Available commands'))).toBe(true);
   });
 
   it('invokes openApp for open command', async () => {


### PR DESCRIPTION
## Summary
- allow users to download the terminal buffer as `.txt` or structured `.json`
- track commands and output with timestamps and expose through new download menu
- cover buffer access with updated unit test

## Testing
- `npx eslint apps/terminal/index.tsx __tests__/terminal.test.tsx && echo ESLINT_OK`
- `yarn test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb1640428c83289ba96ef5d63756e4