### PR TITLE
feat(filemanager): add unlabeled device info tip

### DIFF
--- a/components/filemanager/Sidebar.tsx
+++ b/components/filemanager/Sidebar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+
+export interface Device {
+  id: string;
+  name: string;
+  label?: string;
+}
+
+interface SidebarProps {
+  devices: readonly Device[];
+}
+
+export default function Sidebar({ devices }: SidebarProps) {
+  return (
+    <aside className="p-2 w-48 bg-gray-100" aria-label="device sidebar">
+      <ul>
+        {devices.map((device) => (
+          <li key={device.id} className="mb-1">
+            <span>{device.label || device.name}</span>
+            {!device.label && (
+              <span
+                className="ml-2 text-xs text-ubt-grey italic"
+                title="Label volumes for easier identification"
+              >
+                (Tip: label this volume for easier identification)
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Sidebar component for file manager with tip for unlabeled volumes

## Testing
- `npx eslint components/filemanager/Sidebar.tsx && echo LINT_OK`
- `npx jest components/filemanager/Sidebar.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb47d6fb308328aa2c7bc7dd28717e