### PR TITLE
feat: add folder sharing controls

### DIFF
--- a/__tests__/filemanager-share.test.tsx
+++ b/__tests__/filemanager-share.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import Thunar from '../components/apps/FileManager/Thunar';
+import ShareSettings from '../apps/settings/shares';
+
+test('sharing folder updates file manager and settings page', () => {
+  render(
+    <>
+      <Thunar />
+      <ShareSettings />
+    </>
+  );
+
+  // open Desktop folder
+  fireEvent.click(screen.getAllByText('Desktop')[0]);
+
+  // open share modal
+  fireEvent.click(screen.getByRole('button', { name: /share/i }));
+
+  // confirm share inside modal
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: /share/i }));
+
+  // navigate back up to root
+  fireEvent.click(screen.getByRole('button', { name: /up/i }));
+
+  // shared badge should appear next to Desktop
+  expect(screen.getByLabelText('shared')).toBeInTheDocument();
+
+  // settings page should list the shared folder
+  expect(screen.getByText('/Desktop')).toBeInTheDocument();
+
+  // unshare from settings page
+  fireEvent.click(screen.getByRole('button', { name: /unshare/i }));
+
+  // badge disappears
+  expect(screen.queryByLabelText('shared')).toBeNull();
+  expect(screen.queryByText('/Desktop')).toBeNull();
+});

--- a/apps/settings/shares.tsx
+++ b/apps/settings/shares.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useShares, toggleShare } from '../../hooks/useShares';
+
+export default function ShareSettings() {
+  const shares = useShares();
+  return (
+    <div className="p-4 text-white bg-ub-cool-grey h-full overflow-auto">
+      <h1 className="text-lg font-bold mb-4">Shared Folders</h1>
+      {shares.length === 0 ? (
+        <p>No shared folders</p>
+      ) : (
+        <ul className="space-y-2">
+          {shares.map((p) => (
+            <li key={p} className="flex items-center">
+              <span className="flex-1">{p}</span>
+              <button
+                type="button"
+                className="text-ubt-blue underline"
+                onClick={() => toggleShare(p)}
+              >
+                Unshare
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/apps/FileManager/Thunar.tsx
+++ b/components/apps/FileManager/Thunar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useState } from 'react';
+import ShareModal from '../../filemanager/ShareModal';
+import { useShares } from '../../../hooks/useShares';
 
 interface Entry {
   name: string;
@@ -22,6 +24,8 @@ const fileSystem: Record<string, Entry[]> = {
 
 export default function Thunar() {
   const [path, setPath] = useState('/');
+  const [showShare, setShowShare] = useState(false);
+  const shares = useShares();
 
   const entries = fileSystem[path] || [];
 
@@ -73,6 +77,12 @@ export default function Thunar() {
           >
             Up
           </button>
+          <button
+            onClick={() => setShowShare(true)}
+            className="px-2 py-1 bg-gray-700 rounded hover:bg-gray-600"
+          >
+            Share
+          </button>
         </div>
         <nav className="bg-gray-900 p-2 text-sm">
           {breadcrumbs.map((crumb, i) => (
@@ -84,6 +94,9 @@ export default function Thunar() {
               >
                 {crumb.name}
               </button>
+              {shares.includes(crumb.path) && (
+                <span aria-label="shared" className="ml-1">🔗</span>
+              )}
             </span>
           ))}
         </nav>
@@ -98,6 +111,10 @@ export default function Thunar() {
                   >
                     {entry.name}
                   </button>
+                  {entry.type === 'folder' &&
+                    shares.includes(
+                      path === '/' ? `/${entry.name}` : `${path}/${entry.name}`
+                    ) && <span aria-label="shared" className="ml-1">🔗</span>}
                 </li>
               ))}
             </ul>
@@ -106,6 +123,11 @@ export default function Thunar() {
           )}
         </main>
       </div>
+      <ShareModal
+        isOpen={showShare}
+        onClose={() => setShowShare(false)}
+        path={path}
+      />
     </div>
   );
 }

--- a/components/filemanager/ShareModal.tsx
+++ b/components/filemanager/ShareModal.tsx
@@ -1,22 +1,40 @@
 import React, { useState } from 'react';
 import Modal from '../base/Modal';
+import { useShares, toggleShare } from '../../hooks/useShares';
 
 interface ShareModalProps {
   isOpen: boolean;
   onClose: () => void;
+  /** Path of the folder being shared */
+  path: string;
 }
 
 /**
  * ShareModal presents file sharing options and a Samba requirement notice.
+ * It also allows toggling the share state for the provided path.
  */
-export default function ShareModal({ isOpen, onClose }: ShareModalProps) {
+export default function ShareModal({ isOpen, onClose, path }: ShareModalProps) {
   const [showInfo, setShowInfo] = useState(false);
+  const shares = useShares();
+  const isShared = shares.includes(path);
+
+  const handleToggle = () => {
+    toggleShare(path);
+    onClose();
+  };
 
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose}>
         <div className="p-4 bg-white rounded shadow max-w-sm">
-          {/* Placeholder for future share options */}
+          <h2 className="text-lg font-semibold mb-2">Share this folder</h2>
+          <button
+            type="button"
+            className="px-3 py-1 bg-ubt-blue text-white rounded"
+            onClick={handleToggle}
+          >
+            {isShared ? 'Unshare' : 'Share'}
+          </button>
           <p className="mt-4 text-sm">
             Requires Samba.{' '}
             <button

--- a/hooks/useShares.ts
+++ b/hooks/useShares.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from 'react';
+
+const store = {
+  shares: new Set<string>(),
+  listeners: new Set<() => void>(),
+};
+
+function emit() {
+  store.listeners.forEach((l) => l());
+}
+
+export function toggleShare(path: string) {
+  const next = new Set(store.shares);
+  if (next.has(path)) {
+    next.delete(path);
+  } else {
+    next.add(path);
+  }
+  store.shares = next;
+  emit();
+}
+
+export function useShares() {
+  const set = useSyncExternalStore(
+    (listener) => {
+      store.listeners.add(listener);
+      return () => store.listeners.delete(listener);
+    },
+    () => store.shares,
+    () => store.shares
+  );
+  return Array.from(set);
+}
+
+export function isShared(path: string) {
+  return store.shares.has(path);
+}


### PR DESCRIPTION
## Summary
- add global share store with toggle helper
- support sharing current directory and show badge in file manager
- add settings page to review and remove shares

## Testing
- `yarn test __tests__/filemanager-share.test.tsx`
- `yarn test` *(fails: unable to find role="alert" in nmapNse.test.tsx; TypeError localStorage null in Clipman.test.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_68bbd61a3b3c8328b2d790999b438326