### PR TITLE
fix: include link type for chrome-version package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,11 +3407,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testim/chrome-version@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@testim/chrome-version@npm:1.1.4"
-  checksum: 10c0/b784ea29af42266625684c8a89593edeb6933ebcfe1bdc2d30ff305e2496928e9d5803d94704c95e45c90bba6e4cdc65ca43f13f8e4b3a268249b2f4d3f71f96
-
 "@tailwindcss/typography@npm:^0.5.16":
   version: 0.5.16
   resolution: "@tailwindcss/typography@npm:0.5.16"
@@ -3423,7 +3418,13 @@ __metadata:
   peerDependencies:
     tailwindcss: "*"
   checksum: 10c0/35a7387876810c23c270a23848b920517229b707c8ead6a63c8bb7d6720a62f23728c3117f0a93b422a66d1e5ee9c7ad8a6c3f0fbf5255b535c0e4971ffa0158
+  languageName: node
+  linkType: hard
 
+"@testim/chrome-version@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@testim/chrome-version@npm:1.1.4"
+  checksum: 10c0/b784ea29af42266625684c8a89593edeb6933ebcfe1bdc2d30ff305e2496928e9d5803d94704c95e45c90bba6e4cdc65ca43f13f8e4b3a268249b2f4d3f71f96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- specify `languageName` and `linkType` for `@testim/chrome-version` in `yarn.lock`

## Testing
- `yarn install`
- `yarn test` *(fails: ReferenceError: missingRecaptcha is not defined, Missing remotePatterns for various hosts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be18c6cff08328bbf3ec2040611352