### PR TITLE
Set CI-only Node.js memory limit for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Copy `.env.local.example` to `.env.local` and fill in required API keys:
 - `RECAPTCHA_SECRET` and related `NEXT_PUBLIC_RECAPTCHA_*` keys for contact form spam protection.
 - `RATE_LIMIT_SECRET` – secret used to sign rate limit cookies (configure this in Vercel environment variables).
 - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` – Supabase credentials. When unset, Supabase-backed APIs and features are disabled.
+- `NODE_OPTIONS` – override Node.js memory limits. The build script sets `NODE_OPTIONS="--max-old-space-size=4096"` automatically when `CI` is detected to avoid out-of-memory errors in constrained environments.
 
 See `.env.local.example` for the full list.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,7 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## CI Builds
+
+The build script detects the `CI` environment variable and sets `NODE_OPTIONS="--max-old-space-size=4096"` to accommodate memory-constrained environments. In local development this variable is untouched unless you set it explicitly.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typegen": "next typegen",
     "prebuild": "rm -rf .next && yarn typegen && yarn build:gamepad",
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/build.mjs",
     "postbuild": "node --import tsx/esm scripts/safe-copy.mjs",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+// Increase memory only in CI to avoid local overhead.
+if (process.env.CI && !process.env.NODE_OPTIONS) {
+  process.env.NODE_OPTIONS = '--max-old-space-size=4096';
+}
+
+const result = spawnSync('next', ['build'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- wrap Next.js build in a script that adds `NODE_OPTIONS="--max-old-space-size=4096"` when `CI` is set
- document the `NODE_OPTIONS` variable usage in the README and Getting Started guide

## Testing
- `yarn lint` *(fails: 520 problems)*
- `yarn test` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92e3be8c8328aad7a895d83966d7