### PR TITLE
chore: use standard web Bluetooth and serial types

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -12,9 +12,6 @@ import {
   CharacteristicData,
 } from '../../utils/bleProfiles';
 
-type BluetoothDevice = any;
-type BluetoothRemoteGATTServer = any;
-
 const MAX_RETRIES = 3;
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -72,7 +69,7 @@ const BleSensor: React.FC = () => {
     }
 
     try {
-      const device = await (navigator as any).bluetooth.requestDevice({
+      const device = await navigator.bluetooth.requestDevice({
         acceptAllDevices: true,
         optionalServices: ['battery_service', 'device_information'],
       });
@@ -98,7 +95,7 @@ const BleSensor: React.FC = () => {
       for (const service of primServices) {
         const chars = await service.getCharacteristics();
         const charData: CharacteristicData[] = await Promise.all(
-          chars.map(async (char: any) => {
+          chars.map(async (char) => {
             try {
               const val = await char.readValue();
               const decoder = new TextDecoder();
@@ -157,6 +154,7 @@ const BleSensor: React.FC = () => {
               <li key={p.deviceId} className="flex items-center space-x-2">
                 <input
                   defaultValue={p.name}
+                  aria-label="Device name"
                   onBlur={async (e) => {
                     await renameProfile(p.deviceId, e.target.value);
                     bcRef.current?.postMessage('update');

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@types/seedrandom": "^3",
     "@types/supertest": "^6",
     "@types/three": "^0.179.0",
+    "@types/w3c-web-serial": "^1.0.8",
     "@types/web-bluetooth": "^0.0.21",
     "@types/wicg-file-system-access": "^2023.10.6",
     "eslint": "^9.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/w3c-web-serial@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@types/w3c-web-serial@npm:1.0.8"
+  checksum: 10c0/d8d0974996da8396457aaf41f0925058d60796303e260d6702dcc1788e4148ca4dfa472b5416f226b8c8ab459461c19f8c96f29f4c84492bd555c6aa23ee336b
+  languageName: node
+  linkType: hard
+
 "@types/warning@npm:^3.0.3":
   version: 3.0.3
   resolution: "@types/warning@npm:3.0.3"
@@ -14509,6 +14516,7 @@ __metadata:
     "@types/seedrandom": "npm:^3"
     "@types/supertest": "npm:^6"
     "@types/three": "npm:^0.179.0"
+    "@types/w3c-web-serial": "npm:^1.0.8"
     "@types/web-bluetooth": "npm:^0.0.21"
     "@types/wicg-file-system-access": "npm:^2023.10.6"
     "@vercel/analytics": "npm:^1.5.0"


### PR DESCRIPTION
## Summary
- add official Web Serial and Web Bluetooth types
- drop local Bluetooth and Serial shims

## Testing
- `npx eslint components/apps/ble-sensor.tsx components/apps/serial-terminal.tsx`
- `yarn test __tests__/sensors.spec.ts` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92cfd5408328875f07ea59c5144d