### PR TITLE
Add keyboard skip links for desktop navigation

### DIFF
--- a/__tests__/skip-links.test.tsx
+++ b/__tests__/skip-links.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SkipLinks from "../components/SkipLinks";
+
+test("first tab focuses skip to desktop link", async () => {
+  const user = userEvent.setup();
+  const { getByText } = render(<SkipLinks />);
+  await user.tab();
+  const link = getByText("Skip to desktop");
+  expect(link).toHaveFocus();
+  expect(link).toBeVisible();
+});
+

--- a/components/SkipLinks.jsx
+++ b/components/SkipLinks.jsx
@@ -1,0 +1,25 @@
+export default function SkipLinks() {
+  return (
+    <>
+      <a
+        href="#desktop"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+      >
+        Skip to desktop
+      </a>
+      <a
+        href="#app-grid"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+      >
+        Skip to app grid
+      </a>
+      <a
+        href="#dock"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+      >
+        Skip to dock
+      </a>
+    </>
+  );
+}
+

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1049,7 +1049,7 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="desktop" tabIndex={-1} role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
                 <div

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -40,6 +40,8 @@ export default function SideBar(props) {
     return (
         <>
             <nav
+                id="dock"
+                tabIndex={-1}
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen flex flex-col justify-start items-center pt-7 border-black border-opacity-60"}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -18,6 +18,7 @@ import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import SkipLinks from '../components/SkipLinks';
 
 
 let SpeedInsights = () => null;
@@ -221,12 +222,7 @@ function MyApp(props) {
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
+        <SkipLinks />
         <SettingsProvider>
           <TrayProvider>
             <PipPortalProvider>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -33,9 +33,6 @@ const App = () => {
   const { session, setSession, resetSession } = useSession();
   return (
     <>
-      <a href="#window-area" className="sr-only focus:not-sr-only">
-        Skip to content
-      </a>
       <Meta />
       <Ubuntu
         session={session}


### PR DESCRIPTION
## Summary
- add reusable SkipLinks component with desktop, app grid, and dock links
- focusable nav and desktop regions for skip link targets
- test ensures first Tab focuses the skip link

## Testing
- `yarn eslint pages/_app.jsx pages/index.jsx components/screen/side_bar.js components/screen/desktop.js components/SkipLinks.jsx __tests__/skip-links.test.tsx`
- `yarn test __tests__/skip-links.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdcaa60cc083288661119ca86c0fdf