### PR TITLE
feat(docs): add GitHub source link

### DIFF
--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -14,9 +14,10 @@ interface TocItem {
 interface DocProps {
   html: string;
   toc: TocItem[];
+  githubUrl: string;
 }
 
-export default function DocPage({ html, toc }: DocProps) {
+export default function DocPage({ html, toc, githubUrl }: DocProps) {
   useEffect(() => {
     if (isBrowser() && window.location.hash) {
       const el = document.getElementById(window.location.hash.slice(1));
@@ -35,7 +36,19 @@ export default function DocPage({ html, toc }: DocProps) {
           ))}
         </ul>
       </nav>
-      <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
+      <div className="flex-1">
+        <article className="prose" dangerouslySetInnerHTML={{ __html: html }} />
+        <div className="mt-8">
+          <a
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          >
+            View on GitHub
+          </a>
+        </div>
+      </div>
     </div>
   );
 }
@@ -72,5 +85,9 @@ export const getStaticProps: GetStaticProps<DocProps> = async ({ params }) => {
   };
 
   const html = marked.parse(md, { renderer }) as string;
-  return { props: { html, toc } };
+
+  const relativePath = path.posix.join('public', 'docs', 'seed', `${topic}.md`);
+  const githubUrl = `https://github.com/unnippillil/kali-linux-portfolio/blob/main/${relativePath}`;
+
+  return { props: { html, toc, githubUrl } };
 };


### PR DESCRIPTION
## Summary
- show View on GitHub button on markdown docs
- compute repository URL for each doc

## Testing
- `npx eslint pages/docs/'[topic].tsx'`
- `yarn test` *(fails: Unable to find role="alert")*

------
https://chatgpt.com/codex/tasks/task_e_68be41fc5f34832897b2461abce0f1a3