### PR TITLE
feat: add toast display settings

### DIFF
--- a/apps/settings/notifications.tsx
+++ b/apps/settings/notifications.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import ToggleSwitch from "../../components/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+export default function NotificationSettings() {
+  const {
+    toastPlacement,
+    setToastPlacement,
+    toastFadeOut,
+    setToastFadeOut,
+  } = useSettings();
+
+  return (
+    <div className="p-4 text-ubt-grey select-none">
+      <div className="mb-4 flex items-center">
+        <label className="mr-2">Toast placement:</label>
+        <select
+          value={toastPlacement}
+          onChange={(e) => setToastPlacement(e.target.value as "primary" | "mouse")}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          <option value="primary">Primary display</option>
+          <option value="mouse">Mouse display</option>
+        </select>
+      </div>
+      <div className="mb-4 flex items-center">
+        <ToggleSwitch
+          checked={toastFadeOut}
+          onChange={setToastFadeOut}
+          ariaLabel="Fade out toasts"
+        />
+        <span className="ml-2">Fade out toasts</span>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
 
 interface ToastProps {
   message: string;
@@ -17,22 +18,49 @@ const Toast: React.FC<ToastProps> = ({
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+  const { toastPlacement, toastFadeOut } = useSettings();
+  const mousePosRef = useRef({ x: 0, y: 0 });
+  const spawnRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      mousePosRef.current = { x: e.clientX, y: e.clientY };
+    };
+    window.addEventListener('mousemove', handler);
+    return () => window.removeEventListener('mousemove', handler);
+  }, []);
+
+  useEffect(() => {
+    if (toastPlacement === 'mouse') {
+      spawnRef.current = { ...mousePosRef.current };
+    }
+  }, [toastPlacement]);
 
   useEffect(() => {
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
+      if (toastFadeOut) {
+        setVisible(false);
+        setTimeout(() => onClose && onClose(), 200);
+      } else {
+        onClose && onClose();
+      }
     }, duration);
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, onClose, toastFadeOut]);
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-opacity transition-transform duration-150 ease-in-out ${toastPlacement === 'primary' ? 'top-4 left-1/2 -translate-x-1/2' : ''} ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-full'}`}
+      style={
+        toastPlacement === 'mouse' && spawnRef.current
+          ? { top: spawnRef.current.y + 16, left: spawnRef.current.x + 16 }
+          : undefined
+      }
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,6 +20,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getToastPlacement as loadToastPlacement,
+  setToastPlacement as saveToastPlacement,
+  getToastFadeOut as loadToastFadeOut,
+  setToastFadeOut as saveToastFadeOut,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -62,6 +66,8 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  toastPlacement: 'primary' | 'mouse';
+  toastFadeOut: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -73,6 +79,8 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setToastPlacement: (value: 'primary' | 'mouse') => void;
+  setToastFadeOut: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -87,6 +95,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  toastPlacement: defaults.toastPlacement,
+  toastFadeOut: defaults.toastFadeOut,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -98,6 +108,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setToastPlacement: () => {},
+  setToastFadeOut: () => {},
   setTheme: () => {},
 });
 
@@ -112,6 +124,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [toastPlacement, setToastPlacement] = useState<'primary' | 'mouse'>(
+    defaults.toastPlacement
+  );
+  const [toastFadeOut, setToastFadeOut] = useState<boolean>(
+    defaults.toastFadeOut
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -127,6 +145,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setToastPlacement(await loadToastPlacement());
+      setToastFadeOut(await loadToastFadeOut());
       setTheme(loadTheme());
     })();
   }, []);
@@ -236,6 +256,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveToastPlacement(toastPlacement);
+  }, [toastPlacement]);
+
+  useEffect(() => {
+    saveToastFadeOut(toastFadeOut);
+  }, [toastFadeOut]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -249,6 +277,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        toastPlacement,
+        toastFadeOut,
         theme,
         setAccent,
         setWallpaper,
@@ -260,6 +290,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setToastPlacement,
+        setToastFadeOut,
         setTheme,
       }}
     >

--- a/pages/apps/settings/notifications.tsx
+++ b/pages/apps/settings/notifications.tsx
@@ -1,0 +1,10 @@
+import dynamic from "next/dynamic";
+
+const NotificationsSettings = dynamic(
+  () => import("../../../apps/settings/notifications"),
+  { ssr: false }
+);
+
+export default function NotificationsSettingsPage() {
+  return <NotificationsSettings />;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  toastPlacement: 'primary',
+  toastFadeOut: true,
 };
 
 export async function getAccent() {
@@ -123,6 +125,30 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getToastPlacement() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.toastPlacement;
+  return (
+    window.localStorage.getItem('toast-placement') ||
+    DEFAULT_SETTINGS.toastPlacement
+  );
+}
+
+export async function setToastPlacement(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('toast-placement', value);
+}
+
+export async function getToastFadeOut() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.toastFadeOut;
+  const val = window.localStorage.getItem('toast-fade-out');
+  return val === null ? DEFAULT_SETTINGS.toastFadeOut : val === 'true';
+}
+
+export async function setToastFadeOut(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('toast-fade-out', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +163,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('toast-placement');
+  window.localStorage.removeItem('toast-fade-out');
 }
 
 export async function exportSettings() {
@@ -151,6 +179,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    toastPlacement,
+    toastFadeOut,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +192,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getToastPlacement(),
+    getToastFadeOut(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +207,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    toastPlacement,
+    toastFadeOut,
     theme,
   });
 }
@@ -199,6 +233,8 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    toastPlacement,
+    toastFadeOut,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +247,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (toastPlacement !== undefined) await setToastPlacement(toastPlacement);
+  if (toastFadeOut !== undefined) await setToastFadeOut(toastFadeOut);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add notifications settings screen to control toast placement and fade-out
- persist toast preferences in settings store and hook
- position and animate Toast component based on user settings

## Testing
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47e5f52883289b6db2b5e158f9a4