### PR TITLE
Disable SW outside production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,7 +64,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
-  disable: process.env.NODE_ENV === 'development',
+  disable: process.env.VERCEL_ENV !== 'production',
   buildExcludes: [/dynamic-css-manifest\.json$/],
   workboxOptions: {
     navigateFallback: '/offline.html',

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -45,7 +45,11 @@ function MyApp(props) {
       console.error('Analytics initialization failed', err);
     });
 
-    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.VERCEL_ENV === 'production' &&
+      'serviceWorker' in navigator
+    ) {
       // Register PWA service worker generated via @ducanh2912/next-pwa
       const register = async () => {
         try {

--- a/pages/dev/health.tsx
+++ b/pages/dev/health.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from 'react';
+
+export default function DevHealth() {
+  const [status, setStatus] = useState('');
+
+  const unregister = async () => {
+    if (!('serviceWorker' in navigator)) {
+      setStatus('Service workers are not supported');
+      return;
+    }
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((reg) => reg.unregister()));
+    setStatus('Service workers unregistered');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Dev Health</h1>
+      <button
+        onClick={unregister}
+        className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500"
+      >
+        Unregister SW
+      </button>
+      {status && <p>{status}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- disable PWA build when not running on Vercel production
- only register service worker in production deployments
- add developer health page with button to unregister service workers

## Testing
- `VERCEL_ENV=preview yarn build` *(fails: Module parse failed)*
- `yarn test` *(fails: Unable to find role="alert"; TypeError: Cannot read properties of null (reading '_origin'))*

------
https://chatgpt.com/codex/tasks/task_e_68bbd607126c8328bd8fa8cb5c85e2a1