### PR TITLE
feat: add date-time settings shortcut

### DIFF
--- a/components/screen/navbar/panel/Clock.tsx
+++ b/components/screen/navbar/panel/Clock.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { openDateTime } from '@/pages/apps/settings/date-time';
+
+export default function Clock() {
+  const [now, setNow] = useState<Date>(new Date());
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const timeStr = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="px-2 py-1 text-sm hover:bg-ubt-grey rounded"
+        aria-label="Clock menu"
+      >
+        {timeStr}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 bg-ub-grey text-ubt-grey shadow-md border border-gray-900 z-50">
+          <button
+            type="button"
+            className="block w-full text-left px-4 py-2 hover:bg-ub-cool-grey"
+            onClick={() => {
+              openDateTime();
+              setOpen(false);
+            }}
+          >
+            Time & Date Settings
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/apps/settings/date-time.tsx
+++ b/pages/apps/settings/date-time.tsx
@@ -1,0 +1,15 @@
+import Router from 'next/router';
+
+export function openDateTime() {
+  Router.push('/apps/settings/date-time');
+}
+
+export default function DateTimeSettingsPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Date & Time Settings</h1>
+      <p>Configure your system time and date.</p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add clock panel menu with **Time & Date Settings** link
- expose `openDateTime` page helper to navigate to `/apps/settings/date-time`

## Testing
- `npx eslint components/screen/navbar/panel/Clock.tsx pages/apps/settings/date-time.tsx`
- `yarn test` *(fails: window test, nmapNse test, reconng test)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47c48b5483289611fe39e172980c