### PR TITLE
feat: optimize wallpaper images

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import Image from "next/image";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import AdvancedTab from "./components/AdvancedTab";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
@@ -112,7 +113,7 @@ export default function Settings() {
   const handleReset = async () => {
     if (
       !window.confirm(
-        "Reset desktop to default settings? This will clear all saved data."
+        "Reset desktop to default settings? This will clear all saved data.",
       )
     )
       return;
@@ -162,7 +163,11 @@ export default function Settings() {
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+            <div
+              aria-label="Accent color picker"
+              role="radiogroup"
+              className="flex gap-2"
+            >
               {ACCENT_OPTIONS.map((c) => (
                 <button
                   key={c}
@@ -170,14 +175,16 @@ export default function Settings() {
                   role="radio"
                   aria-checked={accent === c}
                   onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? "border-white" : "border-transparent"}`}
                   style={{ backgroundColor: c }}
                 />
               ))}
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
+            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">
+              Wallpaper:
+            </label>
             <input
               id="wallpaper-slider"
               type="range"
@@ -214,15 +221,18 @@ export default function Settings() {
                   (name === wallpaper
                     ? " border-yellow-700 "
                     : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
+                  " relative md:w-56 md:h-40 w-28 h-20 md:m-4 m-2 outline-none border-4 border-opacity-80"
                 }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
+              >
+                <Image
+                  src={`/wallpapers/${name}.webp`}
+                  alt=""
+                  fill
+                  sizes="(max-width: 768px) 50vw, 25vw"
+                  className="object-cover"
+                  loading="lazy"
+                />
+              </div>
             ))}
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
@@ -238,7 +248,9 @@ export default function Settings() {
       {activeTab === "accessibility" && (
         <>
           <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">
+              Icon Size:
+            </label>
             <input
               id="font-scale"
               type="range"
@@ -297,7 +309,7 @@ export default function Settings() {
         </>
       )}
       {activeTab === "privacy" && (
-        <> 
+        <>
           <div className="flex justify-center my-4 space-x-4">
             <button
               onClick={handleExport}
@@ -330,30 +342,30 @@ export default function Settings() {
       )}
       {activeTab === "kernel" && <KernelTab />}
       {activeTab === "advanced" && <AdvancedTab />}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
-        <input
-          type="file"
-          accept="application/json"
-          ref={panelFileRef}
-          aria-label="Import panel file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handlePanelImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
+      <input
+        type="file"
+        accept="application/json"
+        ref={panelFileRef}
+        aria-label="Import panel file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handlePanelImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,58 +1,73 @@
-import React, { useState, useRef, useEffect } from 'react';
-import Clock from '../util-components/clock';
-import { useSettings } from '../../hooks/useSettings';
+import React, { useState, useRef, useEffect } from "react";
+import Image from "next/image";
+import Clock from "../util-components/clock";
+import { useSettings } from "../../hooks/useSettings";
 
 export default function LockScreen(props) {
+  const { wallpaper } = useSettings();
+  const [password, setPassword] = useState("");
+  const inputRef = useRef(null);
 
-    const { wallpaper } = useSettings();
-    const [password, setPassword] = useState('');
-    const inputRef = useRef(null);
+  useEffect(() => {
+    if (props.isLocked) {
+      inputRef.current?.focus();
+    }
+  }, [props.isLocked]);
 
-    useEffect(() => {
-        if (props.isLocked) {
-            inputRef.current?.focus();
-        }
-    }, [props.isLocked]);
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setPassword("");
+    props.unLockScreen();
+  };
 
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        setPassword('');
-        props.unLockScreen();
-    };
-
-    return (
-        <div
-            id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-md' : 'blur-none'}`}
-            />
-            <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
-                <div className="absolute top-10 text-center">
-                    <div className="text-7xl">
-                        <Clock onlyTime={true} />
-                    </div>
-                    <div className="mt-2 text-xl font-medium">
-                        <Clock onlyDay={true} />
-                    </div>
-                </div>
-                <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
-                    <img src="/images/logos/bitmoji.png" alt="avatar" className="w-24 h-24 rounded-full mb-4 border-2 border-white" />
-                    <div className="text-2xl mb-4">kali</div>
-                    <input
-                        ref={inputRef}
-                        type="password"
-                        className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
-                        placeholder="Password"
-                        aria-label="Password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                    />
-                </form>
-            </div>
+  return (
+    <div
+      id="ubuntu-lock-screen"
+      style={{ zIndex: "100", contentVisibility: "auto" }}
+      className={
+        (props.isLocked
+          ? " visible translate-y-0 "
+          : " invisible -translate-y-full ") +
+        " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"
+      }
+    >
+      <Image
+        src={`/wallpapers/${wallpaper}.webp`}
+        alt=""
+        fill
+        sizes="100vw"
+        className={`object-cover transform z-20 transition duration-500 ${props.isLocked ? "blur-md" : "blur-none"}`}
+      />
+      <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
+        <div className="absolute top-10 text-center">
+          <div className="text-7xl">
+            <Clock onlyTime={true} />
+          </div>
+          <div className="mt-2 text-xl font-medium">
+            <Clock onlyDay={true} />
+          </div>
         </div>
-    )
+        <form
+          onSubmit={handleSubmit}
+          className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center"
+        >
+          <img
+            src="/images/logos/bitmoji.png"
+            alt="avatar"
+            className="w-24 h-24 rounded-full mb-4 border-2 border-white"
+          />
+          <div className="text-2xl mb-4">kali</div>
+          <input
+            ref={inputRef}
+            type="password"
+            className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
+            placeholder="Password"
+            aria-label="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,51 +1,66 @@
 "use client";
 
-import React, { useEffect, useState } from 'react'
-import { useSettings } from '../../hooks/useSettings';
+import React, { useEffect, useState } from "react";
+import Image from "next/image";
+import { useSettings } from "../../hooks/useSettings";
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
-    const [needsOverlay, setNeedsOverlay] = useState(false);
+  const { wallpaper } = useSettings();
+  const [needsOverlay, setNeedsOverlay] = useState(false);
 
-    useEffect(() => {
-        const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
-        img.onload = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = img.width;
-            canvas.height = img.height;
-            const ctx = canvas.getContext('2d');
-            if (!ctx) return;
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-            const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-            let r = 0, g = 0, b = 0, count = 0;
-            for (let i = 0; i < data.length; i += 40) {
-                r += data[i];
-                g += data[i + 1];
-                b += data[i + 2];
-                count++;
-            }
-            const avgR = r / count, avgG = g / count, avgB = b / count;
-            const toLinear = (c) => {
-                c /= 255;
-                return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-            };
-            const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
-            const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
-            setNeedsOverlay(contrast < 4.5);
-        };
-    }, [wallpaper]);
+  useEffect(() => {
+    const img = new Image();
+    img.src = `/wallpapers/${wallpaper}.webp`;
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+      let r = 0,
+        g = 0,
+        b = 0,
+        count = 0;
+      for (let i = 0; i < data.length; i += 40) {
+        r += data[i];
+        g += data[i + 1];
+        b += data[i + 2];
+        count++;
+      }
+      const avgR = r / count,
+        avgG = g / count,
+        avgB = b / count;
+      const toLinear = (c) => {
+        c /= 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      };
+      const lum =
+        0.2126 * toLinear(avgR) +
+        0.7152 * toLinear(avgG) +
+        0.0722 * toLinear(avgB);
+      const contrast = 1.05 / (lum + 0.05); // white text luminance is 1
+      setNeedsOverlay(contrast < 4.5);
+    };
+  }, [wallpaper]);
 
-    return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className="w-full h-full object-cover"
-            />
-            {needsOverlay && (
-                <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
-            )}
-        </div>
-    )
+  return (
+    <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+      <Image
+        src={`/wallpapers/${wallpaper}.webp`}
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover"
+      />
+      {needsOverlay && (
+        <div
+          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent"
+          aria-hidden="true"
+        ></div>
+      )}
+    </div>
+  );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,7 +5,7 @@ import Document, {
   NextScript,
   type DocumentContext,
   type DocumentInitialProps,
-} from 'next/document';
+} from "next/document";
 
 interface Props extends DocumentInitialProps {
   nonce?: string;
@@ -14,18 +14,20 @@ interface Props extends DocumentInitialProps {
 class MyDocument extends Document<Props> {
   static async getInitialProps(ctx: DocumentContext): Promise<Props> {
     const initial = await Document.getInitialProps(ctx);
-    const nonce = ctx.req.headers['x-csp-nonce'] as string | undefined;
+    const nonce = ctx.req.headers["x-csp-nonce"] as string | undefined;
     return { ...initial, nonce };
   }
 
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang={this.props.locale || 'en'} data-csp-nonce={nonce}>
+      <Html lang={this.props.locale || "en"} data-csp-nonce={nonce}>
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
+          <link rel="preconnect" href="/wallpapers" />
+          <link rel="preconnect" href="/images/wallpapers" />
           <link
             href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
             rel="stylesheet"


### PR DESCRIPTION
## Summary
- render wallpapers with responsive `next/image` and priority loading
- add preconnect hints for wallpaper assets
- lazy-load wallpaper options in settings

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `npx eslint components/util-components/background-image.js components/screen/lock_screen.js apps/settings/index.tsx pages/_document.tsx`
- `yarn test` *(fails: Unable to find role="alert")*
- `npx playwright test tests/pages/wallpapers.spec.tsx` *(fails: page.goto('/apps/settings') error)*

------
https://chatgpt.com/codex/tasks/task_e_68be4208a3e083289fb89e5b92e21605