### PR TITLE
feat: add high contrast theme

### DIFF
--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -28,7 +28,11 @@ import {
   setSymbolicTrayIcons as saveSymbolicTrayIcons,
   defaults,
 } from '../utils/settingsStore';
-import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import {
+  getTheme as loadTheme,
+  setTheme as saveTheme,
+  isDarkTheme,
+} from '../utils/theme';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -252,8 +256,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     document.documentElement.classList.toggle('high-contrast', highContrast);
+    document.documentElement.dataset.theme = highContrast ? 'high-contrast' : theme;
+    document.documentElement.classList.toggle(
+      'dark',
+      highContrast || isDarkTheme(theme),
+    );
     saveHighContrast(highContrast);
-  }, [highContrast]);
+  }, [highContrast, theme]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('large-hit-area', largeHitAreas);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -91,20 +91,38 @@ html[data-theme='kali-light'] {
 }
 
 /* Matrix theme */
-html[data-theme='matrix'] {
-  --color-bg: #000000;
-  --color-text: #00ff00;
-  --color-primary: #00ff00;
-  --color-secondary: #001100;
-  --color-accent: #00ff00;
-  --color-muted: #003300;
-  --color-surface: #001100;
-  --color-inverse: #ffffff;
-  --color-border: #003300;
-  --color-terminal: #00ff00;
-  --color-dark: #000000;
+  html[data-theme='matrix'] {
+    --color-bg: #000000;
+    --color-text: #00ff00;
+    --color-primary: #00ff00;
+    --color-secondary: #001100;
+    --color-accent: #00ff00;
+    --color-muted: #003300;
+    --color-surface: #001100;
+    --color-inverse: #ffffff;
+    --color-border: #003300;
+    --color-terminal: #00ff00;
+    --color-dark: #000000;
 
-}
+  }
+
+  /* High contrast theme */
+  html[data-theme='high-contrast'] {
+    --color-bg: #000000;
+    --color-text: #ffffff;
+    --color-primary: #ffff00;
+    --color-secondary: #000000;
+    --color-accent: #ffff00;
+    --color-muted: #1a1a1a;
+    --color-surface: #000000;
+    --color-inverse: #000000;
+    --color-border: #ffff00;
+    --color-terminal: #00ff00;
+    --color-dark: #000000;
+    --color-focus-ring: #ffff00;
+    --color-selection: #ffff00;
+    --color-control-accent: #ffff00;
+  }
 
 ::selection {
   background: var(--color-selection);


### PR DESCRIPTION
## Summary
- add high-contrast theme tokens and accents
- ensure settings toggle applies high-contrast dataset and dark mode

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: missingRecaptcha is not defined)*
- `yarn a11y` *(fails: logger.info is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca9945408328aec112d2b4548148