### PR TITLE
refactor: narrow tree nodes with predicates

### DIFF
--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -18,6 +18,14 @@ interface TreeNode {
   __modules?: Module[];
 }
 
+const isTreeNode = (
+  v: TreeNode | Module[] | undefined,
+): v is TreeNode => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const isModuleArray = (
+  v: TreeNode | Module[] | undefined,
+): v is Module[] => Array.isArray(v);
+
 const typeColors: Record<string, string> = {
   auxiliary: 'bg-blue-500',
   exploit: 'bg-red-500',
@@ -34,8 +42,12 @@ function buildTree(mods: Module[]): TreeNode {
         if (!node.__modules) node.__modules = [];
         node.__modules.push(mod);
       } else {
-        node[part] = (node[part] as TreeNode) || {};
-        node = node[part] as TreeNode;
+        let child = node[part];
+        if (!isTreeNode(child)) {
+          child = {};
+          node[part] = child;
+        }
+        node = child;
       }
     });
   });
@@ -104,30 +116,34 @@ const MetasploitPage: React.FC = () => {
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
       {Object.entries(node)
-        .filter(([k]) => k !== '__modules')
+        .filter(
+          (entry): entry is [string, TreeNode] =>
+            entry[0] !== '__modules' && isTreeNode(entry[1]),
+        )
         .map(([key, child]) => (
           <li key={key}>
             <details>
               <summary className="cursor-pointer">{key}</summary>
-              {renderTree(child as TreeNode)}
+              {renderTree(child)}
             </details>
           </li>
         ))}
-      {(node.__modules || []).map((mod) => (
-        <li key={mod.name}>
-          <button
-            onClick={() => setSelected(mod)}
-            className="flex justify-between w-full text-left px-1 py-0.5 hover:bg-gray-100"
-          >
-            <span>{mod.name.split('/').pop()}</span>
-            <span
-              className={`ml-2 text-xs text-white px-1 rounded ${typeColors[mod.type] || 'bg-gray-500'}`}
+      {isModuleArray(node.__modules) &&
+        node.__modules.map((mod) => (
+          <li key={mod.name}>
+            <button
+              onClick={() => setSelected(mod)}
+              className="flex justify-between w-full text-left px-1 py-0.5 hover:bg-gray-100"
             >
-              {mod.type}
-            </span>
-          </button>
-        </li>
-      ))}
+              <span>{mod.name.split('/').pop()}</span>
+              <span
+                className={`ml-2 text-xs text-white px-1 rounded ${typeColors[mod.type] || 'bg-gray-500'}`}
+              >
+                {mod.type}
+              </span>
+            </button>
+          </li>
+        ))}
     </ul>
   );
 


### PR DESCRIPTION
## Summary
- add type guards to distinguish tree nodes from module arrays
- simplify tree rendering by removing repeated optional checks

## Testing
- `yarn test apps/metasploit/index.tsx --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68be252164c8832885afe88030fdfec5