### PR TITLE
chore: update Vercel config to use runtime-specific settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "nodeVersion": "20.19.5",
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }


### PR DESCRIPTION
## Summary
- remove deprecated `nodeVersion` setting from Vercel config so only runtime mappings remain

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/addon-web-links' from 'apps/terminal/index.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68bbee01143c83288a4222e2721ca3ee