### PR TITLE
Add static export workflow and AWS hosting config

### DIFF
--- a/.github/workflows/static-export.yml
+++ b/.github/workflows/static-export.yml
@@ -1,0 +1,23 @@
+name: Static Export
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn export
+      - uses: actions/upload-artifact@v4
+        with:
+          name: static-site
+          path: out
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ After the server starts, exercise an API route to confirm server-side functional
 curl -X POST http://localhost:3000/api/dummy
 ```
 
-### Static Export (for GitHub Pages / S3 Websites)
+### Static Export (for GitHub Pages / S3 + CloudFront)
 This project supports static export. Serverless API routes will not be available; the UI falls back to demo data or hides features.
 ```bash
 yarn export && npx serve out
 
 ```
+For production hosting, upload the `out/` directory to a **private** S3 bucket behind CloudFront.
+See [deployment docs](./docs/deployment.md) for Terraform and upload steps.
+All access should go through CloudFront – the S3 website endpoint remains disabled.
 Verify that features relying on `/api/*` return 404 or other placeholders when served statically.
 
 ### Install as PWA for Sharing

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,33 @@
+# Static Deployment
+
+This project can be exported to a fully static site and served from AWS.
+The S3 bucket is configured as a **private origin** behind a CloudFront
+ distribution.  CloudFront uses an **Origin Access Control (OAC)** so the
+ bucket does not need to enable the S3 website endpoint or allow public
+ access.  A WAF web ACL provides basic protection and can be extended
+ with additional rules.
+
+## Provisioning
+
+Infrastructure is defined in [`infra/main.tf`](../infra/main.tf).
+To deploy the resources:
+
+```bash
+cd infra
+terraform init
+terraform apply
+```
+
+The outputs include the S3 bucket name and CloudFront domain used for the
+site.
+
+## Build and Upload
+
+```bash
+yarn export
+aws s3 sync out/ s3://<bucket-name> --delete
+aws cloudfront create-invalidation --distribution-id <id> --paths "/*"
+```
+
+Access the site through the CloudFront domain (or a custom domain pointing
+to it).  Do **not** use the S3 website endpoint, which remains disabled.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "site" {
+  bucket        = "${var.project_name}-site"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket                  = aws_s3_bucket.site.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${var.project_name}-oac"
+  description                       = "OAC for ${var.project_name} static site"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_wafv2_web_acl" "main" {
+  name        = "${var.project_name}-waf"
+  description = "Basic rate limiting for static site"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.project_name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "rate-limit"
+    priority = 1
+
+    action { block {} }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "rateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_id                = "s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  web_acl_id = aws_wafv2_web_acl.main.arn
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "cloudfront.amazonaws.com" }
+      Action = "s3:GetObject"
+      Resource = "${aws_s3_bucket.site.arn}/*"
+      Condition = {
+        StringEquals = { "AWS:SourceArn" = aws_cloudfront_distribution.cdn.arn }
+      }
+    }]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "S3 bucket for static site"
+  value       = aws_s3_bucket.site.bucket
+}
+
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain"
+  value       = aws_cloudfront_distribution.cdn.domain_name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Prefix for all created resources"
+  type        = string
+  default     = "kali-portfolio"
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to export static site and upload artifact
- provision AWS S3 bucket, CloudFront OAC distribution and WAF via Terraform
- document static deployment steps using CloudFront instead of S3 website

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: NmapNSEApp › copies example output to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68be421b06bc8328a8a1cb297a848d68