### PR TITLE
fix solitaire dynamic app path

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -42,7 +42,7 @@ const SimonApp = createDynamicApp('simon', 'Simon');
 const SokobanApp = createDynamicApp('sokoban', 'Sokoban');
 // Use the enhanced TypeScript implementation of Solitaire that supports
 // draw-3 mode, hints, animations, and auto-complete.
-const SolitaireApp = createDynamicApp('solitaire/index', 'Solitaire');
+const SolitaireApp = createDynamicApp('solitaire', 'Solitaire');
 const TowerDefenseApp = createDynamicApp('tower-defense', 'Tower Defense');
 const WordSearchApp = createDynamicApp('word-search', 'Word Search');
 const WordleApp = createDynamicApp('wordle', 'Wordle');

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -2,22 +2,28 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { logEvent } from './analytics';
 
+const slugMap = {
+  solitaire: 'apps/solitaire',
+};
+
 export const createDynamicApp = (id, title) =>
   dynamic(
     async () => {
       try {
+        const resolved = slugMap[id] || `components/apps/${id}`;
         const mod = await import(
-          /* webpackChunkName: "[request]", webpackPrefetch: true */ `../components/apps/${id}`
+          /* webpackChunkName: "[request]", webpackPrefetch: true */ `../${resolved}`
         );
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const ErrorComponent = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        return ErrorComponent;
       }
     },
     {


### PR DESCRIPTION
## Summary
- ensure `createDynamicApp('solitaire')` loads new `apps/solitaire` module via slug map
- reference solitaire by slug only in app configuration

## Testing
- `yarn test __tests__/solitaireEngine.test.ts __tests__/solitaireLogic.test.ts`
- `npx eslint utils/createDynamicApp.js apps.config.js`
- `node scripts/validate-apps.mjs` *(fails: missing routes for many dynamic apps)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee092d4083288c93a6fe8d6c9fe1