### PR TITLE
Add folder sharing modal and badge

### DIFF
--- a/components/filemanager/ContextMenu.tsx
+++ b/components/filemanager/ContextMenu.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import ContextMenu, { MenuItem } from '../common/ContextMenu';
+import ShareModal, { ShareSettings } from './ShareModal';
+
+interface FileContextMenuProps {
+  targetRef: React.RefObject<HTMLElement>;
+  folderId: string;
+  folderName: string;
+}
+
+const FileContextMenu: React.FC<FileContextMenuProps> = ({
+  targetRef,
+  folderId,
+  folderName,
+}) => {
+  const [showShare, setShowShare] = useState(false);
+
+  const handleShareSave = (_settings: ShareSettings) => {
+    const node = targetRef.current;
+    if (node) {
+      node.classList.add('relative');
+      if (!node.querySelector('.shared-folder-badge')) {
+        const badge = document.createElement('span');
+        badge.className =
+          'shared-folder-badge absolute bottom-0 right-0 text-xs';
+        badge.textContent = '🔗';
+        node.appendChild(badge);
+      }
+    }
+  };
+
+  const items: MenuItem[] = [
+    {
+      label: 'Share this Folder…',
+      onSelect: () => setShowShare(true),
+    },
+  ];
+
+  return (
+    <>
+      <ContextMenu targetRef={targetRef} items={items} />
+      {showShare && (
+        <ShareModal
+          folderId={folderId}
+          folderName={folderName}
+          onClose={() => setShowShare(false)}
+          onSave={handleShareSave}
+        />
+      )}
+    </>
+  );
+};
+
+export default FileContextMenu;

--- a/components/filemanager/ShareModal.tsx
+++ b/components/filemanager/ShareModal.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+export interface ShareSettings {
+  name: string;
+  guestOk: boolean;
+  comment: string;
+}
+
+interface ShareModalProps {
+  folderId: string;
+  folderName: string;
+  onClose: () => void;
+  onSave?: (settings: ShareSettings) => void;
+}
+
+const STORAGE_KEY = 'filemanager-shares';
+
+const ShareModal: React.FC<ShareModalProps> = ({
+  folderId,
+  folderName,
+  onClose,
+  onSave,
+}) => {
+  const [shareName, setShareName] = useState(folderName);
+  const [guestOk, setGuestOk] = useState(false);
+  const [comment, setComment] = useState('');
+
+  const save = () => {
+    const settings: ShareSettings = { name: shareName, guestOk, comment };
+    try {
+      const raw = safeLocalStorage?.getItem(STORAGE_KEY) ?? '{}';
+      const data = JSON.parse(raw);
+      data[folderId] = settings;
+      safeLocalStorage?.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {}
+    onSave?.(settings);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 text-white p-4 rounded w-80">
+        <h2 className="text-lg mb-2">Share Folder</h2>
+        <label className="block mb-2">
+          <span className="block text-sm mb-1">Share name</span>
+          <input
+            type="text"
+            value={shareName}
+            onChange={(e) => setShareName(e.target.value)}
+            className="w-full px-2 py-1 text-black rounded"
+          />
+        </label>
+        <label className="block mb-2">
+          <input
+            type="checkbox"
+            checked={guestOk}
+            onChange={(e) => setGuestOk(e.target.checked)}
+            className="mr-2"
+          />
+          Guest OK
+        </label>
+        <label className="block mb-4">
+          <span className="block text-sm mb-1">Comment</span>
+          <textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            className="w-full px-2 py-1 text-black rounded"
+            rows={3}
+          />
+        </label>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 bg-gray-600 rounded">
+            Cancel
+          </button>
+          <button onClick={save} className="px-3 py-1 bg-blue-600 rounded">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareModal;


### PR DESCRIPTION
## Summary
- add context menu with "Share this Folder…" option
- implement ShareModal with fields and local storage persistence
- mark shared folders with badge

## Testing
- `yarn test __tests__/window.test.tsx` *(fails: e.preventDefault is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47d7afbc8328a858331d034afc64