### PR TITLE
feat: add mime icon mapping and file properties modal

### DIFF
--- a/components/filemanager/FilePropertiesModal.tsx
+++ b/components/filemanager/FilePropertiesModal.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { getIconForMime } from './IconMapper';
+
+interface FileInfo {
+  name: string;
+  mime: string;
+  size?: number;
+  lastModified?: number;
+}
+
+interface Props {
+  file: FileInfo | null;
+  onClose: () => void;
+  theme: string;
+}
+
+export default function FilePropertiesModal({ file, onClose, theme }: Props) {
+  if (!file) return null;
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 text-black dark:text-white p-4 rounded shadow-md min-w-[250px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center mb-3 space-x-3">
+          {getIconForMime(file.mime, theme)}
+          <div>
+            <div className="font-bold">{file.name}</div>
+            <div className="text-xs opacity-70">{file.mime || 'unknown'}</div>
+          </div>
+        </div>
+        {typeof file.size === 'number' && (
+          <div className="text-xs mb-1">Size: {file.size} bytes</div>
+        )}
+        {typeof file.lastModified === 'number' && (
+          <div className="text-xs mb-1">
+            Modified: {new Date(file.lastModified).toLocaleString()}
+          </div>
+        )}
+        <div className="text-right mt-4">
+          <button
+            onClick={onClose}
+            className="px-2 py-1 bg-black text-white dark:bg-white dark:text-black rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/filemanager/IconMapper.ts
+++ b/components/filemanager/IconMapper.ts
@@ -1,0 +1,79 @@
+import React from 'react';
+import { isDarkTheme } from '../../utils/theme';
+
+// Helper to create an SVG icon component from a path definition without JSX
+const createIcon = (d: string) => ({ className = '' }: { className?: string }) =>
+  React.createElement(
+    'svg',
+    {
+      className,
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      strokeWidth: 1.5,
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round',
+    },
+    React.createElement('path', { d })
+  );
+
+// Individual icon paths sourced from Heroicons (MIT License)
+const paths = {
+  file:
+    'M19.5 14.25V11.625C19.5 9.76104 17.989 8.25 16.125 8.25H14.625C14.0037 8.25 13.5 7.74632 13.5 7.125V5.625C13.5 3.76104 11.989 2.25 10.125 2.25H8.25M10.5 2.25H5.625C5.00368 2.25 4.5 2.75368 4.5 3.375V20.625C4.5 21.2463 5.00368 21.75 5.625 21.75H18.375C18.9963 21.75 19.5 21.2463 19.5 20.625V11.25C19.5 6.27944 15.4706 2.25 10.5 2.25Z',
+  text:
+    'M19.5 14.25V11.625C19.5 9.76104 17.989 8.25 16.125 8.25H14.625C14.0037 8.25 13.5 7.74632 13.5 7.125V5.625C13.5 3.76104 11.989 2.25 10.125 2.25H8.25M8.25 15H15.75M8.25 18H12M10.5 2.25H5.625C5.00368 2.25 4.5 2.75368 4.5 3.375V20.625C4.5 21.2463 5.00368 21.75 5.625 21.75H18.375C18.9963 21.75 19.5 21.2463 19.5 20.625V11.25C19.5 6.27944 15.4706 2.25 10.5 2.25Z',
+  code:
+    'M17.25 6.75L22.5 12L17.25 17.25M6.75 17.25L1.5 12L6.75 6.75M14.25 3.75L9.75 20.25',
+  image:
+    'M2.25 15.75L7.40901 10.591C8.28769 9.71231 9.71231 9.71231 10.591 10.591L15.75 15.75M14.25 14.25L15.659 12.841C16.5377 11.9623 17.9623 11.9623 18.841 12.841L21.75 15.75M3.75 19.5H20.25C21.0784 19.5 21.75 18.8284 21.75 18V6C21.75 5.17157 21.0784 4.5 20.25 4.5H3.75C2.92157 4.5 2.25 5.17157 2.25 6V18C2.25 18.8284 2.92157 19.5 3.75 19.5ZM14.25 8.25H14.2575V8.2575H14.25V8.25ZM14.625 8.25C14.625 8.45711 14.4571 8.625 14.25 8.625C14.0429 8.625 13.875 8.45711 13.875 8.25C13.875 8.04289 14.0429 7.875 14.25 7.875C14.4571 7.875 14.625 8.04289 14.625 8.25Z',
+  audio:
+    'M9 9L19.5 6M19.5 12.5528V16.3028C19.5 17.3074 18.834 18.1903 17.8681 18.4663L16.5481 18.8434C15.3964 19.1724 14.25 18.3077 14.25 17.1099C14.25 16.305 14.7836 15.5975 15.5576 15.3764L17.8681 14.7163C18.834 14.4403 19.5 13.5574 19.5 12.5528ZM19.5 12.5528V2.25L9 5.25V15.5528M9 15.5528V19.3028C9 20.3074 8.33405 21.1903 7.36812 21.4663L6.04814 21.8434C4.89645 22.1724 3.75 21.3077 3.75 20.1099C3.75 19.305 4.2836 18.5975 5.05757 18.3764L7.36812 17.7163C8.33405 17.4403 9 16.5574 9 15.5528Z',
+  video:
+    'M15.75 10.5L20.4697 5.78033C20.9421 5.30786 21.75 5.64248 21.75 6.31066V17.6893C21.75 18.3575 20.9421 18.6921 20.4697 18.2197L15.75 13.5M4.5 18.75H13.5C14.7426 18.75 15.75 17.7426 15.75 16.5V7.5C15.75 6.25736 14.7426 5.25 13.5 5.25H4.5C3.25736 5.25 2.25 6.25736 2.25 7.5V16.5C2.25 17.7426 3.25736 18.75 4.5 18.75Z',
+  archive:
+    'M20.25 7.5L19.6246 18.1321C19.5546 19.3214 18.5698 20.25 17.3785 20.25H6.62154C5.43022 20.25 4.44538 19.3214 4.37542 18.1321L3.75 7.5M9.99976 11.25H13.9998M3.375 7.5H20.625C21.2463 7.5 21.75 6.99632 21.75 6.375V4.875C21.75 4.25368 21.2463 3.75 20.625 3.75H3.375C2.75368 3.75 2.25 4.25368 2.25 4.875V6.375C2.25 6.99632 2.75368 7.5 3.375 7.5Z',
+  folder:
+    'M2.25 12.75V12C2.25 10.7574 3.25736 9.75 4.5 9.75H19.5C20.7426 9.75 21.75 10.7574 21.75 12V12.75M13.0607 6.31066L10.9393 4.18934C10.658 3.90804 10.2765 3.75 9.87868 3.75H4.5C3.25736 3.75 2.25 4.75736 2.25 6V18C2.25 19.2426 3.25736 20.25 4.5 20.25H19.5C20.7426 20.25 21.75 19.2426 21.75 18V9C21.75 7.75736 20.7426 6.75 19.5 6.75H14.1213C13.7235 6.75 13.342 6.59197 13.0607 6.31066Z',
+};
+
+const icons = {
+  file: createIcon(paths.file),
+  text: createIcon(paths.text),
+  code: createIcon(paths.code),
+  image: createIcon(paths.image),
+  audio: createIcon(paths.audio),
+  video: createIcon(paths.video),
+  archive: createIcon(paths.archive),
+  folder: createIcon(paths.folder),
+};
+
+const MIME_MAP: Record<string, keyof typeof icons> = {
+  'application/javascript': 'code',
+  'text/javascript': 'code',
+  'text/html': 'code',
+  'text/css': 'code',
+  'application/json': 'code',
+  'application/x-php': 'code',
+  'text/x-php': 'code',
+  'application/zip': 'archive',
+  'application/x-zip-compressed': 'archive',
+  'application/pdf': 'text',
+  'inode/directory': 'folder',
+};
+
+const CATEGORY_MAP: Record<string, keyof typeof icons> = {
+  text: 'text',
+  image: 'image',
+  audio: 'audio',
+  video: 'video',
+};
+
+export const getIconForMime = (mime: string, theme: string): JSX.Element => {
+  const key = MIME_MAP[mime] || CATEGORY_MAP[mime.split('/')[0]] || 'file';
+  const Icon = icons[key];
+  const color = isDarkTheme(theme) ? 'text-white' : 'text-black';
+  return React.createElement(Icon, { className: `w-4 h-4 mr-1 ${color}` });
+};
+
+export default getIconForMime;


### PR DESCRIPTION
## Summary
- add MIME icon map with theme-aware SVG icons
- integrate icon mapping into file explorer listings
- show file properties modal with icon preview

## Testing
- `yarn lint components/filemanager/IconMapper.ts components/filemanager/FilePropertiesModal.tsx components/apps/file-explorer.js` (fails: Unexpected global 'document' in unrelated files)
- `yarn test --passWithNoTests components/filemanager/IconMapper.ts components/filemanager/FilePropertiesModal.tsx components/apps/file-explorer.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb47ec4d9883288015bd258c948b57