### PR TITLE
feat: add chunk names for heavy modules

### DIFF
--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -12,12 +12,27 @@ import { useSettings } from '../../../hooks/useSettings';
 
 const CytoscapeComponent = dynamic(
   async () => {
-    const cytoscape = (await import('cytoscape')).default;
-    const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
+    const cytoscape = (
+      await import(
+        /* webpackChunkName: "cytoscape-core" */ 'cytoscape'
+      )
+    ).default;
+    const coseBilkent = (
+      await import(
+        /* webpackChunkName: "cytoscape-cose" */ 'cytoscape-cose-bilkent'
+      )
+    ).default;
     cytoscape.use(coseBilkent);
-    return (await import('react-cytoscapejs')).default;
+    return (
+      await import(
+        /* webpackChunkName: "react-cytoscapejs" */ 'react-cytoscapejs'
+      )
+    ).default;
   },
-  { ssr: false },
+  {
+    ssr: false,
+    loading: () => <p>Loading graph...</p>,
+  },
 );
 
 // Built-in modules with simple schemas and canned demo data. Each schema defines

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -5,7 +5,16 @@ import dynamic from 'next/dynamic';
 import apps from '../../apps.config';
 
 // Load the actual VSCode app lazily so no editor dependencies are required
-const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
+const VsCode = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "app-vscode" */ '../../apps/vscode'
+    ),
+  {
+    ssr: false,
+    loading: () => <p>Loading VSCode...</p>,
+  },
+);
 
 // Simple fuzzy match: returns true if query characters appear in order
 function fuzzyMatch(text, query) {

--- a/pages/recon/graph.tsx
+++ b/pages/recon/graph.tsx
@@ -31,8 +31,14 @@ interface GraphLink {
 }
 
 const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false },
+  () =>
+    import(
+      /* webpackChunkName: "react-force-graph" */ 'react-force-graph'
+    ).then((mod) => mod.ForceGraph2D),
+  {
+    ssr: false,
+    loading: () => <p>Loading graph...</p>,
+  },
 );
 
 const ReconGraph: React.FC = () => {


### PR DESCRIPTION
## Summary
- name VSCode chunk and add loading fallback
- name ForceGraph chunk and provide loading state
- name Cytoscape chunk and show loading state

## Testing
- `npm test` (fails: NmapNSEApp copies example output to clipboard)
- `npm test __tests__/nmapNse.test.tsx` (fails: NmapNSEApp copies example output to clipboard)
- `npm run lint` (fails: Command terminated)


------
https://chatgpt.com/codex/tasks/task_e_68bc031c1c74832899b9d99a917be46a