### PR TITLE
fix build dependencies and remove invalid font usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@vercel/toolbar": "^0.1.38",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
@@ -109,6 +110,7 @@
     "tailwindcss": "^3.2.4",
     "three": "^0.179.1",
     "turndown": "^7.2.1",
+    "web-vitals": "^5.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,12 +6,6 @@ import Document, {
   type DocumentContext,
   type DocumentInitialProps,
 } from 'next/document';
-import { Ubuntu } from 'next/font/google';
-
-const ubuntu = Ubuntu({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '700'],
-});
 
 interface Props extends DocumentInitialProps {
   nonce?: string;
@@ -32,9 +26,13 @@ class MyDocument extends Document<Props> {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
+            rel="stylesheet"
+          />
           <script nonce={nonce} src="/theme.js" async />
         </Head>
-        <body className={ubuntu.className}>
+        <body className="font-ubuntu">
           <Main />
           <NextScript nonce={nonce} />
         </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,6 +4652,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xterm/addon-web-links@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@xterm/addon-web-links@npm:0.11.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10c0/9426bed80afa954b0ea97771d041eb44e77a64e560ce8b8ef507a5d3a763979af18ae9f74ed54007bb7e235d0daf035be2a33f90d8edfecb431caf8ba0b0664e
+  languageName: node
+  linkType: hard
+
 "@xterm/xterm@npm:^5.5.0":
   version: 5.5.0
   resolution: "@xterm/xterm@npm:5.5.0"
@@ -14557,6 +14566,7 @@ __metadata:
     "@vercel/toolbar": "npm:^0.1.38"
     "@xterm/addon-fit": "npm:^0.10.0"
     "@xterm/addon-search": "npm:^0.15.0"
+    "@xterm/addon-web-links": "npm:^0.11.0"
     "@xterm/xterm": "npm:^5.5.0"
     "@zxing/browser": "npm:^0.1.5"
     "@zxing/library": "npm:^0.21.3"
@@ -14640,6 +14650,7 @@ __metadata:
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
     wait-on: "npm:^8.0.4"
+    web-vitals: "npm:^5.1.0"
     webpack: "npm:^5.92.0"
     workbox-build: "npm:7.1.1"
     ws: "npm:^8.18.0"
@@ -14838,6 +14849,13 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
   checksum: 10c0/6c0901f75ce245d33991225af915eea1c5ae4ba087f3aee2b70dd377d4cacb34bef02a48daf109da9d59b2d31ec6463d924a0d72f8618ae1643dd07b95de5275
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "web-vitals@npm:5.1.0"
+  checksum: 10c0/1af22ddbe2836ba880fcb492cfba24c3349f4760ebb5e92f38324ea67bca3c4dbb9c86f1a32af4795b6115cdaf98b90000cf3a7402bffef6e8c503f0d1b2e706
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- remove next/font usage from custom Document and link to Ubuntu font manually
- add @xterm/addon-web-links and web-vitals dependencies for missing modules

## Testing
- `yarn lint pages/_document.tsx pages/_app.jsx apps/terminal/index.tsx` *(fails: numerous pre-existing lint errors)*
- `yarn build` *(fails: Module not found: Can't resolve 'fs', 'path')*

------
https://chatgpt.com/codex/tasks/task_e_68bdca88bc3483288ad8c31840f0e0db