### PR TITLE
Add Safe Mode boot handling

### DIFF
--- a/__tests__/ubuntu.safeMode.test.tsx
+++ b/__tests__/ubuntu.safeMode.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("../components/ubuntu", () => {
+  return function BrokenUbuntu() {
+    throw new Error("boot failure");
+  };
+});
+
+import Ubuntu from "../components/screen/ubuntu";
+
+describe("Ubuntu safe mode", () => {
+  it("displays safe mode and clears customizations", async () => {
+    window.localStorage.setItem("app:theme", "dark");
+    window.localStorage.setItem(
+      "panel:profiles",
+      JSON.stringify({ foo: "bar" }),
+    );
+    window.localStorage.setItem("panelLayout", "value");
+    window.localStorage.setItem("pluginStates", "value");
+
+    render(<Ubuntu />);
+    expect(screen.getByText("Safe Mode")).toBeInTheDocument();
+
+    expect(window.localStorage.getItem("app:theme")).toBe('"default"');
+    expect(window.localStorage.getItem("panel:profiles")).toBe("{}");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /return to desktop/i }),
+    );
+  });
+});

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,19 +1,31 @@
-import React, { act } from 'react';
-import { render, screen } from '@testing-library/react';
-import Ubuntu from '../components/ubuntu';
+import React, { act } from "react";
+import { render, screen } from "@testing-library/react";
+import Ubuntu from "../components/screen/ubuntu";
 
-jest.mock('../components/screen/desktop', () => function DesktopMock() {
-  return <div data-testid="desktop" />;
-});
-jest.mock('../components/screen/navbar', () => function NavbarMock() {
-  return <div data-testid="navbar" />;
-});
-jest.mock('../components/screen/lock_screen', () => function LockScreenMock() {
-  return <div data-testid="lock-screen" />;
-});
-jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock(
+  "../components/screen/desktop",
+  () =>
+    function DesktopMock() {
+      return <div data-testid="desktop" />;
+    },
+);
+jest.mock(
+  "../components/screen/navbar",
+  () =>
+    function NavbarMock() {
+      return <div data-testid="navbar" />;
+    },
+);
+jest.mock(
+  "../components/screen/lock_screen",
+  () =>
+    function LockScreenMock() {
+      return <div data-testid="lock-screen" />;
+    },
+);
+jest.mock("react-ga4", () => ({ send: jest.fn(), event: jest.fn() }));
 
