### PR TITLE
chore: remove env from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "env": {
-    "RATE_LIMIT_SECRET": "@rate-limit-secret"
-  },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
     "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }


### PR DESCRIPTION
## Summary
- remove env section from Vercel config so secrets can be managed via dashboard

## Testing
- `yarn lint` (fails: A control must be associated with a text label)
- `yarn test` (fails: Cannot find module './lib/validate')

------
https://chatgpt.com/codex/tasks/task_e_68bc92ba933c8328a752e67c0f7b5b02