### PR TITLE
Add matcher to middleware to skip static assets

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -34,3 +34,9 @@ export function middleware(req: NextRequest) {
 
   return res;
 }
+
+export const config = {
+  matcher: [
+    '/((?!public|_next/static|_next/image|favicon\.ico|robots\.txt|sitemap\.xml|manifest\.webmanifest|sw\.js|workbox-.*\.js).*)'
+  ]
+};


### PR DESCRIPTION
## Summary
- exclude public and other static asset paths from middleware processing via matcher

## Testing
- `npx eslint middleware.ts`
- `yarn test middleware.ts` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92c7f6ec832883d767e6003edb79