### PR TITLE
test: add desktop app launch verification

### DIFF
--- a/tests/desktop/open-apps.spec.ts
+++ b/tests/desktop/open-apps.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+const apps = ['chrome', 'terminal', 'wireshark', 'ghidra'];
+
+test('launch desktop apps without console errors', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on('pageerror', err => consoleErrors.push(err.message));
+
+  await page.goto('/');
+
+  for (const app of apps) {
+    await page.locator('nav [aria-label="Show Applications"]').click();
+    await page.locator(`#app-${app}`).click();
+    const windowLocator = page.locator(`[data-app-id="${app}"]`);
+    await expect(windowLocator).toBeVisible();
+    await windowLocator.locator('[aria-label="Window close"]').click();
+    await expect(windowLocator).toBeHidden();
+  }
+
+  expect(consoleErrors, `Console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+});
+


### PR DESCRIPTION
## Summary
- add Playwright test to open Chrome, Terminal, Wireshark and Ghidra and assert no console errors

## Testing
- `npx eslint tests/desktop/open-apps.spec.ts`
- `npx playwright test tests/desktop/open-apps.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92fd750c8328bdb22b7bdc9add8c