### PR TITLE
feat: add keyboard navigation for menus

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,11 +1,16 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import logger from '../../utils/logger'
 import PolicyKitPrompt from '../common/PolicyKitPrompt'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
     const [showRootPrompt, setShowRootPrompt] = useState(false)
+    const menuRef = useRef(null)
+    useFocusTrap(menuRef, props.active)
+    useRovingTabIndex(menuRef, props.active, 'vertical')
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -49,12 +54,20 @@ function DesktopMenu(props) {
         }
     }
 
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            props.onClose && props.onClose()
+        }
+    }
+
     return (
         <>
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1092,6 +1092,7 @@ export class Desktop extends Component {
                 {/* Context Menus */}
                 <DesktopMenu
                     active={this.state.context_menus.desktop}
+                    onClose={this.hideAllContextMenu}
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useClickOutside } from '../../hooks/useClickOutside';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 import usePersistentState from '../../hooks/usePersistentState';
 
 const pad = (n) => n.toString().padStart(2, '0');
@@ -19,6 +20,7 @@ export default function Clock({ onlyTime, onlyDay }) {
   const [open, setOpen] = useState(false);
 
   useClickOutside(menuRef, () => setOpen(false));
+  useRovingTabIndex(menuRef, open, 'vertical');
 
   // update time
   useEffect(() => {
@@ -79,8 +81,19 @@ export default function Clock({ onlyTime, onlyDay }) {
     window.dispatchEvent(new CustomEvent('clock-seconds', { detail: val }));
   };
 
+  useEffect(() => {
+    if (open && menuRef.current) {
+      const first = menuRef.current.querySelector('[role="menuitem"], [role="menuitemcheckbox"]');
+      first && first.focus();
+    }
+  }, [open]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') setOpen(false);
+  };
+
   return (
-    <div ref={menuRef} className="relative inline-block">
+    <div ref={menuRef} className="relative inline-block" onKeyDown={handleKeyDown}>
       <span
         data-testid="panel-clock"
         suppressHydrationWarning

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import useFocusTrap from '../../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 
 export interface DesktopContextMenuProps {
   /** Position where the menu should appear. `null` hides the menu. */
@@ -42,7 +44,25 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
   onToggleFullScreen,
   onClearSession,
 }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(menuRef, !!position);
+  useRovingTabIndex(menuRef, !!position, 'vertical');
+
+  useEffect(() => {
+    if (position && menuRef.current) {
+      const first = menuRef.current.querySelector<HTMLElement>('[role="menuitem"], [role="menuitemcheckbox"]');
+      first?.focus();
+    }
+  }, [position]);
+
   if (!position) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
 
   const handle = (cb?: () => void) => () => {
     cb?.();
@@ -52,6 +72,8 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
   return (
     <div
       role="menu"
+      ref={menuRef}
+      onKeyDown={handleKeyDown}
       className="absolute z-50 w-52 cursor-default select-none rounded border border-gray-700 bg-gray-800 text-sm text-white shadow-lg"
       style={{ top: position.y, left: position.x }}
     >


### PR DESCRIPTION
## Summary
- support arrow key navigation in clock menu
- close desktop menus with Escape
- add focus trap and keyboard nav to desktop context menu

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92fa32dc832891b794b28572a558