### PR TITLE
test: add smoke tests to apps config

### DIFF
--- a/__tests__/apps.smoke.test.tsx
+++ b/__tests__/apps.smoke.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import fs from 'fs';
-import path from 'path';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import apps from '../apps.config.js';
 
 // Some apps import this package which isn't installed in the test env
 jest.mock('styled-jsx/style', () => () => null, { virtual: true });
@@ -63,50 +62,24 @@ beforeAll(() => {
     }));
 });
 
-describe.skip('App component smoke tests', () => {
-  const appsDir = path.join(process.cwd(), 'components', 'apps');
-  const entries = fs.readdirSync(appsDir);
+describe('App component smoke tests', () => {
+  const noop = () => {};
 
-  const skip = new Set(['quadtree.js']);
+  const skip = new Set(['resource-monitor', 'todoist']);
 
-  const targets = entries.flatMap((entry) => {
-    const fullPath = path.join(appsDir, entry);
-    const stat = fs.statSync(fullPath);
-
-    if (stat.isDirectory()) {
-      const candidate = [
-        'index.tsx',
-        'index.ts',
-        'index.jsx',
-        'index.js',
-        `${entry}.tsx`,
-        `${entry}.ts`,
-        `${entry}.jsx`,
-        `${entry}.js`,
-      ].find((file) => fs.existsSync(path.join(fullPath, file)));
-      return candidate ? [path.join(fullPath, candidate)] : [];
-    }
-
-    if (skip.has(entry)) return [];
-    return /\.(tsx|ts|jsx|js)$/.test(entry) ? [fullPath] : [];
-  });
-
-  targets.forEach((file) => {
-    const importPath = path
-      .relative(__dirname, file)
-      .replace(/\\/g, '/');
-    const name = path.relative(appsDir, file);
-
-    it(`renders ${name} without crashing`, async () => {
-      const mod = await import(importPath);
-      const Component = mod.default || Object.values(mod)[0];
-
-      if (typeof Component !== 'function') {
-        // Skip files that don't default export a component
-        return;
-      }
-
-      render(React.createElement(Component));
+  apps
+    .filter(
+      (app) =>
+        !app.disabled &&
+        typeof app.screen === 'function' &&
+        !skip.has(app.id)
+    )
+    .forEach((app) => {
+      it(`opens ${app.title || app.id}`, async () => {
+        await app.screen.prefetch?.();
+        const { container, unmount } = render(app.screen(noop, noop));
+        fireEvent.click(container);
+        unmount();
+      });
     });
-  });
 });


### PR DESCRIPTION
## Summary
- dynamically load apps from `apps.config.js` for smoke tests
- interact with each app once to ensure mounting
- skip resource monitor and todoist which require extra setup

## Testing
- `npm test __tests__/apps.smoke.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbd61abfe88328abb905472f0969d3