### PR TITLE
test: cover weather and ble sensor error handling

### DIFF
--- a/__tests__/sensors.spec.ts
+++ b/__tests__/sensors.spec.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import BleSensor from '../components/apps/ble-sensor';
+
+jest.mock('../utils/bleProfiles', () => ({
+  loadProfiles: jest.fn().mockResolvedValue([]),
+  loadProfile: jest.fn().mockResolvedValue(null),
+  saveProfile: jest.fn().mockResolvedValue(undefined),
+  renameProfile: jest.fn(),
+  deleteProfile: jest.fn(),
+}));
+
+describe('BleSensor error handling', () => {
+  beforeEach(() => {
+    window.confirm = jest.fn().mockReturnValue(true);
+    (navigator as any).bluetooth = {
+      requestDevice: jest
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error('No devices found'), {
+          name: 'NotFoundError',
+        }))
+        .mockResolvedValueOnce({
+          id: 'dev1',
+          name: 'Device 1',
+          gatt: {
+            connect: jest.fn().mockResolvedValue({
+              getPrimaryServices: jest.fn().mockResolvedValue([]),
+            }),
+          },
+          addEventListener: jest.fn(),
+        }),
+    };
+  });
+
+  it('shows friendly error then connects on retry', async () => {
+    const { getByText, queryByText } = render(React.createElement(BleSensor));
+    fireEvent.click(getByText('Scan for Devices'));
+    await waitFor(() => getByText('No devices found.'));
+    expect(getByText('No devices found.')).toBeInTheDocument();
+
+    await waitFor(() => expect(getByText('Scan for Devices')).toBeEnabled());
+    fireEvent.click(getByText('Scan for Devices'));
+    await waitFor(() => getByText('Connected to: Device 1'));
+    expect(getByText('Connected to: Device 1')).toBeInTheDocument();
+  });
+});

--- a/__tests__/weather.spec.ts
+++ b/__tests__/weather.spec.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import WeatherWidget from '../apps/weather_widget';
+
+describe('WeatherWidget error handling', () => {
+  beforeEach(() => {
+    // Prevent background interval from creating open handles
+    jest.spyOn(global, 'setInterval').mockImplementation(() => 0 as any);
+    // Mock fetch: first call fails, next calls succeed
+    (global as any).fetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('network fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          main: { temp: 15, feels_like: 10 },
+          weather: [{ description: 'Sunny', icon: '01d' }],
+          sys: { sunrise: 1000, sunset: 2000 },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ list: [] }) });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    (setInterval as unknown as jest.SpyInstance).mockRestore?.();
+  });
+
+  it('shows friendly error then recovers on retry', async () => {
+    const { container } = render(React.createElement(WeatherWidget));
+    await waitFor(() => container.querySelector('#city-search'));
+    const cityInput = container.querySelector('#city-search') as HTMLInputElement;
+    const apiInput = container.querySelector('#api-key-input') as HTMLInputElement;
+    const saveBtn = container.querySelector('#save-api-key') as HTMLButtonElement;
+    const errorEl = container.querySelector('#error-message') as HTMLElement;
+    const tempEl = container.querySelector('.temp') as HTMLElement;
+    const widget = container.querySelector('#weather') as HTMLElement;
+
+    cityInput.value = 'Paris';
+    apiInput.value = 'key';
+    fireEvent.click(saveBtn); // first attempt fails
+
+    await waitFor(() => {
+      expect(errorEl.textContent).toContain('Unable to fetch weather data');
+    });
+
+    fireEvent.click(saveBtn); // retry succeeds
+    await waitFor(() => expect((fetch as jest.Mock).mock.calls.length).toBe(3));
+    fireEvent.animationEnd(widget);
+    await waitFor(() => expect(errorEl.textContent).toBe(''));
+    expect(tempEl.textContent).toBe('15°C');
+  });
+});


### PR DESCRIPTION
## Summary
- add weather widget tests for provider failures and retry recovery
- add BLE sensor scan error and retry tests

## Testing
- `yarn test __tests__/weather.spec.ts __tests__/sensors.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb47f2418c8328901875243fde7a90