### PR TITLE
chore: pin react versions for routers

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,10 @@
     "ws": "^8.18.0"
   },
   "resolutions": {
+    "react": "19.1.1",
+    "react-dom": "19.1.1",
+    "@types/react": "19.1.12",
+    "@types/react-dom": "19.1.9",
     "source-map": "^0.7.6",
     "test-exclude": "7.0.1",
     "webpack": "^5.92.0",


### PR DESCRIPTION
## Summary
- pin react and type packages to 19.1 to keep app and pages routers aligned

## Testing
- `yarn test __tests__/reportWebVitals.test.ts`
- `yarn lint package.json` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68be252beb7083289f9ad3f3a1fe26a3