### PR TITLE
fix contact env checks and middleware request handling

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -13,6 +13,7 @@ export default async function handler(req, res) {
   const missingSupabase =
     !process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY;
   const missingRateLimit = !process.env.RATE_LIMIT_SECRET;
+  const missingRecaptcha = missingRecaptchaSecret || missingRecaptchaSiteKey;
 
   if (missingRecaptcha || missingSupabase || missingRateLimit) {
 


### PR DESCRIPTION
## Summary
- avoid undefined missingRecaptcha variable in contact API
- handle Next.js middleware when request lacks nextUrl to prevent crashes

## Testing
- `yarn test __tests__/contact.api.test.ts __tests__/contactRateLimit.test.ts __tests__/hsts.test.ts __tests__/nosniff.test.ts`
- `yarn tsc` *(fails: 59 errors in 28 files)*

------
https://chatgpt.com/codex/tasks/task_e_68be22a0779c83289c7a443fe3fd8d88