### PR TITLE
test: ensure no-top-level-window plugin flags globals

### DIFF
--- a/__tests__/no-top-level-window.test.js
+++ b/__tests__/no-top-level-window.test.js
@@ -1,0 +1,23 @@
+const { RuleTester } = require('eslint');
+const rule = require('../eslint-plugin-no-top-level-window/no-top-level-window-or-document');
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-top-level-window-or-document', rule, {
+  valid: [
+    "function ok() { window.alert('hi'); }",
+    "const fn = () => { document.title; };",
+  ],
+  invalid: [
+    {
+      code: "window.alert('hi');",
+      errors: [{ message: "Unexpected global 'window'." }],
+    },
+    {
+      code: 'document.title;',
+      errors: [{ message: "Unexpected global 'document'." }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add RuleTester cases for no-top-level-window plugin covering window and document

## Testing
- `npx eslint __tests__/no-top-level-window.test.js`
- `yarn test __tests__/no-top-level-window.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc03159ea08328b5dbf67984b1f33f