### PR TITLE
chore: enforce type safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20.x
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn typecheck
 
   test:
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ validate-apps:
 
   vercel-preview:
     runs-on: ubuntu-latest
-    needs: install
+    needs: [install, typecheck]
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/next.config.js
+++ b/next.config.js
@@ -147,6 +147,9 @@ module.exports = withBundleAnalyzer(
     eslint: {
       ignoreDuringBuilds: true,
     },
+    typescript: {
+      ignoreBuildErrors: false,
+    },
     images: {
       unoptimized: true,
       domains: [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint --max-warnings=0 .",
     "tsc": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "a11y": "node --import tsx/esm scripts/a11y.mjs",
     "smoke": "node --import tsx/esm scripts/smoke-all-apps.mjs",
     "module-report": "node --import tsx/esm scripts/generate-module-report.mjs",


### PR DESCRIPTION
## Summary
- run project-wide `typecheck` before builds
- fail Next.js builds on type errors

## Testing
- `yarn typecheck` *(fails: Property 'setThumbLimit' does not exist on type 'Window & typeof globalThis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be25139f888328a1d436fa3f96fabe