### PR TITLE
feat: trigger service worker refresh

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* global clients */
+
 import { isBrowser } from '@/utils/env';
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
@@ -66,7 +68,10 @@ function MyApp(props) {
         try {
           const registration = await navigator.serviceWorker.register('/sw.js');
 
-          window.manualRefresh = () => registration.update();
+          window.manualRefresh = () => {
+            registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+            clients.claim();
+          };
 
           if ('periodicSync' in registration) {
             try {


### PR DESCRIPTION
## Summary
- ensure manualRefresh skips waiting service worker and claims clients

## Testing
- `yarn lint` (fails: control must be associated with a text label, etc.)
- `yarn test` (fails: Unable to find role="alert")

------
https://chatgpt.com/codex/tasks/task_e_68bc0325d120832887802f48a632aabd