### PR TITLE
feat(types): add web bluetooth ambient declarations

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -12,9 +12,6 @@ import {
   CharacteristicData,
 } from '../../utils/bleProfiles';
 
-type BluetoothDevice = any;
-type BluetoothRemoteGATTServer = any;
-
 const MAX_RETRIES = 3;
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -72,7 +69,7 @@ const BleSensor: React.FC = () => {
     }
 
     try {
-      const device = await (navigator as any).bluetooth.requestDevice({
+      const device = await navigator.bluetooth.requestDevice({
         acceptAllDevices: true,
         optionalServices: ['battery_service', 'device_information'],
       });
@@ -98,7 +95,7 @@ const BleSensor: React.FC = () => {
       for (const service of primServices) {
           const chars = await service.getCharacteristics();
           const charData: CharacteristicData[] = await Promise.all(
-            chars.map(async (char: any) => {
+            chars.map(async (char: BluetoothRemoteGATTCharacteristic) => {
               try {
                 const val = await char.readValue();
                 let value = '';

--- a/types/web-bluetooth.d.ts
+++ b/types/web-bluetooth.d.ts
@@ -1,0 +1,37 @@
+export {};
+
+declare global {
+  interface Navigator {
+    readonly bluetooth: Bluetooth;
+  }
+
+  interface Bluetooth {
+    requestDevice(options: RequestDeviceOptions): Promise<BluetoothDevice>;
+  }
+
+  interface RequestDeviceOptions {
+    acceptAllDevices?: boolean;
+    optionalServices?: string[];
+  }
+
+  interface BluetoothDevice extends EventTarget {
+    id: string;
+    name?: string;
+    gatt?: BluetoothRemoteGATTServer;
+  }
+
+  interface BluetoothRemoteGATTServer {
+    connect(): Promise<BluetoothRemoteGATTServer>;
+    getPrimaryServices(): Promise<BluetoothRemoteGATTService[]>;
+  }
+
+  interface BluetoothRemoteGATTService {
+    uuid: string;
+    getCharacteristics(): Promise<BluetoothRemoteGATTCharacteristic[]>;
+  }
+
+  interface BluetoothRemoteGATTCharacteristic {
+    uuid: string;
+    readValue(): Promise<DataView>;
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Web Bluetooth declarations scoped to project's usage
- leverage new types in BLE sensor by removing `any` and using `navigator.bluetooth`

## Testing
- `yarn typecheck` *(fails: Property 'setThumbLimit' does not exist on type 'Window & typeof globalThis', etc.)*
- `yarn lint components/apps/ble-sensor.tsx types/web-bluetooth.d.ts` *(fails: A control must be associated with a text label, etc.)*
- `yarn test __tests__/sensors.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be2517e4c0832888f5ffa653214ad7