### PR TITLE
chore: add middleware matcher config

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,9 @@
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from "next/server";
 
 function nonce() {
   const arr = new Uint8Array(16);
   crypto.getRandomValues(arr);
-  return Buffer.from(arr).toString('base64');
+  return Buffer.from(arr).toString("base64");
 }
 
 export function middleware(req: NextRequest) {
@@ -19,11 +19,17 @@ export function middleware(req: NextRequest) {
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
-  ].join('; ');
+    "form-action 'self'",
+  ].join("; ");
 
   const res = NextResponse.next();
-  res.headers.set('x-csp-nonce', n);
-  res.headers.set('Content-Security-Policy', csp);
+  res.headers.set("x-csp-nonce", n);
+  res.headers.set("Content-Security-Policy", csp);
   return res;
 }
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|static|favicon.ico|robots.txt|manifest.json|.*\\.(?:png|jpg|jpeg|gif|svg|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- add middleware matcher configuration to skip static and asset paths

## Testing
- `yarn eslint middleware.ts`
- `yarn test middleware` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc030bce448328820fca4b432c45a2