### PR TITLE
feat: hide contact widget without reCAPTCHA keys

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -1011,15 +1011,19 @@ const apps = [
     desktop_shortcut: false,
     screen: displayHtmlRewrite,
   },
-  {
-    id: 'contact',
-    title: 'Contact',
-    icon: '/themes/Yaru/apps/project-gallery.svg',
-    disabled: false,
-    favourite: false,
-    desktop_shortcut: false,
-    screen: displayContact,
-  },
+  ...(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+    ? [
+        {
+          id: 'contact',
+          title: 'Contact',
+          icon: '/themes/Yaru/apps/project-gallery.svg',
+          disabled: false,
+          favourite: false,
+          desktop_shortcut: false,
+          screen: displayContact,
+        },
+      ]
+    : []),
   {
     id: 'hydra',
     title: 'Hydra',

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -8,13 +8,15 @@ const RATE_LIMIT_MAX = 5;
 export const RATE_LIMIT_COOKIE = 'contactBackoff';
 
 export default async function handler(req, res) {
-  const missingRecaptcha = !process.env.RECAPTCHA_SECRET;
+  const missingRecaptchaSecret = !process.env.RECAPTCHA_SECRET;
+  const missingRecaptchaSiteKey = !process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   const missingSupabase =
     !process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-  if (missingRecaptcha || missingSupabase) {
+  if (missingRecaptchaSecret || missingRecaptchaSiteKey || missingSupabase) {
     console.warn('Contact API running in demo mode', {
-      missingRecaptcha,
+      missingRecaptchaSecret,
+      missingRecaptchaSiteKey,
       missingSupabase,
     });
   }

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -212,15 +212,16 @@ const InputHub = () => {
           onChange={(e) => setMessage(e.target.value)}
           required
         />
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={useCaptcha}
-            onChange={(e) => setUseCaptcha(e.target.checked)}
-            disabled={!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
-          />
-          <span>Use reCAPTCHA</span>
-        </label>
+        {process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY && (
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={useCaptcha}
+              onChange={(e) => setUseCaptcha(e.target.checked)}
+            />
+            <span>Use reCAPTCHA</span>
+          </label>
+        )}
         <button type="submit" className="bg-blue-500 text-white px-2 py-1">
           Send
         </button>


### PR DESCRIPTION
## Summary
- hide Input Hub reCAPTCHA toggle when no site key is configured
- log missing reCAPTCHA keys in contact API and disable widget when absent

## Testing
- `yarn test __tests__/contact.api.test.ts __tests__/contact.test.tsx __tests__/contactRateLimit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc032853c08328a4a327b019c14f3f