### PR TITLE
feat(settings): add removable media banner

### DIFF
--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,0 @@
-import dynamic from 'next/dynamic';
-
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
-
-export default function SettingsPage() {
-  return <SettingsApp />;
-}
-

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+
+const SettingsApp = dynamic(() => import("../../../apps/settings"), {
+  ssr: false,
+});
+
+export default function SettingsPage() {
+  return <SettingsApp />;
+}

--- a/pages/apps/settings/removable-media.tsx
+++ b/pages/apps/settings/removable-media.tsx
@@ -1,0 +1,34 @@
+import usePersistentState from "../../../hooks/usePersistentState";
+
+export default function RemovableMediaSettings() {
+  const [dismissed, setDismissed] = usePersistentState<boolean>(
+    "removable-media-banner-dismissed",
+    false,
+    (v): v is boolean => typeof v === "boolean",
+  );
+
+  return (
+    <div className="p-4">
+      {!dismissed && (
+        <div
+          role="alert"
+          className="mb-4 flex items-start justify-between rounded bg-ub-yellow p-2 text-black"
+        >
+          <p className="pr-4 text-sm">
+            Real automount typically needs GVFS/Polkit.
+          </p>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="rounded bg-ubt-grey px-2 py-1 text-xs text-white"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+      <p className="text-ubt-grey">
+        Removable media settings are not implemented.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add removable media settings page with dismissible GVFS/Polkit banner
- move settings page to allow subroutes

## Testing
- `yarn test` *(fails: TypeError: e.preventDefault is not a function, Unable to find role="alert", jsdom localStorage origin error)*
- `yarn lint pages/apps/settings/index.tsx pages/apps/settings/removable-media.tsx` *(fails: 576 problems, mainly missing labels and no-top-level-window warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47d68b188328a40749f5b440403e