### PR TITLE
feat: add search overlay

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import SearchOverlay from './ui/SearchOverlay';
+
+export default function Header() {
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  return (
+    <header className="flex items-center justify-between p-2 bg-gray-800 text-white">
+      <div className="font-bold">Kali Linux Portfolio</div>
+      <button
+        type="button"
+        aria-label="Search"
+        onClick={() => setSearchOpen(true)}
+        className="p-2 hover:bg-gray-700 rounded transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-5 h-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 3a7.5 7.5 0 006.15 12.65z"
+          />
+        </svg>
+      </button>
+      <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
+    </header>
+  );
+}

--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { CSSTransition } from 'react-transition-group';
+
+interface SearchOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const pages = [
+  { title: 'Home', href: '/' },
+  { title: 'Docs', href: '/docs' },
+  { title: 'Apps', href: '/apps' },
+];
+
+const tools = [
+  { title: 'Nmap', href: '/apps/nmap' },
+  { title: 'Hydra', href: '/apps/hydra' },
+  { title: 'Nikto', href: '/apps/nikto' },
+];
+
+export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (open) {
+      document.addEventListener('keydown', handleKey);
+      return () => document.removeEventListener('keydown', handleKey);
+    }
+  }, [open, onClose]);
+
+  const results = [...pages, ...tools].filter((item) =>
+    item.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <CSSTransition
+      in={open}
+      timeout={200}
+      classNames={{
+        enter: 'opacity-0',
+        enterActive: 'opacity-100 transition-opacity duration-200',
+        exit: 'opacity-100',
+        exitActive: 'opacity-0 transition-opacity duration-200',
+      }}
+      unmountOnExit
+      nodeRef={nodeRef}
+    >
+      <div
+        ref={nodeRef}
+        className="fixed inset-0 bg-black/70 flex flex-col p-4"
+        role="dialog"
+        aria-modal="true"
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          className="w-full p-3 text-lg rounded"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <ul className="mt-4 text-white space-y-1 overflow-y-auto">
+          {results.map((r) => (
+            <li key={r.href}>
+              <a href={r.href} className="block px-2 py-1 rounded hover:bg-white/10">
+                {r.title}
+              </a>
+            </li>
+          ))}
+          {query && results.length === 0 && (
+            <li className="px-2 py-1 text-gray-300">No results</li>
+          )}
+        </ul>
+      </div>
+    </CSSTransition>
+  );
+}


### PR DESCRIPTION
## Summary
- add header search button that toggles an overlay
- create animated search overlay with placeholder page/tool results

## Testing
- `yarn test` *(fails: nmapNse, appImport, remotePatterns, asciiArt, exo-open, middleware-csp, ubuntu.safeMode)*

------
https://chatgpt.com/codex/tasks/task_e_68be32320d008328a3b1e72320a2428e