### PR TITLE
Warm core desktop modules in idle

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -99,6 +99,24 @@ export class Desktop extends Component {
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
+
+        // Warm commonly used modules during idle periods so the first
+        // interaction is snappy even on a cold cache. Falling back to
+        // setTimeout ensures compatibility with environments lacking
+        // requestIdleCallback.
+        if (typeof window !== 'undefined') {
+            const warmModules = () => {
+                import('../apps/terminal');
+                import('../../apps/terminal/tabs');
+                import('../apps/file-explorer');
+                import('../apps/settings');
+            };
+            if ('requestIdleCallback' in window) {
+                requestIdleCallback(warmModules);
+            } else {
+                setTimeout(warmModules, 0);
+            }
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
## Summary
- Preload terminal, file explorer and settings modules with `requestIdleCallback` during desktop bootstrap
- Fallback to `setTimeout` when idle callbacks aren't supported

## Testing
- `npx eslint components/screen/desktop.js`
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbd60546908328bd402d32630b16af