### PR TITLE
Improve modal accessibility with labelled dialogs

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -70,3 +70,21 @@ test('modal closes when Escape pressed globally', async () => {
   fireEvent.keyDown(document, { key: 'Escape' });
   await waitFor(() => expect(openButton).toHaveFocus());
 });
+
+test('modal associates heading via aria-labelledby', () => {
+  const root = document.createElement('div');
+  root.setAttribute('id', '__next');
+  document.body.appendChild(root);
+
+  const { unmount } = render(
+    <Modal isOpen onClose={() => {}} ariaLabelledby="title-id">
+      <h2 id="title-id">Title</h2>
+    </Modal>,
+    { container: root }
+  );
+
+  expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby', 'title-id');
+
+  unmount();
+  document.body.removeChild(root);
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -12,6 +12,15 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    /**
+     * Optional id of a heading element that labels the dialog.
+     */
+    ariaLabelledby?: string;
+    /**
+     * Optional className applied to the dialog element, allowing styling such
+     * as positioning or background overlays.
+     */
+    className?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -28,7 +37,14 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({
+    isOpen,
+    onClose,
+    children,
+    overlayRoot,
+    ariaLabelledby,
+    className,
+}) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -114,9 +130,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
         <div
             role="dialog"
             aria-modal="true"
+            aria-labelledby={ariaLabelledby}
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className={className}
         >
             {children}
         </div>,

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useId } from 'react';
+import Modal from '@/components/base/Modal';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -19,15 +20,21 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   onConfirm,
   onCancel,
 }) => {
-  if (!open) return null;
+  const headingId = useId();
+
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <Modal
+      isOpen={open}
+      onClose={onCancel}
+      ariaLabelledby={title ? headingId : undefined}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     >
       <div className="bg-gray-800 text-white p-4 rounded shadow-lg w-80 max-w-full">
-        {title && <h2 className="text-lg mb-2">{title}</h2>}
+        {title && (
+          <h2 id={headingId} className="text-lg mb-2">
+            {title}
+          </h2>
+        )}
         <div className="mb-4 text-sm">{message}</div>
         <div className="flex justify-end space-x-2">
           <button
@@ -44,8 +51,9 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 
 export default ConfirmDialog;
+


### PR DESCRIPTION
## Summary
- extend base Modal with `aria-labelledby` support and optional styling class
- refactor ConfirmDialog to use Modal and associate heading for screen readers
- cover dialog labelling with unit tests

## Testing
- `yarn eslint --no-ignore components/base/Modal.tsx src/components/common/ConfirmDialog.tsx __tests__/Modal.test.tsx`
- `yarn test __tests__/Modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdcaa6dfcc8328acfe5842d960bb1a