### PR TITLE
feat: offload article parsing to server

### DIFF
--- a/__tests__/reader.test.tsx
+++ b/__tests__/reader.test.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Reader from '../components/apps/chrome/Reader';
 
-const sampleHtml = `<!DOCTYPE html><html><head><title>t</title></head><body><article><h1>Sample</h1><p>Content here</p></article></body></html>`;
+const sampleArticle = {
+  title: 't',
+  content: '<h1>Sample</h1><p>Content here</p>',
+  excerpt: '',
+  markdown: '# t\n\nContent here',
+};
 
 const writeTextMock = jest.fn();
 
 describe('Reader', () => {
   beforeEach(() => {
-    (global as any).fetch = jest.fn(async () => ({ text: async () => sampleHtml }));
+    (global as any).fetch = jest.fn(async () => ({ json: async () => sampleArticle }));
     writeTextMock.mockClear();
     localStorage.clear();
   });

--- a/apps/chrome/components/ReadingMode.tsx
+++ b/apps/chrome/components/ReadingMode.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { Readability } from '@mozilla/readability';
-import DOMPurify from 'dompurify';
 import { createStore, set as idbSet } from 'idb-keyval';
 import usePersistentState from '../../../hooks/usePersistentState';
 
@@ -27,10 +25,16 @@ const ReadingMode = () => {
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    const doc = document.cloneNode(true) as Document;
-    const article = new Readability(doc).parse();
-    const cleaned = DOMPurify.sanitize(article?.content ?? '');
-    setContent(cleaned);
+    (async () => {
+      const [{ Readability }, { default: DOMPurify }] = await Promise.all([
+        import('@mozilla/readability'),
+        import('dompurify'),
+      ]);
+      const doc = document.cloneNode(true) as Document;
+      const article = new Readability(doc).parse();
+      const cleaned = DOMPurify.sanitize(article?.content ?? '');
+      setContent(cleaned);
+    })();
   }, []);
 
   const saveSnapshot = useCallback(async () => {

--- a/pages/api/reader.ts
+++ b/pages/api/reader.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Readability } from '@mozilla/readability';
+import TurndownService from 'turndown';
+import createDOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { url } = req.query;
+  if (typeof url !== 'string') {
+    res.status(400).json({ error: 'Invalid url' });
+    return;
+  }
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const dom = new JSDOM(html);
+    const reader = new Readability(dom.window.document);
+    const parsed = reader.parse();
+    if (!parsed) {
+      res.status(500).json({ error: 'Unable to parse article.' });
+      return;
+    }
+    const purify = createDOMPurify(dom.window as unknown as Window);
+    const sanitized = purify.sanitize(parsed.content ?? '');
+    const td = new TurndownService();
+    const markdown = `# ${parsed.title ?? ''}\n\n${td.turndown(sanitized)}`;
+    res.status(200).json({
+      title: parsed.title ?? '',
+      content: sanitized,
+      excerpt: parsed.excerpt ?? '',
+      markdown,
+    });
+  } catch {
+    res.status(500).json({ error: 'Unable to load page.' });
+  }
+}


### PR DESCRIPTION
## Summary
- move heavy Readability/Turndown/DOMPurify work into new `/api/reader` endpoint
- fetch pre-parsed article data from Reader component and Chrome app
- lazy-load Readability in the standalone ReadingMode to avoid bundling

## Testing
- `yarn test __tests__/reader.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be252555208328aa42721f4c365d2d