### PR TITLE
refactor: use aliased FormError imports

### DIFF
--- a/components/apps/bluetooth/index.tsx
+++ b/components/apps/bluetooth/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import FormError from "../../ui/FormError";
+import FormError from "@/components/ui/FormError";
 
 interface DeviceInfo {
   address: string;

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import FormError from '../../ui/FormError';
+import FormError from '@/components/ui/FormError';
 import { copyToClipboard } from '../../../utils/clipboard';
 import { openMailto } from '../../../utils/mailto';
 import { contactSchema } from '../../../utils/contactSchema';

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -7,7 +7,7 @@ import {
   generateIncrementalCandidates,
   parsePotfile,
 } from './utils';
-import FormError from '../../ui/FormError';
+import FormError from '@/components/ui/FormError';
 import StatsChart from '../../StatsChart';
 
 // Enhanced John the Ripper interface that supports rule uploads,

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -4,7 +4,7 @@ import HostBubbleChart from './HostBubbleChart';
 import PluginFeedViewer from './PluginFeedViewer';
 import ScanComparison from './ScanComparison';
 import PluginScoreHeatmap from './PluginScoreHeatmap';
-import FormError from '../../ui/FormError';
+import FormError from '@/components/ui/FormError';
 
 // helpers for persistent storage of jobs and false positives
 export const loadJobDefinitions = () => {


### PR DESCRIPTION
## Summary
- fix FormError imports to use project alias

## Testing
- `yarn test components/apps/nessus/index.js --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bc92d1f0c883289671730ecc9782b4