### PR TITLE
test: expect service worker path

### DIFF
--- a/tests/system/sw-recovery.spec.ts
+++ b/tests/system/sw-recovery.spec.ts
@@ -6,6 +6,12 @@ test.describe('Service worker recovery', () => {
   test('clears app caches and reloads', async ({ page }) => {
     await page.goto('/apps/power');
 
+    const swUrl = await page.evaluate(async () => {
+      await navigator.serviceWorker.ready;
+      return navigator.serviceWorker.controller?.scriptURL;
+    });
+    expect(swUrl).toMatch(/\/service-worker\.js$/);
+
     await page.evaluate(async () => {
       await caches.open('KLP_stale-cache');
       await caches.open('unrelated-cache');


### PR DESCRIPTION
## Summary
- verify service worker registration uses `/service-worker.js`

## Testing
- `npx playwright test tests/system/sw-recovery.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92fc10108328b16f0f87e0667ea7