### PR TITLE
Add app-level error boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ play/pause and track controls include keyboard hotkeys.
 
 ## Notable Components
 
-- **`components/base/window.js`** - draggable, focusable window with header controls; integrates with desktop z-index.
+- **`components/base/Window.tsx`** - draggable, focusable window with header controls; integrates with desktop z-index.
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`hooks/useSettings.tsx`** - global settings context exposing theme, accent, wallpaper and other preferences with persistence.

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Window from '../components/base/window';
+import Window from '../components/base/Window';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock('react-draggable', () => ({

--- a/components/panel/SensorsDetails.tsx
+++ b/components/panel/SensorsDetails.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import Window from '../base/window';
+import Window from '../base/Window';
 
 interface SensorInfo {
   id: string;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -9,7 +9,7 @@ const BackgroundImage = dynamic(
 );
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
-import Window from '../base/window';
+import Window from '../base/Window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -6,7 +6,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
 
 1. **Snap-to-grid for move and resize**
    - **Accept:** Dragging and resizing snaps to an 8 px grid. Toggle in Settings.
-   - **Where:** `components/base/window/*`, `components/screen/desktop.js`, `hooks/usePersistentState.ts`.
+   - **Where:** `components/base/Window.tsx`, `components/screen/desktop.js`, `hooks/usePersistentState.ts`.
    - **Why:** Consistent rhythm improves perceived quality.
 
 2. **Window size presets**

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -148,7 +148,7 @@ function MyApp(props) {
   }, []);
 
   return (
-    <ErrorBoundary>
+    <>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
@@ -161,7 +161,9 @@ function MyApp(props) {
           <TrayProvider>
             <PipPortalProvider>
               <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
+              <ErrorBoundary>
+                <Component {...pageProps} />
+              </ErrorBoundary>
               <ShortcutOverlay />
               <Analytics
                 beforeSend={(e) => {
@@ -177,9 +179,7 @@ function MyApp(props) {
           </TrayProvider>
         </SettingsProvider>
       </div>
-    </ErrorBoundary>
-
-
+    </>
   );
 }
 

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
-import { WindowMainScreen } from '../components/base/window';
+import { WindowMainScreen } from '../components/base/Window';
 
 const NessusDashboard: React.FC = () => {
   const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import WorkflowCard from '../components/WorkflowCard';
-import { WindowMainScreen } from '../components/base/window';
+import { WindowMainScreen } from '../components/base/Window';
 
 interface FrameProps {
   title: string;


### PR DESCRIPTION
## Summary
- prevent desktop from crashing by wrapping page component in an error boundary
- protect each app with a window-level error boundary that allows relaunch after a crash
- update imports to new `Window` component

## Testing
- `yarn test __tests__/window.test.tsx`
- `yarn lint` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd5f917c083289570d6091a416b0a