### PR TITLE
chore: clean up install warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,22 @@
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
 nodeLinker: node-modules
 
+packageExtensions:
+  "3d-force-graph-ar@*":
+    peerDependencies:
+      aframe: "*"
+      three: "*"
+  "3d-force-graph-vr@*":
+    peerDependencies:
+      three: "*"
+  "aframe-forcegraph-component@*":
+    peerDependencies:
+      three: "*"
+  "react-force-graph@*":
+    peerDependencies:
+      aframe: "*"
+      three: "*"
+
 logFilters:
   - pattern: "deprecated sourcemap-codec@1.4.8"
     level: discard
@@ -9,6 +25,18 @@ logFilters:
   - pattern: "inflight@1.0.6: This module is not supported"
     level: discard
   - pattern: "The engine \"bare\" appears to be invalid."
+    level: discard
+  - pattern: "deprecated urix@0.1.0"
+    level: discard
+  - pattern: "deprecated source-map-url@0.4.0"
+    level: discard
+  - pattern: "deprecated source-map-resolve@0.5.3"
+    level: discard
+  - pattern: "deprecated resolve-url@0.2.1"
+    level: discard
+  - pattern: "deprecated querystring@0.2.0"
+    level: discard
+  - pattern: "deprecated chokidar@2.1.8"
     level: discard
   - pattern: "Resolution field \"magic-string@*\" is incompatible with requested version"
     level: info

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"
   },
   "engines": {
-    "node": "20.x || 22.x"
+    "node": "20.x"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",


### PR DESCRIPTION
## Summary
- ensure Node 20 is used by narrowing engine
- add yarn package extensions for missing peer deps and filter obsolete dependency warnings

## Testing
- `yarn install --immutable`
- `yarn test` *(fails: Unable to find element text, Missing allowlist entries, ReferenceError: missingRecaptcha, etc.)*
- `yarn lint` *(failed: no output after waiting, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca0787408328b8fe5979687f7d8f