### PR TITLE
chore: update tsconfig for next 15 defaults

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,10 +10,10 @@
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "types": [],
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- set lib to `dom`, `dom.iterable`, `esnext`
- configure JSX and module resolution per Next 15

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate' in next.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92cdefd08328a6a62c4651ae27a4