### PR TITLE
feat: add callout component and platform pages

### DIFF
--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+interface CalloutProps {
+  variant: 'defaultCredentials' | 'readDocs';
+  children: React.ReactNode;
+}
+
+const KeyIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M15.75 5.25C17.4069 5.25 18.75 6.59315 18.75 8.25M21.75 8.25C21.75 11.5637 19.0637 14.25 15.75 14.25C15.3993 14.25 15.0555 14.2199 14.7213 14.1622C14.1583 14.0649 13.562 14.188 13.158 14.592L10.5 17.25H8.25V19.5H6V21.75H2.25V18.932C2.25 18.3352 2.48705 17.7629 2.90901 17.341L9.408 10.842C9.81202 10.438 9.93512 9.84172 9.83785 9.2787C9.7801 8.94446 9.75 8.60074 9.75 8.25C9.75 4.93629 12.4363 2.25 15.75 2.25C19.0637 2.25 21.75 4.93629 21.75 8.25Z"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const BookOpenIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 6.04168C10.4077 4.61656 8.30506 3.75 6 3.75C4.94809 3.75 3.93834 3.93046 3 4.26212V18.5121C3.93834 18.1805 4.94809 18 6 18C8.30506 18 10.4077 18.8666 12 20.2917M12 6.04168C13.5923 4.61656 15.6949 3.75 18 3.75C19.0519 3.75 20.0617 3.93046 21 4.26212V18.5121C20.0617 18.1805 19.0519 18 18 18C15.6949 18 13.5923 18.8666 12 20.2917M12 6.04168V20.2917"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const variants = {
+  defaultCredentials: {
+    icon: KeyIcon,
+    border: 'border-yellow-400',
+    label: 'Default credentials',
+  },
+  readDocs: {
+    icon: BookOpenIcon,
+    border: 'border-blue-400',
+    label: 'Read the docs',
+  },
+};
+
+export default function Callout({ variant, children }: CalloutProps) {
+  const V = variants[variant];
+  const Icon = V.icon;
+  return (
+    <div className={`flex items-start space-x-3 border-l-4 p-4 ${V.border}`}>
+      <Icon className="w-5 h-5 mt-1" aria-hidden="true" />
+      <div>
+        <h3 className="font-semibold">{V.label}</h3>
+        <div className="text-sm">{children}</div>
+      </div>
+    </div>
+  );
+}
+

--- a/pages/install-options.tsx
+++ b/pages/install-options.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 
 const InstallOptions: React.FC = () => (
   <main className="p-4">
@@ -6,38 +7,23 @@ const InstallOptions: React.FC = () => (
       <div className="border rounded p-4 flex flex-col">
         <h2 className="text-xl font-semibold mb-2">VMware</h2>
         <p className="mb-4">Run Kali in a VMware virtual machine and use snapshots to save and revert your setup anytime.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-virtual-machines"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-500 hover:underline mt-auto"
-        >
+        <Link href="/platforms/vmware" className="text-blue-500 hover:underline mt-auto">
           Learn more
-        </a>
+        </Link>
       </div>
       <div className="border rounded p-4 flex flex-col">
         <h2 className="text-xl font-semibold mb-2">USB Live</h2>
         <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-live"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-500 hover:underline mt-auto"
-        >
+        <Link href="/platforms/usb-live" className="text-blue-500 hover:underline mt-auto">
           Learn more
-        </a>
+        </Link>
       </div>
       <div className="border rounded p-4 flex flex-col">
         <h2 className="text-xl font-semibold mb-2">Cloud</h2>
         <p className="mb-4">Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-cloud"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-500 hover:underline mt-auto"
-        >
+        <Link href="/platforms/cloud" className="text-blue-500 hover:underline mt-auto">
           Learn more
-        </a>
+        </Link>
       </div>
     </div>
   </main>

--- a/pages/platforms/cloud.tsx
+++ b/pages/platforms/cloud.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Callout from '../../components/ui/Callout';
+
+const CloudPage: React.FC = () => (
+  <main className="p-4 space-y-4">
+    <h1 className="text-2xl font-semibold">Cloud</h1>
+    <p>Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
+    <Callout variant="readDocs">
+      <p>
+        Read the{' '}
+        <a
+          href="https://www.kali.org/docs/cloud/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          cloud deployment documentation
+        </a>
+        {' '}to get started.
+      </p>
+    </Callout>
+  </main>
+);
+
+export default CloudPage;
+

--- a/pages/platforms/usb-live.tsx
+++ b/pages/platforms/usb-live.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Callout from '../../components/ui/Callout';
+
+const USBLivePage: React.FC = () => (
+  <main className="p-4 space-y-4">
+    <h1 className="text-2xl font-semibold">USB Live</h1>
+    <p>Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
+    <Callout variant="readDocs">
+      <p>
+        Create a persistent live USB by following the{' '}
+        <a
+          href="https://www.kali.org/docs/usb/usb-persistence/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          step-by-step guide
+        </a>
+        .
+      </p>
+    </Callout>
+  </main>
+);
+
+export default USBLivePage;
+

--- a/pages/platforms/vmware.tsx
+++ b/pages/platforms/vmware.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Callout from '../../components/ui/Callout';
+
+const VMwarePage: React.FC = () => (
+  <main className="p-4 space-y-4">
+    <h1 className="text-2xl font-semibold">VMware</h1>
+    <p>Run Kali in a VMware virtual machine and use snapshots to save and revert your setup anytime.</p>
+    <Callout variant="readDocs">
+      <p>
+        For setup instructions, read the{' '}
+        <a
+          href="https://www.kali.org/docs/virtualization/install-vmware/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          official documentation
+        </a>
+        .
+      </p>
+    </Callout>
+    <Callout variant="defaultCredentials">
+      <p>
+        The default login for VMware images is <code>kali/kali</code>.
+      </p>
+    </Callout>
+  </main>
+);
+
+export default VMwarePage;
+


### PR DESCRIPTION
## Summary
- add reusable Callout component with variants for default credentials and docs reminders
- introduce platform detail pages using Callout to highlight guidance
- link install options to new platform pages

## Testing
- `npx eslint components/ui/Callout.tsx pages/install-options.tsx pages/platforms/vmware.tsx pages/platforms/usb-live.tsx pages/platforms/cloud.tsx`
- `yarn test --passWithNoTests Callout`


------
https://chatgpt.com/codex/tasks/task_e_68be323aefa48328a0070f27bd4adeac