### PR TITLE
feat: add client env validation

### DIFF
--- a/lib/validate-public.ts
+++ b/lib/validate-public.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+// Schema for publicly exposed environment variables (client-side)
+const publicEnvSchema = z
+  .object({
+    NEXT_PUBLIC_SUPABASE_URL: z.string().url().optional(),
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+    NEXT_PUBLIC_RECAPTCHA_SITE_KEY: z.string().optional(),
+    NEXT_PUBLIC_SERVICE_ID: z.string().optional(),
+    NEXT_PUBLIC_TEMPLATE_ID: z.string().optional(),
+    NEXT_PUBLIC_USER_ID: z.string().optional(),
+    NEXT_PUBLIC_TRACKING_ID: z.string().optional(),
+    NEXT_PUBLIC_SHOW_BETA: z.string().optional(),
+    NEXT_PUBLIC_VERCEL_ENV: z
+      .enum(['development', 'preview', 'production'])
+      .optional(),
+    NEXT_PUBLIC_STATIC_EXPORT: z.enum(['true', 'false']).optional(),
+  })
+  .passthrough();
+
+export function validatePublicEnv(env: Record<string, unknown>) {
+  publicEnvSchema.parse(env);
+}

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,0 +1,17 @@
+const { z } = require('zod');
+
+// Schema for server-side environment variables
+const serverEnvSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_ANON_KEY: z.string().min(1),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  RECAPTCHA_SECRET: z.string().min(1),
+  RATE_LIMIT_SECRET: z.string().min(1),
+  ADMIN_READ_KEY: z.string().optional(),
+});
+
+function validateServerEnv(env) {
+  serverEnvSchema.parse(env);
+}
+
+module.exports = { validateServerEnv };

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
-const { validateServerEnv: validateEnv } = require('./lib/validate');
+const { validateServerEnv } = require('./lib/validate');
 
 
 const ContentSecurityPolicy = [
@@ -76,7 +76,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   disable: process.env.VERCEL_ENV !== 'production',
   buildExcludes: [/dynamic-css-manifest\.json$/],
   fallbacks: {
-    document: '/offline.html',
+    'document': '/offline.html',
   },
   workboxOptions: {
     cacheId: buildId,

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,6 +6,7 @@ import { isBrowser } from '@/utils/env';
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import dynamic from 'next/dynamic';
+import { validatePublicEnv } from '@/lib/validate-public';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -19,6 +20,8 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
+
+validatePublicEnv(process.env);
 
 let SpeedInsights = () => null;
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
## Summary
- ensure server env vars validated via `lib/validate.js`
- introduce client-side validation for public env vars
- run public env validation in `_app` and fix next config import

## Testing
- `yarn eslint lib/validate.js lib/validate-public.ts next.config.js`
- `yarn test __tests__/nmapNse.test.tsx __tests__/csp.test.ts __tests__/contact.api.test.ts` *(fails: missingRecaptcha, allowlist entries, copy output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92ead7248328b4ebae5c06006112