### PR TITLE
refactor: update xterm theme API

### DIFF
--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -240,11 +240,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
     if (!termRef.current || !containerRef.current) return;
     const preset = THEME_PRESETS[scheme as keyof typeof THEME_PRESETS];
     const bg = hexToRgba(preset.background, opacity);
-    termRef.current.setOption?.('theme', {
+    termRef.current.options.theme = {
       background: bg,
       foreground: preset.foreground,
       cursor: preset.foreground,
-    });
+    };
     containerRef.current.style.backgroundColor = bg;
     containerRef.current.style.color = preset.foreground;
   }, [scheme, opacity]);
@@ -418,11 +418,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(
       container?.addEventListener('contextmenu', handleLinkContext);
       const preset = THEME_PRESETS[scheme as keyof typeof THEME_PRESETS];
       const bg = hexToRgba(preset.background, opacity);
-      term.setOption?.('theme', {
+      term.options.theme = {
         background: bg,
         foreground: preset.foreground,
         cursor: preset.foreground,
-      });
+      };
       container.style.backgroundColor = bg;
       container.style.color = preset.foreground;
       if (opfsSupported) {


### PR DESCRIPTION
## Summary
- update terminal theme handling for xterm v5 API

## Testing
- `npx eslint apps/terminal/index.tsx`
- `yarn test apps/terminal --passWithNoTests`
- `yarn typecheck` *(fails: Property 'setThumbLimit' does not exist on type 'Window'...)*

------
https://chatgpt.com/codex/tasks/task_e_68be412453f48328a17158ce1d592105