### PR TITLE
Add desktop welcome tour and help menu

### DIFF
--- a/components/menu/HelpMenu.tsx
+++ b/components/menu/HelpMenu.tsx
@@ -1,0 +1,55 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+const HelpMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!open) return;
+      const target = e.target as Node;
+      if (!menuRef.current?.contains(target) && !btnRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const showTour = () => {
+    window.dispatchEvent(new CustomEvent('show-welcome-tour'));
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        Help
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 bg-ub-grey text-white shadow-lg p-2"
+          tabIndex={-1}
+        >
+          <button
+            type="button"
+            className="block px-2 py-1 text-left hover:underline"
+            onClick={showTour}
+          >
+            Show Welcome Tour
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HelpMenu;
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -29,6 +29,7 @@ import { safeLocalStorage } from '../../utils/safeStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 import { addRecentApp, getRecentApps } from '../../utils/recent';
 import osdService from '../../utils/osdService';
+import DesktopTour from '../welcome/DesktopTour';
 
 export class Desktop extends Component {
     constructor() {
@@ -1171,6 +1172,8 @@ export class Desktop extends Component {
                         windows={this.state.switcherWindows}
                         onSelect={this.selectWindow}
                         onClose={this.closeWindowSwitcher} /> : null}
+
+                <DesktopTour showAllApps={this.showAllApps} />
 
             </main>
         )

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,6 +4,7 @@ import PanelClock from '../util-components/PanelClock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import HelpMenu from '../menu/HelpMenu';
 
 export default class Navbar extends Component {
         constructor() {
@@ -20,6 +21,7 @@ export default class Navbar extends Component {
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
+                                <HelpMenu />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/welcome/DesktopTour.tsx
+++ b/components/welcome/DesktopTour.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isBrowser } from "@/utils/env";
+
+interface Step {
+  selector: string;
+  message: string;
+  action?: () => void;
+}
+
+const STORAGE_KEY = "desktopTourSeen";
+
+export default function DesktopTour({ showAllApps }: { showAllApps: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+
+  const steps: Step[] = [
+    {
+      selector: ".all-apps-anim",
+      message: "App grid shows all installed applications.",
+      action: () => {
+        if (!document.querySelector(".all-apps-anim")) {
+          showAllApps();
+        }
+      },
+    },
+    {
+      selector: '.all-apps-anim input[aria-label="Search"]',
+      message: "Search instantly filters apps.",
+    },
+    {
+      selector: "#status-bar",
+      message: "Open Quick Settings and more from here.",
+      action: () => {
+        if (document.querySelector(".all-apps-anim")) {
+          showAllApps();
+        }
+      },
+    },
+    {
+      selector: ".opened-window .right-0.top-0",
+      message: "Window controls let you minimize, maximize, or close.",
+    },
+  ];
+
+  useEffect(() => {
+    if (!isBrowser()) return;
+    const seen = window.localStorage.getItem(STORAGE_KEY);
+    if (!seen) {
+      setOpen(true);
+    }
+    const handler = () => {
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch {}
+      setStep(0);
+      setOpen(true);
+    };
+    window.addEventListener("show-welcome-tour", handler);
+    return () => window.removeEventListener("show-welcome-tour", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const current = steps[step];
+    current.action?.();
+    const el = document.querySelector(current.selector) as HTMLElement | null;
+    if (el) {
+      el.classList.add("tour-highlight");
+      el.scrollIntoView({ block: "center", inline: "center" });
+    }
+    return () => {
+      el?.classList.remove("tour-highlight");
+    };
+  }, [open, step]);
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep((s) => s + 1);
+    } else {
+      finish();
+    }
+  };
+
+  const skip = () => finish();
+
+  const finish = () => {
+    if (isBrowser()) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, "true");
+      } catch {}
+    }
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center pointer-events-none"
+      aria-modal="true"
+      role="dialog"
+    >
+      <div className="mb-6 w-full max-w-md rounded bg-black/70 p-4 text-white text-center pointer-events-auto">
+        <p className="mb-4">{steps[step].message}</p>
+        <div className="flex justify-center gap-4">
+          <button
+            type="button"
+            onClick={skip}
+            className="px-4 py-2 rounded bg-gray-600"
+          >
+            Skip
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="px-4 py-2 rounded bg-blue-600"
+          >
+            {step === steps.length - 1 ? "Done" : "Next"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/styles/index.css
+++ b/styles/index.css
@@ -533,3 +533,10 @@ textarea:focus-visible {
     color: #000 !important;
 }
 
+
+.tour-highlight {
+    position: relative;
+    z-index: 60 !important;
+    box-shadow: 0 0 0 4px rgba(251,191,36,0.9);
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- introduce step-by-step DesktopTour overlay to highlight app grid, search, settings and window controls
- store completion in localStorage and expose relaunch via new Help menu
- add highlight styling for tour targets

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: nmapNse app tests, contact API tests, remotePatterns, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bdca9b100083288b5032ac26b70fdf