### PR TITLE
Add platform SVG icons for install options

### DIFF
--- a/components/icons/CloudIcon.tsx
+++ b/components/icons/CloudIcon.tsx
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+
+export function CloudIcon({ size = 40 }: { size?: number }) {
+  return (
+    <Image
+      src="/icons/platforms/cloud.svg"
+      alt="Cloud"
+      width={size}
+      height={size}
+    />
+  );
+}

--- a/components/icons/UsbIcon.tsx
+++ b/components/icons/UsbIcon.tsx
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+
+export function UsbIcon({ size = 40 }: { size?: number }) {
+  return (
+    <Image
+      src="/icons/platforms/usb.svg"
+      alt="USB"
+      width={size}
+      height={size}
+    />
+  );
+}

--- a/components/icons/VmwareIcon.tsx
+++ b/components/icons/VmwareIcon.tsx
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+
+export function VmwareIcon({ size = 40 }: { size?: number }) {
+  return (
+    <Image
+      src="/icons/platforms/vmware.svg"
+      alt="VMware"
+      width={size}
+      height={size}
+    />
+  );
+}

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,0 +1,3 @@
+export { VmwareIcon } from './VmwareIcon';
+export { UsbIcon } from './UsbIcon';
+export { CloudIcon } from './CloudIcon';

--- a/pages/install-options.tsx
+++ b/pages/install-options.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import { VmwareIcon, UsbIcon, CloudIcon } from '../components/icons';
 
 const InstallOptions: React.FC = () => (
   <main className="p-4">
     <div className="grid gap-4 md:grid-cols-3">
       <div className="border rounded p-4 flex flex-col">
-        <h2 className="text-xl font-semibold mb-2">VMware</h2>
+        <div className="flex items-center mb-2">
+          <VmwareIcon size={32} />
+          <h2 className="ml-2 text-xl font-semibold">VMware</h2>
+        </div>
         <p className="mb-4">Run Kali in a VMware virtual machine and use snapshots to save and revert your setup anytime.</p>
         <a
           href="https://www.kali.org/get-kali/#kali-virtual-machines"
@@ -16,7 +20,10 @@ const InstallOptions: React.FC = () => (
         </a>
       </div>
       <div className="border rounded p-4 flex flex-col">
-        <h2 className="text-xl font-semibold mb-2">USB Live</h2>
+        <div className="flex items-center mb-2">
+          <UsbIcon size={32} />
+          <h2 className="ml-2 text-xl font-semibold">USB Live</h2>
+        </div>
         <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
         <a
           href="https://www.kali.org/get-kali/#kali-live"
@@ -28,7 +35,10 @@ const InstallOptions: React.FC = () => (
         </a>
       </div>
       <div className="border rounded p-4 flex flex-col">
-        <h2 className="text-xl font-semibold mb-2">Cloud</h2>
+        <div className="flex items-center mb-2">
+          <CloudIcon size={32} />
+          <h2 className="ml-2 text-xl font-semibold">Cloud</h2>
+        </div>
         <p className="mb-4">Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
         <a
           href="https://www.kali.org/get-kali/#kali-cloud"

--- a/public/icons/platforms/cloud.svg
+++ b/public/icons/platforms/cloud.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 16h14a4 4 0 0 0 0-8 5 5 0 0 0-9.9-1A4 4 0 0 0 5 16z"/>
+</svg>

--- a/public/icons/platforms/usb.svg
+++ b/public/icons/platforms/usb.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+  <rect x="9" y="2" width="6" height="4"/>
+  <rect x="7" y="6" width="10" height="14" rx="2"/>
+</svg>

--- a/public/icons/platforms/vmware.svg
+++ b/public/icons/platforms/vmware.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="8" height="8"/>
+  <rect x="13" y="13" width="8" height="8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simple SVG icons for VMware, USB, and cloud platforms
- export platform icons as reusable React components
- show platform icons on install options cards

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: __tests__/remotePatterns.test.ts, __tests__/appImport.test.ts, __tests__/exo-open.test.ts, __tests__/middleware-csp.test.ts, __tests__/calculator.formulas.test.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be323bf5608328ba736628758a5e26