### PR TITLE
feat: optimize game canvases

### DIFF
--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -29,6 +29,8 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       const canvas = canvasRef.current;
       if (!canvas) return;
 
+      canvas.style.willChange = 'transform';
+
       // Prefer OffscreenCanvas with a worker when supported
       if (typeof Worker === 'function' && hasOffscreenCanvas()) {
         const worker = new Worker(
@@ -56,10 +58,11 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
         );
 
         resize();
-        window.addEventListener('resize', resize);
+        const ro = new ResizeObserver(resize);
+        ro.observe(canvas);
         return () => {
           worker.terminate();
-          window.removeEventListener('resize', resize);
+          ro.disconnect();
         };
       }
 
@@ -77,8 +80,9 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       };
 
       resize();
-      window.addEventListener('resize', resize);
-      return () => window.removeEventListener('resize', resize);
+      const ro = new ResizeObserver(resize);
+      ro.observe(canvas);
+      return () => ro.disconnect();
     }, [width, height]);
 
     useImperativeHandle(ref, () => ({
@@ -95,15 +99,16 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       },
     }));
 
-    return (
-      <canvas
-        ref={canvasRef}
-        className={className}
-        style={{ imageRendering: 'pixelated' }}
-      />
-    );
-  }
-);
+      return (
+        <canvas
+          ref={canvasRef}
+          className={className}
+          style={{ imageRendering: 'pixelated' }}
+          aria-label="Game canvas"
+        />
+      );
+    }
+  );
 
 Canvas.displayName = 'Canvas';
 

--- a/games/asteroids/index.tsx
+++ b/games/asteroids/index.tsx
@@ -234,15 +234,18 @@ const AsteroidsGame: React.FC = () => {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    function resize() {
+    canvas.style.willChange = "transform";
+
+    const resize = () => {
       if (!canvas || !ctx) return;
       const { clientWidth, clientHeight } = canvas;
       canvas.width = clientWidth * DPR;
       canvas.height = clientHeight * DPR;
       ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
-    }
+    };
     resize();
-    window.addEventListener("resize", resize);
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
 
     initGame();
 
@@ -257,7 +260,7 @@ const AsteroidsGame: React.FC = () => {
     id = requestAnimationFrame(loop);
     return () => {
       cancelAnimationFrame(id);
-      window.removeEventListener("resize", resize);
+      ro.disconnect();
     };
   }, [paused, initGame, update, draw]);
 
