### PR TITLE
test: verify NetHunter App Store link

### DIFF
--- a/tests/pages/nethunter-appstore.spec.tsx
+++ b/tests/pages/nethunter-appstore.spec.tsx
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const OFFICIAL_URL = 'https://store.nethunter.com/en/';
+
+test('NetHunter App Store button is prominent and opens official site', async ({ page }) => {
+  await page.goto('/nethunter-appstore');
+
+  const button = page.getByRole('link', { name: /kali nethunter app store/i });
+
+  // ensure the button is visible and within the initial viewport
+  await expect(button).toBeVisible();
+  await expect(button).toBeInViewport();
+
+  // ensure the button points to the official NetHunter App Store
+  await expect(button).toHaveAttribute('href', OFFICIAL_URL);
+});
+


### PR DESCRIPTION
## Summary
- add Playwright test ensuring the NetHunter App Store button is visible and links to the official store

## Testing
- `npx playwright test tests/pages/nethunter-appstore.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fce2080832883b6dacf732f8f94