### PR TITLE
feat: add health check endpoint

### DIFF
--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
+


### PR DESCRIPTION
## Summary
- add `/api/healthz` route responding with `{ ok: true }` for uptime checks

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/appImport.test.ts __tests__/chatManager.test.ts __tests__/adminMessages.test.ts` *(fails: 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc03333da883289014f1bddbd2f6b6