### PR TITLE
feat: add global utility bar

### DIFF
--- a/components/UtilityBar.tsx
+++ b/components/UtilityBar.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const UtilityBar: React.FC = () => (
+  <div className="h-6 w-full bg-ub-dark-grey text-ubt-grey text-xs flex items-center justify-center">
+    <a
+      href="https://www.offsec.com/events/the-gauntlet/?utm_source=kali&utm_medium=web&utm_campaign=menu"
+      className="text-ubt-blue hover:underline focus:underline"
+    >
+      Join Free CTF
+    </a>
+  </div>
+);
+
+export default UtilityBar;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -16,7 +16,7 @@ export default class Navbar extends Component {
 
         render() {
                 return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-6 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-40">
                                 <div className="pl-3 pr-1">
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import UtilityBar from '../components/UtilityBar';
 
 
 let SpeedInsights = () => null;
@@ -236,6 +237,7 @@ function MyApp(props) {
       <ErrorBoundary>
         <Script src="/a2hs.js" strategy="beforeInteractive" />
         <div>
+          <UtilityBar />
           <a
             href="#app-grid"
             className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"


### PR DESCRIPTION
## Summary
- add reusable utility bar with "Join Free CTF" link
- show utility bar on every page
- offset existing navbar to account for bar

## Testing
- `yarn test` *(fails: nmapNSE test, terminal theme errors, missing modules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be41fe7fa883289b7550a288f6d955