### PR TITLE
feat: expand dynamic app import paths

### DIFF
--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -6,9 +6,28 @@ export const createDynamicApp = (id, title) =>
   dynamic(
     async () => {
       try {
-        const mod = await import(
-          /* webpackChunkName: "[request]", webpackPrefetch: true */ `../components/apps/${id}`
-        );
+        let mod;
+        try {
+          mod = await import(
+            /* webpackChunkName: "[request]", webpackPrefetch: true */ `../apps/${id}`
+          );
+        } catch {
+          try {
+            mod = await import(
+              /* webpackChunkName: "[request]", webpackPrefetch: true */ `../apps/${id}/index`
+            );
+          } catch {
+            try {
+              mod = await import(
+                /* webpackChunkName: "[request]", webpackPrefetch: true */ `../apps/${id.replace('_', '-')}`
+              );
+            } catch {
+              mod = await import(
+                /* webpackChunkName: "[request]", webpackPrefetch: true */ `../components/apps/${id}`
+              );
+            }
+          }
+        }
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;
       } catch (err) {


### PR DESCRIPTION
## Summary
- search for app modules in `/apps` variants before falling back to legacy component path

## Testing
- `npm test` *(fails: Cannot find module '@xterm/addon-web-links' from 'apps/terminal/index.tsx')*
- `node scripts/validate-apps.mjs` *(reports missing routes and modules)*
- `yarn dev` *(dev server failed: TypeError "The 'to' argument must be of type string. Received undefined")*


------
https://chatgpt.com/codex/tasks/task_e_68bbee07a96c832899dc07ad6d62b5de