### PR TITLE
feat: add dynamic tool detail pages

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "dirbuster",
+    "name": "DirBuster",
+    "summary": "DirBuster is a multi threaded java application designed to brute force directories and files names on web/application servers.",
+    "packages": [
+      { "name": "dirbuster", "version": "1.0-RC1" }
+    ],
+    "commands": [
+      { "label": "Install", "cmd": "apt install dirbuster" },
+      { "label": "Run", "cmd": "dirbuster" }
+    ],
+    "upstream": "https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project",
+    "related": ["gobuster", "feroxbuster"]
+  },
+  {
+    "id": "gobuster",
+    "name": "GoBuster",
+    "summary": "Directory/file & DNS busting tool written in Go.",
+    "packages": [
+      { "name": "gobuster", "version": "3.5.0" }
+    ],
+    "commands": [
+      { "label": "Install", "cmd": "apt install gobuster" },
+      { "label": "Run", "cmd": "gobuster dir -u https://example.com -w wordlist.txt" }
+    ],
+    "upstream": "https://github.com/OJ/gobuster",
+    "related": ["dirbuster", "feroxbuster"]
+  },
+  {
+    "id": "feroxbuster",
+    "name": "Feroxbuster",
+    "summary": "A simple, fast, recursive content discovery tool written in Rust.",
+    "packages": [
+      { "name": "feroxbuster", "version": "2.10.4" }
+    ],
+    "commands": [
+      { "label": "Install", "cmd": "apt install feroxbuster" },
+      { "label": "Run", "cmd": "feroxbuster -u https://example.com" }
+    ],
+    "upstream": "https://github.com/epi052/feroxbuster",
+    "related": ["dirbuster", "gobuster"]
+  }
+]

--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import tools from '../../data/tools.json';
+import copyToClipboard from '../../utils/clipboard';
+
+interface ToolCommand {
+  label?: string;
+  cmd: string;
+}
+
+interface ToolPackage {
+  name: string;
+  version?: string;
+}
+
+interface Tool {
+  id: string;
+  name: string;
+  summary: string;
+  packages: ToolPackage[];
+  commands: ToolCommand[];
+  upstream: string;
+  related?: string[];
+}
+
+interface Props {
+  tool: Tool;
+}
+
+export default function ToolPage({ tool }: Props) {
+  const handleCopy = (cmd: string) => {
+    copyToClipboard(cmd);
+  };
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{tool.name}</h1>
+      <p className="mb-6">{tool.summary}</p>
+
+      {tool.packages?.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Packages</h2>
+          <ul className="list-disc list-inside">
+            {tool.packages.map((pkg) => (
+              <li key={pkg.name}>
+                {pkg.name}
+                {pkg.version ? ` ${pkg.version}` : ''}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {tool.commands?.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Commands</h2>
+          <ul className="space-y-2">
+            {tool.commands.map((c, i) => (
+              <li key={i} className="flex items-center gap-2">
+                <code className="flex-1 bg-gray-100 dark:bg-gray-800 rounded px-2 py-1 text-sm">
+                  {c.cmd}
+                </code>
+                <button
+                  onClick={() => handleCopy(c.cmd)}
+                  className="px-2 py-1 text-sm border rounded"
+                >
+                  Copy
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {tool.upstream && (
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Upstream</h2>
+          <a
+            href={tool.upstream}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline"
+          >
+            {tool.upstream}
+          </a>
+        </section>
+      )}
+
+      {tool.related && tool.related.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Related Tools</h2>
+          <ul className="list-disc list-inside">
+            {tool.related.map((slug) => {
+              const relatedTool = tools.find((t) => t.id === slug);
+              return (
+                <li key={slug}>
+                  <Link href={`/tools/${slug}`}>{relatedTool?.name || slug}</Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: tools.map((tool) => ({ params: { slug: tool.id } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const slug = params?.slug as string;
+  const tool = tools.find((t) => t.id === slug)!;
+  return { props: { tool } };
+};
+


### PR DESCRIPTION
## Summary
- add data/tools.json with extended tool metadata
- create dynamic tools/[slug] page rendering tool info, commands, and related links

## Testing
- `npx eslint pages/tools/[slug].tsx`
- `yarn test --passWithNoTests pages/tools`


------
https://chatgpt.com/codex/tasks/task_e_68be42004e348328a62a59c0bc0d2365