### PR TITLE
fix: edge safe nonce and sync CSP

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,12 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 function nonce() {
-  const arr = new Uint8Array(16);
-  crypto.getRandomValues(arr);
-  return Buffer.from(arr).toString('base64');
+  const arr = crypto.getRandomValues(new Uint8Array(16));
+  let str = '';
+  arr.forEach((v) => {
+    str += String.fromCharCode(v);
+  });
+  return btoa(str);
 }
 
 export function middleware(req: NextRequest) {
@@ -13,8 +16,8 @@ export function middleware(req: NextRequest) {
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
-    "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
+    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://sdk.scdn.co https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",
     "object-src 'none'",


### PR DESCRIPTION
## Summary
- generate CSP nonce without Buffer for edge compatibility
- align middleware CSP domains with site configuration

## Testing
- `npx eslint middleware.ts`
- `yarn test middleware` *(fails: No tests found)*
- `yarn dev` *(fails: TypeError: The "to" argument must be of type string. Received undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0311f4fc8328a5d807052bce73d5