-describe('Ubuntu component', () => {
+describe("Ubuntu component", () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -23,22 +35,22 @@ describe('Ubuntu component', () => {
     jest.useRealTimers();
   });
 
-  it('renders boot screen then desktop', () => {
+  it("renders boot screen then desktop", () => {
     render(<Ubuntu />);
-    const bootLogo = screen.getByAltText('Ubuntu Logo');
+    const bootLogo = screen.getByAltText("Ubuntu Logo");
     const bootScreen = bootLogo.parentElement as HTMLElement;
-    expect(bootScreen).toHaveClass('visible');
+    expect(bootScreen).toHaveClass("visible");
 
     act(() => {
       jest.advanceTimersByTime(2000);
     });
 
-    expect(bootScreen).toHaveClass('invisible');
-    expect(screen.getByTestId('desktop')).toBeInTheDocument();
+    expect(bootScreen).toHaveClass("invisible");
+    expect(screen.getByTestId("desktop")).toBeInTheDocument();
   });
 
-  it('handles lockScreen when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
+  it("handles lockScreen when status bar is missing", () => {
+    let instance: any | null = null;
     render(<Ubuntu ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {
@@ -48,8 +60,8 @@ describe('Ubuntu component', () => {
     expect(instance!.state.screen_locked).toBe(true);
   });
 
-  it('handles shutDown when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
+  it("handles shutDown when status bar is missing", () => {
+    let instance: any | null = null;
     render(<Ubuntu ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {

--- a/components/screen/ubuntu.tsx
+++ b/components/screen/ubuntu.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useState, forwardRef, type ReactNode } from "react";
+import UbuntuCore from "../ubuntu";
+import usePersistentState from "../../hooks/usePersistentState";
+import { THEME_KEY, setTheme } from "../../utils/theme";
+
+// Simple Safe Mode screen presented when boot fails
+function SafeModeScreen({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-black text-white gap-4">
+      <h1 className="text-2xl font-bold">Safe Mode</h1>
+      <p className="max-w-md text-center">
+        An error occurred before the desktop could load. Custom themes and panel
+        profiles have been disabled.
+      </p>
+      <button onClick={onRetry} className="bg-ub-orange px-4 py-2 rounded">
+        Return to Desktop
+      </button>
+    </div>
+  );
+}
+
+class UbuntuErrorBoundary extends React.Component<
+  { children: ReactNode; onError: (e: Error) => void },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; onError: (e: Error) => void }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export default forwardRef<any, any>(function UbuntuScreen(props, ref) {
+  const [safeMode, setSafeMode] = useState(false);
+  const [, , , clearTheme] = usePersistentState<string>(THEME_KEY, "default");
+  const [, , , clearProfiles] = usePersistentState<Record<string, unknown>>(
+    "panel:profiles",
+    {},
+  );
+
+  const handleError = (err: Error) => {
+    // Remove custom theme and panel profile
+    clearTheme();
+    clearProfiles();
+    try {
+      window.localStorage.removeItem("panelLayout");
+      window.localStorage.removeItem("pluginStates");
+      setTheme("default");
+    } catch {
+      /* ignore storage errors */
+    }
+    setSafeMode(true);
+    console.error("Boot error", err);
+  };
+
+  const retry = () => {
+    setSafeMode(false);
+    // Reload to attempt normal boot again
+    try {
+      window.location.reload();
+    } catch {
+      /* ignore reload issues */
+    }
+  };
+
+  if (safeMode) return <SafeModeScreen onRetry={retry} />;
+
+  return (
+    <UbuntuErrorBoundary onError={handleError}>
+      <UbuntuCore ref={ref} {...props} />
+    </UbuntuErrorBoundary>
+  );
+});

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,29 +1,29 @@
-import dynamic from 'next/dynamic';
-import Meta from '../components/SEO/Meta';
-import BetaBadge from '../components/BetaBadge';
-import useSession from '../hooks/useSession';
+import dynamic from "next/dynamic";
+import Meta from "../components/SEO/Meta";
+import BetaBadge from "../components/BetaBadge";
+import useSession from "../hooks/useSession";
 
 const Ubuntu = dynamic(
   () =>
-    import('../components/ubuntu').catch((err) => {
-      console.error('Failed to load Ubuntu component', err);
+    import("../components/screen/ubuntu").catch((err) => {
+      console.error("Failed to load Ubuntu component", err);
       throw err;
     }),
   {
     ssr: false,
     loading: () => <p>Loading Ubuntu...</p>,
-  }
+  },
 );
 const InstallButton = dynamic(
   () =>
-    import('../components/InstallButton').catch((err) => {
-      console.error('Failed to load InstallButton component', err);
+    import("../components/InstallButton").catch((err) => {
+      console.error("Failed to load InstallButton component", err);
       throw err;
     }),
   {
     ssr: false,
     loading: () => <p>Loading install options...</p>,
-  }
+  },
 );
 
 /**
@@ -37,7 +37,11 @@ const App = () => {
         Skip to content
       </a>
       <Meta />
-      <Ubuntu session={session} setSession={setSession} resetSession={resetSession} />
+      <Ubuntu
+        session={session}
+        setSession={setSession}
+        resetSession={resetSession}
+      />
       <BetaBadge />
       <InstallButton />
     </>


### PR DESCRIPTION
## Summary
- handle boot-time errors with a Safe Mode screen that resets theme and panel profile
- load updated Ubuntu screen component from index page
- add tests for Safe Mode flow

## Testing
- `yarn test __tests__/ubuntu.test.tsx __tests__/ubuntu.safeMode.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbd5fc874c8328acd5a6b448419d55