### PR TITLE
feat(panel): toggle status tray mode and reload icons

### DIFF
--- a/components/panel/LegacyTray.tsx
+++ b/components/panel/LegacyTray.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import Status from "../util-components/status";
+
+export default function LegacyTray() {
+  return (
+    <div className="flex items-center gap-2">
+      <Status mode="legacy" />
+    </div>
+  );
+}

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -28,8 +28,9 @@ export default function Preferences() {
 
   const [profileId, setProfileId] = useState(() => {
     if (typeof window === "undefined") return PANEL_PROFILES[0].id;
-    return localStorage.getItem(`${PANEL_PREFIX}profile`) ||
-      PANEL_PROFILES[0].id;
+    return (
+      localStorage.getItem(`${PANEL_PREFIX}profile`) || PANEL_PROFILES[0].id
+    );
   });
 
   const [confirming, setConfirming] = useState<PanelProfile | null>(null);
@@ -44,16 +45,29 @@ export default function Preferences() {
     const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
     return stored ? parseInt(stored, 10) : 100;
   });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
+  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(
+    () => {
+      if (typeof window === "undefined") return "horizontal";
+      return (
+        (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
+          | "horizontal"
+          | "vertical"
+          | null) || "horizontal"
+      );
+    },
+  );
   const [autohide, setAutohide] = useState(() => {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
+  });
+  const [tray, setTray] = useState<"status" | "legacy">(() => {
+    if (typeof window === "undefined") return "status";
+    return (
+      (localStorage.getItem(`${PANEL_PREFIX}tray`) as
+        | "status"
+        | "legacy"
+        | null) || "status"
+    );
   });
 
   useEffect(() => {
@@ -73,8 +87,16 @@ export default function Preferences() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
+    localStorage.setItem(
+      `${PANEL_PREFIX}autohide`,
+      autohide ? "true" : "false",
+    );
   }, [autohide]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(`${PANEL_PREFIX}tray`, tray);
+  }, [tray]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -129,6 +151,20 @@ export default function Preferences() {
               </select>
             </div>
             <div className="flex items-center justify-between">
+              <label htmlFor="tray" className="text-ubt-grey">
+                System Tray
+              </label>
+              <select
+                id="tray"
+                value={tray}
+                onChange={(e) => setTray(e.target.value as "status" | "legacy")}
+                className="bg-ub-cool-grey text-white px-2 py-1 rounded"
+              >
+                <option value="status">Status Tray</option>
+                <option value="legacy">Legacy Tray</option>
+              </select>
+            </div>
+            <div className="flex items-center justify-between">
               <span className="text-ubt-grey">Autohide</span>
               <ToggleSwitch
                 checked={autohide}
@@ -173,10 +209,14 @@ export default function Preferences() {
           </div>
         )}
         {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
+          <p className="text-ubt-grey">
+            Appearance settings are not available yet.
+          </p>
         )}
         {active === "opacity" && (
-          <p className="text-ubt-grey">Opacity settings are not available yet.</p>
+          <p className="text-ubt-grey">
+            Opacity settings are not available yet.
+          </p>
         )}
         {active === "items" && (
           <p className="text-ubt-grey">Item settings are not available yet.</p>
@@ -210,4 +250,3 @@ export default function Preferences() {
     </div>
   );
 }
-

--- a/components/panel/StatusNotifier.tsx
+++ b/components/panel/StatusNotifier.tsx
@@ -4,16 +4,16 @@ import React, { useState } from "react";
 import Status from "../util-components/status";
 
 export default function StatusNotifier() {
-  const [mounted, setMounted] = useState(true);
+  const [key, setKey] = useState(0);
 
-  const reload = () => {
-    setMounted(false);
-    setTimeout(() => setMounted(true), 0);
+  const reload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setKey((k) => k + 1);
   };
 
   return (
     <div className="flex items-center gap-2">
-      {mounted && <Status />}
+      <Status key={key} />
       <button
         type="button"
         onClick={reload}
@@ -24,4 +24,3 @@ export default function StatusNotifier() {
     </div>
   );
 }
-

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,74 @@
-import React, { Component } from 'react';
-import Image from 'next/image';
-import Clock from '../util-components/clock';
-import Status from '../util-components/status';
-import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
+import React, { Component } from "react";
+import Image from "next/image";
+import Clock from "../util-components/clock";
+import StatusNotifier from "../panel/StatusNotifier";
+import LegacyTray from "../panel/LegacyTray";
+import QuickSettings from "../ui/QuickSettings";
+import WhiskerMenu from "../menu/WhiskerMenu";
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+  constructor() {
+    super();
+    this.state = {
+      status_card: false,
+      tray: "status",
+    };
+    this.handleStorage = this.handleStorage.bind(this);
+  }
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+  componentDidMount() {
+    try {
+      const stored = window.localStorage.getItem("xfce.panel.tray");
+      if (stored) this.setState({ tray: stored });
+    } catch {}
+    window.addEventListener("storage", this.handleStorage);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("storage", this.handleStorage);
+  }
+
+  handleStorage(e) {
+    if (e.key === "xfce.panel.tray") {
+      this.setState({ tray: e.newValue || "status" });
+    }
+  }
+
+  render() {
+    return (
+      <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+        <div className="pl-3 pr-1">
+          <Image
+            src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+            alt="network icon"
+            width={16}
+            height={16}
+            className="w-4 h-4"
+          />
+        </div>
+        <WhiskerMenu />
+        <div
+          className={
+            "pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+          }
+        >
+          <Clock />
+        </div>
+        <button
+          type="button"
+          id="status-bar"
+          aria-label="System status"
+          onClick={() => {
+            this.setState({ status_card: !this.state.status_card });
+          }}
+          className={
+            "relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 "
+          }
+        >
+          {this.state.tray === "legacy" ? <LegacyTray /> : <StatusNotifier />}
+          <QuickSettings open={this.state.status_card} />
+        </button>
+      </div>
+    );
+  }
 }

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
+import Image from "next/image";
 import SmallArrow from "./small_arrow";
-import { useSettings } from '../../hooks/useSettings';
-import { useTray } from '../../hooks/useTray';
+import { useSettings } from "../../hooks/useSettings";
+import { useTray } from "../../hooks/useTray";
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
-export default function Status() {
+export default function Status({ mode = "status" }) {
   const { allowNetwork } = useSettings();
   const { icons, register, unregister } = useTray();
   const [online, setOnline] = useState(true);
@@ -15,8 +15,8 @@ export default function Status() {
     const pingServer = async () => {
       if (!window?.location) return;
       try {
-        const url = new URL('/favicon.ico', window.location.href).toString();
-        await fetch(url, { method: 'HEAD', cache: 'no-store' });
+        const url = new URL("/favicon.ico", window.location.href).toString();
+        await fetch(url, { method: "HEAD", cache: "no-store" });
         setOnline(true);
       } catch (e) {
         setOnline(false);
@@ -32,19 +32,23 @@ export default function Status() {
     };
 
     updateStatus();
-    window.addEventListener('online', updateStatus);
-    window.addEventListener('offline', updateStatus);
+    window.addEventListener("online", updateStatus);
+    window.addEventListener("offline", updateStatus);
     return () => {
-      window.removeEventListener('online', updateStatus);
-      window.removeEventListener('offline', updateStatus);
+      window.removeEventListener("online", updateStatus);
+      window.removeEventListener("offline", updateStatus);
     };
   }, []);
 
   useEffect(() => {
-    const id = 'network';
+    const id = "network";
     register({
       id,
-      tooltip: online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline',
+      tooltip: online
+        ? allowNetwork
+          ? "Online"
+          : "Online (requests blocked)"
+        : "Offline",
       sni: online
         ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
         : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg",
@@ -56,35 +60,39 @@ export default function Status() {
   }, [online, allowNetwork, register, unregister]);
 
   useEffect(() => {
-    const id = 'volume';
-    register({ id, tooltip: 'Volume', sni: VOLUME_ICON, legacy: VOLUME_ICON });
+    const id = "volume";
+    register({ id, tooltip: "Volume", sni: VOLUME_ICON, legacy: VOLUME_ICON });
     return () => unregister(id);
   }, [register, unregister]);
 
   useEffect(() => {
-    const id = 'battery';
+    const id = "battery";
     register({
       id,
-      tooltip: 'Battery',
-      sni: '/themes/Yaru/status/battery-good-symbolic.svg',
-      legacy: '/themes/Yaru/status/battery-good-symbolic.svg',
+      tooltip: "Battery",
+      sni: "/themes/Yaru/status/battery-good-symbolic.svg",
+      legacy: "/themes/Yaru/status/battery-good-symbolic.svg",
     });
     return () => unregister(id);
   }, [register, unregister]);
 
   return (
-    <div className="flex justify-center items-center" role="group" aria-label="System tray">
+    <div
+      className="flex justify-center items-center"
+      role="group"
+      aria-label="System tray"
+    >
       {icons.map((icon) => (
         <span key={icon.id} className="mx-1.5 relative" title={icon.tooltip}>
           <Image
             width={16}
             height={16}
-            src={icon.sni || icon.legacy}
+            src={mode === "legacy" ? icon.legacy : icon.sni || icon.legacy}
             alt={icon.tooltip || icon.id}
             className="inline status-symbol w-4 h-4"
             sizes="16px"
           />
-          {icon.id === 'network' && !allowNetwork && (
+          {icon.id === "network" && !allowNetwork && (
             <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
           )}
         </span>


### PR DESCRIPTION
## Summary
- allow choosing Status or Legacy tray from panel preferences
- add Reload indicators action and legacy tray component
- persist tray mode and load appropriate tray in navbar

## Testing
- `yarn lint components/panel/Preferences.tsx components/panel/StatusNotifier.tsx components/panel/LegacyTray.tsx components/screen/navbar.js components/util-components/status.js` *(fails: A control must be associated with a text label, etc.)*
- `yarn test` *(fails: Unable to find role="alert" in nmapNse.test.tsx; TypeError in settingsStore)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd60bbcfc83288ba1a7089b5c8928