### PR TITLE
feat: show latest kali blog posts

### DIFF
--- a/components/KaliBlogPosts.tsx
+++ b/components/KaliBlogPosts.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+interface BlogPost {
+  title: string;
+  link: string;
+  pubDate: string;
+  description: string;
+}
+
+export default function KaliBlogPosts() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+
+  useEffect(() => {
+    fetch('/api/kali-blog')
+      .then((res) => res.json())
+      .then((data) => setPosts(data.slice(0, 3)))
+      .catch((err) => console.error('Failed to load blog posts', err));
+  }, []);
+
+  if (!posts.length) return null;
+
+  return (
+    <section className="max-w-3xl mx-auto mt-8 text-white">
+      <h2 className="text-xl font-bold mb-4">Latest from Kali Blog</h2>
+      <ul className="space-y-4">
+        {posts.map((post) => (
+          <li key={post.link}>
+            <a
+              href={post.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-ub-orange hover:underline"
+            >
+              {post.title}
+            </a>
+            <div className="text-xs text-gray-400">
+              {new Date(post.pubDate).toLocaleDateString()}
+            </div>
+            <p className="text-sm text-gray-200">{post.description.replace(/<[^>]*>/g, "")}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/pages/api/kali-blog.ts
+++ b/pages/api/kali-blog.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { XMLParser } from 'fast-xml-parser';
+
+interface BlogPost {
+  title: string;
+  link: string;
+  pubDate: string;
+  description: string;
+}
+
+const RSS_URL = 'https://www.kali.org/rss.xml';
+const CACHE_TTL = 1000 * 60 * 30; // 30 minutes
+
+let cache: BlogPost[] | null = null;
+let lastFetch = 0;
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (!cache || Date.now() - lastFetch > CACHE_TTL) {
+    try {
+      const response = await fetch(RSS_URL);
+      const xml = await response.text();
+      const parser = new XMLParser({ ignoreAttributes: false });
+      const data = parser.parse(xml);
+      const items: any[] = data.rss.channel.item || [];
+      cache = items.map((item) => ({
+        title: item.title,
+        link: item.link,
+        pubDate: item.pubDate,
+        description: item.description,
+      }));
+      lastFetch = Date.now();
+    } catch (err) {
+      console.error('Failed to fetch RSS feed', err);
+      if (!cache) {
+        res.status(500).json({ error: 'Failed to load feed' });
+        return;
+      }
+    }
+  }
+
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=3600, stale-while-revalidate=1800',
+  );
+  res.status(200).json(cache);
+}
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 import { baseMetadata } from "../lib/metadata";
 import BetaBadge from "../components/BetaBadge";
 import useSession from "../hooks/useSession";
+import KaliBlogPosts from "../components/KaliBlogPosts";
 
 export const metadata = baseMetadata;
 
@@ -45,6 +46,17 @@ const App = () => {
       />
       <BetaBadge />
       <InstallButton />
+      <KaliBlogPosts />
+      <footer className="mt-8 text-center text-xs text-gray-400">
+        <a
+          href="https://www.kali.org/rss.xml"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          Kali Blog RSS
+        </a>
+      </footer>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add `/api/kali-blog` endpoint that fetches and caches Kali RSS feed
- surface three latest Kali blog posts on the home page
- include Kali RSS link in footer for reference

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, asciiArt.test.tsx, remotePatterns.test.ts, exo-open.test.ts, middleware-csp.test.ts, calculator.formulas.test.ts, terminal.test.tsx)*
- `yarn lint pages/api/kali-blog.ts components/KaliBlogPosts.tsx pages/index.jsx` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be41fe58588328880a990c43ce8044