### PR TITLE
refactor: migrate scripts to Next Script component

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,58 +1,63 @@
 import React from 'react'
 import Head from 'next/head';
+import Script from 'next/script';
 import { getCspNonce } from '../../utils/csp';
 
 export default function Meta() {
     const nonce = getCspNonce();
     return (
-        <Head>
-            {/* Primary Meta Tags */}
-             <title>Alex Unnippillil&apos;s Portfolio </title>
-            <meta charSet="utf-8" />
-            <meta name="title" content="Alex Patel Portfolio - Computer Engineering Student" />
-            <meta name="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="author" content="Alex Unnippillil" />
-            <meta name="keywords"
-                content="Alex Unnippillil, Unnippillil's portfolio, linux, kali portfolio, alex unnippillil portfolio, alex computer, alex unnippillil, alex linux, alex unnippillil kali portfolio" />
-            <meta name="robots" content="index, follow" />
-            <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-            <meta name="language" content="English" />
-            <meta name="category" content="16" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#0f1317" />
+        <>
+            <Head>
+                {/* Primary Meta Tags */}
+                 <title>Alex Unnippillil&apos;s Portfolio </title>
+                <meta charSet="utf-8" />
+                <meta name="title" content="Alex Patel Portfolio - Computer Engineering Student" />
+                <meta name="description"
+                    content="Alex Unnippillil Personal Portfolio Website" />
+                <meta name="author" content="Alex Unnippillil" />
+                <meta name="keywords"
+                    content="Alex Unnippillil, Unnippillil's portfolio, linux, kali portfolio, alex unnippillil portfolio, alex computer, alex unnippillil, alex linux, alex unnippillil kali portfolio" />
+                <meta name="robots" content="index, follow" />
+                <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+                <meta name="language" content="English" />
+                <meta name="category" content="16" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <meta name="theme-color" content="#0f1317" />
 
-            {/* Search Engine */}
-            <meta name="image" content="images/logos/fevicon.png" />
-            {/* Schema.org for Google */}
-            <meta itemProp="name" content="Alex Unnippillil Portfolio " />
-            <meta itemProp="description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta itemProp="image" content="images/logos/fevicon.png" />
-            {/* Twitter */}
-            <meta name="twitter:card" content="summary" />
-            <meta name="twitter:title" content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="twitter:description"
-                content="Alex Unnippillil Personal Portfolio Website" />
-            <meta name="twitter:site" content="alexunnippillil" />
-            <meta name="twitter:creator" content="unnippillil" />
-            <meta name="twitter:image:src" content="images/logos/logo_1024.png" />
-            {/* Open Graph general (Facebook, Pinterest & Google+) */}
-            <meta name="og:title" content="Alex Unnippillil Personal Portfolio Website " />
-            <meta name="og:description"
-                content="Alex Unnippillil Personal Portfolio Website. ." />
-            <meta name="og:image" content="https://unnippillil.com/images/logos/logo_1200.png" />
-            <meta name="og:url" content="https://unnippillil.com/" />
-            <meta name="og:site_name" content="Alex Unnippillil Personal Portfolio" />
-            <meta name="og:locale" content="en_CA" />
-            <meta name="og:type" content="website" />
+                {/* Search Engine */}
+                <meta name="image" content="images/logos/fevicon.png" />
+                {/* Schema.org for Google */}
+                <meta itemProp="name" content="Alex Unnippillil Portfolio " />
+                <meta itemProp="description"
+                    content="Alex Unnippillil Personal Portfolio Website" />
+                <meta itemProp="image" content="images/logos/fevicon.png" />
+                {/* Twitter */}
+                <meta name="twitter:card" content="summary" />
+                <meta name="twitter:title" content="Alex Unnippillil Personal Portfolio Website" />
+                <meta name="twitter:description"
+                    content="Alex Unnippillil Personal Portfolio Website" />
+                <meta name="twitter:site" content="alexunnippillil" />
+                <meta name="twitter:creator" content="unnippillil" />
+                <meta name="twitter:image:src" content="images/logos/logo_1024.png" />
+                {/* Open Graph general (Facebook, Pinterest & Google+) */}
+                <meta name="og:title" content="Alex Unnippillil Personal Portfolio Website " />
+                <meta name="og:description"
+                    content="Alex Unnippillil Personal Portfolio Website. ." />
+                <meta name="og:image" content="https://unnippillil.com/images/logos/logo_1200.png" />
+                <meta name="og:url" content="https://unnippillil.com/" />
+                <meta name="og:site_name" content="Alex Unnippillil Personal Portfolio" />
+                <meta name="og:locale" content="en_CA" />
+                <meta name="og:type" content="website" />
 
-            <link rel="canonical" href="https://unnippillil.com/" />
-            <link rel="icon" href="images/logos/fevicon.svg" />
-            <link rel="apple-touch-icon" href="images/logos/logo.png" />
-            <script
+                <link rel="canonical" href="https://unnippillil.com/" />
+                <link rel="icon" href="images/logos/fevicon.svg" />
+                <link rel="apple-touch-icon" href="images/logos/logo.png" />
+            </Head>
+            <Script
+                id="meta-ld-json"
                 type="application/ld+json"
                 nonce={nonce}
+                strategy="afterInteractive"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify({
                         "@context": "https://schema.org",
@@ -62,6 +67,6 @@ export default function Meta() {
                     }),
                 }}
             />
-        </Head>
+        </>
     )
 }

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Image from 'next/image';
 import Head from 'next/head';
+import Script from 'next/script';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../../GitHubStars';
 import Certs from '../certs';
@@ -113,12 +114,14 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">
         <Head>
           <title>About</title>
-          <script
-            type="application/ld+json"
-            nonce={nonce}
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
-          />
         </Head>
+        <Script
+          id="about-ld-json"
+          type="application/ld+json"
+          nonce={nonce}
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+        />
         <div
           className="md:flex hidden flex-col w-1/4 md:w-1/5 text-sm overflow-y-auto windowMainScreen border-r border-black"
           role="tablist"
@@ -349,13 +352,14 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
   return (
     <div className="px-2 w-full">
       <div className="text-sm text-center md:text-base font-bold">{title}</div>
-      <input
-        type="text"
-        placeholder="Filter..."
-        className="mt-2 w-full px-2 py-1 rounded text-black"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-      />
+        <input
+          type="text"
+          placeholder="Filter..."
+          aria-label="Filter badges"
+          className="mt-2 w-full px-2 py-1 rounded text-black"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
           <img

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,7 @@ import Document, {
   type DocumentContext,
   type DocumentInitialProps,
 } from 'next/document';
+import Script from 'next/script';
 import { Ubuntu } from 'next/font/google';
 
 const ubuntu = Ubuntu({
@@ -32,7 +33,7 @@ class MyDocument extends Document<Props> {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" async />
+          <Script src="/theme.js" nonce={nonce} strategy="afterInteractive" />
         </Head>
         <body className={ubuntu.className}>
           <Main />


### PR DESCRIPTION
## Summary
- use Next `<Script>` for theme loader
- move structured data to `<Script>` in meta and about pages
- add accessibility label to skill filter input

## Testing
- `npx eslint components/SEO/Meta.js components/apps/About/index.tsx pages/_document.tsx`
- `yarn test` *(fails: missing CSP allowlist entries, missingRecaptcha errors, remotePatterns missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaaae9508328bddfec9b40a08999