### PR TITLE
refactor: use relative imports for persistent state hook

### DIFF
--- a/src/plugins/Clock.tsx
+++ b/src/plugins/Clock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import usePersistentState from '@/hooks/usePersistentState';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export type ClockStyle = 'time' | 'date' | 'datetime' | 'custom';
 

--- a/src/plugins/settings/ClockSettings.tsx
+++ b/src/plugins/settings/ClockSettings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChangeEvent } from 'react';
-import usePersistentState from '@/hooks/usePersistentState';
+import usePersistentState from '../../../hooks/usePersistentState';
 import type { ClockStyle } from '../Clock';
 
 const STYLES: { value: ClockStyle; label: string }[] = [

--- a/src/state/workspace.ts
+++ b/src/state/workspace.ts
@@ -1,4 +1,4 @@
-import usePersistentState from '@/hooks/usePersistentState';
+import usePersistentState from '../../hooks/usePersistentState';
 
 export interface WorkspaceMargins {
   top: number;


### PR DESCRIPTION
## Summary
- replace `@/hooks/usePersistentState` imports with relative paths

## Testing
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbee10159c83288cad1ca47e11b999