### PR TITLE
Ensure WebAssembly experiment defined once

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -109,10 +109,8 @@ if (isProd) {
 // Merge experiment settings and production optimizations into a single function.
 function configureWebpack(config, { isServer }) {
   // Enable WebAssembly loading and avoid JSON destructuring bug
-  config.experiments = {
-    ...(config.experiments || {}),
-    asyncWebAssembly: true,
-  };
+  config.experiments ??= {};
+  config.experiments.asyncWebAssembly = true;
   // Prevent bundling of server-only modules in the browser
   config.resolve = config.resolve || {};
   config.resolve.fallback = {


### PR DESCRIPTION
## Summary
- avoid overwriting webpack experiments and set asyncWebAssembly once

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92d7d51483289e8952d007819724