### PR TITLE
Add FlexSearch global search indexing

### DIFF
--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -1,0 +1,30 @@
+import { performance } from 'perf_hooks';
+import { getSearchIndex, searchAll } from '../lib/search';
+
+describe('global search', () => {
+  beforeAll(async () => {
+    await getSearchIndex();
+  });
+
+  it('finds doc headings', async () => {
+    const res = await searchAll('Getting Started');
+    expect(res.some(r => r.section === 'docs' && r.title === 'Getting Started')).toBe(true);
+  });
+
+  it('finds tool names', async () => {
+    const res = await searchAll('Nmap');
+    expect(res.some(r => r.section === 'tools' && r.title === 'Nmap')).toBe(true);
+  });
+
+  it('finds platform slugs', async () => {
+    const res = await searchAll('Pacman');
+    expect(res.some(r => r.section === 'platforms' && r.title === 'Pacman')).toBe(true);
+  });
+
+  it('search is fast', async () => {
+    const start = performance.now();
+    await searchAll('Nmap');
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(200);
+  });
+});

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import path from 'path';
+import { Document } from 'flexsearch';
+
+export interface SearchDoc {
+  id: string;
+  title: string;
+  url: string;
+  section: 'docs' | 'tools' | 'platforms';
+}
+
+let index: Document<SearchDoc> | null = null;
+
+async function buildIndex() {
+  const idx = new Document<SearchDoc>({
+    document: {
+      id: 'id',
+      index: ['title'],
+      tag: 'section',
+      store: ['title', 'url', 'section'],
+    },
+    tokenize: 'forward',
+    cache: 100,
+  });
+
+  // Docs headings
+  const docsDir = path.join(process.cwd(), 'public', 'docs', 'seed');
+  if (fs.existsSync(docsDir)) {
+    const files = fs.readdirSync(docsDir).filter((f) => f.endsWith('.md'));
+    for (const file of files) {
+      const topic = file.replace(/\.md$/, '');
+      const md = fs.readFileSync(path.join(docsDir, file), 'utf8');
+      const headingRegex = /^#{2,3}\s+(.*)$/gm;
+      let m: RegExpExecArray | null;
+      while ((m = headingRegex.exec(md)) !== null) {
+        const text = m[1].trim();
+        const slug = text
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+        idx.add({
+          id: `doc-${topic}#${slug}`,
+          title: text,
+          url: `/docs/${topic}#${slug}`,
+          section: 'docs',
+        });
+      }
+    }
+  }
+
+  // Tool names
+  const toolsPath = path.join(process.cwd(), 'data', 'kali-tools.json');
+  if (fs.existsSync(toolsPath)) {
+    const tools = JSON.parse(fs.readFileSync(toolsPath, 'utf8')) as { id: string; name: string }[];
+    for (const tool of tools) {
+      idx.add({
+        id: `tool-${tool.id}`,
+        title: tool.name,
+        url: `https://www.kali.org/tools/${tool.id}/`,
+        section: 'tools',
+      });
+    }
+  }
+
+  // Platform slugs from apps.config
+  try {
+    const apps = (await import(path.join(process.cwd(), 'apps.config.js'))).default as any[];
+    for (const app of apps) {
+      idx.add({
+        id: `app-${app.id}`,
+        title: app.title,
+        url: `/apps/${app.id}`,
+        section: 'platforms',
+      });
+    }
+  } catch {
+    // ignore if apps.config not available
+  }
+
+  index = idx;
+  return idx;
+}
+
+export async function getSearchIndex() {
+  return index || buildIndex();
+}
+
+export async function searchAll(query: string) {
+  const idx = await getSearchIndex();
+  const results = idx.search(query, { enrich: true }) as any[];
+  const docs: SearchDoc[] = [];
+  for (const result of results) {
+    for (const r of result.result) {
+      if (r.doc) docs.push(r.doc as SearchDoc);
+    }
+  }
+  return docs;
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
     "flags": "^4.0.1",
+    "flexsearch": "0.7.31",
     "fuse.js": "^6.6.2",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { searchAll } from '../../lib/search';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const q = (req.query.q as string) || '';
+  if (!q) {
+    res.status(400).json({ error: 'missing query' });
+    return;
+  }
+  const results = await searchAll(q);
+  res.status(200).json(results);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7998,6 +7998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flexsearch@npm:0.7.31":
+  version: 0.7.31
+  resolution: "flexsearch@npm:0.7.31"
+  checksum: 10c0/d465770d9bbfabcd1628b1c5e6acbb2b283c7e473d79b0c59f1ccbd3d13e392be98943e71a3dc4b311e6d901e5528a640b5ae914fbee603f0c14692720714f11
+  languageName: node
+  linkType: hard
+
 "float-tooltip@npm:^1.7":
   version: 1.7.5
   resolution: "float-tooltip@npm:1.7.5"
@@ -14786,6 +14793,7 @@ __metadata:
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
     flags: "npm:^4.0.1"
+    flexsearch: "npm:0.7.31"
     fuse.js: "npm:^6.6.2"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"


### PR DESCRIPTION
## Summary
- add FlexSearch dependency
- build searchable index of docs, tools, and platforms
- expose `/api/search` endpoint and tests

## Testing
- `yarn test __tests__/search.test.ts`
- `yarn lint lib/search.ts pages/api/search.ts __tests__/search.test.ts` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be421632408328b6f1cc0dae16cc6d