### PR TITLE
chore: add browser api type references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "types": [],
+    "types": [
+      "./types/file-system-access",
+      "./types/web-bluetooth"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]

--- a/types/file-system-access.d.ts
+++ b/types/file-system-access.d.ts
@@ -1,0 +1,3 @@
+// MDN: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+// GitHub issue: https://github.com/microsoft/TypeScript/issues/29548
+/// <reference types="wicg-file-system-access" />

--- a/types/web-bluetooth.d.ts
+++ b/types/web-bluetooth.d.ts
@@ -1,0 +1,3 @@
+// MDN: https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API
+// GitHub issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49051
+/// <reference types="web-bluetooth" />


### PR DESCRIPTION
## Summary
- add stub type declarations for File System Access and Web Bluetooth APIs
- reference new browser API types in tsconfig

## Testing
- `npx eslint types/file-system-access.d.ts types/web-bluetooth.d.ts tsconfig.json`
- `yarn typecheck` *(fails: Module '"./main"' declares 'evaluate' locally, but it is not exported)*
- `yarn test` *(fails: Unable to find role="alert" in NmapNSEApp test, missing remotePatterns, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be252d7874832896632fd03e0973dc