### PR TITLE
Apply Ubuntu font class to document body

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,12 +17,6 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
-import { Ubuntu } from 'next/font/google';
-
-const ubuntu = Ubuntu({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '700'],
-});
 
 let SpeedInsights = () => null;
 if (process.env.NODE_ENV === 'production') {
@@ -200,7 +194,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,10 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { Ubuntu } from 'next/font/google';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+});
 
 class MyDocument extends Document {
   /**
@@ -20,7 +26,7 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
-        <body>
+        <body className={ubuntu.className}>
           <Main />
           <NextScript nonce={nonce} />
         </body>


### PR DESCRIPTION
## Summary
- load Ubuntu font in custom document and apply its class on `<body>`
- remove redundant font wrapper from `_app.jsx`

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/appImport.test.ts`
- `yarn lint` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0316f6348328853d9b4d7dc79309