### PR TITLE
feat: add mock volume management and removable media settings

### DIFF
--- a/components/filemanager/Sidebar.tsx
+++ b/components/filemanager/Sidebar.tsx
@@ -10,23 +10,35 @@ export interface Device {
 
 interface SidebarProps {
   devices: readonly Device[];
+  onEject?: (id: string) => void;
 }
 
-export default function Sidebar({ devices }: SidebarProps) {
+export default function Sidebar({ devices, onEject }: SidebarProps) {
   return (
     <aside className="p-2 w-48 bg-gray-100" aria-label="device sidebar">
       <ul>
         {devices.map((device) => (
-          <li key={device.id} className="mb-1">
+          <li key={device.id} className="mb-1 flex items-center justify-between">
             <span>{device.label || device.name}</span>
-            {!device.label && (
-              <span
-                className="ml-2 text-xs text-ubt-grey italic"
-                title="Label volumes for easier identification"
-              >
-                (Tip: label this volume for easier identification)
-              </span>
-            )}
+            <div className="flex items-center gap-2">
+              {!device.label && (
+                <span
+                  className="text-xs text-ubt-grey italic"
+                  title="Label volumes for easier identification"
+                >
+                  (Tip: label this volume for easier identification)
+                </span>
+              )}
+              {onEject && (
+                <button
+                  onClick={() => onEject(device.id)}
+                  className="text-xs text-ubt-grey underline"
+                  aria-label={`eject-${device.name}`}
+                >
+                  Eject
+                </button>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/pages/apps/settings/removable-media.tsx
+++ b/pages/apps/settings/removable-media.tsx
@@ -4,67 +4,109 @@ import { useState } from 'react';
 import ToggleSwitch from '../../../components/ToggleSwitch';
 import Toast from '../../../components/ui/Toast';
 
+interface Settings {
+  mountDrives: boolean;
+  mountMedia: boolean;
+  browseMedia: boolean;
+  autoRun: boolean;
+  cameraImportCommand: string;
+}
+
 export default function RemovableMediaPage() {
-  const [autoRun, setAutoRun] = useState(false);
-  const [promptOpen, setPromptOpen] = useState(false);
+  const [settings, setSettings] = useState<Settings>({
+    mountDrives: false,
+    mountMedia: false,
+    browseMedia: false,
+    autoRun: false,
+    cameraImportCommand: '',
+  });
   const [toast, setToast] = useState('');
 
+  const update = (partial: Partial<Settings>) =>
+    setSettings((s) => ({ ...s, ...partial }));
+
   const insertDevice = () => {
-    if (autoRun) {
-      setPromptOpen(true);
-    }
+    window.localStorage.setItem(
+      'volume-event',
+      JSON.stringify({
+        type: 'insert',
+        id: 'demo-usb',
+        label: 'Demo USB',
+        open: settings.browseMedia,
+      }),
+    );
+    setToast(settings.autoRun ? 'Demo; no binaries executed' : 'Demo USB inserted');
   };
 
-  const handleRun = () => {
-    setPromptOpen(false);
-    setToast('Demo; no binaries executed');
+  const ejectDevice = () => {
+    window.localStorage.setItem(
+      'volume-event',
+      JSON.stringify({ type: 'eject', id: 'demo-usb' }),
+    );
   };
 
   return (
-    <div className="p-4 text-white">
-      <div className="flex items-center space-x-2">
-        <span className="text-ubt-grey">Auto-run programs when media is inserted</span>
+    <div className="p-4 text-white space-y-4">
+      <div className="flex items-center justify-between">
+        <span>Mount removable drives when hot-plugged</span>
         <ToggleSwitch
-          checked={autoRun}
-          onChange={setAutoRun}
-          ariaLabel="Auto-run programs when media is inserted"
+          checked={settings.mountDrives}
+          onChange={(checked) => update({ mountDrives: checked })}
+          ariaLabel="Mount removable drives when hot-plugged"
         />
       </div>
-      <button
-        onClick={insertDevice}
-        className="mt-4 px-4 py-2 rounded bg-ub-orange text-white"
-      >
-        Insert device with autorun
-      </button>
-
-      {promptOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
-          role="dialog"
-          aria-modal="true"
+      <div className="flex items-center justify-between">
+        <span>Mount removable media when inserted</span>
+        <ToggleSwitch
+          checked={settings.mountMedia}
+          onChange={(checked) => update({ mountMedia: checked })}
+          ariaLabel="Mount removable media when inserted"
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Browse removable media when inserted</span>
+        <ToggleSwitch
+          checked={settings.browseMedia}
+          onChange={(checked) => update({ browseMedia: checked })}
+          ariaLabel="Browse removable media when inserted"
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Auto-run programs on new drives and media</span>
+        <ToggleSwitch
+          checked={settings.autoRun}
+          onChange={(checked) => update({ autoRun: checked })}
+          ariaLabel="Auto-run programs on new drives and media"
+        />
+      </div>
+      <div>
+        <label htmlFor="camera-import" className="block mb-1">
+          Camera import command
+        </label>
+        <input
+          id="camera-import"
+          type="text"
+          value={settings.cameraImportCommand}
+          onChange={(e) => update({ cameraImportCommand: e.target.value })}
+          className="w-full border rounded p-1"
+          aria-label="Camera import command"
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={insertDevice}
+          className="px-4 py-2 rounded bg-ub-orange text-white"
         >
-          <div className="bg-ub-cool-grey p-4 rounded space-y-4">
-            <p>Autorun program detected. Run it?</p>
-            <div className="flex justify-end space-x-2">
-              <button
-                onClick={handleRun}
-                className="px-4 py-2 bg-ub-orange text-white rounded"
-              >
-                Run
-              </button>
-              <button
-                onClick={() => setPromptOpen(false)}
-                className="px-4 py-2 bg-ubt-cool-grey text-white rounded"
-              >
-                Ignore
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
+          Insert mock device
+        </button>
+        <button
+          onClick={ejectDevice}
+          className="px-4 py-2 rounded bg-ubt-cool-grey text-white"
+        >
+          Eject device
+        </button>
+      </div>
       {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 }
-

--- a/tests/file-manager/volume-management.spec.ts
+++ b/tests/file-manager/volume-management.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+// Verify mock device insertion shows toast, opens folder and eject removes sidebar device.
+
+test.describe('Volume management', () => {
+  test('mock device insert and eject', async ({ context }) => {
+    const explorer = await context.newPage();
+    await explorer.goto('/apps/file-explorer');
+
+    const settings = await context.newPage();
+    await settings.goto('/apps/settings/removable-media');
+
+    // Insert device
+    await settings.getByRole('button', { name: 'Insert mock device' }).click();
+    await expect(settings.getByText('Demo USB inserted')).toBeVisible();
+    await expect(explorer.getByText('Mounted Demo USB')).toBeVisible();
+    await expect(explorer.getByText('Demo USB')).toBeVisible();
+
+    // Eject device
+    await settings.getByRole('button', { name: 'Eject device' }).click();
+    await expect(explorer.getByText('Demo USB')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add device eject handling in file explorer sidebar
- support mock device insert/eject with toast notifications
- expose removable media settings with volume management controls

## Testing
- `npx playwright test tests/file-manager/volume-management.spec.ts` *(fails: Test timeout waiting for Insert mock device button)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6193c2c8328ac83984e74e7ffc2