### PR TITLE
feat: symbolic icon style toggle

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -29,6 +29,8 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    symbolicIcons,
+    setSymbolicIcons,
     theme,
     setTheme,
   } = useSettings();
@@ -149,6 +151,14 @@ export default function Settings() {
                 />
               ))}
             </div>
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Prefer Symbolic Icons:</span>
+            <ToggleSwitch
+              checked={symbolicIcons}
+              onChange={setSymbolicIcons}
+              ariaLabel="Prefer symbolic icons"
+            />
           </div>
           <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>

--- a/components/panel/StatusNotifier.tsx
+++ b/components/panel/StatusNotifier.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { useSettings } from "../../hooks/useSettings";
+
+export interface StatusNotifierItem {
+  id: string;
+  /** Default colored icon */
+  icon: React.ReactNode;
+  /** Optional symbolic monochrome variant */
+  symbolic?: React.ReactNode;
+}
+
+interface Props {
+  items: StatusNotifierItem[];
+}
+
+/**
+ * Renders SNI icons and applies a monochrome style when symbolic icons
+ * are preferred. Icons with a provided `symbolic` glyph will swap to it;
+ * otherwise a CSS filter is used to desaturate the colored icon.
+ */
+export default function StatusNotifier({ items }: Props) {
+  const { symbolicIcons } = useSettings();
+
+  return (
+    <div className="flex items-center space-x-2">
+      {items.map((item) => (
+        <span
+          key={item.id}
+          style=
+            symbolicIcons && !item.symbolic
+              ? { filter: "grayscale(1) brightness(0) invert(1)" }
+              : undefined
+        >
+          {symbolicIcons && item.symbolic ? item.symbolic : item.icon}
+        </span>
+      ))}
+    </div>
+  );
+}
+

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getSymbolicIcons as loadSymbolicIcons,
+  setSymbolicIcons as saveSymbolicIcons,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +64,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  symbolicIcons: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +76,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setSymbolicIcons: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +91,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  symbolicIcons: defaults.symbolicIcons,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +103,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setSymbolicIcons: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +118,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [symbolicIcons, setSymbolicIcons] = useState<boolean>(defaults.symbolicIcons);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +134,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setSymbolicIcons(await loadSymbolicIcons());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +244,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveSymbolicIcons(symbolicIcons);
+  }, [symbolicIcons]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +261,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        symbolicIcons,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setSymbolicIcons,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  symbolicIcons: false,
 };
 
 export async function getAccent() {
@@ -102,6 +103,16 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getSymbolicIcons() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.symbolicIcons;
+  return window.localStorage.getItem('symbolic-icons') === 'true';
+}
+
+export async function setSymbolicIcons(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('symbolic-icons', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('symbolic-icons');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    symbolicIcons,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getSymbolicIcons(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    symbolicIcons,
     theme,
   });
 }
@@ -199,6 +214,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    symbolicIcons,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (symbolicIcons !== undefined) await setSymbolicIcons(symbolicIcons);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add settings toggle to prefer symbolic status icons
- persist preference and expose in settings context
- render SNI icons in monochrome when preference enabled

## Testing
- `yarn lint components/panel/StatusNotifier.tsx hooks/useSettings.tsx apps/settings/index.tsx utils/settingsStore.js` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: window snapping finalize and release releases snap with Alt+ArrowDown restoring size; NmapNSEApp copies example output to clipboard; jsdom localStorage _origin error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47cda11c8328a02b3a9770ca0d88