### PR TITLE
feat(panel): add weather popover with location and units

### DIFF
--- a/components/panel/Weather.tsx
+++ b/components/panel/Weather.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import WeatherPopover from "./WeatherPopover";
+import WeatherIcon from "@/apps/weather/components/WeatherIcon";
+
+const WEATHER_PREFIX = "xfce.weather.";
+
+type Unit = "metric" | "imperial";
+
+const MOCK_DATA: Record<string, {
+  code: number;
+  tempC: number;
+  tempF: number;
+  windKph: number;
+  windMph: number;
+  pressure: number;
+  humidity: number;
+}> = {
+  "New York": { code: 0, tempC: 22, tempF: 72, windKph: 15, windMph: 9, pressure: 1012, humidity: 55 },
+  London: { code: 0, tempC: 18, tempF: 64, windKph: 12, windMph: 7, pressure: 1005, humidity: 70 },
+  Tokyo: { code: 0, tempC: 25, tempF: 77, windKph: 20, windMph: 12, pressure: 1018, humidity: 60 },
+};
+
+export default function Weather() {
+  const [open, setOpen] = useState(false);
+  const [location, setLocation] = useState(() => {
+    if (typeof window === "undefined") return "New York";
+    return localStorage.getItem(`${WEATHER_PREFIX}location`) || "New York";
+  });
+  const [unit, setUnit] = useState<Unit>(() => {
+    if (typeof window === "undefined") return "metric";
+    return (localStorage.getItem(`${WEATHER_PREFIX}unit`) as Unit) || "metric";
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(`${WEATHER_PREFIX}location`, location);
+    }
+  }, [location]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(`${WEATHER_PREFIX}unit`, unit);
+    }
+  }, [unit]);
+
+  const data = MOCK_DATA[location];
+  const temperature = unit === "metric" ? `${data.tempC}°C` : `${data.tempF}°F`;
+  const wind = unit === "metric" ? `${data.windKph} km/h` : `${data.windMph} mph`;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center space-x-1 text-white"
+        aria-label="Weather"
+      >
+        <WeatherIcon code={data.code} className="w-4 h-4" />
+        <span className="text-sm">{temperature}</span>
+      </button>
+      {open && (
+        <WeatherPopover
+          location={location}
+          unit={unit}
+          weather={{
+            temperature,
+            wind,
+            pressure: `${data.pressure} hPa`,
+            humidity: `${data.humidity}%`,
+          }}
+          locations={Object.keys(MOCK_DATA)}
+          onLocationChange={(loc) => {
+            if (MOCK_DATA[loc]) setLocation(loc);
+          }}
+          onUnitChange={setUnit}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/components/panel/WeatherPopover.tsx
+++ b/components/panel/WeatherPopover.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useState } from "react";
+
+interface Props {
+  location: string;
+  unit: "metric" | "imperial";
+  locations: string[];
+  weather: {
+    temperature: string;
+    wind: string;
+    pressure: string;
+    humidity: string;
+  };
+  onLocationChange: (loc: string) => void;
+  onUnitChange: (u: "metric" | "imperial") => void;
+  onClose: () => void;
+}
+
+export default function WeatherPopover({
+  location,
+  unit,
+  locations,
+  weather,
+  onLocationChange,
+  onUnitChange,
+  onClose,
+}: Props) {
+  const [query, setQuery] = useState("");
+
+  const filtered = locations.filter((l) =>
+    l.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className="absolute mt-2 p-4 bg-gray-800 text-white rounded shadow-lg z-10 w-56">
+      <div className="flex justify-between items-center mb-2">
+        <span className="font-semibold text-sm">{location}</span>
+        <button onClick={onClose} aria-label="Close" className="text-sm">
+          ✕
+        </button>
+      </div>
+      <div className="mb-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search location"
+          className="w-full mb-1 px-2 py-1 bg-gray-700 rounded text-sm"
+        />
+        {query && (
+          <ul className="max-h-24 overflow-auto bg-gray-700 rounded">
+            {filtered.map((loc) => (
+              <li
+                key={loc}
+                className="px-2 py-1 cursor-pointer hover:bg-gray-600"
+                onClick={() => {
+                  onLocationChange(loc);
+                  setQuery("");
+                }}
+              >
+                {loc}
+              </li>
+            ))}
+            {filtered.length === 0 && (
+              <li className="px-2 py-1 text-sm text-gray-300">No results</li>
+            )}
+          </ul>
+        )}
+      </div>
+      <div className="mb-2">
+        <label className="mr-2 text-sm">Units:</label>
+        <select
+          value={unit}
+          onChange={(e) => onUnitChange(e.target.value as "metric" | "imperial")}
+          className="bg-gray-700 text-white px-2 py-1 rounded text-sm"
+        >
+          <option value="metric">Celsius</option>
+          <option value="imperial">Fahrenheit</option>
+        </select>
+      </div>
+      <div className="space-y-1 text-sm">
+        <div>Temperature: {weather.temperature}</div>
+        <div>Wind: {weather.wind}</div>
+        <div>Pressure: {weather.pressure}</div>
+        <div>Humidity: {weather.humidity}</div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Weather panel component with mocked locations and units selection
- show popover with temperature, wind, pressure, and humidity
- persist chosen location and units in localStorage

## Testing
- `yarn test` *(fails: window, nmapNse)*
- `yarn test components/panel/Weather.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb47daadac8328a4dbcdb3297386cf