### PR TITLE
feat: add workspace switch OSD

### DIFF
--- a/components/osd/WorkspaceSwitch.tsx
+++ b/components/osd/WorkspaceSwitch.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useWorkspaceNames from "../../hooks/useWorkspaceNames";
+import useDoNotDisturb from "../../hooks/useDoNotDisturb";
+import { nextWorkspace, prevWorkspace } from "../../utils/workspaceManager";
+
+export default function WorkspaceSwitch() {
+  const { names } = useWorkspaceNames();
+  const { dnd } = useDoNotDisturb();
+  const [visible, setVisible] = useState(false);
+  const [label, setLabel] = useState(" ");
+  const timeoutRef = useRef<number>();
+
+  useEffect(() => {
+    const show = (index: number) => {
+      if (dnd) return;
+      const name = names[index] ?? `Workspace ${index + 1}`;
+      setLabel(`Workspace ${index + 1} — ${name}`);
+      setVisible(true);
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(() => setVisible(false), 1500);
+    };
+    const handler = (e: Event) => {
+      const idx = (e as CustomEvent<number>).detail ?? 0;
+      show(idx);
+    };
+    window.addEventListener("workspace-changed", handler as EventListener);
+    return () => {
+      window.removeEventListener("workspace-changed", handler as EventListener);
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, [names, dnd]);
+
+  useEffect(() => {
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.altKey && e.key === "ArrowRight") {
+        e.preventDefault();
+        nextWorkspace(names.length);
+      } else if (e.ctrlKey && e.altKey && e.key === "ArrowLeft") {
+        e.preventDefault();
+        prevWorkspace(names.length);
+      }
+    };
+    window.addEventListener("keydown", keyHandler);
+    return () => window.removeEventListener("keydown", keyHandler);
+  }, [names.length]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+      <div className="px-4 py-2 rounded bg-black bg-opacity-75 text-white">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/hooks/useDoNotDisturb.ts
+++ b/hooks/useDoNotDisturb.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import usePersistentState from "./usePersistentState";
+
+export default function useDoNotDisturb() {
+  const [dnd, setDnd] = usePersistentState<boolean>(
+    "do-not-disturb",
+    false,
+    (v): v is boolean => typeof v === "boolean",
+  );
+  return { dnd, setDnd } as const;
+}

--- a/hooks/useWorkspaceNames.ts
+++ b/hooks/useWorkspaceNames.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import usePersistentState from "./usePersistentState";
+
+const DEFAULT_NAMES = ["Workspace 1", "Workspace 2", "Workspace 3", "Workspace 4"];
+
+export default function useWorkspaceNames() {
+  const [names, setNames] = usePersistentState<string[]>(
+    "workspace-names",
+    DEFAULT_NAMES,
+    (v): v is string[] => Array.isArray(v) && v.every(x => typeof x === "string"),
+  );
+  return { names, setNames } as const;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import WorkspaceSwitch from '../components/osd/WorkspaceSwitch';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <WorkspaceSwitch />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/utils/workspaceManager.ts
+++ b/utils/workspaceManager.ts
@@ -1,0 +1,20 @@
+let activeWorkspace = 0;
+
+export const getActiveWorkspace = () => activeWorkspace;
+
+export const setActiveWorkspace = (index: number) => {
+  activeWorkspace = index;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<number>("workspace-changed", { detail: index })
+    );
+  }
+};
+
+export const nextWorkspace = (count: number) => {
+  setActiveWorkspace((activeWorkspace + 1) % count);
+};
+
+export const prevWorkspace = (count: number) => {
+  setActiveWorkspace((activeWorkspace - 1 + count) % count);
+};


### PR DESCRIPTION
## Summary
- show workspace change overlay with name and index
- persist workspace names and do-not-disturb state
- wire overlay into app and keyboard shortcuts

## Testing
- `yarn test` *(fails: Window snapping finalize and release › releases snap with Alt+ArrowDown restoring size, NmapNSEApp › copies example output to clipboard, modal closes when Escape pressed globally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16182f048328b8f6fb7e9e206242