### PR TITLE
Guard client-only audio creation

### DIFF
--- a/hooks/useAssetLoader.ts
+++ b/hooks/useAssetLoader.ts
@@ -30,15 +30,20 @@ export default function useAssetLoader(
       img.src = src;
     });
 
-    const loadSound = (src: string) => new Promise<void>((resolve, reject) => {
-      const audio = new Audio();
-      // oncanplaythrough fires when enough data has loaded to play the audio
-      audio.oncanplaythrough = () => resolve();
-      audio.onerror = () => reject(new Error(`Failed to load audio: ${src}`));
-      audio.src = src;
-      // Some browsers require calling load() manually for audio elements
-      audio.load();
-    });
+    const loadSound = (src: string) =>
+      new Promise<void>((resolve, reject) => {
+        if (typeof window === 'undefined' || typeof Audio === 'undefined') {
+          resolve();
+          return;
+        }
+        const audio = new Audio();
+        // oncanplaythrough fires when enough data has loaded to play the audio
+        audio.oncanplaythrough = () => resolve();
+        audio.onerror = () => reject(new Error(`Failed to load audio: ${src}`));
+        audio.src = src;
+        // Some browsers require calling load() manually for audio elements
+        audio.load();
+      });
 
     Promise.all([
       ...images.map(loadImage),

--- a/player/index.ts
+++ b/player/index.ts
@@ -19,6 +19,9 @@ export function getAudioContext(): AudioContext {
 }
 
 export function getAudioPlayer(src: string): HTMLAudioElement {
+  if (typeof window === 'undefined' || typeof Audio === 'undefined') {
+    throw new Error('Audio element unavailable');
+  }
   let player = players.get(src);
   if (!player) {
     player = new Audio(src);


### PR DESCRIPTION
## Summary
- avoid server-side `Audio` usage by gating player creation on browser availability
- skip audio preloading when `Audio` is undefined

## Testing
- `npx eslint hooks/useAssetLoader.ts player/index.ts`
- `yarn test __tests__/player.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbee1900f08328b0938ed0ef133c5b