### PR TITLE
feat: add person and organization structured data

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -56,9 +56,27 @@ export default function Meta() {
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify({
                         "@context": "https://schema.org",
-                        "@type": "Person",
-                        name: "Alex Unnippillil",
-                        url: "https://unnippillil.com/",
+                        "@graph": [
+                            {
+                                "@type": "Person",
+                                "@id": "https://unnippillil.com/#person",
+                                name: "Alex Unnippillil",
+                                url: "https://unnippillil.com/",
+                                image: "https://unnippillil.com/images/logos/logo_1024.png",
+                                sameAs: [
+                                    "https://github.com/unnippillil",
+                                    "https://www.linkedin.com/in/alex-unnippillil",
+                                ],
+                            },
+                            {
+                                "@type": "Organization",
+                                "@id": "https://unnippillil.com/#organization",
+                                name: "Alex Unnippillil",
+                                url: "https://unnippillil.com/",
+                                logo: "https://unnippillil.com/images/logos/logo_1200.png",
+                                founder: { "@id": "https://unnippillil.com/#person" },
+                            },
+                        ],
                     }),
                 }}
             />


### PR DESCRIPTION
## Summary
- include Person and Organization JSON-LD in Meta head

## Testing
- `npx eslint components/SEO/Meta.js -f json`
- `npx jest components/SEO/Meta.js` *(no tests found)*
- `curl -X POST -H 'Content-Type: application/json' -d '{"url":"https://example.com"}' https://searchconsole.googleapis.com/v1/urlTestingTools/richResults:run` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcab1e58c8328b93ee4c49f9d52f6