### PR TITLE
feat: add dock with running indicators

### DIFF
--- a/__tests__/Dock.test.tsx
+++ b/__tests__/Dock.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Dock from '../src/components/desktop/Dock';
+
+test('renders dock icons and toggles running indicator', () => {
+  render(<Dock />);
+
+  const terminalBtn = screen.getByRole('button', { name: /Terminal/i });
+  const browserBtn = screen.getByRole('button', { name: /Browser/i });
+  const filesBtn = screen.getByRole('button', { name: /Files/i });
+
+  expect(terminalBtn).toBeInTheDocument();
+  expect(browserBtn).toBeInTheDocument();
+  expect(filesBtn).toBeInTheDocument();
+
+  expect(screen.queryByTestId('indicator-terminal')).toBeNull();
+  fireEvent.click(terminalBtn);
+  expect(screen.getByTestId('indicator-terminal')).toBeInTheDocument();
+  fireEvent.click(terminalBtn);
+  expect(screen.queryByTestId('indicator-terminal')).toBeNull();
+});

--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import DesktopContextMenu from './DesktopContextMenu';
+import Dock from './Dock';
+import Panel from '../panel/Panel';
 
 export interface DesktopIcon {
   id: string;
@@ -60,6 +62,9 @@ export const Desktop: React.FC = () => {
       onContextMenu={handleContextMenu}
       onClick={closeMenu}
     >
+      <div className="absolute top-0 left-0 right-0 z-50">
+        <Panel />
+      </div>
       {icons.map((icon) => (
         <div
           key={icon.id}
@@ -71,6 +76,7 @@ export const Desktop: React.FC = () => {
           <div>{icon.title}</div>
         </div>
       ))}
+      <Dock />
       <DesktopContextMenu
         position={menuPos}
         onClose={closeMenu}

--- a/src/components/desktop/Dock.tsx
+++ b/src/components/desktop/Dock.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+interface AppItem {
+  id: string;
+  title: string;
+  icon: string;
+}
+
+const APPS: AppItem[] = [
+  { id: 'terminal', title: 'Terminal', icon: '💻' },
+  { id: 'browser', title: 'Browser', icon: '🌐' },
+  { id: 'files', title: 'Files', icon: '📁' },
+];
+
+/**
+ * Simple vertical dock with launcher icons.
+ * Clicking an icon toggles a running indicator.
+ */
+const Dock: React.FC = () => {
+  const [running, setRunning] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setRunning((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <nav
+      aria-label="Dock"
+      className="fixed left-2 top-1/2 -translate-y-1/2 flex flex-col items-center space-y-2"
+    >
+      {APPS.map((app) => {
+        const isRunning = running[app.id];
+        return (
+          <button
+            key={app.id}
+            type="button"
+            aria-label={app.title}
+            onClick={() => toggle(app.id)}
+            className="relative w-12 h-12 flex items-center justify-center rounded bg-black/20 text-xl text-white transition-colors hover:bg-white/20 active:bg-white/30"
+          >
+            <span>{app.icon}</span>
+            {isRunning && (
+              <span
+                data-testid={`indicator-${app.id}`}
+                className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-1 rounded-full bg-white"
+              />
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default Dock;


### PR DESCRIPTION
## Summary
- introduce vertical Dock component with launcher icons and running app markers
- place TopPanel and Dock inside desktop layout for basic shell structure
- test dock interactions

## Testing
- `yarn test __tests__/Dock.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be3243308083288d414303d7bcd4be