### PR TITLE
feat(api): cache figlet fonts

### DIFF
--- a/pages/api/figlet/fonts.js
+++ b/pages/api/figlet/fonts.js
@@ -1,17 +1,35 @@
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
+import Standard from 'figlet/importable-fonts/Standard.js';
+import Slant from 'figlet/importable-fonts/Slant.js';
+import Big from 'figlet/importable-fonts/Big.js';
 
-export default function handler(req, res) {
+let cachedFonts;
+
+const fallbacks = [
+  { name: 'Standard', data: Standard },
+  { name: 'Slant', data: Slant },
+  { name: 'Big', data: Big },
+];
+
+export default async function handler(req, res) {
   const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
-  let fonts = [];
-  try {
-    const files = fs.readdirSync(fontsDir).filter((f) => f.toLowerCase().endsWith('.flf'));
-    fonts = files.map((file) => ({
-      name: file.replace(/\.flf$/i, ''),
-      data: fs.readFileSync(path.join(fontsDir, file), 'utf8'),
-    }));
-  } catch {
-    // ignore missing dir or read errors
+  if (!cachedFonts || 'refresh' in req.query) {
+    cachedFonts = [];
+    try {
+      const files = (await fs.readdir(fontsDir)).filter((f) =>
+        f.toLowerCase().endsWith('.flf'),
+      );
+      cachedFonts = await Promise.all(
+        files.map(async (file) => ({
+          name: file.replace(/\.flf$/i, ''),
+          data: await fs.readFile(path.join(fontsDir, file), 'utf8'),
+        })),
+      );
+    } catch {
+      // ignore missing dir or read errors
+    }
   }
+  const fonts = cachedFonts.length ? cachedFonts : fallbacks;
   res.status(200).json({ fonts });
 }


### PR DESCRIPTION
## Summary
- cache figlet font files and allow refresh
- provide default figlet fonts when font directory missing

## Testing
- `yarn test` *(fails: ModuleNotFoundError: Cannot find module '@xterm/addon-web-links' from 'apps/terminal/index.tsx')*
- `curl -sSL https://unnippillil.com/api/figlet/fonts | head -c 1000`
- `node -e "import('./pages/api/figlet/fonts.js').then(async (m)=>{const req={query:{}};const res={status:(c)=>({json:(o)=>console.log(JSON.stringify(o).slice(0,200))})};await m.default(req,res);})"`


------
https://chatgpt.com/codex/tasks/task_e_68bbee209e4483289bfa880e389f2801