### PR TITLE
test: verify desktop launcher updates

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/settings/desktop-editor.spec.tsx
+++ b/tests/settings/desktop-editor.spec.tsx
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+// This test ensures that editing fields in the desktop launcher
+// editor is immediately reflected in the application menu.
+test('launcher changes are reflected in menu', async ({ page }) => {
+  // Navigate to the desktop launcher editor
+  await page.goto('/apps/desktop-editor');
+
+  // Edit launcher fields
+  await page.getByLabel('Name').fill('My Test App');
+  await page.getByLabel('Command').fill('/usr/bin/test');
+  await page.getByRole('button', { name: /save/i }).click();
+
+  // Verify the menu entry updates immediately
+  await expect(page.getByRole('menuitem', { name: 'My Test App' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- allow Playwright to execute `.spec.tsx` files
- add test covering desktop launcher editor workflow

## Testing
- `npm test` *(fails: window.test.tsx, nmapNse.test.tsx, Modal.test.tsx)*
- `npx playwright test tests/settings/desktop-editor.spec.tsx` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fbfd6b08328b695dfb416944420