### PR TITLE
feat: enforce HSTS policy for all responses

### DIFF
--- a/__tests__/hsts.test.ts
+++ b/__tests__/hsts.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+
+jest.mock('next/server', () => ({
+  NextResponse: { next: () => ({ headers: new Headers() }) },
+}));
+
+jest.mock('@ducanh2912/next-pwa', () => ({
+  __esModule: true,
+  default: () => (config: any) => config,
+}));
+
+jest.mock('@next/bundle-analyzer', () => () => (config: any) => config);
+
+describe('Strict-Transport-Security header', () => {
+  it('is set by middleware', () => {
+    const { middleware } = require('../middleware');
+    const req = { headers: new Headers({ accept: 'text/html' }) } as any;
+    const res = middleware(req);
+    expect(res.headers.get('Strict-Transport-Security')).toBe(
+      'max-age=31536000; includeSubDomains'
+    );
+  });
+
+  it('is included in next.config headers', async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    jest.resetModules();
+    const config = require('../next.config.js');
+    const headers = await config.headers();
+    process.env.NODE_ENV = prev;
+
+    const hasHsts = headers.some(({ headers }: any) =>
+      headers.some(
+        (h: any) =>
+          h.key === 'Strict-Transport-Security' &&
+          h.value === 'max-age=31536000; includeSubDomains'
+      )
+    );
+    expect(hasHsts).toBe(true);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,6 +34,7 @@ export function middleware(req: NextRequest) {
   });
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   if (req.headers.get('accept')?.includes('text/html')) {
     res.headers.set('X-Content-Type-Options', 'nosniff');
   }

--- a/next.config.js
+++ b/next.config.js
@@ -62,6 +62,10 @@ const securityHeaders = [
     key: 'X-Frame-Options',
     value: 'SAMEORIGIN',
   },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains',
+  },
 ];
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({


### PR DESCRIPTION
## Summary
- add Strict-Transport-Security header to global security headers
- set HSTS policy in middleware
- test middleware and config for HSTS header

## Testing
- `npm test hsts.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdcab46e748328ae07ce30caf16bb4