### PR TITLE
Add WASM typings

### DIFF
--- a/types/capstone-wasm.d.ts
+++ b/types/capstone-wasm.d.ts
@@ -1,0 +1,14 @@
+declare module 'capstone-wasm' {
+  /** Constructor for creating a Capstone disassembler instance. */
+  export class Capstone {
+    constructor(arch: number, mode: number);
+    disasm(code: Uint8Array, options: { address: number }): any[];
+    close(): void;
+  }
+
+  /** Collection of numeric constants used to configure Capstone. */
+  export const Const: Record<string, number>;
+
+  /** Loads the underlying WebAssembly module. */
+  export function loadCapstone(): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add TypeScript declarations for capstone-wasm exports
- tighten hash-worker types by importing IHasher and removing `any`

## Testing
- `npm test __tests__/nmapNse.test.tsx __tests__/remotePatterns.test.ts __tests__/appImport.test.ts __tests__/middleware-csp.test.ts` *(fails: middleware-csp, remotePatterns, appImport, nmapNse)*

------
https://chatgpt.com/codex/tasks/task_e_68be251d0e0883289238379b3acc4e7d