### PR TITLE
feat(csp): propagate nonce to document scripts

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,7 +25,13 @@ export function middleware(req: NextRequest) {
     "form-action 'self'"
   ].join('; ');
 
-  const res = NextResponse.next();
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-csp-nonce', n);
+  const res = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
   if (req.headers.get('accept')?.includes('text/html')) {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,11 @@
-import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  type DocumentContext,
+  type DocumentInitialProps,
+} from 'next/document';
 import { Ubuntu } from 'next/font/google';
 
 const ubuntu = Ubuntu({
@@ -6,13 +13,14 @@ const ubuntu = Ubuntu({
   weight: ['300', '400', '500', '700'],
 });
 
-class MyDocument extends Document {
-  /**
-   * @param {import('next/document').DocumentContext} ctx
-   */
-  static async getInitialProps(ctx) {
+interface Props extends DocumentInitialProps {
+  nonce?: string;
+}
+
+class MyDocument extends Document<Props> {
+  static async getInitialProps(ctx: DocumentContext): Promise<Props> {
     const initial = await Document.getInitialProps(ctx);
-    const nonce = ctx?.res?.getHeader?.('x-csp-nonce');
+    const nonce = ctx.req.headers['x-csp-nonce'] as string | undefined;
     return { ...initial, nonce };
   }
 
@@ -24,7 +32,7 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" />
+          <script nonce={nonce} src="/theme.js" async />
         </Head>
         <body className={ubuntu.className}>
           <Main />


### PR DESCRIPTION
## Summary
- propagate CSP nonce through request/response headers
- apply nonce to theme and Next.js scripts in `_document`

## Testing
- `npx eslint middleware.ts pages/_document.tsx`
- `npm test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92c6af1c8328a4fad80ccb5f3ce6