### PR TITLE
feat(panel): expose now playing controls

### DIFF
--- a/utils/nowPlaying.ts
+++ b/utils/nowPlaying.ts
@@ -1,0 +1,40 @@
+import { publish as pub, subscribe as sub } from './pubsub';
+
+export interface NowPlayingState {
+  track: string | null;
+  playing: boolean;
+}
+
+const STATE_TOPIC = 'nowPlaying:state';
+const CONTROL_TOPIC = 'nowPlaying:control';
+
+let state: NowPlayingState = { track: null, playing: false };
+
+export const getState = () => state;
+
+export const setState = (partial: Partial<NowPlayingState>): void => {
+  state = { ...state, ...partial };
+  pub(STATE_TOPIC, state);
+};
+
+export const subscribeState = (
+  handler: (s: NowPlayingState) => void
+): (() => void) => {
+  handler(state);
+  return sub(STATE_TOPIC, handler);
+};
+
+export type ControlAction = 'play' | 'pause' | 'next' | 'prev';
+
+export const control = (action: ControlAction): void => {
+  pub(CONTROL_TOPIC, action);
+};
+
+export const subscribeControl = (
+  handler: (a: ControlAction) => void
+): (() => void) => sub(CONTROL_TOPIC, handler);
+
+export const play = () => control('play');
+export const pause = () => control('pause');
+export const next = () => control('next');
+export const prev = () => control('prev');


### PR DESCRIPTION
## Summary
- add pubsub-driven now playing API
- wire media player to broadcast state and handle remote controls
- show track info with play/pause/next/prev in panel volume popover

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/Clipman.test.tsx` *(fails: Unable to find role="alert")*
- `yarn lint components/apps/MediaPlayer.tsx components/panel/Volume.tsx utils/nowPlaying.ts` *(fails: 597 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd61771b48328aca62a19d9beac05