### PR TITLE
test: ensure embed domains are allowlisted

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `www.youtube.com` | YouTube IFrame API |
 | `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
 | `open.spotify.com` | Spotify embeds |
+| `react.dev` | React documentation embeds |
+| `sdk.scdn.co` | Spotify Web Playback SDK |
 | `vercel.live` | Vercel toolbar |
 
 **Notes for prod hardening**

--- a/__tests__/csp.test.ts
+++ b/__tests__/csp.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fg from 'fast-glob';
+
+type Ref = { file: string; line: number; domain: string };
+
+function parseConfig() {
+  const configPath = path.join(__dirname, '..', 'next.config.js');
+  const content = fs.readFileSync(configPath, 'utf8');
+
+  const imagesMatch = content.match(/images:\s*{[^}]*domains:\s*\[([\s\S]*?)\]/);
+  const imageDomains = imagesMatch
+    ? Array.from(imagesMatch[1].matchAll(/['"]([^'"]+)['"]/g)).map((m) => m[1])
+    : [];
+
+  const cspMatch = content.match(/ContentSecurityPolicy\s*=\s*\[([\s\S]*?)\]\.join/);
+  const cspLines = cspMatch ? cspMatch[1].split('\n') : [];
+  const cspDomains: string[] = [];
+
+  for (const raw of cspLines) {
+    const line = raw.replace(/^[\s"]+|[\s",]+$/g, '');
+    if (!line) continue;
+    const tokens = line.split(/\s+/);
+    for (const token of tokens) {
+      if (token.startsWith('https://') || token.startsWith('http://')) {
+        const host = token.replace(/^https?:\/\/(\*\.)?/, '$1').replace(/\/.*$/, '');
+        cspDomains.push(host);
+      }
+    }
+  }
+
+  return { imageDomains, cspDomains };
+}
+
+function collectRefs(): Ref[] {
+  const root = path.join(__dirname, '..');
+  const patterns = ['{app,apps,components,pages}/**/*.{js,jsx,ts,tsx}'];
+  const files = fg.sync(patterns, {
+    cwd: root,
+    ignore: ['**/__tests__/**', '**/*.test.*', '**/*.spec.*'],
+  });
+  const refs: Ref[] = [];
+
+  for (const file of files) {
+    const abs = path.join(root, file);
+    const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.includes('https://') || !/\bsrc\b/i.test(line)) continue;
+      if (/href\s*=/.test(line)) continue;
+      const commentIdx = line.indexOf('//');
+      const urlIdx = line.indexOf('https://');
+      if (commentIdx !== -1 && commentIdx < urlIdx) continue;
+      const urlRegex = /https:\/\/[^\s"'`\\]+/g;
+      let match: RegExpExecArray | null;
+      while ((match = urlRegex.exec(line))) {
+        try {
+          const domain = new URL(match[0]).hostname;
+          refs.push({ file, line: i + 1, domain });
+        } catch {
+          /* ignore invalid URLs */
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+function isAllowed(domain: string, allowlist: string[]): boolean {
+  return allowlist.some((allowed) => {
+    if (allowed.startsWith('*.')) {
+      const base = allowed.slice(2);
+      return domain === base || domain.endsWith(`.${base}`);
+    }
+    return domain === allowed;
+  });
+}
+
+test('external embed domains are allowlisted', () => {
+  const { imageDomains, cspDomains } = parseConfig();
+  const allowlist = [...new Set([...imageDomains, ...cspDomains])];
+  const refs = collectRefs();
+  const errors: string[] = [];
+
+  for (const ref of refs) {
+    if (!isAllowed(ref.domain, allowlist)) {
+      errors.push(`${ref.domain} in ${ref.file}:${ref.line}`);
+    }
+  }
+
+  if (errors.length) {
+    throw new Error('Missing allowlist entries for:\n' + errors.join('\n'));
+  }
+});

--- a/next.config.js
+++ b/next.config.js
@@ -21,11 +21,11 @@ const ContentSecurityPolicy = [
   // Restrict fonts to same origin
   "font-src 'self'",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://sdk.scdn.co",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
-  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://react.dev https://example.com https://developer.mozilla.org https://en.wikipedia.org",
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
@@ -142,6 +142,11 @@ module.exports = withBundleAnalyzer(
         'example.com',
         'developer.mozilla.org',
         'en.wikipedia.org',
+        'ghchart.rshah.org',
+        'openweathermap.org',
+        'staticmap.openstreetmap.de',
+        'data.typeracer.com',
+        'images.credly.com',
       ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],


### PR DESCRIPTION
## Summary
- extend CSP and image allowlists for React, Spotify, and external badge providers
- add CSP external domain table entries
- test: verify embedded domain allowlists

## Testing
- `yarn test __tests__/csp.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bbd5fadb4c8328aeb4ee775e558030