### PR TITLE
refactor: replace src alias imports

### DIFF
--- a/__tests__/clipboard.test.ts
+++ b/__tests__/clipboard.test.ts
@@ -1,4 +1,4 @@
-import { stripFormatting } from '@/src/lib/clipboard';
+import { stripFormatting } from '../src/lib/clipboard';
 
 describe('stripFormatting', () => {
   it('removes HTML tags', () => {

--- a/__tests__/clipman.test.tsx
+++ b/__tests__/clipman.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import Clipman from '../components/Clipman';
-import { pastePlainText } from '@/src/lib/clipboard';
+import { pastePlainText } from '../src/lib/clipboard';
 
-jest.mock('@/src/lib/clipboard', () => ({
+jest.mock('../src/lib/clipboard', () => ({
   pastePlainText: jest.fn().mockResolvedValue('hello'),
 }));
 

--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import InstallButton from '../components/InstallButton';
-import { initA2HS } from '@/src/pwa/a2hs';
+import { initA2HS } from '../src/pwa/a2hs';
 
 describe('InstallButton', () => {
   test('shows install prompt when beforeinstallprompt fires', async () => {

--- a/apps/settings/components/PowerProfilesDialog.tsx
+++ b/apps/settings/components/PowerProfilesDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Modal from '../../../components/base/Modal';
-import type { PowerSettings, PowerProfile } from '@/src/lib/power/schema';
+import type { PowerSettings, PowerProfile } from '../../../src/lib/power/schema';
 
 interface Props {
   open: boolean;

--- a/apps/settings/components/WindowManagerTweaks.tsx
+++ b/apps/settings/components/WindowManagerTweaks.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useWorkspaceMargins } from '@/src/state/workspace';
+import { useWorkspaceMargins } from '../../../src/state/workspace';
 
 export default function WindowManagerTweaks() {
   const [margins, setMargins] = useWorkspaceMargins();

--- a/components/Clipman.tsx
+++ b/components/Clipman.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { pastePlainText } from '@/src/lib/clipboard';
+import { pastePlainText } from '../src/lib/clipboard';
 
 interface MenuState {
   x: number;

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
-import { showA2HS } from '@/src/pwa/a2hs';
+import { showA2HS } from '../src/pwa/a2hs';
 
 const InstallButton: React.FC = () => {
   const [visible, setVisible] = useState(false);

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -3,12 +3,12 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
-import PanelProfilesDialog from '@/src/components/panel/PanelProfilesDialog';
+import PanelProfilesDialog from '../../../src/components/panel/PanelProfilesDialog';
 import {
   DEFAULT_PANEL_LAYOUT,
   PANEL_LAYOUT_KEY,
   PanelLayout,
-} from '@/src/components/panel/types';
+} from '../../../src/components/panel/types';
 
 /** Simple Adwaita-like toggle switch */
 function Toggle({

--- a/src/components/settings/AutostartManager.tsx
+++ b/src/components/settings/AutostartManager.tsx
@@ -5,7 +5,7 @@ import {
   readAutostart,
   saveAutostartEntry,
   AutostartEntry,
-} from "@/src/lib/autostart";
+} from "../../lib/autostart";
 
 const AutostartManager: React.FC = () => {
   const [entries, setEntries] = useState<AutostartEntry[]>([]);

--- a/src/wm/placement.ts
+++ b/src/wm/placement.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceMargins } from '@/src/state/workspace';
+import type { WorkspaceMargins } from '../state/workspace';
 
 export interface Rect {
   x: number;


### PR DESCRIPTION
## Summary
- refactor imports that used `@/src` alias to use relative paths
- update tests to match new import locations

## Testing
- `yarn test __tests__/clipboard.test.ts __tests__/clipman.test.tsx __tests__/installButton.test.tsx`
- `yarn lint src/components/settings/AutostartManager.tsx src/wm/placement.ts pages/ui/settings/theme.tsx components/InstallButton.tsx apps/settings/components/PowerProfilesDialog.tsx apps/settings/components/WindowManagerTweaks.tsx components/Clipman.tsx __tests__/installButton.test.tsx __tests__/clipboard.test.ts __tests__/clipman.test.tsx` (fails: A control must be associated with a text label; Component definition is missing display name; Unused eslint-disable directive)

------
https://chatgpt.com/codex/tasks/task_e_68bc0319c10883288cbcaff32f053d1c