### PR TITLE
chore: ignore generated service worker files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 # next.js
 /.next/
 /out/
+/.next/types
+/public/sw.js
+/public/workbox-*.js
 
 # production
 /build


### PR DESCRIPTION
## Summary
- ignore service worker and Next.js types outputs

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, appImport.test.ts, adminMessages.test.ts, chatManager.test.ts)*
- `yarn lint` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0333904c8328a7f3ef862f2db3d9