### PR TITLE
fix: specify node runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
     "RATE_LIMIT_SECRET": "@rate-limit-secret"
   },
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
-    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
+    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
+    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
   }
 }


### PR DESCRIPTION
## Summary
- set serverless functions to use `@vercel/node@5.3.20`

## Testing
- `yarn test` *(fails: NmapNSEApp copies example output to clipboard, contact api returns 200 when inputs pass, and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bda82755f8832896bfac7eb623e8fd