### PR TITLE
Add disclaimer page and footer policies link

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import React from 'react';
+
+const Footer: React.FC = () => (
+  <footer className="bg-ub-cool-grey text-ubt-grey text-sm mt-8 border-t border-gray-800">
+    <div className="max-w-6xl mx-auto p-4 grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div>
+        <h3 className="font-semibold mb-2">Policies</h3>
+        <ul className="space-y-1">
+          <li>
+            <Link href="/legal" className="hover:underline">
+              Legal Notice
+            </Link>
+          </li>
+          <li>
+            <Link href="/disclaimer" className="hover:underline">
+              Disclaimer
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import Footer from '../components/common/Footer';
 
 
 let SpeedInsights = () => null;
@@ -243,10 +244,11 @@ function MyApp(props) {
             Skip to app grid
           </a>
           <SettingsProvider>
-            <TrayProvider>
+              <TrayProvider>
               <PipPortalProvider>
                 <div aria-live="polite" id="live-region" />
                 <Component {...pageProps} />
+                <Footer />
                 <ShortcutOverlay />
                 {process.env.VERCEL_ANALYTICS_ID && (
                   <>

--- a/pages/disclaimer.tsx
+++ b/pages/disclaimer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const DisclaimerPage: React.FC = () => (
+  <div className="p-8 max-w-3xl mx-auto">
+    <h1 className="text-2xl font-bold mb-6">Disclaimer</h1>
+    <p className="mb-4">
+      This site is a personal portfolio that imitates the look of Kali Linux. It is
+      not an official Kali project and is not endorsed by Kali Linux, Offensive
+      Security, or any related organization.
+    </p>
+    <p>
+      For authoritative information, visit the{' '}
+      <a
+        href="https://www.kali.org/docs/policy/official-kali-linux-properties/"
+        className="text-blue-500 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        official Kali Linux sites list
+      </a>.
+    </p>
+  </div>
+);
+
+export default DisclaimerPage;


### PR DESCRIPTION
## Summary
- Add dedicated Disclaimer page clarifying the portfolio is unofficial and linking to the official Kali site list
- Introduce global footer with Policies column linking to Legal Notice and Disclaimer pages
- Wire footer into app layout

## Testing
- `yarn test` *(fails: Jest failed to parse files and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68be41fadcc8832895a1ed299046cd69