### PR TITLE
Add contrast checks for design tokens

### DIFF
--- a/__tests__/tokens-contrast.test.ts
+++ b/__tests__/tokens-contrast.test.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+const tokensPath = path.join(__dirname, '..', 'styles', 'tokens.css');
+const css = fs.readFileSync(tokensPath, 'utf8');
+
+const getVar = (name: string): string => {
+  const regex = new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`);
+  const match = css.match(regex);
+  if (!match) throw new Error(`Token ${name} not found`);
+  return match[1];
+};
+
+describe('design token contrast', () => {
+  const pairs: [string, string][] = [
+    ['--color-text', '--color-bg'],
+    ['--color-ubt-grey', '--color-ub-grey'],
+    ['--color-ubt-warm-grey', '--color-ub-warm-grey'],
+    ['--color-ubt-cool-grey', '--color-ub-cool-grey'],
+  ];
+
+  pairs.forEach(([fgVar, bgVar]) => {
+    test(`${fgVar} on ${bgVar} meets WCAG AA`, () => {
+      const fg = getVar(fgVar);
+      const bg = getVar(bgVar);
+      expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+});

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -3,7 +3,7 @@
 :root {
   /* Theme colors */
   --color-ub-grey: #0f1317;
-  --color-ub-warm-grey: #7d7f83;
+  --color-ub-warm-grey: #4d4d4d;
   --color-ub-cool-grey: #1a1f26;
   --color-ub-orange: #1793d1;
   --color-ub-lite-abrgn: #22262c;
@@ -14,8 +14,8 @@
   --color-ub-gedit-light: #003B70;
   --color-ub-gedit-darker: #010D1A;
   --color-ubt-grey: #F6F6F5;
-  --color-ubt-warm-grey: #AEA79F;
-  --color-ubt-cool-grey: #333333;
+  --color-ubt-warm-grey: #F6F6F5;
+  --color-ubt-cool-grey: #b3b3b3;
   --color-ubt-blue: #62A0EA;
   --color-ubt-green: #73D216;
   --color-ubt-gedit-orange: #F39A21;


### PR DESCRIPTION
## Summary
- add jest tests ensuring key design token text/background pairs meet WCAG AA contrast
- tweak warm and cool grey tokens to pass contrast thresholds

## Testing
- `yarn test __tests__/tokens-contrast.test.ts --runTestsByPath`
- `yarn test __tests__/nmapNse.test.tsx __tests__/contact.api.test.ts __tests__/asciiArt.test.tsx __tests__/contactRateLimit.test.ts` *(fails: ReferenceError: missingRecaptcha is not defined; Unable to find role="alert"; Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaa7e1d08328b7380100af30afe8