### PR TITLE
refactor toggles to avoid stale state

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -14,7 +14,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button aria-label="settings" onClick={() => setOpen((o) => !o)}>
         Settings
       </button>
       {open && (

--- a/components/panel/plugins/Bluetooth.tsx
+++ b/components/panel/plugins/Bluetooth.tsx
@@ -40,7 +40,7 @@ export default function Bluetooth() {
 
   return (
     <div className="relative">
-      <button onClick={() => setOpen(!open)} aria-label="Bluetooth">
+      <button onClick={() => setOpen((o) => !o)} aria-label="Bluetooth">
         <Image
           src="/themes/Yaru/status/bluetooth-symbolic.svg"
           alt="Bluetooth"

--- a/components/panel/plugins/Clock.tsx
+++ b/components/panel/plugins/Clock.tsx
@@ -54,7 +54,7 @@ const Clock: React.FC = () => {
       <button
         type="button"
         className="px-2 py-1 text-white hover:bg-gray-700 rounded"
-        onClick={() => setOpen(!open)}
+        onClick={() => setOpen((o) => !o)}
         title={tooltip}
       >
         {formattedTime}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -13,7 +13,16 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [reduceMotion, setReduceMotion] = usePersistentState(
+    'qs-reduce-motion',
+    false,
+  );
+
+  const toggleTheme = () =>
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+  const toggleSound = () => setSound((s) => !s);
+  const toggleOnline = () => setOnline((o) => !o);
+  const toggleReduceMotion = () => setReduceMotion((r) => !r);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -32,7 +41,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          onClick={toggleTheme}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
@@ -40,18 +49,18 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input type="checkbox" checked={sound} onChange={toggleSound} />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input type="checkbox" checked={online} onChange={toggleOnline} />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
+          onChange={toggleReduceMotion}
         />
       </div>
       <div className="px-4 pt-2 border-t border-black border-opacity-20 mt-2 space-y-1">

--- a/components/util-components/PanelClock.tsx
+++ b/components/util-components/PanelClock.tsx
@@ -57,7 +57,7 @@ export default function PanelClock() {
       <button
         type="button"
         title={tooltip}
-        onClick={() => setOpen(!open)}
+        onClick={() => setOpen((o) => !o)}
         className="outline-none"
       >
         {timeStr}

--- a/hooks/useGameHaptics.js
+++ b/hooks/useGameHaptics.js
@@ -24,7 +24,7 @@ export default function useGameHaptics() {
   const danger = useCallback(() => vibrate(patterns.danger), [vibrate]);
   const gameOver = useCallback(() => vibrate(patterns.gameOver), [vibrate]);
 
-  const toggle = useCallback(() => setHaptics(!enabled), [setHaptics, enabled]);
+  const toggle = useCallback(() => setHaptics((h) => !h), [setHaptics]);
 
   return { enabled, toggle, vibrate, score, danger, gameOver };
 }


### PR DESCRIPTION
## Summary
- consolidate quick settings toggles into dedicated handlers and use functional updates
- use functional state updates for game haptics and panel widgets
- simplify Bluetooth and settings drawer button toggling

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92f55ee88328803b5df5475640ce