### PR TITLE
feat: add i18n routing and hreflang

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -159,6 +159,10 @@ module.exports = withBundleAnalyzer(
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],
     },
+    i18n: {
+      locales: ['en', 'es'],
+      defaultLocale: 'en',
+    },
     async rewrites() {
       return [
         {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,6 +6,8 @@ import { isBrowser } from '@/utils/env';
 import { useEffect } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -31,6 +33,8 @@ if (process.env.NODE_ENV === 'production') {
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+  const { asPath, locales, defaultLocale } = useRouter();
+  const path = asPath.split('?')[0];
 
   useEffect(() => {
     void import('@xterm/xterm/css/xterm.css');
@@ -218,42 +222,49 @@ function MyApp(props) {
   }, []);
 
   return (
-    <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <TrayProvider>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              {process.env.VERCEL_ANALYTICS_ID && (
-                <>
-                  <Analytics
-                    beforeSend={(e) => {
-                      if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                      const evt = e;
-                      if (evt.metadata?.email) delete evt.metadata.email;
-                      return e;
-                    }}
-                  />
+    <>
+      <Head>
+        {locales?.map((l) => {
+          const href = l === defaultLocale ? path : `/${l}${path === '/' ? '' : path}`;
+          return <link key={l} rel="alternate" hrefLang={l} href={href} />;
+        })}
+        <link rel="alternate" hrefLang="x-default" href={path} />
+      </Head>
+      <ErrorBoundary>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <TrayProvider>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                {process.env.VERCEL_ANALYTICS_ID && (
+                  <>
+                    <Analytics
+                      beforeSend={(e) => {
+                        if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                        const evt = e;
+                        if (evt.metadata?.email) delete evt.metadata.email;
+                        return e;
+                      }}
+                    />
 
-                  <SpeedInsights />
-                </>
-              )}
-            </PipPortalProvider>
-          </TrayProvider>
-        </SettingsProvider>
-      </div>
-    </ErrorBoundary>
-
-
+                    <SpeedInsights />
+                  </>
+                )}
+              </PipPortalProvider>
+            </TrayProvider>
+          </SettingsProvider>
+        </div>
+      </ErrorBoundary>
+    </>
   );
 }
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -27,7 +27,7 @@ class MyDocument extends Document<Props> {
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html lang={this.props.locale || 'en'} data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary
- configure Next.js built-in i18n with English and Spanish locales
- inject alternate hreflang links and dynamic HTML language attributes
- redirect non-localized paths to locale-prefixed versions

## Testing
- `npx eslint pages/_app.jsx pages/_document.tsx middleware.ts next.config.js`
- `yarn test` *(fails: unable to find element 'Moves: 2', missing allowlist entries, missingRecaptcha, etc.)*
- `yarn lint middleware.ts next.config.js pages/_app.jsx pages/_document.tsx` *(fails: numerous jsx-a11y control-has-associated-label errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcab337908328a2247234a99940d6