### PR TITLE
feat: improve accessibility labels

### DIFF
--- a/__tests__/Notifier.test.tsx
+++ b/__tests__/Notifier.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Notifier, { useNotifier } from '../src/components/notifications/Notifier';
+
+const Trigger: React.FC = () => {
+  const { notify } = useNotifier();
+  React.useEffect(() => {
+    notify('Hello world');
+  }, [notify]);
+  return null;
+};
+
+test('announces notifications with accessible label', () => {
+  jest.useFakeTimers();
+  render(
+    <Notifier>
+      <Trigger />
+    </Notifier>
+  );
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveAttribute('aria-label', 'Notification');
+  expect(alert).toHaveAttribute('aria-live', 'assertive');
+});

--- a/components/Clipman.tsx
+++ b/components/Clipman.tsx
@@ -54,10 +54,14 @@ const Clipman: React.FC = () => {
       {menu && (
         <ul
           data-testid="context-menu"
+          role="menu"
+          aria-label="Clipboard actions"
           className="absolute bg-gray-800 text-white p-2 z-50"
           style={{ top: menu.y, left: menu.x }}
         >
           <li
+            role="menuitem"
+            tabIndex={-1}
             className="cursor-pointer px-2 py-1 hover:bg-gray-700"
             onClick={paste}
           >

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -12,6 +12,10 @@ interface ContextMenuProps {
   targetRef: React.RefObject<HTMLElement>;
   /** Menu items to render */
   items: MenuItem[];
+  /** Optional accessible label for the menu */
+  ariaLabel?: string;
+  /** ID of element that labels the menu */
+  ariaLabelledBy?: string;
 }
 
 /**
@@ -20,7 +24,12 @@ interface ContextMenuProps {
  * dispatches global events when opened/closed so backgrounds can
  * be made inert.
  */
-const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
+const ContextMenu: React.FC<ContextMenuProps> = ({
+  targetRef,
+  items,
+  ariaLabel = 'Context menu',
+  ariaLabelledBy,
+}) => {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
@@ -104,6 +113,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       role="menu"
       ref={menuRef}
       aria-hidden={!open}
+      {...(ariaLabelledBy
+        ? { 'aria-labelledby': ariaLabelledBy }
+        : { 'aria-label': ariaLabel })}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
         'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -40,6 +40,7 @@ function AppMenu(props) {
         <div
             id="app-menu"
             role="menu"
+            aria-label="App context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -17,6 +17,7 @@ function DefaultMenu(props) {
         <div
             id="default-menu"
             role="menu"
+            aria-label="Default context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -27,6 +27,7 @@ function TaskbarMenu(props) {
         <div
             id="taskbar-menu"
             role="menu"
+            aria-label="Taskbar context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -22,6 +22,7 @@ function WindowMenu(props) {
         <div
             id="window-menu"
             role="menu"
+            aria-label="Window context menu"
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -105,6 +105,7 @@ export default function Clock({ onlyTime, onlyDay }) {
       {open && (
         <div
           role="menu"
+          aria-label="Clock menu"
           className="absolute right-0 mt-2 w-48 bg-neutral-900 text-white rounded shadow-lg z-50"
         >
           <button

--- a/docs/component-naming.md
+++ b/docs/component-naming.md
@@ -1,0 +1,11 @@
+# Component Naming Conventions
+
+To keep the codebase consistent and accessible, new components should follow these guidelines:
+
+- **PascalCase** for React component names and their file names (e.g., `TaskbarMenu.tsx`).
+- **Suffix `Menu`** for components that render a context menu.
+- **Hooks** begin with `use` and use camelCase (e.g., `useFocusTrap`).
+- **ARIA labels**: interactive icons, notifications, and context menus must provide an `aria-label` or `aria-labelledby`.
+- **File structure** mirrors component structure; each major component resides in its own file.
+
+These conventions help ensure future additions remain readable and screen‑reader friendly.

--- a/src/components/desktop/DesktopContextMenu.tsx
+++ b/src/components/desktop/DesktopContextMenu.tsx
@@ -72,6 +72,7 @@ export const DesktopContextMenu: React.FC<DesktopContextMenuProps> = ({
   return (
     <div
       role="menu"
+      aria-label="Desktop context menu"
       ref={menuRef}
       onKeyDown={handleKeyDown}
       className="absolute z-50 w-52 cursor-default select-none rounded border border-gray-700 bg-gray-800 text-sm text-white shadow-lg"

--- a/src/components/notifications/Notifier.tsx
+++ b/src/components/notifications/Notifier.tsx
@@ -58,7 +58,12 @@ export const Notifier: React.FC<{ children?: React.ReactNode }> = ({ children })
     <NotifierContext.Provider value={{ notify }}>
       {children}
       {current && (
-        <div className={`fixed z-50 ${cornerClass(corner)}`} role="alert">
+        <div
+          className={`fixed z-50 ${cornerClass(corner)}`}
+          role="alert"
+          aria-live="assertive"
+          aria-label="Notification"
+        >
           <div className="bg-black text-white px-4 py-2 rounded shadow">{current}</div>
         </div>
       )}

--- a/utils/osdService.ts
+++ b/utils/osdService.ts
@@ -18,6 +18,9 @@ class OSDService {
     if (!this.el) {
       this.el = document.createElement('div');
       this.el.dataset.osd = 'true';
+      this.el.setAttribute('role', 'status');
+      this.el.setAttribute('aria-live', 'polite');
+      this.el.setAttribute('aria-label', 'Notification');
       Object.assign(this.el.style, {
         position: 'fixed',
         top: '20px',


### PR DESCRIPTION
## Summary
- add labelled, assertive notifier and OSD announcements
- expose accessible names on shared and app-specific context menus
- document component naming conventions

## Testing
- `yarn test __tests__/Notifier.test.tsx __tests__/clipman.test.tsx __tests__/osdService.test.ts __tests__/liveRegion.test.tsx`
- `yarn eslint components/common/ContextMenu.tsx src/components/notifications/Notifier.tsx utils/osdService.ts components/context-menus/default.js components/context-menus/app-menu.js components/context-menus/taskbar-menu.js components/context-menus/window-menu.js src/components/desktop/DesktopContextMenu.tsx components/util-components/clock.js components/Clipman.tsx __tests__/Notifier.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be420c8af48328b3e543df58094d5c