### PR TITLE
Add legal notice clarifying unofficial status

### DIFF
--- a/components/welcome/KaliWelcome.tsx
+++ b/components/welcome/KaliWelcome.tsx
@@ -37,7 +37,9 @@ export default function KaliWelcome() {
           {step === 0 && (
             <div>
               <h2 className="text-xl mb-4">About Kali</h2>
-              <p className="mb-4">Welcome to Kali Linux Portfolio.</p>
+              <p className="mb-4">
+                Welcome to Kali Linux Portfolio—an unofficial project not affiliated with Kali Linux or Offensive Security.
+              </p>
               <div className="flex gap-2 mb-4">
                 <button
                   type="button"

--- a/pages/legal.tsx
+++ b/pages/legal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const LegalPage: React.FC = () => (
+  <div className="p-8 max-w-3xl mx-auto">
+    <h1 className="text-2xl font-bold mb-6">Legal Notice</h1>
+    <p className="mb-4">
+      This portfolio is an independent project and is not affiliated with or endorsed by Kali Linux, Offensive Security, or any of their subsidiaries.
+    </p>
+    <p>
+      Kali Linux is a registered trademark of Offensive Security. For information on proper use of the Kali trademarks, please see the{' '}
+      <a
+        href="https://www.kali.org/trademark-policy/"
+        className="text-blue-500 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Kali Linux trademark policy
+      </a>.
+    </p>
+  </div>
+);
+
+export default LegalPage;


### PR DESCRIPTION
## Summary
- add Legal page with unofficial project disclaimer and Kali trademark policy link
- update welcome modal to clarify project is unofficial

## Testing
- `npx eslint pages/legal.tsx components/welcome/KaliWelcome.tsx`
- `yarn tsc --noEmit` *(fails: Module './main' declares 'evaluate' locally, but it is not exported, etc.)*
- `yarn test pages/legal.tsx components/welcome/KaliWelcome.tsx` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcab69f0c832895b93d14aa6eb3b2