### PR TITLE
Ensure ASCII art revokes object URLs

### DIFF
--- a/__tests__/asciiArt.test.tsx
+++ b/__tests__/asciiArt.test.tsx
@@ -1,0 +1,50 @@
+import { render, fireEvent } from '@testing-library/react';
+import AsciiArt from '../components/apps/ascii_art';
+
+describe('AsciiArt file handling', () => {
+  beforeEach(() => {
+    (global as any).URL.createObjectURL = jest
+      .fn()
+      .mockReturnValueOnce('blob:first')
+      .mockReturnValueOnce('blob:second');
+    (global as any).URL.revokeObjectURL = jest.fn();
+    (global as any).createImageBitmap = jest.fn(() => Promise.resolve({ width: 1, height: 1 }));
+    (global as any).requestAnimationFrame = (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0 as any;
+    };
+    (document as any).fonts = { load: jest.fn() };
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      drawImage: jest.fn(),
+      getImageData: jest.fn(() => ({ data: new Uint8ClampedArray(4) })),
+      fillRect: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      imageSmoothingEnabled: true,
+      fillStyle: '',
+      font: '',
+      textBaseline: '',
+      fillText: jest.fn(),
+    }));
+  });
+
+  test('releases object URLs on file change and unmount', async () => {
+    const { container, unmount } = render(<AsciiArt />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    const file1 = new File(['a'], 'a.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file1], configurable: true });
+    await fireEvent.change(input);
+
+    const file2 = new File(['b'], 'b.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file2], configurable: true });
+    await fireEvent.change(input);
+
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalledWith('blob:first');
+
+    unmount();
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalledWith('blob:second');
+  });
+});

--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -233,11 +233,19 @@ export default function AsciiArt() {
       const file = e.target.files[0];
       if (!file || !file.type.startsWith('image/')) return;
       fileRef.current = file;
-      setImgSrc(URL.createObjectURL(file));
+      if (imgSrc) URL.revokeObjectURL(imgSrc);
+      const url = URL.createObjectURL(file);
+      setImgSrc(url);
       processFile();
     },
-    [processFile],
+    [imgSrc, processFile],
   );
+
+  useEffect(() => {
+    return () => {
+      if (imgSrc) URL.revokeObjectURL(imgSrc);
+    };
+  }, [imgSrc]);
 
   useEffect(() => {
     processFile();


### PR DESCRIPTION
## Summary
- release previous object URLs when loading new ASCII art files
- clean up object URL on unmount
- test that imports revoke URLs on change and close

## Testing
- `npm test` *(fails: Cannot find module '@xterm/addon-web-links')*
- `npx jest __tests__/asciiArt.test.tsx --runTestsByPath __tests__/asciiArt.test.tsx`
- `npm run lint -- components/apps/ascii_art/index.js __tests__/asciiArt.test.tsx` *(errors: control-has-associated-label, display-name, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bbee2a9b748328b00ed5c58a34db29