### PR TITLE
feat: add toast provider and hook

### DIFF
--- a/components/ui/ToastProvider.tsx
+++ b/components/ui/ToastProvider.tsx
@@ -1,0 +1,75 @@
+import React, {
+  createContext,
+  useCallback,
+  useRef,
+  useState,
+  ReactNode,
+} from 'react';
+import { kaliTheme } from '../../styles/themes/kali';
+
+interface ToastItem {
+  id: number;
+  message: string;
+  leaving?: boolean;
+}
+
+interface ToastContextValue {
+  toast: (message: string, duration?: number) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const counter = useRef(0);
+
+  const remove = useCallback((id: number) => {
+    setToasts(t => t.filter(toast => toast.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (message: string, duration = 4000) => {
+      const id = ++counter.current;
+      setToasts(t => [...t, { id, message }]);
+      setTimeout(() => {
+        setToasts(t =>
+          t.map(toast =>
+            toast.id === id ? { ...toast, leaving: true } : toast,
+          ),
+        );
+        setTimeout(() => remove(id), 300);
+      }, duration);
+    },
+    [remove],
+  );
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 flex flex-col items-end gap-2 pointer-events-none">
+        {toasts.map(t => (
+          <div
+            key={t.id}
+            role="status"
+            aria-live="polite"
+            className={`px-4 py-3 shadow-md transition-all duration-300 transform pointer-events-auto ${
+              t.leaving
+                ? 'opacity-0 blur-md translate-x-2'
+                : 'opacity-100 blur-0 translate-x-0'
+            }`}
+            style={{
+              background: kaliTheme.bubble.background,
+              color: kaliTheme.bubble.text,
+              border: `1px solid ${kaliTheme.bubble.border}`,
+              borderRadius: 'var(--radius-md)',
+            }}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ToastContext } from '../components/ui/ToastProvider';
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return ctx.toast;
+};
+
+export default useToast;


### PR DESCRIPTION
## Summary
- add ToastProvider to queue messages with blur/fade and timed removal
- expose useToast hook for easy notifications

## Testing
- `yarn eslint components/ui/ToastProvider.tsx hooks/useToast.ts && echo 'Lint OK'`
- `yarn test hooks/useToast.ts components/ui/ToastProvider.tsx --passWithNoTests`
- `yarn tsc --noEmit` *(fails: Module './main' declares 'evaluate' locally, but it is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_68be324608348328871c87b2139999d0