### PR TITLE
chore(ci): enforce bundle budgets

### DIFF
--- a/docs/bundle-budgets.md
+++ b/docs/bundle-budgets.md
@@ -20,3 +20,16 @@ yarn check-budgets
 ```
 
 The build produces `.next/analyze/client.json` via `@next/bundle-analyzer` and the check script exits with a non-zero code if any asset exceeds its limit.
+
+## Addressing regressions
+
+When a pull request fails the budget check, the failing chunk names and sizes
+are printed in the CI log. To resolve the regression:
+
+1. Reproduce locally by running the verification commands above.
+2. Inspect `.next/analyze/client.json` (or the accompanying HTML report if
+   generated) to identify which modules contribute to the oversized chunk.
+3. Reduce the bundle size by code-splitting, removing unnecessary dependencies,
+   or optimising imports. If the increase is expected, update
+   `bundle-budgets.json` with an explanatory commit.
+4. Rebuild and re-run `yarn check-budgets` until it passes.

--- a/scripts/check-bundle-budgets.mjs
+++ b/scripts/check-bundle-budgets.mjs
@@ -10,24 +10,35 @@ const statsPath = path.join(process.cwd(), '.next', 'analyze', 'client.json');
 const stats = JSON.parse(fs.readFileSync(statsPath, 'utf8'));
 
 const assets = stats.assets || [];
-let failed = false;
+const failures = [];
 
 for (const [pattern, limit] of Object.entries(budgets)) {
   const regex = new RegExp(pattern);
-  const match = assets.find((a) => regex.test(a.name));
-  if (!match) {
+  const matches = assets.filter(
+    (a) => regex.test(a.name) && a.name.endsWith('.js'),
+  );
+  if (matches.length === 0) {
     console.warn(`No asset matching pattern ${pattern}`);
     continue;
   }
-  const size = match.size;
-  if (size > limit) {
-    console.error(`Asset ${match.name} (${size} bytes) exceeds budget of ${limit} bytes`);
-    failed = true;
-  } else {
-    console.log(`Asset ${match.name} (${size} bytes) within budget (${limit} bytes)`);
+  for (const match of matches) {
+    const size = match.size;
+    if (size > limit) {
+      failures.push({ name: match.name, size, limit });
+    } else {
+      console.log(
+        `Asset ${match.name} (${size} bytes) within budget (${limit} bytes)`,
+      );
+    }
   }
 }
 
-if (failed) {
+if (failures.length > 0) {
+  console.error('Bundle budget thresholds exceeded for:');
+  for (const { name, size, limit } of failures) {
+    console.error(`- ${name} (${size} bytes > ${limit} bytes)`);
+  }
   process.exit(1);
+} else {
+  console.log('All bundle budgets satisfied.');
 }


### PR DESCRIPTION
## Summary
- check built assets against bundle budgets and report offending chunks
- document how to resolve bundle budget regressions

## Testing
- `npx eslint scripts/check-bundle-budgets.mjs docs/bundle-budgets.md`
- `node scripts/check-bundle-budgets.mjs` *(fails: ENOENT no such file .next/analyze/client.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be420961e08328b689e01facadb93b