### PR TITLE
test: cover terminal control input

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,19 +1,36 @@
 jest.mock(
   '@xterm/xterm',
-  () => ({
-    Terminal: jest.fn().mockImplementation(() => ({
-      open: jest.fn(),
-      focus: jest.fn(),
-      loadAddon: jest.fn(),
-      write: jest.fn(),
-      writeln: jest.fn(),
-      onData: jest.fn(),
-      onKey: jest.fn(),
-      onPaste: jest.fn(),
-      dispose: jest.fn(),
-      clear: jest.fn(),
-    })),
-  }),
+  () => {
+    let lastInstance: any;
+    let onDataHandler: (d: string) => void = () => {};
+    const textarea = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    const Terminal = jest.fn().mockImplementation(() => {
+      lastInstance = {
+        open: jest.fn(),
+        focus: jest.fn(),
+        loadAddon: jest.fn(),
+        write: jest.fn(),
+        writeln: jest.fn(),
+        onData: jest.fn((cb) => {
+          onDataHandler = cb;
+        }),
+        onKey: jest.fn(),
+        onPaste: jest.fn(),
+        dispose: jest.fn(),
+        clear: jest.fn(),
+        textarea,
+      };
+      return lastInstance;
+    });
+    return {
+      Terminal,
+      __getLastInstance: () => lastInstance,
+      __getOnData: () => onDataHandler,
+    };
+  },
   { virtual: true }
 );
 jest.mock(
@@ -36,9 +53,15 @@ import React, { createRef, act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
+// Access helpers from the mocked xterm module for introspection
+const { __getLastInstance, __getOnData } = require('@xterm/xterm');
 
 describe('Terminal component', () => {
   const openApp = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
@@ -68,6 +91,57 @@ describe('Terminal component', () => {
     act(() => {
       ref.current.runCommand('neofetch');
     });
+    expect(ref.current.getContent()).toContain('Theme: Undercover');
+  });
+
+  it('cancels input on Ctrl+C', async () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+    const term = __getLastInstance();
+    const onData = __getOnData();
+    await act(async () => {
+      onData('neof');
+      onData('\u0003');
+      onData('neofetch');
+      onData('\r');
+    });
+    expect(ref.current.getContent()).toContain('Theme: Undercover');
+  });
+
+  it('handles backspace correctly', async () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+    const term = __getLastInstance();
+    const onData = __getOnData();
+    await act(async () => {
+      onData('neofetx');
+      onData('\u007F');
+      onData('ch');
+      onData('\r');
+    });
+    expect(ref.current.getContent()).toContain('Theme: Undercover');
+  });
+
+  it('handles paste events', async () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+    const term = __getLastInstance();
+    const pasteHandler = term.textarea.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === 'paste',
+    )[1];
+    const event = {
+      clipboardData: { getData: () => 'neofetch' },
+      preventDefault: jest.fn(),
+    } as any;
+    await act(async () => {
+      pasteHandler(event);
+      const onData = term.onData.mock.calls[0][0];
+      onData('\r');
+    });
+    expect(event.preventDefault).toHaveBeenCalled();
     expect(ref.current.getContent()).toContain('Theme: Undercover');
   });
 

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -339,6 +339,10 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
               commandRef.current = commandRef.current.slice(0, -1);
               renderHint();
             }
+          } else if (ch === '\u0003') {
+            termRef.current?.writeln('');
+            commandRef.current = '';
+            prompt();
           } else {
             commandRef.current += ch;
             termRef.current?.write(ch);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,0 +1,2 @@
+function validateServerEnv() {}
+module.exports = { validateServerEnv };


### PR DESCRIPTION
## Summary
- handle Ctrl+C to reset terminal input
- add unit tests for Ctrl+C, backspace, and paste handling
- stub server env validation for tests

## Testing
- `npm test __tests__/terminal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc92ee16b88328a750024aca38f788