### PR TITLE
Add purple banner with Learn More CTA to Get Kali page

### DIFF
--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Link from 'next/link';
+
+const GetKali: React.FC = () => (
+  <main className="p-4">
+    <div className="mb-6 flex items-center justify-between rounded bg-purple-600 p-4 text-white">
+      <span className="text-lg">New to Kali Linux? Learn how to get started.</span>
+      <Link href="/install-options" className="rounded bg-white px-4 py-2 font-semibold text-purple-700 hover:bg-purple-50">
+        Learn More
+      </Link>
+    </div>
+    <div className="grid gap-4 md:grid-cols-3">
+      <div className="flex flex-col rounded border p-4">
+        <h2 className="mb-2 text-xl font-semibold">VMware</h2>
+        <p className="mb-4">Run Kali in a VMware virtual machine and use snapshots to save and revert your setup anytime.</p>
+        <a
+          href="https://www.kali.org/get-kali/#kali-virtual-machines"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-auto text-blue-500 hover:underline"
+        >
+          Learn more
+        </a>
+      </div>
+      <div className="flex flex-col rounded border p-4">
+        <h2 className="mb-2 text-xl font-semibold">USB Live</h2>
+        <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
+        <a
+          href="https://www.kali.org/get-kali/#kali-live"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-auto text-blue-500 hover:underline"
+        >
+          Learn more
+        </a>
+      </div>
+      <div className="flex flex-col rounded border p-4">
+        <h2 className="mb-2 text-xl font-semibold">Cloud</h2>
+        <p className="mb-4">Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
+        <a
+          href="https://www.kali.org/get-kali/#kali-cloud"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-auto text-blue-500 hover:underline"
+        >
+          Learn more
+        </a>
+      </div>
+    </div>
+  </main>
+);
+
+export default GetKali;
+


### PR DESCRIPTION
## Summary
- Add `pages/get-kali/index.tsx` page with a purple banner and Learn More CTA
- Show download options tiles to highlight the new banner

## Testing
- `npx eslint pages/get-kali/index.tsx`
- `yarn test pages/get-kali/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be323a01f083288db5ae46351883b0