### PR TITLE
feat: set caching headers for fonts and images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -195,7 +195,7 @@ module.exports = withBundleAnalyzer(
                 ],
               },
               {
-                source: '/fonts/(.*)',
+                source: '/fonts/:path*',
                 headers: [
                   {
                     key: 'Cache-Control',
@@ -204,11 +204,11 @@ module.exports = withBundleAnalyzer(
                 ],
               },
               {
-                source: '/images/(.*)',
+                source: '/images/:path*',
                 headers: [
                   {
                     key: 'Cache-Control',
-                    value: 'public, max-age=86400',
+                    value: 'public, max-age=86400, immutable',
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
- serve fonts from `/fonts/:path*` with long-lived immutable cache
- add immutable day-long caching for `/images/:path*`

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/adminMessages.test.ts __tests__/chatManager.test.ts --silent` *(fails: 3 failed)*
- `yarn lint next.config.js` *(fails: no output, process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bc031ee81083289835ebf9191555a0