### PR TITLE
chore: set /apps as canonical app directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ __tests__/
 ```ts
 import dynamic from 'next/dynamic';
 
-const SudokuApp = dynamic(() => import('./components/apps/sudoku'), {
+const SudokuApp = dynamic(() => import('./apps/sudoku'), {
   ssr: false,
 });
 export const displaySudoku = () => <SudokuApp />;
@@ -479,7 +479,7 @@ play/pause and track controls include keyboard hotkeys.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`hooks/useSettings.tsx`** - global settings context exposing theme, accent, wallpaper and other preferences with persistence.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
-- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
+- **`apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 - **`hooks/useTray.tsx`** & **`components/util-components/status.js`** - unified tray grouping StatusNotifierItem icons with legacy systray fallback. See [`docs/system-tray.md`](./docs/system-tray.md).
 
@@ -487,10 +487,10 @@ play/pause and track controls include keyboard hotkeys.
 
 ## Adding a New App
 
-1. Create your component under `components/apps/my-app/index.tsx`.
+1. Create your component under `apps/my-app/index.tsx`.
 2. Register it in `apps.config.js` using dynamic import:
    ```ts
-   const MyApp = dynamic(() => import('./components/apps/my-app'));
+   const MyApp = dynamic(() => import('./apps/my-app'));
    export const displayMyApp = () => <MyApp />;
    ```
 3. Add metadata (icon, title) where appropriate.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 The project is a desktop-style portfolio built with Next.js.
 
 - **pages/** wraps applications using Next.js routing and dynamic imports.
-- **components/apps/** contains the individual app implementations.
+- **apps/** contains the individual app implementations.
 - **pages/api/** exposes serverless functions for backend features.
 
 For setup instructions, see the [Getting Started](./getting-started.md) guide.

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -13,7 +13,7 @@ Use this checklist when adding a new app to the portfolio.
 ```ts
 import dynamic from 'next/dynamic';
 
-const MyApp = dynamic(() => import('./components/apps/my-app'), {
+const MyApp = dynamic(() => import('./apps/my-app'), {
   ssr: false,
 });
 export const displayMyApp = () => <MyApp />;

--- a/docs/reconng.md
+++ b/docs/reconng.md
@@ -4,7 +4,7 @@
 
 ## Module Schemas
 
-Modules are defined in `components/apps/reconng/index.js` as schema objects with:
+Modules are defined in `apps/reconng/index.js` as schema objects with:
 
 - `input` – expected target type (`domain` or `ip`).
 - `demo(target)` – returns canned text, nodes and edges for offline runs.


### PR DESCRIPTION
## Summary
- designate `/apps` as the canonical app location
- warn when dynamic app lookup fails and remove old `components/apps` fallback
- document the new `/apps` convention

## Testing
- `yarn test utils/createDynamicApp.test.ts --passWithNoTests`
- `yarn eslint README.md docs/architecture.md docs/new-app-checklist.md docs/reconng.md utils/createDynamicApp.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc031450008328a9af1dc164fe199c