### PR TITLE
refactor: wrap wasm modules with client loaders

### DIFF
--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -10,15 +10,15 @@ const GhidraApp = dynamic(() => import('../../../components/apps/ghidra'), {
 });
 
 export default function DemoRunner() {
-  const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;
+  const wrapperUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
-    if (!wasmUrl) {
+    if (!wrapperUrl) {
       return;
     }
     let mounted = true;
-    WebAssembly.instantiateStreaming(fetch(wasmUrl), {})
+    import(/* webpackIgnore: true */ wrapperUrl)
       .then(() => {
         if (mounted) {
           setEnabled(true);
@@ -32,7 +32,7 @@ export default function DemoRunner() {
     return () => {
       mounted = false;
     };
-  }, [wasmUrl]);
+  }, [wrapperUrl]);
 
   if (!enabled) {
     return (

--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -166,11 +166,8 @@ const parsePcapNg = (buf: ArrayBuffer): Packet[] => {
 
 const parseWithWasm = async (buf: ArrayBuffer): Promise<Packet[]> => {
   try {
-    // Attempt to load wasm parser; fall back to JS parsing
-    await WebAssembly.instantiateStreaming(
-      fetch('https://unpkg.com/pcap.js@latest/pcap.wasm'),
-      {}
-    );
+    // Attempt to load wasm parser via its JS wrapper; fall back to JS parsing
+    await import('https://unpkg.com/pcap.js@latest/pcap.js');
   } catch {
     // Ignore errors and use JS parser
   }

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
@@ -9,7 +11,7 @@ let Const;
 let loadCapstone;
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
-const DEFAULT_WASM = '/wasm/ghidra.wasm';
+const DEFAULT_WRAPPER = '/wasm/ghidra.js';
 
 async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
@@ -107,13 +109,14 @@ export default function GhidraApp() {
   }, []);
 
   useEffect(() => {
-    const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
+    const wrapperUrl =
+      process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WRAPPER;
     if (typeof WebAssembly === 'undefined') {
       setEngine('capstone');
       ensureCapstone();
       return;
     }
-    WebAssembly.instantiateStreaming(fetch(wasmUrl), {}).catch(() => {
+    import(/* webpackIgnore: true */ wrapperUrl).catch(() => {
       setEngine('capstone');
       ensureCapstone();
     });


### PR DESCRIPTION
## Summary
- load Ghidra WebAssembly via client-only JS wrapper
- gate Ghidra demo on wrapper import
- load PCAP parser through its JS wrapper instead of .wasm

## Testing
- `yarn test __tests__/wireshark.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be252f4f9c83288df663091108eb0a