### PR TITLE
feat: add tool detail pages

### DIFF
--- a/components/CommandChip.tsx
+++ b/components/CommandChip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface CommandChipProps {
+  command: string;
+}
+
+export default function CommandChip({ command }: CommandChipProps) {
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="px-2 py-0.5 rounded border text-xs font-mono bg-ub-cool-grey text-white hover:bg-ub-orange focus:outline-none focus:ring"
+    >
+      {command}
+    </button>
+  );
+}

--- a/data/tool-details.json
+++ b/data/tool-details.json
@@ -1,0 +1,25 @@
+{
+  "nmap": {
+    "name": "Nmap",
+    "description": "Network exploration tool and security/port scanner.",
+    "commands": [
+      "nmap -sV 192.168.0.1",
+      "nmap -A 192.168.0.1"
+    ],
+    "links": [
+      { "label": "Official Site", "url": "https://nmap.org/" },
+      { "label": "Documentation", "url": "https://nmap.org/book/" }
+    ]
+  },
+  "hydra": {
+    "name": "Hydra",
+    "description": "Parallelized login cracker which supports numerous protocols.",
+    "commands": [
+      "hydra -l user -P passlist.txt ftp://192.168.0.1",
+      "hydra -L users.txt -P passlist.txt ssh://192.168.0.1"
+    ],
+    "links": [
+      { "label": "Project Page", "url": "https://github.com/vanhauser-thc/thc-hydra" }
+    ]
+  }
+}

--- a/pages/tools/[tool].tsx
+++ b/pages/tools/[tool].tsx
@@ -1,0 +1,72 @@
+import CommandChip from '@/components/CommandChip';
+import toolData from '@/data/tool-details.json';
+import { GetStaticPaths, GetStaticProps } from 'next';
+
+interface LinkInfo {
+  label: string;
+  url: string;
+}
+
+interface ToolInfo {
+  name: string;
+  description: string;
+  commands: string[];
+  links: LinkInfo[];
+}
+
+interface ToolPageProps {
+  tool: ToolInfo;
+}
+
+export default function ToolPage({ tool }: ToolPageProps) {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{tool.name}</h1>
+      <p>{tool.description}</p>
+      {tool.commands.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Commands</h2>
+          <div className="flex flex-wrap gap-2">
+            {tool.commands.map((cmd) => (
+              <CommandChip key={cmd} command={cmd} />
+            ))}
+          </div>
+        </section>
+      )}
+      {tool.links.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">External Links</h2>
+          <ul className="list-disc list-inside">
+            {tool.links.map((link) => (
+              <li key={link.url}>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+const tools: Record<string, ToolInfo> = toolData as Record<string, ToolInfo>;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: Object.keys(tools).map((id) => ({ params: { tool: id } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<ToolPageProps> = async ({ params }) => {
+  const id = params?.tool as string;
+  const tool = tools[id];
+  return { props: { tool } };
+};


### PR DESCRIPTION
## Summary
- add reusable `CommandChip` to copy commands
- add tool metadata for Nmap and Hydra
- add dynamic `/tools/[tool]` page to show commands and links

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: nmapNse.test.tsx, weather.spec.ts, appImport.test.ts, remotePatterns.test.ts, exo-open.test.ts, middleware-csp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be323d7a388328beccee72f28c55ad