### PR TITLE
refactor: replace setInterval with rAF in games

### DIFF
--- a/games/memory/index.tsx
+++ b/games/memory/index.tsx
@@ -9,6 +9,7 @@ import {
   recordScore,
   type LeaderboardEntry,
 } from '../../components/apps/Games/common/leaderboard';
+import useRafInterval from '../../hooks/useRafInterval';
 
 const ATTACK_LIMIT = 60_000; // 60 seconds
 
@@ -42,24 +43,21 @@ const MemoryGame: React.FC = () => {
     setTimeLeft(ATTACK_LIMIT);
   }, [size, attackMode]);
 
-  // timer effect
-  useEffect(() => {
+  // timer effect using requestAnimationFrame
+  useRafInterval(() => {
     if (startTime === null) return;
-    const id = setInterval(() => {
-      const now = Date.now();
-      const diff = now - startTime;
-      setElapsed(diff);
-      if (attackMode) {
-        const remaining = ATTACK_LIMIT - diff;
-        setTimeLeft(remaining);
-        if (remaining <= 0) {
-          setCompleted(true);
-          setStartTime(null);
-        }
+    const now = Date.now();
+    const diff = now - startTime;
+    setElapsed(diff);
+    if (attackMode) {
+      const remaining = ATTACK_LIMIT - diff;
+      setTimeLeft(remaining);
+      if (remaining <= 0) {
+        setCompleted(true);
+        setStartTime(null);
       }
-    }, 100);
-    return () => clearInterval(id);
-  }, [startTime, attackMode]);
+    }
+  }, 100);
 
   const handleClick = (idx: number) => {
     if (matched.has(idx) || flipped.includes(idx) || completed) return;

--- a/games/snake/index.tsx
+++ b/games/snake/index.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect, useState } from "react";
 import GameShell from "../../components/games/GameShell";
 import usePersistentState from "../../hooks/usePersistentState";
 import useCanvasResize from "../../hooks/useCanvasResize";
+import useRafInterval from "../../hooks/useRafInterval";
 import { DEFAULT_GRID_SIZE, createState, step, GameState } from "./logic";
 
 const CELL_SIZE = 16;
@@ -31,9 +32,9 @@ const Snake = () => {
     runningRef.current = true;
   }, [wrap, gridSize]);
 
-  // game loop
-  useEffect(() => {
-    const id = setInterval(() => {
+  // game loop using requestAnimationFrame
+  useRafInterval(
+    () => {
       setState((s) => {
         if (!runningRef.current) return s;
         const result = step(s);
@@ -46,9 +47,9 @@ const Snake = () => {
         }
         return result.state;
       });
-    }, speed);
-    return () => clearInterval(id);
-  }, [speed]);
+    },
+    speed,
+  );
 
   // food spawn animation
   useEffect(() => {

--- a/games/sudoku/index.tsx
+++ b/games/sudoku/index.tsx
@@ -15,6 +15,7 @@ import {
   cellsToBoard,
 } from "../../apps/games/sudoku/cell";
 import PencilMarks from "./components/PencilMarks";
+import useRafInterval from "../../hooks/useRafInterval";
 
 const formatTime = (s: number) =>
   `${Math.floor(s / 60)}:${("0" + (s % 60)).slice(-2)}`;
@@ -64,10 +65,7 @@ const SudokuGame: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [difficulty]);
 
-  useEffect(() => {
-    const id = setInterval(() => setTime((t) => t + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
+  useRafInterval(() => setTime((t) => t + 1), 1000);
 
   const handleValue = (
     r: number,

--- a/hooks/useRafInterval.ts
+++ b/hooks/useRafInterval.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Runs the provided callback roughly every `delay` milliseconds using
+ * `requestAnimationFrame` under the hood. The loop is automatically paused
+ * when the document is hidden to avoid unnecessary CPU usage when the
+ * window is minimized.
+ */
+export default function useRafInterval(callback: () => void, delay: number) {
+  const savedCallback = useRef(callback);
+  const delayRef = useRef(delay);
+
+  // Update refs when props change
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    delayRef.current = delay;
+  }, [delay]);
+
+  useEffect(() => {
+    let frameId: number;
+    let last = performance.now();
+
+    const loop = (now: number) => {
+      // only run the callback if enough time has passed and the document is visible
+      if (!document.hidden && now - last >= delayRef.current) {
+        savedCallback.current();
+        last = now;
+      }
+      frameId = requestAnimationFrame(loop);
+    };
+
+    const handleVisibility = () => {
+      if (!document.hidden) {
+        // reset timer when coming back to foreground
+        last = performance.now();
+      }
+    };
+
+    frameId = requestAnimationFrame(loop);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, []);
+}
+


### PR DESCRIPTION
## Summary
- add useRafInterval hook using requestAnimationFrame and visibility pause
- switch snake, memory, and sudoku games to use the new hook

## Testing
- `yarn test games/snake games/memory games/sudoku --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bbee28d42c8328b9fee8dd54cd04dc