### PR TITLE
feat: load Speed Insights only in production

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from '@vercel/speed-insights/next';
+import dynamic from 'next/dynamic';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -24,6 +24,14 @@ const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
 });
+
+let SpeedInsights = () => null;
+if (process.env.NODE_ENV === 'production') {
+  SpeedInsights = dynamic(
+    () => import('@vercel/speed-insights/next').then((m) => m.SpeedInsights),
+    { ssr: false },
+  );
+}
 
 
 function MyApp(props) {


### PR DESCRIPTION
## Summary
- dynamically import Speed Insights only in production builds
- avoid unnecessary Speed Insights calls during development

## Testing
- `yarn test __tests__/speed-insights.test.ts`
- `npx eslint pages/_app.jsx` *(fails: File ignored because no matching configuration was supplied)*
- `yarn dev` *(fails: The "to" argument must be of type string. Received undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee1a2fec8328bcca1d276c2ae83d