### PR TITLE
feat: configure api function resource limits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,11 @@
   "version": 2,
   "functions": {
     "nodeVersion": "20.19.5",
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
+    "pages/api/**/*.{js,ts}": {
+      "runtime": "@vercel/node@5.3.20",
+      "maxDuration": 60,
+      "memory": 1024
+    },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }
 }


### PR DESCRIPTION
## Summary
- add max duration and memory limits for API routes in Vercel config

## Testing
- `npm test` *(fails: Unable to find role="alert" in nmapNse.test.tsx)*
- `npx eslint vercel.json`
- `vercel deploy --prod` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee038470832892624f1376a0c56f