### PR TITLE
feat(taskbar): minimize windows via drag & drop

### DIFF
--- a/__tests__/tasklist_drag_drop.test.tsx
+++ b/__tests__/tasklist_drag_drop.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TaskList from '../components/panel/taskbar/TaskList';
+
+describe('TaskList drag and drop', () => {
+  it('highlights drop target and minimizes on drop', () => {
+    const minimize = jest.fn();
+    const { getByText } = render(
+      <TaskList
+        apps={[{ id: 'app1', title: 'App One' }]}
+        onMinimizeWindow={minimize}
+      />
+    );
+
+    const target = getByText('App One').parentElement as HTMLElement;
+    const dataTransfer = {
+      types: ['application/x-window-id'],
+      getData: () => 'window-1',
+    } as any;
+
+    fireEvent.dragOver(target, { dataTransfer });
+    expect(target.classList.contains('outline')).toBe(true);
+
+    fireEvent.drop(target, { dataTransfer });
+    expect(minimize).toHaveBeenCalledWith('window-1', 'app1');
+  });
+});

--- a/components/panel/taskbar/TaskList.tsx
+++ b/components/panel/taskbar/TaskList.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useCallback } from 'react';
+
+interface AppDefinition {
+  id: string;
+  title: string;
+  icon?: string;
+}
+
+interface TaskListProps {
+  apps: AppDefinition[];
+  /**
+   * Called when a window is dropped onto an app icon. The first argument is
+   * the window id, the second is the target app id.
+   */
+  onMinimizeWindow: (windowId: string, appId: string) => void;
+}
+
+const WINDOW_MIME = 'application/x-window-id';
+
+const TaskList: React.FC<TaskListProps> = ({ apps, onMinimizeWindow }) => {
+  const [dragTarget, setDragTarget] = useState<string | null>(null);
+
+  const handleDragOver = useCallback(
+    (appId: string) => (e: React.DragEvent) => {
+      if (e.dataTransfer.types.includes(WINDOW_MIME)) {
+        e.preventDefault();
+        setDragTarget(appId);
+      }
+    },
+    [],
+  );
+
+  const handleDragLeave = useCallback(
+    (appId: string) => () => {
+      setDragTarget((prev) => (prev === appId ? null : prev));
+    },
+    [],
+  );
+
+  const handleDrop = useCallback(
+    (appId: string) => (e: React.DragEvent) => {
+      const winId = e.dataTransfer.getData(WINDOW_MIME);
+      if (winId) {
+        onMinimizeWindow(winId, appId);
+      }
+      setDragTarget(null);
+      e.preventDefault();
+    },
+    [onMinimizeWindow],
+  );
+
+  return (
+    <div className="flex">
+      {apps.map((app) => (
+        <div
+          key={app.id}
+          data-app-id={app.id}
+          onDragEnter={handleDragOver(app.id)}
+          onDragOver={handleDragOver(app.id)}
+          onDragLeave={handleDragLeave(app.id)}
+          onDrop={handleDrop(app.id)}
+          className={`p-1 transition-outline ${
+            dragTarget === app.id ? 'outline outline-2 outline-blue-500' : ''
+          }`}
+        >
+          {app.icon ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={app.icon} alt="" className="w-5 h-5" />
+          ) : (
+            <span>{app.title}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TaskList;


### PR DESCRIPTION
## Summary
- add TaskList component that highlights app icons when a window is dragged over
- minimize dragged window into app group on drop
- test drag-over highlight and minimize behavior

## Testing
- `yarn test __tests__/tasklist_drag_drop.test.tsx`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68bb47ee45e4832898cd02088c0f5104