### PR TITLE
Remove Vercel secrets config and document dashboard-managed keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+# Secrets configured via your deployment dashboard (e.g., Vercel):
+# ADMIN_READ_KEY=
+# FLAGS_SECRET=

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Always test inside controlled labs and obtain written permission before performi
 
 ### Install & Run (Dev)
 ```bash
-cp .env.local.example .env.local  # populate with required keys
+ cp .env.example .env.local  # populate with required keys
 nvm install 20  # install Node 20.x if needed
 nvm use 20
 yarn install
@@ -74,15 +74,16 @@ To send text or links directly into the Sticky Notes app:
 
 ## Environment Variables
 
-Copy `.env.local.example` to `.env.local` and fill in required API keys:
+Copy `.env.example` to `.env.local` and fill in required API keys:
 
 - `NEXT_PUBLIC_ENABLE_ANALYTICS` – enable client-side analytics when set to `true`.
 - `FEATURE_TOOL_APIS` – toggle simulated tool APIs (`enabled` or `disabled`).
 - `RECAPTCHA_SECRET` and related `NEXT_PUBLIC_RECAPTCHA_*` keys for contact form spam protection.
 - `RATE_LIMIT_SECRET` – secret used to sign rate limit cookies (configure this in Vercel environment variables).
 - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` – Supabase credentials. When unset, Supabase-backed APIs and features are disabled.
+- `ADMIN_READ_KEY` and `FLAGS_SECRET` – set these secrets via your deployment provider's dashboard (e.g., Vercel).
 
-See `.env.local.example` for the full list.
+See `.env.example` for the full list.
 
 ---
 
@@ -206,7 +207,7 @@ keyboard focus so bundles are warmed before launch. When adding a new app, expor
 
 ## Environment Variables
 
-Copy `.env.local.example` to `.env.local` and fill in required values.
+Copy `.env.example` to `.env.local` and fill in required values.
 
 | Name | Purpose |
 | --- | --- |
@@ -221,6 +222,7 @@ Copy `.env.local.example` to `.env.local` and fill in required values.
 | `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | ReCAPTCHA site key used on the client. |
 | `RECAPTCHA_SECRET` | ReCAPTCHA secret key for server-side verification. |
 | `RATE_LIMIT_SECRET` | Secret used to sign rate limiting cookies. |
+| `FLAGS_SECRET` | Secret key for server-side feature flags. Configure this directly as an environment variable (e.g., in the Vercel dashboard). |
 | `SUPABASE_URL` | Supabase project URL for server-side access. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for privileged operations. |
 | `SUPABASE_ANON_KEY` | Supabase anonymous key for server-side reads. |
@@ -308,11 +310,12 @@ Workflow: `.github/workflows/gh-deploy.yml`:
   - `NEXT_PUBLIC_BEEF_URL`
   - `NEXT_PUBLIC_GHIDRA_URL`
   - `NEXT_PUBLIC_GHIDRA_WASM`
-   - `NEXT_PUBLIC_UI_EXPERIMENTS`
-   - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
-   - `RECAPTCHA_SECRET`
-   - `RATE_LIMIT_SECRET`
-   - `ADMIN_READ_KEY` (set manually in Vercel or your host)
+  - `NEXT_PUBLIC_UI_EXPERIMENTS`
+  - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
+  - `RECAPTCHA_SECRET`
+  - `RATE_LIMIT_SECRET`
+  - `ADMIN_READ_KEY` (set manually in Vercel or your host)
+  - `FLAGS_SECRET` (set manually in Vercel or your host)
 - Build command: `yarn build`
 - Output: Next.js (serverless by default on Vercel).
 - If you keep API routes, Vercel deploys them as serverless functions. For a static build, disable API routes or feature-flag those apps.

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "env": {
-    "RATE_LIMIT_SECRET": "@rate-limit-secret"
-  },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
     "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }


### PR DESCRIPTION
## Summary
- drop secret env block from `vercel.json`
- move `.env.local.example` to `.env.example` and note `ADMIN_READ_KEY` and `FLAGS_SECRET` should be set in deployment settings
- document dashboard configuration for `ADMIN_READ_KEY` and new `FLAGS_SECRET`

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92ebc1048328a924cb94c92d8436