### PR TITLE
Guard Vercel analytics components against missing ID

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -183,16 +183,20 @@ function MyApp(props) {
               <div aria-live="polite" id="live-region" />
               <Component {...pageProps} />
               <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+              {process.env.VERCEL_ANALYTICS_ID && (
+                <>
+                  <Analytics
+                    beforeSend={(e) => {
+                      if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                      const evt = e;
+                      if (evt.metadata?.email) delete evt.metadata.email;
+                      return e;
+                    }}
+                  />
 
-              <SpeedInsights />
+                  <SpeedInsights />
+                </>
+              )}
             </PipPortalProvider>
           </TrayProvider>
         </SettingsProvider>


### PR DESCRIPTION
## Summary
- Only render Vercel Analytics and Speed Insights when `VERCEL_ANALYTICS_ID` is available

## Testing
- `yarn test __tests__/terminal.test.tsx` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee06496c83288b8e79231d1b6147