### PR TITLE
feat: add typed dictionary helper

### DIFF
--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const definitionSchema = z.object({
+  definition: z.string(),
+});
+
+const meaningSchema = z.object({
+  definitions: z.array(definitionSchema),
+});
+
+const entrySchema = z.object({
+  meanings: z.array(meaningSchema),
+});
+
+const responseSchema = z.array(entrySchema);
+
+export type Definition = z.infer<typeof definitionSchema>;
+export type DictionaryEntry = z.infer<typeof entrySchema>;
+
+export async function fetchDictionaryEntries(word: string, apiUrl: string): Promise<DictionaryEntry[]> {
+  const res = await fetch(`${apiUrl}/${encodeURIComponent(word.trim())}`);
+  if (!res.ok) throw new Error('Request failed');
+  const json = await res.json();
+  return responseSchema.parse(json);
+}
+
+export function extractDefinitions(entries: DictionaryEntry[]): Definition[] {
+  const defs: Definition[] = [];
+  for (const entry of entries) {
+    for (const meaning of entry.meanings) {
+      defs.push(...meaning.definitions);
+    }
+  }
+  return defs;
+}
+
+export async function fetchDefinitions(word: string, apiUrl: string): Promise<Definition[]> {
+  const entries = await fetchDictionaryEntries(word, apiUrl);
+  return extractDefinitions(entries);
+}

--- a/src/plugins/Dictionary.tsx
+++ b/src/plugins/Dictionary.tsx
@@ -2,13 +2,17 @@
 
 import { useState } from "react";
 import Modal from "../../components/base/Modal";
+import {
+  Definition,
+  fetchDefinitions,
+} from "../lib/dictionary";
 
 const DEFAULT_API = "https://api.dictionaryapi.dev/api/v2/entries/en";
 
 export default function Dictionary() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<string[]>([]);
+  const [results, setResults] = useState<Definition[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,22 +25,12 @@ export default function Dictionary() {
     setError(null);
     setResults([]);
     try {
-      const res = await fetch(
-        `${apiUrl}/${encodeURIComponent(query.trim())}`
-      );
-      if (!res.ok) throw new Error("Request failed");
-      const json = await res.json();
-      const definitions: string[] = [];
-      if (Array.isArray(json)) {
-        json.forEach((entry: any) => {
-          entry.meanings?.forEach((m: any) => {
-            m.definitions?.forEach((d: any) => {
-              if (d.definition) definitions.push(d.definition);
-            });
-          });
-        });
+      const defs = await fetchDefinitions(query.trim(), apiUrl);
+      if (defs.length === 0) {
+        setError("No results found");
+      } else {
+        setResults(defs);
       }
-      setResults(definitions.length ? definitions : ["No results"]);
     } catch {
       setError("No results found");
     } finally {
@@ -90,7 +84,7 @@ export default function Dictionary() {
             {!loading && !error && results.length > 0 && (
               <ul className="list-disc pl-5 max-h-64 overflow-auto">
                 {results.map((r, i) => (
-                  <li key={i}>{r}</li>
+                  <li key={i}>{r.definition}</li>
                 ))}
               </ul>
             )}


### PR DESCRIPTION
## Summary
- add dictionary API helper with Zod parsing
- remove `any` usages in Dictionary plugin by using typed DTOs

## Testing
- `yarn test src/plugins/Dictionary.tsx --passWithNoTests`
- `npx eslint src/lib/dictionary.ts src/plugins/Dictionary.tsx` *(files ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68be2520c2e883288754308bea9babca