### PR TITLE
chore: use npm three-bmfont-text

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "test-exclude": "7.0.1",
     "webpack": "^5.92.0",
     "glob@npm:^7.1.6": "npm:glob@^9.3.5",
-    "workbox-build@npm:7.1.0": "npm:workbox-build@7.1.1"
+    "workbox-build@npm:7.1.0": "npm:workbox-build@7.1.1",
+    "three-bmfont-text": "npm:three-bmfont-text@^3.0.1"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8722,7 +8722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:~2.0.3":
+"inherits@npm:^2.0.1, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -14183,15 +14183,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three-bmfont-text@github:dmarcos/three-bmfont-text#eed4878795be9b3e38cf6aec6b903f56acd1f695":
-  version: 3.0.0
-  resolution: "three-bmfont-text@https://github.com/dmarcos/three-bmfont-text.git#commit=eed4878795be9b3e38cf6aec6b903f56acd1f695"
+"three-bmfont-text@npm:three-bmfont-text@^3.0.1":
+  version: 3.0.1
+  resolution: "three-bmfont-text@npm:3.0.1"
   dependencies:
     array-shuffle: "npm:^1.0.1"
+    inherits: "npm:^2.0.1"
     layout-bmfont-text: "npm:^1.2.0"
     nice-color-palettes: "npm:^3.0.0"
+    object-assign: "npm:^4.0.1"
     quad-indices: "npm:^2.0.1"
-  checksum: 10c0/1364e859ab88baf64fb54ccc6048ab970b3dc8467ee425769bf7a2fcade373bb4465d288271b0bdbf434c3f0fe843f1ba72c14358d13d3d5166a8b5d5ece0c99
+  checksum: 10c0/69dd96ea7716ccc11e787a455f9e823fab420f299a6fad0acf0c4b0b194c7909895df6fe7be88174fd329ce961c5dba182bc2aebfa46ddf5f854121c7dff3a65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- resolve `three-bmfont-text` from the npm registry instead of a GitHub commit to drop deprecated dependency warnings

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: nmapNse.test.tsx, contact.api.test.ts, remotePatterns.test.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be2128830c8328b5c06ff4bb2ce08f