### PR TITLE
Configure long-term caching for static images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -221,7 +221,7 @@ module.exports = withBundleAnalyzer(
                 headers: [
                   {
                     key: 'Cache-Control',
-                    value: 'public, max-age=86400, immutable',
+                    value: 'public, max-age=31536000, immutable',
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
- set one-year immutable caching on public images

## Testing
- `yarn lint` *(fails: A control must be associated with a text label; etc.)*
- `yarn build` *(fails: next/font error, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcaac0bf483289eed816616043af9