### PR TITLE
Pause games when out of view

### DIFF
--- a/__tests__/game-shell.test.jsx
+++ b/__tests__/game-shell.test.jsx
@@ -15,12 +15,12 @@ function HookTester({ hook }) {
 
 describe('game utilities', () => {
   it('mounts and unmounts GameShell', () => {
-    const { unmount, getByRole } = render(
-      <GameShell game="test" controls={<div />} settings={<div />}>child</GameShell>
-    );
-    getByRole('button', { name: /pause/i });
-    unmount();
-  });
+      const { unmount, getByRole } = render(
+        <GameShell game="test" controls={<div />} settings={<div />}>child</GameShell>
+      );
+      getByRole('button', { name: /pause|resume/i });
+      unmount();
+    });
 
   it('mounts and unmounts VirtualControls', () => {
     const { unmount } = render(


### PR DESCRIPTION
## Summary
- use IntersectionObserver in GameShell to track visibility and auto-pause games
- wire Snake game to pause its loop when hidden and resume when visible
- adjust GameShell test for new behavior

## Testing
- `yarn test game-shell.test.jsx`
- `npx eslint components/games/GameShell.tsx games/snake/index.tsx __tests__/game-shell.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbee2936a08328a9aef0d562bd0745