### PR TITLE
test: add date time e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: npx playwright test tests/e2e
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/tests/e2e/date-time.spec.ts
+++ b/tests/e2e/date-time.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// Tests for panel clock behaviour
+
+// Ensure toggling 24-hour and seconds options updates the panel clock display
+ test('toggles 24-hour and seconds update panel clock', async ({ page }) => {
+  await page.goto('/');
+  const clock = page.locator('[data-testid="panel-clock"]');
+  await clock.click();
+  // Toggle 24-hour time
+  await page.getByRole('menuitemcheckbox', { name: /24-hour/i }).click();
+  const twentyFour = await clock.textContent();
+  expect(twentyFour).not.toBeNull();
+  // Enable showing seconds
+  await page.getByRole('menuitemcheckbox', { name: /seconds/i }).click();
+  const withSeconds = await clock.textContent();
+  expect(withSeconds).toMatch(/:\d{2}$/);
+ });
+
+ // Ensure Date/Time settings menu item opens the settings page
+ test('clock menu opens Date/Time settings page', async ({ page }) => {
+  await page.goto('/');
+  const clock = page.locator('[data-testid="panel-clock"]');
+  await clock.click();
+  await page.getByRole('menuitem', { name: /date\/time settings/i }).click();
+  await expect(page).toHaveURL(/settings/);
+ });


### PR DESCRIPTION
## Summary
- add end-to-end tests for clock 24-hour and seconds toggles
- ensure clock menu links to Date/Time settings
- run e2e tests in CI

## Testing
- `npx playwright test tests/e2e/date-time.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47f00b7483289284e778cda3c82e