### PR TITLE
refactor: use named logger export

### DIFF
--- a/__tests__/displayFilter.benchmark.ts
+++ b/__tests__/displayFilter.benchmark.ts
@@ -2,7 +2,7 @@
 // Baseline before caching: ~29.66ms for 100k calls
 // After caching optimization: ~26.32ms for 100k calls
 import { matchesDisplayFilter, getRowColor } from '../components/apps/wireshark/utils';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 describe('display filter benchmark', () => {
   const packets = Array.from({ length: 1000 }, (_, i) => ({

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -15,7 +15,7 @@ import {
   serialize as serializeRng,
   deserialize as deserializeRng,
 } from '../../apps/games/rng';
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 interface GameLayoutProps {
   gameId?: string;

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import logger from '../../utils/logger'
+import { logger } from '../../utils/logger'
 import PolicyKitPrompt from '../common/PolicyKitPrompt'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -3,7 +3,7 @@
 import { isBrowser } from '@/utils/env';
 import React, { Component } from 'react';
 import dynamic from 'next/dynamic';
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),

--- a/data/vscode-example/main.js
+++ b/data/vscode-example/main.js
@@ -1,4 +1,4 @@
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 function greet(name) {
   logger.info('Hello ' + name)

--- a/john/potfile.mjs
+++ b/john/potfile.mjs
@@ -2,7 +2,7 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { parsePotfile } from '../components/apps/john/utils.js';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 function main() {

--- a/john/status.js
+++ b/john/status.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 function renderProgressBar(completed, total) {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,4 @@
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'key']);
 

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import pa11y from 'pa11y';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const configPath = new URL('../pa11yci.json', import.meta.url);

--- a/scripts/cron-next-run.mjs
+++ b/scripts/cron-next-run.mjs
@@ -1,5 +1,5 @@
 import { CronExpressionParser } from 'cron-parser';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const expression = process.argv[2];

--- a/scripts/examples/hash.ts
+++ b/scripts/examples/hash.ts
@@ -1,5 +1,5 @@
 import { createMD5, createSHA1 } from 'hash-wasm';
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 export async function hashExample() {
   const samples = ['hello', 'world'];

--- a/scripts/examples/terminal-worker.ts
+++ b/scripts/examples/terminal-worker.ts
@@ -1,5 +1,5 @@
 // Example scripts demonstrating the terminal worker
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;

--- a/scripts/examples/terminal.ts
+++ b/scripts/examples/terminal.ts
@@ -1,5 +1,5 @@
 // Example scripts demonstrating the terminal worker
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;

--- a/scripts/export-icons.mjs
+++ b/scripts/export-icons.mjs
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import sharp from 'sharp';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const __filename = fileURLToPath(import.meta.url);

--- a/scripts/generate-module-report.mjs
+++ b/scripts/generate-module-report.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const __filename = fileURLToPath(import.meta.url);

--- a/scripts/generate-nmconnection-previews.ts
+++ b/scripts/generate-nmconnection-previews.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { toKeyfile, NMConnection } from '../utils/nmconnection.ts';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const dir = join(process.cwd(), 'data', 'network-connections');

--- a/scripts/safe-copy.mjs
+++ b/scripts/safe-copy.mjs
@@ -1,6 +1,6 @@
 import { access, mkdir, copyFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const src = 'dist/utils/gamepad.js';

--- a/scripts/smoke-all-apps.mjs
+++ b/scripts/smoke-all-apps.mjs
@@ -1,6 +1,6 @@
 import { chromium, firefox, webkit } from 'playwright';
 import fs from 'fs';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -2,7 +2,7 @@ import { execSync, spawn } from 'child_process';
 import { createRequire } from 'module';
 import net from 'net';
 import waitOn from 'wait-on';
-import logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 const require = createRequire(import.meta.url);
 

--- a/src/apps/appfinder/AppFinder.tsx
+++ b/src/apps/appfinder/AppFinder.tsx
@@ -1,6 +1,6 @@
 import { isBrowser } from '@/utils/env';
 import React, { useEffect, useState } from 'react';
-import logger from '../../../utils/logger';
+import { logger } from '../../../utils/logger';
 
 // Representation of a parsed .desktop entry
 export interface DesktopEntry {

--- a/src/plugins/Clipman.tsx
+++ b/src/plugins/Clipman.tsx
@@ -2,7 +2,7 @@ import { isBrowser } from '@/utils/env';
 import { useEffect, useState } from 'react';
 import fs from 'fs';
 import path from 'path';
-import logger from '../../utils/logger';
+import { logger } from '../../utils/logger';
 
 interface ClipmanSettings {
   syncSelections: boolean;

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -22,7 +22,7 @@ function shouldLog(level: LogLevel) {
   return levelOrder[level] <= levelOrder[activeLevel];
 }
 
-const logger = {
+export const logger = {
   error: (...args: any[]) => {
     if (isProd) return;
     if (shouldLog('error')) console.error(...args);
@@ -45,4 +45,3 @@ const logger = {
   },
 };
 
-export default logger;

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -1,6 +1,6 @@
 import ReactGA from 'react-ga4';
 import { track } from '@vercel/analytics';
-import logger from './logger';
+import { logger } from './logger';
 
 interface WebVitalMetric {
   id: string;


### PR DESCRIPTION
## Summary
- refactor logger utility to use a named export
- update all logger imports across scripts and components

## Testing
- `yarn lint utils/logger.ts`
- `yarn test __tests__/displayFilter.benchmark.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be252e9e108328854add58662ba81b