### PR TITLE
Add Get Kali platform cards

### DIFF
--- a/content/get-kali/arm.mdx
+++ b/content/get-kali/arm.mdx
@@ -1,0 +1,3 @@
+export const title = 'ARM';
+export const summary = 'Images for ARM-based single-board computers.';
+export const badges = ['arm', 'arm64'];

--- a/content/get-kali/cloud.mdx
+++ b/content/get-kali/cloud.mdx
@@ -1,0 +1,3 @@
+export const title = 'Cloud';
+export const summary = 'Images for AWS, Azure, and other cloud providers.';
+export const badges = ['aws', 'azure', 'gcp'];

--- a/content/get-kali/containers.mdx
+++ b/content/get-kali/containers.mdx
@@ -1,0 +1,3 @@
+export const title = 'Containers';
+export const summary = 'Docker and LXC/LXD container images.';
+export const badges = ['docker', 'lxc'];

--- a/content/get-kali/installer.mdx
+++ b/content/get-kali/installer.mdx
@@ -1,0 +1,3 @@
+export const title = 'Installer';
+export const summary = 'Full-featured ISO for bare-metal installation.';
+export const badges = ['amd64', 'arm64'];

--- a/content/get-kali/live.mdx
+++ b/content/get-kali/live.mdx
@@ -1,0 +1,3 @@
+export const title = 'Live';
+export const summary = 'Bootable live system with optional persistence.';
+export const badges = ['usb'];

--- a/content/get-kali/mobile.mdx
+++ b/content/get-kali/mobile.mdx
@@ -1,0 +1,3 @@
+export const title = 'Mobile (NetHunter)';
+export const summary = 'Kali NetHunter for Android devices.';
+export const badges = ['android'];

--- a/content/get-kali/purple.mdx
+++ b/content/get-kali/purple.mdx
@@ -1,0 +1,3 @@
+export const title = 'Kali Purple';
+export const summary = 'Security operations-focused Kali variant.';
+export const badges = ['soc'];

--- a/content/get-kali/vms.mdx
+++ b/content/get-kali/vms.mdx
@@ -1,0 +1,3 @@
+export const title = 'Virtual Machines';
+export const summary = 'Pre-built images for VMware and VirtualBox.';
+export const badges = ['vmware', 'virtualbox'];

--- a/content/get-kali/wsl.mdx
+++ b/content/get-kali/wsl.mdx
@@ -1,0 +1,3 @@
+export const title = 'WSL';
+export const summary = 'Kali Linux for Windows Subsystem for Linux.';
+export const badges = ['wsl'];

--- a/pages/get-kali.tsx
+++ b/pages/get-kali.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import * as Installer from '../content/get-kali/installer.mdx';
+import * as VMs from '../content/get-kali/vms.mdx';
+import * as ARM from '../content/get-kali/arm.mdx';
+import * as Mobile from '../content/get-kali/mobile.mdx';
+import * as Cloud from '../content/get-kali/cloud.mdx';
+import * as Containers from '../content/get-kali/containers.mdx';
+import * as Live from '../content/get-kali/live.mdx';
+import * as WSL from '../content/get-kali/wsl.mdx';
+import * as Purple from '../content/get-kali/purple.mdx';
+
+type Platform = {
+  slug: string;
+  title: string;
+  summary: string;
+  badges: string[];
+};
+
+const platforms: Platform[] = [
+  { slug: 'installer', ...(Installer as any) },
+  { slug: 'virtual-machines', ...(VMs as any) },
+  { slug: 'arm', ...(ARM as any) },
+  { slug: 'mobile', ...(Mobile as any) },
+  { slug: 'cloud', ...(Cloud as any) },
+  { slug: 'containers', ...(Containers as any) },
+  { slug: 'live', ...(Live as any) },
+  { slug: 'wsl', ...(WSL as any) },
+  { slug: 'purple', ...(Purple as any) },
+];
+
+const GetKali: React.FC = () => (
+  <main className="p-4">
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {platforms.map(({ slug, title, summary, badges }) => (
+        <div key={slug} className="border rounded p-4 flex flex-col">
+          <h2 className="text-xl font-semibold mb-2">{title}</h2>
+          <p className="mb-4">{summary}</p>
+          {badges?.length > 0 && (
+            <ul className="flex flex-wrap gap-2 mb-4">
+              {badges.map((badge) => (
+                <li
+                  key={badge}
+                  className="bg-gray-200 text-gray-800 px-2 py-1 rounded text-xs"
+                >
+                  {badge}
+                </li>
+              ))}
+            </ul>
+          )}
+          <a
+            href={`https://www.kali.org/get-kali/#kali-${slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline mt-auto"
+          >
+            Learn more
+          </a>
+        </div>
+      ))}
+    </div>
+  </main>
+);
+
+export default GetKali;


### PR DESCRIPTION
## Summary
- add MDX modules for Installer, Virtual Machines, ARM, NetHunter, Cloud, Containers, Live, WSL and Kali Purple
- create Get Kali page that maps platform modules to cards

## Testing
- `npx eslint pages/get-kali.tsx content/get-kali/*.mdx`
- `yarn test --passWithNoTests pages/get-kali.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be41f76a7083289fce3aa5407ac77f