### PR TITLE
feat: allow contact demo mode

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -24,6 +24,7 @@ const getRecaptchaToken = (siteKey: string): Promise<string> =>
   });
 
 const ContactApp: React.FC = () => {
+  const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
@@ -83,12 +84,15 @@ const ContactApp: React.FC = () => {
     }
 
     const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || "";
-    const recaptchaToken = await getRecaptchaToken(siteKey);
-    if (!recaptchaToken) {
-      setError("Captcha verification failed. Please try again.");
-      setSubmitting(false);
-      trackEvent("contact_submit_error", { method: "form" });
-      return;
+    let recaptchaToken = "";
+    if (siteKey) {
+      recaptchaToken = await getRecaptchaToken(siteKey);
+      if (!recaptchaToken && !demoMode) {
+        setError("Captcha verification failed. Please try again.");
+        setSubmitting(false);
+        trackEvent("contact_submit_error", { method: "form" });
+        return;
+      }
     }
 
     try {
@@ -121,6 +125,11 @@ const ContactApp: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-4">
+      {demoMode && (
+        <div className="mb-4 rounded bg-yellow-700 p-2 text-sm text-yellow-100">
+          Demo mode: messages are not stored.
+        </div>
+      )}
       <h1 className="mb-4 text-2xl">Contact</h1>
       <p className="mb-4 text-sm">
         Prefer email?{" "}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -140,6 +140,7 @@ const uploadAttachments = async (files: File[]) => {
 };
 
 const ContactApp: React.FC = () => {
+  const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
@@ -215,11 +216,13 @@ const ContactApp: React.FC = () => {
     let recaptchaToken = '';
     const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
     let shouldFallback = fallback;
-    if (!shouldFallback && siteKey && (window as any).grecaptcha) {
-      recaptchaToken = await getRecaptchaToken(siteKey);
-      if (!recaptchaToken) shouldFallback = true;
-    } else {
-      shouldFallback = true;
+    if (!shouldFallback) {
+      if (siteKey && (window as any).grecaptcha) {
+        recaptchaToken = await getRecaptchaToken(siteKey);
+        if (!recaptchaToken && !demoMode) shouldFallback = true;
+      } else if (!demoMode) {
+        shouldFallback = true;
+      }
     }
     if (shouldFallback) {
       setFallback(true);
@@ -263,6 +266,11 @@ const ContactApp: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">
       <h1 className="mb-6 text-2xl">Contact</h1>
+      {demoMode && (
+        <div className="mb-6 rounded bg-yellow-700 p-3 text-sm text-yellow-100">
+          Demo mode: messages are not stored.
+        </div>
+      )}
       {banner && (
         <div
           className={`mb-6 rounded p-3 text-sm ${

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,6 +1,5 @@
 import { randomBytes } from 'crypto';
 import { contactSchema } from '../../utils/contactSchema';
-import { validateServerEnv } from '../../lib/validate';
 import { getServiceSupabase } from '../../lib/supabase';
 
 // Simple in-memory rate limiter. Not suitable for distributed environments.
@@ -10,16 +9,15 @@ const RATE_LIMIT_MAX = 5;
 export const rateLimit = new Map();
 
 export default async function handler(req, res) {
-  try {
-    validateServerEnv(process.env);
-  } catch {
-    if (!process.env.RECAPTCHA_SECRET) {
-      res.status(503).json({ ok: false, code: 'recaptcha_disabled' });
-    } else {
-      res.status(500).json({ ok: false });
-    }
+  const missingRecaptcha = !process.env.RECAPTCHA_SECRET;
+  const missingSupabase =
+    !process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-    return;
+  if (missingRecaptcha || missingSupabase) {
+    console.warn('Contact API running in demo mode', {
+      missingRecaptcha,
+      missingSupabase,
+    });
   }
   if (req.method === 'GET') {
     const token = randomBytes(32).toString('hex');
@@ -67,40 +65,41 @@ export default async function handler(req, res) {
 
   const { recaptchaToken = '', ...rest } = req.body || {};
   const secret = process.env.RECAPTCHA_SECRET;
-  if (!secret) {
-    console.warn('Contact submission rejected', { ip, reason: 'recaptcha_disabled' });
-    res.status(503).json({ ok: false, code: 'recaptcha_disabled' });
-    return;
-  }
-  if (!recaptchaToken) {
-    console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
-    res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
-    return;
-  }
-  try {
-    const verify = await fetch(
-      'https://www.google.com/recaptcha/api/siteverify',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          secret: String(secret ?? ''),
-          response: String(recaptchaToken ?? ''),
-        }),
-      }
-    );
-    const captcha = await verify.json();
-    if (!captcha.success) {
+  if (secret) {
+    if (!recaptchaToken) {
       console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
       res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
       return;
     }
-  } catch {
-    console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
-    res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
-    return;
+    try {
+      const verify = await fetch(
+        'https://www.google.com/recaptcha/api/siteverify',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            secret: String(secret ?? ''),
+            response: String(recaptchaToken ?? ''),
+          }),
+        }
+      );
+      const captcha = await verify.json();
+      if (!captcha.success) {
+        console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
+        res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
+        return;
+      }
+    } catch {
+      console.warn('Contact submission rejected', { ip, reason: 'invalid_recaptcha' });
+      res.status(400).json({ ok: false, code: 'invalid_recaptcha' });
+      return;
+    }
+  } else {
+    console.warn('Contact submission accepted without reCAPTCHA verification', {
+      ip,
+    });
   }
 
   let sanitized;


### PR DESCRIPTION
## Summary
- warn and proceed when contact API keys are missing
- show demo mode banner and allow contact form submissions without reCAPTCHA

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*
- `yarn typecheck` *(fails: Cannot find module '@xterm/addon-web-links')*


------
https://chatgpt.com/codex/tasks/task_e_68bbee1fb3308328a784ecd500091bac