### PR TITLE
feat: add undercover windows theme toggle

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { isBrowser } from '@/utils/env';
-import React, { Component } from 'react';
+import React, { Component, useEffect, useState } from 'react';
 import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
@@ -890,6 +890,16 @@ export class WindowXBorder extends Component {
 export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = isBrowser() && !!window.documentPictureInPicture;
+    const [, setVersion] = useState(0);
+
+    useEffect(() => {
+        const handler = () => setVersion((v) => v + 1);
+        window.addEventListener('themechange', handler);
+        return () => window.removeEventListener('themechange', handler);
+    }, []);
+
+    const theme = typeof document !== 'undefined' ? document.documentElement.dataset.theme : 'default';
+    const iconBase = theme === 'undercover' ? '/themes/Windows/window' : '/themes/Yaru/window';
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
             {pipSupported && props.pip && (
@@ -900,7 +910,7 @@ export function WindowEditButtons(props) {
                     onClick={togglePin}
                 >
                     <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
+                        src={`${iconBase}/window-pin-symbolic.svg`}
                         alt="Kali window pin"
                         className="h-4 w-4 inline"
                         width={16}
@@ -916,7 +926,7 @@ export function WindowEditButtons(props) {
                 onClick={props.minimize}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
+                    src={`${iconBase}/window-minimize-symbolic.svg`}
                     alt="Kali window minimize"
                     className="h-4 w-4 inline"
                     width={16}
@@ -934,7 +944,7 @@ export function WindowEditButtons(props) {
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
+                                src={`${iconBase}/window-restore-symbolic.svg`}
                                 alt="Kali window restore"
                                 className="h-4 w-4 inline"
                                 width={16}
@@ -950,7 +960,7 @@ export function WindowEditButtons(props) {
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
+                                src={`${iconBase}/window-maximize-symbolic.svg`}
                                 alt="Kali window maximize"
                                 className="h-4 w-4 inline"
                                 width={16}
@@ -968,7 +978,7 @@ export function WindowEditButtons(props) {
                 onClick={props.close}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
+                    src={`${iconBase}/window-close-symbolic.svg`}
                     alt="Kali window close"
                     className="h-4 w-4 inline"
                     width={16}

--- a/components/panel/ActiveWindowTitle.tsx
+++ b/components/panel/ActiveWindowTitle.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import { isBrowser } from '@/utils/env';
+import { useSettings } from '../../hooks/useSettings';
 
 const BLUR_DATA_URL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -61,6 +62,9 @@ export default function ActiveWindowTitle({
   const app = apps.find((a) => a.id === activeId);
   if (!app) return null;
 
+  const { theme } = useSettings();
+  const iconBase = theme === 'undercover' ? '/themes/Windows/window' : '/themes/Yaru/window';
+
   return (
     <div className="flex items-center space-x-2 text-white" data-testid="active-window-title">
       <span className="truncate">{app.title}</span>
@@ -72,7 +76,7 @@ export default function ActiveWindowTitle({
           onClick={() => minimize(activeId)}
         >
           <Image
-            src="/themes/Yaru/window/window-minimize-symbolic.svg"
+            src={`${iconBase}/window-minimize-symbolic.svg`}
             alt="Kali window minimize"
             className="h-3 w-3"
             width={12}
@@ -90,7 +94,7 @@ export default function ActiveWindowTitle({
           onClick={() => maximize(activeId)}
         >
           <Image
-            src="/themes/Yaru/window/window-maximize-symbolic.svg"
+            src={`${iconBase}/window-maximize-symbolic.svg`}
             alt="Kali window maximize"
             className="h-3 w-3"
             width={12}
@@ -108,7 +112,7 @@ export default function ActiveWindowTitle({
           onClick={() => close(activeId)}
         >
           <Image
-            src="/themes/Yaru/window/window-close-symbolic.svg"
+            src={`${iconBase}/window-close-symbolic.svg`}
             alt="Kali window close"
             className="h-3 w-3"
             width={12}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,6 +5,7 @@ import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import HelpMenu from '../menu/HelpMenu';
+import UndercoverToggle from '../ui/UndercoverToggle';
 
 export default class Navbar extends Component {
         constructor() {
@@ -22,6 +23,7 @@ export default class Navbar extends Component {
                                 </div>
                                 <WhiskerMenu />
                                 <HelpMenu />
+                                <UndercoverToggle />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/ui/UndercoverToggle.tsx
+++ b/components/ui/UndercoverToggle.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Image from 'next/image';
+import { useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+
+export default function UndercoverToggle() {
+  const { theme, setTheme } = useSettings();
+  const [tooltip, setTooltip] = useState(false);
+  const [prev, setPrev] = useState('default');
+
+  const isUndercover = theme === 'undercover';
+
+  const toggle = () => {
+    if (isUndercover) {
+      setTheme(prev);
+    } else {
+      setPrev(theme);
+      setTheme('undercover');
+    }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('themechange'));
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Undercover"
+        onClick={toggle}
+        onMouseEnter={() => setTooltip(true)}
+        onMouseLeave={() => setTooltip(false)}
+        className="p-2"
+      >
+        <Image
+          src="/themes/Windows/status/undercover-symbolic.svg"
+          alt="Undercover"
+          width={16}
+          height={16}
+        />
+      </button>
+      {tooltip && (
+        <div
+          role="tooltip"
+          className="absolute left-1/2 -translate-x-1/2 mt-2 whitespace-nowrap rounded bg-black px-2 py-1 text-xs text-white"
+        >
+          <p>Windows-like theme</p>
+          <a
+            className="underline"
+            href="https://www.kali.org/docs/general-use/undercover/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Learn more
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -87,6 +87,7 @@ export default function ThemeSettings() {
           <option value="kali-light">Kali Light</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
+          <option value="undercover">Undercover</option>
           <option value="matrix">Matrix</option>
         </select>
         <label className="mt-4 flex items-center gap-2">

--- a/public/themes/Windows/status/undercover-symbolic.svg
+++ b/public/themes/Windows/status/undercover-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+  <rect x="1" y="1" width="6" height="6" />
+  <rect x="9" y="1" width="6" height="6" />
+  <rect x="1" y="9" width="6" height="6" />
+  <rect x="9" y="9" width="6" height="6" />
+</svg>

--- a/public/themes/Windows/window/window-close-symbolic.svg
+++ b/public/themes/Windows/window/window-close-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+  <line x1="4" y1="4" x2="12" y2="12" />
+  <line x1="12" y1="4" x2="4" y2="12" />
+</svg>

--- a/public/themes/Windows/window/window-maximize-symbolic.svg
+++ b/public/themes/Windows/window/window-maximize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="3" y="3" width="10" height="10" />
+</svg>

--- a/public/themes/Windows/window/window-minimize-symbolic.svg
+++ b/public/themes/Windows/window/window-minimize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+  <rect x="3" y="7" width="10" height="2" />
+</svg>

--- a/public/themes/Windows/window/window-pin-symbolic.svg
+++ b/public/themes/Windows/window/window-pin-symbolic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+  <path d="M6 1l1 3 4 2-1 1H9v5l1 1v2H6v-2l1-1V7H6L5 6l4-2-1-3z"/>
+</svg>

--- a/public/themes/Windows/window/window-restore-symbolic.svg
+++ b/public/themes/Windows/window/window-restore-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="5" y="5" width="8" height="8" />
+  <path d="M3 11V3H11" />
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -106,6 +106,31 @@ html[data-theme='matrix'] {
 
 }
 
+/* Undercover Windows-like theme */
+html[data-theme='undercover'] {
+  --color-bg: #f0f0f0;
+  --color-text: #000000;
+  --color-primary: #0078d7;
+  --color-secondary: #e5e5e5;
+  --color-accent: #0078d7;
+  --color-muted: #d0d0d0;
+  --color-surface: #e5e5e5;
+  --color-inverse: #ffffff;
+  --color-border: #c0c0c0;
+  --color-terminal: #00ff00;
+  --color-dark: #005a9e;
+}
+
+html[data-theme='undercover'] .main-navbar-vp {
+  background-color: #e5e5e5;
+  color: #000000;
+}
+
+html[data-theme='undercover'] .windowMainScreen {
+  background-color: #ffffff;
+  color: #000000;
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -6,6 +6,7 @@ export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
   'kali-light': 0,
   'kali-dark': 0,
+  undercover: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,


### PR DESCRIPTION
## Summary
- add Windows-like "undercover" theme with panel and window styling
- provide Undercover toggle with tooltip linking to documentation
- switch window control icons based on active theme

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, remotePatterns.test.ts, appImport.test.ts, asciiArt.test.tsx, exo-open.test.ts, middleware-csp.test.ts, ubuntu.safeMode.test.tsx)*
- `npx playwright test tests/ui/undercover-tooltip.spec.tsx` *(fails: missing browser dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68be3246b4a483289af854f28047984e