### PR TITLE
Use createImageBitmap and free offscreen sprite strips

### DIFF
--- a/__tests__/spriteStrip.test.tsx
+++ b/__tests__/spriteStrip.test.tsx
@@ -1,28 +1,71 @@
 import { render } from '@testing-library/react';
 import { act } from 'react';
 import SpriteStripPreview from '../components/SpriteStripPreview';
-import { importSpriteStrip, clearSpriteStripCache } from '../utils/spriteStrip';
+import {
+  importSpriteStrip,
+  clearSpriteStripCache,
+  stripCacheSize,
+} from '../utils/spriteStrip';
 
 jest.useFakeTimers();
 
+// Minimal 1x1 PNG
+const base64Png =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAn8B9/4afyoAAAAASUVORK5CYII=';
+
+beforeAll(() => {
+  const blob = new Blob([Uint8Array.from(atob(base64Png), (c) => c.charCodeAt(0))], {
+    type: 'image/png',
+  });
+  global.fetch = jest
+    .fn(() => Promise.resolve({ blob: () => Promise.resolve(blob) })) as unknown as typeof fetch;
+  global.createImageBitmap = jest
+    .fn(() => Promise.resolve({ close: jest.fn() })) as unknown as typeof createImageBitmap;
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+  global.IntersectionObserver = class {
+    private cb: IntersectionObserverCallback;
+    constructor(cb: IntersectionObserverCallback) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ isIntersecting: true } as IntersectionObserverEntry]);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof IntersectionObserver;
+});
+
 describe('sprite strip utilities', () => {
-  test('imports strips with caching', () => {
+  test('imports strips with caching', async () => {
     clearSpriteStripCache();
-    const img1 = importSpriteStrip('foo.png');
-    const img2 = importSpriteStrip('foo.png');
-    expect(img1).toBe(img2);
+    const p1 = importSpriteStrip('foo.png');
+    const p2 = importSpriteStrip('foo.png');
+    expect(p1).toBe(p2);
+    await p1;
   });
 
-  test('preview advances frames', () => {
+  test('preview advances frames', async () => {
     const { getByTestId } = render(
       <SpriteStripPreview src="foo.png" frameWidth={10} frameHeight={10} frames={3} fps={10} />,
     );
     const el = getByTestId('sprite-strip-preview');
     expect(el).toBeTruthy();
     expect(el).toHaveStyle('background-position: 0px 0px');
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(100);
     });
     expect(el).toHaveStyle('background-position: -10px 0px');
+  });
+
+  test('releases resources to keep memory stable', async () => {
+    clearSpriteStripCache();
+    const before = stripCacheSize();
+    for (let i = 0; i < 50; i++) {
+      const res = await importSpriteStrip('foo.png');
+      res.release();
+    }
+    const after = stripCacheSize();
+    expect(after).toBe(before);
   });
 });

--- a/components/SpriteStripPreview.tsx
+++ b/components/SpriteStripPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { importSpriteStrip } from '../utils/spriteStrip';
 
 interface SpriteStripPreviewProps {
@@ -27,10 +27,39 @@ const SpriteStripPreview: React.FC<SpriteStripPreviewProps> = ({
   fps = 12,
 }) => {
   const [frame, setFrame] = useState(0);
+  const [url, setUrl] = useState<string | null>(null);
+  const releaseRef = useRef<() => void>(() => {});
+  const divRef = useRef<HTMLDivElement>(null);
 
-  // Preload and cache the sprite strip
+  // Observe visibility to load/unload strip
   useEffect(() => {
-    importSpriteStrip(src);
+    const node = divRef.current;
+    if (!node) return;
+
+    const load = async () => {
+      const res = await importSpriteStrip(src);
+      setUrl(res.url);
+      releaseRef.current = res.release;
+    };
+
+    const onChange: IntersectionObserverCallback = (entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          load();
+        } else {
+          releaseRef.current();
+          releaseRef.current = () => {};
+          setUrl(null);
+        }
+      });
+    };
+
+    const obs = new IntersectionObserver(onChange);
+    obs.observe(node);
+    return () => {
+      obs.disconnect();
+      releaseRef.current();
+    };
   }, [src]);
 
   // Cycle through frames
@@ -45,13 +74,13 @@ const SpriteStripPreview: React.FC<SpriteStripPreviewProps> = ({
   const style: React.CSSProperties = {
     width: frameWidth,
     height: frameHeight,
-    backgroundImage: `url(${src})`,
+    backgroundImage: url ? `url(${url})` : undefined,
     backgroundPosition: `-${frame * frameWidth}px 0px`,
     backgroundRepeat: 'no-repeat',
     imageRendering: 'pixelated',
   };
 
-  return <div style={style} data-testid="sprite-strip-preview" />;
+  return <div ref={divRef} style={style} data-testid="sprite-strip-preview" />;
 };
 
 export default SpriteStripPreview;


### PR DESCRIPTION
## Summary
- Decode sprite strip images using `createImageBitmap`
- Revoke object URLs and release filmstrip images when offscreen
- Add regression tests to ensure repeated navigation doesn't leak memory

## Testing
- `yarn test __tests__/spriteStrip.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbd616f75083288dca13ecfac39575