### PR TITLE
Use service-worker.js for SW registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To send text or links directly into the Sticky Notes app:
 
 ### Service Worker (SW)
 
-- Generated via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa); output is `public/sw.js`.
+- Generated via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa); output is `public/service-worker.js`.
 - Only assets under `public/` are precached.
 - Dynamic routes or API responses are not cached.
 - Future work may use `injectManifest` for finer control.

--- a/next.config.js
+++ b/next.config.js
@@ -72,7 +72,7 @@ const buildId =
 
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
-  sw: 'sw.js',
+  sw: 'service-worker.js',
   disable: process.env.VERCEL_ENV !== 'production',
   buildExcludes: [/dynamic-css-manifest\.json$/],
   fallbacks: {
@@ -243,7 +243,7 @@ module.exports = withBundleAnalyzer(
                 ],
               },
               {
-                source: '/sw.js',
+                source: '/service-worker.js',
                 headers: [
                   {
                     key: 'Cache-Control',

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -61,7 +61,7 @@ function MyApp(props) {
     ) {
       const register = async () => {
         try {
-          const registration = await navigator.serviceWorker.register('/sw.js');
+          const registration = await navigator.serviceWorker.register('/service-worker.js');
 
           window.manualRefresh = () => {
             registration.waiting.postMessage({ type: 'SKIP_WAITING' });

--- a/tests/system/sw-recovery.spec.ts
+++ b/tests/system/sw-recovery.spec.ts
@@ -7,6 +7,11 @@ test.describe('Service worker recovery', () => {
     await page.goto('/apps/power');
 
     await page.evaluate(async () => {
+      try {
+        await navigator.serviceWorker.register('/service-worker.js');
+      } catch {
+        /* ignore registration errors in test env */
+      }
       await caches.open('KLP_stale-cache');
       await caches.open('unrelated-cache');
     });


### PR DESCRIPTION
## Summary
- register service worker from `/service-worker.js`
- configure Next.js and docs for `/service-worker.js`
- align service worker recovery test with new path

## Testing
- `npx playwright test tests/system/sw-recovery.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92e768548328af48dfffe5f0c420