### PR TITLE
feat(session): warn when session restore enabled

### DIFF
--- a/apps/settings/session-startup/autostart.tsx
+++ b/apps/settings/session-startup/autostart.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import WarningBanner from '../../../components/WarningBanner';
+import usePersistentState from '../../../hooks/usePersistentState';
+import { AUTO_SAVE_KEY } from '../../../utils/sessionSettings';
 
 interface Entry {
   name: string;
@@ -13,6 +16,11 @@ const STORAGE_KEY = 'autostart-user';
 export default function AutostartSettings() {
   const [userEntries, setUserEntries] = useState<Entry[]>([]);
   const [systemEntries, setSystemEntries] = useState<Entry[]>([]);
+  const [autoRestore] = usePersistentState<boolean>(
+    AUTO_SAVE_KEY,
+    false,
+    (v): v is boolean => typeof v === 'boolean',
+  );
 
   useEffect(() => {
     async function load() {
@@ -48,25 +56,37 @@ export default function AutostartSettings() {
 
   return (
     <div className="p-4 text-white text-sm space-y-4">
+      {autoRestore && (
+        <WarningBanner>
+          Autostart entries are ignored when Restore session on login is enabled.
+        </WarningBanner>
+      )}
       <div>
         <h2 className="font-bold mb-2">User Autostart</h2>
         <ul className="space-y-2">
           {userEntries.map((e, i) => (
-            <li key={i} className="flex items-center gap-2">
+            <li
+              key={i}
+              data-testid="autostart-user-entry"
+              className="flex items-center gap-2"
+            >
               <input
                 type="checkbox"
                 checked={e.enabled}
                 onChange={(ev) => updateUser(i, { enabled: ev.target.checked })}
+                aria-label="Enable entry"
               />
               <input
                 value={e.name}
                 onChange={(ev) => updateUser(i, { name: ev.target.value })}
                 className="bg-ub-cool-grey text-white px-1 py-0.5 rounded w-1/4"
+                aria-label="Entry name"
               />
               <input
                 value={e.exec}
                 onChange={(ev) => updateUser(i, { exec: ev.target.value })}
                 className="bg-ub-cool-grey text-white px-1 py-0.5 rounded flex-grow"
+                aria-label="Entry command"
               />
             </li>
           ))}
@@ -76,8 +96,17 @@ export default function AutostartSettings() {
         <h2 className="font-bold mb-2">System Autostart</h2>
         <ul className="space-y-2">
           {systemEntries.map((e, i) => (
-            <li key={i} className="flex items-center gap-2 italic opacity-75">
-              <input type="checkbox" checked={e.enabled} disabled />
+            <li
+              key={i}
+              data-testid="autostart-system-entry"
+              className="flex items-center gap-2 italic opacity-75"
+            >
+              <input
+                type="checkbox"
+                checked={e.enabled}
+                disabled
+                aria-label="Enabled"
+              />
               <span className="w-1/4">{e.name}</span>
               <span className="flex-grow">{e.exec}</span>
             </li>


### PR DESCRIPTION
## Summary
- show warning banner in Autostart settings when restoring session on login
- test banner with Playwright

## Testing
- `npx eslint apps/settings/session-startup/autostart.tsx tests/e2e/autostart.spec.ts`
- `npx playwright test tests/e2e/autostart.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd60e08908328913bbf4b2a7ad6fc