### PR TITLE
Add workspace switch OSD with DND suppression

### DIFF
--- a/__tests__/osdService.test.ts
+++ b/__tests__/osdService.test.ts
@@ -1,0 +1,24 @@
+import osdService from '../utils/osdService';
+
+jest.useFakeTimers();
+
+describe('osdService', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.localStorage.clear();
+  });
+
+  test('shows and hides message after duration', () => {
+    osdService.show('Hello', 1200);
+    const node = document.querySelector('[data-osd]');
+    expect(node?.textContent).toBe('Hello');
+    jest.advanceTimersByTime(1200);
+    expect(document.querySelector('[data-osd]')).toBeNull();
+  });
+
+  test('suppresses message when Do Not Disturb is enabled', () => {
+    window.localStorage.setItem('notifications-dnd', 'true');
+    osdService.show('Quiet', 1200);
+    expect(document.querySelector('[data-osd]')).toBeNull();
+  });
+});

--- a/__tests__/workspaceOsd.test.ts
+++ b/__tests__/workspaceOsd.test.ts
@@ -1,0 +1,27 @@
+import { Desktop } from '../components/screen/desktop';
+import osdService from '../utils/osdService';
+
+jest.mock('../utils/osdService', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+describe('workspace switch OSD', () => {
+  beforeEach(() => {
+    (osdService.show as jest.Mock).mockClear();
+    window.localStorage.clear();
+  });
+
+  test('displays workspace number and name', () => {
+    window.localStorage.setItem('workspaces', JSON.stringify(['Alpha', 'Beta', 'Gamma']));
+    const desktop = new Desktop();
+    desktop.setState = (updater: any, cb?: () => void) => {
+      const prev = desktop.state;
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      desktop.state = { ...prev, ...next };
+      cb && cb();
+    };
+    desktop.switchWorkspace(1);
+    expect(osdService.show).toHaveBeenCalledWith('Workspace 2 — Beta', 1200);
+  });
+});

--- a/utils/osdService.ts
+++ b/utils/osdService.ts
@@ -1,0 +1,47 @@
+import { getDoNotDisturb } from './notificationSettings';
+
+/**
+ * Simple on-screen display (OSD) service for showing transient messages.
+ * Messages are suppressed when Do Not Disturb is enabled.
+ */
+class OSDService {
+  private el: HTMLDivElement | null = null;
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Show an OSD message for the given duration in milliseconds.
+   */
+  show(message: string, duration = 1200): void {
+    if (getDoNotDisturb()) return;
+    if (typeof document === 'undefined') return;
+
+    if (!this.el) {
+      this.el = document.createElement('div');
+      this.el.dataset.osd = 'true';
+      Object.assign(this.el.style, {
+        position: 'fixed',
+        top: '20px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        padding: '8px 12px',
+        background: 'var(--toast-bg)',
+        color: 'var(--toast-text)',
+        border: '1px solid var(--toast-border)',
+        borderRadius: 'var(--radius-md)',
+        zIndex: '9999',
+      });
+      document.body.appendChild(this.el);
+    }
+
+    this.el.textContent = message;
+
+    if (this.timeout) clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.el?.remove();
+      this.el = null;
+    }, duration);
+  }
+}
+
+const osdService = new OSDService();
+export default osdService;


### PR DESCRIPTION
## Summary
- Add on-screen display service that shows transient messages and respects Do Not Disturb
- Show "Workspace # — Name" for 1.2s when switching workspaces

## Testing
- `yarn test __tests__/osdService.test.ts __tests__/workspaceOsd.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bbd61027488328b9b959f3788e5ab4