### PR TITLE
ci: verify security headers on preview deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,11 @@ validate-apps:
       - run: yarn install --immutable --immutable-cache
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: |
+          url=$(npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --json | jq -r '.url')
+          echo "preview_url=https://$url" >> "$GITHUB_OUTPUT"
+      - run: node scripts/check-security-headers.mjs ${{ steps.deploy.outputs.preview_url }}
 
   export:
     runs-on: ubuntu-latest

--- a/scripts/check-security-headers.mjs
+++ b/scripts/check-security-headers.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const url = process.argv[2];
+if (!url) {
+  console.error('Usage: node scripts/check-security-headers.mjs <url>');
+  process.exit(1);
+}
+
+const res = await fetch(url, { headers: { Accept: 'text/html' } });
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+const csp = res.headers.get('content-security-policy');
+if (!csp || !csp.includes("default-src 'self'")) {
+  fail(`Invalid Content-Security-Policy: ${csp}`);
+}
+
+const hsts = res.headers.get('strict-transport-security');
+if (!hsts || !/max-age=\d+/.test(hsts)) {
+  fail(`Invalid Strict-Transport-Security: ${hsts}`);
+}
+
+const xcto = res.headers.get('x-content-type-options');
+if (xcto !== 'nosniff') {
+  fail(`Invalid X-Content-Type-Options: ${xcto}`);
+}
+
+const referrer = res.headers.get('referrer-policy');
+if (referrer !== 'strict-origin-when-cross-origin') {
+  fail(`Invalid Referrer-Policy: ${referrer}`);
+}
+
+console.log('Security headers validated');


### PR DESCRIPTION
## Summary
- check Vercel preview deployment for Content-Security-Policy, HSTS, X-Content-Type-Options, and Referrer-Policy headers
- fail CI if required security headers are missing or incorrect

## Testing
- `npx eslint scripts/check-security-headers.mjs`
- `yarn test __tests__/reportWebVitals.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdcab72d288328a368871e626fb7c3