### PR TITLE
Persist window layout

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -94,6 +94,14 @@ export class Window extends Component {
         }
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.width !== this.state.width || prevState.height !== this.state.height) {
+            if (this.props.onSizeChange) {
+                this.props.onSizeChange(this.state.width, this.state.height);
+            }
+        }
+    }
+
     setDefaultWindowDimenstion = () => {
         if (this.props.defaultHeight && this.props.defaultWidth) {
             this.setState(

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,7 +5,10 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
-  snap?: 'left' | 'right' | 'top' | null;
+  width: number;
+  height: number;
+  order: number;
+  snap?: 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | null;
 }
 
 export interface DesktopSession {
@@ -31,11 +34,19 @@ function isSession(value: unknown): value is DesktopSession {
         typeof w.id === 'string' &&
         typeof w.x === 'number' &&
         typeof w.y === 'number' &&
+        typeof w.width === 'number' &&
+        typeof w.height === 'number' &&
+        typeof w.order === 'number' &&
         (w.snap === undefined ||
           w.snap === null ||
           w.snap === 'left' ||
           w.snap === 'right' ||
-          w.snap === 'top'),
+          w.snap === 'top' ||
+          w.snap === 'bottom' ||
+          w.snap === 'top-left' ||
+          w.snap === 'top-right' ||
+          w.snap === 'bottom-left' ||
+          w.snap === 'bottom-right'),
     ) &&
     typeof s.wallpaper === 'string' &&
     Array.isArray(s.dock)


### PR DESCRIPTION
## Summary
- persist window position, size, and stacking order in session storage
- restore saved window layout on boot
- propagate window resize events to parent for persistence

## Testing
- `yarn lint` *(fails: A control must be associated with a text label, Unused eslint-disable directive)*
- `yarn test` *(fails: multiple failing suites, e.g. nmapNse.test.tsx)*
- `yarn test __tests__/zorder.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be4202ce788328b64813d15bcd4dd5