### PR TITLE
Add mock Users & Groups settings page

### DIFF
--- a/data/mock-users.json
+++ b/data/mock-users.json
@@ -1,0 +1,5 @@
+[
+  { "username": "root", "uid": 0, "groups": ["root"] },
+  { "username": "kali", "uid": 1000, "groups": ["kali", "sudo"] },
+  { "username": "guest", "uid": 1001, "groups": ["guest"] }
+]

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), { ssr: false });
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/users-groups.tsx
+++ b/pages/apps/settings/users-groups.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import users from '../../../data/mock-users.json';
+
+type User = {
+  username: string;
+  uid: number;
+  groups: string[];
+};
+
+export default function UsersGroupsPage() {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <div className="p-4 text-ubt-grey bg-ub-cool-grey min-h-screen">
+      <h1 className="text-xl mb-4">Users &amp; Groups</h1>
+      <ul className="mb-6">
+        {(users as User[]).map((user) => (
+          <li key={user.uid} className="mb-1">
+            <span className="font-bold">{user.username}</span> (uid: {user.uid}) – {user.groups.join(', ')}
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-wrap gap-2 mb-6">
+        <button
+          disabled
+          className="px-3 py-1 bg-gray-700 text-white rounded opacity-50 cursor-not-allowed"
+        >
+          Add User
+        </button>
+        <button
+          disabled
+          className="px-3 py-1 bg-gray-700 text-white rounded opacity-50 cursor-not-allowed"
+        >
+          Remove User
+        </button>
+        <button
+          disabled
+          className="px-3 py-1 bg-gray-700 text-white rounded opacity-50 cursor-not-allowed"
+        >
+          Set Password
+        </button>
+        <button
+          disabled
+          className="px-3 py-1 bg-gray-700 text-white rounded opacity-50 cursor-not-allowed"
+        >
+          Group Membership
+        </button>
+      </div>
+      <p className="mb-4">
+        Most distributions provide GUI tools like <code>users-admin</code> for managing accounts. Xfce lacks a native user management utility, so these actions are disabled.
+      </p>
+      <button className="text-sky-400 underline" onClick={() => setShowModal(true)}>
+        Learn more
+      </button>
+      {showModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-ub-cool-grey p-4 rounded max-w-md">
+            <h2 className="text-lg mb-2">User management in Linux</h2>
+            <p className="mb-4">
+              Tools such as <code>users-admin</code> or command line utilities like <code>useradd</code> and <code>usermod</code> are typically used to manage users. Consider installing a dedicated tool for your distribution if you need a graphical interface.
+            </p>
+            <button className="text-sky-400 underline" onClick={() => setShowModal(false)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- restructure settings route into folder with new dynamic import
- add Users & Groups subpage showing mock user list and disabled management controls
- store mock user data in local JSON

## Testing
- `npx eslint pages/apps/settings/index.tsx pages/apps/settings/users-groups.tsx`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --passWithNoTests pages/apps/settings/users-groups.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb47c6bc948328baa450af37da0479