### PR TITLE
chore: externalize server-side cjs deps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -141,6 +141,10 @@ function configureWebpack(config, { isServer }) {
 module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
+    serverExternalPackages: [
+      '@supabase/supabase-js',
+      '@tinyhttp/cookie-signature',
+    ],
     webpack: configureWebpack,
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI


### PR DESCRIPTION
## Summary
- identify CommonJS modules used on the server
- declare them in `serverExternalPackages` so Next.js treats them as externals

## Testing
- `yarn test __tests__/validateServerEnv.test.ts`
- `yarn lint next.config.js` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68be251ab9448328b9f192ac81278daf