### PR TITLE
feat: add plugin config import export

### DIFF
--- a/__tests__/pluginManager.test.tsx
+++ b/__tests__/pluginManager.test.tsx
@@ -71,4 +71,31 @@ describe('PluginManager', () => {
     fireEvent.click(exportBtn);
     expect((global as any).URL.createObjectURL).toHaveBeenCalled();
   });
+
+  test('exports and imports plugin config', async () => {
+    render(<PluginManager />);
+    const installBtn = await screen.findByText('Install');
+    fireEvent.click(installBtn);
+    await waitFor(() =>
+      expect(localStorage.getItem('installedPlugins')).toContain('demo')
+    );
+    const exportBtn = screen.getByText('Export Config');
+    fireEvent.click(exportBtn);
+    expect((global as any).URL.createObjectURL).toHaveBeenCalled();
+
+    const input = screen.getByTestId('import-demo');
+    const file = new File(
+      [JSON.stringify({ sandbox: 'iframe', extra: 'x' })],
+      'cfg.json',
+      { type: 'application/json' }
+    );
+    Object.defineProperty(input, 'files', {
+      value: [file],
+    });
+    fireEvent.change(input);
+    await waitFor(() =>
+      expect(localStorage.getItem('installedPlugins')).toContain('iframe')
+    );
+    expect(await screen.findByText(/Import successful/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- allow plugin manager to export and import plugin configs with success and error messages
- add tests for exporting and importing plugin configurations

## Testing
- `npm test __tests__/pluginManager.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb162a4b6c8328a67380e94a770b83