### PR TITLE
Add CSP reporting and Report-To header

### DIFF
--- a/__tests__/middleware-csp.test.ts
+++ b/__tests__/middleware-csp.test.ts
@@ -27,5 +27,9 @@ describe('middleware CSP header', () => {
     expect(csp).toContain('nonce-');
     expect(csp).toContain('https://platform.twitter.com');
     expect(csp).toContain('https://cdn.jsdelivr.net');
+    expect(csp).toContain('report-to csp-endpoint');
+    expect(csp).toContain('report-uri /api/csp-report');
+    expect(res.headers['report-to']).toBeDefined();
+    expect(res.headers['report-to']).toContain('/api/csp-report');
   });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,12 +22,22 @@ export function middleware(req: NextRequest) {
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
+    "form-action 'self'",
+    'report-to csp-endpoint',
+    'report-uri /api/csp-report'
   ].join('; ');
 
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.headers.set(
+    'Report-To',
+    JSON.stringify({
+      group: 'csp-endpoint',
+      max_age: 10886400,
+      endpoints: [{ url: '/api/csp-report' }],
+    }),
+  );
   if (req.headers.get('accept')?.includes('text/html')) {
     res.headers.set('X-Content-Type-Options', 'nosniff');
   }


### PR DESCRIPTION
## Summary
- add CSP reporting directives and Report-To header
- test CSP header for report-uri and report-to directives

## Testing
- `yarn lint middleware.ts __tests__/middleware-csp.test.ts __tests__/nosniff.test.ts` *(fails: A control must be associated with a text label ...)*
- `yarn test __tests__/middleware-csp.test.ts __tests__/nosniff.test.ts` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92c280f08328a1e653a6faf8d56d