### PR TITLE
feat: add IA data and nav components

### DIFF
--- a/__tests__/ia.test.tsx
+++ b/__tests__/ia.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import Header from '../components/kali/Header';
+import Footer from '../components/kali/Footer';
+import ia from '../data/ia.json';
+
+describe('IA navigation', () => {
+  test('header renders items from ia.json', () => {
+    render(<Header />);
+    (ia as any).header.forEach((item: any) => {
+      expect(screen.getByText(item.label)).toBeInTheDocument();
+    });
+  });
+
+  test('footer renders groups and social links from ia.json', () => {
+    render(<Footer />);
+    (ia as any).footer.groups.forEach((group: any) => {
+      expect(screen.getByText(group.label)).toBeInTheDocument();
+      group.items.forEach((it: any) => {
+        expect(screen.getByText(it.label)).toBeInTheDocument();
+      });
+    });
+    (ia as any).footer.social.forEach((s: any) => {
+      expect(screen.getByText(s.label)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/kali/Footer.tsx
+++ b/components/kali/Footer.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ia from '../../data/ia.json';
+
+interface Group {
+  label: string;
+  items: { label: string; href: string }[];
+}
+
+const Footer: React.FC = () => (
+  <footer className="border-t border-gray-700 p-4 mt-8 text-sm">
+    <div className="grid gap-6 md:grid-cols-3 lg:grid-cols-5">
+      {(ia as any).footer.groups.map((group: Group) => (
+        <div key={group.label}>
+          <h4 className="font-semibold mb-2">{group.label}</h4>
+          <ul className="space-y-1">
+            {group.items.map((item) => (
+              <li key={item.label}>
+                <a href={item.href} className="hover:underline">
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      <div>
+        <h4 className="font-semibold mb-2">Follow Us</h4>
+        <ul className="flex flex-wrap gap-2">
+          {(ia as any).footer.social.map((s: { label: string; href: string }) => (
+            <li key={s.label}>
+              <a href={s.href} className="hover:underline">
+                {s.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/components/kali/Header.tsx
+++ b/components/kali/Header.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ia from '../../data/ia.json';
+
+interface NavItem {
+  label: string;
+  href?: string;
+  children?: NavItem[];
+}
+
+const Header: React.FC = () => (
+  <header className="border-b border-gray-700 p-4">
+    <nav aria-label="Main navigation">
+      <ul className="flex flex-wrap gap-4">
+        {(ia as any).header.map((item: NavItem) => (
+          <li key={item.label} className="relative">
+            {item.children ? (
+              <details>
+                <summary className="cursor-pointer list-none">{item.label}</summary>
+                <ul className="mt-2 space-y-1">
+                  {item.children.map((child) => (
+                    <li key={child.label}>
+                      <a href={child.href} className="hover:underline">
+                        {child.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            ) : (
+              <a href={item.href} className="hover:underline">
+                {item.label}
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </header>
+);
+
+export default Header;

--- a/data/ia.json
+++ b/data/ia.json
@@ -1,0 +1,102 @@
+{
+  "header": [
+    {"label": "Get Kali", "href": "https://www.kali.org/get-kali/"},
+    {"label": "Blog", "href": "https://www.kali.org/blog/"},
+    {"label": "Documentation", "children": [
+      {"label": "Documentation Pages", "href": "https://www.kali.org/docs/"},
+      {"label": "Tools Documentation", "href": "https://www.kali.org/tools/"},
+      {"label": "Frequently Asked Questions", "href": "https://www.kali.org/faq/"},
+      {"label": "Known Issues", "href": "https://bugs.kali.org/search.php?project_id=1&category_id[]=General%20Bug&category_id[]=Kali%20Package%20Bug&category_id[]=Kali%20Package%20Improvement&status[]=30&status[]=40&status[]=50&sticky=on&sort=id%2Clast_updated&dir=DESC%2CDESC&hide_status=-2&match_type=0"}
+    ]},
+    {"label": "Community", "children": [
+      {"label": "Community Support", "href": "https://www.kali.org/community/"},
+      {"label": "Forums", "href": "https://forums.kali.org/"},
+      {"label": "Discord", "href": "https://discord.kali.org/"},
+      {"label": "Join Newsletter", "href": "https://www.kali.org/newsletter/"},
+      {"label": "Mirror Location", "href": "https://http.kali.org/README?mirrorlist"},
+      {"label": "Get Involved", "href": "https://www.kali.org/docs/community/contribute/"}
+    ]},
+    {"label": "Developers", "children": [
+      {"label": "Git Repositories", "href": "https://gitlab.com/kalilinux"},
+      {"label": "Packages", "href": "https://pkg.kali.org/"},
+      {"label": "Auto Package Test", "href": "https://autopkgtest.kali.org/"},
+      {"label": "Bug Tracker", "href": "https://bugs.kali.org/"},
+      {"label": "Kali NetHunter Stats", "href": "https://nethunter.kali.org/"}
+    ]},
+    {"label": "About", "children": [
+      {"label": "Kali Linux Overview", "href": "https://www.kali.org/features/"},
+      {"label": "Press Pack", "href": "https://gitlab.com/kalilinux/documentation/press-pack/-/archive/main/press-pack-main.zip"},
+      {"label": "Wallpapers", "href": "https://www.kali.org/wallpapers/"},
+      {"label": "Kali Swag Store", "href": "https://offsec.usa.dowlis.com/kali/view-all.html"},
+      {"label": "Meet The Kali Team", "href": "https://www.kali.org/about-us/"},
+      {"label": "Partnerships", "href": "https://www.kali.org/partnerships/"},
+      {"label": "Contact Us", "href": "https://www.kali.org/contact/"}
+    ]}
+  ],
+  "footer": {
+    "groups": [
+      {
+        "label": "Links",
+        "items": [
+          {"label": "Home", "href": "https://www.kali.org/"},
+          {"label": "Download / Get Kali", "href": "https://www.kali.org/get-kali/"},
+          {"label": "Blog", "href": "https://www.kali.org/blog/"},
+          {"label": "OS Documentation", "href": "https://www.kali.org/docs/"},
+          {"label": "Tool Documentation", "href": "https://www.kali.org/tools/"},
+          {"label": "System Status", "href": "https://status.kali.org/"},
+          {"label": "Archived Releases", "href": "https://old.kali.org/"},
+          {"label": "Partnerships", "href": "https://www.kali.org/partnerships/"}
+        ]
+      },
+      {
+        "label": "Platforms",
+        "items": [
+          {"label": "ARM (SBC)", "href": "https://arm.kali.org/"},
+          {"label": "NetHunter (Mobile)", "href": "https://nethunter.kali.org/"},
+          {"label": "Amazon AWS", "href": "https://aws.amazon.com/marketplace/pp/B08LL91KKB"},
+          {"label": "Docker", "href": "https://hub.docker.com/u/kalilinux"},
+          {"label": "Linode", "href": "https://www.linode.com/marketplace/apps/kali-linux/kali-linux/"},
+          {"label": "Microsoft Azure", "href": "https://azuremarketplace.microsoft.com/en/marketplace/apps/kali-linux.kali"},
+          {"label": "Microsoft Store (WSL)", "href": "https://www.microsoft.com/en-us/p/kali-linux/9pkr34tncv07"},
+          {"label": "Vagrant", "href": "https://portal.cloud.hashicorp.com/vagrant/discover/kalilinux"}
+        ]
+      },
+      {
+        "label": "Development",
+        "items": [
+          {"label": "Bug Tracker", "href": "https://bugs.kali.org/"},
+          {"label": "Continuous Integration", "href": "https://autopkgtest.kali.org/"},
+          {"label": "Network Mirror", "href": "https://http.kali.org/README?mirrorlist"},
+          {"label": "Package Tracker", "href": "https://pkg.kali.org/"},
+          {"label": "GitLab", "href": "https://gitlab.com/kalilinux"}
+        ]
+      },
+      {
+        "label": "Community",
+        "items": [
+          {"label": "Discord", "href": "https://discord.kali.org/"},
+          {"label": "Support Forum", "href": "https://forums.kali.org/"},
+          {"label": "PeerTube", "href": "https://video.infosec.exchange/c/kalilinux/videos"}
+        ]
+      },
+      {
+        "label": "Policies",
+        "items": [
+          {"label": "Cookie Policy", "href": "https://www.kali.org/docs/policy/cookie/"},
+          {"label": "Privacy Policy", "href": "https://www.kali.org/docs/policy/privacy/"},
+          {"label": "Trademark Policy", "href": "https://www.kali.org/docs/policy/trademark/"}
+        ]
+      }
+    ],
+    "social": [
+      {"label": "Bluesky", "href": "https://bsky.app/profile/kalilinux.bsky.social"},
+      {"label": "Facebook", "href": "https://www.facebook.com/KaliLinux"},
+      {"label": "Instagram", "href": "https://www.instagram.com/kalilinux/"},
+      {"label": "Mastodon", "href": "https://infosec.exchange/@kalilinux"},
+      {"label": "Substack", "href": "https://kalilinux.substack.com/"},
+      {"label": "X", "href": "https://x.com/kalilinux"},
+      {"label": "Newsletter", "href": "https://www.kali.org/newsletter/"},
+      {"label": "RSS", "href": "https://www.kali.org/rss.xml"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `data/ia.json` reflecting Kali.org header and footer
- build `Header` and `Footer` components powered by IA data
- test navigation rendering against IA spec

## Testing
- `npx eslint components/kali/Header.tsx components/kali/Footer.tsx __tests__/ia.test.tsx data/ia.json`
- `npx jest __tests__/ia.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be41f6cad88328abc31fecff334f66