### PR TITLE
feat: optimize font loading

### DIFF
--- a/hooks/useReportWebVitals.ts
+++ b/hooks/useReportWebVitals.ts
@@ -7,6 +7,10 @@ const vitals = new Set(['LCP', 'CLS', 'INP']);
 export default function useReportWebVitals(): void {
   useNextReportWebVitals((metric) => {
     const { id, name, value } = metric;
+    if (name === 'CLS') {
+      // Log CLS to monitor layout stability
+      console.log('[Web Vitals] CLS:', value);
+    }
     if (vitals.has(name)) {
       track(name, { id, value });
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -39,8 +39,8 @@ export function middleware(req: NextRequest | { headers: Headers; nextUrl?: URL;
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
-    "style-src 'self' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
+    "style-src 'self'",
+    "font-src 'self'",
     `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://*.twitter.com https://*.twimg.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://sdk.scdn.co https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
     "connect-src 'self' https://example.com https://*.twitter.com https://*.twimg.com https://*.x.com https://*.google.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://react.dev https://example.com",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,15 @@ import Document, {
   type DocumentContext,
   type DocumentInitialProps,
 } from 'next/document';
+import { Ubuntu } from 'next/font/google';
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '700'],
+  variable: '--font-ubuntu',
+  display: 'optional',
+  preload: true,
+});
 
 interface Props extends DocumentInitialProps {
   nonce?: string;
@@ -21,15 +30,15 @@ class MyDocument extends Document<Props> {
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang={this.props.locale || 'en'} data-csp-nonce={nonce}>
+      <Html
+        lang={this.props.locale || 'en'}
+        data-csp-nonce={nonce}
+        className={ubuntu.variable}
+      >
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-            rel="stylesheet"
-          />
           <script nonce={nonce} src="/theme.js" async />
         </Head>
         <body className="font-ubuntu">

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,7 +52,7 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: var(--font-ubuntu), sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,7 +38,7 @@ module.exports = {
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
         fontFamily: {
-          ubuntu: ['Ubuntu', 'sans-serif'],
+          ubuntu: ['var(--font-ubuntu)', 'sans-serif'],
         },
         fontSize: {
           base: ['1rem', { lineHeight: '1.5' }],


### PR DESCRIPTION
## Summary
- replace Google Fonts link with next/font and optional display
- preload heading weights and update CSP
- log CLS metric for layout stability monitoring

## Testing
- `yarn test` *(fails: nmapNse.test.tsx, terminal.test.tsx, remotePatterns.test.ts, asciiArt.test.tsx)*
- `npx eslint pages/_document.tsx hooks/useReportWebVitals.ts tailwind.config.js styles/tokens.css middleware.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be4209b4fc8328acd9d589901efdf3