### PR TITLE
feat: add tight spacing utilities

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,10 +28,7 @@ const InstallButton = dynamic(
   },
 );
 
-/**
- * @returns {JSX.Element}
- */
-const App = () => {
+const App = (): JSX.Element => {
   const { session, setSession, resetSession } = useSession();
   return (
     <>
@@ -45,6 +42,18 @@ const App = () => {
       />
       <BetaBadge />
       <InstallButton />
+      <section className="prose p-tight">
+        <h1 className="leading-tight">Sample Heading</h1>
+        <ul className="space-y-tight">
+          <li>First item</li>
+          <li>Second item</li>
+        </ul>
+        <pre className="leading-tight p-tight">
+          <code>{`const greet = (name: string) => {
+  console.log('Hello, ' + name);
+};`}</code>
+        </pre>
+      </section>
     </>
   );
 };

--- a/styles/index.css
+++ b/styles/index.css
@@ -15,7 +15,12 @@ body{
 
 /* Heading scale for vertical rhythm */
 h1, h2, h3, h4, h5, h6 {
-    line-height: 1.2;
+    @apply leading-tight;
+}
+
+ul,
+ol {
+    @apply space-y-tight;
 }
 
 h1 {
@@ -530,9 +535,10 @@ dialog {
 
 /* Ensure monospace layout for app outputs */
 textarea,
-pre {
+pre,
+code {
     font-family: monospace;
-    line-height: 1.2;
+    @apply leading-tight;
 }
 
 /* Visible focus rings for copy buttons and text areas */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,12 @@ module.exports = {
           h2: ['clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem)', { lineHeight: '1.3' }],
           h3: ['clamp(1.25rem, 1rem + 0.5vw, 1.5rem)', { lineHeight: '1.4' }],
         },
+      lineHeight: {
+        tight: '1.2',
+      },
+      spacing: {
+        tight: '0.125rem',
+      },
       minWidth: {
         '0': '0',
         '1/4': '25%',


### PR DESCRIPTION
## Summary
- extend tailwind config with tight line-height and spacing utilities
- apply tight leading/spacing to headings, lists, and code blocks
- add markdown sample verifying spacing on home page

## Testing
- `yarn lint` *(fails: A control must be associated with a text label, Unused eslint-disable directive)*
- `yarn test` *(fails: NmapNSEApp copies example output to clipboard, remotePatterns cover referenced remote image hosts, asciiArt.test.tsx encountered unexpected token, exo-open helpers rc handling reads defaults and persists selections, middleware CSP header includes nonce and allowed hosts)*

------
https://chatgpt.com/codex/tasks/task_e_68be322ccc5483289dcc36939be0fa0a