### PR TITLE
docs: document app finder shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ See `.env.local.example` for the full list.
 
 ---
 
+## App Finder
+
+- Press **Ctrl+Space** to open a compact run dialog.
+- The expanded view organizes results into categories and favorites.
+- Drag a search result onto the panel to create a launcher.
+- Press **Esc** to close the finder.
+
+---
+
 ## Speed Insights
 
 - Enable Speed Insights in the Vercel project dashboard.

--- a/data/xfce4/default-shortcuts.json
+++ b/data/xfce4/default-shortcuts.json
@@ -1,5 +1,5 @@
 [
-  { "command": "xfce4-appfinder", "keys": "Alt+F2" },
+  { "command": "xfce4-appfinder", "keys": "Ctrl+Space" },
   { "command": "xfce4-terminal", "keys": "Ctrl+Alt+T" },
   { "command": "thunar", "keys": "Super+E" },
   { "command": "xfce4-session-logout", "keys": "Ctrl+Alt+Delete" },


### PR DESCRIPTION
## Summary
- document App Finder features and shortcuts
- update default shortcut to use Ctrl+Space for app finder

## Testing
- `yarn lint data/xfce4/default-shortcuts.json README.md`
- `yarn test` *(fails: Unable to find role="alert" in nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd617ba3c8328911b5732f561b3f6