### PR TITLE
Fix Next.js build by excluding non-JS app files and removing Node deps

### DIFF
--- a/src/lib/exo-open.ts
+++ b/src/lib/exo-open.ts
@@ -1,7 +1,3 @@
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-
 export type HelperType = 'TerminalEmulator' | 'WebBrowser' | 'FileManager';
 
 const DEFAULT_APPS: Record<HelperType, string> = {
@@ -10,37 +6,25 @@ const DEFAULT_APPS: Record<HelperType, string> = {
   FileManager: 'file-explorer',
 };
 
-const rcPath = path.join(os.homedir(), '.config', 'xfce4', 'helpers.rc');
+const STORAGE_KEY = 'xfce-helpers';
 
-async function readRc(): Promise<Record<string, string>> {
+function readRc(): Record<string, string> {
+  if (typeof localStorage === 'undefined') return {};
   try {
-    const data = await fs.readFile(rcPath, 'utf-8');
-    const lines = data.split(/\r?\n/);
-    const map: Record<string, string> = {};
-    for (const line of lines) {
-      const m = /^([^=]+)=(.*)$/.exec(line.trim());
-      if (m) {
-        map[m[1]] = m[2];
-      }
-    }
-    return map;
-  } catch (err: any) {
-    if (err && err.code === 'ENOENT') return {};
-    throw err;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
   }
 }
 
-async function writeRc(data: Record<string, string>): Promise<void> {
-  const dir = path.dirname(rcPath);
-  await fs.mkdir(dir, { recursive: true });
-  const content = Object.entries(data)
-    .map(([k, v]) => `${k}=${v}`)
-    .join('\n');
-  await fs.writeFile(rcPath, content + '\n', 'utf-8');
+function writeRc(data: Record<string, string>): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
 
 export async function getPreferredApp(type: HelperType): Promise<string> {
-  const rc = await readRc();
+  const rc = readRc();
   return rc[type] || DEFAULT_APPS[type];
 }
 
@@ -48,9 +32,9 @@ export async function setPreferredApp(
   type: HelperType,
   appId: string,
 ): Promise<void> {
-  const rc = await readRc();
+  const rc = readRc();
   rc[type] = appId;
-  await writeRc(rc);
+  writeRc(rc);
 }
 
 export async function exoOpen(

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -12,17 +12,26 @@ export const createDynamicApp = (id, title) => {
         let mod;
         try {
           mod = await import(
-            /* webpackChunkName: "[request]", webpackPrefetch: true */ `${APP_DIR}/${id}`
+            /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
+               webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
+               webpackChunkName: "[request]",
+               webpackPrefetch: true */ `../apps/${id}`
           );
         } catch {
           try {
             mod = await import(
-              /* webpackChunkName: "[request]", webpackPrefetch: true */ `${APP_DIR}/${id}/index`
+              /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
+                 webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
+                 webpackChunkName: "[request]",
+                 webpackPrefetch: true */ `../apps/${id}/index`
             );
           } catch {
             try {
               mod = await import(
-                /* webpackChunkName: "[request]", webpackPrefetch: true */ `${APP_DIR}/${id.replace('_', '-')}`
+                /* webpackInclude: /\.(js|jsx|ts|tsx)$/,
+                   webpackExclude: /\.test\.(js|jsx|ts|tsx)$/,
+                   webpackChunkName: "[request]",
+                   webpackPrefetch: true */ `../apps/${id.replace('_', '-')}`
               );
             } catch {
               console.warn(
@@ -35,24 +44,24 @@ export const createDynamicApp = (id, title) => {
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;
       } catch (err) {
-        console.error(`Failed to load ${title}`, err);
-        const Fallback = () => {
-          const handleRetry = () => window.location.reload();
-          return (
-            <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
-              <p className="mb-2">{`Unable to load ${title}.`}</p>
-              <button
-                type="button"
-                onClick={handleRetry}
-                className="px-3 py-1 bg-ub-orange text-black rounded"
-              >
-                Retry
-              </button>
-            </div>
-          );
-        };
-        Fallback.displayName = 'DynamicAppError';
-        return Fallback;
+          console.error(`Failed to load ${title}`, err);
+          const Fallback = () => {
+            const handleRetry = () => window.location.reload();
+            return (
+              <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
+                <p className="mb-2">{`Unable to load ${title}.`}</p>
+                <button
+                  type="button"
+                  onClick={handleRetry}
+                  className="px-3 py-1 bg-ub-orange text-black rounded"
+                >
+                  Retry
+                </button>
+              </div>
+            );
+          };
+          Fallback.displayName = 'DynamicAppError';
+          return Fallback;
       }
     },
     {


### PR DESCRIPTION
## Summary
- avoid Node.js modules in `exo-open` by using browser storage
- restrict dynamic app imports to JavaScript/TypeScript files and ignore tests

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68be267a8240832896e3ac5e133c686e