### PR TITLE
feat: add server-side CSRF protections

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -25,8 +25,10 @@ const fs = require('fs').promises;
 const sessionDir = path.join(process.cwd(), 'hydra');
 
 test('removes temp files after hydra execution', async () => {
-  const req = {
+const req = {
     method: 'POST',
+    headers: { 'x-csrf-token': 'token' },
+    cookies: { csrfToken: 'token' },
     body: { target: 'target', service: 'ssh', userList: 'u', passList: 'p' },
   };
   const res = {

--- a/__tests__/hydra.api.test.ts
+++ b/__tests__/hydra.api.test.ts
@@ -40,6 +40,8 @@ describe('Hydra API temp file cleanup', () => {
 
     const req: any = {
       method: 'POST',
+      headers: { 'x-csrf-token': 'token' },
+      cookies: { csrfToken: 'token' },
       body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -68,6 +70,8 @@ describe('Hydra API temp file cleanup', () => {
 
     const req: any = {
       method: 'POST',
+      headers: { 'x-csrf-token': 'token' },
+      cookies: { csrfToken: 'token' },
       body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -111,7 +115,12 @@ describe('Hydra API resume session', () => {
 
     const handler = (await import('../pages/api/hydra')).default;
 
-    const req: any = { method: 'POST', body: { action: 'resume' } };
+    const req: any = {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'token' },
+      cookies: { csrfToken: 'token' },
+      body: { action: 'resume' },
+    };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
     await handler(req, res);

--- a/__tests__/mimikatz.test.ts
+++ b/__tests__/mimikatz.test.ts
@@ -26,7 +26,12 @@ describe('mimikatz api', () => {
   });
 
   test('executes script template', async () => {
-    const req: any = { method: 'POST', body: { script: 'test' } };
+    const req: any = {
+      method: 'POST',
+      headers: { 'x-csrf-token': 'token' },
+      cookies: { csrfToken: 'token' },
+      body: { script: 'test' },
+    };
     const res: Res = mockRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -1,0 +1,19 @@
+import { randomBytes } from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const COOKIE_NAME = 'csrfToken';
+
+export function generateCsrfToken(res: NextApiResponse): string {
+  const token = randomBytes(32).toString('hex');
+  res.setHeader(
+    'Set-Cookie',
+    `${COOKIE_NAME}=${token}; HttpOnly; Path=/; SameSite=Strict`
+  );
+  return token;
+}
+
+export function validateCsrfToken(req: NextApiRequest): boolean {
+  const header = req.headers['x-csrf-token'];
+  const cookie = req.cookies?.[COOKIE_NAME];
+  return typeof header === 'string' && typeof cookie === 'string' && header === cookie;
+}

--- a/pages/api/clear-sessions.ts
+++ b/pages/api/clear-sessions.ts
@@ -1,11 +1,16 @@
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
+import { validateCsrfToken } from '../../lib/csrf';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end('Method Not Allowed');
+  }
+
+  if (!validateCsrfToken(req)) {
+    return res.status(403).json({ error: 'invalid_csrf' });
   }
 
   const sessionDir = path.join(os.homedir(), '.cache', 'xfce4-session');

--- a/pages/api/csrf.js
+++ b/pages/api/csrf.js
@@ -1,0 +1,10 @@
+import { generateCsrfToken } from '../../lib/csrf';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ ok: false });
+    return;
+  }
+  const token = generateCsrfToken(res);
+  res.status(200).json({ ok: true, csrfToken: token });
+}

--- a/pages/api/dummy.js
+++ b/pages/api/dummy.js
@@ -1,5 +1,11 @@
+import { validateCsrfToken } from '../../lib/csrf';
+
 export default function handler(req, res) {
   if (req.method === 'POST') {
+    if (!validateCsrfToken(req)) {
+      res.status(403).json({ message: 'invalid_csrf' });
+      return;
+    }
     res.status(200).json({ message: 'Received' });
   } else {
     res.status(405).json({ message: 'Method not allowed' });

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import path from 'path';
+import { validateCsrfToken } from '../../lib/csrf';
 
 const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
@@ -19,6 +20,11 @@ export default async function handler(req, res) {
   // actual binary may stub this handler for demonstration purposes.
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (!validateCsrfToken(req)) {
+    res.status(403).json({ error: 'invalid_csrf' });
     return;
   }
 

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import { validateCsrfToken } from '../../lib/csrf';
 
 const execAsync = promisify(exec);
 
@@ -16,6 +17,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  if (!validateCsrfToken(req)) {
+    res.status(403).json({ error: 'invalid_csrf' });
     return;
   }
   const { hash } = req.body || {};

--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { validateCsrfToken } from '../../../lib/csrf';
 
 export default async function handler(
   req,
@@ -7,6 +8,11 @@ export default async function handler(
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  if (!validateCsrfToken(req)) {
+    res.status(403).json({ error: 'invalid_csrf' });
     return;
   }
 

--- a/pages/api/metasploit.js
+++ b/pages/api/metasploit.js
@@ -1,4 +1,5 @@
 import modules from '../../components/apps/metasploit/modules.json';
+import { validateCsrfToken } from '../../lib/csrf';
 
 export default function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
@@ -8,6 +9,10 @@ export default function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end('Method Not Allowed');
+  }
+
+  if (!validateCsrfToken(req)) {
+    return res.status(403).json({ error: 'invalid_csrf' });
   }
 
   const { command } = req.body || {};

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,4 +1,5 @@
 import modules from '../../components/apps/mimikatz/modules.json';
+import { validateCsrfToken } from '../../lib/csrf';
 
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
@@ -14,6 +15,9 @@ export default async function handler(req, res) {
   }
 
   if (req.method === 'POST') {
+    if (!validateCsrfToken(req)) {
+      return res.status(403).json({ error: 'invalid_csrf' });
+    }
     const { script } = req.body || {};
     if (!script) {
       return res.status(400).json({ error: 'No script provided' });

--- a/pages/api/network/connections.js
+++ b/pages/api/network/connections.js
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { validateCsrfToken } from '../../lib/csrf';
 
 const filePath = path.join(process.cwd(), 'data', 'network-connections.json');
 
@@ -15,6 +16,10 @@ export default async function handler(req, res) {
     return;
   }
   if (req.method === 'POST') {
+    if (!validateCsrfToken(req)) {
+      res.status(403).json({ error: 'invalid_csrf' });
+      return;
+    }
     const { connections } = req.body || {};
     if (!Array.isArray(connections)) {
       res.status(400).json({ error: 'Invalid connections' });

--- a/pages/api/pacman/leaderboard.js
+++ b/pages/api/pacman/leaderboard.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { validateCsrfToken } from '../../lib/csrf';
 
 const filePath = path.join(process.cwd(), 'data', 'pacman-leaderboard.json');
 const MAX_ENTRIES = 10;
@@ -33,6 +34,10 @@ export default function handler(
   }
 
   if (req.method === 'POST') {
+    if (!validateCsrfToken(req)) {
+      res.status(403).json({ error: 'invalid_csrf' });
+      return;
+    }
     const { name, score } = req.body || {};
     if (typeof name !== 'string' || typeof score !== 'number') {
       res.status(400).json(readBoard());

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import { validateCsrfToken } from '../../lib/csrf';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,6 +17,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!validateCsrfToken(req)) {
+    return res.status(403).json({ error: 'invalid_csrf' });
   }
 
   const { action, hex, file } = req.body || {};

--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,6 +1,13 @@
+import { validateCsrfToken } from '../../lib/csrf';
+
 export default function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).end();
+    return;
+  }
+
+  if (!validateCsrfToken(req)) {
+    res.status(403).json({ ok: false, code: 'invalid_csrf' });
     return;
   }
 

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { validateCsrfToken } from "../../lib/csrf";
 
 export default async function handler(
   req,
@@ -6,6 +7,11 @@ export default async function handler(
 ) {
   if (req.method !== "POST") {
     res.status(405).json({ ok: false });
+    return;
+  }
+
+  if (!validateCsrfToken(req)) {
+    res.status(403).json({ ok: false, code: "invalid_csrf" });
     return;
   }
 


### PR DESCRIPTION
## Summary
- add reusable CSRF token utility and endpoint for fetching tokens
- enforce CSRF validation on API routes that modify state

## Testing
- `yarn test` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee203370832898d7ebab034166d4