### PR TITLE
refactor: generate nonce with btoa

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 function nonce() {
-  const arr = new Uint8Array(16);
-  crypto.getRandomValues(arr);
-  return Buffer.from(arr).toString('base64');
+  const arr = crypto.getRandomValues(new Uint8Array(16));
+  return btoa(String.fromCharCode(...arr));
 }
 
 export function middleware(req: NextRequest) {


### PR DESCRIPTION
## Summary
- use Web Crypto and btoa to generate CSP nonce
- drop Node-only Buffer usage in middleware

## Testing
- `npx eslint middleware.ts && echo 'Lint passed'`
- `yarn test --passWithNoTests middleware`

------
https://chatgpt.com/codex/tasks/task_e_68bc030adcc083288d6d5029eac7fdeb