### PR TITLE
Use Next Image for panel icons

### DIFF
--- a/components/panel/ActiveWindowTitle.tsx
+++ b/components/panel/ActiveWindowTitle.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React, { useState } from "react";
+import Image from "next/image";
 import { isBrowser } from '@/utils/env';
+
+const BLUR_DATA_URL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -67,12 +71,14 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => minimize(activeId)}
         >
-          <img
+          <Image
             src="/themes/Yaru/window/window-minimize-symbolic.svg"
             alt="Kali window minimize"
             className="h-3 w-3"
             width={12}
             height={12}
+            placeholder="blur"
+            blurDataURL={BLUR_DATA_URL}
           />
         </button>
       )}
@@ -83,12 +89,14 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => maximize(activeId)}
         >
-          <img
+          <Image
             src="/themes/Yaru/window/window-maximize-symbolic.svg"
             alt="Kali window maximize"
             className="h-3 w-3"
             width={12}
             height={12}
+            placeholder="blur"
+            blurDataURL={BLUR_DATA_URL}
           />
         </button>
       )}
@@ -99,12 +107,14 @@ export default function ActiveWindowTitle({
           className="h-5 w-5 flex items-center justify-center rounded hover:bg-white hover:bg-opacity-10"
           onClick={() => close(activeId)}
         >
-          <img
+          <Image
             src="/themes/Yaru/window/window-close-symbolic.svg"
             alt="Kali window close"
             className="h-3 w-3"
             width={12}
             height={12}
+            placeholder="blur"
+            blurDataURL={BLUR_DATA_URL}
           />
         </button>
       )}

--- a/components/panel/GenMon.tsx
+++ b/components/panel/GenMon.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { type ReactNode, useEffect, useState } from "react";
+import Image from "next/image";
 import DOMPurify from "dompurify";
 import { XMLParser } from "fast-xml-parser";
+
+const BLUR_DATA_URL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
 interface GenMonProps {
   code: string;
@@ -109,7 +113,15 @@ export default function GenMon({ code, interval = 60 }: GenMonProps) {
   return (
     <div className="flex items-center gap-2">
       {icon && (
-        <img src={icon} alt="" className="w-4 h-4" width={16} height={16} />
+        <Image
+          src={icon}
+          alt=""
+          className="w-4 h-4"
+          width={16}
+          height={16}
+          placeholder="blur"
+          blurDataURL={BLUR_DATA_URL}
+        />
       )}
       {text && <span>{text}</span>}
       {bar !== null && (

--- a/components/panel/taskbar/TaskList.tsx
+++ b/components/panel/taskbar/TaskList.tsx
@@ -1,5 +1,9 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import Image from 'next/image';
 import usePersistentState from '../../../hooks/usePersistentState';
+
+const BLUR_DATA_URL =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
 interface AppDefinition {
   id: string;
@@ -85,13 +89,14 @@ const TaskList: React.FC<TaskListProps> = ({ apps, onMinimizeWindow }) => {
           style={{ width: rowSize, height: rowSize }}
         >
           {app.icon ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={app.icon}
               alt=""
               className="max-w-full max-h-full"
               width={rowSize}
               height={rowSize}
+              placeholder="blur"
+              blurDataURL={BLUR_DATA_URL}
             />
           ) : (
             <span>{app.title}</span>


### PR DESCRIPTION
## Summary
- replace `<img>` tags in panel components with Next.js `<Image>`
- add width, height, and blur placeholder values

## Testing
- `yarn lint components/panel/ActiveWindowTitle.tsx components/panel/GenMon.tsx components/panel/taskbar/TaskList.tsx` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: e.g., __tests__/nmapNse.test.tsx, __tests__/contact.api.test.ts)*
- `npx --yes lighthouse https://example.com --quiet --chrome-flags="--headless"` *(fails: no output generated)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaaa7f9883288c0e996ac362095a