### PR TITLE
ci: add verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  verify:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn verify:all
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install
@@ -119,6 +131,7 @@ jobs:
       - test
       - e2e
       - security
+      - verify
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- run `yarn verify:all` in CI
- gate `export` job on new `verify` job

## Testing
- `yarn verify:all` *(fails: logger.error is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bc033153008328bc7beed60942fe56