### PR TITLE
Add headers for PWA manifest and service worker

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -165,6 +165,28 @@ module.exports = withBundleAnalyzer(
                 headers: securityHeaders,
               },
               {
+                source: '/manifest.webmanifest',
+                headers: [
+                  {
+                    key: 'Content-Type',
+                    value: 'application/manifest+json',
+                  },
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=0, must-revalidate',
+                  },
+                ],
+              },
+              {
+                source: '/sw.js',
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=0, must-revalidate',
+                  },
+                ],
+              },
+              {
                 source: '/fonts/(.*)',
                 headers: [
                   {


### PR DESCRIPTION
## Summary
- Add explicit headers for manifest.webmanifest
- Add service worker caching headers matching PWA configuration

## Testing
- `yarn test __tests__/terminal.test.tsx` *(fails: Cannot find module '@xterm/addon-web-links')*
- `VERCEL_ENV=production yarn build` *(fails: Module not found: Can't resolve '@xterm/addon-web-links')*
- `npx -y lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee05a1e08328bd579115cccb00e4