### PR TITLE
feat: hash public assets for precache

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -70,6 +70,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const buildId =
   process.env.NEXT_BUILD_ID || process.env.BUILD_ID || 'dev';
 
+const precacheManifest = require('./precache-manifest.json');
+
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
@@ -81,13 +83,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   workboxOptions: {
     cacheId: buildId,
     navigateFallback: '/offline.html',
-
-    additionalManifestEntries: [
-      { url: '/favicon.ico', revision: null },
-      { url: '/favicon.svg', revision: null },
-      { url: '/images/logos/fevicon.png', revision: null },
-      { url: '/images/logos/logo_1024.png', revision: null },
-    ],
+    additionalManifestEntries: precacheManifest,
 
     // Cache only images and fonts to ensure app shell updates while assets work offline
     runtimeCaching: require('./cache.js')(buildId),
@@ -229,6 +225,15 @@ module.exports = withBundleAnalyzer(
                 source: '/(.*)',
                 headers: securityHeaders,
               },
+              ...precacheManifest.map(({ url }) => ({
+                source: url,
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=31536000, immutable',
+                  },
+                ],
+              })),
               {
                 source: '/manifest.webmanifest',
                 headers: [

--- a/precache-manifest.json
+++ b/precache-manifest.json
@@ -1,0 +1,1134 @@
+[
+  {
+    "url": "/a2hs.js",
+    "revision": "bbe292aee771c6c7bb133b1b01da171714839797494245b3af5c9f4a7d12ee7a"
+  },
+  {
+    "url": "/autopsy-demo.json",
+    "revision": "40a965dac5f93cb78e133c31de48114312a831183cc0ccb4aebff492f793c679"
+  },
+  {
+    "url": "/checkers-worker.js",
+    "revision": "c41f0122f445f5944005dd2a14589cba64e23472f51cda72d333b729daf054d5"
+  },
+  {
+    "url": "/empty-tasks.svg",
+    "revision": "6c5f2b88180c03a1d025838f5b9bbfbce0db4aaea3e9107cb9aac46cb84d7d01"
+  },
+  {
+    "url": "/favicon.ico",
+    "revision": "bdc2b25011c740d3d534049f9e735b9e5406598d74d615273d4cecc96a94f0e8"
+  },
+  {
+    "url": "/favicon.svg",
+    "revision": "c29c7d08368d0ce0f6458c79e1a7819b58f7f2ab592dcd101fa2283b398d96d3"
+  },
+  {
+    "url": "/hook-flow.svg",
+    "revision": "9364a41f0303962a3f09459ab7e6cb5cb26b6f8913fc3105ca845a308144ab9f"
+  },
+  {
+    "url": "/manifest.webmanifest",
+    "revision": "4f2dcc014a214c468dab91c8ab636ae6243b489bafb46dcc134d46997b566587"
+  },
+  {
+    "url": "/module-report.html",
+    "revision": "efb59565c07f57acc2eedb2adc130a78363edf6fc974030a973e0dbd7657576b"
+  },
+  {
+    "url": "/offline.css",
+    "revision": "7568347a520bf910cb02109874d3f3902e4f210a80b7d4fdc53250051038045d"
+  },
+  {
+    "url": "/offline.html",
+    "revision": "fb4627138098cefcb3acccd11976d6174e68bef99ddb33864c6b26a8deb1b599"
+  },
+  {
+    "url": "/offline.js",
+    "revision": "fff6c053f292eca8ff170c10c2faed633cb06699cf13ce70d8583c349cd1e23d"
+  },
+  {
+    "url": "/pacman-levels.json",
+    "revision": "3da50c626e6942ada2bd3f674b6610ab8639cb6750d446073263e5f48a204824"
+  },
+  {
+    "url": "/plugin-marketplace.json",
+    "revision": "b35ffec26d3df479b71f575ebcb689a5525ed8ba7c77ccc9c023e9c742290cf7"
+  },
+  {
+    "url": "/projects.json",
+    "revision": "f19137056d1d60505316f569ab3b6dd699260e9bef6656423efe50f2ad189980"
+  },
+  {
+    "url": "/reconng-chain.json",
+    "revision": "6d51e8097aee04b950aeb96538cfe12afaeb5129eec2a4be02814dc2e155bcfb"
+  },
+  {
+    "url": "/reconng-marketplace.json",
+    "revision": "baabc9f4c944fa13b4747f13a88d8d4c151e3efd9772cd437456b6622d416e59"
+  },
+  {
+    "url": "/resume.pdf",
+    "revision": "b9d140fca33fd7d15073be92c209d5f1eba12a29ce24e61250c376552da51d17"
+  },
+  {
+    "url": "/robots.txt",
+    "revision": "90d24bc3bf698ac1e173739502298ccca72adf1f564fab05f484b8c48d1cadd2"
+  },
+  {
+    "url": "/sitemap.xml",
+    "revision": "3d759ae49dde31bf345d99a93fd1609e67d2f68d8f16aae5c0abdb7b29d04575"
+  },
+  {
+    "url": "/spotify-playlists.json",
+    "revision": "a307f4638bba727fec9bd92b77ef6f505ebfed531010f932cbfe53fe225bcf88"
+  },
+  {
+    "url": "/theme.js",
+    "revision": "2a747cff4077bde052f4f8a0b1e92c577666b81ade67e1c9693245eba4e56691"
+  },
+  {
+    "url": "/assets/Alex-Unnippillil-Resume.pdf",
+    "revision": "fd870e1e4b94088b9767d79df8da5c4bb7377942d4893d7b1712aae2f94c4773"
+  },
+  {
+    "url": "/assets/alex-unnippillil.vcf",
+    "revision": "7ad85d825767e3f47a695e530e8f8e687f9dd4fee2e68a5799b7893485c81eff"
+  },
+  {
+    "url": "/assets/timeline.pdf",
+    "revision": "851117fd5e1e46f62e94dacddca30a3c50664b7282ffac541cdaedd9473b336a"
+  },
+  {
+    "url": "/bluetooth/known_devices.json",
+    "revision": "5bc327ec84fd0c532b2cbcfa8287ddf34c6a986351547917a09b5a28d5e9c19b"
+  },
+  {
+    "url": "/chess/openings.pgn",
+    "revision": "9bdcb1ac5bbd391dcfdb3f910edddc5793795557e8ad84bb5d3ab01ff97fea24"
+  },
+  {
+    "url": "/chess/puzzles.pgn",
+    "revision": "5d57f2d5ef1ff2311ef6158c3ba00d7ab49c735e236c30d734f6e9a29edb52c1"
+  },
+  {
+    "url": "/demo/nikto-output.txt",
+    "revision": "c367ebe843e439db81fa77bbdc5d360faf9b9714a4ae66a5cd097a68dcd8018b"
+  },
+  {
+    "url": "/demo/nmap-nse.json",
+    "revision": "ad9523a2210fecea67a27ef966c0935a8a1e0e5a9abc0e01498344db82ed31a1"
+  },
+  {
+    "url": "/demo/nmap-results.json",
+    "revision": "607f5054a7d43a78804c598f2c5fe1063e7807b30a4ec230beaedeafb9fb0791"
+  },
+  {
+    "url": "/fixtures/autostart-system.json",
+    "revision": "f2d5b72a2589caa388f565a43f0194abd454249e24d58561b2d51a919e6ced07"
+  },
+  {
+    "url": "/fixtures/autostart-user.json",
+    "revision": "308a338587b324b7a1dff54c070c6a744fe9c71a80307d689ca7a76b056a017b"
+  },
+  {
+    "url": "/fixtures/hydra-timeline.json",
+    "revision": "4579c2dcfec3c5651375c187a41e3961816775532dab56e90ca8a5b420813d6e"
+  },
+  {
+    "url": "/fixtures/metasploit_loot.json",
+    "revision": "707f6cd99e49d7e45bc4e42cee73b5627dd5485cd3a833d9bd404681fbad6224"
+  },
+  {
+    "url": "/fixtures/mitre.json",
+    "revision": "7f1917ee508ca8da0f7d417d6b36449e8cfb7e8cc69ee0604a9c2dac97945841"
+  },
+  {
+    "url": "/fixtures/sample.json",
+    "revision": "ce948fc84c69072fec71ca11e6e9c592273e85cb43ee3f8131311491441bce2e"
+  },
+  {
+    "url": "/fixtures/sigma.json",
+    "revision": "d62dfa75dd2860a110d80f8c875f14f172de1df321d2f7a348fa65c0080449d4"
+  },
+  {
+    "url": "/fixtures/suricata.json",
+    "revision": "bd99570134e19371e94a90433f34e2144562ddaf4dffab4d5e87745058190ec6"
+  },
+  {
+    "url": "/fixtures/yara_sample.txt",
+    "revision": "4fe0512158dcb96fe4e9f1083e98fc69edb0b351d596e5bb1f439fd2d2eb0a25"
+  },
+  {
+    "url": "/fixtures/zeek.json",
+    "revision": "b8a880af45593c0fe6cb022ba4ef6a328503ed51d82567dfefec3721fa26df47"
+  },
+  {
+    "url": "/pieces/bB.svg",
+    "revision": "ba67da76ce919addc60ecb8b46801def073dd54149b2c038a2d07a16d904d5e4"
+  },
+  {
+    "url": "/pieces/bK.svg",
+    "revision": "025eea92e0ef8eb1fd06b1c58d0d112948f08bf66cea6b5d003659569949b41c"
+  },
+  {
+    "url": "/pieces/bN.svg",
+    "revision": "735cc58315b123a56632d4877a6b976c827481fa97bf9a5c8f459ec969bc2549"
+  },
+  {
+    "url": "/pieces/bP.svg",
+    "revision": "4413bf7c18a341f9723d97e6f92c985e30b6167b037e80842cea59b7541bb074"
+  },
+  {
+    "url": "/pieces/bQ.svg",
+    "revision": "70191a3fbc729ef629661e2419a66ab8024c49277aab8ccae3a5ef61372ab802"
+  },
+  {
+    "url": "/pieces/bR.svg",
+    "revision": "6abf617a9e26902e0734d85897c9ca55e29d7be2928142aa21032c38967e34ba"
+  },
+  {
+    "url": "/pieces/wB.svg",
+    "revision": "1d7beace24d455c923ee80d27125963eaf0287b956c5576dbf790c97ac0b97eb"
+  },
+  {
+    "url": "/pieces/wK.svg",
+    "revision": "56f55c784843b1ac272b8745d740aa2a3e6c585513ef889978916f88e5d0b70b"
+  },
+  {
+    "url": "/pieces/wN.svg",
+    "revision": "5486791207156f7ae8b8678187648df45085d726334c2862e73b077dea00641e"
+  },
+  {
+    "url": "/pieces/wP.svg",
+    "revision": "cc7de30708dcec8f4d593a89d10893d5f9c063682039a1c441e86c44cf2096db"
+  },
+  {
+    "url": "/pieces/wQ.svg",
+    "revision": "b72b864e2a5b6c8f8afb7f260130c10e649ff063f4ef58190c00a35c56364327"
+  },
+  {
+    "url": "/pieces/wR.svg",
+    "revision": "4d42ab45afd862c704eb9b35317102d453a7a6b9b71d40f18958c8eadc829e4b"
+  },
+  {
+    "url": "/quotes/quotes.json",
+    "revision": "576854410ff11462951f6d934514e856c45feb6b441d1661fe37d914baedc6d7"
+  },
+  {
+    "url": "/samples/common.txt",
+    "revision": "e0fa5b50fb68ca97e372bbdf710726069687cfbf6a161ae34b7c69c46ed44a8f"
+  },
+  {
+    "url": "/samples/names.txt",
+    "revision": "4c6bc1701401c6b9888cc2f9b435101d3646c3e05b2b57b9404ac89c600f93d2"
+  },
+  {
+    "url": "/wallpapers/wall-1.webp",
+    "revision": "478c286ed459e317aad10ac264121c359c684c2310f91e5fdc77d26fc0ed4e73"
+  },
+  {
+    "url": "/wallpapers/wall-2.webp",
+    "revision": "94987b083c3c2d8f5c1d17f12bc42ebb1c29b01fc8efd0462a1d369503d5caed"
+  },
+  {
+    "url": "/wallpapers/wall-3.webp",
+    "revision": "b45e5501ff89c6932cba142295ccff285ad147bb144cd166e4266e065efce789"
+  },
+  {
+    "url": "/wallpapers/wall-4.webp",
+    "revision": "4095cc87c92efc89e7ed0e13fb0edb3873956f64cfeafa36f9350c4e5a98f86b"
+  },
+  {
+    "url": "/wallpapers/wall-5.webp",
+    "revision": "f2b7750a22d5f9d4a0afa5c58a572d7a1895ce8741e18768690dda7d463d74a4"
+  },
+  {
+    "url": "/wallpapers/wall-6.webp",
+    "revision": "25d4d7debc49b920b3a7114d5efa3b1b8165c79f22e512274f7da5438188db18"
+  },
+  {
+    "url": "/wallpapers/wall-7.webp",
+    "revision": "16df4d2d8513be46fe8a0537fd0803ea2eecccab6bf6820a6733185718b20c78"
+  },
+  {
+    "url": "/wallpapers/wall-8.webp",
+    "revision": "d45c3a3c2c9019877d6dcd923ae32664fba8dbd35fd59a256ae78b0a8d387577"
+  },
+  {
+    "url": "/workers/service-worker.js",
+    "revision": "2ba0aff0d9e83c9459143761360152adad1a587e60ea21687301e5e6b0285159"
+  },
+  {
+    "url": "/apps/asteroids/index.css",
+    "revision": "47c50061fe7c646920a434ad171f4fc7ef8a946c4d78f1d611fb3c780c22e85a"
+  },
+  {
+    "url": "/apps/asteroids/index.html",
+    "revision": "6d8495902b0e62b890c9667e347fabafc6e1578b8199f021a220cfdf4f491bf0"
+  },
+  {
+    "url": "/apps/asteroids/main.js",
+    "revision": "f2851e813c46a10f953295f81b129af3983eb7cc9cd0cd89a79f2b8a3a933a1c"
+  },
+  {
+    "url": "/apps/car-racer/editor.css",
+    "revision": "7181337e156c5e299d9b71e148a136fdaa7d6e862caea3ff0b836deb4bfeec91"
+  },
+  {
+    "url": "/apps/car-racer/editor.html",
+    "revision": "b136ed0fc64ef4e24e5df0af97ce6d6c3119bafa064856d9184a6ca08cd79708"
+  },
+  {
+    "url": "/apps/car-racer/editor.js",
+    "revision": "f3663515eadcb7263c60a46bca616f7694e198a78572c3350ebc7ada480f97bf"
+  },
+  {
+    "url": "/apps/car-racer/index.css",
+    "revision": "46ff1cb785591c1cd784dc082957095e7a6b2d8b4c5677e567d8fd4b65371541"
+  },
+  {
+    "url": "/apps/car-racer/index.html",
+    "revision": "5c43d9140625b626bf2563ddae4f554900af67e17b08fe97a4bb32aa6550942a"
+  },
+  {
+    "url": "/apps/car-racer/main.js",
+    "revision": "765fe1f0ae589b522ffd41297e8a90a50278ecf960bedf71d8bba0ec50c6ad90"
+  },
+  {
+    "url": "/apps/frogger/index.css",
+    "revision": "cb5d3962e0c26dcdef053d12db621f51e5fce00461dd0ebf741aa77d61337c95"
+  },
+  {
+    "url": "/apps/frogger/index.html",
+    "revision": "21a2dbbabf47eb19e806c3339a128ebe27dfafd82e102b9e311a07ddc5da74da"
+  },
+  {
+    "url": "/apps/frogger/main.js",
+    "revision": "b903b7437eb9ada085af7ff1276da727c0b86d604be6d34538f2d715a7fb45ed"
+  },
+  {
+    "url": "/apps/frogger/splash.svg",
+    "revision": "7870825c7e747222e7425029d498332114a06e8b037228e3b35359651c9203ed"
+  },
+  {
+    "url": "/apps/phaser_matter/level1.json",
+    "revision": "bb7dd9a7b17522d893680406e078b444c765bce35008794bec743c7a8dcf88b4"
+  },
+  {
+    "url": "/apps/phaser_matter/player.svg",
+    "revision": "15d9cbed05d03961835ab58a7f06c3980c3585bc6987c13e99a8da0c7b3d42f8"
+  },
+  {
+    "url": "/apps/platformer/editor.css",
+    "revision": "fabd0938449bab5ac6561ded8c55dcd95963e63ea22c271c1d84646a61b350ce"
+  },
+  {
+    "url": "/apps/platformer/editor.html",
+    "revision": "ca91872bb904a00b12d420e9650b74ff5ef0e1ddf48644e26170f1d91583c260"
+  },
+  {
+    "url": "/apps/platformer/editor.js",
+    "revision": "1ea88c37d18c0cffbdaf3514148e0859a8c95a465f21f4b49917bcaf49163d41"
+  },
+  {
+    "url": "/apps/platformer/engine.js",
+    "revision": "1fe4ad54cbbc3c6b89b10068fe7811d36dd0744726fc850bd4c5da1d3a56356c"
+  },
+  {
+    "url": "/apps/platformer/index.html",
+    "revision": "cdbd89b1288595d31cbcc8c80342897097ffa88c4909b1dcc19a1ae3bf1e8172"
+  },
+  {
+    "url": "/apps/platformer/levels.json",
+    "revision": "4db50add89a23c2b8d4ad6f166ddc92636620a8d953272ae28bfc58f05c8b85b"
+  },
+  {
+    "url": "/apps/platformer/main.js",
+    "revision": "ce10748a931c8bbb3375f5130b9afb3a3d870e177737e5651110237b3fdded60"
+  },
+  {
+    "url": "/apps/platformer/styles.css",
+    "revision": "9be64eb81be75d6e4eb8b0e49824171220df0e0c562a8b99d48bf3a521801d6e"
+  },
+  {
+    "url": "/apps/pong/index.css",
+    "revision": "24eea2ce3bb5c9eb6e87308a8029bbf34801901faacf0c982bc8b27471d1402d"
+  },
+  {
+    "url": "/apps/pong/index.html",
+    "revision": "0d9252b566c9954d6b0872558dbb4f5c735d45e54c91de27ce781e36443b7df0"
+  },
+  {
+    "url": "/apps/pong/main.js",
+    "revision": "d17f96dc93a1ca897bf8d95d8b440f032be0962de537280ed4a3e5aff48ec53f"
+  },
+  {
+    "url": "/apps/tetris/index.css",
+    "revision": "f54f8cecef20bdab389c947b5be11eb6a73694f50f098af3c601c4ad9419e946"
+  },
+  {
+    "url": "/apps/tetris/index.html",
+    "revision": "6e7ef28731b9e81d3afd12649faa38dfa72de8df0029cbb3787aa93fb9f5cd34"
+  },
+  {
+    "url": "/apps/tetris/main.js",
+    "revision": "4ab078348f4f1d70097550d25035e3a65c29a550bbab55e25d2280919d27ae42"
+  },
+  {
+    "url": "/demo-data/autopsy/filetree.json",
+    "revision": "38935a7cf42611a7aa16f303406f75e420c4bfd2dd0279962105e976ff6a0c82"
+  },
+  {
+    "url": "/demo-data/autopsy/hashes.json",
+    "revision": "2ffbd9a09c43c3e2edf94943aecb5dcac4f932bb8366970f7dee9b576900c25b"
+  },
+  {
+    "url": "/demo-data/beef/hooks.json",
+    "revision": "c68d75d33e2f2da84f1a57f38e67ab60ed2f1017afe1be2718850931a34fd9c0"
+  },
+  {
+    "url": "/demo-data/beef/modules.json",
+    "revision": "3d5abf3cce57c7982bfb4a551cadf025e73bd5b3281069bfa17625c7041b4858"
+  },
+  {
+    "url": "/demo-data/bluetooth/scan.json",
+    "revision": "b9e8dd22fd11db74774460b547843e4a334d8726e6596a5d20112267576445a0"
+  },
+  {
+    "url": "/demo-data/dsniff/arpspoof.json",
+    "revision": "54c7d64ba1ca0905a0b46f2bd8c8cfd8357ba71dbbf42f44194678619071e1fb"
+  },
+  {
+    "url": "/demo-data/dsniff/pcap.json",
+    "revision": "e90cef459c8640557e0aad883dd49be687605f8a325c851c3991da2a643f3bae"
+  },
+  {
+    "url": "/demo-data/dsniff/urlsnarf.json",
+    "revision": "1643e232ee8dccc20f47d4bf19a38dcf2deddfe1cc7bb9b6a2ea14c88887d9e9"
+  },
+  {
+    "url": "/demo-data/ghidra/disassembly.json",
+    "revision": "b0c8783b42aa2b63f407336ab80d736fb8258dba79a80d6ef4ae03f0d4b6476f"
+  },
+  {
+    "url": "/demo-data/ghidra/pseudocode.json",
+    "revision": "50550c85c853936b4bdcaf0c77cfd2cccf27e739f7fb084a6f47b80a348ca8f7"
+  },
+  {
+    "url": "/demo-data/ghidra/strings.json",
+    "revision": "fe478042e3b573961f74df600a80ce777c826732bb2dc84928cdaa4688e083e2"
+  },
+  {
+    "url": "/demo-data/nessus/plugins.json",
+    "revision": "762afe54fe76ca69692b6dcba4a9522a97454ad79d63cd14e1a7b37614f44234"
+  },
+  {
+    "url": "/demo-data/nessus/scanA.json",
+    "revision": "3faf08915c9a9a173af8f1d1a7881b9c6b5f624b87c368d2117def2140ef0cd1"
+  },
+  {
+    "url": "/demo-data/nessus/scanB.json",
+    "revision": "b67d87f79ef687a5cb3ff34bf554f9fb71f98eec3e8c0abe279e52db6f1c9675"
+  },
+  {
+    "url": "/demo-data/nikto/report.json",
+    "revision": "df8e9ca4353c0f9680a73f9e6072e4968b4bd5c500b91f74b6443e8a495fe273"
+  },
+  {
+    "url": "/demo-data/nmap/script-db-version.json",
+    "revision": "8ea9d8b069825fed4ecef7662b86f353d0b629683faa581aac03e675d7c79f4f"
+  },
+  {
+    "url": "/demo-data/nmap/scripts.json",
+    "revision": "f42623e42e70a2b63d53809726b23892d914b6092f4915975a06409b5267c557"
+  },
+  {
+    "url": "/demo-data/reaver/aps.json",
+    "revision": "be66dc1cb565cb4afc2a736ba9fd8f45c26dab7179b1bb8bb514046b0c095e96"
+  },
+  {
+    "url": "/demo-data/reaver/routers.json",
+    "revision": "48d1c90b6889b5f325c51ae8bffb7abbcaf35cb84e9d154d7d6e86f954eaecf7"
+  },
+  {
+    "url": "/demo-data/volatility/memory.json",
+    "revision": "614172fa3c91cd2ed777fb3a72a809d3986bd9a40d8c1ce9fe310b1caf7a4fa7"
+  },
+  {
+    "url": "/demo-data/volatility/netscan.json",
+    "revision": "b8376279d55add476bcdfaf3c291e6062f73c6196db5a8acbe176503fb48f16b"
+  },
+  {
+    "url": "/demo-data/volatility/plugins.json",
+    "revision": "b49a85ecb60bb2172f2827cd80956037f11fec3d377ce78b1d1c705925007d81"
+  },
+  {
+    "url": "/demo-data/volatility/pslist.json",
+    "revision": "33ab3dbcb4581572c9709546ad6c0e5f8010d3c7cb98c42b5b0bc99d9e512705"
+  },
+  {
+    "url": "/docs/apps/terminal.md",
+    "revision": "1994e7f8ce012d2918c96bc702ad5844467463eaa433dc2289da93ce015db4ca"
+  },
+  {
+    "url": "/docs/seed/branches.md",
+    "revision": "3cbabc17278ec074f984418fc6b61792a4a39edb41b0bd42c8d5e04c42c5d617"
+  },
+  {
+    "url": "/docs/seed/installation.md",
+    "revision": "deb8e16c4e96a7c88a41f724bf4b371fc073c701d68f8ba22ea22421b03dce02"
+  },
+  {
+    "url": "/docs/seed/introduction.md",
+    "revision": "4aae6971ae41cccde368a0b5ab00feb839e2c3b998543df85e85bb909db98bbf"
+  },
+  {
+    "url": "/docs/seed/repos.md",
+    "revision": "670e72db406a7475de71d09a2e368af7bd4176c0792efdf068fd83a560543206"
+  },
+  {
+    "url": "/docs/seed/virtualization.md",
+    "revision": "8462948545ef1b4e1c8c5f7a38c7bd5886791651229f0e9dd95356227635d597"
+  },
+  {
+    "url": "/images/logos/bitmoji.png",
+    "revision": "1b21789f838c8e7622845eef06f80c75bed9797d35f5ea4026fc13fd1835d94e"
+  },
+  {
+    "url": "/images/logos/fevicon.png",
+    "revision": "6ecd8f549f83934741043de86680f6d0c04ac1487acd1c5fa96b0c669768a8b5"
+  },
+  {
+    "url": "/images/logos/fevicon.svg",
+    "revision": "b89c13d3dc39efc7ade6962cf94119c4c7ab4ee7f0c61f7e16cdcdc7a1946cd6"
+  },
+  {
+    "url": "/images/logos/logo.png",
+    "revision": "3d30ab8f09797eb6ab0dbdd4afadcb52e943dd0fbad3a2bef0dc4f9fc6608b74"
+  },
+  {
+    "url": "/images/logos/logo_1024.png",
+    "revision": "87b54bff8d85b92485563f41b49b5088b8d4fc59bfa873bf95e51263a6332b97"
+  },
+  {
+    "url": "/images/logos/logo_1200.png",
+    "revision": "87b54bff8d85b92485563f41b49b5088b8d4fc59bfa873bf95e51263a6332b97"
+  },
+  {
+    "url": "/images/logos/search.png",
+    "revision": "d5ac90b28f42878b69fb347bea1ecb0c12935b3261c34580424fa7186d6688b6"
+  },
+  {
+    "url": "/images/memes/used-sudo-command.webp",
+    "revision": "1f2f78cd1e7ddaad2491115153ecade25bdfd665ce6be493508bcef4edf0e827"
+  },
+  {
+    "url": "/samples/wireshark/README.md",
+    "revision": "f9bb96167a0e8ae5603a9dbe1083c428402f28c8c55eb4550d0a9b3f06793a3b"
+  },
+  {
+    "url": "/samples/wireshark/dns.pcap",
+    "revision": "8c471ab122efaa21f4e9b7312db64868436ecb987f25b3817aa5deb442fa7dfe"
+  },
+  {
+    "url": "/samples/wireshark/http.pcap",
+    "revision": "41abecabf5332b095e719c9617ca8ae6a5cee132f23bc7d943e1aecab415a07e"
+  },
+  {
+    "url": "/themes/filetypes/js.png",
+    "revision": "cc16d9d4dc17fe8437a33becf7c97836c25bae93da55372a914f6460d3919384"
+  },
+  {
+    "url": "/themes/filetypes/php.png",
+    "revision": "f546571d68036d25cada3dbe55b9406593e3c7916e2743c4d57de279b7234a47"
+  },
+  {
+    "url": "/themes/filetypes/zip.png",
+    "revision": "374e96ddc956fd5ce015ee0d4e182ade0eebcaa9e99b711073eaaec8a8c6f511"
+  },
+  {
+    "url": "/apps/flappy/skins/blue.svg",
+    "revision": "ec00d66c07665fd96ead43cc7da866ac4c35cbbf7cba31ca1f53dfdc09b599de"
+  },
+  {
+    "url": "/apps/flappy/skins/red.svg",
+    "revision": "ccfb5e1390a066fcd6ae167b928b4e49fc6a15004569b4560b6e977714f19ee6"
+  },
+  {
+    "url": "/apps/flappy/skins/yellow.svg",
+    "revision": "dfe1a3e8173a365dc3284d64987f8834436da64cb9506bf544534e1682316d88"
+  },
+  {
+    "url": "/images/wallpapers/wall-1.webp",
+    "revision": "478c286ed459e317aad10ac264121c359c684c2310f91e5fdc77d26fc0ed4e73"
+  },
+  {
+    "url": "/images/wallpapers/wall-2.webp",
+    "revision": "94987b083c3c2d8f5c1d17f12bc42ebb1c29b01fc8efd0462a1d369503d5caed"
+  },
+  {
+    "url": "/images/wallpapers/wall-3.webp",
+    "revision": "b45e5501ff89c6932cba142295ccff285ad147bb144cd166e4266e065efce789"
+  },
+  {
+    "url": "/images/wallpapers/wall-4.webp",
+    "revision": "4095cc87c92efc89e7ed0e13fb0edb3873956f64cfeafa36f9350c4e5a98f86b"
+  },
+  {
+    "url": "/images/wallpapers/wall-5.webp",
+    "revision": "f2b7750a22d5f9d4a0afa5c58a572d7a1895ce8741e18768690dda7d463d74a4"
+  },
+  {
+    "url": "/images/wallpapers/wall-6.webp",
+    "revision": "25d4d7debc49b920b3a7114d5efa3b1b8165c79f22e512274f7da5438188db18"
+  },
+  {
+    "url": "/images/wallpapers/wall-7.webp",
+    "revision": "16df4d2d8513be46fe8a0537fd0803ea2eecccab6bf6820a6733185718b20c78"
+  },
+  {
+    "url": "/images/wallpapers/wall-8.webp",
+    "revision": "d45c3a3c2c9019877d6dcd923ae32664fba8dbd35fd59a256ae78b0a8d387577"
+  },
+  {
+    "url": "/apps/platformer/levels/level1.json",
+    "revision": "c7344c71b68b141cbf285b541722cc1360ae47569de8c7fb146c0593f9229be8"
+  },
+  {
+    "url": "/apps/platformer/levels/level2.json",
+    "revision": "5045840fcf454e3827db915a888243da1223f22a9917ea0c74f0582ef9dded4b"
+  },
+  {
+    "url": "/apps/platformer/levels/sample1.json",
+    "revision": "2581007bf65baa7099d6fee78275b50756de4ad13b817127d35f855eaefbbdac"
+  },
+  {
+    "url": "/apps/platformer/levels/sample2.json",
+    "revision": "57c6dd6f723ec2e172ac74bfa59e3f9b54035f938f324bbb16fbad46b036dd26"
+  },
+  {
+    "url": "/demo-data/radare2/tutorial/basic.r2",
+    "revision": "7c2626c40b6ffba53505a702fc267ca3b8b9aa2995d7593b9ce17b89be500bc2"
+  },
+  {
+    "url": "/images/logos/New folder/fevicon.png",
+    "revision": "ec9f49dd129f3971512295e7312e062a819691bd83267dcfbbc1bb2c340c0e58"
+  },
+  {
+    "url": "/images/logos/New folder/fevicon.svg",
+    "revision": "75133849c5cdad278f7b2e4a9200812c3e13a23d11aedca10a9a3435ca6eaec7"
+  },
+  {
+    "url": "/images/logos/New folder/logo_1024.png",
+    "revision": "be56b3cc2af6e937b75a2bb2ab5a125452fdbb4587e6ced5e96adc03fc838257"
+  },
+  {
+    "url": "/themes/Yaru/actions/document-save-as-png-symbolic.svg",
+    "revision": "8935f2023d8a5da264b4c73b3fcda2a5f6e10538a85aa420a4651c94f0c70f6f"
+  },
+  {
+    "url": "/themes/Yaru/actions/document-save-as-svg-symbolic.svg",
+    "revision": "049ca6d799c59c4743f68a819c30efec7770e55d72207e6b19d23814e1869bed"
+  },
+  {
+    "url": "/themes/Yaru/apps/2048.svg",
+    "revision": "00e6aa22459c3c6b3a74d7237a245649c25da9b1cab8beace6e2e5d0cb83e11f"
+  },
+  {
+    "url": "/themes/Yaru/apps/asteroids.svg",
+    "revision": "2b11c189b38176520afd75e8d87ac502ecc947698ffd5b67da443cb4e1711118"
+  },
+  {
+    "url": "/themes/Yaru/apps/autopsy.svg",
+    "revision": "5bf5accce33dac2098b5cd65b8e8e48d16150a5da7abd6527cdcfba2dd1fa139"
+  },
+  {
+    "url": "/themes/Yaru/apps/bash.png",
+    "revision": "8642ed01bb59f23d4cf991e90a918928937913820d0f1674044eade1e970d03d"
+  },
+  {
+    "url": "/themes/Yaru/apps/battleship.svg",
+    "revision": "4cacb935efd5f2cf1e19e2b33d023418c2feaf858ba057a9929918a59092ea46"
+  },
+  {
+    "url": "/themes/Yaru/apps/beef-idle.svg",
+    "revision": "aab58c558a31c06187924089f3f0e06e17255c3993feea9f4e3449745c5cf74c"
+  },
+  {
+    "url": "/themes/Yaru/apps/beef-offline.svg",
+    "revision": "c3f9e3a505e2c69e08fce5624bf99be3dc59a2cc745edac9478950d171f90440"
+  },
+  {
+    "url": "/themes/Yaru/apps/beef-online.svg",
+    "revision": "cf0cdd9328ff1497c27be23e5ce2e272837d71384e4c0a037fb2b0dc1a0f8aa4"
+  },
+  {
+    "url": "/themes/Yaru/apps/beef.svg",
+    "revision": "84b410dbdd965aebe51191e35e8e074168461e8706339324c86bcbd2112528ed"
+  },
+  {
+    "url": "/themes/Yaru/apps/blackjack.svg",
+    "revision": "ec0279fa7da36af6ae212d6a932ec3c2cdffc64b1196eeece823e93fc4ff6e81"
+  },
+  {
+    "url": "/themes/Yaru/apps/bluetooth.svg",
+    "revision": "330e896ff381b45729aaea3d8a9ec103dc251d6facf8dd89bf8c6d16b26e2f22"
+  },
+  {
+    "url": "/themes/Yaru/apps/brasero.svg",
+    "revision": "014bfb023e0bfc38d9f8a0c72b6396a09efe05249306d0b866f7280608862a36"
+  },
+  {
+    "url": "/themes/Yaru/apps/breakout.svg",
+    "revision": "d7f457962239ce5450eb302bbc6f8f629da6af0707fb22ed72591dc56b3134ad"
+  },
+  {
+    "url": "/themes/Yaru/apps/calc.png",
+    "revision": "04cdb7b1c202449401278c341a41da6312dce613e1a3cc1b8fe91a97619b3c3d"
+  },
+  {
+    "url": "/themes/Yaru/apps/candy-crush.svg",
+    "revision": "33f2cd0667cb641b6794b9aadc5e3eaa631735ea570b580bf25582ec3b20c051"
+  },
+  {
+    "url": "/themes/Yaru/apps/car-racer.svg",
+    "revision": "11bdea162ce2084c6862f9c436150ac57b67bed015220cfa3d1019cadda7b0ed"
+  },
+  {
+    "url": "/themes/Yaru/apps/checkers.svg",
+    "revision": "c751c37f8d1e44a228559950a715fe34b91edc9d9f2f2feb9900c9b4e5e69820"
+  },
+  {
+    "url": "/themes/Yaru/apps/chess.svg",
+    "revision": "5d3afa270cbbc45e0bd4f37a371c86dcb24b0ceafdac088af96a076ec983bd7a"
+  },
+  {
+    "url": "/themes/Yaru/apps/chrome.png",
+    "revision": "5ac4f8216a41b673937dca752d131a1b8235746a9103b89d3a467d1bb48070d4"
+  },
+  {
+    "url": "/themes/Yaru/apps/connect-four.svg",
+    "revision": "03683adfb444d8dbe2dcc743b262a54ad6d864a35c6997b932afe65a8eed2ff0"
+  },
+  {
+    "url": "/themes/Yaru/apps/dsniff.svg",
+    "revision": "9cea26a484d00c2da1e2953c2ed25ab3ecd0e40ba1fe43daeb9d6b1c28d3fef0"
+  },
+  {
+    "url": "/themes/Yaru/apps/ettercap.svg",
+    "revision": "b1de53f840225a7a54f6b66de3cfe4e6d468688abd9f86a64ab116c1a9ca4465"
+  },
+  {
+    "url": "/themes/Yaru/apps/flappy-bird.svg",
+    "revision": "c3935dc34bf397c7f8d4b02b81cbaad2ceb0bb4d80f72488c9cb87abb46338b7"
+  },
+  {
+    "url": "/themes/Yaru/apps/frogger.svg",
+    "revision": "3e11db134095a862c491b7b39923395ceb3f8b1c8e3e4f83b2e5002f492f4215"
+  },
+  {
+    "url": "/themes/Yaru/apps/ftp.svg",
+    "revision": "7cdcfb8241eb9db3e25d814f2a1182200f4f6800e6ce57abea110c98e25445c6"
+  },
+  {
+    "url": "/themes/Yaru/apps/game.svg",
+    "revision": "991275bfc18dc77665c744a0643bf5302b0e055a403bacf8ae5100ab0d637cc5"
+  },
+  {
+    "url": "/themes/Yaru/apps/gedit.png",
+    "revision": "b2507d7394f42302355b9fb501576849f2cb518022e5cafeac8b3aad6d8d752e"
+  },
+  {
+    "url": "/themes/Yaru/apps/ghidra.svg",
+    "revision": "f99a8adcf1ffb7dfad48f74530f06b0dcab7b65e2df258882e7d09374b346ffb"
+  },
+  {
+    "url": "/themes/Yaru/apps/gnome-control-center.png",
+    "revision": "95be8a6fca76b97365f1580d7e31270afa2196320f5cb87e41ea447236b69fa3"
+  },
+  {
+    "url": "/themes/Yaru/apps/gomoku.svg",
+    "revision": "eb02fdf9af41d3f677ca1c4b910a13292daa55be26d2b9c03d632ac4bc50ea90"
+  },
+  {
+    "url": "/themes/Yaru/apps/hangman.svg",
+    "revision": "82719c5b84b6f4f421dc8758accfed9b200c2235bde7fb0789edb934ba2d30f0"
+  },
+  {
+    "url": "/themes/Yaru/apps/hashcat.svg",
+    "revision": "b3c2bb4d3e11cd079482bc1878008eb4886e0b75997de1cb7c772db4a25929be"
+  },
+  {
+    "url": "/themes/Yaru/apps/http.svg",
+    "revision": "b179d2e2095a8ba39e84a3e4d6a72f1daf88414919e59096a359298b5a492ddc"
+  },
+  {
+    "url": "/themes/Yaru/apps/hydra.svg",
+    "revision": "fe38ea3bea34c0c8d6ddbb72df8069ef8978f8ad2cfb4d7017ce87d008546eb8"
+  },
+  {
+    "url": "/themes/Yaru/apps/input-lab.svg",
+    "revision": "7bf987cf25f697201e6a10d7515abeb1279881b465270560206ec788dd02eb74"
+  },
+  {
+    "url": "/themes/Yaru/apps/john.svg",
+    "revision": "0680faf1c5095776f8469b5edf654f77c604f426fb8fc7efe7ec3375c49f89e1"
+  },
+  {
+    "url": "/themes/Yaru/apps/kismet.svg",
+    "revision": "ba76c7d89e90813bc210c7b5e9d09c5424317c3e8c4916a1bca1a54f5e8ade1d"
+  },
+  {
+    "url": "/themes/Yaru/apps/memory.svg",
+    "revision": "d46e5e13958b25803102376435593a7f30110f64c72ae9c9ba2f4e217bb86b24"
+  },
+  {
+    "url": "/themes/Yaru/apps/metasploit.svg",
+    "revision": "9180b9ea704d6ad26a3f8605066466cd41ffa3e431a1cfb123b65e3a4f90fcd8"
+  },
+  {
+    "url": "/themes/Yaru/apps/mimikatz.svg",
+    "revision": "e856c0a6417a8ea16a2cb42b7c9063f7989db5caf3fa2a59f089c9c0839deaca"
+  },
+  {
+    "url": "/themes/Yaru/apps/minesweeper.svg",
+    "revision": "29f0e96d387d650774c8ea82f764c64eb1d387728271942e91e2496c99073161"
+  },
+  {
+    "url": "/themes/Yaru/apps/msf-post.svg",
+    "revision": "779acf798beb88525ff931b80de307bcd398bd57e0bc7a4327d8950c1a809518"
+  },
+  {
+    "url": "/themes/Yaru/apps/nessus.svg",
+    "revision": "b9cb3eac72d36c564755da494fa358198c5c9e2347d567173831fbf719d42853"
+  },
+  {
+    "url": "/themes/Yaru/apps/nikto.svg",
+    "revision": "594ff2cfbd5b46d1d17be399d29ed9ceaad1f1e11caff4bd8aaeadf34d5f5310"
+  },
+  {
+    "url": "/themes/Yaru/apps/nmap-nse.svg",
+    "revision": "7ac2052e41a636e1356b29826b0866975bdaa842ce6627b3dbd35a4ceb34d44b"
+  },
+  {
+    "url": "/themes/Yaru/apps/nonogram.svg",
+    "revision": "f88c2ec53e045833205b4a7a943020576d4ad3d826f0aeee1a1ba567e0487687"
+  },
+  {
+    "url": "/themes/Yaru/apps/openvas.svg",
+    "revision": "ee8426ae7f3855a8e5a4e797659eef1c28db3e13791dacc6d9b5696849091e04"
+  },
+  {
+    "url": "/themes/Yaru/apps/pacman.svg",
+    "revision": "a8033f1e618c7ec08709dc8a4c79e4893d8eb43221acf79e1a9bf6bb55de2102"
+  },
+  {
+    "url": "/themes/Yaru/apps/pinball.svg",
+    "revision": "e6c6115670e69053bd0ce6d81fc8323ab8d89b3652b021f35d071f47fc96b86b"
+  },
+  {
+    "url": "/themes/Yaru/apps/platformer.svg",
+    "revision": "e9f304f669488879e80ce1875367adce91768f5501dced062da7bb7eda9bb2e5"
+  },
+  {
+    "url": "/themes/Yaru/apps/pong.svg",
+    "revision": "daed159119054329b2d4d1b290ce2a8b728c48ec3e892d573e25c596a406ef05"
+  },
+  {
+    "url": "/themes/Yaru/apps/project-gallery.svg",
+    "revision": "235d08cf64c1a34ed585d44af677e98552284155cb6bcb7848b18f05d019c0ab"
+  },
+  {
+    "url": "/themes/Yaru/apps/qr.svg",
+    "revision": "ea51a38b49a337a23dbb349dfabc70c29a67f0705a8c5636bf8207cc38a9bc87"
+  },
+  {
+    "url": "/themes/Yaru/apps/quote.svg",
+    "revision": "95aed4a72f180df9b0f30dbc2971b423c0c285d285d18f3f25e707c1bc02a374"
+  },
+  {
+    "url": "/themes/Yaru/apps/radar-symbolic.svg",
+    "revision": "2eb41fdbc46f003de4204994401ef8b5a240e83591137b0f603323809926866a"
+  },
+  {
+    "url": "/themes/Yaru/apps/radare2.svg",
+    "revision": "b0d247d0e4303e52508bbda5b4c16c039153ab5982ae416e5edda0a301218947"
+  },
+  {
+    "url": "/themes/Yaru/apps/reaver.svg",
+    "revision": "6e1eb29cc08ea8604c1cb3c74acccf66d4398302f65671780a5a2172e6980f69"
+  },
+  {
+    "url": "/themes/Yaru/apps/reconng.svg",
+    "revision": "69b56b7fa85a289652939795aaa815fcaaa5a7a4716f5c570c929ad9d56c5e4d"
+  },
+  {
+    "url": "/themes/Yaru/apps/resource-monitor.svg",
+    "revision": "45233621d87307427c7f19404c86aaf3fa050688ce21b6f450b560bada8ac8b5"
+  },
+  {
+    "url": "/themes/Yaru/apps/reversi.svg",
+    "revision": "6a6051bb7da899ceba073968f171365c7c7375355b1d28caa142ff59c0445057"
+  },
+  {
+    "url": "/themes/Yaru/apps/ristretto.svg",
+    "revision": "2076895d1bb1e2659ae82fb5259f1a765772a6bb06389d88cb8684bebd6f758b"
+  },
+  {
+    "url": "/themes/Yaru/apps/screen-recorder.svg",
+    "revision": "ad9437a8228547d76eb0b806cf9e34ab8dff808c0138ad59ef0ea7e633a652e2"
+  },
+  {
+    "url": "/themes/Yaru/apps/simon.svg",
+    "revision": "6e330b707a2fd7a075475e065be134770d20a126138948f42f4a7d05f07e63be"
+  },
+  {
+    "url": "/themes/Yaru/apps/snake.svg",
+    "revision": "e4b7836e8a8861adc53667c9f4fa2fc11a0fa0646977b7607c6dd1533fa3d5cf"
+  },
+  {
+    "url": "/themes/Yaru/apps/sokoban.svg",
+    "revision": "e0ec659590816981b7f5e8e1b3e915a5d99664038caf354e68fbfa4765f07aa0"
+  },
+  {
+    "url": "/themes/Yaru/apps/solitaire.svg",
+    "revision": "b33d364ec1ed80eff9fecce27e9cec4f7cfaf9095582109566fea7e9b99f92be"
+  },
+  {
+    "url": "/themes/Yaru/apps/space-invaders.svg",
+    "revision": "71fe052abd4afda25c5ebcb8b5fa986fd40cb4bc675446a83af640fb86dfb9e7"
+  },
+  {
+    "url": "/themes/Yaru/apps/spotify.svg",
+    "revision": "366bb7f8086dd7c7e0d9edc4c54b0b47fd3b003f6d10a04d83c4ccff8e6f4bf5"
+  },
+  {
+    "url": "/themes/Yaru/apps/ssh.svg",
+    "revision": "ea730b252cccface6c93df02f59d76157a1f47e597c46b63d99fea972c1a6ae9"
+  },
+  {
+    "url": "/themes/Yaru/apps/sudoku.svg",
+    "revision": "93e723ffff5be9792d76c8fcb4d48ffbf9b47d6048d5187eea9ee008b402b63b"
+  },
+  {
+    "url": "/themes/Yaru/apps/tetris.svg",
+    "revision": "0a4f0c39fe47e138c521e241310347e1d42f0fc40b48a9e54fc023d99099af25"
+  },
+  {
+    "url": "/themes/Yaru/apps/tictactoe.svg",
+    "revision": "20d9e6332f72eee9b584e6664f9f2e018200cb60d1404595e6ac7dbf7e923430"
+  },
+  {
+    "url": "/themes/Yaru/apps/todoist.png",
+    "revision": "608653cbc0eeb530c7224d2529d488c44358e0b046d9cc4fc43e11f2c6e24152"
+  },
+  {
+    "url": "/themes/Yaru/apps/tower-defense.svg",
+    "revision": "9c010fe8379eaea4b3a8b74e40a6d928dd8755df778225d3b970180b32908512"
+  },
+  {
+    "url": "/themes/Yaru/apps/volatility.svg",
+    "revision": "5d26241abd4cbcf38fc1a7968fadd0f87fe66a523e4e2c8b1dd9ac9c82c1f4a7"
+  },
+  {
+    "url": "/themes/Yaru/apps/vscode.png",
+    "revision": "8f39867f7089387e15539bbbc154cf85b25aeca10a6f878b14d7d78af04a5252"
+  },
+  {
+    "url": "/themes/Yaru/apps/weather.svg",
+    "revision": "4ffe26834c698cf481ba7289501ff56f1194329a0dec002935a59bfb8552d450"
+  },
+  {
+    "url": "/themes/Yaru/apps/wireshark.svg",
+    "revision": "c3ec3f93364c032b7f179ead14816bf2fe639744526ce1be2895bfb0d75c0c07"
+  },
+  {
+    "url": "/themes/Yaru/apps/word-search.svg",
+    "revision": "2d238191f6139122edd1a78598b85811195fa03756ab814d0cb0af39a07be0e5"
+  },
+  {
+    "url": "/themes/Yaru/apps/wordle.svg",
+    "revision": "1ee57fc0cb991f4a46de97ac6e89888e2a651910458fc8811b906779d52c057c"
+  },
+  {
+    "url": "/themes/Yaru/apps/x.png",
+    "revision": "5b805e6af8b6569d27f2b5f8006e087a3c343f72eeba4787a0be53afd3a303cf"
+  },
+  {
+    "url": "/themes/Yaru/apps/youtube.svg",
+    "revision": "8d9ceaeace6034c820093c6be4b018692a6d357302d7c296a7c0246d8805b948"
+  },
+  {
+    "url": "/themes/Yaru/status/about.svg",
+    "revision": "aeab90f540525b5029c98d71c8d170ce61b5b4776fe69ffc2afb397e6eb29d5a"
+  },
+  {
+    "url": "/themes/Yaru/status/audio-headphones-symbolic.svg",
+    "revision": "67514369b9f2d6f85b8767c34c6396eb7359dbc8fc84a1b4dc346662853aedf6"
+  },
+  {
+    "url": "/themes/Yaru/status/audio-volume-medium-symbolic.svg",
+    "revision": "f8a554e46bdb0fb305c88eec21b582778dbaec7aec8a1575f0093e56216697ac"
+  },
+  {
+    "url": "/themes/Yaru/status/battery-good-symbolic.svg",
+    "revision": "dc05af60e905db0c331db1d0d4aab3bbd8a0bdb7d7661f2de9face3c29a12465"
+  },
+  {
+    "url": "/themes/Yaru/status/bluetooth-symbolic.svg",
+    "revision": "29e39e2518fb063d839e6da39218fb5986c8e516d2a617933bb141516f910088"
+  },
+  {
+    "url": "/themes/Yaru/status/changes-prevent-symbolic.svg",
+    "revision": "48ead42b5050abcc7dd63a46ab578d3c1e82c19949aa373c6825505d6c2b04bf"
+  },
+  {
+    "url": "/themes/Yaru/status/chrome_home.svg",
+    "revision": "383dd54984199c527118437956fe00ac2357f9553da9d54ce59e2a76deaea484"
+  },
+  {
+    "url": "/themes/Yaru/status/chrome_refresh.svg",
+    "revision": "add2e602e155682695aa458e557f9c99e737a5a8f5963c08d3e8328a7af1e0d9"
+  },
+  {
+    "url": "/themes/Yaru/status/cof_orange_hex.svg",
+    "revision": "19c820b05709d55e3ccd5a0d12b9fa0ee0055eb9185b413660e6bfd1e1341981"
+  },
+  {
+    "url": "/themes/Yaru/status/contact.svg",
+    "revision": "e55952902a4e166cc08e98998f170242abf1572f8c1e12ae55d4b7ae545d2152"
+  },
+  {
+    "url": "/themes/Yaru/status/decompiler-symbolic.svg",
+    "revision": "d9d86d3615f2278cac8f6ed2e78cc5736d0cee4367908ee97b0ee0e170b7e222"
+  },
+  {
+    "url": "/themes/Yaru/status/display-brightness-symbolic.svg",
+    "revision": "bf306aadfba324d6a648cd5510293d87665e3b00fb5d81fd6f80ad3eac6786a4"
+  },
+  {
+    "url": "/themes/Yaru/status/download.svg",
+    "revision": "659303d7ec1ef1c8415137b684f740799e1416be66029cafa15f749d4f3c0399"
+  },
+  {
+    "url": "/themes/Yaru/status/education.svg",
+    "revision": "4d5d80d5950956dab96da018ba7a4836b5b74072102640c3b758fe259afd9152"
+  },
+  {
+    "url": "/themes/Yaru/status/emblem-system-symbolic.svg",
+    "revision": "5f218b3087e9f387960acbce07aeb53d59e6757f3d0c446569be3e9a104c687c"
+  },
+  {
+    "url": "/themes/Yaru/status/experience.svg",
+    "revision": "4572fde1aa4663be9d9c659316f2aa7c0fbb2a62d8a42ea1a4e12485496208e6"
+  },
+  {
+    "url": "/themes/Yaru/status/icons8-kali-linux.svg",
+    "revision": "72e4060eb8f8aaddd9a042c057553b216202f57761c969896d853e75c5eb3952"
+  },
+  {
+    "url": "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg",
+    "revision": "ea2d863b241d7d5387e42020060a6c729e329daec759635e6df64b746cd13283"
+  },
+  {
+    "url": "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg",
+    "revision": "28baec34193e74dacd7bd22d2165a5fa99a0fee21389c29b66ff58af039b585e"
+  },
+  {
+    "url": "/themes/Yaru/status/power-button.svg",
+    "revision": "7a124eb53720cfe5d5a285f7f24058f76e60b85ab3ad51a11908c8583382c5c8"
+  },
+  {
+    "url": "/themes/Yaru/status/process-working-symbolic.svg",
+    "revision": "fc35cd765ba5492ed986a127816de1474418855c771045d677e145ba842e9c0f"
+  },
+  {
+    "url": "/themes/Yaru/status/projects.svg",
+    "revision": "98fa34b27d595aa1f0f65ed99567b869d03656180011a999332d35cd31110ea2"
+  },
+  {
+    "url": "/themes/Yaru/status/skills.svg",
+    "revision": "79c5fc61c1d2ddb7360c058e48a8b2e63a2cb98d3732cbe92edd998afcd68f60"
+  },
+  {
+    "url": "/themes/Yaru/status/system-shutdown-symbolic.svg",
+    "revision": "b015c1ed24f9f8863f9562625852bf65dab4c9f6ca72645a951afaf09362b84d"
+  },
+  {
+    "url": "/themes/Yaru/status/ubuntu_white_hex.svg",
+    "revision": "609955e15f498c1ef8f6f610c7c1e798c567b743edc86c6c629ff2668688d864"
+  },
+  {
+    "url": "/themes/Yaru/status/user-trash-full-symbolic.svg",
+    "revision": "0e7c65fc7d3e23ded18d0ae841b75f0e2ff98226512cdb8e3cf7771ad6d55ae7"
+  },
+  {
+    "url": "/themes/Yaru/status/user-trash-symbolic.svg",
+    "revision": "5353f9ccab9635ce2e7b71ba7749868341a5f4d6b5f3d0223899b4c4064fced9"
+  },
+  {
+    "url": "/themes/Yaru/system/folder.png",
+    "revision": "56386b84eff9ee5a7f69374ddea7fcef580214a50a6d6192c4e7071f5974cfde"
+  },
+  {
+    "url": "/themes/Yaru/system/user-desktop.png",
+    "revision": "77af82ac51112a64ed0430df9c602e9768f162bbb7a12fbd7c14a66ab0134622"
+  },
+  {
+    "url": "/themes/Yaru/system/user-home.png",
+    "revision": "d99c67357450cc7f9822596f0afcd62fcd8c8290ed481192cc94e82c005c5da2"
+  },
+  {
+    "url": "/themes/Yaru/system/user-trash-full.png",
+    "revision": "0fe4bd32deda9eecef55a3f8e900b28cb57103f1ce5ea20406a5dd92e15f219a"
+  },
+  {
+    "url": "/themes/Yaru/system/view-app-grid-symbolic.svg",
+    "revision": "d905c1b673b1bc5b88d2c5340bd85d26b8211a0f81577fff14de7529b6892895"
+  },
+  {
+    "url": "/themes/Yaru/window/window-close-symbolic.svg",
+    "revision": "36d472f00b50166a5713de930738383cdf8ad97a8a67fc26ac493671dd6cd4c6"
+  },
+  {
+    "url": "/themes/Yaru/window/window-maximize-symbolic.svg",
+    "revision": "ca4c1623db3d8fa613571be5437b5bedcd5443e56bb4fe8a80e0a9337196f518"
+  },
+  {
+    "url": "/themes/Yaru/window/window-minimize-symbolic.svg",
+    "revision": "6ffdeef3310161547020ae0c2eb228487474211cabb82437788aacaa8d3af165"
+  },
+  {
+    "url": "/themes/Yaru/window/window-pin-symbolic.svg",
+    "revision": "648d5260c06092fbce05dad65e71d04748a399439f50ec5205c834fa14e50d4c"
+  },
+  {
+    "url": "/themes/Yaru/window/window-restore-symbolic.svg",
+    "revision": "cc329dc7bd342c812d8807c2f96a7c73b8aee35fec4bd2eb9c6077c9c3030248"
+  },
+  {
+    "url": "/themes/Yaru/status/New folder/ubuntu_white_hex.svg",
+    "revision": "94c6bb545d177a8ac7068b917d7cf46370012abe45c9e545c9245b26dc17a99f"
+  },
+  {
+    "url": "/themes/Yaru/system/old system/folder.png",
+    "revision": "f6f1cc4144d91abd9cf837203b7d1592de092e59326fc1aff406c4e247b1e7fd"
+  },
+  {
+    "url": "/themes/Yaru/system/old system/user-desktop.png",
+    "revision": "3c0458863fdadc60673676b49aadf8523195c1ae0b9fde63203dc005c91ffa3e"
+  },
+  {
+    "url": "/themes/Yaru/system/old system/user-home.png",
+    "revision": "2086cbcbfe32dabe0e2f92448fa1d7fffef4dbbdba92adb94f96d7717c9376da"
+  },
+  {
+    "url": "/themes/Yaru/system/old system/user-trash-full.png",
+    "revision": "0fe4bd32deda9eecef55a3f8e900b28cb57103f1ce5ea20406a5dd92e15f219a"
+  },
+  {
+    "url": "/themes/Yaru/system/old system/view-app-grid-symbolic.svg",
+    "revision": "d905c1b673b1bc5b88d2c5340bd85d26b8211a0f81577fff14de7529b6892895"
+  }
+]

--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -1,0 +1,23 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import fg from 'fast-glob';
+
+const publicDir = join(process.cwd(), 'public');
+const manifestPath = join(process.cwd(), 'precache-manifest.json');
+
+const files = await fg(['**/*.*'], {
+  cwd: publicDir,
+  ignore: ['sw.js', 'workbox-*.js', 'service-worker.js'],
+});
+
+const manifest = [];
+for (const file of files) {
+  const filePath = join(publicDir, file);
+  const buffer = await fs.readFile(filePath);
+  const hash = createHash('sha256').update(buffer).digest('hex');
+  manifest.push({ url: '/' + file.replace(/\\/g, '/'), revision: hash });
+}
+
+await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+console.info(`Generated ${manifest.length} precache entries`);


### PR DESCRIPTION
## Summary
- generate `precache-manifest.json` by hashing public files
- include precached asset hashes in Workbox config
- send `Cache-Control: immutable` for assets listed in the precache manifest

## Testing
- `npx eslint scripts/generate-sw.mjs next.config.js` (fails: Unexpected global 'document')
- `yarn test scripts/generate-sw.mjs next.config.js` (fails: Cannot find module './lib/validate')


------
https://chatgpt.com/codex/tasks/task_e_68bc92e860bc83289443b441588475f0