### PR TITLE
Add notifications panel with DND toggle

### DIFF
--- a/components/ui/NotificationsPanel.tsx
+++ b/components/ui/NotificationsPanel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { AppNotification } from '../common/NotificationCenter';
+
+interface Props {
+  open: boolean;
+  notifications: AppNotification[];
+  onClose: () => void;
+}
+
+const NotificationsPanel: React.FC<Props> = ({ open, notifications, onClose }) => (
+  <div
+    className={`fixed top-8 right-2 w-80 max-h-96 overflow-auto bg-ub-cool-grey text-white rounded-md shadow border-black border border-opacity-20 ${open ? '' : 'hidden'}`}
+  >
+    <div className="flex justify-between items-center px-4 py-2 border-b border-gray-500">
+      <span>Notifications</span>
+      <button aria-label="Close" onClick={onClose}>
+        &times;
+      </button>
+    </div>
+    <ul className="p-2 space-y-2">
+      {notifications.length === 0 && (
+        <li className="text-sm text-center text-ubt-grey">No notifications</li>
+      )}
+      {notifications.map(n => (
+        <li key={n.id} className="text-sm">
+          {n.message}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default NotificationsPanel;

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
+import { NotificationsContext } from '../common/NotificationCenter';
 
 interface ToastProps {
   message: string;
@@ -17,6 +18,13 @@ const Toast: React.FC<ToastProps> = ({
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
+  const ctx = useContext(NotificationsContext);
+  const pushNotification = ctx?.pushNotification;
+  const dnd = ctx?.dnd ?? false;
+
+  useEffect(() => {
+    pushNotification?.(message);
+  }, [message, pushNotification]);
 
   useEffect(() => {
     setVisible(true);
@@ -27,6 +35,10 @@ const Toast: React.FC<ToastProps> = ({
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, [duration, onClose]);
+
+  if (dnd) {
+    return null;
+  }
 
   return (
     <div

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,12 +2,19 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import { useNotifications } from '../../hooks/useNotifications';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const { dnd, toggleDnd, openPanel } = useNotifications();
+
+  const handleBellClick = () => {
+    toggleDnd();
+    openPanel();
+  };
 
   useEffect(() => {
     const pingServer = async () => {
@@ -40,6 +47,23 @@ export default function Status() {
 
   return (
     <div className="flex justify-center items-center">
+      <span className="mx-1.5 relative">
+        <button
+          type="button"
+          aria-label="Notifications"
+          onClick={handleBellClick}
+        >
+          <Image
+            width={16}
+            height={16}
+            src="/themes/Yaru/status/notification-symbolic.svg"
+            alt="notifications"
+            className="inline status-symbol w-4 h-4"
+            sizes="16px"
+          />
+        </button>
+        {dnd && <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />}
+      </span>
       <span
         className="mx-1.5 relative"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/public/themes/Yaru/status/notification-symbolic.svg
+++ b/public/themes/Yaru/status/notification-symbolic.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>


### PR DESCRIPTION
## Summary
- add NotificationCenter context with Do Not Disturb mode and panel UI
- record toasts silently during DND via context-aware Toast component
- show bell icon in status bar to toggle DND and open notifications panel

## Testing
- `npx jest __tests__/liveRegion.test.tsx __tests__/nmapNse.test.tsx __tests__/window.test.tsx` (fails: window.test.tsx, nmapNse.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ba6f998e848328a5d8459658d14f05