### PR TITLE
Add file manager transfer queue with pause/resume

### DIFF
--- a/__tests__/fileManagerStatusBar.test.tsx
+++ b/__tests__/fileManagerStatusBar.test.tsx
@@ -14,7 +14,7 @@ const folder: FileItem = {
 describe('StatusBar', () => {
   test('updates count and size when selection changes', async () => {
     const { rerender } = render(<StatusBar selectedItems={[]} />);
-    expect(screen.getByText('0 items selected')).toBeInTheDocument();
+    expect(screen.getByText('No items selected')).toBeInTheDocument();
     expect(screen.getByText('0 B')).toBeInTheDocument();
 
     rerender(<StatusBar selectedItems={[file]} />);

--- a/__tests__/transfersDialog.test.tsx
+++ b/__tests__/transfersDialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+import TransfersDialog from '../components/file-manager/TransfersDialog';
+import { TransferManager } from '../components/file-manager/TransferManager';
+
+function mockJob() {
+  return {
+    run: () => new Promise<void>(() => {}),
+    pause: () => {},
+    resume: () => {},
+  };
+}
+
+describe('TransfersDialog', () => {
+  test('shows copying and queued counts', () => {
+    const manager = new TransferManager();
+    manager.setMode('queued');
+    render(<TransfersDialog manager={manager} />);
+    act(() => {
+      manager.start(mockJob());
+      manager.start(mockJob());
+    });
+    expect(screen.getByTestId('summary').textContent).toBe('Copying 1, Queued 1');
+  });
+
+  test('pauses and resumes transfers', () => {
+    const manager = new TransferManager();
+    manager.setMode('queued');
+    render(<TransfersDialog manager={manager} />);
+    let job: any;
+    act(() => {
+      job = manager.start(mockJob());
+      manager.start(mockJob());
+    });
+    const pauseBtn = screen.getByText('Pause');
+    act(() => {
+      fireEvent.click(pauseBtn);
+    });
+    expect(screen.getByTestId('summary').textContent).toBe('Copying 1');
+    const resumeBtn = screen.getByText('Resume');
+    act(() => {
+      fireEvent.click(resumeBtn);
+    });
+    expect(screen.getByTestId('summary').textContent).toBe('Copying 1, Queued 1');
+  });
+});

--- a/components/file-manager/StatusBar.tsx
+++ b/components/file-manager/StatusBar.tsx
@@ -61,9 +61,11 @@ export default function StatusBar({ selectedItems }: StatusBarProps) {
   }, [selectedItems]);
 
   const count = selectedItems.length;
+  const label =
+    count === 0 ? 'No items selected' : `${count} item${count === 1 ? '' : 's'} selected`;
   return (
     <div className="w-full px-2 py-1 border-t border-gray-600 flex justify-between text-xs text-white bg-ub-warm-grey bg-opacity-40">
-      <span>{count} item{count === 1 ? '' : 's'} selected</span>
+      <span>{label}</span>
       <span>{formatBytes(size)}</span>
     </div>
   );

--- a/components/file-manager/TransferManager.ts
+++ b/components/file-manager/TransferManager.ts
@@ -1,0 +1,99 @@
+export type TransferMode = 'parallel' | 'queued';
+
+export type TransferStatus = 'queued' | 'copying' | 'paused' | 'completed';
+
+export interface TransferJob {
+  id: number;
+  run: () => Promise<void>;
+  pause?: () => void;
+  resume?: () => void;
+  status: TransferStatus;
+}
+
+type Listener = () => void;
+
+export class TransferManager {
+  private mode: TransferMode = 'parallel';
+  private queue: TransferJob[] = [];
+  private active: TransferJob[] = [];
+  private paused: TransferJob[] = [];
+  private listeners: Set<Listener> = new Set();
+  private nextId = 1;
+
+  setMode(mode: TransferMode) {
+    this.mode = mode;
+  }
+
+  start(job: Omit<TransferJob, 'id' | 'status'>): TransferJob {
+    const full: TransferJob = { ...job, id: this.nextId++, status: 'queued' };
+    if (this.mode === 'parallel' || this.active.length === 0) {
+      this.run(full);
+    } else {
+      this.queue.push(full);
+      this.notify();
+    }
+    return full;
+  }
+
+  pause(job: TransferJob) {
+    if (job.status === 'copying') {
+      job.pause?.();
+      job.status = 'paused';
+      this.active = this.active.filter((j) => j.id !== job.id);
+      this.paused.push(job);
+      this.notify();
+      if (this.mode === 'queued' && this.queue.length > 0) {
+        this.run(this.queue.shift()!);
+      }
+    }
+  }
+
+  resume(job: TransferJob) {
+    if (job.status === 'paused') {
+      this.paused = this.paused.filter((j) => j.id !== job.id);
+      if (this.mode === 'queued' && this.active.length > 0) {
+        job.status = 'queued';
+        this.queue.push(job);
+        this.notify();
+      } else {
+        this.run(job);
+      }
+    }
+  }
+
+  getSummary(): string {
+    const copying = this.active.length;
+    const queued = this.queue.length;
+    let summary = `Copying ${copying}`;
+    if (queued > 0) summary += `, Queued ${queued}`;
+    return summary;
+  }
+
+  getJobs(): TransferJob[] {
+    return [...this.active, ...this.queue, ...this.paused];
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify() {
+    for (const l of this.listeners) l();
+  }
+
+  private run(job: TransferJob) {
+    job.status = 'copying';
+    this.active.push(job);
+    this.notify();
+    job.run().finally(() => {
+      job.status = 'completed';
+      this.active = this.active.filter((j) => j.id !== job.id);
+      this.notify();
+      if (this.mode === 'queued' && this.queue.length > 0) {
+        this.run(this.queue.shift()!);
+      }
+    });
+  }
+}
+

--- a/components/file-manager/TransfersDialog.tsx
+++ b/components/file-manager/TransfersDialog.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TransferManager, TransferJob } from './TransferManager';
+
+interface TransfersDialogProps {
+  manager: TransferManager;
+}
+
+export default function TransfersDialog({ manager }: TransfersDialogProps) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    return manager.subscribe(() => setTick((t) => t + 1));
+  }, [manager]);
+
+  const jobs = manager.getJobs();
+
+  return (
+    <div className="p-2 text-sm text-white bg-ub-warm-grey bg-opacity-40">
+      <div className="mb-2" data-testid="summary">
+        {manager.getSummary()}
+      </div>
+      <ul>
+        {jobs.map((job) => (
+          <li key={job.id} className="mb-1 flex gap-2 items-center">
+            <span className="flex-1">Job {job.id} - {job.status}</span>
+            {job.status === 'copying' && (
+              <button onClick={() => manager.pause(job)}>Pause</button>
+            )}
+            {job.status === 'paused' && (
+              <button onClick={() => manager.resume(job)}>Resume</button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- show explicit message when no items are selected in file manager status bar
- introduce TransferManager with queuing and pause/resume support
- add Transfers dialog to display active and queued operations

## Testing
- `yarn test __tests__/transfersDialog.test.tsx __tests__/fileManagerStatusBar.test.tsx`
- `yarn test` *(fails: Unable to find role="alert" in __tests__/nmapNse.test.tsx, localStorage origin error)*
- `yarn lint` *(fails: 614 problems, e.g., A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd615e3f083288e8663731ab5fd27