### PR TITLE
Defer app module prefetch until user intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ export const displaySudoku = () => <SudokuApp />;
 Heavy apps are wrapped with **dynamic import** and most games share a `GameLayout` with a help overlay.
 
 ### Prefetching dynamic apps
-Dynamic app modules include a `webpackPrefetch` hint and expose a `prefetch()` helper. Desktop tiles call this helper on hover or
-keyboard focus so bundles are warmed before launch. When adding a new app, export a default component and register it with
+Dynamic app modules expose a `prefetch()` helper. Desktop tiles call this helper after hovering or focusing for roughly
+150&nbsp;ms so bundles are warmed before launch. When adding a new app, export a default component and register it with
 `createDynamicApp` to opt into this behaviour.
 
 ---

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -7,7 +7,7 @@ export const createDynamicApp = (id, title) =>
     async () => {
       try {
         const mod = await import(
-          /* webpackChunkName: "[request]", webpackPrefetch: true */ `../components/apps/${id}`
+          /* webpackChunkName: "[request]" */ `../components/apps/${id}`
         );
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;


### PR DESCRIPTION
## Summary
- remove webpackPrefetch hints so app modules only load when requested
- document 150ms hover/focus delay before prefetching

## Testing
- `yarn test __tests__/terminal.test.tsx` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee2792d08328a6dc1b59dd8c5498