### PR TITLE
feat: add Kali theme color tokens

### DIFF
--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -31,7 +31,7 @@ function LinkedInIcon({ className }: { className?: string }) {
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen w-full bg-[var(--kali-bg)] text-sm">
+    <div className="min-h-screen w-full bg-kali-bg text-sm">
       <div className="max-w-screen-md mx-auto my-4 sm:my-8 p-4 sm:p-6">
         <section className="flex items-center mb-8">
           <Image
@@ -44,7 +44,7 @@ export default function AboutPage() {
           />
           <div className="ml-4 flex-1 space-y-1.5">
             <h1 className="text-xl font-bold">Alex Unnippillil</h1>
-            <p className="text-gray-200">Cybersecurity Specialist</p>
+            <p className="text-kali-primary">Cybersecurity Specialist</p>
           </div>
           <div className="ml-4 flex gap-3">
             <a
@@ -52,7 +52,7 @@ export default function AboutPage() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"
-              className="text-white"
+              className="text-kali-accent"
             >
               <GitHubIcon className="w-6 h-6" />
             </a>
@@ -61,7 +61,7 @@ export default function AboutPage() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn"
-              className="text-white"
+              className="text-kali-accent"
             >
               <LinkedInIcon className="w-6 h-6" />
             </a>

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -32,16 +32,16 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+    <div className="p-2 text-xs text-white bg-kali-bg">
       <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
+      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-kali-bg-elev">
+        {active.length === 0 && <li className="p-1 text-kali-muted">None</li>}
         {active.map((f) => (
           <li key={f.id} className="p-1">
             <div className="truncate">
               {f.method} {f.url}
             </div>
-            <div className="text-gray-400">
+            <div className="text-kali-muted">
               {((typeof performance !== 'undefined' ? performance.now() : Date.now()) - f.startTime).toFixed(0)}ms elapsed
             </div>
           </li>
@@ -51,13 +51,13 @@ export default function NetworkInsights() {
         <h2 className="font-bold">History</h2>
         <button
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          className="ml-auto px-2 py-1 rounded bg-kali-bg-elev"
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
+      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-kali-bg-elev">
+        {history.length === 0 && <li className="p-1 text-kali-muted">No requests</li>}
         {history.map((f) => (
           <li key={f.id} className="p-1">
             <div className="truncate">
@@ -66,7 +66,7 @@ export default function NetworkInsights() {
                 <span className="ml-2 text-green-400">(SW cache)</span>
               )}
             </div>
-            <div className="text-gray-400">
+            <div className="text-kali-muted">
               {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
             </div>
           </li>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,14 @@
 @import './globals.css';
 @import './whisker.css';
 
+:root {
+    --kali-bg: var(--color-bg);
+    --kali-bg-elev: var(--color-surface);
+    --kali-primary: var(--color-primary);
+    --kali-accent: var(--color-accent);
+    --kali-muted: var(--color-muted);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,11 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        'kali-bg': 'var(--kali-bg)',
+        'kali-bg-elev': 'var(--kali-bg-elev)',
+        'kali-primary': 'var(--kali-primary)',
+        'kali-accent': 'var(--kali-accent)',
+        'kali-muted': 'var(--kali-muted)',
       },
         fontFamily: {
           ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- define Kali color CSS variables
- map Kali colors into Tailwind theme
- use new color tokens in components

## Testing
- `yarn test __tests__/nmapNse.test.tsx __tests__/remotePatterns.test.ts __tests__/asciiArt.test.tsx __tests__/exo-open.test.ts __tests__/middleware-csp.test.ts` *(fails: nmapNse, remotePatterns, asciiArt, exo-open, middleware-csp)*

------
https://chatgpt.com/codex/tasks/task_e_68be322aa6288328901429cf24d71282