### PR TITLE
feat(autostart): add trigger chips and reset

### DIFF
--- a/apps/settings/session-startup/autostart.tsx
+++ b/apps/settings/session-startup/autostart.tsx
@@ -6,6 +6,7 @@ interface Entry {
   name: string;
   exec: string;
   enabled: boolean;
+  trigger: 'login' | 'suspend' | 'resume';
 }
 
 const STORAGE_KEY = 'autostart-user';
@@ -13,51 +14,101 @@ const STORAGE_KEY = 'autostart-user';
 export default function AutostartSettings() {
   const [userEntries, setUserEntries] = useState<Entry[]>([]);
   const [systemEntries, setSystemEntries] = useState<Entry[]>([]);
+  const [initialUser, setInitialUser] = useState<Entry[]>([]);
 
   useEffect(() => {
     async function load() {
+      let user: Entry[] = [];
       if (typeof window !== 'undefined') {
         const stored = window.localStorage.getItem(STORAGE_KEY);
         if (stored) {
           try {
-            setUserEntries(JSON.parse(stored));
+            user = JSON.parse(stored);
           } catch {
             // ignore
           }
         } else {
           const res = await fetch('/fixtures/autostart-user.json');
-          setUserEntries(await res.json());
+          user = await res.json();
         }
+      } else {
+        const res = await fetch('/fixtures/autostart-user.json');
+        user = await res.json();
       }
+      user = user.map((e) => ({ trigger: 'login', ...e }));
+      setUserEntries(user);
+      setInitialUser(JSON.parse(JSON.stringify(user)));
+
       const sysRes = await fetch('/fixtures/autostart-system.json');
-      setSystemEntries(await sysRes.json());
+      const sys = (await sysRes.json()).map((e: Entry) => ({ trigger: 'login', ...e }));
+      setSystemEntries(sys);
     }
     load();
   }, []);
+
+  const persist = (next: Entry[]) => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    }
+  };
 
   const updateUser = (idx: number, changes: Partial<Entry>) => {
     setUserEntries((prev) => {
       const next = [...prev];
       next[idx] = { ...next[idx], ...changes };
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      }
+      persist(next);
       return next;
     });
   };
 
