### PR TITLE
feat: add theme toggle

### DIFF
--- a/__tests__/ThemeToggle.test.tsx
+++ b/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThemeToggle from '../components/ui/ThemeToggle';
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.dataset.theme = 'default';
+    document.documentElement.className = '';
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+  });
+
+  test('switches theme and updates variables', async () => {
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root { --color-bg: white; }
+      html[data-theme='dark'] { --color-bg: black; }
+    `;
+    document.head.appendChild(style);
+
+    render(<ThemeToggle />);
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+    const getBg = () =>
+      getComputedStyle(document.documentElement).getPropertyValue('--color-bg');
+
+    expect(document.documentElement.dataset.theme).toBe('default');
+    expect(getBg()).toBe('white');
+
+    await userEvent.click(button);
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(getBg()).toBe('black');
+    expect(window.localStorage.getItem('app:theme')).toBe('dark');
+  });
+});

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+import { getTheme, setTheme, isDarkTheme } from '@/utils/theme';
+
+const ThemeToggle = () => {
+  const [theme, setThemeState] = useState(() => getTheme());
+
+  const toggleTheme = () => {
+    const nextTheme = isDarkTheme(theme) ? 'default' : 'dark';
+    setTheme(nextTheme);
+    setThemeState(nextTheme);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className="p-2 border rounded"
+    >
+      {isDarkTheme(theme) ? 'Light Theme' : 'Dark Theme'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import ThemeToggle from '../components/ui/ThemeToggle';
 
 
 let SpeedInsights = () => null;
@@ -248,6 +249,9 @@ function MyApp(props) {
                 <div aria-live="polite" id="live-region" />
                 <Component {...pageProps} />
                 <ShortcutOverlay />
+                <footer className="fixed bottom-4 right-4">
+                  <ThemeToggle />
+                </footer>
                 {process.env.VERCEL_ANALYTICS_ID && (
                   <>
                     <Analytics


### PR DESCRIPTION
## Summary
- add ThemeToggle component with localStorage-backed theme switching
- render ThemeToggle in a footer to allow toggling between light and dark
- test theme toggle updates CSS variables and localStorage

## Testing
- `npx eslint components/ui/ThemeToggle.tsx pages/_app.jsx __tests__/ThemeToggle.test.tsx`
- `yarn test __tests__/ThemeToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be322b50dc8328af650c30c33f96b9