### PR TITLE
feat: add social links footer

### DIFF
--- a/__tests__/Footer.test.tsx
+++ b/__tests__/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import Footer from '../components/common/Footer';
+
+describe('Footer', () => {
+  test('renders social links with correct destinations', () => {
+    render(<Footer />);
+    const links: [string, string][] = [
+      ['Bluesky', 'https://bsky.app/profile/kalilinux.bsky.social'],
+      ['Facebook', 'https://www.facebook.com/KaliLinux'],
+      ['Instagram', 'https://www.instagram.com/kalilinux/'],
+      ['Mastodon', 'https://infosec.exchange/@kalilinux'],
+      ['Substack', 'https://kalilinux.substack.com/'],
+      ['X', 'https://x.com/kalilinux'],
+      ['Newsletter', 'https://www.kali.org/newsletter/'],
+      ['RSS', 'https://www.kali.org/rss.xml'],
+    ];
+
+    for (const [name, href] of links) {
+      const link = screen.getByRole('link', { name });
+      expect(link).toHaveAttribute('href', href);
+    }
+  });
+});

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const socialLinks = [
+  { href: 'https://bsky.app/profile/kalilinux.bsky.social', label: 'Bluesky' },
+  { href: 'https://www.facebook.com/KaliLinux', label: 'Facebook' },
+  { href: 'https://www.instagram.com/kalilinux/', label: 'Instagram' },
+  { href: 'https://infosec.exchange/@kalilinux', label: 'Mastodon' },
+  { href: 'https://kalilinux.substack.com/', label: 'Substack' },
+  { href: 'https://x.com/kalilinux', label: 'X' },
+  { href: 'https://www.kali.org/newsletter/', label: 'Newsletter' },
+  { href: 'https://www.kali.org/rss.xml', label: 'RSS' },
+];
+
+export default function Footer() {
+  return (
+    <footer className="mt-16 border-t border-gray-200 p-4 text-sm" role="contentinfo">
+      <div>
+        <h2 className="font-semibold">Follow Us</h2>
+        <ul className="mt-2 space-y-1">
+          {socialLinks.map(({ href, label }) => (
+            <li key={label}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={label}
+                className="text-blue-600 underline hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                {label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </footer>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -15,6 +15,7 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import Footer from '../components/common/Footer';
 import PipPortalProvider from '../components/common/PipPortal';
 import { TrayProvider } from '../hooks/useTray';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -248,6 +249,7 @@ function MyApp(props) {
                 <div aria-live="polite" id="live-region" />
                 <Component {...pageProps} />
                 <ShortcutOverlay />
+                <Footer />
                 {process.env.VERCEL_ANALYTICS_ID && (
                   <>
                     <Analytics


### PR DESCRIPTION
## Summary
- add `Footer` component with social links (Bluesky, Facebook, Instagram, Mastodon, Substack, X, Newsletter, RSS)
- render footer across app layout
- test social links for correct destinations

## Testing
- `yarn test __tests__/Footer.test.tsx`
- `yarn a11y` *(fails: logger.info is not a function)*
- `yarn lint components/common/Footer.tsx pages/_app.jsx __tests__/Footer.test.tsx` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68be421938248328ab4c27338dcfcb88