### PR TITLE
Add loading fallbacks to dynamic app imports

### DIFF
--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 
 const AppGrid = dynamic(() => import('../../components/apps/app-grid'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 
 const AppsPage = () => {

--- a/pages/apps/input-lab.jsx
+++ b/pages/apps/input-lab.jsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
 
-const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
+const InputLab = dynamic(() => import('../../apps/input-lab'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function InputLabPage() {
   return <InputLab />;

--- a/pages/apps/settings/index.tsx
+++ b/pages/apps/settings/index.tsx
@@ -3,21 +3,27 @@ import { useEffect, useState } from 'react';
 
 const SettingsApp = dynamic(() => import('../../../apps/settings'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 const DateTimeSettings = dynamic(() => import('./date-time'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 const IconSettings = dynamic(() => import('./icons'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 const FontSettings = dynamic(() => import('./fonts'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 const DpiSettings = dynamic(() => import('./dpi'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 const MouseSettings = dynamic(() => import('./mouse'), {
   ssr: false,
+  loading: () => <p>Loading...</p>,
 });
 
 export default function SettingsPage() {

--- a/pages/apps/settings/mouse/index.tsx
+++ b/pages/apps/settings/mouse/index.tsx
@@ -2,7 +2,7 @@ import dynamic from "next/dynamic";
 
 const MouseSettings = dynamic(
   () => import("../../../../apps/settings/mouse"),
-  { ssr: false }
+  { ssr: false, loading: () => <p>Loading...</p> }
 );
 
 export default function MouseSettingsPage() {

--- a/pages/apps/settings/session-startup/autostart.tsx
+++ b/pages/apps/settings/session-startup/autostart.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic';
 
 const Autostart = dynamic(
   () => import('../../../../apps/settings/session-startup/autostart'),
-  { ssr: false }
+  { ssr: false, loading: () => <p>Loading...</p> }
 );
 
 export default function AutostartPage() {


### PR DESCRIPTION
## Summary
- ensure dynamic imports in `/pages/apps` include a `loading` fallback component
- cover app grid, input lab, and settings pages

## Testing
- `npm test` *(fails: getChatId › throws and logs when chat is undefined)*
- `npm run lint` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bc03150b688328a47a14aef4ca1f24