### PR TITLE
Add shared folder settings and badges

### DIFF
--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -106,7 +106,7 @@ export default function FileExplorer() {
   const fallbackInputRef = useRef(null);
 
   const hasWorker = typeof Worker !== 'undefined';
-  const {
+  const { 
     supported: opfsSupported,
     root,
     getDir,
@@ -115,11 +115,31 @@ export default function FileExplorer() {
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+  const [shares, setShares] = useState({});
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
     setSupported(ok);
     if (ok) getRecentDirs().then(setRecent);
+  }, []);
+
+  useEffect(() => {
+    const load = () => {
+      try {
+        const data = JSON.parse(localStorage.getItem('shares') || '{}');
+        setShares(data);
+      } catch {
+        setShares({});
+      }
+    };
+    load();
+    const handler = () => load();
+    window.addEventListener('shares-updated', handler);
+    window.addEventListener('storage', handler);
+    return () => {
+      window.removeEventListener('shares-updated', handler);
+      window.removeEventListener('storage', handler);
+    };
   }, []);
 
   useEffect(() => {
@@ -319,20 +339,30 @@ export default function FileExplorer() {
           {recent.map((r, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 flex items-center"
               onClick={() => openRecent(r)}
             >
               {r.name}
+              {shares[r.name] && (
+                <span className="ml-1 text-xs text-green-400" aria-label="Shared">
+                  LAN
+                </span>
+              )}
             </div>
           ))}
           <div className="p-2 font-bold">Directories</div>
           {dirs.map((d, i) => (
             <div
               key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30 flex items-center"
               onClick={() => openDir(d)}
             >
               {d.name}
+              {shares[d.name] && (
+                <span className="ml-1 text-xs text-green-400" aria-label="Shared">
+                  LAN
+                </span>
+              )}
             </div>
           ))}
           <div className="p-2 font-bold">Files</div>

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), { ssr: false });
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/shares.tsx
+++ b/pages/apps/settings/shares.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import ToggleSwitch from '../../../components/ToggleSwitch';
+
+interface ShareEntry {
+  name: string;
+  enabled: boolean;
+}
+
+export default function ShareSettings() {
+  const [shares, setShares] = useState<ShareEntry[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/data/shared-folders.json');
+        const data: ShareEntry[] = await res.json();
+        let stored: Record<string, boolean> = {};
+        try {
+          stored = JSON.parse(localStorage.getItem('shares') || '{}');
+        } catch {}
+        setShares(
+          data.map((s) => ({ ...s, enabled: stored[s.name] ?? s.enabled }))
+        );
+      } catch {
+        setShares([]);
+      }
+    };
+    load();
+  }, []);
+
+  const toggleShare = (name: string) => {
+    setShares((prev) => {
+      const next = prev.map((s) =>
+        s.name === name ? { ...s, enabled: !s.enabled } : s
+      );
+      const store = Object.fromEntries(next.map((s) => [s.name, s.enabled]));
+      try {
+        localStorage.setItem('shares', JSON.stringify(store));
+      } catch {}
+      window.dispatchEvent(new CustomEvent('shares-updated', { detail: store }));
+      return next;
+    });
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      {shares.map((s) => (
+        <div
+          key={s.name}
+          className="flex items-center justify-between py-2 border-b border-gray-700 last:border-b-0"
+        >
+          <span>{s.name}</span>
+          <div className="flex items-center space-x-2">
+            {s.enabled && (
+              <span className="text-xs text-green-400">Available on LAN</span>
+            )}
+            <ToggleSwitch
+              checked={s.enabled}
+              onChange={() => toggleShare(s.name)}
+              ariaLabel={`Toggle ${s.name}`}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/public/data/shared-folders.json
+++ b/public/data/shared-folders.json
@@ -1,0 +1,5 @@
+[
+  { "name": "Documents", "enabled": true },
+  { "name": "Downloads", "enabled": false },
+  { "name": "Pictures", "enabled": false }
+]


### PR DESCRIPTION
## Summary
- add shared folder settings page that loads JSON data and lets users toggle network availability
- update file explorer to display LAN badges for shared folders and react to status changes
- include sample shared-folder metadata

## Testing
- `yarn test __tests__/window.test.tsx __tests__/nmapNse.test.tsx` *(fails: e.preventDefault is not a function; Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68bb47df42a88328886011f03ba943f7