### PR TITLE
refactor: use shared persistent state hook

### DIFF
--- a/components/apps/word-search.js
+++ b/components/apps/word-search.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import seedrandom from "seedrandom";
 import useOPFS from "../../hooks/useOPFS.js";
+import usePersistentState from "../../hooks/usePersistentState";
 
 // Approximate pixel size of each grid cell for SVG overlay calculations
 const CELL_SIZE = 32;
@@ -63,30 +64,6 @@ const DIFFICULTIES = {
   easy: { size: 10, count: 5 },
   medium: { size: 12, count: 8 },
   hard: { size: 15, count: 10 },
-};
-
-const usePersistentState = (key, initial) => {
-  const [state, setState] = useState(() => {
-    if (typeof window !== "undefined") {
-      const stored = window.localStorage.getItem(key);
-      if (stored) {
-        try {
-          return JSON.parse(stored);
-        } catch {
-          // ignore parse errors
-        }
-      }
-    }
-    return typeof initial === "function" ? initial() : initial;
-  });
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(key, JSON.stringify(state));
-    }
-  }, [key, state]);
-
-  return [state, setState];
 };
 
 const pickWords = (count, list, rng, lists, language) => {

--- a/components/apps/wordle.js
+++ b/components/apps/wordle.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
 import {
   getWordOfTheDay,
   buildResultMosaic,
@@ -9,30 +10,6 @@ import {
 const todayKey = new Date().toISOString().split('T')[0];
 
 const dictionaries = wordleDictionaries;
-
-// Persist state to localStorage so that refreshes keep progress/history
-// and games reset each day.
-function usePersistentState(key, defaultValue) {
-  const [state, setState] = useState(defaultValue);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = localStorage.getItem(key);
-      setState(stored ? JSON.parse(stored) : defaultValue);
-    } catch {
-      setState(defaultValue);
-    }
-  }, [key, defaultValue]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(key, JSON.stringify(state));
-    }
-  }, [key, state]);
-
-  return [state, setState];
-}
 
 // Evaluate a guess against the solution producing statuses for each letter.
 const evaluateGuess = (guess, answer) => {


### PR DESCRIPTION
## Summary
- Remove local usePersistentState implementations in Wordle and Word Search
- Import shared persistent state hook instead

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/wordle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbee10acac832899d31741d18e5be4