### PR TITLE
feat(settings): add event-driven settings bus

### DIFF
--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -3,10 +3,16 @@
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
-import { useSettings } from '../../../hooks/useSettings';
+import useSettingsBus from '../../../hooks/useSettingsBus';
+import { defaults } from '../../../utils/settingsStore';
 
 export default function BackgroundSlideshow() {
-  const { setWallpaper } = useSettings();
+  const [, setWallpaper] = useSettingsBus(
+    'appearance',
+    'wallpaper',
+    defaults.wallpaper,
+    'bg-image',
+  );
   const [available, setAvailable] = useState<string[]>([]);
   const [selected, setSelected] = usePersistentState<string[]>(
     'bg-slideshow-selected',

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import { ACCENT_OPTIONS } from "../../hooks/useSettings";
+import useSettingsBus from "../../hooks/useSettingsBus";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import KernelTab from "./components/KernelTab";
 import {
@@ -17,24 +18,49 @@ import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 
 export default function Settings() {
-  const {
-    accent,
-    setAccent,
-    wallpaper,
-    setWallpaper,
-    density,
-    setDensity,
-    reducedMotion,
-    setReducedMotion,
-    fontScale,
-    setFontScale,
-    highContrast,
-    setHighContrast,
-    haptics,
-    setHaptics,
-    theme,
-    setTheme,
-  } = useSettings();
+  const [accent, setAccent] = useSettingsBus(
+    "appearance",
+    "accent",
+    defaults.accent,
+    "accent",
+  );
+  const [wallpaper, setWallpaper] = useSettingsBus(
+    "appearance",
+    "wallpaper",
+    defaults.wallpaper,
+    "bg-image",
+  );
+  const [density, setDensity] = useSettingsBus(
+    "ui",
+    "density",
+    defaults.density as any,
+    "density",
+  );
+  const [reducedMotion, setReducedMotion] = useSettingsBus(
+    "ui",
+    "reducedMotion",
+    defaults.reducedMotion,
+    "reduced-motion",
+  );
+  const [fontScale, setFontScale] = useSettingsBus(
+    "ui",
+    "fontScale",
+    defaults.fontScale,
+    "font-scale",
+  );
+  const [highContrast, setHighContrast] = useSettingsBus(
+    "ui",
+    "highContrast",
+    defaults.highContrast,
+    "high-contrast",
+  );
+  const [haptics, setHaptics] = useSettingsBus(
+    "ui",
+    "haptics",
+    defaults.haptics,
+    "haptics",
+  );
+  const [theme, setTheme] = useSettingsBus("ui", "theme", "default");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const panelFileRef = useRef<HTMLInputElement>(null);
 

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
 import { PANEL_PROFILES, type PanelProfile } from "./profiles";
+import useSettingsBus from "../../hooks/useSettingsBus";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -26,60 +27,39 @@ export default function Preferences() {
 
   const [active, setActive] = useState<TabId>("display");
 
-  const [profileId, setProfileId] = useState(() => {
-    if (typeof window === "undefined") return PANEL_PROFILES[0].id;
-    return localStorage.getItem(`${PANEL_PREFIX}profile`) ||
-      PANEL_PROFILES[0].id;
-  });
+  const [profileId, setProfileId] = useSettingsBus(
+    "panel",
+    "profile",
+    PANEL_PROFILES[0].id,
+    `${PANEL_PREFIX}profile`,
+  );
 
   const [confirming, setConfirming] = useState<PanelProfile | null>(null);
 
-  const [size, setSize] = useState(() => {
-    if (typeof window === "undefined") return 24;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
-    return stored ? parseInt(stored, 10) : 24;
-  });
-  const [length, setLength] = useState(() => {
-    if (typeof window === "undefined") return 100;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
-    return stored ? parseInt(stored, 10) : 100;
-  });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
-  const [autohide, setAutohide] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
-  }, [size]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}length`, String(length));
-  }, [length]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}orientation`, orientation);
-  }, [orientation]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
-  }, [autohide]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}profile`, profileId);
-  }, [profileId]);
+  const [size, setSize] = useSettingsBus(
+    "panel",
+    "size",
+    24,
+    `${PANEL_PREFIX}size`,
+  );
+  const [length, setLength] = useSettingsBus(
+    "panel",
+    "length",
+    100,
+    `${PANEL_PREFIX}length`,
+  );
+  const [orientation, setOrientation] = useSettingsBus<"horizontal" | "vertical">(
+    "panel",
+    "orientation",
+    "horizontal",
+    `${PANEL_PREFIX}orientation`,
+  );
+  const [autohide, setAutohide] = useSettingsBus(
+    "panel",
+    "autohide",
+    false,
+    `${PANEL_PREFIX}autohide`,
+  );
 
   const applyProfile = (profile: PanelProfile) => {
     setOrientation(profile.settings.orientation);

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,10 +1,16 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Clock from '../util-components/clock';
-import { useSettings } from '../../hooks/useSettings';
+import useSettingsBus from '../../hooks/useSettingsBus';
+import { defaults } from '../../utils/settingsStore';
 
 export default function LockScreen(props) {
 
-    const { wallpaper } = useSettings();
+    const [wallpaper] = useSettingsBus(
+        'appearance',
+        'wallpaper',
+        defaults.wallpaper,
+        'bg-image',
+    );
     const [password, setPassword] = useState('');
     const inputRef = useRef(null);
 

--- a/hooks/useSettingsBus.ts
+++ b/hooks/useSettingsBus.ts
@@ -1,0 +1,206 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import settingsBus from '../utils/settingsBus';
+import {
+  setAccent,
+  getAccent,
+  setWallpaper,
+  getWallpaper,
+  setDensity,
+  getDensity,
+  setReducedMotion,
+  getReducedMotion,
+  setFontScale,
+  getFontScale,
+  setHighContrast,
+  getHighContrast,
+  setHaptics,
+  getHaptics,
+} from '../utils/settingsStore';
+import { setTheme, getTheme, THEME_KEY } from '../utils/theme';
+
+// Utility to lighten or darken a hex color
+const shadeColor = (color: string, percent: number): string => {
+  const f = parseInt(color.slice(1), 16);
+  const t = percent < 0 ? 0 : 255;
+  const p = Math.abs(percent);
+  const R = f >> 16;
+  const G = (f >> 8) & 0x00ff;
+  const B = f & 0x0000ff;
+  const newR = Math.round((t - R) * p) + R;
+  const newG = Math.round((t - G) * p) + G;
+  const newB = Math.round((t - B) * p) + B;
+  return `#${(0x1000000 + newR * 0x10000 + newG * 0x100 + newB)
+    .toString(16)
+    .slice(1)}`;
+};
+
+const spacing: Record<'regular' | 'compact', Record<string, string>> = {
+  regular: {
+    '--space-1': '0.25rem',
+    '--space-2': '0.5rem',
+    '--space-3': '0.75rem',
+    '--space-4': '1rem',
+    '--space-5': '1.5rem',
+    '--space-6': '2rem',
+  },
+  compact: {
+    '--space-1': '0.125rem',
+    '--space-2': '0.25rem',
+    '--space-3': '0.5rem',
+    '--space-4': '0.75rem',
+    '--space-5': '1rem',
+    '--space-6': '1.5rem',
+  },
+};
+
+interface Handler {
+  load?: () => Promise<any> | any;
+  save?: (v: any) => Promise<any> | any;
+  apply?: (v: any) => void;
+  key?: string;
+}
+
+const HANDLERS: Record<string, Handler> = {
+  theme: {
+    load: getTheme,
+    save: setTheme,
+    key: THEME_KEY,
+  },
+  accent: {
+    load: getAccent,
+    save: setAccent,
+    apply: (accent: string) => {
+      const border = shadeColor(accent, -0.2);
+      const vars: Record<string, string> = {
+        '--color-ub-orange': accent,
+        '--color-ub-border-orange': border,
+        '--color-primary': accent,
+        '--color-accent': accent,
+        '--color-focus-ring': accent,
+        '--color-selection': accent,
+        '--color-control-accent': accent,
+      };
+      Object.entries(vars).forEach(([k, v]) =>
+        document.documentElement.style.setProperty(k, v),
+      );
+    },
+  },
+  wallpaper: {
+    load: getWallpaper,
+    save: setWallpaper,
+    key: 'bg-image',
+  },
+  density: {
+    load: getDensity,
+    save: setDensity,
+    apply: (density: 'regular' | 'compact') => {
+      const vars = spacing[density];
+      Object.entries(vars).forEach(([k, v]) =>
+        document.documentElement.style.setProperty(k, v),
+      );
+    },
+  },
+  reducedMotion: {
+    load: getReducedMotion,
+    save: setReducedMotion,
+    apply: (v: boolean) =>
+      document.documentElement.classList.toggle('reduced-motion', v),
+    key: 'reduced-motion',
+  },
+  fontScale: {
+    load: getFontScale,
+    save: setFontScale,
+    apply: (v: number) =>
+      document.documentElement.style.setProperty('--font-multiplier', String(v)),
+    key: 'font-scale',
+  },
+  highContrast: {
+    load: getHighContrast,
+    save: setHighContrast,
+    apply: (v: boolean) =>
+      document.documentElement.classList.toggle('high-contrast', v),
+    key: 'high-contrast',
+  },
+  haptics: {
+    load: getHaptics,
+    save: setHaptics,
+    key: 'haptics',
+  },
+};
+
+export default function useSettingsBus<T>(
+  channel: string,
+  property: string,
+  initial: T,
+  storageKey?: string,
+): [T, (v: T) => void] {
+  const handler = HANDLERS[property];
+  const key = storageKey ?? handler?.key ?? property;
+
+  const [value, setValue] = useState<T>(() => initial);
+  const skipRef = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    const loadValue = async () => {
+      if (handler?.load) {
+        try {
+          const loaded = await handler.load();
+          if (active) {
+            skipRef.current = true;
+            setValue(loaded);
+          }
+          return;
+        } catch {
+          /* ignore */
+        }
+      }
+      if (typeof window !== 'undefined') {
+        try {
+          const stored = window.localStorage.getItem(key);
+          if (stored !== null && active) {
+            skipRef.current = true;
+            setValue(JSON.parse(stored));
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    loadValue();
+    return () => {
+      active = false;
+    };
+  }, [key, handler]);
+
+  useEffect(() => {
+    return settingsBus.subscribe((msg) => {
+      if (msg.channel === channel && msg.property === property) {
+        skipRef.current = true;
+        setValue(msg.value as T);
+      }
+    });
+  }, [channel, property]);
+
+  useEffect(() => {
+    if (handler?.apply) handler.apply(value);
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(value));
+      }
+    } catch {
+      /* ignore */
+    }
+    if (handler?.save) handler.save(value);
+    if (skipRef.current) {
+      skipRef.current = false;
+    } else {
+      settingsBus.publish(channel, property, value);
+    }
+  }, [value, channel, property, key, handler]);
+
+  return [value, setValue];
+}
+


### PR DESCRIPTION
## Summary
- add `useSettingsBus` for persisted settings events
- refactor settings screen, panel preferences, and lock screen to use bus

## Testing
- `npm test __tests__/nmapNse.test.tsx __tests__/desktopNameBar.test.tsx` (fails: Cannot find module 'fuse.js'; Unable to find role="alert")
- `npm run lint` (fails: jsx-a11y/control-has-associated-label, react/display-name, etc.)


------
https://chatgpt.com/codex/tasks/task_e_68bbd5fce6948328b397c1a32a6e9d0a