### PR TITLE
chore: tighten permissions policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Defined in `next.config.js`. See [CSP External Domains](#csp-external-domains) f
 - **Content-Security-Policy (CSP)** (string built from `ContentSecurityPolicy[]`; see [CSP External Domains](#csp-external-domains))
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`
-- `Permissions-Policy: camera=(), microphone=(), geolocation=*, interest-cohort=()`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()`
 - `X-Frame-Options: SAMEORIGIN`
 
 ### CSP External Domains

--- a/__tests__/security-headers.test.ts
+++ b/__tests__/security-headers.test.ts
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+
+describe('security headers', () => {
+  it('disables camera, microphone, geolocation and sets referrer policy', async () => {
+    process.env.NODE_ENV = 'production';
+    jest.resetModules();
+    const config = require('../next.config.js');
+    const headersList = await config.headers();
+    const headerMap = Object.fromEntries(headersList.find((h: any) => h.source === '/(.*)').headers.map((h: any) => [h.key, h.value]));
+    expect(headerMap['Permissions-Policy']).toBe('camera=(), microphone=(), geolocation=(), interest-cohort=()');
+    expect(headerMap['Referrer-Policy']).toBe('strict-origin-when-cross-origin');
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,7 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=*, interest-cohort=()',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
   },
   {
     // Allow same-origin framing so the PDF resume renders in an <object>


### PR DESCRIPTION
## Summary
- restrict geolocation in the `Permissions-Policy`
- document updated policy
- test for expected `Permissions-Policy` and `Referrer-Policy` headers

## Testing
- `yarn test __tests__/security-headers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bdcab665f4832894d333cd353362ce