### PR TITLE
Document App Router WASM workaround and mark Ghidra client component

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -35,3 +35,8 @@ test('My App launches', async ({ page }) => {
   await expect(page.locator('[data-testid="my-app"]')).toBeVisible();
 });
 ```
+
+## WebAssembly and the App Router
+
+- WebAssembly modules may fail to load under the App Router (Next.js issue [#83046](https://github.com/vercel/next.js/issues/83046)).
+- If a WASM package fails, wrap the importing component with `'use client'` or expose it via the Pages Router instead.


### PR DESCRIPTION
## Summary
- mark Ghidra app component as a client component so its WebAssembly loader runs in the browser
- note App Router WebAssembly issue in new app checklist with link to upstream tracking issue

## Testing
- `yarn test __tests__/nmapNse.test.tsx`
- `yarn test __tests__/remotePatterns.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be252ad9888328b63e6340631bd094