### PR TITLE
fix: export calculator evaluate

### DIFF
--- a/apps/calculator/main.js
+++ b/apps/calculator/main.js
@@ -293,7 +293,7 @@ function getLastResult() {
   return lastResult;
 }
 
-module.exports = {
+export {
   tokenize,
   toRPN,
   evalRPN,


### PR DESCRIPTION
## Summary
- export calculator helpers with ES module syntax

## Testing
- `npx eslint apps/calculator/main.js apps/calculator/formulas.ts`
- `yarn test apps/calculator --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be2a5b28908328874c3439f34e8f2c