### PR TITLE
feat: preconnect external app origins

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Head from 'next/head';
 import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
@@ -8,100 +9,105 @@ import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
 export default function VsCode() {
   return (
-    <div
-      className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
-      style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
-    >
-      <aside
-        className="flex flex-col items-center gap-2 p-1"
-        style={{ width: SIDEBAR_WIDTH, backgroundColor: kaliTheme.sidebar }}
+    <>
+      <Head>
+        <link rel="preconnect" href="https://stackblitz.com" />
+      </Head>
+      <div
+        className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
+        style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
       >
-        <div
-          className="rounded"
-          style={{
-            width: ICON_SIZE,
-            height: ICON_SIZE,
-            backgroundColor: kaliTheme.accent,
-          }}
-        />
-        <div
-          className="rounded"
-          style={{
-            width: ICON_SIZE,
-            height: ICON_SIZE,
-            backgroundColor: kaliTheme.accent,
-          }}
-        />
-      </aside>
-      <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
-        <div
-          className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
-          style={{ backgroundColor: kaliTheme.background }}
+        <aside
+          className="flex flex-col items-center gap-2 p-1"
+          style={{ width: SIDEBAR_WIDTH, backgroundColor: kaliTheme.sidebar }}
         >
-          <button aria-label="Minimize">
-            <MinimizeIcon />
-          </button>
-          <button aria-label="Maximize">
-            <MaximizeIcon />
-          </button>
-          <button aria-label="Close">
-            <CloseIcon />
-          </button>
-        </div>
-        <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
-          <ExternalFrame
-            src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
-            title="VsCode"
-            className="w-full h-full"
-            onLoad={() => {}}
+          <div
+            className="rounded"
+            style={{
+              width: ICON_SIZE,
+              height: ICON_SIZE,
+              backgroundColor: kaliTheme.accent,
+            }}
           />
-          <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
-            <Image
-              src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-              alt="Open Folder"
-              width={64}
-              height={64}
+          <div
+            className="rounded"
+            style={{
+              width: ICON_SIZE,
+              height: ICON_SIZE,
+              backgroundColor: kaliTheme.accent,
+            }}
+          />
+        </aside>
+        <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
+          <div
+            className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
+            style={{ backgroundColor: kaliTheme.background }}
+          >
+            <button aria-label="Minimize">
+              <MinimizeIcon />
+            </button>
+            <button aria-label="Maximize">
+              <MaximizeIcon />
+            </button>
+            <button aria-label="Close">
+              <CloseIcon />
+            </button>
+          </div>
+          <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>
+            <ExternalFrame
+              src="https://stackblitz.com/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md"
+              title="VsCode"
+              className="w-full h-full"
+              onLoad={() => {}}
             />
-            <span className="text-lg">Open Folder</span>
+            <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
+              <Image
+                src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+                alt="Open Folder"
+                width={64}
+                height={64}
+              />
+              <span className="text-lg">Open Folder</span>
+            </div>
+          </div>
+          <div
+            className="flex items-center gap-2 px-2 py-1 border-t border-black/20"
+            style={{ backgroundColor: kaliTheme.sidebar }}
+          >
+            <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="w-3 h-3"
+              >
+                <line x1="6" y1="3" x2="6" y2="15" />
+                <circle cx="18" cy="6" r="3" />
+                <circle cx="6" cy="18" r="3" />
+                <path d="M18 9a9 9 0 0 1-9 9" />
+              </svg>
+              MAIN
+            </span>
+            <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="w-3 h-3"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              CHECKS
+            </span>
           </div>
         </div>
-        <div
-          className="flex items-center gap-2 px-2 py-1 border-t border-black/20"
-          style={{ backgroundColor: kaliTheme.sidebar }}
-        >
-          <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="w-3 h-3"
-            >
-              <line x1="6" y1="3" x2="6" y2="15" />
-              <circle cx="18" cy="6" r="3" />
-              <circle cx="6" cy="18" r="3" />
-              <path d="M18 9a9 9 0 0 1-9 9" />
-            </svg>
-            MAIN
-          </span>
-          <span className="flex items-center gap-1 text-[12px] uppercase bg-black/30 px-[6px] py-[2px] rounded-full">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="w-3 h-3"
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-            CHECKS
-          </span>
-        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -9,6 +9,7 @@ import {
   type SVGProps,
 } from 'react';
 import DOMPurify from 'dompurify';
+import Head from 'next/head';
 import Script from 'next/script';
 import usePersistentState from '../../hooks/usePersistentState';
 import { useSettings } from '../../hooks/useSettings';
@@ -163,7 +164,6 @@ export default function XTimeline() {
   useEffect(() => {
     if (!loaded || !scriptLoaded) return;
     loadTimeline();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [theme, feed, timelineType, scriptLoaded]);
 
   const loadTimeline = () => {
@@ -254,6 +254,9 @@ export default function XTimeline() {
 
   return (
     <>
+      <Head>
+        <link rel="preconnect" href="https://platform.twitter.com" />
+      </Head>
       {showSetup && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center"
@@ -327,6 +330,7 @@ export default function XTimeline() {
         <div className="p-1.5 space-y-4 flex-1 overflow-auto">
         <form onSubmit={handleScheduleTweet} className="space-y-2">
           <textarea
+            aria-label="Tweet text"
             value={tweetText}
             onChange={(e) => setTweetText(e.target.value)}
             placeholder="Tweet text"
@@ -334,6 +338,7 @@ export default function XTimeline() {
           />
           <div className="flex gap-2 items-center">
             <input
+              aria-label="Schedule time"
               type="datetime-local"
               value={tweetTime}
               onChange={(e) => setTweetTime(e.target.value)}
@@ -405,6 +410,7 @@ export default function XTimeline() {
         </div>
         <form onSubmit={handleAddPreset} className="flex gap-2">
           <input
+            aria-label="Add feed"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder={

--- a/apps/youtube/index.tsx
+++ b/apps/youtube/index.tsx
@@ -1,11 +1,18 @@
 'use client';
 
+import Head from 'next/head';
 import YouTubeApp from '../../components/apps/youtube';
 
 export default function YouTubePage() {
   return (
-    <div className="h-full w-full bg-ub-dark-grey font-sans text-ubt-cool-grey">
-      <YouTubeApp />
-    </div>
+    <>
+      <Head>
+        <link rel="preconnect" href="https://www.youtube-nocookie.com" />
+        <link rel="preconnect" href="https://i.ytimg.com" />
+      </Head>
+      <div className="h-full w-full bg-ub-dark-grey font-sans text-ubt-cool-grey">
+        <YouTubeApp />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- preconnect to YouTube and image hosts when opening the YouTube window
- preconnect to StackBlitz when launching the VS Code window
- preconnect to Twitter widgets and label timeline inputs for accessibility

## Testing
- `yarn lint apps/youtube/index.tsx apps/vscode/index.tsx apps/x/index.tsx` *(fails: A control must be associated with a text label)*
- `npx eslint apps/youtube/index.tsx apps/vscode/index.tsx apps/x/index.tsx`
- `yarn test __tests__/youtube.test.tsx __tests__/vscode.test.tsx` *(fails: Cannot find module './lib/validate')*

------
https://chatgpt.com/codex/tasks/task_e_68bc930453dc832894481fc8401d57fe