### PR TITLE
feat: add kali hero gradient

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,6 +45,7 @@ const App = () => {
       />
       <BetaBadge />
       <InstallButton />
+      <div className="bg-kali-hero h-64 w-full" />
     </>
   );
 };

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,19 @@
 @import './globals.css';
 @import './whisker.css';
 
+:root {
+    --kali-hero-linear: linear-gradient(
+        180deg,
+        var(--color-ub-gedit-dark) 0%,
+        var(--color-ub-gedit-darker) 100%
+    );
+    --kali-hero-radial: radial-gradient(
+        circle at 50% 50%,
+        var(--color-ub-gedit-light) 0%,
+        var(--color-ub-gedit-darker) 100%
+    );
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,9 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
+        backgroundImage: {
+          'kali-hero': 'var(--kali-hero-radial)',
+        },
         fontFamily: {
           ubuntu: ['Ubuntu', 'sans-serif'],
         },


### PR DESCRIPTION
## Summary
- define radial and linear Kali hero gradients as CSS variables
- add `bg-kali-hero` Tailwind utility for the dark navy hero gradient
- demo the gradient on the home page with a test div

## Testing
- `yarn eslint pages/index.tsx tailwind.config.js styles/index.css`
- `yarn test` *(fails: __tests__/nmapNse.test.tsx and others)*
- `yarn test __tests__/blackjack.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be322a89a48328b10ab0dfca4784ca