### PR TITLE
Limit Workbox caching to fonts and images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -68,25 +68,13 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   disable: process.env.VERCEL_ENV !== 'production',
   buildExcludes: [/dynamic-css-manifest\.json$/],
   workboxOptions: {
-    navigateFallback: '/offline.html',
     additionalManifestEntries: [
-      { url: '/', revision: null },
-      { url: '/feeds', revision: null },
-      { url: '/about', revision: null },
-      { url: '/projects', revision: null },
-      { url: '/projects.json', revision: null },
-      { url: '/apps', revision: null },
-      { url: '/apps/weather', revision: null },
-      { url: '/apps/terminal', revision: null },
-      { url: '/apps/checkers', revision: null },
-      { url: '/offline.html', revision: null },
-      { url: '/manifest.webmanifest', revision: null },
       { url: '/favicon.ico', revision: null },
       { url: '/favicon.svg', revision: null },
       { url: '/images/logos/fevicon.png', revision: null },
       { url: '/images/logos/logo_1024.png', revision: null },
     ],
-    // Cache only images and fonts to ensure app shell updates while assets work offline
+    // Cache only images and fonts; avoid HTML caching so the app shell always updates
     runtimeCaching: require('./cache.js'),
   },
 });


### PR DESCRIPTION
## Summary
- Remove HTML routes from Workbox precache configuration
- Keep only favicon and logo assets in additional manifest entries

## Testing
- `npx eslint next.config.js`
- `npx jest __tests__/appImport.test.ts __tests__/adminMessages.test.ts __tests__/chatManager.test.ts` (fails: 3 failed)


------
https://chatgpt.com/codex/tasks/task_e_68bc0323d9cc8328a83b66a72fa8c26c