### PR TITLE
feat: debounce window drag and resize handlers

### DIFF
--- a/components/window/DragSnapHandler.tsx
+++ b/components/window/DragSnapHandler.tsx
@@ -41,6 +41,12 @@ const DragSnapHandler: React.FC<DragSnapHandlerProps> = ({ children }) => {
     }
   };
 
+  const dragTimeout = useRef<number>();
+  const handleDrag: DraggableEventHandler = (...args) => {
+    if (dragTimeout.current) window.clearTimeout(dragTimeout.current);
+    dragTimeout.current = window.setTimeout(() => checkSnapPreview(...args), 50);
+  };
+
   const handleStop: DraggableEventHandler = () => {
     const node = nodeRef.current;
     if (!node) return;
@@ -72,11 +78,7 @@ const DragSnapHandler: React.FC<DragSnapHandlerProps> = ({ children }) => {
           style={snapPreview}
         />
       )}
-      <Draggable
-        onDrag={checkSnapPreview}
-        onStop={handleStop}
-        nodeRef={nodeRef}
-      >
+      <Draggable onDrag={handleDrag} onStop={handleStop} nodeRef={nodeRef}>
         <div ref={nodeRef}>{children}</div>
       </Draggable>
     </>


### PR DESCRIPTION
## Summary
- add small debounce helper for window management
- debounce window resize and drag handlers to reduce event churn
- debounce drag snap preview logic

## Testing
- `yarn test __tests__/window.test.tsx __tests__/window.snap.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bc92f6cbf08328aac38b82b5f9ebf3