### PR TITLE
feat: add hash routes for settings

### DIFF
--- a/components/util-components/calendar-popup.js
+++ b/components/util-components/calendar-popup.js
@@ -74,6 +74,14 @@ export default function CalendarPopup() {
           </div>
         )) : <div>No events</div>}
       </div>
+      <div className="mt-2 text-xs">
+        <a
+          href="/apps/settings#datetime"
+          className="text-blue-400 hover:underline"
+        >
+          Time & Date Settings
+        </a>
+      </div>
     </div>
   );
 }

--- a/pages/apps/settings/dpi.tsx
+++ b/pages/apps/settings/dpi.tsx
@@ -1,0 +1,21 @@
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function DpiSettings() {
+  const { density, setDensity } = useSettings();
+  return (
+    <div className="p-4 text-ubt-grey">
+      <h1 className="text-xl mb-4">Display</h1>
+      <div className="flex items-center gap-2">
+        <span>Interface density</span>
+        <select
+          value={density}
+          onChange={(e) => setDensity(e.target.value as any)}
+          className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+        >
+          <option value="regular">Regular</option>
+          <option value="compact">Compact</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/pages/apps/settings/fonts.tsx
+++ b/pages/apps/settings/fonts.tsx
@@ -1,0 +1,23 @@
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function FontsSettings() {
+  const { fontScale, setFontScale } = useSettings();
+  return (
+    <div className="p-4 text-ubt-grey">
+      <h1 className="text-xl mb-4">Fonts</h1>
+      <div className="flex items-center gap-2">
+        <span>Font scale</span>
+        <input
+          type="range"
+          min="0.75"
+          max="1.5"
+          step="0.05"
+          value={fontScale}
+          onChange={(e) => setFontScale(parseFloat(e.target.value))}
+          className="ubuntu-slider"
+          aria-label="Font scale"
+        />
+      </div>
+    </div>
+  );
+}

--- a/pages/apps/settings/icons.tsx
+++ b/pages/apps/settings/icons.tsx
@@ -1,0 +1,19 @@
+import ToggleSwitch from '../../../components/ToggleSwitch';
+import { useSettings } from '../../../hooks/useSettings';
+
+export default function IconsSettings() {
+  const { highContrast, setHighContrast } = useSettings();
+  return (
+    <div className="p-4 text-ubt-grey">
+      <h1 className="text-xl mb-4">Icons</h1>
+      <div className="flex items-center gap-2">
+        <span>High contrast icons</span>
+        <ToggleSwitch
+          checked={highContrast}
+          onChange={setHighContrast}
+          ariaLabel="Toggle high contrast icons"
+        />
+      </div>
+    </div>
+  );
+}

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -1,10 +1,48 @@
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 
 const SettingsApp = dynamic(() => import('../../../apps/settings'), {
   ssr: false,
 });
+const DateTimeSettings = dynamic(() => import('./date-time'), {
+  ssr: false,
+});
+const IconSettings = dynamic(() => import('./icons'), {
+  ssr: false,
+});
+const FontSettings = dynamic(() => import('./fonts'), {
+  ssr: false,
+});
+const DpiSettings = dynamic(() => import('./dpi'), {
+  ssr: false,
+});
+const MouseSettings = dynamic(() => import('./mouse'), {
+  ssr: false,
+});
 
 export default function SettingsPage() {
-  return <SettingsApp />;
+  const [hash, setHash] = useState('');
+
+  useEffect(() => {
+    const handle = () => setHash(window.location.hash.slice(1));
+    handle();
+    window.addEventListener('hashchange', handle);
+    return () => window.removeEventListener('hashchange', handle);
+  }, []);
+
+  switch (hash) {
+    case 'datetime':
+      return <DateTimeSettings />;
+    case 'icons':
+      return <IconSettings />;
+    case 'fonts':
+      return <FontSettings />;
+    case 'dpi':
+      return <DpiSettings />;
+    case 'mouse':
+      return <MouseSettings />;
+    default:
+      return <SettingsApp />;
+  }
 }
 

--- a/pages/apps/settings/mouse.tsx
+++ b/pages/apps/settings/mouse.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+import ToggleSwitch from '../../../components/ToggleSwitch';
+
+export default function MouseSettings() {
+  const [accel, setAccel] = useState(false);
+  return (
+    <div className="p-4 text-ubt-grey">
+      <h1 className="text-xl mb-4">Mouse</h1>
+      <div className="flex items-center gap-2">
+        <span>Enable acceleration</span>
+        <ToggleSwitch
+          checked={accel}
+          onChange={setAccel}
+          ariaLabel="Toggle mouse acceleration"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support deep linking to settings sections via URL hash fragments
- add placeholder pages for icons, fonts, DPI and mouse settings
- link calendar popup to `Time & Date Settings` section

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/Modal.test.tsx __tests__/flappyBird.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6115b408328abf09f1f016c58ee