+  const handleReset = () => {
+    const reset = initialUser.map((e) => ({ ...e }));
+    setUserEntries(reset);
+    persist(reset);
+  };
+
+  const chip = (
+    value: Entry['trigger'],
+    current: Entry['trigger'],
+    onClick?: () => void,
+  ) => (
+    <button
+      type="button"
+      data-testid={`trigger-chip-${value}`}
+      data-active={current === value}
+      onClick={onClick}
+      disabled={!onClick}
+      className={`px-2 py-0.5 rounded border text-xs ${
+        current === value
+          ? 'bg-ub-orange text-black'
+          : 'bg-ub-cool-grey text-white'
+      } ${!onClick ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      {value.charAt(0).toUpperCase() + value.slice(1)}
+    </button>
+  );
+
   return (
     <div className="p-4 text-white text-sm space-y-4">
       <div>
-        <h2 className="font-bold mb-2">User Autostart</h2>
+        <h2 className="font-bold mb-2">User Autostart (~/.config/autostart)</h2>
         <ul className="space-y-2">
           {userEntries.map((e, i) => (
-            <li key={i} className="flex items-center gap-2">
+            <li
+              key={i}
+              data-testid="autostart-user-entry"
+              className="flex items-center gap-2"
+            >
               <input
                 type="checkbox"
                 checked={e.enabled}
                 onChange={(ev) => updateUser(i, { enabled: ev.target.checked })}
               />
+              <div className="flex gap-1">
+                {chip('login', e.trigger, () => updateUser(i, { trigger: 'login' }))}
+                {chip('suspend', e.trigger, () => updateUser(i, { trigger: 'suspend' }))}
+                {chip('resume', e.trigger, () => updateUser(i, { trigger: 'resume' }))}
+              </div>
               <input
                 value={e.name}
                 onChange={(ev) => updateUser(i, { name: ev.target.value })}
@@ -73,17 +124,33 @@ export default function AutostartSettings() {
         </ul>
       </div>
       <div>
-        <h2 className="font-bold mb-2">System Autostart</h2>
+        <h2 className="font-bold mb-2">System Autostart (/etc/xdg/autostart)</h2>
         <ul className="space-y-2">
           {systemEntries.map((e, i) => (
-            <li key={i} className="flex items-center gap-2 italic opacity-75">
+            <li
+              key={i}
+              data-testid="autostart-system-entry"
+              className="flex items-center gap-2 italic opacity-75"
+            >
               <input type="checkbox" checked={e.enabled} disabled />
+              <div className="flex gap-1">
+                {chip('login', e.trigger)}
+                {chip('suspend', e.trigger)}
+                {chip('resume', e.trigger)}
+              </div>
               <span className="w-1/4">{e.name}</span>
               <span className="flex-grow">{e.exec}</span>
             </li>
           ))}
         </ul>
       </div>
+      <button
+        type="button"
+        className="px-2 py-1 border rounded"
+        onClick={handleReset}
+      >
+        Reset Autostart
+      </button>
     </div>
   );
 }

--- a/pages/autostart.tsx
+++ b/pages/autostart.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const Autostart = dynamic(() => import('../apps/settings/session-startup/autostart'), {
+  ssr: false,
+});
+
+export default function AutostartPage() {
+  return <Autostart />;
+}

--- a/tests/e2e/autostart.spec.ts
+++ b/tests/e2e/autostart.spec.ts
@@ -1,31 +1,36 @@
 import { test, expect } from '@playwright/test';
 
 // E2E tests for the Autostart settings page
-// 1. Verify enabling/disabling user entries persists.
+// 1. Verify edits to user entries persist.
 // 2. Confirm system entries cannot be edited.
-// 3. Test Trigger dropdown and Reset autostart action.
+// 3. Test Trigger chips and Reset autostart action.
 
 test.describe('Autostart settings', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/autostart');
   });
 
-  test('enabling/disabling user entries persists after reload', async ({ page }) => {
+  test('edits to user entries persist after reload', async ({ page }) => {
     const userEntry = page.getByTestId('autostart-user-entry').first();
     const toggle = userEntry.getByRole('checkbox');
+    const suspend = userEntry.getByTestId('trigger-chip-suspend');
 
     const initial = await toggle.isChecked();
+    await suspend.click();
     await toggle.click();
-    await expect(toggle).toBeChecked({ checked: !initial });
 
     await page.reload();
 
-    const toggled = userEntry.getByRole('checkbox');
-    await expect(toggled).toBeChecked({ checked: !initial });
+    const toggled = page.getByTestId('autostart-user-entry').first();
+    const toggleReload = toggled.getByRole('checkbox');
+    const suspendReload = toggled.getByTestId('trigger-chip-suspend');
+    const loginReload = toggled.getByTestId('trigger-chip-login');
+    await expect(toggleReload).toBeChecked({ checked: !initial });
+    await expect(suspendReload).toHaveAttribute('data-active', 'true');
 
     // restore original state to avoid side effects
-    await toggled.click();
-    await expect(toggled).toBeChecked({ checked: initial });
+    await loginReload.click();
+    await toggleReload.click();
   });
 
   test('system entries cannot be edited', async ({ page }) => {
@@ -38,28 +43,22 @@ test.describe('Autostart settings', () => {
     await expect(toggle).toBeChecked({ checked });
   });
 
-  test('Trigger dropdown and Reset autostart', async ({ page }) => {
+  test('Trigger chips and Reset autostart', async ({ page }) => {
     const entry = page.getByTestId('autostart-user-entry').first();
-    const trigger = entry.getByTestId('trigger-select');
     const toggle = entry.getByRole('checkbox');
+    const suspend = entry.getByTestId('trigger-chip-suspend');
+    const login = entry.getByTestId('trigger-chip-login');
     const reset = page.getByRole('button', { name: /reset autostart/i });
 
     const initialToggle = await toggle.isChecked();
-    const initialValue = await trigger.inputValue();
-
-    const options = await trigger.locator('option').all();
-    if (options.length > 1) {
-      const newValue = await options[1].getAttribute('value');
-      await trigger.selectOption(newValue!);
-      await expect(trigger).toHaveValue(newValue!);
-    }
-
+    await suspend.click();
     await toggle.click();
+    await expect(suspend).toHaveAttribute('data-active', 'true');
     await expect(toggle).toBeChecked({ checked: !initialToggle });
 
     await reset.click();
 
-    await expect(trigger).toHaveValue(initialValue);
+    await expect(login).toHaveAttribute('data-active', 'true');
     await expect(toggle).toBeChecked({ checked: initialToggle });
   });
 });


### PR DESCRIPTION
## Summary
- show both user and system autostart entries with trigger chips and reset support
- expose autostart settings at `/autostart`
- add e2e coverage for trigger chip interactions

## Testing
- `npx playwright test tests/e2e/autostart.spec.ts` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd60e6f60832888720dd2b3860c08