### PR TITLE
Handle decoding failures in BLE and pcap parsers

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -96,18 +96,35 @@ const BleSensor: React.FC = () => {
       const serviceData: ServiceData[] = [];
 
       for (const service of primServices) {
-        const chars = await service.getCharacteristics();
-        const charData: CharacteristicData[] = await Promise.all(
-          chars.map(async (char: any) => {
-            try {
-              const val = await char.readValue();
-              const decoder = new TextDecoder();
-              return { uuid: char.uuid, value: decoder.decode(val.buffer) };
-            } catch {
-              return { uuid: char.uuid, value: '[unreadable]' };
-            }
-          })
-        );
+          const chars = await service.getCharacteristics();
+          const charData: CharacteristicData[] = await Promise.all(
+            chars.map(async (char: any) => {
+              try {
+                const val = await char.readValue();
+                let value = '';
+
+                try {
+                  const decoder = new TextDecoder();
+                  value = decoder.decode(val.buffer);
+                } catch {
+                  try {
+                    const view = new DataView(val.buffer);
+                    const hex: string[] = [];
+                    for (let i = 0; i < view.byteLength; i++) {
+                      hex.push(view.getUint8(i).toString(16).padStart(2, '0'));
+                    }
+                    value = hex.join(' ');
+                  } catch {
+                    value = '[unreadable]';
+                  }
+                }
+
+                return { uuid: char.uuid, value };
+              } catch {
+                return { uuid: char.uuid, value: '[unreadable]' };
+              }
+            })
+          );
         serviceData.push({ uuid: service.uuid, characteristics: charData });
       }
       setServices(serviceData);

--- a/components/apps/kismet.jsx
+++ b/components/apps/kismet.jsx
@@ -15,74 +15,82 @@ const parseMgmtFrame = (frame) => {
   // Skip header (24 bytes) + fixed params (12 bytes)
   let off = 36;
   while (off + 2 <= frame.length) {
-    const tag = frame[off];
-    const len = frame[off + 1];
-    const data = frame.slice(off + 2, off + 2 + len);
-    if (tag === 0) {
-      ssid = new TextDecoder().decode(data);
-    } else if (tag === 3 && data.length) {
-      channel = data[0];
+      const tag = frame[off];
+      const len = frame[off + 1];
+      const data = frame.slice(off + 2, off + 2 + len);
+      if (tag === 0) {
+        try {
+          ssid = new TextDecoder().decode(data);
+        } catch {
+          ssid = '';
+        }
+      } else if (tag === 3 && data.length) {
+        channel = data[0];
+      }
+      off += 2 + len;
     }
-    off += 2 + len;
-  }
 
   return { ssid, bssid, channel };
 };
 
 // Parse packets from a pcap ArrayBuffer
 const parsePcap = (arrayBuffer, onNetwork) => {
-  const dv = new DataView(arrayBuffer);
-  const packets = [];
-  let offset = 24; // global header
-  while (offset + 16 <= dv.byteLength) {
-    const tsSec = dv.getUint32(offset, true);
-    const tsUsec = dv.getUint32(offset + 4, true);
-    const inclLen = dv.getUint32(offset + 8, true);
-    offset += 16;
-    const data = new Uint8Array(arrayBuffer, offset, inclLen);
-    packets.push({ tsSec, tsUsec, data });
-    offset += inclLen;
-  }
-
-  const networks = {};
-  const channelCounts = {};
-  const timeCounts = {};
-  const startTime = packets[0]?.tsSec || 0;
-
-  for (const pkt of packets) {
-    if (pkt.data.length < 4) continue;
-    const rtLen = pkt.data[2] | (pkt.data[3] << 8);
-    if (pkt.data.length < rtLen + 24) continue;
-    const frame = pkt.data.subarray(rtLen);
-    const fc = frame[0] | (frame[1] << 8);
-    const type = (fc >> 2) & 0x3;
-    const subtype = (fc >> 4) & 0xf;
-    // Only management beacons/probe responses
-    if (type !== 0 || (subtype !== 8 && subtype !== 5)) continue;
-
-    const info = parseMgmtFrame(frame);
-    const key = info.bssid || info.ssid;
-    if (!networks[key]) {
-      networks[key] = { ...info, frames: 0 };
-      onNetwork?.({
-        ssid: info.ssid,
-        bssid: info.bssid,
-        discoveredAt: pkt.tsSec * 1000 + Math.floor(pkt.tsUsec / 1000),
-      });
+  try {
+    const dv = new DataView(arrayBuffer);
+    const packets = [];
+    let offset = 24; // global header
+    while (offset + 16 <= dv.byteLength) {
+      const tsSec = dv.getUint32(offset, true);
+      const tsUsec = dv.getUint32(offset + 4, true);
+      const inclLen = dv.getUint32(offset + 8, true);
+      offset += 16;
+      const data = new Uint8Array(arrayBuffer, offset, inclLen);
+      packets.push({ tsSec, tsUsec, data });
+      offset += inclLen;
     }
-    networks[key].frames += 1;
-    if (info.channel != null) {
-      channelCounts[info.channel] = (channelCounts[info.channel] || 0) + 1;
-    }
-    const t = pkt.tsSec - startTime;
-    timeCounts[t] = (timeCounts[t] || 0) + 1;
-  }
 
-  return {
-    networks: Object.values(networks),
-    channelCounts,
-    timeCounts,
-  };
+    const networks = {};
+    const channelCounts = {};
+    const timeCounts = {};
+    const startTime = packets[0]?.tsSec || 0;
+
+    for (const pkt of packets) {
+      if (pkt.data.length < 4) continue;
+      const rtLen = pkt.data[2] | (pkt.data[3] << 8);
+      if (pkt.data.length < rtLen + 24) continue;
+      const frame = pkt.data.subarray(rtLen);
+      const fc = frame[0] | (frame[1] << 8);
+      const type = (fc >> 2) & 0x3;
+      const subtype = (fc >> 4) & 0xf;
+      // Only management beacons/probe responses
+      if (type !== 0 || (subtype !== 8 && subtype !== 5)) continue;
+
+      const info = parseMgmtFrame(frame);
+      const key = info.bssid || info.ssid;
+      if (!networks[key]) {
+        networks[key] = { ...info, frames: 0 };
+        onNetwork?.({
+          ssid: info.ssid,
+          bssid: info.bssid,
+          discoveredAt: pkt.tsSec * 1000 + Math.floor(pkt.tsUsec / 1000),
+        });
+      }
+      networks[key].frames += 1;
+      if (info.channel != null) {
+        channelCounts[info.channel] = (channelCounts[info.channel] || 0) + 1;
+      }
+      const t = pkt.tsSec - startTime;
+      timeCounts[t] = (timeCounts[t] || 0) + 1;
+    }
+
+    return {
+      networks: Object.values(networks),
+      channelCounts,
+      timeCounts,
+    };
+  } catch {
+    return { networks: [], channelCounts: {}, timeCounts: {} };
+  }
 };
 
 const ChannelChart = ({ data }) => {
@@ -140,14 +148,20 @@ const KismetApp = ({ onNetworkDiscovered }) => {
   const handleFile = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const buffer = await file.arrayBuffer();
-    const { networks, channelCounts, timeCounts } = parsePcap(
-      buffer,
-      onNetworkDiscovered,
-    );
-    setNetworks(networks);
-    setChannels(channelCounts);
-    setTimes(timeCounts);
+    try {
+      const buffer = await file.arrayBuffer();
+      const { networks, channelCounts, timeCounts } = parsePcap(
+        buffer,
+        onNetworkDiscovered,
+      );
+      setNetworks(networks);
+      setChannels(channelCounts);
+      setTimes(timeCounts);
+    } catch {
+      setNetworks([]);
+      setChannels({});
+      setTimes({});
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- wrap BLE characteristic decoding with nested try/catch and hex fallback
- guard kismet pcap parsing with error handling for DataView/TextDecoder

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92f47d3c83289568fbc7fdd4238e