### PR TITLE
Prefetch Ghidra WASM

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,5 +1,6 @@
 import { isBrowser } from '@/utils/env';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Head from 'next/head';
 import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
@@ -249,6 +250,9 @@ export default function GhidraApp() {
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
+        <Head>
+          <link rel="prefetch" href="/wasm/ghidra.wasm" />
+        </Head>
         <div className="p-2 flex space-x-2">
           <button
             onClick={switchEngine}
@@ -295,6 +299,9 @@ export default function GhidraApp() {
 
   return (
     <div className="w-full h-full flex flex-col bg-gray-900 text-gray-100">
+      <Head>
+        <link rel="prefetch" href="/wasm/ghidra.wasm" />
+      </Head>
       <div className="p-2">
         <button
           onClick={switchEngine}


### PR DESCRIPTION
## Summary
- Prefetch Ghidra's WebAssembly by injecting a `<link rel="prefetch" href="/wasm/ghidra.wasm">` tag into the Ghidra app head

## Testing
- `npx eslint components/apps/ghidra/index.js` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92db8d7483289df4bda918ac6d70