### PR TITLE
feat: add desktop app menu

### DIFF
--- a/components/desktop/AppMenu.tsx
+++ b/components/desktop/AppMenu.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import Image from 'next/image';
+import UbuntuApp from '../base/ubuntu_app';
+import apps, { utilities, games } from '../../apps.config';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+interface AppMeta {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+}
+
+const CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'favorites', label: 'Favorites' },
+  { id: 'recent', label: 'Recent' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'games', label: 'Games' },
+];
+
+const COLS = 3; // number of columns in the app grid
+
+const AppMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('all');
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const allApps: AppMeta[] = apps as any;
+  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const recentApps = useMemo(() => {
+    try {
+      const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
+      return ids
+        .map(id => allApps.find(a => a.id === id))
+        .filter(Boolean) as AppMeta[];
+    } catch {
+      return [];
+    }
+  }, [allApps, open]);
+  const utilityApps: AppMeta[] = utilities as any;
+  const gameApps: AppMeta[] = games as any;
+
+  const currentApps = useMemo(() => {
+    let list: AppMeta[];
+    switch (category) {
+      case 'favorites':
+        list = favoriteApps;
+        break;
+      case 'recent':
+        list = recentApps;
+        break;
+      case 'utilities':
+        list = utilityApps;
+        break;
+      case 'games':
+        list = gameApps;
+        break;
+      default:
+        list = allApps;
+    }
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter(a => a.title.toLowerCase().includes(q));
+    }
+    return list;
+  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlight(0);
+  }, [open, category, query]);
+
+  const openSelectedApp = (id: string) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.code === 'Space' && !e.altKey && !e.shiftKey) {
+        e.preventDefault();
+        setOpen(o => !o);
+        return;
+      }
+      if (!open) return;
+      if (e.key === 'Escape') {
+        setOpen(false);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const app = currentApps[highlight];
+        if (app) openSelectedApp(app.id);
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlight(h => Math.min(h + COLS, currentApps.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlight(h => Math.max(h - COLS, 0));
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setHighlight(h => Math.max(h - 1, 0));
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, currentApps, highlight]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!open) return;
+      const target = e.target as Node;
+      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        <Image
+          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          alt="Menu"
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
+        Applications
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          tabIndex={-1}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setOpen(false);
+            }
+          }}
+        >
+          <div className="flex flex-col bg-gray-800 p-2">
+            {CATEGORIES.map(cat => (
+              <button
+                key={cat.id}
+                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                onClick={() => setCategory(cat.id)}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+          <div className="p-3">
+            <input
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              placeholder="Search"
+              aria-label="Search applications"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              autoFocus
+            />
+            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+              {currentApps.map((app, idx) => (
+                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
+                  <UbuntuApp
+                    id={app.id}
+                    icon={app.icon}
+                    name={app.title}
+                    openApp={() => openSelectedApp(app.id)}
+                    disabled={app.disabled}
+                    tabIndex={-1}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AppMenu;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import PanelClock from '../util-components/PanelClock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
+import AppMenu from '../desktop/AppMenu';
 import HelpMenu from '../menu/HelpMenu';
 
 export default class Navbar extends Component {
@@ -20,7 +20,7 @@ export default class Navbar extends Component {
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
-                                <WhiskerMenu />
+                                <AppMenu />
                                 <HelpMenu />
                                 <div
                                         className={


### PR DESCRIPTION
## Summary
- add desktop AppMenu with category sidebar and grid of applications
- allow opening via panel icon or Ctrl+Space and navigate with arrow keys
- wire menu into navbar

## Testing
- `npx eslint components/desktop/AppMenu.tsx components/screen/navbar.js && echo ESLINT-PASS`
- `yarn test components/desktop/AppMenu.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be32437c248328845353d5f9518e25