### PR TITLE
Add documentation mega menu for docs nav

### DIFF
--- a/components/layout/DocMegaMenu.tsx
+++ b/components/layout/DocMegaMenu.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface DocMegaMenuProps {
+  onClose: () => void;
+}
+
+export default function DocMegaMenu({ onClose }: DocMegaMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed left-0 top-12 z-50 w-full bg-white shadow-lg p-4"
+    >
+      <ul className="grid gap-2 sm:grid-cols-2">
+        <li>
+          <a href="/docs" className="block hover:underline">
+            Docs pages
+          </a>
+        </li>
+        <li>
+          <a href="/tools" className="block hover:underline">
+            Tools docs
+          </a>
+        </li>
+        <li>
+          <a href="/faq" className="block hover:underline">
+            FAQ
+          </a>
+        </li>
+        <li>
+          <a href="/known-issues" className="block hover:underline">
+            Known Issues
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import DocMegaMenu from './DocMegaMenu';
+
+export default function Header() {
+  const [docsOpen, setDocsOpen] = useState(false);
+  const closeDocs = () => setDocsOpen(false);
+
+  return (
+    <header className="relative bg-gray-900 text-white">
+      <nav className="flex gap-4 p-4">
+        <a href="/" className="hover:underline">
+          Home
+        </a>
+        <div
+          className="relative"
+          onMouseEnter={() => setDocsOpen(true)}
+        >
+          <button
+            type="button"
+            onClick={() => setDocsOpen((v) => !v)}
+            className="hover:underline"
+          >
+            Documentation
+          </button>
+          {docsOpen && <DocMegaMenu onClose={closeDocs} />}
+        </div>
+      </nav>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add DocMegaMenu component listing docs, tools docs, FAQ, and known issues
- toggle menu on Documentation nav item hover/click

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, exo-open.test.ts, middleware-csp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be32308e348328bfa2b2cf7bb2fffb