### PR TITLE
feat: add printers settings page

### DIFF
--- a/apps/settings/printers.tsx
+++ b/apps/settings/printers.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function PrintersSettings() {
+  const openCUPS = () => {
+    window.open("http://localhost:631", "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <div className="w-full h-full p-4 bg-ub-cool-grey text-ubt-grey">
+      <p className="mb-4">
+        Configure printers using your Linux distribution&apos;s tools or the CUPS
+        web interface. This page provides information only and does not interact
+        with the underlying operating system.
+      </p>
+      <button
+        onClick={openCUPS}
+        className="px-4 py-2 rounded bg-ub-grey text-white hover:bg-gray-600"
+      >
+        Open CUPS (localhost:631)
+      </button>
+    </div>
+  );
+}
+

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,0 @@
-import dynamic from 'next/dynamic';
-
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
-
-export default function SettingsPage() {
-  return <SettingsApp />;
-}
-

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,0 +1,8 @@
+import dynamic from "next/dynamic";
+
+const SettingsApp = dynamic(() => import("../../../apps/settings"), { ssr: false });
+
+export default function SettingsPage() {
+  return <SettingsApp />;
+}
+

--- a/pages/apps/settings/printers.tsx
+++ b/pages/apps/settings/printers.tsx
@@ -1,0 +1,11 @@
+import dynamic from "next/dynamic";
+
+const PrintersSettings = dynamic(
+  () => import("../../../apps/settings/printers"),
+  { ssr: false }
+);
+
+export default function PrintersPage() {
+  return <PrintersSettings />;
+}
+


### PR DESCRIPTION
## Summary
- add printers settings page with read-only instructions
- link to CUPS localhost interface

## Testing
- `yarn eslint pages/apps/settings/index.tsx pages/apps/settings/printers.tsx apps/settings/printers.tsx`
- `yarn test pages/apps/settings/printers.tsx` *(fails: No tests found)*
- `yarn tsc --noEmit -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68bb47c8616c8328a088165684dd8f98