### PR TITLE
Defer dynamic import prefetch

### DIFF
--- a/__tests__/appGrid.prefetch.test.tsx
+++ b/__tests__/appGrid.prefetch.test.tsx
@@ -42,6 +42,13 @@ import AppGrid from '../components/apps/app-grid';
 
 beforeEach(() => {
   prefetch.mockClear();
+  // Mock fetch HEAD requests for prefetch size checks
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      headers: { get: () => '1000' },
+    }) as any,
+  );
   global.IntersectionObserver = class {
     constructor(cb) {
       this.cb = cb;
@@ -55,11 +62,11 @@ beforeEach(() => {
   } as any;
 });
 
-test('prefetches when grid item becomes visible', () => {
+test('prefetches when grid item becomes visible', async () => {
   jest.useFakeTimers();
   render(<AppGrid openApp={() => {}} />);
   expect(prefetch).not.toHaveBeenCalled();
-  jest.runAllTimers();
+  await jest.runAllTimersAsync();
   expect(prefetch).toHaveBeenCalledTimes(1);
   jest.useRealTimers();
 });

--- a/__tests__/apps.smoke.test.tsx
+++ b/__tests__/apps.smoke.test.tsx
@@ -38,7 +38,10 @@ beforeAll(() => {
 
   // mock fetch for components that request external resources
   (global as any).fetch = jest.fn(() =>
-    Promise.resolve({ json: () => Promise.resolve({}) })
+    Promise.resolve({
+      json: () => Promise.resolve({}),
+      headers: { get: () => '0' },
+    }),
   );
 
   // basic Worker mock for components using web workers

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -4,6 +4,7 @@ import apps, { games, utilities } from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Grid } from 'react-window';
 import useIntersection from '../../hooks/useIntersection';
+import prefetchDynamicImport from '../../utils/prefetchDynamicImport';
 
 function fuzzyHighlight(text, query) {
   const q = query.toLowerCase();
@@ -109,7 +110,7 @@ export default function AppGrid({ openApp }) {
         !prefetchedRef.current.has(app.id)
       ) {
         const timer = setTimeout(() => {
-          app.screen.prefetch();
+          prefetchDynamicImport(app.screen.prefetch, `/apps/${app.id}.js`);
           prefetchedRef.current.add(app.id);
         }, 200);
         return () => clearTimeout(timer);

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
+import prefetchDynamicImport from '../../utils/prefetchDynamicImport'
 
 export class UbuntuApp extends Component {
     constructor() {
@@ -26,7 +27,7 @@ export class UbuntuApp extends Component {
 
     handlePrefetch = () => {
         if (!this.state.prefetched && typeof this.props.prefetch === 'function') {
-            this.props.prefetch();
+            prefetchDynamicImport(this.props.prefetch, `/apps/${this.props.id}.js`);
             this.setState({ prefetched: true });
         }
     }

--- a/utils/prefetchDynamicImport.js
+++ b/utils/prefetchDynamicImport.js
@@ -1,0 +1,30 @@
+const MAX_PREFETCH_BYTES = 200 * 1024; // 200KB threshold
+
+function schedulePrefetch(fn) {
+  if (typeof window !== 'undefined') {
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(fn);
+    } else {
+      setTimeout(fn, 0);
+    }
+  }
+}
+
+export default function prefetchDynamicImport(prefetchFn, url) {
+  if (typeof prefetchFn !== 'function') return;
+
+  if (!url || typeof fetch !== 'function') {
+    schedulePrefetch(prefetchFn);
+    return;
+  }
+
+  fetch(url, { method: 'HEAD' })
+    .then((res) => {
+      const len = parseInt(res.headers.get('content-length') || '0', 10);
+      if (len && len > MAX_PREFETCH_BYTES) return;
+      schedulePrefetch(prefetchFn);
+    })
+    .catch(() => {
+      schedulePrefetch(prefetchFn);
+    });
+}


### PR DESCRIPTION
## Summary
- defer dynamic import prefetch until idle
- skip prefetch for large chunks using HEAD size checks
- test dynamic prefetch behavior

## Testing
- `yarn test __tests__/appGrid.prefetch.test.tsx`
- `yarn test __tests__/appImport.test.ts` (fails: Cannot find module for some app ids)
- `yarn test __tests__/adminMessages.test.ts` (fails: Expected number of calls >= 1, Received 0)
- `yarn test __tests__/chatManager.test.ts` (fails: Expected number of calls >= 1, Received 0)


------
https://chatgpt.com/codex/tasks/task_e_68bc031c7e488328af1fabc0e22666c5