### PR TITLE
feat: make header sticky

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export default function Header() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setDark(window.scrollY > 64);
+    window.addEventListener("scroll", onScroll);
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <header
+      className={`sticky top-0 z-50 transition-colors ${dark ? "bg-gray-900" : "bg-transparent"}`}
+    >
+      <div className="mx-auto max-w-screen-xl p-4">Header</div>
+    </header>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 import { baseMetadata } from "../lib/metadata";
 import BetaBadge from "../components/BetaBadge";
 import useSession from "../hooks/useSession";
+import Header from "../components/Header";
 
 export const metadata = baseMetadata;
 
@@ -38,6 +39,7 @@ const App = () => {
       <a href="#window-area" className="sr-only focus:not-sr-only">
         Skip to content
       </a>
+      <Header />
       <Ubuntu
         session={session}
         setSession={setSession}


### PR DESCRIPTION
## Summary
- add sticky header component that darkens after scrolling
- include header on landing page

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, appImport.test.ts, asciiArt.test.tsx, exo-open.test.ts, middleware-csp.test.ts, ubuntu.safeMode.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68be322f88d08328a1d11c492a3682c9