### PR TITLE
Mock external tool executions in API endpoints

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -1,49 +1,20 @@
-const randomUUIDMock = jest
-  .fn()
-  .mockReturnValueOnce('u')
-  .mockReturnValueOnce('p');
-
-jest.mock('crypto', () => ({
-  randomUUID: randomUUIDMock,
-}));
-
 process.env.FEATURE_TOOL_APIS = 'enabled';
 process.env.FEATURE_HYDRA = 'enabled';
 
-jest.mock('child_process', () => ({
-  execFile: (cmd, args, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-    }
-    callback(null, 'done', '');
-  },
-}));
-
 const handler = require('../pages/api/hydra').default;
-const path = require('path');
-const fs = require('fs').promises;
-const sessionDir = path.join(process.cwd(), 'hydra');
 
-test('removes temp files after hydra execution', async () => {
+test('returns mock output', async () => {
   const req = {
     method: 'POST',
-    body: { target: 'target', service: 'ssh', userList: 'u', passList: 'p' },
+    body: { target: 't', service: 'ssh', userList: 'u', passList: 'p' },
   };
-  const res = {
-    status: jest.fn().mockReturnThis(),
-    json: jest.fn(),
-  };
-
-  const userPath = '/tmp/hydra-users-u.txt';
-  const passPath = '/tmp/hydra-pass-p.txt';
-
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   await handler(req, res);
-
-  await expect(fs.access(userPath)).rejects.toBeTruthy();
-  await expect(fs.access(passPath)).rejects.toBeTruthy();
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ output: 'hydra mock' });
 });
