### PR TITLE
chore: allow shields badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `react.dev` | React documentation embeds |
 | `sdk.scdn.co` | Spotify Web Playback SDK |
 | `vercel.live` | Vercel toolbar |
+| `img.shields.io` | Skill badge images |
 
 **Notes for prod hardening**
 - Review `connect-src` and `frame-src` to ensure only required domains are present for your deployment.

--- a/next.config.js
+++ b/next.config.js
@@ -149,6 +149,7 @@ module.exports = withBundleAnalyzer(
         'openweathermap.org',
         'staticmap.openstreetmap.de',
         'data.typeracer.com',
+        'img.shields.io',
         'images.credly.com',
       ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],


### PR DESCRIPTION
## Summary
- allow images from img.shields.io
- document shields domain in CSP notes

## Testing
- `yarn build` *(fails: Module not found: Can't resolve '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee04bdec83288564079ce86f2c73