### PR TITLE
feat: cycle windows with alt wheel

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -23,6 +23,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import { registerAltWheelWindowCycle } from '../../utils/keyboardShortcuts';
 
 export class Desktop extends Component {
     constructor() {
@@ -30,6 +31,7 @@ export class Desktop extends Component {
         this.app_stack = [];
         this.initFavourite = {};
         this.allWindowClosed = false;
+        this.removeAltWheelShortcut = null;
         this.state = {
             focused_windows: {},
             closed_windows: {},
@@ -88,12 +90,14 @@ export class Desktop extends Component {
         this.updateTrashIcon();
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
+        this.removeAltWheelShortcut = registerAltWheelWindowCycle(this.cycleAppWindows);
     }
 
     componentWillUnmount() {
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
+        if (this.removeAltWheelShortcut) this.removeAltWheelShortcut();
     }
 
     checkForNewFolders = () => {

--- a/utils/keyboardShortcuts.ts
+++ b/utils/keyboardShortcuts.ts
@@ -1,0 +1,12 @@
+export function registerAltWheelWindowCycle(
+  cycle: (direction: number) => void
+) {
+  const handleWheel = (e: WheelEvent) => {
+    if (!e.altKey) return;
+    e.preventDefault();
+    const direction = e.deltaY > 0 ? 1 : -1;
+    cycle(direction);
+  };
+  window.addEventListener('wheel', handleWheel, { passive: false });
+  return () => window.removeEventListener('wheel', handleWheel);
+}


### PR DESCRIPTION
## Summary
- add utility to bind Alt + mouse wheel to window cycling
- wire desktop to register and clean up shortcut

## Testing
- `yarn test` *(fails: e.preventDefault is not a function; Unable to find role="alert")*


------
https://chatgpt.com/codex/tasks/task_e_68bb47edc2208328969802bd6e59fa65