### PR TITLE
refactor: register service worker after render

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -55,18 +55,32 @@ function MyApp(props) {
     initAnalytics().catch((err) => {
       console.error('Analytics initialization failed', err);
     });
+  }, []);
 
+  useEffect(() => {
     if (
       process.env.NODE_ENV === 'production' &&
       process.env.VERCEL_ENV === 'production' &&
       'serviceWorker' in navigator
     ) {
-      // Register PWA service worker generated via @ducanh2912/next-pwa
       const register = async () => {
         try {
           const registration = await navigator.serviceWorker.register('/sw.js');
 
           window.manualRefresh = () => registration.update();
+
+          registration.addEventListener('updatefound', () => {
+            const installing = registration.installing;
+            if (!installing) return;
+            installing.addEventListener('statechange', () => {
+              if (
+                installing.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                registration.update();
+              }
+            });
+          });
 
           if ('periodicSync' in registration) {
             try {


### PR DESCRIPTION
## Summary
- register service worker in post-render effect with update handling

## Testing
- `yarn lint pages/_app.jsx` *(fails: A control must be associated with a text label, Component definition is missing display name, Unused eslint-disable directive)*
- `npx eslint pages/_app.jsx` *(warn: File ignored because no matching configuration was supplied)*
- `yarn test` *(fails: Unable to find role="alert", logs unauthorized access, chat is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0325143083289f27c7e7ab95dc47