### PR TITLE
Prefetch launcher modules on hover and track TTI metrics

### DIFF
--- a/__tests__/reportWebVitals.test.ts
+++ b/__tests__/reportWebVitals.test.ts
@@ -47,4 +47,24 @@ describe('reportWebVitals', () => {
     );
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it('records TTI metric in preview', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    reportWebVitals({ id: '4', name: 'TTI', value: 4000 });
+    expect(mockEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'TTI' })
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('alerts when TTI exceeds threshold', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    reportWebVitals({ id: '5', name: 'TTI', value: 6000 });
+    expect(mockEvent).toHaveBeenCalledTimes(2);
+    expect(mockEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: 'TTI degraded' })
+    );
+    expect(warnSpy).toHaveBeenCalled();
+  });
 });

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -5,6 +5,7 @@ export class UbuntuApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
+        this.prefetchTimer = null;
     }
 
     handleDragStart = () => {
@@ -30,6 +31,25 @@ export class UbuntuApp extends Component {
         }
     }
 
+    startPrefetchTimer = () => {
+        if (this.state.prefetched || this.prefetchTimer) return;
+        this.prefetchTimer = setTimeout(() => {
+            this.prefetchTimer = null;
+            this.handlePrefetch();
+        }, 150);
+    }
+
+    clearPrefetchTimer = () => {
+        if (this.prefetchTimer) {
+            clearTimeout(this.prefetchTimer);
+            this.prefetchTimer = null;
+        }
+    }
+
+    componentWillUnmount() {
+        this.clearPrefetchTimer();
+    }
+
     render() {
         return (
             <div
@@ -47,8 +67,10 @@ export class UbuntuApp extends Component {
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
-                onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onMouseEnter={this.startPrefetchTimer}
+                onMouseLeave={this.clearPrefetchTimer}
+                onFocus={this.startPrefetchTimer}
+                onBlur={this.clearPrefetchTimer}
             >
                 <Image
                     width={40}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -82,6 +82,22 @@ function MyApp(props) {
   }, []);
 
   useEffect(() => {
+    let active = true;
+    import('web-vitals/attribution')
+      .then(({ onTTI }) => {
+        onTTI(({ value, id }) => {
+          if (active) {
+            reportWebVitalsUtil({ id, name: 'TTI', value });
+          }
+        });
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
     const liveRegion = document.getElementById('live-region');
     if (!liveRegion) return;
 

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -9,11 +9,12 @@ interface WebVitalMetric {
 const thresholds: Record<string, number> = {
   LCP: 2500,
   INP: 200,
+  TTI: 5000,
 };
 
 export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
   if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview') return;
-  if (name !== 'LCP' && name !== 'INP') return;
+  if (name !== 'LCP' && name !== 'INP' && name !== 'TTI') return;
 
   const rounded = Math.round(value);
 


### PR DESCRIPTION
## Summary
- Delay module prefetching in app launcher items until hovered or focused for 150ms to reduce unnecessary loading.
- Capture Time to Interactive (TTI) via web-vitals and report it with other metrics for performance health.
- Test coverage for new TTI reporting.

## Testing
- `npx eslint components/base/ubuntu_app.js utils/reportWebVitals.ts pages/_app.jsx __tests__/reportWebVitals.test.ts`
- `npx jest __tests__/reportWebVitals.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbd60163a483289e40aaf1909c47be