### PR TITLE
feat(panel): add status notifier and legacy tray settings

### DIFF
--- a/components/panel/LegacyTray.tsx
+++ b/components/panel/LegacyTray.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import React from "react";
+
+export default function LegacyTray() {
+  return (
+    <div className="text-ubt-grey">
+      LegacyTray placeholder for classic systray icons.
+    </div>
+  );
+}
+

--- a/components/panel/PanelSettings.tsx
+++ b/components/panel/PanelSettings.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import ToggleSwitch from "../ToggleSwitch";
+import StatusNotifier from "./StatusNotifier";
+import LegacyTray from "./LegacyTray";
+
+const PANEL_PREFIX = "xfce.panel.";
+
+export default function PanelSettings() {
+  const [useLegacyTray, setUseLegacyTray] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(`${PANEL_PREFIX}useLegacyTray`) === "true";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(
+      `${PANEL_PREFIX}useLegacyTray`,
+      useLegacyTray ? "true" : "false"
+    );
+  }, [useLegacyTray]);
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <span className="text-ubt-grey">Legacy Tray</span>
+        <ToggleSwitch
+          checked={useLegacyTray}
+          onChange={setUseLegacyTray}
+          ariaLabel="Toggle legacy tray"
+        />
+      </div>
+      {useLegacyTray ? <LegacyTray /> : <StatusNotifier />}
+    </div>
+  );
+}
+

--- a/components/panel/StatusNotifier.tsx
+++ b/components/panel/StatusNotifier.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import React from "react";
+
+export default function StatusNotifier() {
+  return (
+    <div className="text-ubt-grey">
+      StatusNotifier placeholder for modern indicators.
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add placeholder StatusNotifier for modern indicator icons
- add placeholder LegacyTray for traditional systray icons
- introduce PanelSettings toggle to switch between StatusNotifier and LegacyTray with persistence

## Testing
- `yarn lint components/panel/StatusNotifier.tsx components/panel/LegacyTray.tsx components/panel/PanelSettings.tsx` *(fails: command not found: yarn)*
- `yarn test` *(fails: command not found: yarn)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47ccefe48328b2d4c8d2280c5c75