### PR TITLE
feat(terminal): add theme presets and opacity control

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,7 +9,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
-      className={`text-white ${className}`}
+      className={className}
       style={{
         background: 'var(--kali-bg)',
         fontFamily: 'monospace',

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,20 +1,34 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
 import Terminal, { TerminalProps } from '..';
 
 const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
   const countRef = useRef(1);
+  const [scheme, setScheme] = useState('Kali-Dark');
+  const [opacity, setOpacity] = useState(1);
 
-  const createTab = (): TabDefinition => {
+  const handleSettingsChange = useCallback((s: string, o: number) => {
+    setScheme(s);
+    setOpacity(o);
+  }, []);
+
+  const createTab = useCallback((): TabDefinition => {
     const id = Date.now().toString();
     return {
       id,
       title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      content: (
+        <Terminal
+          openApp={openApp}
+          scheme={scheme}
+          opacity={opacity}
+          onSettingsChange={handleSettingsChange}
+        />
+      ),
     };
-  };
+  }, [openApp, scheme, opacity, handleSettingsChange]);
 
   return (
     <TabbedWindow


### PR DESCRIPTION
## Summary
- add built‑in terminal themes (Kali-Dark, Kali-Light, Solarized, Dracula)
- add background opacity slider and apply scheme/opacity immediately across tabs
- wire terminal tabs to share theme settings

## Testing
- `yarn test` *(fails: window snapping test preventDefault error, nmap NSE alert missing, jsdom localStorage null)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16417a14832886b6a163f6ff4b85