### PR TITLE
fix: guard periodic background sync permission query

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -70,13 +70,20 @@ function MyApp(props) {
 
           if ('periodicSync' in registration) {
             try {
-              const status = await navigator.permissions.query({
-                name: 'periodic-background-sync',
-              });
-              if (status.state === 'granted') {
-                await registration.periodicSync.register('content-sync', {
-                  minInterval: 24 * 60 * 60 * 1000,
+              if (
+                'permissions' in navigator &&
+                typeof navigator.permissions.query === 'function'
+              ) {
+                const status = await navigator.permissions.query({
+                  name: 'periodic-background-sync',
                 });
+                if (status.state === 'granted') {
+                  await registration.periodicSync.register('content-sync', {
+                    minInterval: 24 * 60 * 60 * 1000,
+                  });
+                } else {
+                  registration.update();
+                }
               } else {
                 registration.update();
               }


### PR DESCRIPTION
## Summary
- wrap `navigator.permissions.query` for periodic background sync behind feature detection

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/appImport.test.ts` *(fails: Unable to find role="alert"; dynamic app imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0326e77483289f4eb9af9abe78b4