### PR TITLE
Fix evaluate import in calculator formulas

### DIFF
--- a/apps/calculator/formulas.ts
+++ b/apps/calculator/formulas.ts
@@ -1,5 +1,5 @@
 import usePersistentState from '../../hooks/usePersistentState';
-import { evaluate } from './main';
+import { evaluate } from './utils/parser';
 
 export interface Formula {
   name: string;


### PR DESCRIPTION
## Summary
- fix formulas module to import evaluate from parser

## Testing
- `yarn eslint apps/calculator/formulas.ts`
- `yarn tsc --noEmit apps/calculator/formulas.ts` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68be3a1f78a48328ab219c84981ced73