### PR TITLE
chore: upgrade Node to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "nodeVersion": "22.x",
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
   }
 }


### PR DESCRIPTION
## Summary
- configure Vercel functions to use Node 22
- require Node 22.x via package engines

## Testing
- `yarn test` *(fails: nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68be252fa7a8832895d13c1d99251f8d