### PR TITLE
Add test for panel separator expansion

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/tests/panel/separators.spec.tsx
+++ b/tests/panel/separators.spec.tsx
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+// This test ensures dragging a separator with the "Expand" option
+// pushes adjacent panels to the container edges while in Edit Mode.
+
+const PANEL_ROUTE = '/panel';
+
+function closeEnough(a: number | undefined, b: number | undefined, tol = 1) {
+  if (typeof a !== 'number' || typeof b !== 'number') return false;
+  return Math.abs(a - b) <= tol;
+}
+
+test.describe('Panel separators', () => {
+  test('Expand pushes neighbors to panel edges', async ({ page }) => {
+    await page.goto(PANEL_ROUTE);
+
+    // Enter Edit Mode
+    await page.getByRole('button', { name: /edit mode/i }).click();
+
+    // Drag the first separator and choose the Expand option
+    const separator = page.getByRole('separator').first();
+    await separator.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: /expand/i }).click();
+
+    const group = page.locator('[data-testid="panel-group"]');
+    const first = group.locator('[data-testid="panel"]').first();
+    const last = group.locator('[data-testid="panel"]').last();
+
+    const groupBox = await group.boundingBox();
+    const firstBox = await first.boundingBox();
+    const lastBox = await last.boundingBox();
+
+    // Verify the first panel aligns with the left edge
+    expect(closeEnough(firstBox?.x, groupBox?.x)).toBeTruthy();
+
+    // Verify the last panel aligns with the right edge
+    const lastRight = (lastBox?.x ?? 0) + (lastBox?.width ?? 0);
+    const groupRight = (groupBox?.x ?? 0) + (groupBox?.width ?? 0);
+    expect(closeEnough(lastRight, groupRight)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test covering panel separator Expand behavior
- allow Playwright to discover `.tsx` specs

## Testing
- `npx playwright test tests/panel/separators.spec.tsx` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fb9259c83288350eabab8237f35