### PR TITLE
feat: add tool schema and pages

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "Nmap",
+    "packages": ["nmap"],
+    "commands": ["nmap -sV target"],
+    "category": "Information Gathering",
+    "short": "Network exploration tool and security scanner.",
+    "links": [
+      "https://nmap.org",
+      "https://nmap.org/book/man.html"
+    ]
+  },
+  {
+    "name": "John the Ripper",
+    "packages": ["john"],
+    "commands": ["john --wordlist=password.lst hash.txt"],
+    "category": "Password Attacks",
+    "short": "Popular password cracking tool.",
+    "links": [
+      "https://www.openwall.com/john/"
+    ]
+  },
+  {
+    "name": "Metasploit Framework",
+    "packages": ["metasploit-framework"],
+    "commands": ["msfconsole"],
+    "category": "Exploitation",
+    "short": "Comprehensive penetration testing framework.",
+    "links": [
+      "https://www.metasploit.com/"
+    ]
+  }
+]

--- a/pages/tools/[tool].tsx
+++ b/pages/tools/[tool].tsx
@@ -1,0 +1,55 @@
+import { useRouter } from 'next/router';
+import type { Tool } from '../../types/tool';
+import toolsData from '../../data/tools.json';
+
+const slugify = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
+
+const tools = toolsData as Tool[];
+
+const ToolDetail = () => {
+  const router = useRouter();
+  const { tool } = router.query;
+
+  if (typeof tool !== 'string') {
+    return null;
+  }
+
+  const data = tools.find(t => slugify(t.name) === tool);
+
+  if (!data) {
+    return <div className="p-4">Tool not found.</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-2 text-xl font-bold">{data.name}</h1>
+      <p className="mb-4">{data.short}</p>
+      <h2 className="font-semibold">Packages</h2>
+      <ul className="mb-4 list-disc list-inside">
+        {data.packages.map(pkg => (
+          <li key={pkg}>{pkg}</li>
+        ))}
+      </ul>
+      <h2 className="font-semibold">Commands</h2>
+      <ul className="mb-4 list-disc list-inside">
+        {data.commands.map((cmd, i) => (
+          <li key={i}>
+            <code>{cmd}</code>
+          </li>
+        ))}
+      </ul>
+      <h2 className="font-semibold">Links</h2>
+      <ul className="list-disc list-inside">
+        {data.links.map((url, i) => (
+          <li key={i}>
+            <a href={url} target="_blank" rel="noopener noreferrer" className="underline text-blue-600">
+              {url}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ToolDetail;

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import type { Tool } from '../../types/tool';
+import toolsData from '../../data/tools.json';
+
+const slugify = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
+
+const tools = toolsData as Tool[];
+
+const ToolsPage = () => {
+  const [active, setActive] = useState<string | null>(null);
+
+  const categories = tools.reduce<Record<string, number>>((acc, tool) => {
+    acc[tool.category] = (acc[tool.category] || 0) + 1;
+    return acc;
+  }, {});
+
+  const filtered = active ? tools.filter(t => t.category === active) : tools;
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 flex flex-wrap gap-2">
+        {Object.entries(categories).map(([category, count]) => (
+          <button
+            key={category}
+            onClick={() => setActive(category)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            {category} ({count})
+          </button>
+        ))}
+      </div>
+      <div id="tools-grid" className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+        {filtered.map(tool => (
+          <a
+            key={tool.name}
+            href={`/tools/${slugify(tool.name)}`}
+            className="rounded border p-4 text-center"
+          >
+            {tool.name}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ToolsPage;

--- a/types/tool.ts
+++ b/types/tool.ts
@@ -1,0 +1,9 @@
+export interface Tool {
+  name: string;
+  packages: string[];
+  commands: string[];
+  category: string;
+  short: string;
+  links: string[];
+}
+


### PR DESCRIPTION
## Summary
- define Tool interface and sample data
- implement tools list page with category filters
- add tool detail page using new schema

## Testing
- `npm test`
- `npx playwright test tests/pages/tools-filters.spec.tsx` *(fails: host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be41ff272c832885b8500f7728b834