### PR TITLE
ci: export build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,26 @@ jobs:
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  export:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test
+      - e2e
+      - security
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - run: yarn export
+      - uses: actions/upload-artifact@v4
+        with:
+          name: export
+          path: out
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- run `yarn build` then `yarn export` in CI
- upload static export as artifact and depend on checks

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: nmapNse test copy example output)*
- `yarn build` *(fails: missing module 'fuse.js')*


------
https://chatgpt.com/codex/tasks/task_e_68bbd5f87fc883289a0e926178d23b19