### PR TITLE
Prefetch apps grid items on visibility

### DIFF
--- a/__tests__/appGrid.prefetch.test.tsx
+++ b/__tests__/appGrid.prefetch.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+var apps: any[];
+var prefetch: jest.Mock;
+
+jest.mock('../apps.config', () => {
+  prefetch = jest.fn();
+  apps = [{ id: 'test', title: 'Test', icon: '/test.png', screen: { prefetch } }];
+  return {
+    __esModule: true,
+    default: apps,
+    games: [],
+    utilities: [],
+  };
+});
+
+jest.mock('../components/base/ubuntu_app', () => ({
+  __esModule: true,
+  default: ({ id, name }) => <div data-testid={id}>{name}</div>,
+}));
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }) => children({ width: 100, height: 100 }),
+}));
+
+jest.mock('react-window', () => ({
+  Grid: ({ columnCount, rowCount, children }) => {
+    const cells = [];
+    const data = { items: apps, columnCount };
+    for (let row = 0; row < rowCount; row++) {
+      for (let col = 0; col < columnCount; col++) {
+        cells.push(children({ columnIndex: col, rowIndex: row, style: {}, data }));
+      }
+    }
+    return <div>{cells}</div>;
+  },
+}));
+
+import AppGrid from '../components/apps/app-grid';
+
+beforeEach(() => {
+  prefetch.mockClear();
+  global.IntersectionObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ isIntersecting: true }]);
+    }
+    unobserve() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  } as any;
+});
+
+test('prefetches when grid item becomes visible', () => {
+  jest.useFakeTimers();
+  render(<AppGrid openApp={() => {}} />);
+  expect(prefetch).not.toHaveBeenCalled();
+  jest.runAllTimers();
+  expect(prefetch).toHaveBeenCalledTimes(1);
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- prefetch app modules when grid items enter the viewport
- track already prefetched apps to avoid duplicate requests
- add test covering visibility-based prefetch

## Testing
- `yarn test __tests__/appGrid.prefetch.test.tsx`
- `yarn lint components/apps/app-grid.js __tests__/appGrid.prefetch.test.tsx` *(fails: A control must be associated with a text label, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee0c59948328a90d3a4fb9c61e9f