### PR TITLE
Add Speed Insights reachability test

### DIFF
--- a/__tests__/speed-insights.test.ts
+++ b/__tests__/speed-insights.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from '@jest/globals';
+import { exec } from 'child_process';
+import util from 'util';
+
+const execAsync = util.promisify(exec);
+
+// Ensure the Speed Insights script endpoint responds successfully.
+describe('Speed Insights script', () => {
+  it('returns 200 from /_vercel/speed-insights/script.js', async () => {
+    const { stdout } = await execAsync('curl -s -o /dev/null -w "%{http_code}" https://vercel.live/_vercel/speed-insights/script.js');
+    expect(stdout.trim()).toBe('200');
+  });
+});

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -172,7 +172,7 @@ function MyApp(props) {
                 }}
               />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              <SpeedInsights />
             </PipPortalProvider>
           </TrayProvider>
         </SettingsProvider>


### PR DESCRIPTION
## Summary
- Render `<SpeedInsights />` in `_app.jsx`
- Add test verifying Speed Insights script endpoint returns 200

## Testing
- `npm test -- __tests__/speed-insights.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5fb9c5c8328866d402853d8e94a