### PR TITLE
Add local image patterns for app icon directories

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -151,6 +151,10 @@ module.exports = withBundleAnalyzer(
         'data.typeracer.com',
         'images.credly.com',
       ],
+      localPatterns: [
+        { pathname: '/themes/Yaru/apps/**' },
+        { pathname: '/icons/**' },
+      ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],
     },


### PR DESCRIPTION
## Summary
- allow app icons from `/themes/Yaru/apps/**` and `/icons/**` via Next.js `images.localPatterns`

## Testing
- `npx eslint next.config.js`
- `yarn build` *(fails: Module not found: Can't resolve 'fs')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee1d566c8328b3999cd73336d1ea