### PR TITLE
feat: add unique metadata for core pages

### DIFF
--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -49,4 +49,36 @@ export const baseMetadata: Metadata = {
   },
 };
 
+export function createMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}): Metadata {
+  const url = new URL(path, baseMetadata.metadataBase).toString();
+  return {
+    ...baseMetadata,
+    title,
+    description,
+    openGraph: {
+      ...baseMetadata.openGraph,
+      title,
+      description,
+      url,
+    },
+    twitter: {
+      ...baseMetadata.twitter,
+      title,
+      description,
+    },
+    alternates: {
+      ...(baseMetadata.alternates || {}),
+      canonical: url,
+    },
+  };
+}
+
 export default baseMetadata;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,9 +1,13 @@
 import dynamic from "next/dynamic";
-import { baseMetadata } from "../lib/metadata";
+import { createMetadata } from "../lib/metadata";
 import BetaBadge from "../components/BetaBadge";
 import useSession from "../hooks/useSession";
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: "Alex Unnippillil's Portfolio",
+  description: 'Personal portfolio showcasing security tools and demos.',
+  path: '/',
+});
 
 const Ubuntu = dynamic(
   () =>

--- a/pages/network-topology.tsx
+++ b/pages/network-topology.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
-import { baseMetadata } from '../lib/metadata';
+import { createMetadata } from '../lib/metadata';
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: 'Network Topology Visualization',
+  description: 'Interactive network topology demonstrating mitigation effects.',
+  path: '/network-topology',
+});
 
 const NetworkTopology: React.FC = () => {
   const [mitigated, setMitigated] = useState(false);

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import React, { useState } from 'react';
-import { baseMetadata } from '../lib/metadata';
+import { createMetadata } from '../lib/metadata';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
 import VirtualList from 'rc-virtual-list';
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: 'Metasploit Post-Exploitation Modules',
+  description: 'Browse and search Metasploit post-exploitation modules by tag.',
+  path: '/post_exploitation',
+});
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');

--- a/pages/sekurlsa_logonpasswords.tsx
+++ b/pages/sekurlsa_logonpasswords.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from 'react';
-import { baseMetadata } from '../lib/metadata';
+import { createMetadata } from '../lib/metadata';
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: 'Mimikatz sekurlsa::logonpasswords Output',
+  description: 'Sample output of the Mimikatz sekurlsa::logonpasswords command.',
+  path: '/sekurlsa_logonpasswords',
+});
 
 const rawOutput = `Authentication Id : 0 ; 123 (00000000:0000007B)
 Session           : Interactive from 1

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { baseMetadata } from '../lib/metadata';
+import { createMetadata } from '../lib/metadata';
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: 'ARP & DNS Spoofing Tools',
+  description: 'Quick references for performing ARP and DNS spoofing attacks.',
+  path: '/spoofing',
+});
 
 interface TileProps {
   title: string;

--- a/pages/wps-attack.tsx
+++ b/pages/wps-attack.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
-import { baseMetadata } from '../lib/metadata';
+import { createMetadata } from '../lib/metadata';
 
-export const metadata = baseMetadata;
+export const metadata = createMetadata({
+  title: 'WPS Attack Walkthrough',
+  description: 'Step-by-step simulation of cracking a WPS-enabled access point.',
+  path: '/wps-attack',
+});
 
 interface Step {
   title: string;


### PR DESCRIPTION
## Summary
- add helper to build metadata with custom titles, descriptions, and canonicals
- apply metadata to core pages to reflect page-specific content

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: TypeError: Cannot set properties of undefined (setting 'theme'))*
- `yarn dev` *(fails: TypeError: The "to" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_68be4210bde083288c41ac5160e3216b