### PR TITLE
feat(settings): add advanced CSP domain list

### DIFF
--- a/apps/settings/components/AdvancedTab.tsx
+++ b/apps/settings/components/AdvancedTab.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+interface DomainInfo {
+  domain: string;
+  allowed: boolean;
+  purpose: string;
+}
+
+const domains: DomainInfo[] = [
+  { domain: "platform.twitter.com", allowed: true, purpose: "Twitter widgets" },
+  { domain: "syndication.twitter.com", allowed: true, purpose: "Twitter embeds" },
+  { domain: "cdn.syndication.twimg.com", allowed: true, purpose: "Twitter CDN" },
+  { domain: "stackblitz.com", allowed: true, purpose: "StackBlitz IDE" },
+  { domain: "www.youtube-nocookie.com", allowed: true, purpose: "YouTube videos" },
+  { domain: "open.spotify.com", allowed: true, purpose: "Spotify embeds" },
+  { domain: "example.com", allowed: true, purpose: "Chrome demo" },
+  { domain: "developer.mozilla.org", allowed: true, purpose: "Chrome demo" },
+  { domain: "en.wikipedia.org", allowed: true, purpose: "Chrome demo" },
+  { domain: "react.dev", allowed: false, purpose: "React docs" },
+];
+
+const snippet = `const ContentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "img-src 'self' https: data:",
+  "style-src 'self' 'unsafe-inline'",
+  "style-src-elem 'self' 'unsafe-inline'",
+  "font-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
+  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+  "frame-ancestors 'self'",
+  "upgrade-insecure-requests",
+].join('; ');`;
+
+export default function AdvancedTab() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <h2 className="mb-2 font-bold">External Domains</h2>
+        <ul className="space-y-1">
+          {domains.map(({ domain, allowed, purpose }) => (
+            <li key={domain} className="flex items-center gap-2">
+              <span>{domain}</span>
+              <span
+                className={`px-2 py-0.5 text-xs rounded text-white ${
+                  allowed ? "bg-green-600" : "bg-red-600"
+                }`}
+              >
+                {allowed ? "Allowed" : "Blocked"}
+              </span>
+              <span className="text-xs text-gray-300">{purpose}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="mb-2 font-bold">next.config.js</h2>
+        <pre
+          aria-label="next-config-snippet"
+          className="bg-ub-cool-grey text-ubt-grey p-2 rounded overflow-auto"
+        >
+{snippet}
+        </pre>
+        <button
+          type="button"
+          onClick={copy}
+          className="mt-2 px-4 py-1 rounded bg-ub-orange text-white"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import AdvancedTab from "./components/AdvancedTab";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import KernelTab from "./components/KernelTab";
 import {
@@ -43,6 +44,7 @@ export default function Settings() {
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
     { id: "kernel", label: "Kernel" },
+    { id: "advanced", label: "Advanced" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -327,6 +329,7 @@ export default function Settings() {
         </>
       )}
       {activeTab === "kernel" && <KernelTab />}
+      {activeTab === "advanced" && <AdvancedTab />}
         <input
           type="file"
           accept="application/json"


### PR DESCRIPTION
## Summary
- add Advanced tab that surfaces external embed domains and CSP status
- include copyable `next.config.js` snippet in settings

## Testing
- `npx eslint apps/settings/index.tsx apps/settings/components/AdvancedTab.tsx`
- `npx playwright test tests/settings/helpers-pane.spec.tsx` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd61503f8832884b34708e8350040