### PR TITLE
feat: add reduced motion toggle

### DIFF
--- a/apps/phaser_matter/index.tsx
+++ b/apps/phaser_matter/index.tsx
@@ -24,7 +24,12 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
     if (!gameRef.current) return;
     const scene = gameRef.current.scene.getScene('level') as Phaser.Scene & {
       matter: Phaser.Physics.Matter.MatterPhysics;
+      parallax: Phaser.GameObjects.Rectangle[];
     };
+    scene.parallax?.forEach((p) => {
+      const orig = p.getData('scrollFactor') ?? 1;
+      p.setScrollFactor(prefersReducedMotion ? 1 : orig);
+    });
     if (prefersReducedMotion) {
       scene.scene.pause();
       scene.matter.world.pause();
@@ -170,8 +175,9 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
               data.bounds.height,
               color,
             )
-            .setScrollFactor(l.scrollFactor)
             .setDepth(-100);
+          rect.setData('scrollFactor', l.scrollFactor);
+          rect.setScrollFactor(prefersRef.current ? 1 : l.scrollFactor);
           this.parallax.push(rect);
         });
 
@@ -479,15 +485,18 @@ const PhaserMatter: React.FC<PhaserMatterProps> = ({ getDailySeed }) => {
           </button>
         </div>
         <div className="pt-2">
-          Buffer:
-          <input
-            type="range"
-            min={0}
-            max={300}
-            value={bufferWindow}
-            onChange={(e) => setBufferWindow(Number(e.target.value))}
-            className="mx-1"
-          />
+          <label>
+            Buffer:
+            <input
+              type="range"
+              min={0}
+              max={300}
+              value={bufferWindow}
+              onChange={(e) => setBufferWindow(Number(e.target.value))}
+              className="mx-1"
+              aria-label="Buffer window"
+            />
+          </label>
           {bufferWindow}ms
         </div>
       </div>

--- a/components/apps/frogger.js
+++ b/components/apps/frogger.js
@@ -7,6 +7,7 @@ import {
   getRandomSkin,
 } from '../../apps/games/frogger/config';
 import { getLevelConfig } from '../../apps/games/frogger/levels';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
 
 const WIDTH = 7;
 const HEIGHT = 8;
@@ -142,8 +143,8 @@ const Frogger = () => {
   const [sound, setSound] = useState(true);
   const soundRef = useRef(sound);
   const [highScore, setHighScore] = useState(0);
-  const [reduceMotion, setReduceMotion] = useState(false);
-  const reduceMotionRef = useRef(reduceMotion);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const reduceMotionRef = useRef(prefersReducedMotion);
   const canvasRef = useRef(null);
   const audioCtxRef = useRef(null);
   const nextLife = useRef(500);
@@ -169,7 +170,7 @@ const Frogger = () => {
   useEffect(() => { padsRef.current = pads; }, [pads]);
   useEffect(() => { pausedRef.current = paused; }, [paused]);
   useEffect(() => { soundRef.current = sound; }, [sound]);
-  useEffect(() => { reduceMotionRef.current = reduceMotion; }, [reduceMotion]);
+  useEffect(() => { reduceMotionRef.current = prefersReducedMotion; }, [prefersReducedMotion]);
   useEffect(() => { slowTimeRef.current = slowTime; }, [slowTime]);
   useEffect(() => { livesRef.current = lives; }, [lives]);
   useEffect(() => { levelRef.current = level; }, [level]);
@@ -190,13 +191,7 @@ const Frogger = () => {
     }
   }, [score, highScore]);
 
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const handler = () => setReduceMotion(mql.matches);
-    handler();
-    mql.addEventListener('change', handler);
-    return () => mql.removeEventListener('change', handler);
-  }, []);
+  // reduced motion preference handled via usePrefersReducedMotion
 
   const playTone = (freq, duration = 0.1) => {
     if (!soundRef.current) return;
@@ -396,24 +391,26 @@ const Frogger = () => {
           ctx.fillRect(x * CELL, CELL * 3 - 4 + offset, CELL, 4);
         }
       }
-      // parallax background for logs
-      logsRef.current.forEach((lane) => {
-        const bgOffset =
-          ((rippleRef.current * lane.speed * lane.dir * 20) % CELL) - CELL;
-        ctx.fillStyle = 'rgba(255,255,255,0.05)';
-        for (let x = bgOffset; x < WIDTH * CELL + CELL; x += CELL) {
-          ctx.fillRect(x, lane.y * CELL, CELL / 8, CELL);
-        }
-      });
-      // parallax background for car lanes
-      carsRef.current.forEach((lane) => {
-        const bgOffset =
-          ((rippleRef.current * lane.speed * lane.dir * 20) % CELL) - CELL;
-        ctx.fillStyle = 'rgba(255,255,255,0.1)';
-        for (let x = bgOffset; x < WIDTH * CELL + CELL; x += CELL) {
-          ctx.fillRect(x, lane.y * CELL, CELL / 4, CELL);
-        }
-      });
+      if (!reduceMotionRef.current) {
+        // parallax background for logs
+        logsRef.current.forEach((lane) => {
+          const bgOffset =
+            ((rippleRef.current * lane.speed * lane.dir * 20) % CELL) - CELL;
+          ctx.fillStyle = 'rgba(255,255,255,0.05)';
+          for (let x = bgOffset; x < WIDTH * CELL + CELL; x += CELL) {
+            ctx.fillRect(x, lane.y * CELL, CELL / 8, CELL);
+          }
+        });
+        // parallax background for car lanes
+        carsRef.current.forEach((lane) => {
+          const bgOffset =
+            ((rippleRef.current * lane.speed * lane.dir * 20) % CELL) - CELL;
+          ctx.fillStyle = 'rgba(255,255,255,0.1)';
+          for (let x = bgOffset; x < WIDTH * CELL + CELL; x += CELL) {
+            ctx.fillRect(x, lane.y * CELL, CELL / 4, CELL);
+          }
+        });
+      }
       // draw logs and cars
       logsRef.current.forEach((lane) => {
         ctx.fillStyle = colors.log;
@@ -608,6 +605,7 @@ const Frogger = () => {
         width={WIDTH * CELL}
         height={HEIGHT * CELL}
         className="border border-gray-700"
+        aria-label="Frogger game area"
       />
       <div className="mt-4" aria-live="polite">
         Score: {score} High: {highScore} Lives: {lives} Level: {level}

--- a/styles/index.css
+++ b/styles/index.css
@@ -62,6 +62,20 @@ select:focus-visible,
     scroll-behavior: auto !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .all-apps-anim,
+    .app-icon-launch,
+    .scalable-app-icon.scale {
+        animation: none !important;
+    }
+}
+
+.reduced-motion .all-apps-anim,
+.reduced-motion .app-icon-launch,
+.reduced-motion .scalable-app-icon.scale {
+    animation: none !important;
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {


### PR DESCRIPTION
## Summary
- disable major animations when `prefers-reduced-motion` is set
- wire Frogger and Phaser Matter games to honor reduced motion setting
- ensure parallax backdrops stop when motion reduction is enabled

## Testing
- `npx eslint apps/phaser_matter/index.tsx components/apps/frogger.js`
- `yarn test frogger phaserMatter`


------
https://chatgpt.com/codex/tasks/task_e_68be3248fe6c8328822cdd7371cb0b29