### PR TITLE
feat: add responsive desktop top panel

### DIFF
--- a/components/desktop/DesktopLayout.tsx
+++ b/components/desktop/DesktopLayout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React, { type ReactNode } from "react";
+import TopPanel from "./TopPanel";
+
+interface Props {
+  /** Title to display in the TopPanel */
+  title?: string;
+  /** Page content */
+  children: ReactNode;
+}
+
+/**
+ * Simple layout that places a TopPanel above arbitrary content, mimicking a
+ * desktop environment. The panel remains at the top while content fills the
+ * remaining viewport height.
+ */
+export default function DesktopLayout({ title, children }: Props) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <TopPanel title={title} />
+      <main className="flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}
+

--- a/components/desktop/TopPanel.tsx
+++ b/components/desktop/TopPanel.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import WhiskerMenu from "../menu/WhiskerMenu";
+import PanelClock from "../util-components/PanelClock";
+import Status from "../util-components/status";
+
+interface Props {
+  /** Optional title shown in the center of the panel */
+  title?: string;
+}
+
+/**
+ * A simple top panel for desktop-style layouts.
+ * Displays an application menu on the left, the current window title in the
+ * center and various system indicators on the right. The title and clock are
+ * hidden on very small screens to keep the panel usable on mobile devices.
+ */
+export default function TopPanel({ title }: Props) {
+  return (
+    <header className="flex items-center justify-between w-full bg-ub-grey text-ubt-grey h-8 px-2 text-sm sticky top-0 z-40">
+      {/* App menu */}
+      <div className="flex items-center">
+        <WhiskerMenu />
+      </div>
+
+      {/* Window title */}
+      <div className="flex-1 flex justify-center">
+        {title && (
+          <span className="hidden sm:block truncate max-w-xs text-center" data-testid="window-title">
+            {title}
+          </span>
+        )}
+      </div>
+
+      {/* System indicators */}
+      <div className="flex items-center space-x-2" aria-label="System indicators">
+        <div className="hidden sm:block">
+          <PanelClock />
+        </div>
+        <Status />
+      </div>
+    </header>
+  );
+}
+

--- a/pages/dev/health.tsx
+++ b/pages/dev/health.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from 'react';
+import DesktopLayout from '../../components/desktop/DesktopLayout';
 
 export default function DevHealth() {
   const [status, setStatus] = useState('');
@@ -16,15 +17,18 @@ export default function DevHealth() {
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-bold">Dev Health</h1>
-      <button
-        onClick={unregister}
-        className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500"
-      >
-        Unregister SW
-      </button>
-      {status && <p>{status}</p>}
-    </div>
+    <DesktopLayout title="Dev Health">
+      <div className="p-4 space-y-4">
+        <h1 className="text-xl font-bold">Dev Health</h1>
+        <button
+          onClick={unregister}
+          className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500"
+        >
+          Unregister SW
+        </button>
+        {status && <p>{status}</p>}
+      </div>
+    </DesktopLayout>
   );
 }
+


### PR DESCRIPTION
## Summary
- add reusable `TopPanel` with app menu, window title and system indicators
- create `DesktopLayout` wrapper using the new top panel
- wrap dev health page with desktop layout

## Testing
- `npx eslint components/desktop/TopPanel.tsx components/desktop/DesktopLayout.tsx pages/dev/health.tsx`
- `yarn test __tests__/betaBadge.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be324429ec8328bce24223b1c2eb6f