### PR TITLE
feat: add surface color tokens

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -81,7 +81,7 @@ describe('Terminal component', () => {
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'Tab' });
     const headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
-    expect((headers[0] as HTMLElement).className).toContain('bg-gray-700');
+    expect((headers[0] as HTMLElement).className).toContain('bg-surface-300');
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
     expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);

--- a/components/ui/ProgressDialog.tsx
+++ b/components/ui/ProgressDialog.tsx
@@ -51,12 +51,12 @@ export default function ProgressDialog({ isOpen, onCancel }: ProgressDialogProps
 
   return (
     <Modal isOpen={isOpen} onClose={handleCancel}>
-      <div className="p-4 bg-white rounded shadow w-64 text-center space-y-4">
+      <div className="p-4 bg-surface-300 rounded shadow w-64 text-center space-y-4">
         <div>Processing… {Math.round(progress)}%</div>
         <ProgressBar progress={progress} className="w-full" />
         <button
           onClick={handleCancel}
-          className="px-2 py-1 bg-gray-200 rounded"
+          className="px-2 py-1 bg-surface-100 rounded"
         >
           Cancel
         </button>

--- a/components/ui/PropertiesDialog.tsx
+++ b/components/ui/PropertiesDialog.tsx
@@ -46,7 +46,7 @@ const PropertiesDialog: React.FC<Props> = ({ item, onClose, onRenamed }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="bg-ub-cool-grey p-4 rounded shadow-md text-white w-64">
+      <div className="bg-surface-300 p-4 rounded shadow-md text-white w-64">
         <div className="flex items-center mb-4">
           <img
             src={iconSrc}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -34,7 +34,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-surface-200 rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -168,12 +168,12 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       tabIndex={0}
       onKeyDown={onKeyDown}
     >
-      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+      <div className="flex flex-shrink-0 bg-surface-200 text-white text-sm overflow-x-auto">
         {tabs.map((t, i) => (
           <div
             key={t.id}
             className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
-              t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
+              t.id === activeId ? 'bg-surface-300' : 'bg-surface-200'
             }`}
             draggable
             onDragStart={handleDragStart(i)}
@@ -198,7 +198,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         ))}
         {onNewTab && (
           <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            className="px-2 py-1 bg-surface-200 hover:bg-surface-300"
             onClick={addTab}
             aria-label="New Tab"
           >

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,6 +1,13 @@
 @import './globals.css';
 @import './whisker.css';
 
+:root {
+    --surface-0: var(--color-bg);
+    --surface-100: var(--color-surface);
+    --surface-200: var(--color-muted);
+    --surface-300: var(--color-dark);
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,10 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        'surface-0': 'var(--surface-0)',
+        'surface-100': 'var(--surface-100)',
+        'surface-200': 'var(--surface-200)',
+        'surface-300': 'var(--surface-300)',
       },
         fontFamily: {
           ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add surface-level CSS variables for multiple elevations
- expose bg-surface-* Tailwind utilities
- refactor QuickSettings, PropertiesDialog, ProgressDialog, and TabbedWindow to use surface classes

## Testing
- `yarn test __tests__/terminal.test.tsx __tests__/nmapNse.test.tsx __tests__/asciiArt.test.tsx __tests__/exo-open.test.ts __tests__/middleware-csp.test.ts` *(fails: asciiArt.test.tsx, exo-open.test.ts, middleware-csp.test.ts, nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68be322b0a208328af6b9855682c395a