### PR TITLE
chore: validate env in prod builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
-const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const { validateServerEnv } = require('./lib/validate.js');
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -94,6 +94,14 @@ const withPWA = require('@ducanh2912/next-pwa').default({
 const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 const isProd = process.env.NODE_ENV === 'production';
 
+if (isProd) {
+  try {
+    validateServerEnv(process.env);
+  } catch {
+    console.warn('Missing env vars; running without validation');
+  }
+}
+
 // Merge experiment settings and production optimizations into a single function.
 function configureWebpack(config, { isServer }) {
   // Enable WebAssembly loading and avoid JSON destructuring bug
@@ -119,12 +127,6 @@ function configureWebpack(config, { isServer }) {
     };
   }
   return config;
-}
-
-try {
-  validateEnv?.(process.env);
-} catch {
-  console.warn('Missing env vars; running without validation');
 }
 
 module.exports = withBundleAnalyzer(


### PR DESCRIPTION
## Summary
- validate environment variables when building in production

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, appImport.test.ts, adminMessages.test.ts, chatManager.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0329f7c483289c778714445a22b9