### PR TITLE
chore: lazy-load xterm and leaflet styles

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -186,3 +186,15 @@ jest.mock(
   }),
   { virtual: true }
 );
+
+jest.mock(
+  '@xterm/addon-web-links',
+  () => ({
+    WebLinksAddon: class {
+      activate() {}
+      dispose() {}
+    },
+
+  }),
+  { virtual: true }
+);

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,8 +8,6 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
-import '@xterm/xterm/css/xterm.css';
-import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
@@ -29,6 +27,10 @@ const ubuntu = Ubuntu({
 function MyApp(props) {
   const { Component, pageProps } = props;
 
+  useEffect(() => {
+    void import('@xterm/xterm/css/xterm.css');
+    void import('leaflet/dist/leaflet.css');
+  }, []);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {


### PR DESCRIPTION
## Summary
- load xterm and leaflet styles client-side to avoid SSR issues
- mock xterm web-links addon for jest

## Testing
- `yarn test __tests__/terminal.test.tsx`
- `yarn test __tests__/map.test.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee174ff083289790aa14acd4029f