### PR TITLE
feat: show focus rings on menus and icons

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -110,7 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
         >
           {item.label}
         </button>

--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -63,8 +63,9 @@ export const Desktop: React.FC = () => {
       {icons.map((icon) => (
         <div
           key={icon.id}
-          className="absolute text-center text-xs text-white"
+          className="absolute text-center text-xs text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
           style={{ left: icon.x, top: icon.y, width: 80 }}
+          tabIndex={0}
         >
           <div className="h-16 w-16 rounded bg-black bg-opacity-20" />
           <div>{icon.title}</div>

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -59,7 +59,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onNewFolder)}
           >
             New Folder
@@ -68,7 +68,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onCreateShortcut)}
           >
             Create Shortcut...
@@ -78,7 +78,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onArrange)}
           >
             Arrange Icons
@@ -88,7 +88,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onOpenTerminal)}
           >
             Open in Terminal
@@ -97,7 +97,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onChangeBackground)}
           >
             Change Background...
@@ -106,7 +106,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onOpenSettings)}
           >
             Settings
@@ -115,7 +115,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onToggleFullScreen)}
           >
             Toggle Full Screen
@@ -125,7 +125,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
         <li>
           <button
             type="button"
-            className="block w-full px-4 py-1 text-left hover:bg-gray-700"
+            className="block w-full px-4 py-1 text-left hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
             onClick={handle(onClearSession)}
           >
             Clear Session

--- a/src/components/desktop/DesktopIcons.tsx
+++ b/src/components/desktop/DesktopIcons.tsx
@@ -14,8 +14,24 @@ export default function DesktopIcons() {
 
   return (
     <div>
-      {prefs.showHome && <div data-testid="desktop-icon-home">Home</div>}
-      {prefs.showTrash && <div data-testid="desktop-icon-trash">Trash</div>}
+      {prefs.showHome && (
+        <div
+          data-testid="desktop-icon-home"
+          tabIndex={0}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+        >
+          Home
+        </div>
+      )}
+      {prefs.showTrash && (
+        <div
+          data-testid="desktop-icon-trash"
+          tabIndex={0}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+        >
+          Trash
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure context menu items display a visible focus ring
- add focusable desktop icons with accessible ring styling

## Testing
- `yarn test` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc92f7cc8483289e11243823273c5c