### PR TITLE
test: ensure apps dynamic imports

### DIFF
--- a/__tests__/appImport.test.ts
+++ b/__tests__/appImport.test.ts
@@ -1,0 +1,81 @@
+import apps from '../apps.config.js';
+
+// Some apps import this package which isn't installed in the test env
+jest.mock('styled-jsx/style', () => () => null, { virtual: true });
+
+// Mock browser APIs that may be missing in the Jest environment
+beforeAll(() => {
+  // Some apps rely on canvas APIs which aren't implemented in jsdom
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    getImageData: jest.fn(() => ({ data: [] })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => []),
+    setTransform: jest.fn(),
+    drawImage: jest.fn(),
+    save: jest.fn(),
+    fillText: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    rotate: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 })),
+    transform: jest.fn(),
+    rect: jest.fn(),
+    clip: jest.fn(),
+    createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
+  }));
+
+  // mock fetch for components that request external resources
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({}) })
+  );
+
+  // basic Worker mock for components using web workers
+  class WorkerMock {
+    onmessage: ((e: any) => void) | null = null;
+    postMessage() {}
+    terminate() {}
+    addEventListener() {}
+    removeEventListener() {}
+  }
+  (global as any).Worker = WorkerMock;
+
+  // matchMedia mock
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+    }));
+});
+
+describe('dynamic app imports', () => {
+  it('imports every app module without error', async () => {
+    const ids = Array.from(new Set(apps.map((app) => app.id)));
+    const results = await Promise.allSettled(
+      ids.map((id) => import(`../components/apps/${id}`))
+    );
+
+    const failures = results
+      .map((result, index) => ({ result, id: ids[index] }))
+      .filter((item) => item.result.status === 'rejected');
+
+    if (failures.length > 0) {
+      const messages = failures.map(
+        ({ id, result }) => `${id}: ${(result as PromiseRejectedResult).reason}`
+      );
+      throw new Error(`Failed to import:\n${messages.join('\n')}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add jest test iterating over `apps.config.js` ids and dynamically import each app component

## Testing
- `yarn test __tests__/appImport.test.ts` *(fails: Failed to import: terminal, about, power, files, resource-monitor, task-manager, ssh, http, html-rewriter, weather-widget, network-manager, recon-ng, kali-tools, kali-tweaks, ascii-art, clipboard-manager)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee0e1dd48328bbb0fac8fbe3e5ca