### PR TITLE
chore: regenerate route types during build

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "typegen": "next typegen",
+    "prebuild": "rm -rf .next && yarn typegen && yarn build:gamepad",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node --import tsx/esm scripts/safe-copy.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,16 @@
     "paths": {
       "@/*": ["./*"]
 
-    }
+    },
+    "noEmit": true,
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "types/**/*.d.ts",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
 }


### PR DESCRIPTION
## Summary
- run `next typegen` after clearing `.next` to ensure route types exist
- configure TypeScript for typed routes

## Testing
- `yarn typegen`
- `yarn build:gamepad`
- `yarn build` *(fails: Module parse failed: Unexpected token...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc031b8788832880be9e452903debe