### PR TITLE
feat: add CommandChip component

### DIFF
--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import CommandChip from '../../components/ui/CommandChip';
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
@@ -55,9 +56,13 @@ const HTTPBuilder: React.FC = () => {
       </form>
       <div>
         <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
+        {command ? (
+          <CommandChip command={command} />
+        ) : (
+          <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+            # Fill in the form to generate a command
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/apps/nikto/index.tsx
+++ b/apps/nikto/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import HeaderLab from './components/HeaderLab';
+import CommandChip from '../../components/ui/CommandChip';
 
 interface NiktoFinding {
   path: string;
@@ -156,7 +157,7 @@ const NiktoPage: React.FC = () => {
       </form>
       <div>
         <h2 className="text-lg mb-2">Command Preview</h2>
-        <pre className="bg-black text-green-400 p-2 rounded overflow-auto">{command}</pre>
+        <CommandChip command={command} />
       </div>
       <div className="relative bg-gray-800 p-4 rounded shadow space-y-4">
         <div className="absolute top-2 right-2 bg-gray-700 text-xs px-2 py-1 rounded-full">

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import CommandChip from '../../components/ui/CommandChip';
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
@@ -64,9 +65,13 @@ const SSHBuilder: React.FC = () => {
       </form>
       <div>
         <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
+        {command ? (
+          <CommandChip command={command} />
+        ) : (
+          <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+            # Fill in the form to generate a command
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -3,6 +3,7 @@ import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
 import TerminalOutput from '../../TerminalOutput';
+import CommandChip from '../../ui/CommandChip';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes
@@ -235,12 +236,6 @@ const Dsniff = () => {
   const sampleCommand = 'urlsnarf -i eth0';
   const sampleOutput = urlsnarfLines.slice(0, 1).join('\n');
 
-  const copySampleCommand = () => {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(sampleCommand);
-    }
-  };
-
   const copySelectedPacket = () => {
     if (selectedPacket !== null && navigator.clipboard) {
       const pkt = pcapSummary[selectedPacket];
@@ -439,17 +434,9 @@ const Dsniff = () => {
         <div className="md:w-1/2 bg-black p-2 flex flex-col">
           <div className="flex items-center justify-between mb-2">
             <span className="font-bold text-sm">Sample command</span>
-            <button
-              onClick={copySampleCommand}
-              className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
-            >
-              Copy sample command
-            </button>
+            <CommandChip command={sampleCommand} />
           </div>
-          <TerminalOutput
-            text={`${sampleCommand}\n${sampleOutput}`}
-            ariaLabel="sample command output"
-          />
+          <TerminalOutput text={sampleOutput} ariaLabel="sample command output" />
         </div>
       </div>
       <div className="mb-4" data-testid="pcap-demo">

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import usePrefersReducedMotion from '../../../hooks/usePrefersReducedMotion';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
+import CommandChip from '../../ui/CommandChip';
 
 export const hashTypes = [
   {
@@ -494,34 +495,14 @@ function HashcatApp() {
       </div>
       <div className="mt-2">
         <div className="text-sm">Demo Command:</div>
-        <div className="flex items-center">
-          <code
-            className="bg-black px-2 py-1 text-xs"
-            data-testid="demo-command"
-          >
-            {`hashcat -m ${hashType} -a ${attackMode} ${
-              hashInput || 'hash.txt'
-            } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
-              showMask && mask ? ` ${mask}` : ''
-            }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`}
-          </code>
-          <button
-            className="ml-2"
-            onClick={() => {
-              if (navigator?.clipboard?.writeText) {
-                navigator.clipboard.writeText(
-                  `hashcat -m ${hashType} -a ${attackMode} ${
-                    hashInput || 'hash.txt'
-                  } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
-                    showMask && mask ? ` ${mask}` : ''
-                  }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`
-                );
-              }
-            }}
-          >
-            Copy
-          </button>
-        </div>
+        <CommandChip
+          command={`hashcat -m ${hashType} -a ${attackMode} ${
+            hashInput || 'hash.txt'
+          } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
+            showMask && mask ? ` ${mask}` : ''
+          }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`}
+          data-testid="demo-command"
+        />
       </div>
       <div className="mt-4 w-full max-w-md">
         <div className="text-sm">Sample Output:</div>

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -2,6 +2,7 @@ import { isBrowser } from '@/utils/env';
 import React, { useEffect, useRef, useState } from 'react';
 import Toast from '../../ui/Toast';
 import DiscoveryMap from './DiscoveryMap';
+import CommandChip from '../../ui/CommandChip';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
 const scripts = [
@@ -130,17 +131,6 @@ const NmapNSEApp = () => {
   } ${argsString ? `--script-args ${argsString}` : ''} ${target}`
     .replace(/\s+/g, ' ')
     .trim();
-
-  const copyCommand = async () => {
-    if (isBrowser()) {
-      try {
-        await navigator.clipboard.writeText(command);
-        setToast('Command copied');
-      } catch (e) {
-        // ignore
-      }
-    }
-  };
 
   const copyOutput = async () => {
     const text = selectedScripts
@@ -276,16 +266,7 @@ const NmapNSEApp = () => {
           </div>
         </div>
         <div className="flex items-center mb-4">
-          <pre className="flex-1 bg-black text-green-400 p-2 rounded overflow-auto">
-            {command}
-          </pre>
-          <button
-            type="button"
-            onClick={copyCommand}
-            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
-          >
-            Copy Command
-          </button>
+          <CommandChip command={command} />
         </div>
       </div>
       <div className="md:w-1/2 p-4 bg-black overflow-y-auto">

--- a/components/ui/CommandChip.tsx
+++ b/components/ui/CommandChip.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface CommandChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  command: string;
+}
+
+export default function CommandChip({ command, className = '', ...props }: CommandChipProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className={`inline-flex items-center rounded bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
+      aria-label={`Copy ${command}`}
+      {...props}
+    >
+      <span className="select-all">$ {command}</span>
+      {copied && <span className="ml-2 text-xs text-gray-400">Copied</span>}
+    </button>
+  );
+}
+

--- a/pages/apps/help/win-kex.tsx
+++ b/pages/apps/help/win-kex.tsx
@@ -1,20 +1,7 @@
 "use client";
 
 import React from 'react';
-import copyToClipboard from '../../../utils/clipboard';
-
-const CommandBlock = ({ command }: { command: string }) => (
-  <div className="flex items-start gap-2 my-2">
-    <pre className="flex-1 overflow-x-auto rounded bg-black p-3 text-green-400 font-mono">{command}</pre>
-    <button
-      onClick={() => copyToClipboard(command)}
-      className="px-2 py-1 text-sm rounded bg-gray-700"
-      aria-label={`Copy ${command}`}
-    >
-      Copy
-    </button>
-  </div>
-);
+import CommandChip from '../../../components/ui/CommandChip';
 
 const WindowModeDiagram = () => (
   <svg viewBox="0 0 120 80" className="mx-auto mb-4 w-full h-auto max-w-[200px]">
@@ -75,7 +62,7 @@ export default function WinKexHelp() {
           Runs a full Kali desktop inside a single window. Press <kbd>F8</kbd> to release the
           pointer or toggle the control menu.
         </p>
-        <CommandBlock command="kex --win" />
+        <CommandChip command="kex --win" />
       </section>
 
       <section>
@@ -85,7 +72,7 @@ export default function WinKexHelp() {
           Integrates Kali apps directly onto the Windows desktop. Use <kbd>F8</kbd> to bring up the
           menu for moving or resizing windows.
         </p>
-        <CommandBlock command="kex --sl" />
+        <CommandChip command="kex --sl" />
       </section>
 
       <section>
@@ -95,7 +82,7 @@ export default function WinKexHelp() {
           Uses an RDP connection for features like clipboard and sound. Tap <kbd>F8</kbd> to access
           session options or send <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Del</kbd>.
         </p>
-        <CommandBlock command="kex --esm" />
+        <CommandChip command="kex --esm" />
       </section>
     </main>
   );

--- a/pages/apps/settings/date-time.tsx
+++ b/pages/apps/settings/date-time.tsx
@@ -1,6 +1,7 @@
 import ToggleSwitch from '../../../components/ToggleSwitch';
 import { useSettings } from '../../../hooks/useSettings';
 import usePersistentState from '../../../hooks/usePersistentState';
+import CommandChip from '../../../components/ui/CommandChip';
 import type { ChangeEvent } from 'react';
 
 export default function DateTimeSettings() {
@@ -115,12 +116,10 @@ export default function DateTimeSettings() {
         />
         <span className="cursor-help" title={tooltip} aria-label="NTP info">ℹ️</span>
       </div>
-      <textarea
-        readOnly
-        value={`sudo apt install chrony\nsudo systemctl enable --now chrony`}
-        className="w-full bg-ub-cool-grey text-ubt-grey p-2 rounded"
-        aria-label="NTP commands"
-      />
+      <div className="space-y-2" aria-label="NTP commands">
+        <CommandChip command="sudo apt install chrony" />
+        <CommandChip command="sudo systemctl enable --now chrony" />
+      </div>
     </div>
   );
 }

--- a/pages/hydra-preview.tsx
+++ b/pages/hydra-preview.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import FormError from '../components/ui/FormError';
+import CommandChip from '../components/ui/CommandChip';
 
 const protocols = ['ssh', 'ftp', 'http', 'smtp'];
 
@@ -92,7 +93,7 @@ const HydraPreview: React.FC = () => {
             <p className="mb-4 text-sm text-yellow-700">
               Use this command only on systems you own or have explicit permission to test. Unauthorized access is illegal.
             </p>
-            <pre className="overflow-auto rounded bg-black p-2 text-green-400">{command}</pre>
+            <CommandChip command={command} />
           </div>
         )}
         <div className="mt-4 flex justify-between">

--- a/pages/wps-attack.tsx
+++ b/pages/wps-attack.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { baseMetadata } from '../lib/metadata';
+import CommandChip from '../components/ui/CommandChip';
 
 export const metadata = baseMetadata;
 
@@ -57,10 +58,12 @@ const WpsAttack = () => {
             >
               <div className="font-bold">{`Step ${idx + 1}: ${s.title}`}</div>
               {idx === current && (
-                <pre className="bg-ub-black text-green-400 p-2 mt-2 text-sm overflow-auto whitespace-pre-wrap">
-{`$ ${s.command}
-${s.output}`}
-                </pre>
+                <>
+                  <CommandChip command={s.command} className="mt-2" />
+                  <pre className="bg-ub-black text-green-400 p-2 mt-2 text-sm overflow-auto whitespace-pre-wrap">
+                    {s.output}
+                  </pre>
+                </>
               )}
             </li>
           ))}


### PR DESCRIPTION
## Summary
- add reusable CommandChip with copy-to-clipboard
- replace inline command previews with CommandChip across apps and docs

## Testing
- `yarn test` *(fails: remotePatterns, exo-open, middleware-csp, flappyBird, asciiArt)*

------
https://chatgpt.com/codex/tasks/task_e_68be323dfc0c83288ce7c396a40c0fb4