### PR TITLE
feat: ensure wasm runs client-side

### DIFF
--- a/apps/chess/index.tsx
+++ b/apps/chess/index.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import ChessGame from '../../components/apps/chess';
+
+export default ChessGame;

--- a/components/apps/chess.js
+++ b/components/apps/chess.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useRef, useEffect, useState } from "react";
 import { Chess } from "chess.js";
 import { suggestMoves } from "../../games/chess/engine/wasmEngine";

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';

--- a/pages/apps/chess.jsx
+++ b/pages/apps/chess.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const ChessApp = dynamic(() => import('../../apps/chess'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function ChessPage() {
+  return <ChessApp />;
+}


### PR DESCRIPTION
## Summary
- mark Ghidra and Chess apps as client components to keep WebAssembly in the browser
- add chess app entry and client-only page wrapper

## Testing
- `yarn test` *(fails: remotePatterns.test.ts, middleware-csp.test.ts, asciiArt.test.tsx, ubuntu.safeMode.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be251c591c83288828804fd4e12559