### PR TITLE
chore: clean up vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "nodeVersion": "20.19.5",
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }


### PR DESCRIPTION
## Summary
- remove deprecated `nodeVersion` from Vercel config
- validate configuration against Vercel JSON schema

## Testing
- `npx --yes ajv-cli@3 validate -s /tmp/vercel-schema.json -d vercel.json`
- `npm test` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee03f28083289a8a27059db28005