### PR TITLE
feat: add panel power menu

### DIFF
--- a/__tests__/panel_power_menu.test.tsx
+++ b/__tests__/panel_power_menu.test.tsx
@@ -1,0 +1,96 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Panel from '../src/components/panel/Panel';
+
+jest.mock('react-dnd', () => ({
+  DndProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useDrag: () => [{ isDragging: false }, () => {}],
+  useDrop: () => [{}, () => {}],
+}));
+
+jest.mock('react-dnd-html5-backend', () => ({}));
+jest.mock('../src/components/panel/PanelPreferences', () => ({
+  usePanelPreferences: () => ({ editMode: false, locked: false }),
+}));
+
+function navigateToPower(getByRole: any, getByText: any) {
+  const panel = getByRole('toolbar', { name: 'Panel' });
+  panel.focus();
+  fireEvent.keyDown(panel, { key: 'ArrowRight' });
+  const first = getByText('Plugin A');
+  fireEvent.keyDown(first, { key: 'ArrowRight' });
+  const second = getByText('Plugin B');
+  fireEvent.keyDown(second, { key: 'ArrowRight' });
+  const third = getByText('Plugin C');
+  fireEvent.keyDown(third, { key: 'ArrowRight' });
+  const power = getByText('Power');
+  return { panel, power };
+}
+
+describe('panel power menu', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('is keyboard navigable', () => {
+    const { getByRole, getByText } = render(<Panel />);
+    const { power } = navigateToPower(getByRole, getByText);
+    fireEvent.keyDown(power, { key: 'Enter' });
+    const restart = getByText('Restart');
+    expect(restart).toHaveFocus();
+    fireEvent.keyDown(restart, { key: 'ArrowDown' });
+    const logout = getByText('Log Out');
+    expect(logout).toHaveFocus();
+    fireEvent.keyDown(logout, { key: 'ArrowDown' });
+    const theme = getByText('Theme');
+    expect(theme).toHaveFocus();
+    fireEvent.keyDown(theme, { key: 'ArrowUp' });
+    expect(logout).toHaveFocus();
+    fireEvent.keyDown(logout, { key: 'Escape' });
+    expect(document.activeElement).toBe(power);
+  });
+
+  it('reloads on restart', () => {
+    const listener = jest.fn();
+    window.addEventListener('power-restart', listener);
+    const { getByRole, getByText } = render(<Panel />);
+    const { power } = navigateToPower(getByRole, getByText);
+    fireEvent.keyDown(power, { key: 'Enter' });
+    const restart = getByText('Restart');
+    fireEvent.keyDown(restart, { key: 'Enter' });
+    fireEvent.keyUp(restart, { key: 'Enter' });
+    fireEvent.click(restart);
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('clears storage on log out', () => {
+    const { getByRole, getByText } = render(<Panel />);
+    window.localStorage.setItem('foo', 'bar');
+    const { power } = navigateToPower(getByRole, getByText);
+    fireEvent.keyDown(power, { key: 'Enter' });
+    const restart = getByText('Restart');
+    fireEvent.keyDown(restart, { key: 'ArrowDown' });
+    const logout = getByText('Log Out');
+    fireEvent.keyDown(logout, { key: 'Enter' });
+    fireEvent.keyUp(logout, { key: 'Enter' });
+    fireEvent.click(logout);
+    expect(window.localStorage.getItem('foo')).toBeNull();
+  });
+
+  it('toggles theme', () => {
+    const { getByRole, getByText } = render(<Panel />);
+    const { power } = navigateToPower(getByRole, getByText);
+    fireEvent.keyDown(power, { key: 'Enter' });
+    const restart = getByText('Restart');
+    fireEvent.keyDown(restart, { key: 'ArrowDown' });
+    const logout = getByText('Log Out');
+    fireEvent.keyDown(logout, { key: 'ArrowDown' });
+    const theme = getByText('Theme');
+    fireEvent.keyDown(theme, { key: 'Enter' });
+    fireEvent.keyUp(theme, { key: 'Enter' });
+    fireEvent.click(theme);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});
+

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -6,6 +6,7 @@ import { useDrag, useDrop } from 'react-dnd';
 import layoutData from './layout.json';
 import { usePanelPreferences } from './PanelPreferences';
 import keybindingManager from '../../wm/keybindingManager';
+import PowerMenu from './PowerMenu';
 
 interface PluginItem {
   id: string;
@@ -145,17 +146,28 @@ export default function Panel() {
         aria-label="Panel"
         tabIndex={0}
       >
-        {plugins.map((p, i) => (
-          <DraggablePlugin
-            key={p.id}
-            plugin={p}
-            index={i}
-            move={move}
-            innerRef={(el) => (pluginRefs.current[i] = el)}
-            focused={focusedIndex === i}
-            onFocus={() => setFocusedIndex(i)}
-          />
-        ))}
+        {plugins.map((p, i) =>
+          p.id === 'power' ? (
+            <PowerMenu
+              key={p.id}
+              index={i}
+              move={move}
+              innerRef={(el) => (pluginRefs.current[i] = el)}
+              focused={focusedIndex === i}
+              onFocus={() => setFocusedIndex(i)}
+            />
+          ) : (
+            <DraggablePlugin
+              key={p.id}
+              plugin={p}
+              index={i}
+              move={move}
+              innerRef={(el) => (pluginRefs.current[i] = el)}
+              focused={focusedIndex === i}
+              onFocus={() => setFocusedIndex(i)}
+            />
+          )
+        )}
       </div>
     </DndProvider>
   );

--- a/src/components/panel/PowerMenu.tsx
+++ b/src/components/panel/PowerMenu.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useDrag, useDrop } from 'react-dnd';
+import { usePanelPreferences } from './PanelPreferences';
+
+interface Props {
+  index: number;
+  move: (from: number, to: number) => void;
+  innerRef?: (el: HTMLDivElement | null) => void;
+  focused: boolean;
+  onFocus: () => void;
+}
+
+const type = 'PLUGIN_ITEM';
+
+export default function PowerMenu({ index, move, innerRef, focused, onFocus }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { editMode, locked } = usePanelPreferences();
+
+  const [, drop] = useDrop<{ index: number }>({
+    accept: type,
+    hover(item) {
+      if (!ref.current || item.index === index) return;
+      move(item.index, index);
+      item.index = index;
+    },
+  }, [index]);
+
+  const [{ isDragging }, drag] = useDrag({
+    type,
+    item: { index },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+    canDrag: editMode && !locked,
+  }, [index, editMode, locked]);
+
+  drag(drop(ref));
+
+  const [open, setOpen] = useState(false);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (open) {
+      itemRefs.current[0]?.focus();
+    }
+  }, [open]);
+
+  const handleItemKey = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const items = itemRefs.current;
+    const idx = items.findIndex((i) => i === e.currentTarget);
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = (idx + 1) % items.length;
+      items[next]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = (idx - 1 + items.length) % items.length;
+      items[prev]?.focus();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      ref.current?.focus();
+    }
+  };
+
+  const restart = () => {
+    window.dispatchEvent(new Event('power-restart'));
+    window.location.reload();
+  };
+
+  const logOut = () => {
+    try {
+      window.localStorage.clear();
+      window.sessionStorage?.clear();
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const toggleTheme = () => {
+    document.documentElement.classList.toggle('dark');
+  };
+
+  return (
+    <div
+      ref={(el) => {
+        ref.current = el;
+        innerRef?.(el);
+      }}
+      tabIndex={focused ? 0 : -1}
+      onFocus={onFocus}
+      onClick={() => setOpen((o) => !o)}
+      className={`relative flex items-center p-2 border mb-1 bg-black/20 text-white focus:outline focus:outline-2 focus:outline-white ${
+        editMode && !locked ? 'cursor-move' : ''
+      }`}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      Power
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-2 w-32 bg-black text-white rounded shadow-lg flex flex-col"
+        >
+          <button
+            role="menuitem"
+            ref={(el) => (itemRefs.current[0] = el)}
+            onKeyDown={handleItemKey}
+            onClick={() => {
+              setOpen(false);
+              restart();
+              ref.current?.focus();
+            }}
+            className="px-2 py-1 text-left hover:bg-gray-700"
+          >
+            Restart
+          </button>
+          <button
+            role="menuitem"
+            ref={(el) => (itemRefs.current[1] = el)}
+            onKeyDown={handleItemKey}
+            onClick={() => {
+              setOpen(false);
+              logOut();
+              ref.current?.focus();
+            }}
+            className="px-2 py-1 text-left hover:bg-gray-700"
+          >
+            Log Out
+          </button>
+          <button
+            role="menuitem"
+            ref={(el) => (itemRefs.current[2] = el)}
+            onKeyDown={handleItemKey}
+            onClick={() => {
+              setOpen(false);
+              toggleTheme();
+              ref.current?.focus();
+            }}
+            className="px-2 py-1 text-left hover:bg-gray-700"
+          >
+            Theme
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/panel/layout.json
+++ b/src/components/panel/layout.json
@@ -1,5 +1,6 @@
 [
   { "id": "plugin-a", "title": "Plugin A" },
   { "id": "plugin-b", "title": "Plugin B" },
-  { "id": "plugin-c", "title": "Plugin C" }
+  { "id": "plugin-c", "title": "Plugin C" },
+  { "id": "power", "title": "Power" }
 ]


### PR DESCRIPTION
## Summary
- add panel power menu with restart, log out and theme options
- wire power plugin into panel with keyboard focus support
- test power menu actions and focus handling

## Testing
- `yarn test __tests__/panel_keyboard_navigation.test.tsx __tests__/panel_power_menu.test.tsx`
- `yarn lint src/components/panel/Panel.tsx src/components/panel/PowerMenu.tsx __tests__/panel_power_menu.test.tsx` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68be42043f208328aa72fea85764959e