### PR TITLE
test: add PWA Playwright spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,23 @@ jobs:
           npx wait-on http://localhost:3000
       - run: npx playwright test tests/e2e
 
+  pwa:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn start &
+          npx wait-on http://localhost:3000
+      - run: npx playwright test -c playwright/playwright.config.ts pwa.spec.ts
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './',
+  testMatch: /.*\.spec\.(ts|tsx)/,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  },
+});

--- a/playwright/pwa.spec.ts
+++ b/playwright/pwa.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Test that the web app manifest is present and contains required fields
+test('manifest is installable', async ({ page }) => {
+  await page.goto('/');
+  const manifestHref = await page.locator('link[rel="manifest"]').getAttribute('href');
+  expect(manifestHref).toBeTruthy();
+  const manifest = await page.evaluate(async (href) => {
+    const res = await fetch(href!);
+    return res.json();
+  }, manifestHref);
+  expect(manifest.name).toBeTruthy();
+  expect(manifest.display).toBe('standalone');
+});
+
+// Service worker should register when running in production
+test.describe('service worker', () => {
+  test.skip(process.env.NODE_ENV !== 'production', 'Service worker only available in production');
+
+  test('registers service worker', async ({ page }) => {
+    await page.goto('/');
+    const active = await page.evaluate(async () => {
+      await navigator.serviceWorker.ready;
+      return navigator.serviceWorker.controller !== null;
+    });
+    expect(active).toBe(true);
+  });
+});
+
+// Update banner should appear when a new service worker is available
+test.describe('update banner', () => {
+  test.skip(process.env.NODE_ENV !== 'production', 'Update banner only shown in production');
+
+  test('shows update banner when service worker updates', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.dispatchEvent(
+          new MessageEvent('message', { data: { type: 'SKIP_WAITING' } }),
+        );
+      }
+    });
+    const banner = page.locator('[aria-label="update banner"], text=/update available/i');
+    await expect(banner).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright tests covering manifest, service worker, and update banner
- configure Playwright for repo-level tests
- run PWA tests in CI workflow

## Testing
- `npx playwright test -c playwright/playwright.config.ts pwa.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd609882c8328952ee883e5434f31