### PR TITLE
feat: retry dynamic imports and toast on failure

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1,4 +1,4 @@
-import { createDynamicApp, createDisplay } from './utils/createDynamicApp';
+import { createDynamicAppWithRetry as createDynamicApp, createDisplay } from './utils/createDynamicApp';
 
 import { displayX } from './components/apps/x';
 import { displaySpotify } from './components/apps/spotify';

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,23 +1,34 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { logEvent } from './analytics';
+import Toast from '../components/ui/Toast';
 
-export const createDynamicApp = (id, title) =>
+export const createDynamicAppWithRetry = (id, title) =>
   dynamic(
     async () => {
+      const load = async () =>
+        import(/* webpackPrefetch: true */ `../components/apps/${id}`);
       try {
-        const mod = await import(
-          /* webpackPrefetch: true */ `../components/apps/${id}`
-        );
+        const mod = await load();
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;
       } catch (err) {
-        console.error(`Failed to load ${title}`, err);
-        return () => (
-          <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-            {`Unable to load ${title}`}
-          </div>
-        );
+        try {
+          const mod = await load();
+          logEvent({ category: 'Application', action: `Loaded ${title}` });
+          return mod.default;
+        } catch (err2) {
+          console.error(`Failed to load ${title}`, err2);
+          const LoadError = () => (
+            <>
+              <Toast message={`Unable to load ${title}`} />
+              <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+                {`Unable to load ${title}`}
+              </div>
+            </>
+          );
+          return LoadError;
+        }
       }
     },
     {
@@ -29,6 +40,8 @@ export const createDynamicApp = (id, title) =>
       ),
     }
   );
+
+export const createDynamicApp = createDynamicAppWithRetry;
 
 export const createDisplay = (Component) => {
   const DynamicComponent = dynamic(() => Promise.resolve({ default: Component }), {


### PR DESCRIPTION
## Summary
- retry dynamic imports with one automatic retry and error toast
- use retry-enabled dynamic app loader in apps.config

## Testing
- `npx eslint apps.config.js utils/createDynamicApp.js`
- `npx jest utils/createDynamicApp.test.ts --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5fec86883288321ae52b77e1ba2