### PR TITLE
Guard matchMedia with browser checks

### DIFF
--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -1,6 +1,8 @@
 /* eslint-env browser */
 
-if (isBrowser) {
+import { isBrowser } from '../../utils/env';
+
+if (isBrowser()) {
   const historyKey = 'clipboardHistory';
   let history = JSON.parse(safeLocalStorage?.getItem(historyKey) || '[]');
 

--- a/apps/color_picker/main.js
+++ b/apps/color_picker/main.js
@@ -1,12 +1,8 @@
 /* eslint-disable no-top-level-window/no-top-level-window-or-document */
-const colors = [];
-const input = document.getElementById('color-input');
-const swatches = document.getElementById('swatches');
-const hexOutput = document.getElementById('hex-output');
-hexOutput.textContent = input.value;
 
+import { isBrowser } from '../../utils/env';
 
-if (isBrowser) {
+if (isBrowser()) {
   const colors = [];
   const input = document.getElementById('color-input');
   const swatches = document.getElementById('swatches');

--- a/apps/dsniff/components/CredentialExplainer.tsx
+++ b/apps/dsniff/components/CredentialExplainer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { isBrowser } from '../../utils/env';
 
 // Simulation: illustrates how weak protocols expose credentials. For educational use only.
 const steps = [
@@ -10,7 +11,7 @@ const steps = [
 const CredentialExplainer: React.FC = () => {
   const [step, setStep] = useState(0);
   const prefersReducedMotion =
-    typeof window !== 'undefined' &&
+    isBrowser() &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   useEffect(() => {

--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -7,7 +7,7 @@ let notesContainer = null;
 let addNoteBtn = null;
 
 function initDom() {
-  if (!isBrowser) return;
+  if (!isBrowser()) return;
   notesContainer = document.getElementById('notes');
   addNoteBtn = document.getElementById('add-note');
 }
@@ -183,7 +183,7 @@ async function init() {
   }
 }
 
-if (isBrowser && addNoteBtn) {
+if (isBrowser() && addNoteBtn) {
   addNoteBtn.addEventListener('click', addNote);
   void init();
 }

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -1,6 +1,6 @@
 import { isBrowser } from '../../utils/env';
 
-if (isBrowser) {
+if (isBrowser()) {
 const WORK_DURATION = 25 * 60;
 const BREAK_DURATION = 5 * 60;
 const POSTPONE_DURATION = 5 * 60;

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -2,7 +2,7 @@ import demoCity from './demoCity.json';
 import { isBrowser } from '../../utils/env';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
-if (isBrowser) {
+if (isBrowser()) {
 const widget = document.getElementById('weather');
 const tempEl = widget.querySelector('.temp');
 const feelsEl = widget.querySelector('.feels-like');

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import { isBrowser } from '../../utils/env';
 import styles from './window.module.css';
 
 export class Window extends Component {
@@ -444,7 +445,10 @@ export class Window extends Component {
 
         const node = document.querySelector("#" + this.id);
         const endTransform = `translate(${posx}px,${sidebBarApp.y.toFixed(1) - 240}px) scale(0.2)`;
-        const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const prefersReducedMotion =
+            isBrowser() &&
+            window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
         if (prefersReducedMotion) {
             node.style.transform = endTransform;
@@ -472,7 +476,10 @@ export class Window extends Component {
         let posy = node.style.getPropertyValue("--window-transform-y");
         const startTransform = node.style.transform;
         const endTransform = `translate(${posx},${posy})`;
-        const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const prefersReducedMotion =
+            isBrowser() &&
+            window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
         if (prefersReducedMotion) {
             node.style.transform = endTransform;

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useSettings } from './useSettings';
+import { isBrowser } from '../utils/env';
 
 export default function usePrefersReducedMotion() {
   const { reducedMotion } = useSettings();
   const [prefersReduced, setPrefersReduced] = useState(false);
 
   useEffect(() => {
+    if (!isBrowser()) return;
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     const update = () => setPrefersReduced(mq.matches);
     update();

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import { TextEncoder, TextDecoder } from 'util';
+import { isBrowser } from './utils/env';
 // Polyfill structuredClone before requiring modules that depend on it
 // @ts-ignore
 if (typeof global.structuredClone !== 'function') {
@@ -82,7 +83,7 @@ if (typeof HTMLCanvasElement !== 'undefined') {
 
 // Basic matchMedia mock for libraries that expect it
 (() => {
-  if (typeof window !== 'undefined' && !window.matchMedia) {
+  if (isBrowser() && !window.matchMedia) {
     // @ts-ignore
     window.matchMedia = () => ({
       matches: false,
@@ -96,7 +97,7 @@ if (typeof HTMLCanvasElement !== 'undefined') {
 
 // Minimal IntersectionObserver mock so components relying on it don't crash in tests
 (() => {
-  if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
+  if (isBrowser() && !('IntersectionObserver' in window)) {
     class IntersectionObserverMock {
       constructor() {}
       observe() {}

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,4 +1,7 @@
 (function () {
+  function isBrowser() {
+    return typeof window !== 'undefined';
+  }
   var THEME_KEY = 'app:theme';
   try {
     var stored = null;
@@ -7,7 +10,7 @@
     }
 
     var prefersDark = false;
-    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    if (isBrowser() && typeof window.matchMedia === 'function') {
       prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 

--- a/utils/isBrowser.ts
+++ b/utils/isBrowser.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-top-level-window/no-top-level-window-or-document */
-export const isBrowser =
+export const isBrowser = (): boolean =>
   typeof window !== 'undefined' && typeof document !== 'undefined';
-export const hasIndexedDB =
-  isBrowser && typeof indexedDB !== 'undefined';
+export const hasIndexedDB = (): boolean =>
+  isBrowser() && typeof indexedDB !== 'undefined';

--- a/utils/qrStorage.ts
+++ b/utils/qrStorage.ts
@@ -8,10 +8,10 @@ const FILE_NAME = 'qr-scans.json';
 const getStorage = (): StorageManager => navigator.storage;
 
 const hasOpfs =
-  isBrowser && 'storage' in navigator && Boolean(getStorage().getDirectory);
+  isBrowser() && 'storage' in navigator && Boolean(getStorage().getDirectory);
 
 export const loadScans = async (): Promise<string[]> => {
-  if (!isBrowser) return [];
+  if (!isBrowser()) return [];
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -30,7 +30,7 @@ export const loadScans = async (): Promise<string[]> => {
 };
 
 export const saveScans = async (scans: string[]): Promise<void> => {
-  if (!isBrowser) return;
+  if (!isBrowser()) return;
   if (hasOpfs) {
     const root = await getStorage().getDirectory();
     const handle = await root.getFileHandle(FILE_NAME, { create: true });
@@ -43,7 +43,7 @@ export const saveScans = async (scans: string[]): Promise<void> => {
 };
 
 export const clearScans = async (): Promise<void> => {
-  if (!isBrowser) return;
+  if (!isBrowser()) return;
   if (hasOpfs) {
     try {
       const root = await getStorage().getDirectory();
@@ -57,21 +57,21 @@ export const clearScans = async (): Promise<void> => {
 };
 
 export const loadLastScan = (): string => {
-  if (!isBrowser) return '';
+  if (!isBrowser()) return '';
   return localStorage.getItem(LAST_SCAN_KEY) || '';
 };
 
 export const saveLastScan = (scan: string): void => {
-  if (!isBrowser) return;
+  if (!isBrowser()) return;
   localStorage.setItem(LAST_SCAN_KEY, scan);
 };
 
 export const loadLastGeneration = (): string => {
-  if (!isBrowser) return '';
+  if (!isBrowser()) return '';
   return localStorage.getItem(LAST_GEN_KEY) || '';
 };
 
 export const saveLastGeneration = (payload: string): void => {
-  if (!isBrowser) return;
+  if (!isBrowser()) return;
   localStorage.setItem(LAST_GEN_KEY, payload);
 };

--- a/utils/safeIDB.ts
+++ b/utils/safeIDB.ts
@@ -2,6 +2,6 @@ import { openDB } from 'idb';
 import { hasIndexedDB } from './isBrowser';
 
 export function getDb(name: string, version = 1, upgrade?: Parameters<typeof openDB>[2]) {
-  if (!hasIndexedDB) return null;
+  if (!hasIndexedDB()) return null;
   return openDB(name, version, upgrade);
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -3,6 +3,7 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 import { safeLocalStorage } from './safeStorage';
+import { isBrowser } from './env';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -50,7 +51,7 @@ export async function setDensity(density) {
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  if (!isBrowser()) return DEFAULT_SETTINGS.reducedMotion;
   const stored = window.localStorage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';

--- a/utils/sync.ts
+++ b/utils/sync.ts
@@ -6,7 +6,7 @@ type StateMessage = { type: 'state'; state: unknown };
 type LeaderboardMessage = { type: 'leaderboard'; leaderboard: unknown };
 type SyncMessage = StateMessage | LeaderboardMessage;
 
-const channel = isBrowser && 'BroadcastChannel' in self
+const channel = isBrowser() && 'BroadcastChannel' in self
   ? new BroadcastChannel('sync')
   : null;
 

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from './env';
+
 export const THEME_KEY = 'app:theme';
 
 // Score required to unlock each theme
@@ -16,13 +18,14 @@ export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
 export const getTheme = (): string => {
-  if (typeof window === 'undefined') return 'default';
+  if (!isBrowser()) return 'default';
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
     if (stored) return stored;
-    const prefersDark = window.matchMedia?.(
-      '(prefers-color-scheme: dark)'
-    ).matches;
+    const prefersDark =
+      isBrowser() &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
     return prefersDark ? 'dark' : 'default';
   } catch {
     return 'default';
@@ -30,7 +33,7 @@ export const getTheme = (): string => {
 };
 
 export const setTheme = (theme: string): void => {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;


### PR DESCRIPTION
## Summary
- convert `isBrowser` utility to a function and update callers
- guard matchMedia usage across utilities and components with `isBrowser()`
- add local `isBrowser()` checks for scripts such as `public/theme.js`

## Testing
- `npm test` *(fails: ModuleNotFoundError: Cannot find module '@xterm/addon-web-links')*
- `grep -i "ReferenceError" /tmp/dev.log`

------
https://chatgpt.com/codex/tasks/task_e_68bbee17fdfc8328ab0c79716ffeb494