### PR TITLE
chore: remove redundant DOM types

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "@types/supertest": "^6",
     "@types/three": "^0.179.0",
     "@types/web-bluetooth": "^0.0.21",
-    "@types/wicg-file-system-access": "^2023.10.6",
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,27 @@
   ,
   "overrides": [
     {
+      "files": [
+        "scripts/**/*.ts",
+        "tests/**/*.ts",
+        "tests/**/*.tsx",
+        "pages/api/**/*.ts",
+        "pages/docs/**/*.tsx",
+        "src/lib/**/*.ts",
+        "src/lib/**/*.tsx",
+        "src/plugins/**/*.ts",
+        "src/plugins/**/*.tsx",
+        "src/utils/desktopIconSettings.ts",
+        "src/components/settings/WMKeyboard.tsx",
+        "src/tumbler/**/*.ts",
+        "jest.setup.ts",
+        "playwright.config.ts"
+      ],
+      "compilerOptions": {
+        "types": ["node"]
+      }
+    },
+    {
       "files": ["apps/games/**/*.ts", "games/**/*.ts"],
       "compilerOptions": {
         "noImplicitAny": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,13 +4075,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wicg-file-system-access@npm:^2023.10.6":
-  version: 2023.10.6
-  resolution: "@types/wicg-file-system-access@npm:2023.10.6"
-  checksum: 10c0/6d1086450b28351ea5c8c6078411930984a16588b40d999f9abdc42c9bff63de93101bd7b1edcaba5c5c9ea83acdeb277bcaff913f39f6dac12091459974631f
-  languageName: node
-  linkType: hard
-
 "@types/ws@npm:^8.18.1":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
@@ -14754,7 +14747,6 @@ __metadata:
     "@types/supertest": "npm:^6"
     "@types/three": "npm:^0.179.0"
     "@types/web-bluetooth": "npm:^0.0.21"
-    "@types/wicg-file-system-access": "npm:^2023.10.6"
     "@vercel/analytics": "npm:^1.5.0"
     "@vercel/speed-insights": "npm:^1.2.0"
     "@vercel/toolbar": "npm:^0.1.38"


### PR DESCRIPTION
## Summary
- remove unused `@types/wicg-file-system-access`
- scope `@types/node` to server/tooling files via tsconfig overrides

## Testing
- `yarn typecheck` *(fails: Property 'setThumbLimit' does not exist...)*
- `yarn lint` *(fails: jsx-a11y/control-has-associated-label errors)*
- `yarn test` *(fails: NmapNSEApp copies example output to clipboard...)*

------
https://chatgpt.com/codex/tasks/task_e_68be251d86788328be526e8791126c98