### PR TITLE
test: cover safe mode and failing app

### DIFF
--- a/__tests__/appLoadError.test.tsx
+++ b/__tests__/appLoadError.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createDynamicApp } from "../utils/createDynamicApp";
+
+jest.mock("next/dynamic", () => {
+  return (importer: () => Promise<any>) => {
+    let Loaded: any = null;
+    return function DynamicComponent(props: any) {
+      if (!Loaded) {
+        throw importer().then((mod) => {
+          Loaded = mod.default || mod;
+        });
+      }
+      const C = Loaded;
+      return <C {...props} />;
+    };
+  };
+});
+
+describe("createDynamicApp", () => {
+  it("renders fallback when app fails to load", async () => {
+    const BrokenApp = createDynamicApp("missing-app", "Missing App");
+    render(
+      <div>
+        <span>Shell Ready</span>
+        <React.Suspense fallback={null}>
+          <BrokenApp />
+        </React.Suspense>
+      </div>,
+    );
+    expect(screen.getByText("Shell Ready")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Unable to load Missing App"),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/ubuntu.safeMode.test.tsx
+++ b/__tests__/ubuntu.safeMode.test.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 
-jest.mock("../components/ubuntu", () => {
-  return function BrokenUbuntu() {
+jest.mock("../components/screen/desktop", () => {
+  return function BrokenDesktop() {
     throw new Error("boot failure");
   };
 });
@@ -11,7 +10,7 @@ jest.mock("../components/ubuntu", () => {
 import Ubuntu from "../components/screen/ubuntu";
 
 describe("Ubuntu safe mode", () => {
-  it("displays safe mode and clears customizations", async () => {
+  it("displays safe mode and clears customizations", () => {
     window.localStorage.setItem("app:theme", "dark");
     window.localStorage.setItem(
       "panel:profiles",
@@ -25,9 +24,5 @@ describe("Ubuntu safe mode", () => {
 
     expect(window.localStorage.getItem("app:theme")).toBe('"default"');
     expect(window.localStorage.getItem("panel:profiles")).toBe("{}");
-
-    await userEvent.click(
-      screen.getByRole("button", { name: /return to desktop/i }),
-    );
   });
 });


### PR DESCRIPTION
## Summary
- verify safe mode activates when the desktop component fails
- ensure dynamic app loader displays a fallback if an app import fails

## Testing
- `yarn test __tests__/ubuntu.safeMode.test.tsx __tests__/appLoadError.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc0317e6f08328aaee2011e2fc784e