### PR TITLE
fix: guard document calls in settings

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import usePersistentState from '../../hooks/usePersistentState';
+import { isBrowser } from '../../utils/env';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
@@ -45,6 +46,7 @@ export function Settings() {
     }, []);
 
     useEffect(() => {
+        if (!isBrowser) return;
         const tab = window.localStorage.getItem('settings-open-tab');
         if (tab === 'power') {
             document.getElementById('power-section')?.scrollIntoView();


### PR DESCRIPTION
## Summary
- guard Settings DOM access with `isBrowser`

## Testing
- `npx eslint components/apps/settings.js`
- `node -e "require('esbuild-register/dist/node').register({loader:'tsx'}); const React=require('react'); const ReactDOMServer=require('react-dom/server'); const Settings=require('./components/apps/settings.js').Settings; console.log('len', ReactDOMServer.renderToString(React.createElement(Settings)).length);"`
- `yarn test components/apps/settings.js >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bbee189ecc8328ae03ed44e377065d