### PR TITLE
Enable PWA during production builds and sync TS config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -88,7 +88,9 @@ const precacheManifest = require('./precache-manifest.json');
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'service-worker.js',
-  disable: process.env.VERCEL_ENV !== 'production',
+  // Enable the service worker for all production builds, even when not on Vercel.
+  // This avoids the "PWA support is disabled" message in local builds.
+  disable: process.env.NODE_ENV !== 'production',
   buildExcludes: [/dynamic-css-manifest\.json$/],
     fallbacks: {
       'document': '/offline.html',
@@ -143,9 +145,9 @@ module.exports = withBundleAnalyzer(
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
 
-    // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
+    // Run ESLint during builds so linting problems surface in CI and local builds.
     eslint: {
-      ignoreDuringBuilds: true,
+      ignoreDuringBuilds: false,
     },
     images: {
       unoptimized: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    // Next.js handles the JSX transform internally; preserve JSX for its compiler
+    "jsx": "preserve",
     "incremental": true,
     "types": [],
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- Enable service worker when building for production and run ESLint during builds
- Set `jsx` to `preserve` so Next.js no longer rewrites `tsconfig.json`

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `NEXT_DISABLE_ESLINT=1 yarn build` *(fails: Module "./main" declares 'evaluate' locally, but it is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_68be2a33e5708328987de5783e605feb