### PR TITLE
feat: persist snapped window positions

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -62,6 +62,9 @@ export class Window extends Component {
         if (this._uiExperiments) {
             this.scheduleUsageCheck();
         }
+        if (this.props.initialSnap) {
+            this.snapWindow(this.props.initialSnap);
+        }
     }
 
     componentWillUnmount() {
@@ -268,16 +271,17 @@ export class Window extends Component {
         r.style.setProperty('--window-transform-x', x.toFixed(1).toString() + "px");
         r.style.setProperty('--window-transform-y', y.toFixed(1).toString() + "px");
         if (this.props.onPositionChange) {
-            this.props.onPositionChange(x, y);
+            this.props.onPositionChange(x, y, this.state.snapped);
         }
     }
 
     unsnapWindow = () => {
         if (!this.state.snapped) return;
+        const prev = this.state.prevBounds;
         var r = document.querySelector("#" + this.id);
         if (r) {
-            if (this.state.prevBounds) {
-                const { x, y } = this.state.prevBounds;
+            if (prev) {
+                const { x, y } = prev;
                 r.style.transform = `translate(${x}px,${y}px)`;
             } else {
                 const x = r.style.getPropertyValue('--window-transform-x');
@@ -286,6 +290,9 @@ export class Window extends Component {
                     r.style.transform = `translate(${x},${y})`;
                 }
             }
+        }
+        if (this.props.onPositionChange && prev) {
+            this.props.onPositionChange(prev.x, prev.y, null);
         }
         if (this.state.lastSize) {
             this.setState({
@@ -330,6 +337,9 @@ export class Window extends Component {
         }
         if (r && transform) {
             r.style.transform = transform;
+        }
+        if (this.props.onPositionChange && prevBounds) {
+            this.props.onPositionChange(prevBounds.x, prevBounds.y, position);
         }
         this.setState({
             snapPreview: null,

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -83,8 +83,8 @@ export class Desktop extends Component {
             }
 
             if (session.windows && session.windows.length) {
-                session.windows.forEach(({ id, x, y }) => {
-                    positions[id] = { x, y };
+                session.windows.forEach(({ id, x, y, snap }) => {
+                    positions[id] = { x, y, snap };
                 });
                 this.setState({ window_positions: positions }, () => {
                     session.windows.forEach(({ id }) => this.openApp(id));
@@ -575,7 +575,8 @@ export class Desktop extends Component {
                     defaultHeight: app.defaultHeight,
                     initialX: pos ? pos.x : undefined,
                     initialY: pos ? pos.y : undefined,
-                    onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
+                    initialSnap: pos ? pos.snap : undefined,
+                    onPositionChange: (x, y, snap) => this.updateWindowPosition(app.id, x, y, snap),
                     snapEnabled: this.props.snapEnabled,
                 }
 
@@ -591,12 +592,15 @@ export class Desktop extends Component {
         return windowsJsx;
     }
 
-    updateWindowPosition = (id, x, y) => {
+    updateWindowPosition = (id, x, y, snapPos = null) => {
         const snap = this.props.snapEnabled
             ? (v) => Math.round(v / 8) * 8
             : (v) => v;
         this.setState(prev => ({
-            window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
+            window_positions: {
+                ...prev.window_positions,
+                [id]: { x: snap(x), y: snap(y), snap: snapPos }
+            }
         }), this.saveSession);
     }
 
@@ -606,7 +610,8 @@ export class Desktop extends Component {
         const windows = openWindows.map(id => ({
             id,
             x: this.state.window_positions[id] ? this.state.window_positions[id].x : 60,
-            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10
+            y: this.state.window_positions[id] ? this.state.window_positions[id].y : 10,
+            snap: this.state.window_positions[id] ? this.state.window_positions[id].snap : null,
         }));
         const dock = Object.keys(this.state.favourite_apps).filter(id => this.state.favourite_apps[id]);
         this.props.setSession({ ...this.props.session, windows, dock });

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,6 +5,7 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  snap?: 'left' | 'right' | 'top' | null;
 }
 
 export interface DesktopSession {
@@ -24,6 +25,18 @@ function isSession(value: unknown): value is DesktopSession {
   const s = value as DesktopSession;
   return (
     Array.isArray(s.windows) &&
+    s.windows.every(
+      (w) =>
+        w &&
+        typeof w.id === 'string' &&
+        typeof w.x === 'number' &&
+        typeof w.y === 'number' &&
+        (w.snap === undefined ||
+          w.snap === null ||
+          w.snap === 'left' ||
+          w.snap === 'right' ||
+          w.snap === 'top'),
+    ) &&
     typeof s.wallpaper === 'string' &&
     Array.isArray(s.dock)
   );


### PR DESCRIPTION
## Summary
- store snap alignment with each window session and restore on boot
- track snapped/unsnapped coords with `onPositionChange`
- auto-apply initial snap when windows mount

## Testing
- `npm test --silent` *(fails: Test Suites: 4 failed, 3 skipped, 168 passed, 172 of 177 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bc031de1c08328abd5c7ad81235610