### PR TITLE
ci: use immutable yarn cache

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20.x
           cache: yarn
-      - run: yarn install --immutable
+      - run: yarn install --immutable --immutable-cache
       - run: npx playwright install --with-deps
       - run: |
           yarn dev &

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
       - name: Installing Packages
-        run: yarn install --immutable
+        run: yarn install --immutable --immutable-cache
 
       - name: Test
         run: yarn jest -w=1


### PR DESCRIPTION
## Summary
- use `yarn install --immutable --immutable-cache` in deploy and accessibility workflows
- ensure workflows target Node.js 20.x

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*
- `yarn lint` *(fails: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92beccfc8328887d84c98a370386