### PR TITLE
chore: enforce bundle size budgets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn build
+      - run: ANALYZE=true yarn build
+      - run: yarn check-budgets
       - run: yarn export
       - uses: actions/upload-artifact@v4
         with:

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -1,0 +1,4 @@
+{
+  "^chunks/framework": 300000,
+  "^chunks/main-app": 350000
+}

--- a/next.config.js
+++ b/next.config.js
@@ -60,6 +60,8 @@ const securityHeaders = [
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
+  openAnalyzer: false,
+  analyzerMode: 'json',
 });
 
 const withPWA = require('@ducanh2912/next-pwa').default({

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke": "node --import tsx/esm scripts/smoke-all-apps.mjs",
     "module-report": "node --import tsx/esm scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
+    "check-budgets": "node scripts/check-bundle-budgets.mjs",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node --import tsx/esm scripts/verify.mjs",
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"

--- a/scripts/check-bundle-budgets.mjs
+++ b/scripts/check-bundle-budgets.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const budgets = JSON.parse(fs.readFileSync(new URL('../bundle-budgets.json', import.meta.url)));
+const statsPath = path.join(process.cwd(), '.next', 'analyze', 'client.json');
+const stats = JSON.parse(fs.readFileSync(statsPath, 'utf8'));
+
+const assets = stats.assets || [];
+let failed = false;
+
+for (const [pattern, limit] of Object.entries(budgets)) {
+  const regex = new RegExp(pattern);
+  const match = assets.find((a) => regex.test(a.name));
+  if (!match) {
+    console.warn(`No asset matching pattern ${pattern}`);
+    continue;
+  }
+  const size = match.size;
+  if (size > limit) {
+    console.error(`Asset ${match.name} (${size} bytes) exceeds budget of ${limit} bytes`);
+    failed = true;
+  } else {
+    console.log(`Asset ${match.name} (${size} bytes) within budget (${limit} bytes)`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- run Next.js analyze build during CI export
- check bundle chunk sizes against budgets
- disable analyzer UI and output JSON stats

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert")*
- `yarn build` *(fails: Module parse failed for index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0330bb5c8328a44e6d5542fb11c4