### PR TITLE
feat: add get involved page

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -21,6 +21,12 @@ export default class Navbar extends Component {
                                         <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
                                 </div>
                                 <WhiskerMenu />
+                                <a
+                                        href="/get-involved"
+                                        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+                                >
+                                        Community
+                                </a>
                                 <HelpMenu />
                                 <div
                                         className={

--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const GetInvolvedPage: React.FC = () => (
+  <div className="p-8 max-w-3xl mx-auto">
+    <h1 className="text-2xl font-bold mb-4">Get Involved</h1>
+    <p className="mb-4">
+      Kali Linux Portfolio is an open, unofficial effort driven by our community. Your ideas and
+      contributions help shape its future.
+    </p>
+    <ul className="list-disc pl-6 mb-4">
+      <li>Report bugs or request features through the issue tracker.</li>
+      <li>Improve the interface and docs with pull requests.</li>
+      <li>Share feedback and suggestions with fellow contributors.</li>
+    </ul>
+    <p>
+      For guidance on contributing to Kali Linux itself, visit the{' '}
+      <a
+        href="https://www.kali.org/docs/community/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 underline"
+      >
+        official Kali documentation
+      </a>
+      .
+    </p>
+  </div>
+);
+
+export default GetInvolvedPage;
+


### PR DESCRIPTION
## Summary
- add a Get Involved page outlining ways to contribute and linking to official Kali docs
- expose the new page from the header via a Community link

## Testing
- `yarn lint` *(fails: command hung)*
- `yarn typecheck` *(fails: command hung)*
- `yarn test` *(fails: tests reported errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be421a12b88328b39e18d017189e78