### PR TITLE
Add offline fallback caching for core assets

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -11,10 +11,6 @@
     <h1>Offline</h1>
     <p>You appear to be offline. Please check your connection.</p>
     <button id="retry">Retry</button>
-    <section>
-      <h2>Recent Apps</h2>
-      <ul id="apps"></ul>
-    </section>
   </main>
   <script src="/offline.js" defer></script>
 </body>

--- a/public/offline.js
+++ b/public/offline.js
@@ -2,35 +2,3 @@
 document.getElementById('retry').addEventListener('click', () => {
   window.location.reload();
 });
-
-(async () => {
-  const list = document.getElementById('apps');
-  try {
-    const names = await caches.keys();
-    const urls = new Set();
-    for (const name of names) {
-      const cache = await caches.open(name);
-      const keys = await cache.keys();
-      for (const request of keys) {
-        const url = new URL(request.url);
-        if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
-          urls.add(url.pathname);
-        }
-      }
-    }
-    if (urls.size === 0) {
-      list.innerHTML = '<li>No recent apps available.</li>';
-    } else {
-      urls.forEach((path) => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = path;
-        a.textContent = path.replace('/apps/', '');
-        li.appendChild(a);
-        list.appendChild(li);
-      });
-    }
-  } catch (err) {
-    list.innerHTML = '<li>Unable to access recent apps.</li>';
-  }
-})();

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,6 +12,8 @@ const ASSETS = [
   "/apps/terminal",
   "/apps/checkers",
   "/offline.html",
+  "/offline.css",
+  "/offline.js",
   "/manifest.webmanifest",
 ];
 


### PR DESCRIPTION
## Summary
- streamline `offline.html` and `offline.js` for a minimal offline message
- pre-cache offline assets in the service worker to keep core pages available

## Testing
- `yarn test` *(fails: nmapNSE, contact API, asciiArt, remotePatterns, contactRateLimit, appImport, game2048, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcab0d1b48328a691a67372d01c2c