### PR TITLE
Ensure terminal resizes on tiling and prevent text wrap

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -15,6 +15,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         fontFamily: 'monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
+        whiteSpace: 'pre',
         ...style,
       }}
       {...props}

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -496,15 +496,23 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
     ]);
 
   useEffect(() => {
-    const handleResize = () => fitRef.current?.fit();
+    const handleFit = () => fitRef.current?.fit();
     let observer: ResizeObserver | undefined;
+    const root = containerRef.current?.closest('[data-app-id]') as HTMLElement | null;
+
+    const handleTiling = () => requestAnimationFrame(handleFit);
+
     if (typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(handleResize);
+      observer = new ResizeObserver(handleFit);
       if (containerRef.current) observer.observe(containerRef.current);
     }
-    window.addEventListener('resize', handleResize);
+    window.addEventListener('resize', handleFit);
+    root?.addEventListener('super-arrow', handleTiling);
+    root?.addEventListener('transitionend', handleFit);
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', handleFit);
+      root?.removeEventListener('super-arrow', handleTiling);
+      root?.removeEventListener('transitionend', handleFit);
       observer?.disconnect();
     };
   }, []);


### PR DESCRIPTION
## Summary
- fit terminal on window resize and tiling events
- keep terminal output from wrapping off-screen

## Testing
- `npm test __tests__/terminal.test.tsx` *(fails: Cannot find module '@xterm/addon-web-links')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee2a1d2883289e31797092a4a87a