### PR TITLE
feat: add offline overlay and fallback

### DIFF
--- a/public/offline.css
+++ b/public/offline.css
@@ -1,2 +1,12 @@
 body { font-family: sans-serif; padding: 2rem; text-align: center; }
 ul { list-style: none; padding: 0; }
+#overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 0.5rem;
+  font-weight: bold;
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <main>
+    <div id="overlay">Offline: Apps limited to cached demos</div>
     <h1>Offline</h1>
     <p>You appear to be offline. Please check your connection.</p>
     <button id="retry">Retry</button>

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -1,5 +1,6 @@
 const CACHE_NAME = 'periodic-cache-v1';
 const ASSETS = [
+  '/',
   '/apps/weather.js',
   '/feeds',
   '/about',
@@ -67,6 +68,18 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(request).then((cached) => cached || fetch(request)),
+    caches.match(request).then(async (cached) => {
+      try {
+        return cached || (await fetch(request));
+      } catch (err) {
+        if (
+          request.mode === 'navigate' ||
+          request.destination === 'document'
+        ) {
+          return caches.match('/offline.html');
+        }
+        return cached;
+      }
+    }),
   );
 });

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -1,5 +1,6 @@
 const CACHE_NAME = 'periodic-cache-v1';
 const ASSETS = [
+  '/',
   '/apps/weather.js',
   '/feeds',
   '/about',
@@ -67,6 +68,18 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(request).then((cached) => cached || fetch(request)),
+    caches.match(request).then(async (cached) => {
+      try {
+        return cached || (await fetch(request));
+      } catch (err) {
+        if (
+          request.mode === 'navigate' ||
+          request.destination === 'document'
+        ) {
+          return caches.match('/offline.html');
+        }
+        return cached;
+      }
+    }),
   );
 });


### PR DESCRIPTION
## Summary
- show offline overlay message at `/offline.html`
- style offline overlay banner
- enhance service worker caching and fallback for offline support

## Testing
- `npx eslint workers/service-worker.js public/workers/service-worker.js && echo 'eslint success'`
- `yarn test workers/service-worker.js --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bbd6078f1c832886f13ee0242c97c2