### PR TITLE
feat: add theme-aware window and card utilities

### DIFF
--- a/components/ui/ProgressDialog.tsx
+++ b/components/ui/ProgressDialog.tsx
@@ -51,7 +51,7 @@ export default function ProgressDialog({ isOpen, onCancel }: ProgressDialogProps
 
   return (
     <Modal isOpen={isOpen} onClose={handleCancel}>
-      <div className="p-4 bg-white rounded shadow w-64 text-center space-y-4">
+      <div className="p-4 bg-white rounded border border-window shadow-window w-64 text-center space-y-4">
         <div>Processing… {Math.round(progress)}%</div>
         <ProgressBar progress={progress} className="w-full" />
         <button

--- a/components/ui/PropertiesDialog.tsx
+++ b/components/ui/PropertiesDialog.tsx
@@ -46,7 +46,7 @@ const PropertiesDialog: React.FC<Props> = ({ item, onClose, onRenamed }) => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="bg-ub-cool-grey p-4 rounded shadow-md text-white w-64">
+      <div className="bg-ub-cool-grey p-4 rounded border border-window shadow-window text-white w-64">
         <div className="flex items-center mb-4">
           <img
             src={iconSrc}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -34,7 +34,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 border border-card shadow-card ${
         open ? '' : 'hidden'
       }`}
     >
@@ -49,11 +49,21 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={toggleSound} />
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={toggleSound}
+          aria-label="Sound"
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={toggleOnline} />
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={toggleOnline}
+          aria-label="Network"
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
@@ -61,9 +71,10 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
           type="checkbox"
           checked={reduceMotion}
           onChange={toggleReduceMotion}
+          aria-label="Reduced motion"
         />
       </div>
-      <div className="px-4 pt-2 border-t border-black border-opacity-20 mt-2 space-y-1">
+      <div className="px-4 pt-2 border-t border-card mt-2 space-y-1">
         <button
           type="button"
           className="w-full text-left hover:underline"

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -164,7 +164,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full ${className}`.trim()}
+      className={`flex flex-col w-full h-full border border-window shadow-window ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,11 +38,10 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 shadow-md flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform px-4 py-3 border border-card shadow-card flex items-center transition-transform duration-300 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
       style={{
         background: kaliTheme.bubble.background,
         color: kaliTheme.bubble.text,
-        border: `1px solid ${kaliTheme.bubble.border}`,
         borderRadius: 'var(--radius-md)',
       }}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,16 @@ module.exports = {
         'tray-icon': '16px',
         'tray-icon-lg': '32px',
       },
+      boxShadow: {
+        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
+        window: '0 4px 8px rgba(0,0,0,0.3)',
+        card: '0 2px 4px rgba(0,0,0,0.2)',
+      },
+      borderColor: {
+        // eslint-disable-next-line no-top-level-window/no-top-level-window-or-document
+        window: 'var(--color-border)',
+        card: 'var(--color-border)',
+      },
       keyframes: {
         glow: {
           '0%, 100%': { boxShadow: '0 0 0px theme("colors.amber.400")' },


### PR DESCRIPTION
## Summary
- extend Tailwind with `shadow-window`/`shadow-card` and `border-window`/`border-card`
- apply window utilities to dialog and tabbed window components
- style QuickSettings and Toast with card utilities and consistent separators

## Testing
- `npx eslint tailwind.config.js components/ui/PropertiesDialog.tsx components/ui/ProgressDialog.tsx components/ui/QuickSettings.tsx components/ui/TabbedWindow.tsx components/ui/Toast.tsx`
- `yarn test components/ui --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be322df1a48328bfa249484eb56ed3