### PR TITLE
Load env defaults

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,14 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
+// Ensure environment variables are loaded even when a local file is absent.
+// This falls back to the example file so builds don't fail due to missing
+// secrets during development or in CI.
+try {
+  require('dotenv').config({ path: '.env.local' });
+  require('dotenv').config({ path: '.env.local.example', override: false });
+} catch {}
+
 let validateEnv = null;
 try {
   ({ validateServerEnv: validateEnv } = require('./lib/validate'));

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "decimal.js": "^10.4.3",
     "diff": "^8",
     "dompurify": "^3.2.6",
+    "dotenv": "^16.4.5",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
     "flags": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14776,6 +14776,7 @@ __metadata:
     decimal.js: "npm:^10.4.3"
     diff: "npm:^8"
     dompurify: "npm:^3.2.6"
+    dotenv: "npm:^16.4.5"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:15.5.2"
     fake-indexeddb: "npm:^6.1.0"


### PR DESCRIPTION
## Summary
- load environment variables from `.env.local` with `.env.local.example` as fallback
- add `dotenv` dependency for env file support

## Testing
- `yarn run build` *(fails: Module not found: Can't resolve 'fs', 'node:path', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68be1de03424832882211ad295b54937