### PR TITLE
Add outbound icons and noopener for external links

### DIFF
--- a/components/OutboundLinkIcon.tsx
+++ b/components/OutboundLinkIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function OutboundLinkIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="12"
+      height="12"
+      {...props}
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,8 @@ import { Analytics } from '@vercel/analytics/next';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { createRoot } from 'react-dom/client';
+import OutboundLinkIcon from '@/components/OutboundLinkIcon';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -59,6 +61,21 @@ function MyApp(props) {
       console.error('Analytics initialization failed', err);
     });
   }, []);
+
+  useEffect(() => {
+    const links = document.querySelectorAll('a[target="_blank"]');
+    links.forEach((link) => {
+      if (!link.rel.includes('noopener')) {
+        link.rel = `${link.rel ? link.rel + ' ' : ''}noopener noreferrer`;
+      }
+      if (!link.querySelector('.outbound-icon')) {
+        const span = document.createElement('span');
+        span.className = 'inline-block ml-1 outbound-icon';
+        link.appendChild(span);
+        createRoot(span).render(<OutboundLinkIcon />);
+      }
+    });
+  }, [path]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- ensure external links get `rel="noopener noreferrer"`
- append outbound icon component to external links

## Testing
- `npm test` *(fails: Unable to find role="alert" in __tests__/nmapNse.test.tsx; calculator.formulas.test.ts also failing)*
- `npx -y lighthouse http://localhost:3000 --quiet --chrome-flags="--headless" --only-audits=external-anchors-use-rel-noopener` *(fails: CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68be4214e7e883289f0b3075c3839a96