### PR TITLE
chore: add performance budgets and checks

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,28 @@
+name: Performance Budgets
+
+on:
+  pull_request:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: echo "url=$(npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          configPath: perf/lhci.config.js
+          urls: ${{ steps.deploy.outputs.url }}

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -1,4 +1,4 @@
 {
-  "^chunks/framework": 300000,
-  "^chunks/main-app": 350000
+  "^chunks/framework": 250000,
+  "^chunks/main-app": 300000
 }

--- a/next.config.js
+++ b/next.config.js
@@ -169,6 +169,7 @@ module.exports = withBundleAnalyzer(
       ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],
+      formats: ['image/avif', 'image/webp'],
     },
     async rewrites() {
       return [
@@ -183,6 +184,28 @@ module.exports = withBundleAnalyzer(
       ? {
           async headers() {
             return [
+              {
+                source: '/:path*',
+                headers: [
+                  {
+                    key: 'Link',
+                    value: '<https://fonts.googleapis.com>; rel=preconnect; crossorigin',
+                  },
+                  {
+                    key: 'Link',
+                    value: '<https://fonts.gstatic.com>; rel=preconnect; crossorigin',
+                  },
+                ],
+              },
+              {
+                source: '/_next/static/:path*',
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=31536000, immutable',
+                  },
+                ],
+              },
               {
                 source: '/(.*)',
                 headers: securityHeaders,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "module-report": "node --import tsx/esm scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "check-budgets": "node scripts/check-bundle-budgets.mjs",
+    "perf:check": "node scripts/perf-check.mjs",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node --import tsx/esm scripts/verify.mjs",
     "validate:apps": "node --import tsx/esm scripts/validate-apps.mjs"

--- a/perf/lhci.config.js
+++ b/perf/lhci.config.js
@@ -1,0 +1,27 @@
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        '/',
+        '/apps',
+        '/apps/code-editor',
+        '/apps/monaco',
+        '/apps/chess',
+      ],
+      numberOfRuns: 3,
+      settings: {
+        preset: 'mobile',
+      },
+    },
+    assert: {
+      assertions: {
+        'largest-contentful-paint': ['error', {maxNumericValue: 2500, aggregationMethod: 'optimistic'}],
+        'experimental-interaction-to-next-paint': ['error', {maxNumericValue: 200, aggregationMethod: 'optimistic'}],
+        'cumulative-layout-shift': ['error', {maxNumericValue: 0.1, aggregationMethod: 'pessimistic'}],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/perf/plan.md
+++ b/perf/plan.md
@@ -1,0 +1,31 @@
+# Performance Plan
+
+This document outlines steps to improve LCP, INP, and CLS for `/`, `/apps`, and the three heaviest app routes. It also lists the budgets and checks added in this PR.
+
+## Above-the-fold optimizations
+- **Preload LCP images**: hero images on `/` and `/apps` should use `<link rel="preload" as="image">` for the first paint. Heaviest app routes should preload their primary background/hero images.
+- **Font loading**: use `next/font` with `display: swap` and preload the Inter subset. Added preconnect headers for Google Fonts to reduce DNS and TLS cost.
+- **Image formats**: enable AVIF/WebP output via `next/image` so modern browsers get smaller assets. Ensure images have width/height to avoid CLS.
+- **Preconnect**: added `Link` headers to preconnect `fonts.googleapis.com` and `fonts.gstatic.com`.
+- **Defer non-critical scripts**: convert blocking scripts to `strategy: 'lazyOnload'` and mark analytics bundles with `defer`.
+
+## Route-level improvements
+- `/` and `/apps`: verify hero image dimensions and use CSS `aspect-ratio`.
+- **Heavy apps** (`/apps/code-editor`, `/apps/monaco`, `/apps/chess`):
+  - Strengthen dynamic imports with explicit boundaries using `next/dynamic` and SSR disabled where possible.
+  - Confirm `webpackPrefetch` is used for desktop tiles and opt‑out for multi‑MB modules to avoid wasteful prefetching.
+
+## Performance budgets
+- **Largest Contentful Paint** < 2500 ms.
+- **Interaction to Next Paint** < 200 ms.
+- **Cumulative Layout Shift** < 0.1.
+- Bundle budgets enforced via `bundle-budgets.json` and `yarn perf:check`.
+
+## Tooling
+- Added `perf/lhci.config.js` and GitHub workflow to run Lighthouse CI against Vercel preview URLs. Job fails if budgets above are exceeded.
+- Added bundle size check script `scripts/perf-check.mjs` and `yarn perf:check` script.
+
+## Next.js configuration
+- Added global headers for font preconnect and caching tweaks.
+- Enabled AVIF/WebP formats in `next.config.js`.
+

--- a/scripts/perf-check.mjs
+++ b/scripts/perf-check.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const budgets = JSON.parse(
+  fs.readFileSync(new URL('../bundle-budgets.json', import.meta.url), 'utf8'),
+);
+const statsPath = path.join(process.cwd(), '.next', 'analyze', 'client.json');
+if (!fs.existsSync(statsPath)) {
+  console.error('Missing build stats at .next/analyze/client.json. Run `ANALYZE=true yarn build` first.');
+  process.exit(1);
+}
+const stats = JSON.parse(fs.readFileSync(statsPath, 'utf8'));
+
+const assets = stats.assets || [];
+let failed = false;
+
+for (const [pattern, limit] of Object.entries(budgets)) {
+  const regex = new RegExp(pattern);
+  const match = assets.find((a) => regex.test(a.name));
+  if (!match) {
+    console.warn(`No asset matching pattern ${pattern}`);
+    continue;
+  }
+  const size = match.size;
+  if (size > limit) {
+    console.error(`Asset ${match.name} (${size} bytes) exceeds budget of ${limit} bytes`);
+    failed = true;
+  } else {
+    console.log(`Asset ${match.name} (${size} bytes) within budget (${limit} bytes)`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- set explicit bundle size limits and add `perf:check` script
- add Lighthouse CI config and workflow with LCP/INP/CLS budgets
- tune Next.js headers and image formats for better loading

## Testing
- `yarn perf:check` *(fails: Missing build stats at .next/analyze/client.json)*
- `yarn lint` *(fails: A control must be associated with a text label)*

------
https://chatgpt.com/codex/tasks/task_e_68be425332e88328b9dd25a0b1855333