@@ -268,7 +271,7 @@ const AsteroidsGame: React.FC = () => {
 
   return (
     <div className="relative w-full h-full bg-black" data-testid="asteroids-game">
-      <canvas ref={canvasRef} className="w-full h-full" />
+      <canvas ref={canvasRef} className="w-full h-full" aria-label="Asteroids game canvas" />
       <div className="pointer-events-none absolute inset-0 select-none">
         <div className="absolute top-2 left-2 flex gap-1">
           {Array.from({ length: lives }).map((_, i) => (

--- a/games/pinball/components/TableEditor.tsx
+++ b/games/pinball/components/TableEditor.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
+import useCanvasResize from '../../../hooks/useCanvasResize';
 
 interface Wall {
   type: 'wall';
@@ -30,7 +31,7 @@ function decode(code: string): TableObject[] {
 }
 
 export default function TableEditor() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useCanvasResize(400, 600);
   const [objects, setObjects] = useState<TableObject[]>([]);
   const [tool, setTool] = useState<'wall' | 'bumper'>('wall');
   const [code, setCode] = useState('');
@@ -78,26 +79,28 @@ export default function TableEditor() {
   return (
     <div className="flex flex-col space-y-2">
       <div className="flex space-x-2 text-xs">
-        <label className="flex items-center space-x-1">
-          <input
-            type="radio"
-            name="tool"
-            value="wall"
-            checked={tool === 'wall'}
-            onChange={() => setTool('wall')}
-          />
-          <span>Wall</span>
-        </label>
-        <label className="flex items-center space-x-1">
-          <input
-            type="radio"
-            name="tool"
-            value="bumper"
-            checked={tool === 'bumper'}
-            onChange={() => setTool('bumper')}
-          />
-          <span>Bumper</span>
-        </label>
+          <label className="flex items-center space-x-1">
+            <input
+              type="radio"
+              name="tool"
+              value="wall"
+              aria-label="Wall tool"
+              checked={tool === 'wall'}
+              onChange={() => setTool('wall')}
+            />
+            <span>Wall</span>
+          </label>
+          <label className="flex items-center space-x-1">
+            <input
+              type="radio"
+              name="tool"
+              value="bumper"
+              aria-label="Bumper tool"
+              checked={tool === 'bumper'}
+              onChange={() => setTool('bumper')}
+            />
+            <span>Bumper</span>
+          </label>
         <button
           className="border px-2"
           type="button"
@@ -106,23 +109,23 @@ export default function TableEditor() {
           Clear
         </button>
       </div>
-      <canvas
-        ref={canvasRef}
-        width={400}
-        height={600}
-        className="border"
-        onClick={handleClick}
-      />
+          <canvas
+            ref={canvasRef}
+            className="border"
+            aria-label="Pinball table canvas"
+            onClick={handleClick}
+          />
       <div className="flex flex-col text-xs space-y-1">
         <button className="border px-2" type="button" onClick={handleExport}>
           Export Code
         </button>
-        <textarea
-          className="border p-1"
-          rows={3}
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-        />
+          <textarea
+            className="border p-1"
+            rows={3}
+            aria-label="Table code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
         <button className="border px-2" type="button" onClick={handleImport}>
           Import Code
         </button>

--- a/games/snake/index.tsx
+++ b/games/snake/index.tsx
@@ -3,12 +3,12 @@
 import React, { useRef, useEffect, useState } from "react";
 import GameShell from "../../components/games/GameShell";
 import usePersistentState from "../../hooks/usePersistentState";
+import useCanvasResize from "../../hooks/useCanvasResize";
 import { DEFAULT_GRID_SIZE, createState, step, GameState } from "./logic";
 
 const CELL_SIZE = 16;
 
 const Snake = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const [wrap, setWrap] = usePersistentState<boolean>("snake:wrap", false);
   const [speed, setSpeed] = usePersistentState<number>("snake:speed", 150);
   const [gridSize, setGridSize] = usePersistentState<number>(
@@ -21,6 +21,8 @@ const Snake = () => {
   const [score, setScore] = useState(0);
   const [foodAnim, setFoodAnim] = useState(1);
   const runningRef = useRef(true);
+  const width = state.gridSize * CELL_SIZE;
+  const canvasRef = useCanvasResize(width, width);
 
   // reset when wrap or grid size changes
   useEffect(() => {
@@ -106,6 +108,7 @@ const Snake = () => {
       <label className="flex items-center space-x-2">
         <input
           type="checkbox"
+          aria-label="Wrap edges"
           checked={wrap}
           onChange={(e) => setWrap(e.target.checked)}
         />
@@ -114,6 +117,7 @@ const Snake = () => {
       <label className="flex items-center space-x-2">
         <span>Map size</span>
         <select
+          aria-label="Map size"
           value={gridSize}
           onChange={(e) => setGridSize(parseInt(e.target.value, 10))}
         >
@@ -132,8 +136,6 @@ const Snake = () => {
     { label: "Normal", value: 150 },
     { label: "Fast", value: 100 },
   ];
-
-  const width = state.gridSize * CELL_SIZE;
 
   return (
     <GameShell game="snake" settings={settings}>
@@ -156,7 +158,7 @@ const Snake = () => {
           </div>
           <div>Score: {score}</div>
         </div>
-        <canvas ref={canvasRef} width={width} height={width} />
+          <canvas ref={canvasRef} aria-label="Snake game canvas" />
       </div>
     </GameShell>
   );

--- a/hooks/useCanvasResize.ts
+++ b/hooks/useCanvasResize.ts
@@ -10,6 +10,8 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    canvas.style.willChange = 'transform';
+
     const resize = () => {
       const parent = canvas.parentElement;
       if (!parent) return;
@@ -31,10 +33,12 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
     resize();
     const ro = new ResizeObserver(resize);
     const parent = canvas.parentElement;
-    if (parent) ro.observe(parent);
-    window.addEventListener('resize', resize);
+    if (parent) {
+      ro.observe(parent);
+    } else {
+      ro.observe(canvas);
+    }
     return () => {
-      window.removeEventListener('resize', resize);
       ro.disconnect();
     };
   }, [baseWidth, baseHeight]);


### PR DESCRIPTION
## Summary
- use ResizeObserver and will-change on reusable game canvas
- hook game canvases in Snake, Asteroids, and Pinball to responsive resizing
- mark canvases with aria-labels and cleanup listeners on unmount

## Testing
- `yarn eslint hooks/useCanvasResize.ts components/apps/Games/common/canvas/index.tsx games/snake/index.tsx games/asteroids/index.tsx games/pinball/components/TableEditor.tsx`
- `yarn test __tests__/asteroids-utils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbd6049bf4832883a700c94b9fd67f