### PR TITLE
Add Do Not Disturb-aware notifications and volume sample button

### DIFF
--- a/components/panel/Volume.tsx
+++ b/components/panel/Volume.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import useDoNotDisturb from '../../hooks/useDoNotDisturb';
+
+export default function Volume() {
+  const [volume, setVolume] = useState(0.5);
+  const [dnd] = useDoNotDisturb();
+
+  const playSample = () => {
+    if (dnd || typeof window === 'undefined') return;
+    const AudioCtx =
+      (window as any).AudioContext || (window as any).webkitAudioContext;
+    const ctx = new AudioCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = 440;
+    gain.gain.value = volume;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.5);
+  };
+
+  return (
+    <div className='p-2 space-y-2 w-40'>
+      <input
+        type='range'
+        min='0'
+        max='1'
+        step='0.01'
+        value={volume}
+        onChange={(e) => setVolume(parseFloat(e.target.value))}
+        aria-label='Volume'
+        className='ubuntu-slider w-full'
+      />
+      <button
+        onClick={playSample}
+        disabled={dnd}
+        className='px-2 py-1 bg-ubt-grey text-white rounded w-full'
+      >
+        Play sample track
+      </button>
+    </div>
+  );
+}

--- a/hooks/useDoNotDisturb.ts
+++ b/hooks/useDoNotDisturb.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'do-not-disturb';
+
+export function useDoNotDisturb() {
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+  }, [enabled]);
+
+  return [enabled, setEnabled] as const;
+}
+
+export default useDoNotDisturb;

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../../apps/settings'), {
+  ssr: false,
+});
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/settings/notifications.tsx
+++ b/pages/apps/settings/notifications.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import useDoNotDisturb from '../../../hooks/useDoNotDisturb';
+
+export default function NotificationsSettings() {
+  const [dnd, setDnd] = useDoNotDisturb();
+
+  const sendTest = async () => {
+    if (dnd || typeof window === 'undefined') return;
+    if ('Notification' in window) {
+      if (Notification.permission === 'granted') {
+        new Notification('This is a test notification');
+      } else if (Notification.permission !== 'denied') {
+        const perm = await Notification.requestPermission();
+        if (perm === 'granted') {
+          new Notification('This is a test notification');
+        }
+      }
+    }
+  };
+
+  return (
+    <div className='p-4 space-y-4'>
+      <div className='flex items-center justify-between'>
+        <span className='text-ubt-grey'>Do Not Disturb</span>
+        <ToggleSwitch
+          checked={dnd}
+          onChange={setDnd}
+          ariaLabel='Toggle Do Not Disturb'
+        />
+      </div>
+      <button
+        onClick={sendTest}
+        className='px-4 py-2 rounded bg-ubt-grey text-white'
+        disabled={dnd}
+      >
+        Send test notification
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Do Not Disturb toggle and test notification button in settings
- introduce reusable hook for Do Not Disturb state
- add panel volume component with sample track respecting Do Not Disturb

## Testing
- `yarn lint` *(fails: Unexpected global 'document')*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47e7f35483289e1a7a1880e81909