### PR TITLE
test: cover node api routes

### DIFF
--- a/__tests__/nodeApiRoutes.test.ts
+++ b/__tests__/nodeApiRoutes.test.ts
@@ -1,0 +1,35 @@
+// @jest-environment node
+import { createMocks } from 'node-mocks-http';
+import dummyHandler from '../pages/api/dummy';
+import wallpapersHandler from '../pages/api/wallpapers';
+import quoteHandler from '../pages/api/quote';
+
+const describeIfEnabled =
+  process.env.FEATURE_NODE_APIS === 'enabled' ? describe : describe.skip;
+
+describeIfEnabled('Node API routes', () => {
+  test('dummy API accepts POST and returns message', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await dummyHandler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ message: 'Received' });
+  });
+
+  test('wallpapers API lists available images', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await wallpapersHandler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+  });
+
+  test('quote API returns content and author', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await quoteHandler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(typeof data.content).toBe('string');
+    expect(typeof data.author).toBe('string');
+  });
+});

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,0 +1,4 @@
+function validateServerEnv(_env) {
+  // no-op
+}
+module.exports = { validateServerEnv };

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -1,0 +1,3 @@
+export function validateServerEnv(_env: NodeJS.ProcessEnv) {
+  // No-op validation for tests.
+}


### PR DESCRIPTION
## Summary
- add feature-flagged tests for dummy, wallpapers, and quote node API routes
- stub missing env validator so Next config loads during tests

## Testing
- `FEATURE_NODE_APIS=enabled yarn test __tests__/nodeApiRoutes.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc930151e88328a8d975a000361bc3