### PR TITLE
test: add e2e coverage for desktop features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,13 @@ jobs:
       - run: |
           yarn dev &
           npx wait-on http://localhost:3000
-      - run: npx playwright test tests/e2e
+      - run: npx playwright test tests/e2e --trace on
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-traces
+          path: test-results/**/*.zip
+          if-no-files-found: ignore
 
   pa11y:
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
   testMatch: /.*\.spec\.(ts|tsx)/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    headless: true,
+    trace: process.env.CI ? 'on' : 'retain-on-failure',
   },
 });

--- a/tests/e2e/app-launch.spec.ts
+++ b/tests/e2e/app-launch.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+// Verify a desktop application opens from the applications grid.
+test('launches terminal app from application grid', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', err => consoleErrors.push(err.message));
+
+  await page.goto('/');
+  await page.locator('nav [aria-label="Show Applications"]').click();
+  await page.locator('#app-terminal').click();
+
+  const windowLocator = page.locator('[data-app-id="terminal"]');
+  await expect(windowLocator).toBeVisible();
+
+  expect(consoleErrors, `Console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+});

--- a/tests/e2e/keyboard-nav.spec.ts
+++ b/tests/e2e/keyboard-nav.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Validate basic keyboard navigation inside a window.
+test('tab moves focus to window controls and back', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('nav [aria-label="Show Applications"]').click();
+  await page.locator('#app-terminal').click();
+
+  const win = page.locator('[data-app-id="terminal"]');
+  await win.focus();
+
+  await page.keyboard.press('Tab');
+  const closeBtn = page.getByLabel('Window close');
+  await expect(closeBtn).toBeFocused();
+
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Tab');
+  await page.keyboard.up('Shift');
+  await expect(win).toBeFocused();
+});

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+// Confirm the home page can be loaded while offline after the service worker is ready.
+test('serves home page offline', async ({ page }) => {
+  const swPath = path.join(process.cwd(), 'public', 'sw.js');
+  await page.route('**/service-worker.js', route =>
+    route.fulfill({ path: swPath, contentType: 'application/javascript' })
+  );
+
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.register('/service-worker.js');
+    await navigator.serviceWorker.ready;
+  });
+
+  await page.context().setOffline(true);
+  const response = await page.reload();
+  expect(response?.status()).toBe(200);
+  await expect(page.locator('nav [aria-label="Show Applications"]')).toBeVisible();
+});

--- a/tests/e2e/window-snap.spec.ts
+++ b/tests/e2e/window-snap.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure window snapping via keyboard works and can be undone.
+test.describe('window snapping', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.locator('nav [aria-label="Show Applications"]').click();
+    await page.locator('#app-terminal').click();
+    await page.locator('[data-app-id="terminal"]').focus();
+  });
+
+  test('snap left and restore with Alt+ArrowDown', async ({ page }) => {
+    const win = page.locator('[data-app-id="terminal"]');
+
+    await page.keyboard.down('Alt');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.up('Alt');
+
+    const snapped = await win.getAttribute('style');
+    expect(snapped).toContain('left: 0');
+    expect(snapped).toContain('width: 50%');
+
+    await page.keyboard.down('Alt');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.up('Alt');
+
+    const restored = await win.getAttribute('style');
+    expect(restored).not.toContain('width: 50%');
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests for app launch, window snapping, keyboard navigation and offline support
- run Playwright headless with traces in CI and upload trace artifacts
- always record traces in Playwright config

## Testing
- `npx wait-on http://localhost:3000` *(fails: TypeError: The "to" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcab7919c832892da0f3c08caeccd