### PR TITLE
feat: add drag-edge snapping with quadrant preview

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -63,13 +63,13 @@ describe('Window snapping preview', () => {
     // Simulate being near the left edge
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -80,7 +80,7 @@ describe('Window snapping preview', () => {
     expect(screen.getByTestId('snap-preview')).toBeInTheDocument();
   });
 
-  it('shows fullscreen preview when dragged near top edge', () => {
+  it('shows top-half preview when dragged near top edge', () => {
     const ref = React.createRef<Window>();
     render(
       <Window
@@ -115,7 +115,123 @@ describe('Window snapping preview', () => {
     });
 
     const preview = screen.getByTestId('snap-preview');
-    expect(preview).toHaveStyle({ left: '0', top: '0', width: '100%', height: '100%' });
+    expect(preview).toHaveStyle({ left: '0', top: '0', width: '100%', height: '50%' });
+  });
+
+  it('shows bottom-half preview when dragged near bottom edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Simulate being near the bottom edge
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: window.innerHeight - 105,
+      right: 300,
+      bottom: window.innerHeight - 5,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: window.innerHeight - 105,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    const preview = screen.getByTestId('snap-preview');
+    expect(preview).toHaveStyle({ left: '0', top: '50%', width: '100%', height: '50%' });
+  });
+
+  it('shows quadrant preview when dragged to top-left corner', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    // Simulate being near top-left corner
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 5,
+      right: 105,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 5,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    const preview = screen.getByTestId('snap-preview');
+    expect(preview).toHaveStyle({ left: '0', top: '0', width: '50%', height: '50%' });
+  });
+
+  it('cancels snap preview on Escape', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 100,
+      right: 105,
+      bottom: 200,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 100,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+
+    act(() => {
+      ref.current!.handleKeyDown({ key: 'Escape', preventDefault: () => {}, stopPropagation: () => {} } as any);
+    });
+
+    expect(screen.queryByTestId('snap-preview')).toBeNull();
   });
 
   it('hides preview when away from edge', () => {
@@ -176,13 +292,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -238,6 +354,84 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('top');
   });
 
+  it('snaps window on drag stop near bottom edge', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="bottom-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('bottom-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 200,
+      top: window.innerHeight - 105,
+      right: 300,
+      bottom: window.innerHeight - 5,
+      width: 100,
+      height: 100,
+      x: 200,
+      y: window.innerHeight - 105,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    expect(ref.current!.state.snapPosition).toBe('bottom');
+    act(() => {
+      ref.current!.handleStop();
+    });
+    expect(ref.current!.state.snapped).toBe('bottom');
+  });
+
+  it('snaps window on drag stop near top-left corner', () => {
+    const ref = React.createRef<Window>();
+    render(
+      <Window
+        id="corner-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const winEl = document.getElementById('corner-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 5,
+      top: 5,
+      right: 105,
+      bottom: 105,
+      width: 100,
+      height: 100,
+      x: 5,
+      y: 5,
+      toJSON: () => {}
+    });
+
+    act(() => {
+      ref.current!.handleDrag();
+    });
+    expect(ref.current!.state.snapPosition).toBe('top-left');
+    act(() => {
+      ref.current!.handleStop();
+    });
+    expect(ref.current!.state.snapped).toBe('top-left');
+  });
+
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
     render(
@@ -257,13 +451,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 
@@ -351,13 +545,13 @@ describe('Window snapping finalize and release', () => {
     const winEl = document.getElementById('test-window')!;
     winEl.getBoundingClientRect = () => ({
       left: 5,
-      top: 10,
+      top: 100,
       right: 105,
-      bottom: 110,
+      bottom: 200,
       width: 100,
       height: 100,
       x: 5,
-      y: 10,
+      y: 100,
       toJSON: () => {}
     });
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -347,8 +347,28 @@ export class Window extends Component {
             transform = `translate(${window.innerWidth / 2}px,-2pt)`;
         } else if (position === 'top') {
             newWidth = 100.2;
-            newHeight = 96.3;
+            newHeight = 50;
             transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'bottom') {
+            newWidth = 100.2;
+            newHeight = 50;
+            transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+        } else if (position === 'top-left') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = 'translate(-1pt,-2pt)';
+        } else if (position === 'top-right') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(${window.innerWidth / 2}px,-2pt)`;
+        } else if (position === 'bottom-left') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(-1pt,${window.innerHeight / 2}px)`;
+        } else if (position === 'bottom-right') {
+            newWidth = 50;
+            newHeight = 50;
+            transform = `translate(${window.innerWidth / 2}px,${window.innerHeight / 2}px)`;
         }
         if (r && transform) {
             r.style.transform = transform;
@@ -398,17 +418,41 @@ export class Window extends Component {
         var rect = r.getBoundingClientRect();
         const threshold = 30;
         let snap = null;
-        if (rect.left <= threshold) {
+        const nearLeft = rect.left <= threshold;
+        const nearRight = rect.right >= window.innerWidth - threshold;
+        const nearTop = rect.top <= threshold;
+        const nearBottom = rect.bottom >= window.innerHeight - threshold;
+        if (nearLeft && nearTop) {
+            snap = { left: '0', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-left' });
+        }
+        else if (nearRight && nearTop) {
+            snap = { left: '50%', top: '0', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'top-right' });
+        }
+        else if (nearLeft && nearBottom) {
+            snap = { left: '0', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-left' });
+        }
+        else if (nearRight && nearBottom) {
+            snap = { left: '50%', top: '50%', width: '50%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom-right' });
+        }
+        else if (nearLeft) {
             snap = { left: '0', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'left' });
         }
-        else if (rect.right >= window.innerWidth - threshold) {
+        else if (nearRight) {
             snap = { left: '50%', top: '0', width: '50%', height: '100%' };
             this.setState({ snapPreview: snap, snapPosition: 'right' });
         }
-        else if (rect.top <= threshold) {
-            snap = { left: '0', top: '0', width: '100%', height: '100%' };
+        else if (nearTop) {
+            snap = { left: '0', top: '0', width: '100%', height: '50%' };
             this.setState({ snapPreview: snap, snapPosition: 'top' });
+        }
+        else if (nearBottom) {
+            snap = { left: '0', top: '50%', width: '100%', height: '50%' };
+            this.setState({ snapPreview: snap, snapPosition: 'bottom' });
         }
         else {
             if (this.state.snapPreview) this.setState({ snapPreview: null, snapPosition: null });
@@ -600,6 +644,12 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        if (this.state.snapPreview && e.key === 'Escape') {
+            e.preventDefault?.();
+            e.stopPropagation?.();
+            this.setState({ snapPreview: null, snapPosition: null });
+            return;
+        }
         if (this.state.resizing) {
             const step = 1;
             if (e.key === 'Enter' || e.key === 'Escape') {


### PR DESCRIPTION
## Summary
- support snapping windows to edges and corners with preview overlay
- allow Escape to cancel an active snap preview
- test snapping to halves and quadrants

## Testing
- `yarn test __tests__/window.test.tsx`
- `./node_modules/.bin/eslint components/base/window.js __tests__/window.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdca9bd304832892292ec61e72b857