### PR TITLE
Enable stricter TypeScript indexing and optional property checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "strict": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- enable `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` in tsconfig
- ensure strict mode remains enabled

## Testing
- `yarn test __tests__/nmapNse.test.tsx` *(fails: Unable to find role="alert" and 1 failed test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68be2515a4bc83289afe0b0e8f7b824f