-afterAll(async () => {
-  await fs.rm(sessionDir, { recursive: true, force: true });
+
+afterAll(() => {
   delete process.env.FEATURE_TOOL_APIS;
   delete process.env.FEATURE_HYDRA;
 });

--- a/__tests__/hydra.api.test.ts
+++ b/__tests__/hydra.api.test.ts
@@ -1,122 +1,35 @@
 // @jest-environment node
-import { promises as fs } from 'fs';
-import path from 'path';
 
-const USER_PATH = '/tmp/hydra-users-test-uuid.txt';
-const PASS_PATH = '/tmp/hydra-pass-test-uuid.txt';
-const SESSION_DIR = path.join(process.cwd(), 'hydra');
-
-async function cleanup() {
-  await fs.unlink(USER_PATH).catch(() => {});
-  await fs.unlink(PASS_PATH).catch(() => {});
-  await fs.rm(SESSION_DIR, { recursive: true, force: true }).catch(() => {});
-}
-
-describe('Hydra API temp file cleanup', () => {
+describe('Hydra API mock', () => {
   beforeEach(() => {
     process.env.FEATURE_TOOL_APIS = 'enabled';
     process.env.FEATURE_HYDRA = 'enabled';
   });
-  afterEach(async () => {
-    jest.resetModules();
-    jest.dontMock('child_process');
-    jest.dontMock('crypto');
-    await cleanup();
+
+  afterEach(() => {
     delete process.env.FEATURE_TOOL_APIS;
     delete process.env.FEATURE_HYDRA;
+    jest.resetModules();
   });
 
-  it('removes temp files after successful run', async () => {
-    jest.doMock('crypto', () => ({ randomUUID: () => 'test-uuid' }));
-    const execFileMock = jest.fn((cmd: string, args: any, options: any, cb: any) => {
-      if (typeof options === 'function') {
-        cb = options;
-      }
-      cb(null, '', '');
-    });
-    jest.doMock('child_process', () => ({ execFile: execFileMock }));
-
+  it('returns mock output', async () => {
     const handler = (await import('../pages/api/hydra')).default;
-
     const req: any = {
       method: 'POST',
       body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
     };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
-
     await handler(req, res);
-
-    await expect(fs.access(USER_PATH)).rejects.toThrow();
-    await expect(fs.access(PASS_PATH)).rejects.toThrow();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ output: 'hydra mock' });
   });
 
-  it('removes temp files if hydra missing', async () => {
-    jest.doMock('crypto', () => ({ randomUUID: () => 'test-uuid' }));
-    const execFileMock = jest.fn((cmd: string, args: any, options: any, cb: any) => {
-      if (typeof options === 'function') {
-        cb = options;
-      }
-      if (cmd === 'which') {
-        cb(new Error('missing'), '', '');
-      } else {
-        cb(null, '', '');
-      }
-    });
-    jest.doMock('child_process', () => ({ execFile: execFileMock }));
-
+  it('returns mock output for resume', async () => {
     const handler = (await import('../pages/api/hydra')).default;
-
-    const req: any = {
-      method: 'POST',
-      body: { target: 'host', service: 'ssh', userList: 'u', passList: 'p' },
-    };
-    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
-
-    await handler(req, res);
-
-    await expect(fs.access(USER_PATH)).rejects.toThrow();
-    await expect(fs.access(PASS_PATH)).rejects.toThrow();
-  });
-});
-
-describe('Hydra API resume session', () => {
-  const sessionDir = path.join(process.cwd(), 'hydra');
-  const sessionFile = path.join(sessionDir, 'session');
-
-  beforeEach(async () => {
-    process.env.FEATURE_TOOL_APIS = 'enabled';
-    process.env.FEATURE_HYDRA = 'enabled';
-    await fs.mkdir(sessionDir, { recursive: true });
-    await fs.writeFile(sessionFile, 'dummy');
-  });
-
-  afterEach(async () => {
-    jest.resetModules();
-    jest.dontMock('child_process');
-    await fs.rm(sessionDir, { recursive: true, force: true });
-    delete process.env.FEATURE_TOOL_APIS;
-    delete process.env.FEATURE_HYDRA;
-  });
-
-  it('resumes from saved session', async () => {
-    const execFileMock = jest.fn(
-      (cmd: string, args: any, options: any, cb: any) => {
-        if (typeof options === 'function') {
-          cb = options;
-        }
-        cb(null, '', '');
-      }
-    );
-    jest.doMock('child_process', () => ({ execFile: execFileMock }));
-
-    const handler = (await import('../pages/api/hydra')).default;
-
     const req: any = { method: 'POST', body: { action: 'resume' } };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
-
     await handler(req, res);
-
-    const hydraCall = execFileMock.mock.calls.find((c) => c[0] === 'hydra');
-    expect(hydraCall[1]).toEqual(['-R']);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ output: 'hydra resume mock' });
   });
 });

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -1,10 +1,3 @@
-import { execFile } from 'child_process';
-import { promises as fs } from 'fs';
-import { randomUUID } from 'crypto';
-import { promisify } from 'util';
-import path from 'path';
-
-const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
 export default async function handler(req, res) {
@@ -24,36 +17,8 @@ export default async function handler(req, res) {
 
   const { action, target, service, userList, passList } = req.body || {};
 
-  const sessionDir = path.join(process.cwd(), 'hydra');
-  const restoreFile = path.join(sessionDir, 'hydra.restore');
-  const sessionFile = path.join(sessionDir, 'session');
-  await fs.mkdir(sessionDir, { recursive: true });
-
   if (action === 'resume') {
-    try {
-      await fs.copyFile(sessionFile, restoreFile);
-    } catch {
-      res.status(400).json({ error: 'No saved session' });
-      return;
-    }
-    try {
-      await execFileAsync('which', ['hydra']);
-    } catch {
-      res.status(500).json({ error: 'Hydra not installed' });
-      return;
-    }
-    try {
-      const { stdout } = await execFileAsync('hydra', ['-R'], {
-        cwd: sessionDir,
-        timeout: 1000 * 60,
-      });
-      res.status(200).json({ output: stdout.toString() });
-    } catch (error) {
-      const msg = error.stderr?.toString() || error.message;
-      res.status(500).json({ error: msg });
-    } finally {
-      await fs.copyFile(restoreFile, sessionFile).catch(() => {});
-    }
+    res.status(200).json({ output: 'hydra resume mock' });
     return;
   }
 
@@ -66,44 +31,5 @@ export default async function handler(req, res) {
     return;
   }
 
-  const userPath = `/tmp/hydra-users-${randomUUID()}.txt`;
-  const passPath = `/tmp/hydra-pass-${randomUUID()}.txt`;
-
-  try {
-    await fs.writeFile(userPath, userList);
-    await fs.writeFile(passPath, passList);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-    return;
-  }
-
-  try {
-    await execFileAsync('which', ['hydra']);
-  } catch {
-    await Promise.all([
-      fs.unlink(userPath).catch(() => {}),
-      fs.unlink(passPath).catch(() => {}),
-    ]);
-    res.status(500).json({ error: 'Hydra not installed' });
-    return;
-  }
-
-  const args = ['-L', userPath, '-P', passPath, `${service}://${target}`];
-
-  try {
-    const { stdout } = await execFileAsync('hydra', args, {
-      cwd: sessionDir,
-      timeout: 1000 * 60,
-    });
-    res.status(200).json({ output: stdout.toString() });
-  } catch (error) {
-    const msg = error.stderr?.toString() || error.message;
-    res.status(500).json({ error: msg });
-  } finally {
-    await Promise.all([
-      fs.unlink(userPath).catch(() => {}),
-      fs.unlink(passPath).catch(() => {}),
-    ]);
-    await fs.copyFile(restoreFile, sessionFile).catch(() => {});
-  }
+  res.status(200).json({ output: 'hydra mock' });
 }

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -1,11 +1,3 @@
-import { exec } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import path from 'path';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
-
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
@@ -23,22 +15,7 @@ export default async function handler(req, res) {
     res.status(400).json({ error: 'No hash provided' });
     return;
   }
-  try {
-    await execAsync('which john');
-  } catch {
-    return res.status(500).json({ error: 'John the Ripper not installed' });
-  }
 
-  const file = path.join(tmpdir(), `john-${Date.now()}.txt`);
-  try {
-    await fs.writeFile(file, `${hash}\n`);
-    const { stdout, stderr } = await execAsync(`john ${file}`, {
-      timeout: 1000 * 60,
-    });
-    await fs.unlink(file).catch(() => {});
-    res.status(200).json({ output: stdout || stderr });
-  } catch (e) {
-    await fs.unlink(file).catch(() => {});
-    res.status(500).json({ error: e.stderr || e.message });
-  }
+  // Return mock output instead of executing john
+  res.status(200).json({ output: 'john mock output' });
 }

--- a/pages/api/processes.js
+++ b/pages/api/processes.js
@@ -1,22 +1,6 @@
-import { exec } from 'child_process';
-
-export default function handler(req, res) {
-  exec('ps -eo pid,ppid,pcpu,pmem,comm --no-headers', (err, stdout) => {
-    if (err) {
-      res.status(500).json({ error: err.message });
-      return;
-    }
-    const lines = stdout.trim().split('\n').filter(Boolean);
-    const processes = lines.map((line) => {
-      const [pid, ppid, cpu, mem, command] = line.trim().split(/\s+/, 5);
-      return {
-        pid: Number(pid),
-        ppid: Number(ppid),
-        cpu: Number(cpu),
-        mem: Number(mem),
-        name: command,
-      };
-    });
-    res.status(200).json({ processes });
-  });
+export default function handler(_req, res) {
+  const processes = [
+    { pid: 1, ppid: 0, cpu: 0, mem: 0, name: 'init' },
+  ];
+  res.status(200).json({ processes });
 }

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -1,11 +1,3 @@
-import { execFile } from 'child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { promisify } from 'util';
-
-const execFileAsync = promisify(execFile);
-
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
@@ -17,52 +9,16 @@ export default async function handler(req, res) {
     res.setHeader('Allow', ['POST']);
     return res.status(405).json({ error: 'Method not allowed' });
   }
+  const { action } = req.body || {};
 
-  const { action, hex, file } = req.body || {};
-
-  try {
-    if (action === 'disasm' && hex) {
-      try {
-        await execFileAsync('which', ['rasm2']);
-      } catch {
-        return res.status(500).json({ error: 'radare2 not installed' });
-      }
-      try {
-        const { stdout } = await execFileAsync('rasm2', ['-d', hex], {
-          timeout: 1000 * 60,
-        });
-        return res.status(200).json({ result: stdout });
-      } catch (error) {
-        const msg = error.stderr?.toString() || error.message;
-        return res.status(500).json({ error: msg });
-      }
-    }
-
-    if (action === 'analyze' && file) {
-      try {
-        await execFileAsync('which', ['rabin2']);
-      } catch {
-        return res.status(500).json({ error: 'radare2 not installed' });
-      }
-      const buffer = Buffer.from(file, 'base64');
-      const tmpPath = path.join(os.tmpdir(), `radare2-${Date.now()}`);
-      fs.writeFileSync(tmpPath, buffer);
-      try {
-        const { stdout } = await execFileAsync('rabin2', ['-I', tmpPath], {
-          timeout: 1000 * 60,
-        });
-        fs.unlink(tmpPath, () => {});
-        return res.status(200).json({ result: stdout });
-      } catch (error) {
-        fs.unlink(tmpPath, () => {});
-        const msg = error.stderr?.toString() || error.message;
-        return res.status(500).json({ error: msg });
-      }
-    }
-
-    return res.status(400).json({ error: 'Invalid request' });
-  } catch (e) {
-    return res.status(500).json({ error: e.message });
+  if (action === 'disasm') {
+    return res.status(200).json({ result: 'radare2 disassembly mock' });
   }
+
+  if (action === 'analyze') {
+    return res.status(200).json({ result: 'radare2 analysis mock' });
+  }
+
+  return res.status(400).json({ error: 'Invalid request' });
 }
 


### PR DESCRIPTION
## Summary
- Stub radare2, john, hydra, and processes API endpoints to avoid spawning child processes
- Add matching hydra API tests for mocked responses

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/terminal.test.tsx __tests__/adminMessages.test.ts __tests__/chatManager.test.ts` *(fails: ModuleNotFoundError: Cannot find module '@xterm/addon-web-links', NmapNSEApp copies example output to clipboard, admin messages api logs unauthorized access, getChatId throws and logs when chat is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee21b9808328b1b64431c5eda60b