### PR TITLE
feat: add roving tabindex to menus and app grid

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -67,10 +67,10 @@ export class UbuntuApp extends Component {
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                tabIndex={this.props.disabled ? -1 : (this.props.tabIndex ?? 0)}
                 onMouseEnter={this.startPrefetchTimer}
                 onMouseLeave={this.clearPrefetchTimer}
-                onFocus={this.startPrefetchTimer}
+                onFocus={(e) => { this.startPrefetchTimer(); this.props.onFocus && this.props.onFocus(e); }}
                 onBlur={this.clearPrefetchTimer}
             >
                 <Image

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -33,6 +33,13 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   );
 
   useEffect(() => {
+    if (open && menuRef.current) {
+      const first = menuRef.current.querySelector<HTMLElement>('[role="menuitem"], [role="menuitemcheckbox"]');
+      first?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
     const node = targetRef.current;
     if (!node) return;
 


### PR DESCRIPTION
## Summary
- focus first item when opening context menus
- support custom tabIndex/onFocus in UbuntuApp to drive roving focus
- enable arrow-key roving tabindex in AppGrid and label search input

## Testing
- `npx eslint components/common/ContextMenu.tsx components/base/ubuntu_app.js components/apps/app-grid.js && echo 'Lint passed'`
- `npx jest __tests__/appGrid.prefetch.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bdca9b498c8328b895dea3ce3ea02d