### PR TITLE
docs: note no-ssr in dynamic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ __tests__/
 ```ts
 import dynamic from 'next/dynamic';
 
-const SudokuApp = dynamic(() => import('./components/apps/sudoku'));
+const SudokuApp = dynamic(() => import('./components/apps/sudoku'), {
+  ssr: false,
+});
 export const displaySudoku = () => <SudokuApp />;
 ```
 Heavy apps are wrapped with **dynamic import** and most games share a `GameLayout` with a help overlay.


### PR DESCRIPTION
## Summary
- clarify README dynamic import example to include `{ ssr: false }` for client-only app windows

## Testing
- `for f in $(rg -l 'dynamic\(' pages components utils); do rg -l 'ssr:\s*false' "$f" >/dev/null || echo "$f"; done; echo ALL_OK`
- `npm test` *(fails: Cannot find module '@xterm/addon-web-links')*


------
https://chatgpt.com/codex/tasks/task_e_68bbee1561248328b6efee364c5af835