### PR TITLE
feat(settings): add date-time controls and live clock

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
-import Clock from '../util-components/clock';
+import Clock from './navbar/panel/Clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 

--- a/components/screen/navbar/panel/Clock.tsx
+++ b/components/screen/navbar/panel/Clock.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import usePersistentState from '../../../../hooks/usePersistentState';
+import { subscribe } from '../../../../utils/pubsub';
+
+interface DateTimeSettings {
+  timeZone: string;
+  hour12: boolean;
+  showSeconds: boolean;
+  firstDayOfWeek: number;
+}
+
+const defaults: DateTimeSettings = {
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  hour12: Intl.DateTimeFormat().resolvedOptions().hour12 ?? true,
+  showSeconds: false,
+  firstDayOfWeek: 0,
+};
+
+export default function Clock() {
+  const [settings, setSettings] = usePersistentState<DateTimeSettings>(
+    'settings.datetime',
+    { ...defaults },
+  );
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const unsub = subscribe('settings.datetime', (data) => {
+      setSettings(data as DateTimeSettings);
+    });
+    return unsub;
+  }, [setSettings]);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setNow(new Date()),
+      settings.showSeconds ? 1000 : 60000,
+    );
+    return () => clearInterval(interval);
+  }, [settings.showSeconds]);
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    timeZone: settings.timeZone,
+    hour12: settings.hour12,
+    hour: 'numeric',
+    minute: 'numeric',
+    ...(settings.showSeconds ? { second: 'numeric' } : {}),
+  });
+
+  return <span suppressHydrationWarning>{formatter.format(now)}</span>;
+}
+

--- a/pages/apps/settings/date-time.tsx
+++ b/pages/apps/settings/date-time.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import usePersistentState from '../../../hooks/usePersistentState';
+import { publish } from '../../../utils/pubsub';
+
+interface DateTimeSettings {
+  timeZone: string;
+  hour12: boolean;
+  showSeconds: boolean;
+  firstDayOfWeek: number;
+}
+
+const defaults: DateTimeSettings = {
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  hour12: Intl.DateTimeFormat().resolvedOptions().hour12 ?? true,
+  showSeconds: false,
+  firstDayOfWeek: 0,
+};
+
+const timeZones =
+  typeof Intl.supportedValuesOf === 'function'
+    ? Intl.supportedValuesOf('timeZone')
+    : [defaults.timeZone];
+
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+export default function DateTimeSettings() {
+  const [settings, setSettings] = usePersistentState<DateTimeSettings>(
+    'settings.datetime',
+    { ...defaults },
+  );
+
+  const update = (patch: Partial<DateTimeSettings>) =>
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      publish('settings.datetime', next);
+      return next;
+    });
+
+  const [now, setNow] = useState(new Date());
+  useEffect(() => {
+    const interval = setInterval(
+      () => setNow(new Date()),
+      settings.showSeconds ? 1000 : 60000,
+    );
+    return () => clearInterval(interval);
+  }, [settings.showSeconds]);
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    timeZone: settings.timeZone,
+    hour12: settings.hour12,
+    hour: 'numeric',
+    minute: 'numeric',
+    ...(settings.showSeconds ? { second: 'numeric' } : {}),
+  });
+
+  return (
+    <div className="p-4 space-y-4 text-ubt-grey">
+      <div>
+        <label htmlFor="timezone" className="mr-2">
+          Time zone:
+        </label>
+        <select
+          id="timezone"
+          value={settings.timeZone}
+          onChange={(e) => update({ timeZone: e.target.value })}
+          className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+        >
+          {timeZones.map((tz) => (
+            <option key={tz} value={tz}>
+              {tz}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Use 12-hour clock</span>
+        <ToggleSwitch
+          checked={settings.hour12}
+          onChange={(v) => update({ hour12: v })}
+          ariaLabel="Toggle 12-hour clock"
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Show seconds</span>
+        <ToggleSwitch
+          checked={settings.showSeconds}
+          onChange={(v) => update({ showSeconds: v })}
+          ariaLabel="Toggle seconds display"
+        />
+      </div>
+      <div>
+        <label htmlFor="first-day" className="mr-2">
+          First day of week:
+        </label>
+        <select
+          id="first-day"
+          value={settings.firstDayOfWeek}
+          onChange={(e) => update({ firstDayOfWeek: parseInt(e.target.value, 10) })}
+          className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+        >
+          {days.map((d, i) => (
+            <option key={d} value={i}>
+              {d}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mt-4 text-center text-xl">
+        {formatter.format(now)}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add date/time settings with timezone picker, 12/24-hour toggle, seconds toggle, and first-day-of-week selector
- render live clock preview and persist settings
- publish date/time changes and subscribe navbar clock for instant updates

## Testing
- `npx eslint pages/apps/settings/date-time.tsx components/screen/navbar/panel/Clock.tsx components/screen/navbar.js`
- `yarn test pages/apps/settings/date-time.tsx components/screen/navbar/panel/Clock.tsx components/screen/navbar.js --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb47c48ff88328b964a93270d7088f