### PR TITLE
chore: add Pa11y coverage for app routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,21 @@ jobs:
           npx wait-on http://localhost:3000
       - run: npx playwright test tests/e2e
 
+  pa11y:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: |
+          yarn dev &
+          npx wait-on http://localhost:3000
+      - run: npx pa11y-ci --config pa11yci.json
+
   security:
     runs-on: ubuntu-latest
     needs: install

--- a/pa11yci.json
+++ b/pa11yci.json
@@ -12,8 +12,18 @@
     }
   },
   "urls": [
-    "http://localhost:3000",
-    "http://localhost:3000/apps"
+    "http://localhost:3000/",
+    "http://localhost:3000/apps",
+    "http://localhost:3000/apps/chess",
+    "http://localhost:3000/apps/sudoku",
+    "http://localhost:3000/apps/youtube",
+    "http://localhost:3000/apps/vscode",
+    "http://localhost:3000/apps/spotify",
+    "http://localhost:3000/apps/x",
+    "http://localhost:3000/apps/chrome",
+    "http://localhost:3000/apps/trash",
+    "http://localhost:3000/apps/gedit",
+    "http://localhost:3000/apps/todoist"
   ],
   "scenarios": [
     {},


### PR DESCRIPTION
## Summary
- expand pa11yci config to audit `/`, `/apps`, and several app windows
- run pa11y-ci in CI to fail on new critical WCAG issues

## Testing
- `npx wait-on http://localhost:3000` *(fails: server failed to start in time)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd61b9cbc8328aa0ddf6213065b59