### PR TITLE
test: verify alt-tab z-order

### DIFF
--- a/__tests__/WindowSwitcher.test.tsx
+++ b/__tests__/WindowSwitcher.test.tsx
@@ -11,4 +11,20 @@ describe('WindowSwitcher', () => {
     });
     expect(screen.getByText('Window 1')).toBeInTheDocument();
   });
+
+  it('selects window on Alt release', () => {
+    const windows: WindowInfo[] = [
+      { id: '1', title: 'Window 1', icon: '/icon.png' },
+      { id: '2', title: 'Window 2', icon: '/icon2.png' },
+    ];
+    const onSelect = jest.fn();
+    render(<WindowSwitcher windows={windows} onSelect={onSelect} />);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', altKey: true }));
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+    });
+    expect(onSelect).toHaveBeenCalledWith('2');
+  });
 });

--- a/__tests__/adminMessages.test.ts
+++ b/__tests__/adminMessages.test.ts
@@ -17,7 +17,7 @@ describe('admin messages api', () => {
   it('logs unauthorized access', async () => {
     process.env.ADMIN_READ_KEY = 'secret';
     const { req, res } = createMocks({ method: 'GET', headers: {} });
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const spy = jest.spyOn(console, 'info').mockImplementation(() => {});
     const { default: handler } = await import('../pages/api/admin/messages');
     await handler(req as any, res as any);
     expect(res._getStatusCode()).toBe(401);

--- a/__tests__/chatManager.test.ts
+++ b/__tests__/chatManager.test.ts
@@ -4,7 +4,7 @@ import { createLogger } from '../lib/logger';
 describe('getChatId', () => {
   it('throws and logs when chat is undefined', () => {
     const logger = createLogger('test');
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const spy = jest.spyOn(console, 'info').mockImplementation(() => {});
     expect(() => getChatId(undefined as any, logger)).toThrow('chat is required');
     expect(spy).toHaveBeenCalled();
     const log = JSON.parse((spy.mock.calls[0] as any)[0]);

--- a/__tests__/zorder.test.tsx
+++ b/__tests__/zorder.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Taskbar from '../components/screen/taskbar';
+import { Desktop } from '../components/screen/desktop';
+
+describe('z-order logic', () => {
+  const apps = [
+    { id: 'app1', title: 'App One', icon: '/1.png' },
+    { id: 'app2', title: 'App Two', icon: '/2.png' },
+    { id: 'app3', title: 'App Three', icon: '/3.png' },
+  ];
+
+  function createDesktop() {
+    const desktop = new Desktop();
+    desktop.state = {
+      focused_windows: { app1: true, app2: false, app3: false },
+      minimized_windows: { app1: false, app2: false, app3: false },
+      closed_windows: { app1: false, app2: false, app3: false },
+    } as any;
+    desktop.app_stack = ['app1', 'app2', 'app3'];
+    // make setState synchronous for tests
+    desktop.setState = function (update: any, cb?: () => void) {
+      const next = typeof update === 'function' ? update(this.state, this.props) : update;
+      this.state = { ...this.state, ...next };
+      cb?.();
+    };
+    return desktop;
+  }
+
+  it('changes active window and taskbar highlight with Alt+Tab', () => {
+    const desktop = createDesktop();
+
+    // simulate Alt+Tab cycling to next window
+    desktop.cycleApps(1);
+
+    expect(desktop.getFocusedWindowId()).toBe('app2');
+
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={desktop.state.closed_windows}
+        minimized_windows={desktop.state.minimized_windows}
+        focused_windows={desktop.state.focused_windows}
+        openApp={() => {}}
+        minimize={() => {}}
+      />
+    );
+
+    const focused = screen.getByRole('button', { name: /app two/i });
+    expect(focused.className).toMatch(/bg-white/);
+  });
+
+  it('skips minimized windows when cycling', () => {
+    const desktop = createDesktop();
+    desktop.state.minimized_windows.app2 = true;
+
+    desktop.cycleApps(1);
+
+    expect(desktop.getFocusedWindowId()).toBe('app3');
+  });
+});


### PR DESCRIPTION
## Summary
- add z-order unit tests for Alt+Tab cycling and taskbar highlight
- ensure window switcher selects the correct window on Alt release
- update logging tests to spy on `console.info`

## Testing
- `yarn test` *(fails: Unable to find role="alert" in nmapNse.test.tsx; dynamic app imports missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc032cda448328b5fc7c662d46bbd7