### PR TITLE
Add responsive header with navigation

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+const navItems = [
+  { href: '/get-kali', label: 'Get Kali' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/docs', label: 'Documentation' },
+  { href: '/community', label: 'Community' },
+  { href: '/dev', label: 'Developers' },
+  { href: '/about', label: 'About' },
+];
+
+export default function Header() {
+  return (
+    <header className="w-full bg-gray-900 text-white">
+      <nav className="flex flex-col flex-wrap items-center justify-center gap-4 p-4 sm:flex-row">
+        {navItems.map((item) => (
+          <Link key={item.href} href={item.href} className="hover:underline">
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -18,6 +18,7 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import Header from '../components/layout/Header';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
@@ -246,6 +247,7 @@ function MyApp(props) {
             <TrayProvider>
               <PipPortalProvider>
                 <div aria-live="polite" id="live-region" />
+                <Header />
                 <Component {...pageProps} />
                 <ShortcutOverlay />
                 {process.env.VERCEL_ANALYTICS_ID && (

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">About</h1>
+      <p>About this project.</p>
+    </main>
+  );
+}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,8 @@
+export default function Blog() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Blog</h1>
+      <p>Placeholder blog page.</p>
+    </main>
+  );
+}

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -1,0 +1,8 @@
+export default function Community() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Community</h1>
+      <p>Community resources will appear here.</p>
+    </main>
+  );
+}

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -1,0 +1,8 @@
+export default function Developers() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Developers</h1>
+      <p>Developer resources will be listed here.</p>
+    </main>
+  );
+}

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,0 +1,8 @@
+export default function Documentation() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Documentation</h1>
+      <p>Welcome to the documentation.</p>
+    </main>
+  );
+}

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,0 +1,8 @@
+export default function GetKali() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Get Kali</h1>
+      <p>Placeholder page for getting Kali.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add flex-based `Header` component with navigation links
- integrate header into app layout
- create placeholder pages for Get Kali, Blog, Documentation, Community, Developers, and About

## Testing
- `npx eslint components/layout/Header.tsx pages/get-kali.tsx pages/blog.tsx pages/community.tsx pages/about.tsx pages/docs/index.tsx pages/dev/index.tsx pages/_app.jsx`
- `npx jest --passWithNoTests --findRelatedTests components/layout/Header.tsx pages/get-kali.tsx pages/blog.tsx pages/community.tsx pages/about.tsx pages/docs/index.tsx pages/dev/index.tsx pages/_app.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68be322ecb588328bd0688ed3d0f7179