### PR TITLE
chore: warn on circular imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ const config = [
       'jsx-a11y/role-supports-aria-props': 'off',
       'react-hooks/exhaustive-deps': 'off',
       'import/no-anonymous-default-export': 'off',
+      'import/no-cycle': 'warn',
     },
   }),
 ];


### PR DESCRIPTION
## Summary
- enable `import/no-cycle` eslint rule at warn level

## Testing
- `npx eslint utils --max-warnings=0 --config eslint.config.mjs` *(fails: Component definition is missing display name)*
- `npx -y madge --circular . --exclude "node_modules|public|docs|scripts|tests|__tests__|storyboard|games|chrome-extension|worker|workers|playwright|components/apps/Chrome"`


------
https://chatgpt.com/codex/tasks/task_e_68bbee14b1cc832892b85fbdaca31c27