### PR TITLE
chore: remove unsupported i18n config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -168,10 +168,6 @@ module.exports = withBundleAnalyzer(
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],
     },
-    i18n: {
-      locales: ['en', 'es'],
-      defaultLocale: 'en',
-    },
     async rewrites() {
       return [
         {


### PR DESCRIPTION
## Summary
- remove legacy i18n configuration not supported by Next.js App Router

## Testing
- `npx eslint next.config.js`
- `yarn test next.config --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be22adaba883288796681f56a65bd0