### PR TITLE
feat: add session save option to logout modal

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
+import { PROMPT_LOGOUT_KEY } from '../utils/sessionSettings';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
@@ -39,6 +40,7 @@ describe('Ubuntu component', () => {
 
   it('handles lockScreen when status bar is missing', () => {
     let instance: Ubuntu | null = null;
+    window.localStorage.setItem(PROMPT_LOGOUT_KEY, 'false');
     render(<Ubuntu ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {

--- a/components/screen/logout_modal.tsx
+++ b/components/screen/logout_modal.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import Modal from '../base/Modal';
+
+interface LogoutModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (save: boolean) => void;
+  initialSave: boolean;
+}
+
+const LogoutModal: React.FC<LogoutModalProps> = ({ open, onClose, onConfirm, initialSave }) => {
+  const [save, setSave] = useState(initialSave);
+
+  useEffect(() => {
+    setSave(initialSave);
+  }, [initialSave, open]);
+
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70">
+        <div className="w-80 rounded bg-gray-800 p-4 text-white">
+          <h2 className="mb-4 text-lg font-bold">Log out of this session?</h2>
+          <div className="mb-4 flex items-center gap-2 text-sm">
+            <input
+              id="save-session"
+              type="checkbox"
+              checked={save}
+              onChange={() => setSave(!save)}
+              aria-label="Save session for future logins"
+            />
+            <label htmlFor="save-session">Save session for future logins</label>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              className="rounded bg-gray-600 px-3 py-1"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => onConfirm(save)}
+              className="rounded bg-red-600 px-3 py-1"
+            >
+              Log Out
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default LogoutModal;
+


### PR DESCRIPTION
## Summary
- add logout modal with 'Save session for future logins' option
- persist desktop layout when saving session and clear when not
- adjust Ubuntu component test for new prompt behavior

## Testing
- `npx eslint components/ubuntu.js components/screen/logout_modal.tsx __tests__/ubuntu.test.tsx`
- `npx jest __tests__/ubuntu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbd60fbbac8328b45b81b484402214