### PR TITLE
fix FormError path and enforce unresolved import rule

### DIFF
--- a/components/apps/serial-terminal.tsx
+++ b/components/apps/serial-terminal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import FormError from '../ui/FormError';
+import FormError from '@/components/ui/FormError';
 
 interface SerialPort {
   readonly readable: ReadableStream<Uint8Array> | null;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,7 @@ const config = [
       'react-hooks/exhaustive-deps': 'off',
       'import/no-anonymous-default-export': 'off',
       'import/no-cycle': 'warn',
+      'import/no-unresolved': 'error',
     },
   }),
 ];


### PR DESCRIPTION
## Summary
- use project alias for Serial Terminal's `FormError` import
- add `import/no-unresolved` ESLint rule to catch bad paths

## Testing
- `yarn lint` *(fails: A control must be associated with a text label; 521 errors)*
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92f22df8832891758d8354f435c3