### PR TITLE
chore(pwa): cache icons for faster return visits

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -35,6 +35,17 @@ module.exports = [
     }
   },
   {
+    urlPattern: /\/(?:favicon\.ico|favicon\.svg|images\/logos\/.*\.(?:png|svg))$/i,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'static-icon-assets',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
+      }
+    }
+  },
+  {
     urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
     handler: 'StaleWhileRevalidate',
     options: {

--- a/next.config.js
+++ b/next.config.js
@@ -81,6 +81,10 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/apps/checkers', revision: null },
       { url: '/offline.html', revision: null },
       { url: '/manifest.webmanifest', revision: null },
+      { url: '/favicon.ico', revision: null },
+      { url: '/favicon.svg', revision: null },
+      { url: '/images/logos/fevicon.png', revision: null },
+      { url: '/images/logos/logo_1024.png', revision: null },
     ],
     // Cache only images and fonts to ensure app shell updates while assets work offline
     runtimeCaching: require('./cache.js'),


### PR DESCRIPTION
## Summary
- pre-cache favicons and logo icons so service worker can serve them immediately on repeat visits
- cache site icons with a CacheFirst strategy alongside existing next/image caching

## Testing
- `yarn eslint cache.js next.config.js --max-warnings=0`
- `yarn test __tests__/installButton.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bbee2424f88328a481cc0c28773a71