### PR TITLE
feat: add high-contrast focus outlines

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -18,7 +18,12 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
     outline-offset: 2px;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,7 +57,7 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
+  --focus-outline-color: var(--color-accent);
   --focus-outline-width: 2px;
 }
 


### PR DESCRIPTION
## Summary
- use accent color for focus outline to ensure high contrast
- apply uniform focus-visible outline across interactive elements

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, contact.api.test.ts, remotePatterns.test.ts, appImport.test.ts, contactRateLimit.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaa6e36883289f14c1381ff831f4