### PR TITLE
chore: set node runtime to 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"
   },
   "engines": {
-    "node": "20.x"
+    "node": "20.x || 22.x"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- ensure Vercel functions run on Node.js 20
- allow Node 20 or 22 in package engines

## Testing
- `yarn lint` *(fails: no output, possible environment limitation)*
- `yarn test` *(fails: no output, possible environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68bc030da3508328827df606cc4f655c