### PR TITLE
feat: add notification bell with DND

### DIFF
--- a/components/notifications/RecentNotifications.tsx
+++ b/components/notifications/RecentNotifications.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from "react";
+import useNotifications from "../../hooks/useNotifications";
+
+interface RecentNotificationsProps {
+  onClose: () => void;
+}
+
+const RecentNotifications: React.FC<RecentNotificationsProps> = ({ onClose }) => {
+  const { notifications } = useNotifications();
+  const items = [...notifications].slice(-50).reverse();
+
+  return (
+    <div className="fixed bottom-8 right-8 w-64 max-h-80 overflow-y-auto bg-gray-900 text-white border border-gray-700 rounded shadow-lg z-50">
+      <div className="flex items-center justify-between p-2 border-b border-gray-700">
+        <span className="text-sm font-semibold">Notifications</span>
+        <button aria-label="Close" onClick={onClose} className="text-sm">×</button>
+      </div>
+      {items.length === 0 ? (
+        <p className="p-2 text-xs text-gray-300">No notifications</p>
+      ) : (
+        <ul className="p-2 space-y-1 text-xs">
+          {items.map(n => (
+            <li key={n.id}>{n.message}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default RecentNotifications;
+

--- a/components/panel/NotifyBell.tsx
+++ b/components/panel/NotifyBell.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React, { useState } from "react";
+import useNotifications from "../../hooks/useNotifications";
+import RecentNotifications from "../notifications/RecentNotifications";
+
+const NotifyBell: React.FC = () => {
+  const { notifications, doNotDisturb, toggleDoNotDisturb } = useNotifications();
+  const [open, setOpen] = useState(false);
+
+  const handleClick = () => setOpen(o => !o);
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    toggleDoNotDisturb();
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        aria-label="Notifications"
+        className="relative p-1"
+      >
+        <svg viewBox="0 0 24 24" className="w-5 h-5" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2a7 7 0 00-7 7v5.586L3.293 16.293A1 1 0 004 18h16a1 1 0 00.707-1.707L19 14.586V9a7 7 0 00-7-7z" />
+          <path d="M9 19a3 3 0 006 0H9z" />
+          {doNotDisturb && <path d="M4 4l16 16" stroke="currentColor" strokeWidth="2" />}
+        </svg>
+        {notifications.length > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 bg-red-600 text-white rounded-full text-[10px] w-4 h-4 flex items-center justify-center">
+            {notifications.length}
+          </span>
+        )}
+      </button>
+      {open && <RecentNotifications onClose={() => setOpen(false)} />}
+    </>
+  );
+};
+
+export default NotifyBell;
+

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { NotificationsContext } from '../common/NotificationCenter';
 
 interface ToastProps {
   message: string;
@@ -17,8 +18,14 @@ const Toast: React.FC<ToastProps> = ({
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+  const ctx = useContext(NotificationsContext);
 
   useEffect(() => {
+    ctx?.pushNotification(message);
+  }, [ctx, message]);
+
+  useEffect(() => {
+    if (ctx?.doNotDisturb) return;
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
       onClose && onClose();
@@ -26,7 +33,9 @@ const Toast: React.FC<ToastProps> = ({
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, onClose, ctx?.doNotDisturb]);
+
+  if (ctx?.doNotDisturb) return null;
 
   return (
     <div

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import NotifyBell from "../panel/NotifyBell";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
@@ -75,6 +76,9 @@ export default function Status() {
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />
+      </span>
+      <span className="mx-1.5">
+        <NotifyBell />
       </span>
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add NotificationCenter with Do Not Disturb support
- add NotifyBell and RecentNotifications components
- suppress toasts when DND active and show notification list

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `yarn lint components/panel/NotifyBell.tsx components/notifications/RecentNotifications.tsx components/common/NotificationCenter.tsx components/ui/Toast.tsx components/util-components/status.js pages/_app.jsx` *(fails: Unexpected global 'document', Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47e4af108328b9141c6c55999ca9