### PR TITLE
feat: normalize app ids on apps listing

### DIFF
--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -18,9 +18,27 @@ const AppsPage = () => {
   useEffect(() => {
     let isMounted = true;
     import('../../apps.config').then((mod) => {
-      if (isMounted) {
-        setApps(mod.default);
-      }
+      if (!isMounted) return;
+      const list = mod.default.map((app) => {
+        let id = app.id;
+        try {
+          const fn = app.screen?.toString?.();
+          const match = fn && fn.match(/components\/apps\/([^"']+)/);
+          if (match) {
+            const dynId = match[1].replace(/\/index$/, '');
+            id = dynId
+              .split('/')
+              .pop()
+              .replace(/([a-z])([A-Z])/g, '$1-$2')
+              .replace(/_/g, '-')
+              .toLowerCase();
+          }
+        } catch (err) {
+          // ignore parsing errors and fall back to existing id
+        }
+        return { ...app, id };
+      });
+      setApps(list);
     });
     return () => {
       isMounted = false;


### PR DESCRIPTION
## Summary
- derive app IDs from dynamic import paths so grid links open correct components

## Testing
- `npm test` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee0b81b0832888a44bb0a5b54a17