### PR TITLE
refactor: use named exports

### DIFF
--- a/__tests__/betaBadge.test.tsx
+++ b/__tests__/betaBadge.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import BetaBadge from '../components/BetaBadge';
+import { BetaBadge } from '../components/BetaBadge';
 
 describe('BetaBadge', () => {
   test('is focusable via keyboard', async () => {

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import ExternalFrame from '../../components/ExternalFrame';
+import { ExternalFrame } from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,4 +1,4 @@
-export default function BetaBadge() {
+export function BetaBadge() {
   if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
   return (
     <button

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import TerminalOutput from './TerminalOutput';
+import { TerminalOutput } from './TerminalOutput';
 
 interface BuilderProps {
   doc: string;

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -15,7 +15,7 @@ const isAllowed = (src) => {
  * Iframe wrapper for allowed external sources.
  * Optionally prefetches the iframe source.
  */
-export default function ExternalFrame({ src, title, prefetch = false, onLoad: onLoadProp, ...props }) {
+export function ExternalFrame({ src, title, prefetch = false, onLoad: onLoadProp, ...props }) {
   const [cookiesBlocked, setCookiesBlocked] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
   const [loaded, setLoaded] = useState(false);

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -5,7 +5,7 @@ interface TerminalOutputProps {
   ariaLabel?: string;
 }
 
-export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps) {
+export function TerminalOutput({ text, ariaLabel }: TerminalOutputProps) {
   const lines = text.split('\n');
   const copyLine = async (line: string) => {
     try {

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
-import TerminalOutput from '../../TerminalOutput';
+import { TerminalOutput } from '../../TerminalOutput';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 import { baseMetadata } from "../lib/metadata";
-import BetaBadge from "../components/BetaBadge";
+import { BetaBadge } from "../components/BetaBadge";
 import useSession from "../hooks/useSession";
 
 export const metadata = baseMetadata;


### PR DESCRIPTION
## Summary
- refactor: replace default export in BetaBadge with named export
- refactor: replace default export in TerminalOutput with named export and update usage
- refactor: replace default export in ExternalFrame with named export and update usage

## Testing
- `npm test` *(fails: nmapNse, remotePatterns, appImport, asciiArt, middleware-csp)*

------
https://chatgpt.com/codex/tasks/task_e_68be25262b0483288e16e8232d17facf