### PR TITLE
feat: validate server env vars

### DIFF
--- a/__tests__/validateServerEnv.test.ts
+++ b/__tests__/validateServerEnv.test.ts
@@ -1,0 +1,25 @@
+// @jest-environment node
+const { validateServerEnv } = require('../lib/validate');
+
+describe('validateServerEnv', () => {
+  const baseEnv = {
+    NEXT_PUBLIC_SUPABASE_URL: 'url',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+    SUPABASE_URL: 'url',
+    SUPABASE_ANON_KEY: 'anon',
+    SUPABASE_SERVICE_ROLE_KEY: 'service',
+    RATE_LIMIT_SECRET: 'rate',
+    FLAGS_SECRET: 'flags',
+    RECAPTCHA_SECRET: 'recaptcha',
+  };
+
+  it('does not throw when all required vars are present', () => {
+    expect(() => validateServerEnv(baseEnv)).not.toThrow();
+  });
+
+  it('throws when required vars are missing', () => {
+    const { RATE_LIMIT_SECRET, RECAPTCHA_SECRET, ...env } = baseEnv;
+    expect(() => validateServerEnv(env)).toThrow(/RATE_LIMIT_SECRET/);
+    expect(() => validateServerEnv(env)).toThrow(/RECAPTCHA_SECRET/);
+  });
+});

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,3 +1,24 @@
-function validateServerEnv() {}
+/**
+ * Validate that all required environment variables are present.
+ * @param {NodeJS.ProcessEnv} env
+ * @throws {Error} If any required variable is missing.
+ */
+function validateServerEnv(env) {
+  const required = [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_URL',
+    'SUPABASE_ANON_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'RATE_LIMIT_SECRET',
+    'FLAGS_SECRET',
+    'RECAPTCHA_SECRET',
+  ];
+
+  const missing = required.filter((name) => !env?.[name]);
+  if (missing.length > 0) {
+    throw new Error(`Missing environment variables: ${missing.join(', ')}`);
+  }
+}
 
 module.exports = { validateServerEnv };


### PR DESCRIPTION
## Summary
- ensure server environment variables are present at runtime
- add unit tests for validateServerEnv

## Testing
- `npx eslint lib/validate.js __tests__/validateServerEnv.test.ts && echo 'Lint OK'`
- `yarn test __tests__/validateServerEnv.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bdc9d9e4e883289ae2051460c378ab