### PR TITLE
Respect reduced motion preferences

### DIFF
--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,5 +1,6 @@
 import { isBrowser } from '@/utils/env';
 import React, { useState, useEffect, useRef } from 'react';
+import usePrefersReducedMotion from '../../../hooks/usePrefersReducedMotion';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
 
@@ -170,7 +171,7 @@ function HashcatApp() {
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState('');
   const [isCracking, setIsCracking] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
   const [attackMode, setAttackMode] = useState('0');
   const [mask, setMask] = useState('');
   const appendMask = (token) => setMask((m) => m + token);
@@ -217,15 +218,6 @@ function HashcatApp() {
       setGpuUsage(Math.floor(Math.random() * 100));
     }, 3000);
     return () => clearInterval(interval);
-  }, []);
-
-  useEffect(() => {
-    if (!isBrowser()) return;
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
-    handleChange();
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
   const startCracking = () => {

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -549,12 +549,16 @@ export class Window extends Component {
 
     closeWindow = () => {
         this.setWinowsPosition();
+        const prefersReducedMotion =
+            window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const delay = prefersReducedMotion ? 0 : 300;
         this.setState({ closed: true }, () => {
             this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
             setTimeout(() => {
                 this.props.closed(this.id)
-            }, 300) // after 300ms this window will be unmounted from parent (Desktop)
+            }, delay); // skip delay when reduced motion is preferred
         });
     }
 


### PR DESCRIPTION
## Summary
- Skip window close animation when user prefers reduced motion
- Use shared reduced-motion hook in Hashcat app to avoid requestAnimationFrame when reduced motion is enabled

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68bdcaa78afc83289e3af35a6b99d483