### PR TITLE
refactor: defer keybinding registration

### DIFF
--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -95,6 +95,7 @@ export default function Panel() {
   const [focusedIndex, setFocusedIndex] = useState(-1);
 
   useEffect(() => {
+    keybindingManager.init();
     const focusPanel = () => {
       if (plugins.length === 0) return;
       setFocusedIndex(0);

--- a/src/wm/WindowSwitcher.tsx
+++ b/src/wm/WindowSwitcher.tsx
@@ -19,6 +19,7 @@ export default function WindowSwitcher({ windows, onSelect }: Props) {
   const [cycleAll, setCycleAll] = useState(false);
 
   useEffect(() => {
+    keybindingManager.init();
     const handleAltTab = () => {
       setVisible(true);
       setIndex((i) => (i + 1) % windows.length);

--- a/src/wm/keybindingManager.ts
+++ b/src/wm/keybindingManager.ts
@@ -2,11 +2,12 @@ export type KeyComboHandler = (event: KeyboardEvent) => void;
 
 class KeybindingManager {
   private bindings = new Map<string, Set<KeyComboHandler>>();
+  private initialized = false;
 
-  constructor() {
-    if (typeof window !== 'undefined') {
-      window.addEventListener('keydown', this.handleKeyDown);
-    }
+  init(): void {
+    if (this.initialized || typeof window === 'undefined') return;
+    window.addEventListener('keydown', this.handleKeyDown);
+    this.initialized = true;
   }
 
   register(combo: string, handler: KeyComboHandler): void {


### PR DESCRIPTION
## Summary
- avoid top-level `window` access by lazy-initializing keybinding manager
- initialize keybinding manager within `Panel` and `WindowSwitcher`

## Testing
- `npx eslint src/wm/keybindingManager.ts src/components/panel/Panel.tsx src/wm/WindowSwitcher.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbee11b6648328954a294feaf500b9