### PR TITLE
feat: forward web vitals to analytics

### DIFF
--- a/__tests__/reportWebVitals.test.ts
+++ b/__tests__/reportWebVitals.test.ts
@@ -1,20 +1,27 @@
 import ReactGA from 'react-ga4';
+import { track } from '@vercel/analytics';
 import { reportWebVitals } from '../utils/reportWebVitals';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
 }));
 
+jest.mock('@vercel/analytics', () => ({
+  track: jest.fn(),
+}));
+
 describe('reportWebVitals', () => {
   const mockEvent = ReactGA.event as jest.Mock;
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const mockTrack = track as jest.Mock;
   const originalEnv = process.env;
 
   beforeEach(() => {
     mockEvent.mockReset();
     warnSpy.mockClear();
     logSpy.mockClear();
+    mockTrack.mockReset();
     process.env = { ...originalEnv };
   });
 
@@ -29,6 +36,7 @@ describe('reportWebVitals', () => {
     reportWebVitals({ id: '1', name: 'LCP', value: 3000 });
     expect(mockEvent).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 
   it('records LCP metric in preview', () => {
@@ -40,6 +48,7 @@ describe('reportWebVitals', () => {
     );
     expect(warnSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 
   it('alerts when INP exceeds threshold', () => {
@@ -52,6 +61,11 @@ describe('reportWebVitals', () => {
     );
     expect(warnSpy).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('web-vitals-alert', {
+      name: 'INP',
+      id: '3',
+      value: 300,
+    });
   });
 
   it('records TTI metric in preview', () => {
@@ -62,6 +76,7 @@ describe('reportWebVitals', () => {
     );
     expect(warnSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 
   it('alerts when TTI exceeds threshold', () => {
@@ -74,6 +89,11 @@ describe('reportWebVitals', () => {
     );
     expect(warnSpy).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('web-vitals-alert', {
+      name: 'TTI',
+      id: '5',
+      value: 6000,
+    });
   });
 
   it('logs TTFB and CLS metrics', () => {
@@ -81,5 +101,6 @@ describe('reportWebVitals', () => {
     reportWebVitals({ id: '6', name: 'TTFB', value: 100 });
     reportWebVitals({ id: '7', name: 'CLS', value: 0.2 });
     expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/useReportWebVitals.test.ts
+++ b/__tests__/useReportWebVitals.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react';
+import { track } from '@vercel/analytics';
+import { reportWebVitals } from '@/utils/reportWebVitals';
+import useReportWebVitals from '@/hooks/useReportWebVitals';
+import { useReportWebVitals as nextUseReportWebVitals } from 'next/web-vitals';
+
+jest.mock('next/web-vitals', () => ({
+  useReportWebVitals: jest.fn(),
+}));
+
+jest.mock('@vercel/analytics', () => ({
+  track: jest.fn(),
+}));
+
+jest.mock('@/utils/reportWebVitals', () => ({
+  reportWebVitals: jest.fn(),
+}));
+
+describe('useReportWebVitals', () => {
+  it('forwards metrics to analytics services', () => {
+    const metric = { id: '1', name: 'LCP', value: 123 } as any;
+    (nextUseReportWebVitals as jest.Mock).mockImplementation((cb: any) => cb(metric));
+
+    renderHook(() => useReportWebVitals());
+
+    expect(track).toHaveBeenCalledWith('LCP', { id: '1', value: 123 });
+    expect(reportWebVitals).toHaveBeenCalledWith(metric);
+  });
+});

--- a/hooks/useReportWebVitals.ts
+++ b/hooks/useReportWebVitals.ts
@@ -1,0 +1,15 @@
+import { track } from '@vercel/analytics';
+import { useReportWebVitals as useNextReportWebVitals } from 'next/web-vitals';
+import { reportWebVitals } from '@/utils/reportWebVitals';
+
+const vitals = new Set(['LCP', 'CLS', 'INP']);
+
+export default function useReportWebVitals(): void {
+  useNextReportWebVitals((metric) => {
+    const { id, name, value } = metric;
+    if (vitals.has(name)) {
+      track(name, { id, value });
+    }
+    reportWebVitals({ id, name, value });
+  });
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -18,6 +18,7 @@ import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import useReportWebVitals from '../hooks/useReportWebVitals';
 
 
 let SpeedInsights = () => null;
@@ -31,6 +32,8 @@ if (process.env.NODE_ENV === 'production') {
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+
+  useReportWebVitals();
 
   useEffect(() => {
     void import('@xterm/xterm/css/xterm.css');

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga4';
+import { track } from '@vercel/analytics';
 import logger from './logger';
 
 interface WebVitalMetric {
@@ -39,6 +40,7 @@ export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
       label: id,
       value: rounded,
     });
+    track('web-vitals-alert', { name, id, value: rounded });
     if (typeof console !== 'undefined') {
       console.warn(`Web Vitals alert: ${name} ${rounded}`);
     }


### PR DESCRIPTION
## Summary
- add `useReportWebVitals` hook to forward LCP, CLS, INP to Vercel Analytics and GA4
- track web vitals alerts when thresholds are exceeded
- integrate the hook in the Next.js app and add tests

## Testing
- `yarn lint` *(fails: A control must be associated with a text label; Unused eslint-disable directive)*
- `yarn test` *(fails: game2048.component.test.tsx, csp.test.ts, contact.api.test.ts, contactRateLimit.test.ts, remotePatterns.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaabcf1c8328b58f31b485ac965b