### PR TITLE
Wire logout and lock in quick settings

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -6,15 +6,15 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+        constructor() {
+                super();
+                this.state = {
+                        status_card: false
+                };
+        }
 
-	render() {
-		return (
+        render() {
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
@@ -39,9 +39,13 @@ export default class Navbar extends Component {
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings
+                                                open={this.state.status_card}
+                                                lockScreen={this.props.lockScreen}
+                                                logOut={this.props.logOut}
+                                        />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -111,10 +111,15 @@ export default class Ubuntu extends Component {
                 this.maybeShowSessionChooser();
         };
 
-	changeBackgroundImage = (img_name) => {
-		this.setState({ bg_image_name: img_name });
+        changeBackgroundImage = (img_name) => {
+                this.setState({ bg_image_name: img_name });
                 safeLocalStorage?.setItem('bg-image', img_name);
-	};
+        };
+
+        logOut = () => {
+                this.props.resetSession && this.props.resetSession();
+                this.lockScreen();
+        };
 
         shutDown = () => {
                 const autoSave = safeLocalStorage?.getItem(AUTO_SAVE_KEY) === 'true';
@@ -156,7 +161,7 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Navbar lockScreen={this.lockScreen} logOut={this.logOut} />
                                 <Desktop
                                         ref={this.desktopRef}
                                         bg_image_name={this.state.bg_image_name}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -5,9 +5,11 @@ import { useEffect } from 'react';
 
 interface Props {
   open: boolean;
+  lockScreen: () => void;
+  logOut: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
@@ -52,9 +54,42 @@ const QuickSettings = ({ open }: Props) => {
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>
-      <div className="px-4 pt-2 border-t border-black border-opacity-20 mt-2">
+      <div className="px-4 pt-2 border-t border-black border-opacity-20 mt-2 space-y-1">
         <button
-          className="w-full text-left text-blue-300 hover:underline"
+          type="button"
+          className="w-full text-left hover:underline"
+          onClick={lockScreen}
+        >
+          Lock
+        </button>
+        <button
+          type="button"
+          className="w-full text-left hover:underline"
+          onClick={logOut}
+        >
+          Log Out
+        </button>
+        <button
+          type="button"
+          className="w-full text-left text-gray-400 cursor-not-allowed"
+          disabled
+          title="Restart is disabled in this demo"
+          aria-disabled="true"
+        >
+          Restart
+        </button>
+        <button
+          type="button"
+          className="w-full text-left text-gray-400 cursor-not-allowed"
+          disabled
+          title="Shut Down is disabled in this demo"
+          aria-disabled="true"
+        >
+          Shut Down
+        </button>
+        <button
+          type="button"
+          className="w-full text-left text-blue-300 hover:underline pt-1"
           onClick={() => {
             window.localStorage.setItem('settings-open-tab', 'power');
             document.dispatchEvent(


### PR DESCRIPTION
## Summary
- add Lock and Log Out actions to Quick Settings panel
- disable Restart/Shut Down with explanatory tooltips
- connect logout action to session reset and lock screen

## Testing
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbd61099c08328b91f7f90f07fe03c