### PR TITLE
Wrap dynamic apps with error boundaries

### DIFF
--- a/__tests__/appLoadError.test.tsx
+++ b/__tests__/appLoadError.test.tsx
@@ -30,7 +30,10 @@ describe("createDynamicApp", () => {
     );
     expect(screen.getByText("Shell Ready")).toBeInTheDocument();
     expect(
-      await screen.findByText("Unable to load Missing App"),
+      await screen.findByText(/Unable to load Missing App/),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /retry/i }),
     ).toBeInTheDocument();
   });
 });

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -25,12 +25,23 @@ class ErrorBoundary extends Component<Props, State> {
     log.error('ErrorBoundary caught an error', { error, errorInfo });
   }
 
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
   render() {
     if (this.state.hasError) {
       return (
         <div role="alert" className="p-4 text-center">
           <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
+          <p className="mb-2">Please try again.</p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="px-4 py-2 bg-ub-orange text-white rounded"
+          >
+            Retry
+          </button>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- wrap dynamic apps in an ErrorBoundary
- show retry action when a dynamic app fails to load
- provide retry button in generic ErrorBoundary fallback

## Testing
- `npx eslint components/core/ErrorBoundary.tsx utils/createDynamicApp.js __tests__/appLoadError.test.tsx`
- `yarn test __tests__/appLoadError.test.tsx` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92dea0388328b49edc923d1f6ef8