### PR TITLE
chore: drop unnecessary client directives

### DIFF
--- a/components/panel/plugins/Separator.tsx
+++ b/components/panel/plugins/Separator.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 
 export type SeparatorStyle = "transparent" | "line" | "handle" | "dots";

--- a/games/sudoku/components/EliminationHelper.tsx
+++ b/games/sudoku/components/EliminationHelper.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { SIZE, getCandidates } from "../../../apps/games/sudoku";
 


### PR DESCRIPTION
## Summary
- remove `"use client"` from Separator plugin
- remove `"use client"` from Sudoku elimination helper

## Testing
- `yarn test` *(fails: `__tests__/nmapNse.test.tsx`, `__tests__/remotePatterns.test.ts`, `__tests__/asciiArt.test.tsx`, `__tests__/middleware-csp.test.ts`, `__tests__/ubuntu.safeMode.test.tsx`)*
- `yarn lint components/panel/plugins/Separator.tsx games/sudoku/components/EliminationHelper.tsx` *(no output)*
- `node --import tsx/esm -e "import SepModule from './components/panel/plugins/Separator.tsx'; import React from 'react'; import { renderToString } from 'react-dom/server'; const Separator=SepModule.default; console.log(renderToString(React.createElement(Separator,{style:'line'})));"`

------
https://chatgpt.com/codex/tasks/task_e_68be251f99b48328acf728460c79a2a3