### PR TITLE
feat: add tools strip component

### DIFF
--- a/components/home/ToolsStrip.tsx
+++ b/components/home/ToolsStrip.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+
+const tools = [
+  { name: "Nmap", src: "/tools/nmap.svg" },
+  { name: "Metasploit", src: "/tools/metasploit.svg" },
+];
+
+export default function ToolsStrip() {
+  return (
+    <div className="flex justify-center gap-8 py-8">
+      {tools.map((tool) => (
+        <Image
+          key={tool.name}
+          src={tool.src}
+          alt={tool.name}
+          width={48}
+          height={48}
+          className="transition-transform duration-200 hover:scale-105"
+        />
+      ))}
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 import { baseMetadata } from "../lib/metadata";
 import BetaBadge from "../components/BetaBadge";
 import useSession from "../hooks/useSession";
+import ToolsStrip from "../components/home/ToolsStrip";
 
 export const metadata = baseMetadata;
 
@@ -28,10 +29,7 @@ const InstallButton = dynamic(
   },
 );
 
-/**
- * @returns {JSX.Element}
- */
-const App = () => {
+const App = (): JSX.Element => {
   const { session, setSession, resetSession } = useSession();
   return (
     <>
@@ -45,6 +43,7 @@ const App = () => {
       />
       <BetaBadge />
       <InstallButton />
+      <ToolsStrip />
     </>
   );
 };

--- a/public/tools/metasploit.svg
+++ b/public/tools/metasploit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6b7280" stroke-width="2">
+  <path d="M12 3l7 4v5c0 5-3.5 9-7 9s-7-4-7-9V7l7-4z"/>
+  <path d="M12 11v5"/>
+  <circle cx="12" cy="9" r="1"/>
+</svg>

--- a/public/tools/nmap.svg
+++ b/public/tools/nmap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6b7280" stroke-width="2">
+  <circle cx="5" cy="5" r="3"/>
+  <circle cx="19" cy="5" r="3"/>
+  <circle cx="12" cy="19" r="3"/>
+  <line x1="7.6" y1="7.2" x2="16.4" y2="7.2"/>
+  <line x1="6.4" y1="7.9" x2="10.6" y2="16.1"/>
+  <line x1="17.6" y1="7.9" x2="13.4" y2="16.1"/>
+</svg>


### PR DESCRIPTION
## Summary
- add ToolsStrip component displaying tool icons with hover scaling
- place ToolsStrip on the homepage
- add neutral SVG icons for Nmap and Metasploit under public/tools

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, remotePatterns.test.ts, appImport.test.ts, exo-open.test.ts, middleware-csp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be3234730c832898a2fa7f7bd52e67