### PR TITLE
feat: add cache reset to power settings

### DIFF
--- a/apps/power/index.tsx
+++ b/apps/power/index.tsx
@@ -35,6 +35,24 @@ export default function PowerSettings() {
               ariaLabel="Handle display brightness keys"
             />
           </div>
+          <div className="flex items-center justify-between">
+            <span>Reset application cache</span>
+            <button
+              className="px-2 py-1 rounded border border-ubt-cool-grey"
+              aria-label="Clear cached data and reload"
+              onClick={async () => {
+                const keys = await caches.keys();
+                await Promise.all(
+                  keys
+                    .filter((name) => name.startsWith('KLP'))
+                    .map((name) => caches.delete(name)),
+                );
+                location.reload();
+              }}
+            >
+              Reload
+            </button>
+          </div>
         </div>
       )}
       {activeTab === 'system' && (

--- a/tests/system/sw-recovery.spec.ts
+++ b/tests/system/sw-recovery.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// Ensures users can recover from a stale service worker by clearing caches
+// via the Power settings UI.
+test.describe('Service worker recovery', () => {
+  test('clears app caches and reloads', async ({ page }) => {
+    await page.goto('/apps/power');
+
+    await page.evaluate(async () => {
+      await caches.open('KLP_stale-cache');
+      await caches.open('unrelated-cache');
+    });
+
+    let keys = await page.evaluate<string[]>(() => caches.keys());
+    expect(keys).toContain('KLP_stale-cache');
+    expect(keys).toContain('unrelated-cache');
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole('button', { name: /reload/i }).click(),
+    ]);
+
+    keys = await page.evaluate<string[]>(() => caches.keys());
+    expect(keys).not.toContain('KLP_stale-cache');
+    expect(keys).toContain('unrelated-cache');
+  });
+});


### PR DESCRIPTION
## Summary
- allow clearing service worker caches via new "Reload" button in Power settings
- add Playwright test verifying cache clearing triggers reload

## Testing
- `npx playwright test tests/system/sw-recovery.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*
- `yarn test __tests__/contact.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bbee26ac4c8328a4f068331410b868