### PR TITLE
feat: improve tools page accessibility

### DIFF
--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -189,7 +189,15 @@ export default function SecurityTools() {
               <div>Sample text contains &quot;{query}&quot;</div>
             </div>
           )}
-            {!hasResults && <div>No results found.</div>}
+            {!hasResults && (
+              <p
+                role="status"
+                aria-live="polite"
+                className="mt-2 text-center text-xs text-gray-500"
+              >
+                No results found.
+              </p>
+            )}
           </div>
         ) : (
           <>

--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -3,9 +3,12 @@ import tools from '../../../data/kali-tools.json';
 
 const KaliToolsPage = () => {
   const [query, setQuery] = useState('');
-  const filteredTools = tools.filter((tool) =>
-    tool.name.toLowerCase().includes(query.toLowerCase()),
-  );
+  const hasError = !Array.isArray(tools);
+  const filteredTools = hasError
+    ? []
+    : tools.filter((tool) =>
+        tool.name.toLowerCase().includes(query.toLowerCase()),
+      );
 
   return (
     <div className="p-4">
@@ -20,19 +23,39 @@ const KaliToolsPage = () => {
         placeholder="Search tools"
         className="mb-4 w-full rounded border p-2"
       />
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-        {filteredTools.map((tool) => (
-          <a
-            key={tool.id}
-            href={`https://www.kali.org/tools/${tool.id}/`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-          >
-            <span>{tool.name}</span>
-          </a>
-        ))}
-      </div>
+      {hasError ? (
+        <p
+          role="alert"
+          className="mt-4 text-center text-sm text-red-600"
+        >
+          Unable to load tools.
+        </p>
+      ) : filteredTools.length === 0 ? (
+        <p
+          role="status"
+          aria-live="polite"
+          className="mt-4 text-center text-sm text-gray-500"
+        >
+          No tools found.
+        </p>
+      ) : (
+        <div
+          id="tools-grid"
+          className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+        >
+          {filteredTools.map((tool) => (
+            <a
+              key={tool.id}
+              href={`https://www.kali.org/tools/${tool.id}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+            >
+              <span>{tool.name}</span>
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- handle empty and error states on Kali tools page with accessible messaging
- announce no result state in security tools search

## Testing
- `npm test` *(fails: Unable to find role="alert" in nmapNse.test.tsx; Jest worker exceptions; multiple failing suites)*
- `npm run lint` *(terminated: command exceeded time limits)*

------
https://chatgpt.com/codex/tasks/task_e_68be4201aef48328bcbf97f3154f5001