### PR TITLE
fix: remove missing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Copy `.env.local.example` to `.env.local` and fill in required API keys:
 - `NEXT_PUBLIC_ENABLE_ANALYTICS` – enable client-side analytics when set to `true`.
 - `FEATURE_TOOL_APIS` – toggle simulated tool APIs (`enabled` or `disabled`).
 - `RECAPTCHA_SECRET` and related `NEXT_PUBLIC_RECAPTCHA_*` keys for contact form spam protection.
-- `RATE_LIMIT_SECRET` – secret used to sign rate limit cookies (configure this in Vercel environment variables).
+- `RATE_LIMIT_SECRET` – secret used to sign rate limit cookies. Define this as a project environment variable in Vercel; no secret is referenced in `vercel.json`.
 - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` – Supabase credentials. When unset, Supabase-backed APIs and features are disabled.
 - `NODE_OPTIONS` – override Node.js memory limits. The build script sets `NODE_OPTIONS="--max-old-space-size=4096"` automatically when `CI` is detected to avoid out-of-memory errors in constrained environments.
 
@@ -221,7 +221,7 @@ Copy `.env.local.example` to `.env.local` and fill in required values.
 | `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |
 | `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | ReCAPTCHA site key used on the client. |
 | `RECAPTCHA_SECRET` | ReCAPTCHA secret key for server-side verification. |
-| `RATE_LIMIT_SECRET` | Secret used to sign rate limiting cookies. |
+| `RATE_LIMIT_SECRET` | Secret used to sign rate limiting cookies. Configure this as an environment variable in Vercel. |
 | `SUPABASE_URL` | Supabase project URL for server-side access. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for privileged operations. |
 | `SUPABASE_ANON_KEY` | Supabase anonymous key for server-side reads. |

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "env": {
-    "RATE_LIMIT_SECRET": "@rate-limit-secret"
-  },
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }


### PR DESCRIPTION
## Summary
- remove missing Vercel secret reference so deployments don't fail
- document that RATE_LIMIT_SECRET must be set via project env variables

## Testing
- `yarn lint` (fails: A control must be associated with a text label)
- `yarn test` (fails: Missing allowlist entries for external domains)


------
https://chatgpt.com/codex/tasks/task_e_68bdc36062a883288442768723afbbd7