### PR TITLE
feat: add monospaced code block styling

### DIFF
--- a/components/ui/CodeBlock.tsx
+++ b/components/ui/CodeBlock.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
+  children: React.ReactNode;
+}
+
+export default function CodeBlock({
+  children,
+  className = "",
+  ...props
+}: CodeBlockProps) {
+  return (
+    <pre className={className} {...props}>
+      <code>{children}</code>
+    </pre>
+  );
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -529,10 +529,22 @@ dialog {
 }
 
 /* Ensure monospace layout for app outputs */
-textarea,
-pre {
-    font-family: monospace;
+textarea {
+    font-family: var(--font-family-mono, monospace);
     line-height: 1.2;
+}
+
+/* Monospaced elements */
+code,
+kbd,
+pre {
+    font-family: var(--font-family-mono, monospace);
+}
+
+pre {
+    line-height: 1.2;
+    padding: var(--space-2);
+    overflow-x: auto;
 }
 
 /* Visible focus rings for copy buttons and text areas */


### PR DESCRIPTION
## Summary
- apply monospace font to `code`, `kbd`, and `pre` elements and pad `pre`
- introduce reusable `CodeBlock` component

## Testing
- `yarn lint`
- `yarn test __tests__/blackjack.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be322d60a083289ee840f38a8a9374