### PR TITLE
Enforce noImplicitAny in game modules

### DIFF
--- a/apps/games/rng.ts
+++ b/apps/games/rng.ts
@@ -1,19 +1,23 @@
 import seedrandom from 'seedrandom';
 
-let rng = seedrandom('', { state: true });
+let rng: seedrandom.StatefulPRNG<seedrandom.State.Arc4> = seedrandom('', {
+  state: true,
+});
 
-export const random = () => rng();
+export const random = (): number => rng();
 
-export const reset = (seed?: string) => {
+export const reset = (seed?: string): void => {
   rng = seedrandom(seed ?? '', { state: true });
 };
 
-export const serialize = () => {
-  return JSON.stringify((rng as any).state());
+export const serialize = (): string => {
+  return JSON.stringify(rng.state());
 };
 
-export const deserialize = (state: string) => {
-  rng = seedrandom('', { state: JSON.parse(state) });
+export const deserialize = (state: string): void => {
+  rng = seedrandom('', {
+    state: JSON.parse(state) as seedrandom.State.Arc4,
+  });
 };
 
 const rngApi = { random, reset, serialize, deserialize };

--- a/apps/games/tictactoe/logic.ts
+++ b/apps/games/tictactoe/logic.ts
@@ -53,9 +53,11 @@ export const minimax = (
   if (winner === 'X') return { score: depth - 10, index: -1 };
   if (winner === 'draw') return { score: 0, index: -1 };
 
-  const key = player + (misere ? 'M' : 'N') + boardKey(board);
-  const cached = memo.get(key);
-  if (cached && cached.index !== undefined) return cached as any;
+    const key = player + (misere ? 'M' : 'N') + boardKey(board);
+    const cached = memo.get(key);
+    if (cached && cached.index !== undefined) {
+      return { index: cached.index, score: cached.score };
+    }
 
   let best: { index: number; score: number } = {
     index: -1,

--- a/apps/games/tower-defense/components/DpsCharts.tsx
+++ b/apps/games/tower-defense/components/DpsCharts.tsx
@@ -18,12 +18,12 @@ const DpsCharts = ({ towers }: DpsChartsProps) => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const dpsMap: Partial<Record<TowerType, number>> = {};
-    towers.forEach((t) => {
-      const type = ((t as any).type || 'single') as TowerType;
+      const dpsMap: Partial<Record<TowerType, number>> = {};
+      towers.forEach((t) => {
+        const type = t.type ?? 'single';
 
-      dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
-    });
+        dpsMap[type] = (dpsMap[type] || 0) + getTowerDPS(type, t.level);
+      });
 
     const entries = Object.entries(dpsMap) as [TowerType, number][];
     const w = canvas.width;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,4 +32,13 @@
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
+  ,
+  "overrides": [
+    {
+      "files": ["apps/games/**/*.ts", "games/**/*.ts"],
+      "compilerOptions": {
+        "noImplicitAny": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable noImplicitAny for `apps/games` and `games` folders in tsconfig overrides
- improve RNG helper typing and remove loose casts
- fix tic-tac-toe and tower-defense modules to avoid `any`

## Testing
- `npx tsc -p tsconfig.games.temp.json --noEmit`
- `npm test` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92d443148328af0477bc7fa664b8