### PR TITLE
feat(player): pool audio contexts

### DIFF
--- a/__tests__/player.test.ts
+++ b/__tests__/player.test.ts
@@ -1,0 +1,45 @@
+describe('audio player pooling', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    class MockAudioContext {
+      static count = 0;
+      state: 'running' | 'suspended' = 'running';
+      constructor() {
+        MockAudioContext.count += 1;
+      }
+      resume() {
+        this.state = 'running';
+      }
+    }
+    // @ts-ignore
+    window.AudioContext = MockAudioContext as any;
+    // @ts-ignore
+    window.webkitAudioContext = MockAudioContext as any;
+    Object.defineProperty(window.HTMLMediaElement.prototype, 'pause', {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  test('getAudioContext returns singleton', () => {
+    const { getAudioContext } = require('../player');
+    const ctx1 = getAudioContext();
+    const ctx2 = getAudioContext();
+    expect(ctx1).toBe(ctx2);
+    expect((window.AudioContext as any).count).toBe(1);
+  });
+
+  test('players are pooled and context reused', () => {
+    const { getAudioContext, getAudioPlayer, releaseAudioPlayer } = require('../player');
+    const ctx1 = getAudioContext();
+    const a1 = getAudioPlayer('test.mp3');
+    const a2 = getAudioPlayer('test.mp3');
+    expect(a1).toBe(a2);
+    releaseAudioPlayer('test.mp3');
+    const a3 = getAudioPlayer('test.mp3');
+    expect(a3).not.toBe(a1);
+    const ctx2 = getAudioContext();
+    expect(ctx2).toBe(ctx1);
+    expect((window.AudioContext as any).count).toBe(1);
+  });
+});

--- a/player/index.ts
+++ b/player/index.ts
@@ -1,0 +1,36 @@
+let ctx: AudioContext | null = null;
+const players = new Map<string, HTMLAudioElement>();
+
+export function getAudioContext(): AudioContext {
+  if (typeof window === 'undefined') {
+    throw new Error('AudioContext unavailable');
+  }
+  if (!ctx) {
+    const Ctor =
+      (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext | undefined;
+    if (!Ctor) {
+      throw new Error('AudioContext constructor missing');
+    }
+    ctx = new Ctor();
+  } else if (ctx.state === 'suspended') {
+    ctx.resume();
+  }
+  return ctx;
+}
+
+export function getAudioPlayer(src: string): HTMLAudioElement {
+  let player = players.get(src);
+  if (!player) {
+    player = new Audio(src);
+    players.set(src, player);
+  }
+  return player;
+}
+
+export function releaseAudioPlayer(src: string): void {
+  const player = players.get(src);
+  if (player) {
+    player.pause();
+    players.delete(src);
+  }
+}

--- a/utils/audio.ts
+++ b/utils/audio.ts
@@ -3,22 +3,11 @@
  * Provides precise tone playback per color and helpers for scheduling.
  */
 
+import { getAudioContext } from "../player";
+
 const TONE_FREQUENCIES = [329.63, 261.63, 220, 164.81];
 
-let ctx: AudioContext | null = null;
-
-export function getAudioContext(): AudioContext {
-  if (typeof window === "undefined") {
-    throw new Error("AudioContext unavailable");
-  }
-  if (!ctx) {
-    ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
-  }
-  if (ctx.state === "suspended") {
-    ctx.resume();
-  }
-  return ctx;
-}
+export { getAudioContext };
 
 /**
  * Play the tone associated with a Simon pad index at a specific time.


### PR DESCRIPTION
## Summary
- pool AudioContext and HTMLAudioElement instances in shared `player` module
- refactor Simon audio utilities to reuse shared context
- test that contexts and players are reused across app lifecycles

## Testing
- `yarn test __tests__/player.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbd60387c883288f6375a265132435