### PR TITLE
feat: show update banner for new service worker

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,21 @@
+declare const self: ServiceWorkerGlobalScope;
+
+self.addEventListener('install', (event) => {
+  if (self.registration?.active) {
+    event.waitUntil(
+      self.clients.matchAll({ type: 'window' }).then((clients) => {
+        clients.forEach((client) => client.postMessage('UPDATE_READY'));
+      }),
+    );
+  }
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
## Summary
- announce service worker updates and allow skipping waiting workers
- display clickable banner in desktop environment when an update is ready

## Testing
- `npx eslint components/ubuntu.js worker/index.ts`
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbd606b2b48328b43a3636fd0bfd2b