### PR TITLE
feat: add offline fallback page

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -12,7 +12,7 @@
     <p>You appear to be offline. Please check your connection.</p>
     <button id="retry">Retry</button>
     <section>
-      <h2>Cached Apps</h2>
+      <h2>Recent Apps</h2>
       <ul id="apps"></ul>
     </section>
   </main>

--- a/public/offline.js
+++ b/public/offline.js
@@ -19,7 +19,7 @@ document.getElementById('retry').addEventListener('click', () => {
       }
     }
     if (urls.size === 0) {
-      list.innerHTML = '<li>No apps available offline.</li>';
+      list.innerHTML = '<li>No recent apps available.</li>';
     } else {
       urls.forEach((path) => {
         const li = document.createElement('li');
@@ -31,6 +31,6 @@ document.getElementById('retry').addEventListener('click', () => {
       });
     }
   } catch (err) {
-    list.innerHTML = '<li>Unable to access cached apps.</li>';
+    list.innerHTML = '<li>Unable to access recent apps.</li>';
   }
 })();

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -83,6 +83,13 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request).catch(() => caches.match("/offline.html")),
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(request).then((cached) => cached || fetch(request)),
   );

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -84,6 +84,13 @@ self.addEventListener("fetch", (event: FetchEvent) => {
     return;
   }
 
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request).catch(() => caches.match("/offline.html")),
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(request).then((cached) => cached || fetch(request)),
   );

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -83,6 +83,13 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request).catch(() => caches.match("/offline.html")),
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(request).then((cached) => cached || fetch(request)),
   );


### PR DESCRIPTION
## Summary
- add dedicated offline page with retry and recent apps links
- show friendly messages when recent apps aren't available
- return offline page from service worker when navigation fails

## Testing
- `yarn test` *(fails: ModuleNotFoundError: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee253a908328bcf583e9585e354e