### PR TITLE
feat: add audio context manager for games

### DIFF
--- a/__tests__/gameAudioNodes.test.ts
+++ b/__tests__/gameAudioNodes.test.ts
@@ -1,0 +1,52 @@
+describe('game audio node manager', () => {
+  let close: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    close = jest.fn().mockResolvedValue(undefined);
+
+    class MockGainNode {
+      connect = jest.fn();
+      disconnect = jest.fn();
+    }
+
+    class MockAudioContext {
+      static count = 0;
+      state: 'running' | 'suspended' = 'running';
+      destination = {};
+      constructor() {
+        MockAudioContext.count += 1;
+      }
+      createGain() {
+        return new MockGainNode() as unknown as GainNode;
+      }
+      resume() {
+        this.state = 'running';
+      }
+      close = close;
+    }
+
+    // @ts-ignore
+    window.AudioContext = MockAudioContext as any;
+    // @ts-ignore
+    window.webkitAudioContext = MockAudioContext as any;
+  });
+
+  test('getAudioContext returns singleton', () => {
+    const { getAudioContext } = require('../games/common/audio');
+    const ctx1 = getAudioContext();
+    const ctx2 = getAudioContext();
+    expect(ctx1).toBe(ctx2);
+    expect((window.AudioContext as any).count).toBe(1);
+  });
+
+  test('request and release nodes, closing context when unused', () => {
+    const { requestAudioNode, releaseAudioNode } = require('../games/common/audio');
+    const node1 = requestAudioNode();
+    const node2 = requestAudioNode();
+    releaseAudioNode(node1);
+    expect(close).not.toHaveBeenCalled();
+    releaseAudioNode(node2);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/games/common/audio.ts
+++ b/games/common/audio.ts
@@ -1,0 +1,44 @@
+let ctx: AudioContext | null = null;
+const nodes = new Set<AudioNode>();
+
+export function getAudioContext(): AudioContext {
+  if (typeof window === 'undefined') {
+    throw new Error('AudioContext unavailable');
+  }
+  if (!ctx) {
+    const Ctor =
+      (window.AudioContext || (window as any).webkitAudioContext) as
+        | typeof AudioContext
+        | undefined;
+    if (!Ctor) {
+      throw new Error('AudioContext constructor missing');
+    }
+    ctx = new Ctor();
+  } else if (ctx.state === 'suspended') {
+    ctx.resume();
+  }
+  return ctx;
+}
+
+export function requestAudioNode(): GainNode {
+  const context = getAudioContext();
+  const node = context.createGain();
+  node.connect(context.destination);
+  nodes.add(node);
+  return node;
+}
+
+export function releaseAudioNode(node: AudioNode): void {
+  if (nodes.has(node)) {
+    try {
+      node.disconnect();
+    } catch {
+      /* ignore */
+    }
+    nodes.delete(node);
+  }
+  if (ctx && nodes.size === 0) {
+    ctx.close();
+    ctx = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared audio module that maintains a singleton AudioContext
- support requesting and releasing game-specific gain nodes
- cover new audio manager with unit tests

## Testing
- `yarn test __tests__/gameAudioNodes.test.ts __tests__/player.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc031d64c483288d42266c538ab3ad