### PR TITLE
feat: simulate removable media auto-open

### DIFF
--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), { ssr: false });
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/removable-media.tsx
+++ b/pages/apps/settings/removable-media.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import ToggleSwitch from "../../../components/ToggleSwitch";
+
+const FileExplorer = dynamic(
+  () => import("../../../components/apps/file-explorer.js"),
+  { ssr: false }
+);
+
+export default function RemovableMedia() {
+  const [autoOpen, setAutoOpen] = useState(false);
+  const [showManager, setShowManager] = useState(false);
+
+  useEffect(() => {
+    if (autoOpen) {
+      const timer = setTimeout(() => setShowManager(true), 500);
+      return () => clearTimeout(timer);
+    }
+    setShowManager(false);
+  }, [autoOpen]);
+
+  return (
+    <div className="w-full flex flex-col flex-grow max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
+      <div className="p-4 flex items-center justify-center">
+        <span className="mr-2 text-ubt-grey">Auto-open files on insert</span>
+        <ToggleSwitch
+          checked={autoOpen}
+          onChange={setAutoOpen}
+          ariaLabel="Auto-open files on insert"
+        />
+      </div>
+      {showManager && (
+        <div className="flex-grow">
+          <FileExplorer />
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- restructure settings page into directory
- add removable media settings to auto-open File Manager on simulated insert

## Testing
- `npm test` *(fails: TypeError: e.preventDefault is not a function; Unable to find role="alert" in NmapNSEApp test)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47d453e8832896d5b01ed461ee9a