### PR TITLE
test: add coverage for tool metapackage badges

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.tsx?/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/pages/tools-badges.spec.tsx
+++ b/tests/pages/tools-badges.spec.tsx
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure tools that are part of Kali metapackages display
+// badges linking to their package information page.
+test('metapackage tools expose package badges', async ({ page }) => {
+  await page.goto('/tools/nmap');
+
+  // Locate all metapackage badges linking to the kali-meta page
+  const badgeLinks = page.locator('#metapackages a[href*="kali-meta"]');
+
+  // At least one badge should be present
+  const count = await badgeLinks.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Each badge should link to package info under kali-meta
+  const hrefs = await badgeLinks.allAttribute('href');
+  for (const href of hrefs) {
+    expect(href).toContain('kali-meta');
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright test for tools page to confirm metapackage badges link to package info
- expand Playwright config to run both `.ts` and `.tsx` specs

## Testing
- `npx playwright test tests/pages/tools-badges.spec.tsx` *(fails: Expected > 0 badges)*
- `yarn test` *(fails: window.test.tsx, nmapNse.test.tsx, unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb023b2b2c8328b0be2bd2b6b5bed5