### PR TITLE
feat: add platform card component

### DIFF
--- a/components/platforms/PlatformCard.tsx
+++ b/components/platforms/PlatformCard.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image';
+
+interface PlatformCardProps {
+  title: string;
+  bullets: string[];
+  thumbnail: string;
+}
+
+export default function PlatformCard({ title, bullets, thumbnail }: PlatformCardProps) {
+  return (
+    <div className="flex gap-4 rounded border p-4">
+      <Image src={thumbnail} alt="" width={64} height={64} className="rounded" />
+      <div className="space-y-2">
+        <h3 className="font-bold">{title}</h3>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          {bullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/pages/get-kali/installers.tsx
+++ b/pages/get-kali/installers.tsx
@@ -1,0 +1,30 @@
+import PlatformCard from '../../components/platforms/PlatformCard';
+
+export default function Installers() {
+  const platforms = [
+    {
+      title: 'Virtual Machines',
+      bullets: ['VMware', 'VirtualBox', 'Hyper-V'],
+      thumbnail: '/themes/Yaru/apps/ssh.svg',
+    },
+    {
+      title: 'Bare Metal',
+      bullets: ['USB Installer', 'Boot ISO', 'NetInstall'],
+      thumbnail: '/themes/Yaru/apps/gnome-control-center.png',
+    },
+    {
+      title: 'WSL',
+      bullets: ['Run Kali on Windows', 'Easy setup', 'Integration'],
+      thumbnail: '/themes/Yaru/apps/bash.png',
+    },
+  ];
+
+  return (
+    <main className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold mb-4">Installers</h1>
+      {platforms.map((platform) => (
+        <PlatformCard key={platform.title} {...platform} />
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable `PlatformCard` with title, bullet list, and thumbnail
- show example usage on new `get-kali/installers` page

## Testing
- `npx eslint components/platforms/PlatformCard.tsx pages/get-kali/installers.tsx`
- `npx tsc --noEmit --jsx react-jsx --skipLibCheck components/platforms/PlatformCard.tsx pages/get-kali/installers.tsx`
- `npx jest pages/get-kali/installers.tsx components/platforms/PlatformCard.tsx --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68be32397af0832889f57137f9f69752