### PR TITLE
Ensure null-safe refs in canvas and game components

### DIFF
--- a/apps/ascii-art/index.tsx
+++ b/apps/ascii-art/index.tsx
@@ -76,8 +76,8 @@ const AsciiArtApp = () => {
   const [bgColor, setBgColor] = useState('#000000');
   const [fontSize, setFontSize] = useState<number>(12);
 
-  const canvasRef = useRef<HTMLCanvasElement>(null); // for image processing
-  const displayCanvasRef = useRef<HTMLCanvasElement>(null); // for final rendering
+  const canvasRef = useRef<HTMLCanvasElement | null>(null); // for image processing
+  const displayCanvasRef = useRef<HTMLCanvasElement | null>(null); // for final rendering
   const [imgOutput, setImgOutput] = useState('');
   const [brightness, setBrightness] = useState(0); // -1 to 1
   const [contrast, setContrast] = useState(1); // 0 to 2

--- a/apps/calculator/components/GraphPanel.tsx
+++ b/apps/calculator/components/GraphPanel.tsx
@@ -192,7 +192,7 @@ export default function GraphPanel({
   width = 500,
   height = 500,
 }: GraphPanelProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const origin = useRef({ x: width / 2, y: height / 2 });
   const scale = useRef(40); // pixels per unit
   const compiled = useRef<(x: number) => number>(() => 0);

--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -10,7 +10,7 @@ interface DpsChartsProps {
 }
 
 const DpsCharts = ({ towers }: DpsChartsProps) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/apps/games/tower-defense/components/RangeUpgradeTree.tsx
+++ b/apps/games/tower-defense/components/RangeUpgradeTree.tsx
@@ -8,7 +8,7 @@ interface RangeUpgradeTreeProps {
 }
 
 const RangeUpgradeTree = ({ tower }: RangeUpgradeTreeProps) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -14,7 +14,7 @@ interface PhaserMatterProps {
 
 const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
   void getDailySeed;
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
   const prefersRef = useRef(prefersReducedMotion);

--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -11,7 +11,7 @@ const themes: Record<string, { bg: string; flipper: string }> = {
 };
 
 export default function Pinball() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   // References for core Matter.js entities
 
   const engineRef = useRef<Engine | null>(null);

--- a/apps/qr/index.tsx
+++ b/apps/qr/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../utils/qrStorage';
 
 export default function QR() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [payload, setPayload] = useState('');
   const [mode, setMode] = useState<'generate' | 'scan'>('generate');
   const [size, setSize] = useState(256);

--- a/apps/quote/components/Posterizer.tsx
+++ b/apps/quote/components/Posterizer.tsx
@@ -38,7 +38,7 @@ const STYLES = [
 ];
 
 export default function Posterizer({ quote }: { quote: Quote | null }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [styleIndex, setStyleIndex] = useState(0);
   const [bg, setBg] = useState(STYLES[0].bg);
   const [fg, setFg] = useState(STYLES[0].fg);

--- a/apps/spotify/Visualizer.tsx
+++ b/apps/spotify/Visualizer.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export default function Visualizer({ analyser }: Props) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
     if (!analyser) return;

--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -87,7 +87,7 @@ interface EnemyInstance extends Enemy {
 }
 
 const TowerDefense = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [editing, setEditing] = useState(true);
   const [path, setPath] = useState<{ x: number; y: number }[]>([]);
   const pathSetRef = useRef<Set<string>>(new Set());
@@ -162,7 +162,9 @@ const TowerDefense = () => {
   };
 
   const handleCanvasClick = (e: React.MouseEvent) => {
-    const rect = canvasRef.current!.getBoundingClientRect();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
     const x = Math.floor((e.clientX - rect.left) / CELL_SIZE);
     const y = Math.floor((e.clientY - rect.top) / CELL_SIZE);
     const key = `${x},${y}`;
@@ -180,7 +182,9 @@ const TowerDefense = () => {
   };
 
   const handleCanvasMove = (e: React.MouseEvent) => {
-    const rect = canvasRef.current!.getBoundingClientRect();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
     const x = Math.floor((e.clientX - rect.left) / CELL_SIZE);
     const y = Math.floor((e.clientY - rect.top) / CELL_SIZE);
     const idx = towers.findIndex((t) => t.x === x && t.y === y);

--- a/components/apps/camera.tsx
+++ b/components/apps/camera.tsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 const CameraApp: React.FC = () => {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const overlayRef = useRef<HTMLCanvasElement>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const overlayRef = useRef<HTMLCanvasElement | null>(null);
   const [snapshot, setSnapshot] = useState<string>('');
   const [drawing, setDrawing] = useState(false);
 
@@ -38,14 +38,18 @@ const CameraApp: React.FC = () => {
   };
 
   const getPos = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const rect = overlayRef.current!.getBoundingClientRect();
+    const overlay = overlayRef.current;
+    if (!overlay) return { x: 0, y: 0 };
+    const rect = overlay.getBoundingClientRect();
     return { x: e.clientX - rect.left, y: e.clientY - rect.top };
   };
 
   const startDrawing = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const overlay = overlayRef.current;
+    if (!overlay) return;
     setDrawing(true);
     const { x, y } = getPos(e);
-    const ctx = overlayRef.current!.getContext('2d');
+    const ctx = overlay.getContext('2d');
     if (!ctx) return;
     ctx.strokeStyle = 'red';
     ctx.lineWidth = 2;
@@ -55,8 +59,10 @@ const CameraApp: React.FC = () => {
 
   const draw = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!drawing) return;
+    const overlay = overlayRef.current;
+    if (!overlay) return;
     const { x, y } = getPos(e);
-    const ctx = overlayRef.current!.getContext('2d');
+    const ctx = overlay.getContext('2d');
     if (!ctx) return;
     ctx.lineTo(x, y);
     ctx.stroke();

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -34,7 +34,7 @@ const Checkers = () => {
   const [cursor, setCursor] = useState<[number, number]>([0, 0]);
   const [showLegal, setShowLegal] = useState(false);
   const [rule, setRule] = useState<'forced' | 'relaxed'>('forced');
-  const boardRef = useRef<HTMLDivElement>(null);
+  const boardRef = useRef<HTMLDivElement | null>(null);
 
   const workerRef = useRef<Worker | null>(null);
   const hintRequest = useRef(false);

--- a/components/games/GameShell.tsx
+++ b/components/games/GameShell.tsx
@@ -56,7 +56,7 @@ export default function GameShell({
 
   useGameInput({ onInput: handleInput, game });
 
-  const fileRef = useRef<HTMLInputElement>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
 
   const handleExport = () => {
     const data = exportGameSettings(game);

--- a/components/panel/CpuGraph.tsx
+++ b/components/panel/CpuGraph.tsx
@@ -25,7 +25,7 @@ export default function CpuGraph({
   width = 100,
   height = 30,
 }: CpuGraphProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const dataRef = useRef<number[][]>([]);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/games/2048/index.tsx
+++ b/games/2048/index.tsx
@@ -70,7 +70,7 @@ const Game2048 = () => {
   const [merged, setMerged] = useState<Array<[number, number]>>([]);
   const [paused, setPaused] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const boardRef = useRef<HTMLDivElement>(null);
+  const boardRef = useRef<HTMLDivElement | null>(null);
   const touchStart = useRef<{ x: number; y: number } | null>(null);
   const { scores, addScore } = useOPFSLeaderboard('game_2048');
 

--- a/games/asteroids/index.tsx
+++ b/games/asteroids/index.tsx
@@ -27,7 +27,7 @@ const DPR =
     : 1;
 
 const AsteroidsGame: React.FC = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const shipRef = useRef({
     x: 0,
     y: 0,

--- a/games/word-search/components/ListImport.tsx
+++ b/games/word-search/components/ListImport.tsx
@@ -5,7 +5,7 @@ interface ListImportProps {
 }
 
 const ListImport: React.FC<ListImportProps> = ({ onImport }) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## Summary
- Type canvas and game refs as `useRef<ElementType | null>` across apps and games
- Guard ref usage with null checks in camera and tower-defense handlers
- Align with safer DOM handling for rendering logic

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92d30b8c8328ad9a02eda9b4ff81