### PR TITLE
feat: add JSON-LD schemas to docs and tools

### DIFF
--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import { useState } from 'react';
 import tools from '../../../data/kali-tools.json';
 
@@ -7,33 +8,52 @@ const KaliToolsPage = () => {
     tool.name.toLowerCase().includes(query.toLowerCase()),
   );
 
+  const softwareLd = filteredTools.map((tool) => ({
+    '@type': 'SoftwareApplication',
+    name: tool.name,
+    url: `https://www.kali.org/tools/${tool.id}/`,
+  }));
+
   return (
-    <div className="p-4">
-      <label htmlFor="tool-search" className="sr-only">
-        Search tools
-      </label>
-      <input
-        id="tool-search"
-        type="search"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search tools"
-        className="mb-4 w-full rounded border p-2"
-      />
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-        {filteredTools.map((tool) => (
-          <a
-            key={tool.id}
-            href={`https://www.kali.org/tools/${tool.id}/`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-          >
-            <span>{tool.name}</span>
-          </a>
-        ))}
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@graph': softwareLd,
+            }),
+          }}
+        />
+      </Head>
+      <div className="p-4">
+        <label htmlFor="tool-search" className="sr-only">
+          Search tools
+        </label>
+        <input
+          id="tool-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search tools"
+          className="mb-4 w-full rounded border p-2"
+        />
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+          {filteredTools.map((tool) => (
+            <a
+              key={tool.id}
+              href={`https://www.kali.org/tools/${tool.id}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+            >
+              <span>{tool.name}</span>
+            </a>
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add WebSite and BreadcrumbList JSON-LD to documentation pages
- expose SoftwareApplication schema for Kali tools listing

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Unable to find role="alert")*
- `curl -s -X POST ... https://search.google.com/test/rich-results/api/validate` *(returns 404)*

------
https://chatgpt.com/codex/tasks/task_e_68be42125a2c832892223e82511355c4