### PR TITLE
feat(settings): add avatar upload and display

### DIFF
--- a/components/greeter/GreeterPreview.tsx
+++ b/components/greeter/GreeterPreview.tsx
@@ -1,0 +1,16 @@
+import { useSettings } from '../../hooks/useSettings';
+
+export default function GreeterPreview() {
+  const { avatar } = useSettings();
+  return (
+    <div className="flex items-center justify-center p-4">
+      {avatar && (
+        <img
+          src={avatar}
+          alt="user avatar"
+          className="w-24 h-24 rounded-full border"
+        />
+      )}
+    </div>
+  );
+}

--- a/components/lock/LockScreenHeader.tsx
+++ b/components/lock/LockScreenHeader.tsx
@@ -1,0 +1,16 @@
+import { useSettings } from '../../hooks/useSettings';
+
+export default function LockScreenHeader() {
+  const { avatar } = useSettings();
+  return (
+    <header className="flex items-center justify-center p-4">
+      {avatar && (
+        <img
+          src={avatar}
+          alt="user avatar"
+          className="w-24 h-24 rounded-full border"
+        />
+      )}
+    </header>
+  );
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getAvatar as loadAvatar,
+  setAvatar as saveAvatar,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -63,6 +65,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  avatar: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +77,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setAvatar: (value: string) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  avatar: defaults.avatar,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setAvatar: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +119,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [avatar, setAvatar] = useState<string>(defaults.avatar);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +135,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setAvatar(await loadAvatar());
     })();
   }, []);
 
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveAvatar(avatar);
+  }, [avatar]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        avatar,
         theme,
         setAccent,
         setWallpaper,
@@ -261,6 +274,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setAvatar,
       }}
     >
       {children}

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), { ssr: false });
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/users-groups.tsx
+++ b/pages/apps/settings/users-groups.tsx
@@ -1,0 +1,45 @@
+import { useRef, ChangeEvent } from 'react';
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function UsersGroups() {
+  const { avatar, setAvatar } = useSettings();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.type !== 'image/png') {
+      alert('Please select a PNG image');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      if (typeof ev.target?.result === 'string') {
+        setAvatar(ev.target.result);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="p-4">
+      <label className="block mb-2">
+        <span className="mb-1 block">User avatar (96×96 PNG preferred)</span>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/png"
+          onChange={handleFileChange}
+          aria-label="Upload avatar"
+        />
+      </label>
+      {avatar && (
+        <img
+          src={avatar}
+          alt="avatar preview"
+          className="w-24 h-24 rounded-full border"
+        />
+      )}
+    </div>
+  );
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  avatar: '',
 };
 
 export async function getAccent() {
@@ -128,6 +129,7 @@ export async function resetSettings() {
   await Promise.all([
     del('accent'),
     del('bg-image'),
+    del('avatar'),
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
@@ -151,6 +153,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    avatar,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +165,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getAvatar(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +179,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    avatar,
     theme,
   });
 }
@@ -199,6 +204,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    avatar,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,7 +217,18 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (avatar !== undefined) await setAvatar(avatar);
   if (theme !== undefined) setTheme(theme);
 }
 
 export const defaults = DEFAULT_SETTINGS;
+
+export async function getAvatar() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.avatar;
+  return (await get('avatar')) || DEFAULT_SETTINGS.avatar;
+}
+
+export async function setAvatar(avatar) {
+  if (typeof window === 'undefined') return;
+  await set('avatar', avatar);
+}


### PR DESCRIPTION
## Summary
- enable user avatar upload in settings and store path
- expose avatar in settings context
- show selected avatar on lock screen and greeter preview

## Testing
- `npx eslint pages/apps/settings/index.tsx pages/apps/settings/users-groups.tsx hooks/useSettings.tsx utils/settingsStore.js components/lock/LockScreenHeader.tsx components/greeter/GreeterPreview.tsx`
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size; NmapNSEApp › copies example output to clipboard; TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68bb47c7bd3883288953c2695447d7d2