### PR TITLE
feat: add community dropdown menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Menu, { MenuItem } from "./ui/Menu";
+
+const communityItems: MenuItem[] = [
+  { label: "Forums", href: "/forums" },
+  { label: "Discord", href: "/discord" },
+  { label: "Newsletter", href: "/newsletter" },
+  { label: "Mirror", href: "/mirror" },
+  { label: "Get Involved", href: "/get-involved" },
+];
+
+export default function Header() {
+  return (
+    <header className="bg-ub-grey text-white">
+      <nav className="flex gap-4 p-2">
+        <Menu label="Community" items={communityItems} />
+      </nav>
+    </header>
+  );
+}

--- a/components/ui/Menu.tsx
+++ b/components/ui/Menu.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+
+export interface MenuItem {
+  label: string;
+  href: string;
+}
+
+interface MenuProps {
+  label: string;
+  items: MenuItem[];
+}
+
+export default function Menu({ label, items }: MenuProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className="relative"
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onClick={() => setOpen(!open)}
+        className="px-3 py-2 text-white hover:bg-ubt-blue focus:outline-none"
+      >
+        {label}
+      </button>
+      {open && (
+        <ul className="absolute left-0 mt-1 bg-ub-cool-grey text-white shadow-lg min-w-[10rem]">
+          {items.map((item) => (
+            <li key={item.label}>
+              <a
+                href={item.href}
+                className="block px-4 py-2 hover:bg-ubt-blue"
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import Header from '../components/Header';
 
 
 let SpeedInsights = () => null;
@@ -236,6 +237,7 @@ function MyApp(props) {
       <ErrorBoundary>
         <Script src="/a2hs.js" strategy="beforeInteractive" />
         <div>
+          <Header />
           <a
             href="#app-grid"
             className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"


### PR DESCRIPTION
## Summary
- add reusable dropdown menu component
- integrate Community dropdown with Forums, Discord, Newsletter, Mirror and Get Involved links
- render site header globally

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: multiple test suites failing such as nmapNse.test.tsx, remotePatterns.test.ts, asciiArt.test.tsx, exo-open.test.ts, middleware-csp.test.ts, ubuntu.safeMode.test.tsx)*
- `yarn typecheck` *(fails: various TS errors like Property 'setThumbLimit' does not exist and missing names)*

------
https://chatgpt.com/codex/tasks/task_e_68be3231160c83288196b579d2ba06b7