### PR TITLE
feat: patch notifications in browser

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -137,22 +137,6 @@ function MyApp(props) {
       };
     }
 
-    const OriginalNotification = window.Notification;
-    if (OriginalNotification) {
-      const WrappedNotification = function (title, options) {
-        update(`${title}${options?.body ? ' ' + options.body : ''}`);
-        return new OriginalNotification(title, options);
-      };
-      WrappedNotification.requestPermission = OriginalNotification.requestPermission.bind(
-        OriginalNotification,
-      );
-      Object.defineProperty(WrappedNotification, 'permission', {
-        get: () => OriginalNotification.permission,
-      });
-      WrappedNotification.prototype = OriginalNotification.prototype;
-      window.Notification = WrappedNotification;
-    }
-
     return () => {
       window.removeEventListener('copy', handleCopy);
       window.removeEventListener('cut', handleCut);
@@ -161,9 +145,44 @@ function MyApp(props) {
         if (originalWrite) clipboard.writeText = originalWrite;
         if (originalRead) clipboard.readText = originalRead;
       }
-      if (OriginalNotification) {
-        window.Notification = OriginalNotification;
-      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const liveRegion = document.getElementById('live-region');
+    if (!liveRegion) return;
+
+    const update = (message) => {
+      liveRegion.textContent = '';
+      setTimeout(() => {
+        liveRegion.textContent = message;
+      }, 100);
+    };
+
+    const OriginalNotification = window.Notification;
+    if (!OriginalNotification) return;
+
+    const WrappedNotification = function (title, options) {
+      update(`${title}${options?.body ? ' ' + options.body : ''}`);
+      return new OriginalNotification(title, options);
+    };
+
+    WrappedNotification.requestPermission = OriginalNotification.requestPermission.bind(
+      OriginalNotification,
+    );
+
+    Object.defineProperty(WrappedNotification, 'permission', {
+      get: () => OriginalNotification.permission,
+    });
+
+    WrappedNotification.prototype = OriginalNotification.prototype;
+
+    window.Notification = WrappedNotification;
+
+    return () => {
+      window.Notification = OriginalNotification;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- patch Notification API only in browser using useEffect
- restore original Notification on unmount

## Testing
- `npx eslint pages/_app.jsx` *(fails: File ignored because no matching configuration was supplied)*
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68bbee162b7c8328a8537db077456dc8