### PR TITLE
feat: add status notifier reload

### DIFF
--- a/components/panel/StatusNotifier.tsx
+++ b/components/panel/StatusNotifier.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React, { useState } from "react";
+import Status from "../util-components/status";
+
+export default function StatusNotifier() {
+  const [mounted, setMounted] = useState(true);
+
+  const reload = () => {
+    setMounted(false);
+    setTimeout(() => setMounted(true), 0);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {mounted && <Status />}
+      <button
+        type="button"
+        onClick={reload}
+        className="px-2 py-1 text-ubt-grey hover:text-white hover:bg-ub-grey rounded"
+      >
+        Reload indicators
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add StatusNotifier component with reload indicators button
- clicking reload unmounts and remounts status indicators

## Testing
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert"; Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68bb47cea3d08328a1553562e330a828