### PR TITLE
feat(settings): add NTP toggle

### DIFF
--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getNetworkTime as loadNetworkTime,
+  setNetworkTime as saveNetworkTime,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  networkTime: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setNetworkTime: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  networkTime: defaults.networkTime,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setNetworkTime: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [networkTime, setNetworkTime] = useState<boolean>(defaults.networkTime);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setNetworkTime(await loadNetworkTime());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveNetworkTime(networkTime);
+  }, [networkTime]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        networkTime,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setNetworkTime,
         setTheme,
       }}
     >

--- a/pages/apps/settings/date-time.tsx
+++ b/pages/apps/settings/date-time.tsx
@@ -1,0 +1,26 @@
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function DateTimeSettings() {
+  const { networkTime, setNetworkTime } = useSettings();
+  const tooltip = `Network Time Protocol (NTP) keeps your clock in sync using chrony.\nCommands:\n  sudo apt install chrony\n  sudo systemctl enable --now chrony`;
+  return (
+    <div className="p-4 text-ubt-grey">
+      <h1 className="text-xl mb-4">Date &amp; Time</h1>
+      <div className="flex items-center gap-2 mb-4">
+        <span>Use network time (NTP)</span>
+        <ToggleSwitch
+          checked={networkTime}
+          onChange={setNetworkTime}
+          ariaLabel="use-network-time"
+        />
+        <span className="cursor-help" title={tooltip} aria-label="NTP info">ℹ️</span>
+      </div>
+      <textarea
+        readOnly
+        value={`sudo apt install chrony\nsudo systemctl enable --now chrony`}
+        className="w-full bg-ub-cool-grey text-ubt-grey p-2 rounded"
+      />
+    </div>
+  );
+}

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), {
+  ssr: false,
+});
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  networkTime: false,
 };
 
 export async function getAccent() {
@@ -123,6 +124,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getNetworkTime() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.networkTime;
+  return window.localStorage.getItem('network-time') === 'true';
+}
+
+export async function setNetworkTime(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('network-time', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('network-time');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    networkTime,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getNetworkTime(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    networkTime,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    networkTime,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (networkTime !== undefined) await setNetworkTime(networkTime);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add Date & Time settings page with NTP toggle and chrony tooltip
- persist network time preference in settings store and hook

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, TypeError in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47c63fa8832892365dcb09fc0c70