### PR TITLE
feat: add ubuntu font class to document body

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,10 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { Ubuntu } from 'next/font/google';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+});
 
 class MyDocument extends Document {
   /**
@@ -20,7 +26,7 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#0f1317" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
-        <body>
+        <body className={ubuntu.className}>
           <Main />
           <NextScript nonce={nonce} />
         </body>


### PR DESCRIPTION
## Summary
- apply Ubuntu font className to `<body>` in `_document.jsx`

## Testing
- `npx eslint pages/_document.jsx`
- `yarn test --passWithNoTests pages/_document.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc032cde74832894974f49e92fc219