### PR TITLE
docs: log first load js size

### DIFF
--- a/docs/first-load-js-size.md
+++ b/docs/first-load-js-size.md
@@ -1,0 +1,7 @@
+# First Load JS Size Log
+
+This document records the first-load JavaScript size after each batch build. If the build fails, the failure is logged instead.
+
+| Date (UTC) | Commit | First Load JS | Notes |
+|------------|--------|---------------|-------|
+| 2025-09-08 | bc63e7c | N/A | `yarn build` failed: Module not found for 'fs' and 'path'; cannot measure size |


### PR DESCRIPTION
## Summary
- track first-load JavaScript sizes across batches

## Testing
- `yarn build` (fails: Module not found: Can't resolve 'fs')
- `yarn test` (fails: some test suites)


------
https://chatgpt.com/codex/tasks/task_e_68be253152088328849bbdb9bab02e6d