### PR TITLE
chore: bump node to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
   }
 }


### PR DESCRIPTION
## Summary
- update engines field to node 22.x
- set Vercel functions to runtime nodejs22.x

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Unable to find role="alert" etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68be251e45488328ba1d8b80b9b189db