### PR TITLE
refactor: use server env for supabase

### DIFF
--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -21,7 +21,7 @@ export default async function handler(
     return;
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) {
     console.warn('Leaderboard submission disabled: missing Supabase env');

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -13,8 +13,8 @@ export default async function handler(
   const game = typeof req.query.game === 'string' ? req.query.game : '2048';
   const limit = Number(req.query.limit ?? 10);
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
   if (!url || !key) {
     console.warn('Leaderboard read disabled: missing Supabase env');
     res.status(503).json([]);


### PR DESCRIPTION
## Summary
- use `SUPABASE_URL` and `SUPABASE_ANON_KEY` in leaderboard read API
- use server-side `SUPABASE_URL` in leaderboard submit API

## Testing
- `npm test __tests__/adminMessages.test.ts __tests__/chatManager.test.ts` *(fails: chatManager, adminMessages)*
- `SUPABASE_URL=https://example.com SUPABASE_SERVICE_ROLE_KEY=service_role SUPABASE_ANON_KEY=anon NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build` *(fails: Module parse failed: Unexpected token in various HTML/text imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bc032973608328acbc6d9c204a6c59