### PR TITLE
feat: improve window focus management

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -42,6 +42,26 @@ describe('Window lifecycle', () => {
   });
 });
 
+it('hides inactive windows from accessibility tree', () => {
+  render(
+    <Window
+      id="inactive"
+      title="Test"
+      screen={() => <div>content</div>}
+      focus={() => {}}
+      hasMinimised={() => {}}
+      closed={() => {}}
+      hideSideBar={() => {}}
+      openApp={() => {}}
+      isFocused={false}
+    />
+  );
+
+  const winEl = document.getElementById('inactive')!;
+  expect(winEl).toHaveAttribute('aria-hidden', 'true');
+  expect(winEl).toHaveAttribute('tabindex', '-1');
+});
+
 describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
     const ref = React.createRef<Window>();

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -19,6 +19,10 @@ const debounce = (fn, delay) => {
 };
 
 export class Window extends Component {
+    static defaultProps = {
+        isFocused: true,
+        zIndex: 1,
+    };
     constructor(props) {
         super(props);
         this.id = null;
@@ -52,6 +56,7 @@ export class Window extends Component {
         this._usageTimeout = null;
         this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
         this._menuOpener = null;
+        this.rootRef = React.createRef();
     }
 
     componentDidMount() {
@@ -203,6 +208,10 @@ export class Window extends Component {
             this._menuOpener.focus();
         }
         this._menuOpener = null;
+    }
+
+    focusSelf = () => {
+        this.rootRef.current?.focus();
     }
 
     changeCursorToMove = () => {
@@ -458,6 +467,7 @@ export class Window extends Component {
 
     focusWindow = () => {
         this.props.focus(this.id);
+        this.focusSelf();
     }
 
     minimizeWindow = () => {
@@ -714,7 +724,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
+                        ref={this.rootRef}
+                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%`, zIndex: (this.props.zIndex || 0) + (this.state.alwaysOnTop ? 1000 : 0) }}
                         className={
                             this.state.cursorType + " " +
                             (this.state.closed ? " closed-window " : "") +
@@ -722,16 +733,16 @@ export class Window extends Component {
                             (this.props.minimized ? " opacity-0 invisible duration-200 " : "") +
                             (this.state.grabbed ? " opacity-70 " : "") +
                             (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") +
-                            (this.props.isFocused
-                                ? (this.state.alwaysOnTop ? " z-50 " : " z-30 ")
-                                : (this.state.alwaysOnTop ? " z-40 " : " z-20 notFocused")) +
+                            (this.props.isFocused ? "" : " notFocused") +
                             " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         data-context="window"
                         data-app-id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
-                        tabIndex={0}
+                        aria-selected={this.props.isFocused}
+                        aria-hidden={!this.props.isFocused}
+                        tabIndex={this.props.isFocused ? 0 : -1}
                         onKeyDown={this.handleKeyDown}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.debouncedHandleHorizontalResize} />}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -557,6 +557,8 @@ export class Desktop extends Component {
             if (this.state.closed_windows[app.id] === false) {
 
                 const pos = this.state.window_positions[app.id];
+                const index = this.app_stack.indexOf(app.id);
+                const zIndex = 100 + (index === -1 ? 0 : index);
                 const props = {
                     title: app.title,
                     id: app.id,
@@ -566,6 +568,7 @@ export class Desktop extends Component {
                     openApp: this.openApp,
                     focus: this.focus,
                     isFocused: this.state.focused_windows[app.id],
+                    zIndex,
                     hideSideBar: this.hideSideBar,
                     hasMinimised: this.hasMinimised,
                     minimized: this.state.minimized_windows[app.id],
@@ -857,18 +860,23 @@ export class Desktop extends Component {
     }
 
     focus = (objId) => {
-        // removes focus from all window and 
-        // gives focus to window with 'id = objId'
-        var focused_windows = this.state.focused_windows;
+        // removes focus from all windows and gives focus to window with 'id = objId'
+        const focused_windows = { ...this.state.focused_windows };
         focused_windows[objId] = true;
-        for (let key in focused_windows) {
-            if (focused_windows.hasOwnProperty(key)) {
-                if (key !== objId) {
-                    focused_windows[key] = false;
-                }
+        for (const key in focused_windows) {
+            if (key !== objId) {
+                focused_windows[key] = false;
             }
         }
-        this.setState({ focused_windows });
+        this.setState({ focused_windows }, () => {
+            this.windowRefs[objId]?.focusSelf?.();
+        });
+
+        const index = this.app_stack.indexOf(objId);
+        if (index !== -1) {
+            this.app_stack.splice(index, 1);
+        }
+        this.app_stack.push(objId);
     }
 
     addNewFolder = () => {


### PR DESCRIPTION
## Summary
- manage active window z-index through Desktop stack tracking
- expose window focus state via ARIA attributes and DOM focus helpers
- test inactive windows are removed from keyboard navigation

## Testing
- `yarn test` *(fails: Missing allowlist entries for openweathermap.org...; Missing remotePatterns for i.ytimg.com; ReferenceError: missingRecaptcha is not defined)*
- `npx eslint components/base/window.js components/screen/desktop.js __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdca9b09c883288c6687c6fbb398ca