### PR TITLE
feat: add wallpaper picker

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -16,6 +16,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import WallpaperPicker from "../../components/ui/WallpaperPicker";
 
 export default function Settings() {
   const {
@@ -49,18 +50,6 @@ export default function Settings() {
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
-
-  const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -176,54 +165,11 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpapers.indexOf(wallpaper)}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
+          <div className="border-t border-gray-900">
+            <WallpaperPicker />
           </div>
           <div className="flex justify-center my-4">
             <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
-                  }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button

--- a/components/ui/WallpaperPicker.tsx
+++ b/components/ui/WallpaperPicker.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSettings } from "../../hooks/useSettings";
+
+const WALLPAPERS = [
+  "wall-1",
+  "wall-2",
+  "wall-3",
+  "wall-4",
+  "wall-5",
+  "wall-6",
+  "wall-7",
+  "wall-8",
+];
+
+export default function WallpaperPicker() {
+  const { wallpaper, setWallpaper } = useSettings();
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--background-image",
+      `url(/wallpapers/${wallpaper}.webp)`
+    );
+  }, [wallpaper]);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center">
+      {WALLPAPERS.map((name) => (
+        <button
+          key={name}
+          type="button"
+          aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+          aria-pressed={name === wallpaper}
+          onClick={() => setWallpaper(name)}
+          className={`md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80 ${
+            name === wallpaper ? "border-yellow-700" : "border-transparent"
+          }`}
+          style={{
+            backgroundImage: `url(/wallpapers/${name}.webp)`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "center center",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,6 +28,7 @@
   --kali-bg: var(--color-bg);
   --kali-panel: var(--color-surface);
   --icon-spacing: var(--space-2);
+  --background-image: url(/wallpapers/wall-2.webp);
 }
 
 /* Dark theme */

--- a/styles/index.css
+++ b/styles/index.css
@@ -9,6 +9,10 @@ body{
     font-family: var(--font-family-base);
     font-display: swap;
     background-color: var(--color-bg);
+    background-image: var(--background-image);
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
     color: var(--color-text);
     line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- add `WallpaperPicker` component that updates `--background-image`
- integrate picker into Appearance settings
- apply wallpaper CSS variable as body background

## Testing
- `npx eslint apps/settings/index.tsx components/ui/WallpaperPicker.tsx`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Module './main' declares 'evaluate' locally, but it is not exported)*
- `npx jest --passWithNoTests apps/settings/index.tsx components/ui/WallpaperPicker.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be3241cfc88328b306262937cc8b9d