### PR TITLE
chore: lazy load activity calendar

### DIFF
--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -5,7 +5,12 @@ import GitHubStars from '../GitHubStars';
 import Certs from './certs';
 import data from './alex/data.json';
 import resumeData from './alex/resume.json';
-import ActivityCalendar from 'react-activity-calendar';
+import dynamic from 'next/dynamic';
+
+const ActivityCalendar = dynamic(
+    () => import('react-activity-calendar'),
+    { ssr: false },
+);
 
 export class AboutAlex extends Component {
 


### PR DESCRIPTION
## Summary
- lazy load react-activity-calendar on the client

## Testing
- `yarn test components/apps/alex --passWithNoTests`
- `yarn analyze` *(fails: Module build failed: UnhandledSchemeError: Reading from "node:fs" is not handled by plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68be252458f08328889a2d2c7eb17436