### PR TITLE
feat: add explicit image dimensions

### DIFF
--- a/apps/contact/components/AttachmentCarousel.tsx
+++ b/apps/contact/components/AttachmentCarousel.tsx
@@ -39,7 +39,13 @@ const AttachmentCarousel: React.FC<AttachmentCarouselProps> = ({
     <div className="mt-6">
       <div className="relative">
         {isImage ? (
-          <img src={url} alt={file.name} className="max-h-48 object-contain" />
+          <img
+            src={url}
+            alt={file.name}
+            width={192}
+            height={192}
+            className="max-h-48 object-contain"
+          />
         ) : (
           <div className="p-3 bg-gray-800 rounded">{file.name}</div>
         )}

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -222,6 +222,8 @@ export default function YouTubePlayer({ videoId }) {
                 src={`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`}
                 alt="YouTube video thumbnail"
                 loading="lazy"
+                width={480}
+                height={360}
                 className="absolute inset-0 w-full h-full object-cover"
               />
               <svg

--- a/components/common/Icon.tsx
+++ b/components/common/Icon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface IconProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  /**
+   * Convenience prop to set both width and height simultaneously. If provided,
+   * it will be used when explicit width/height props are not supplied.
+   */
+  size?: number;
+}
+
+/**
+ * Generic icon component that ensures width/height attributes are provided to
+ * prevent layout shift.
+ */
+export default function Icon({ size, width, height, alt = '', ...rest }: IconProps) {
+  const resolvedWidth = width ?? size ?? 16;
+  const resolvedHeight = height ?? size ?? 16;
+
+  return <img alt={alt} width={resolvedWidth} height={resolvedHeight} {...rest} />;
+}

--- a/components/panel/ActiveWindowTitle.tsx
+++ b/components/panel/ActiveWindowTitle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Icon from "@/components/common/Icon";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -66,9 +67,11 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => minimize(activeId)}
         >
-          <img
+          <Icon
             src="/themes/Yaru/window/window-minimize-symbolic.svg"
             alt="Kali window minimize"
+            width={12}
+            height={12}
             className="h-3 w-3"
           />
         </button>
@@ -80,9 +83,11 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => maximize(activeId)}
         >
-          <img
+          <Icon
             src="/themes/Yaru/window/window-maximize-symbolic.svg"
             alt="Kali window maximize"
+            width={12}
+            height={12}
             className="h-3 w-3"
           />
         </button>
@@ -94,9 +99,11 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => close(activeId)}
         >
-          <img
+          <Icon
             src="/themes/Yaru/window/window-close-symbolic.svg"
             alt="Kali window close"
+            width={12}
+            height={12}
             className="h-3 w-3"
           />
         </button>

--- a/components/panel/GenMon.tsx
+++ b/components/panel/GenMon.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ReactNode, useEffect, useState } from "react";
+import Icon from "@/components/common/Icon";
 import DOMPurify from "dompurify";
 import { XMLParser } from "fast-xml-parser";
 
@@ -108,7 +109,7 @@ export default function GenMon({ code, interval = 60 }: GenMonProps) {
 
   return (
     <div className="flex items-center gap-2">
-      {icon && <img src={icon} alt="" className="w-4 h-4" />}
+      {icon && <Icon src={icon} alt="" size={16} className="w-4 h-4" />}
       {text && <span>{text}</span>}
       {bar !== null && (
         <div className="w-16 h-2 bg-gray-700 rounded overflow-hidden">

--- a/components/panel/taskbar/TaskList.tsx
+++ b/components/panel/taskbar/TaskList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import Icon from '@/components/common/Icon';
 
 interface AppDefinition {
   id: string;
@@ -64,8 +65,7 @@ const TaskList: React.FC<TaskListProps> = ({ apps, onMinimizeWindow }) => {
           }`}
         >
           {app.icon ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={app.icon} alt="" className="w-5 h-5" />
+            <Icon src={app.icon} alt="" size={20} className="w-5 h-5" />
           ) : (
             <span>{app.title}</span>
           )}

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -28,6 +28,8 @@ export default function LockScreen(props) {
             <img
                 src={`/wallpapers/${wallpaper}.webp`}
                 alt=""
+                width={1920}
+                height={1080}
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-md' : 'blur-none'}`}
             />
             <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
@@ -40,7 +42,7 @@ export default function LockScreen(props) {
                     </div>
                 </div>
                 <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
-                    <img src="/images/logos/bitmoji.png" alt="avatar" className="w-24 h-24 rounded-full mb-4 border-2 border-white" />
+                    <img src="/images/logos/bitmoji.png" alt="avatar" width={96} height={96} className="w-24 h-24 rounded-full mb-4 border-2 border-white" />
                     <div className="text-2xl mb-4">kali</div>
                     <input
                         ref={inputRef}

--- a/src/apps/appfinder/AppFinder.tsx
+++ b/src/apps/appfinder/AppFinder.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Icon from '@/components/common/Icon';
 
 // Representation of a parsed .desktop entry
 export interface DesktopEntry {
@@ -169,12 +170,13 @@ export default function AppFinder() {
       {expanded && (
         <div className="finder-panel">
           <form onSubmit={handleSubmit} className="search">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search or enter command"
-              autoFocus
-            />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search or enter command"
+                aria-label="Search or enter command"
+                autoFocus
+              />
           </form>
 
           {apps.length > 0 && (
@@ -188,7 +190,7 @@ export default function AppFinder() {
                     }}
                   >
                     {app.icon && (
-                      <img src={app.icon} alt="" className="icon" />
+                      <Icon src={app.icon} alt="" size={16} className="icon" />
                     )}
                     {app.name}
                   </button>

--- a/src/plugins/WorkspaceSwitcher.tsx
+++ b/src/plugins/WorkspaceSwitcher.tsx
@@ -93,6 +93,8 @@ const WorkspaceSwitcher: React.FC<WorkspaceSwitcherProps> = ({
                 alt={win.title}
                 draggable
                 onDragStart={handleDragStart(win.id)}
+                width={64}
+                height={48}
                 className="w-16 h-12 object-cover rounded"
               />
             ))}

--- a/src/wm/WindowSwitcher.tsx
+++ b/src/wm/WindowSwitcher.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import keybindingManager from './keybindingManager';
+import Icon from '@/components/common/Icon';
 
 export interface WindowInfo {
   id: string;
@@ -80,12 +81,14 @@ export default function WindowSwitcher({ windows, onSelect }: Props) {
               textAlign: 'center',
             }}
           >
-            <img src={win.icon} alt="" style={{ width: '32px', height: '32px' }} />
+            <Icon src={win.icon} alt="" width={32} height={32} />
             <div>{win.title}</div>
             {win.preview && (
               <img
                 src={win.preview}
                 alt="preview"
+                width={200}
+                height={112}
                 style={{ width: '100%', marginTop: '0.5rem' }}
               />
             )}


### PR DESCRIPTION
## Summary
- add Icon component that enforces width/height to reduce layout shift
- specify intrinsic sizes for common images and icons

## Testing
- `npx eslint components/common/Icon.tsx components/panel/taskbar/TaskList.tsx components/panel/GenMon.tsx components/panel/ActiveWindowTitle.tsx src/wm/WindowSwitcher.tsx src/apps/appfinder/AppFinder.tsx src/plugins/WorkspaceSwitcher.tsx apps/contact/components/AttachmentCarousel.tsx components/screen/lock_screen.js components/YouTubePlayer.js && echo 'lint ok'`
- `yarn test __tests__/nmapNse.test.tsx 2>&1 | tail -n 20` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbd603b1808328875c33401d6f7c6d