### PR TITLE
Ensure nosniff header for HTML responses

### DIFF
--- a/__tests__/nosniff.test.ts
+++ b/__tests__/nosniff.test.ts
@@ -1,0 +1,21 @@
+function makeReq(accept: string) {
+  return { headers: new Headers({ accept }) } as any;
+}
+
+jest.mock('next/server', () => ({
+  NextResponse: { next: () => ({ headers: new Headers() }) },
+}));
+
+const { middleware } = require('../middleware');
+
+describe('X-Content-Type-Options header', () => {
+  it('sets nosniff for HTML responses', () => {
+    const res = middleware(makeReq('text/html'));
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('does not set nosniff for non-HTML responses', () => {
+    const res = middleware(makeReq('application/json'));
+    expect(res.headers.get('X-Content-Type-Options')).toBeNull();
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,5 +25,8 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  if (req.headers.get('accept')?.includes('text/html')) {
+    res.headers.set('X-Content-Type-Options', 'nosniff');
+  }
   return res;
 }


### PR DESCRIPTION
## Summary
- set `X-Content-Type-Options: nosniff` for HTML responses in middleware
- add tests verifying nosniff header behavior

## Testing
- `yarn lint middleware.ts __tests__/nosniff.test.ts` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/nosniff.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc0321295c8328a8dc3c4ef9fa597c