### PR TITLE
feat(wm): debounce focus events

### DIFF
--- a/__tests__/WindowSwitcher.test.tsx
+++ b/__tests__/WindowSwitcher.test.tsx
@@ -11,4 +11,19 @@ describe('WindowSwitcher', () => {
     });
     expect(screen.getByText('Window 1')).toBeInTheDocument();
   });
+
+  it('ignores selection if mouse is clicked before Alt release', () => {
+    const windows: WindowInfo[] = [{ id: '1', title: 'Window 1', icon: '/icon.png' }];
+    const onSelect = jest.fn();
+    render(<WindowSwitcher windows={windows} onSelect={onSelect} />);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', altKey: true }));
+    });
+    expect(screen.getByText('Window 1')).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousedown'));
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/eventLayer.test.ts
+++ b/__tests__/eventLayer.test.ts
@@ -1,0 +1,21 @@
+import wmEvents from '../src/wm/eventLayer';
+
+describe('wm event layer', () => {
+  jest.useFakeTimers();
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('prevents keyboard focus from overriding recent mouse focus', () => {
+    const handler = jest.fn();
+    wmEvents.on('focus', handler);
+    wmEvents.focus({ id: 'mouse', source: 'mouse' });
+    wmEvents.focus({ id: 'keyboard', source: 'keyboard' });
+    jest.advanceTimersByTime(60);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ id: 'mouse', source: 'mouse' });
+    wmEvents.off('focus', handler);
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import wmEvents from '@/src/wm/eventLayer';
 
 export class Window extends Component {
     constructor(props) {
@@ -412,7 +413,8 @@ export class Window extends Component {
     }
 
     focusWindow = () => {
-        this.props.focus(this.id);
+        wmEvents.raise({ id: this.id });
+        wmEvents.focus({ id: this.id, source: 'mouse' });
     }
 
     minimizeWindow = () => {

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -4,6 +4,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
+  const cancelRef = useRef(false);
 
   const filtered = windows.filter((w) =>
     w.title.toLowerCase().includes(query.toLowerCase())
@@ -15,7 +16,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
 
   useEffect(() => {
     const handleKeyUp = (e) => {
-      if (e.key === 'Alt') {
+      if (e.key === 'Alt' && !cancelRef.current) {
         const win = filtered[selected];
         if (win && typeof onSelect === 'function') {
           onSelect(win.id);
@@ -23,9 +24,18 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           onClose();
         }
       }
+      cancelRef.current = false;
+    };
+    const handleMouseDown = () => {
+      cancelRef.current = true;
+      if (typeof onClose === 'function') onClose();
     };
     window.addEventListener('keyup', handleKeyUp);
-    return () => window.removeEventListener('keyup', handleKeyUp);
+    window.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('mousedown', handleMouseDown);
+    };
   }, [filtered, selected, onSelect, onClose]);
 
   const handleKeyDown = (e) => {

--- a/src/wm/WindowSwitcher.tsx
+++ b/src/wm/WindowSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import keybindingManager from './keybindingManager';
 
 export interface WindowInfo {
@@ -17,6 +17,7 @@ export default function WindowSwitcher({ windows, onSelect }: Props) {
   const [visible, setVisible] = useState(false);
   const [index, setIndex] = useState(0);
   const [cycleAll, setCycleAll] = useState(false);
+  const cancelRef = useRef(false);
 
   useEffect(() => {
     const handleAltTab = () => {
@@ -27,18 +28,25 @@ export default function WindowSwitcher({ windows, onSelect }: Props) {
     keybindingManager.register('Alt+Tab', handleAltTab);
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (visible && e.key === 'Alt') {
+      if (visible && !cancelRef.current && e.key === 'Alt') {
         setVisible(false);
         onSelect?.(windows[index]?.id);
         setIndex(0);
       }
+      cancelRef.current = false;
     };
 
     window.addEventListener('keyup', handleKeyUp);
+    const handleMouseDown = () => {
+      cancelRef.current = true;
+      if (visible) setVisible(false);
+    };
+    window.addEventListener('mousedown', handleMouseDown);
 
     return () => {
       keybindingManager.unregister('Alt+Tab', handleAltTab);
       window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('mousedown', handleMouseDown);
     };
   }, [visible, windows, index, onSelect]);
 

--- a/src/wm/eventLayer.ts
+++ b/src/wm/eventLayer.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from 'events';
+
+export type FocusSource = 'mouse' | 'keyboard' | 'other';
+export interface FocusEvent { id: string; source?: FocusSource }
+export interface RaiseEvent { id: string; }
+
+type EventName = 'focus' | 'raise';
+
+class WMEventLayer extends EventEmitter {
+  private debounceTimers: Partial<Record<EventName, NodeJS.Timeout>> = {};
+  private pending: Partial<Record<EventName, any>> = {};
+  private lastMouseFocus = 0;
+  private DEBOUNCE_MS = 50;
+  private CLICK_GUARD_MS = 100;
+
+  private emitDebounced(event: EventName, payload: any) {
+    this.pending[event] = payload;
+    if (!this.debounceTimers[event]) {
+      this.debounceTimers[event] = setTimeout(() => {
+        const data = this.pending[event];
+        this.debounceTimers[event] = undefined;
+        this.emit(event, data);
+      }, this.DEBOUNCE_MS);
+    }
+  }
+
+  focus(payload: FocusEvent) {
+    const now = Date.now();
+    const source = payload.source || 'other';
+    if (source === 'keyboard' && now - this.lastMouseFocus < this.CLICK_GUARD_MS) {
+      return; // don't steal focus from recent click
+    }
+    if (source === 'mouse') {
+      this.lastMouseFocus = now;
+    }
+    this.emitDebounced('focus', payload);
+  }
+
+  raise(payload: RaiseEvent) {
+    this.emitDebounced('raise', payload);
+  }
+}
+
+const wmEvents = new WMEventLayer();
+export default wmEvents;


### PR DESCRIPTION
## Summary
- debounce window-manager focus/raise events and guard against Alt+Tab stealing click focus
- integrate debounced event layer with desktop window manager and window switcher

## Testing
- `npx jest __tests__/WindowSwitcher.test.tsx`
- `yarn test` *(fails: __tests__/nmapNse.test.tsx, __tests__/Modal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd60b0fe4832882c0d4639f399497