### PR TITLE
chore: upgrade vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
     "RATE_LIMIT_SECRET": "@rate-limit-secret"
   },
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }
 }


### PR DESCRIPTION
## Summary
- use `@vercel/node@5.3.20` for API routes in `vercel.json`

## Testing
- `npx eslint vercel.json`
- `npx jest vercel.json --passWithNoTests` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92b97a248328ba6fc8550a54949e