### PR TITLE
feat(settings): add session autostart management

### DIFF
--- a/apps/settings/session-startup/autostart.tsx
+++ b/apps/settings/session-startup/autostart.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Entry {
+  name: string;
+  exec: string;
+  enabled: boolean;
+}
+
+const STORAGE_KEY = 'autostart-user';
+
+export default function AutostartSettings() {
+  const [userEntries, setUserEntries] = useState<Entry[]>([]);
+  const [systemEntries, setSystemEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      if (typeof window !== 'undefined') {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          try {
+            setUserEntries(JSON.parse(stored));
+          } catch {
+            // ignore
+          }
+        } else {
+          const res = await fetch('/fixtures/autostart-user.json');
+          setUserEntries(await res.json());
+        }
+      }
+      const sysRes = await fetch('/fixtures/autostart-system.json');
+      setSystemEntries(await sysRes.json());
+    }
+    load();
+  }, []);
+
+  const updateUser = (idx: number, changes: Partial<Entry>) => {
+    setUserEntries((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], ...changes };
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="p-4 text-white text-sm space-y-4">
+      <div>
+        <h2 className="font-bold mb-2">User Autostart</h2>
+        <ul className="space-y-2">
+          {userEntries.map((e, i) => (
+            <li key={i} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={e.enabled}
+                onChange={(ev) => updateUser(i, { enabled: ev.target.checked })}
+              />
+              <input
+                value={e.name}
+                onChange={(ev) => updateUser(i, { name: ev.target.value })}
+                className="bg-ub-cool-grey text-white px-1 py-0.5 rounded w-1/4"
+              />
+              <input
+                value={e.exec}
+                onChange={(ev) => updateUser(i, { exec: ev.target.value })}
+                className="bg-ub-cool-grey text-white px-1 py-0.5 rounded flex-grow"
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="font-bold mb-2">System Autostart</h2>
+        <ul className="space-y-2">
+          {systemEntries.map((e, i) => (
+            <li key={i} className="flex items-center gap-2 italic opacity-75">
+              <input type="checkbox" checked={e.enabled} disabled />
+              <span className="w-1/4">{e.name}</span>
+              <span className="flex-grow">{e.exec}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), {
+  ssr: false,
+});
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/session-startup/autostart.tsx
+++ b/pages/apps/settings/session-startup/autostart.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Autostart = dynamic(
+  () => import('../../../../apps/settings/session-startup/autostart'),
+  { ssr: false }
+);
+
+export default function AutostartPage() {
+  return <Autostart />;
+}

--- a/public/fixtures/autostart-system.json
+++ b/public/fixtures/autostart-system.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Network Manager",
+    "exec": "/usr/bin/nm-applet",
+    "enabled": true
+  },
+  {
+    "name": "Update Notifier",
+    "exec": "/usr/bin/update-notifier",
+    "enabled": true
+  }
+]

--- a/public/fixtures/autostart-user.json
+++ b/public/fixtures/autostart-user.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Custom App",
+    "exec": "/usr/bin/custom-app",
+    "enabled": true
+  },
+  {
+    "name": "My Script",
+    "exec": "/home/user/myscript.sh",
+    "enabled": false
+  }
+]


### PR DESCRIPTION
## Summary
- load user and system autostart fixtures
- allow editing/toggling user entries and show system ones read-only
- persist user autostart settings in local storage

## Testing
- `npm test` *(fails: TypeError e.preventDefault and missing alert, localStorage error)*
- `npm run lint` *(no output, process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47c9a868832889ab82cb83e4fdc9