### PR TITLE
feat: add network disable options

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, wifiEnabled, setWifiEnabled, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -142,6 +142,17 @@ export function Settings() {
                         className="mr-2"
                     />
                     High Contrast
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={wifiEnabled}
+                        onChange={(e) => setWifiEnabled(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Enable Wi-Fi
                 </label>
             </div>
             <div className="flex justify-center my-4">

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useSettings } from '../../hooks/useSettings';
 
 interface Props {
   open: boolean;
@@ -10,8 +11,8 @@ interface Props {
 const QuickSettings = ({ open }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { wifiEnabled, setWifiEnabled, allowNetwork, setAllowNetwork } = useSettings();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -41,8 +42,20 @@ const QuickSettings = ({ open }: Props) => {
         <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
       </div>
       <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <span>Wi-Fi</span>
+        <input
+          type="checkbox"
+          checked={wifiEnabled}
+          onChange={() => setWifiEnabled(!wifiEnabled)}
+        />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>Networking</span>
+        <input
+          type="checkbox"
+          checked={allowNetwork}
+          onChange={() => setAllowNetwork(!allowNetwork)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -6,7 +6,7 @@ import { useSettings } from '../../hooks/useSettings';
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
-  const { allowNetwork } = useSettings();
+  const { allowNetwork, wifiEnabled } = useSettings();
   const [online, setOnline] = useState(true);
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function Status() {
     };
 
     const updateStatus = () => {
-      const isOnline = navigator.onLine;
+      const isOnline = navigator.onLine && wifiEnabled;
       setOnline(isOnline);
       if (isOnline) {
         pingServer();
@@ -36,18 +36,30 @@ export default function Status() {
       window.removeEventListener('online', updateStatus);
       window.removeEventListener('offline', updateStatus);
     };
-  }, []);
+  }, [wifiEnabled]);
 
   return (
     <div className="flex justify-center items-center">
       <span
         className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+        title={
+          !wifiEnabled
+            ? 'Wi-Fi disabled'
+            : online
+            ? allowNetwork
+              ? 'Online'
+              : 'Online (requests blocked)'
+            : 'Offline'
+        }
       >
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={
+            online
+              ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+              : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"
+          }
           alt={online ? "online" : "offline"}
           className="inline status-symbol w-4 h-4"
           sizes="16px"

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -18,6 +18,8 @@ import {
   setPongSpin as savePongSpin,
   getAllowNetwork as loadAllowNetwork,
   setAllowNetwork as saveAllowNetwork,
+  getWifiEnabled as loadWifiEnabled,
+  setWifiEnabled as saveWifiEnabled,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
   defaults,
@@ -61,6 +63,7 @@ interface SettingsContextValue {
   largeHitAreas: boolean;
   pongSpin: boolean;
   allowNetwork: boolean;
+  wifiEnabled: boolean;
   haptics: boolean;
   theme: string;
   setAccent: (accent: string) => void;
@@ -72,6 +75,7 @@ interface SettingsContextValue {
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
+  setWifiEnabled: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
@@ -86,6 +90,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
+  wifiEnabled: defaults.wifiEnabled,
   haptics: defaults.haptics,
   theme: 'default',
   setAccent: () => {},
@@ -97,6 +102,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
   setAllowNetwork: () => {},
+  setWifiEnabled: () => {},
   setHaptics: () => {},
   setTheme: () => {},
 });
@@ -111,6 +117,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
+  const [wifiEnabled, setWifiEnabled] = useState<boolean>(defaults.wifiEnabled);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
@@ -126,6 +133,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
+      setWifiEnabled(await loadWifiEnabled());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
     })();
@@ -233,6 +241,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [allowNetwork]);
 
   useEffect(() => {
+    saveWifiEnabled(wifiEnabled);
+  }, [wifiEnabled]);
+
+  useEffect(() => {
     saveHaptics(haptics);
   }, [haptics]);
 
@@ -248,6 +260,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         largeHitAreas,
         pongSpin,
         allowNetwork,
+        wifiEnabled,
         haptics,
         theme,
         setAccent,
@@ -259,6 +272,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setLargeHitAreas,
         setPongSpin,
         setAllowNetwork,
+        setWifiEnabled,
         setHaptics,
         setTheme,
       }}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   largeHitAreas: false,
   pongSpin: true,
   allowNetwork: false,
+  wifiEnabled: true,
   haptics: true,
 };
 
@@ -123,6 +124,17 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getWifiEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wifiEnabled;
+  const val = window.localStorage.getItem('wifi-enabled');
+  return val === null ? DEFAULT_SETTINGS.wifiEnabled : val === 'true';
+}
+
+export async function setWifiEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('wifi-enabled', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -136,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
+  window.localStorage.removeItem('wifi-enabled');
   window.localStorage.removeItem('haptics');
 }
 
@@ -150,6 +163,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    wifiEnabled,
     haptics,
   ] = await Promise.all([
     getAccent(),
@@ -161,6 +175,7 @@ export async function exportSettings() {
     getLargeHitAreas(),
     getPongSpin(),
     getAllowNetwork(),
+    getWifiEnabled(),
     getHaptics(),
   ]);
   const theme = getTheme();
@@ -174,6 +189,7 @@ export async function exportSettings() {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    wifiEnabled,
     haptics,
     theme,
   });
@@ -198,6 +214,7 @@ export async function importSettings(json) {
     largeHitAreas,
     pongSpin,
     allowNetwork,
+    wifiEnabled,
     haptics,
     theme,
   } = settings;
@@ -210,6 +227,7 @@ export async function importSettings(json) {
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
+  if (wifiEnabled !== undefined) await setWifiEnabled(wifiEnabled);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
 }


### PR DESCRIPTION
## Summary
- add Wi-Fi and Networking toggles in quick settings
- persist Wi-Fi status and expose through settings context
- update status icon and settings page to reflect connectivity flags

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, jsdom localStorage TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16268a5c8328baf95928af60d72e