### PR TITLE
docs: enforce and document bundle size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ validate-apps:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: ANALYZE=true yarn build
-      - run: yarn check-budgets
+      - name: Enforce bundle budgets
+        run: yarn check-budgets
       - run: yarn export
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ To send text or links directly into the Sticky Notes app:
 - Dynamic routes or API responses are not cached.
 - Future work may use `injectManifest` for finer control.
 
+### Bundle size budgets
+
+Client bundle size is tracked using `@next/bundle-analyzer`. Thresholds defined in
+[`bundle-budgets.json`](./bundle-budgets.json) are enforced in CI and can be
+verified locally:
+
+```bash
+ANALYZE=true yarn build
+yarn check-budgets
+```
+
+Current limits:
+
+- `^chunks/framework`: 300000 bytes
+- `^chunks/main-app`: 350000 bytes
+
 ---
 
 ## Environment Variables
@@ -94,6 +110,7 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `yarn check-budgets` – verify client bundle size against configured limits.
 
 ---
 

--- a/docs/bundle-budgets.md
+++ b/docs/bundle-budgets.md
@@ -1,0 +1,22 @@
+# Bundle Budgets
+
+To prevent client bundles from growing unexpectedly, size budgets are maintained in [`bundle-budgets.json`](../bundle-budgets.json).
+These budgets are enforced in CI after every build.
+
+## Current thresholds
+
+| Chunk pattern | Limit (bytes) |
+| ------------- | ------------- |
+| `^chunks/framework` | 300000 |
+| `^chunks/main-app` | 350000 |
+
+## Local verification
+
+Generate bundle statistics and check them against the budgets:
+
+```bash
+ANALYZE=true yarn build
+yarn check-budgets
+```
+
+The build produces `.next/analyze/client.json` via `@next/bundle-analyzer` and the check script exits with a non-zero code if any asset exceeds its limit.

--- a/scripts/check-bundle-budgets.mjs
+++ b/scripts/check-bundle-budgets.mjs
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const budgets = JSON.parse(fs.readFileSync(new URL('../bundle-budgets.json', import.meta.url)));
+// Budget thresholds for client bundle chunks are defined in bundle-budgets.json.
+// CI uses this script to enforce those limits after a build.
+const budgets = JSON.parse(
+  fs.readFileSync(new URL('../bundle-budgets.json', import.meta.url), 'utf8'),
+);
 const statsPath = path.join(process.cwd(), '.next', 'analyze', 'client.json');
 const stats = JSON.parse(fs.readFileSync(statsPath, 'utf8'));
 


### PR DESCRIPTION
## Summary
- clarify CI to enforce bundle size budgets
- document bundle budget thresholds and local verification steps
- comment bundle budget script for clarity

## Testing
- `npx eslint README.md scripts/check-bundle-budgets.mjs docs/bundle-budgets.md`
- `ANALYZE=true yarn build` *(fails: next/font cannot be used within pages/_document.js)*
- `yarn check-budgets` *(fails: .next/analyze/client.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaa8e5308328a176a71c650a1435