### PR TITLE
feat(settings): handle shortcut conflicts

### DIFF
--- a/__tests__/KeymapOverlay.test.tsx
+++ b/__tests__/KeymapOverlay.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import KeymapOverlay from '../apps/settings/components/KeymapOverlay';
+
+describe('KeymapOverlay conflict handling', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('keymap');
+  });
+
+  it('prompts to reassign when choosing an existing shortcut', () => {
+    render(<KeymapOverlay open={true} onClose={() => {}} />);
+
+    const openSettingsItem = screen.getByText('Open settings').closest('li')!;
+    fireEvent.click(within(openSettingsItem).getByRole('button'));
+    fireEvent.keyDown(window, { key: 'Tab', altKey: true });
+
+    expect(
+      screen.getByRole('button', { name: /Reassign Window switcher/ }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Reassign Window switcher/ }),
+    );
+    fireEvent.keyDown(window, { key: 'w', altKey: true });
+
+    expect(
+      screen.queryByRole('button', { name: /Reassign Window switcher/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByText('Open settings').closest('li')!).getByText(
+        'Alt+Tab',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByText('Window switcher').closest('li')!).getByText(
+        'Alt+W',
+      ),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -47,7 +47,7 @@ export function useKeymap() {
   }));
 
   const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+    setMap((m) => ({ ...m, [description]: keys }));
 
   return { shortcuts, updateShortcut };
 }


### PR DESCRIPTION
## Summary
- detect conflicting keyboard shortcuts and prompt for reassignment
- keep shortcut mappings unique by updating state functionally
- test conflict resolution workflow

## Testing
- `yarn test __tests__/KeymapOverlay.test.tsx`
- `yarn lint apps/settings/components/KeymapOverlay.tsx apps/settings/keymapRegistry.ts __tests__/KeymapOverlay.test.tsx` *(fails: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6137b88832884ed0912d6bfebd3