### PR TITLE
chore: add JS logger wrapper for Node scripts

### DIFF
--- a/data/vscode-example/main.js
+++ b/data/vscode-example/main.js
@@ -1,4 +1,4 @@
-import logger from '../../utils/logger';
+import logger from '../../utils/logger.js';
 
 function greet(name) {
   logger.info('Hello ' + name)

--- a/john/potfile.mjs
+++ b/john/potfile.mjs
@@ -2,7 +2,7 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { parsePotfile } from '../components/apps/john/utils.js';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 function main() {
   const [filePath, filter = ''] = process.argv.slice(2);

--- a/john/status.js
+++ b/john/status.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 function renderProgressBar(completed, total) {
   const percent = total === 0 ? 0 : (completed / total);

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import pa11y from 'pa11y';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const configPath = new URL('../pa11yci.json', import.meta.url);
 const { defaults = {}, urls = [], scenarios = [{}] } = JSON.parse(

--- a/scripts/cron-next-run.mjs
+++ b/scripts/cron-next-run.mjs
@@ -1,5 +1,5 @@
 import { CronExpressionParser } from 'cron-parser';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const expression = process.argv[2];
 const count = Number(process.argv[3] ?? 5);

--- a/scripts/examples/hash.ts
+++ b/scripts/examples/hash.ts
@@ -1,5 +1,5 @@
 import { createMD5, createSHA1 } from 'hash-wasm';
-import logger from '../../utils/logger';
+import logger from '../../utils/logger.js';
 
 export async function hashExample() {
   const samples = ['hello', 'world'];

--- a/scripts/examples/terminal-worker.ts
+++ b/scripts/examples/terminal-worker.ts
@@ -1,5 +1,5 @@
 // Example scripts demonstrating the terminal worker
-import logger from '../../utils/logger';
+import logger from '../../utils/logger.js';
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;

--- a/scripts/examples/terminal.ts
+++ b/scripts/examples/terminal.ts
@@ -1,5 +1,5 @@
 // Example scripts demonstrating the terminal worker
-import logger from '../../utils/logger';
+import logger from '../../utils/logger.js';
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;

--- a/scripts/export-icons.mjs
+++ b/scripts/export-icons.mjs
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import sharp from 'sharp';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/generate-module-report.mjs
+++ b/scripts/generate-module-report.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/generate-nmconnection-previews.ts
+++ b/scripts/generate-nmconnection-previews.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { toKeyfile, NMConnection } from '../utils/nmconnection.ts';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const dir = join(process.cwd(), 'data', 'network-connections');
 

--- a/scripts/safe-copy.mjs
+++ b/scripts/safe-copy.mjs
@@ -1,6 +1,6 @@
 import { access, mkdir, copyFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const src = 'dist/utils/gamepad.js';
 const destDir = 'public/vendor';

--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -1,6 +1,6 @@
 import { chromium, firefox, webkit } from 'playwright';
 import fs from 'fs';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -2,7 +2,7 @@ import { execSync, spawn } from 'child_process';
 import { createRequire } from 'module';
 import net from 'net';
 import waitOn from 'wait-on';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 const require = createRequire(import.meta.url);
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,41 @@
+const levelOrder = { error: 0, warn: 1, info: 2, debug: 3 };
+
+function getLogLevel() {
+  const env = process.env.LOG_LEVEL?.toLowerCase();
+  if (env && env in levelOrder) {
+    return env;
+  }
+  return 'info';
+}
+
+const activeLevel = getLogLevel();
+const isProd = process.env.NODE_ENV === 'production';
+
+function shouldLog(level) {
+  return levelOrder[level] <= levelOrder[activeLevel];
+}
+
+const logger = {
+  error: (...args) => {
+    if (isProd) return;
+    if (shouldLog('error')) console.error(...args);
+  },
+  warn: (...args) => {
+    if (isProd) return;
+    if (shouldLog('warn')) console.warn(...args);
+  },
+  info: (...args) => {
+    if (isProd) return;
+    if (shouldLog('info')) console.info(...args);
+  },
+  log: (...args) => {
+    if (isProd) return;
+    if (shouldLog('info')) console.log(...args);
+  },
+  debug: (...args) => {
+    if (isProd) return;
+    if (shouldLog('debug')) console.debug(...args);
+  },
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add `utils/logger.js` as a Node-friendly wrapper around the TypeScript logger
- update Node-run scripts to import from the new `utils/logger.js`

## Testing
- `npx eslint utils/logger.js scripts/generate-module-report.mjs scripts/cron-next-run.mjs scripts/safe-copy.mjs scripts/generate-nmconnection-previews.ts scripts/smoke-all-apps.mjs scripts/verify.mjs scripts/a11y.mjs scripts/export-icons.mjs scripts/examples/terminal.ts scripts/examples/terminal-worker.ts scripts/examples/hash.ts john/status.js john/potfile.mjs data/vscode-example/main.js && echo 'eslint:success'`
- `node scripts/cron-next-run.mjs "* * * * *" 1`
- `yarn test __tests__/chatManager.test.ts` *(fails: Expected number of calls: >= 1, Received: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee134658832887fb59e649055138