### PR TITLE
feat: lazy load security tool components

### DIFF
--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
-import GhidraApp from '../../../components/apps/ghidra';
+
+const GhidraApp = dynamic(() => import('../../../components/apps/ghidra'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function DemoRunner() {
   const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;

--- a/apps/ghidra/index.tsx
+++ b/apps/ghidra/index.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import DemoRunner from './components/DemoRunner';
+import dynamic from 'next/dynamic';
+
+const DemoRunner = dynamic(() => import('./components/DemoRunner'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export default function GhidraPage() {
   return (

--- a/apps/volatility/index.tsx
+++ b/apps/volatility/index.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import React from 'react';
-import VolatilityApp from '../../components/apps/volatility';
+import dynamic from 'next/dynamic';
 import TriageFilters from './components/TriageFilters';
+
+const VolatilityApp = dynamic(() => import('../../components/apps/volatility'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 const VolatilityPage: React.FC = () => {
   return (

--- a/apps/wireshark/index.tsx
+++ b/apps/wireshark/index.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React, { useState } from 'react';
-import PcapViewer from './components/PcapViewer';
+import dynamic from 'next/dynamic';
+
+const PcapViewer = dynamic(() => import('./components/PcapViewer'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 const WiresharkPage: React.FC = () => {
   const [showLegend, setShowLegend] = useState(true);

--- a/pages/apps/ghidra.jsx
+++ b/pages/apps/ghidra.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const Ghidra = dynamic(() => import('../../apps/ghidra'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function GhidraPage() {
+  return <Ghidra />;
+}


### PR DESCRIPTION
## Summary
- dynamically import Ghidra app components and add lazy route
- lazily load Volatility and Wireshark components to reduce initial bundle

## Testing
- `yarn eslint apps/ghidra/components/DemoRunner.tsx apps/ghidra/index.tsx apps/volatility/index.tsx apps/wireshark/index.tsx pages/apps/ghidra.jsx`
- `yarn test __tests__/volatilityApp.test.tsx __tests__/wireshark.test.tsx` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92dc950083289a594a1016279bf8