### PR TITLE
chore: remove redundant dom types

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,8 +140,6 @@
     "@types/seedrandom": "^3",
     "@types/supertest": "^6",
     "@types/three": "^0.179.0",
-    "@types/web-bluetooth": "^0.0.21",
-    "@types/wicg-file-system-access": "^2023.10.6",
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4061,24 +4061,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/web-bluetooth@npm:^0.0.21":
-  version: 0.0.21
-  resolution: "@types/web-bluetooth@npm:0.0.21"
-  checksum: 10c0/5f47c5ec452ca31e6a9b44c8aaa54b66c4f57d4aca00166c45902a3883139580e14b254b774172ff982ba4458cc444b5aa59bb4573c2fd34562cfa599721f8e4
-  languageName: node
-  linkType: hard
-
 "@types/webxr@npm:*":
   version: 0.5.23
   resolution: "@types/webxr@npm:0.5.23"
   checksum: 10c0/4108d29844cbbae2e765df2948b7af1db5dcf1fd15f10c300186e1a711c0eb5ca2d9e0205c58043b35d46474e1405805c11381bb12318e15ff77cb57243767e1
-  languageName: node
-  linkType: hard
-
-"@types/wicg-file-system-access@npm:^2023.10.6":
-  version: 2023.10.6
-  resolution: "@types/wicg-file-system-access@npm:2023.10.6"
-  checksum: 10c0/6d1086450b28351ea5c8c6078411930984a16588b40d999f9abdc42c9bff63de93101bd7b1edcaba5c5c9ea83acdeb277bcaff913f39f6dac12091459974631f
   languageName: node
   linkType: hard
 
@@ -14753,8 +14739,6 @@ __metadata:
     "@types/seedrandom": "npm:^3"
     "@types/supertest": "npm:^6"
     "@types/three": "npm:^0.179.0"
-    "@types/web-bluetooth": "npm:^0.0.21"
-    "@types/wicg-file-system-access": "npm:^2023.10.6"
     "@vercel/analytics": "npm:^1.5.0"
     "@vercel/speed-insights": "npm:^1.2.0"
     "@vercel/toolbar": "npm:^0.1.38"


### PR DESCRIPTION
## Summary
- remove obsolete DOM type packages from devDependencies
- refresh yarn.lock after removing redundant types

## Testing
- `yarn typecheck` *(fails: Property 'setThumbLimit' does not exist on type 'Window & typeof globalThis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be251ea598832881b295faac86f006