### PR TITLE
Limit PWA caching to fonts and images

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,59 @@
+'use strict'
+
+module.exports = [
+  {
+    urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'google-fonts-webfonts',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 365 * 24 * 60 * 60 // 365 days
+      }
+    }
+  },
+  {
+    urlPattern: /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'google-fonts-stylesheets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-font-assets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-image-assets',
+      expiration: {
+        maxEntries: 64,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\/_next\/image\?url=.+$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'next-image',
+      expiration: {
+        maxEntries: 64,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  }
+]

--- a/next.config.js
+++ b/next.config.js
@@ -81,6 +81,8 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/offline.html', revision: null },
       { url: '/manifest.webmanifest', revision: null },
     ],
+    // Cache only images and fonts to ensure app shell updates while assets work offline
+    runtimeCaching: require('./cache.js'),
   },
 });
 


### PR DESCRIPTION
## Summary
- add runtime cache config for fonts and images only
- wire cache.js into Next.js PWA workbox setup

## Testing
- `yarn lint` *(fails: no output, likely environment issue)*
- `yarn test` *(fails: FAIL __tests__/nmapNse.test.tsx, FAIL __tests__/Modal.test.tsx)*
- `yarn build` *(fails: Module parse failed: Identifier 'usePersistentState' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6063b4483288fcb58fe781cc90b