### PR TITLE
feat: add SEO metadata and OG image generator

### DIFF
--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -24,7 +24,7 @@ export const baseMetadata: Metadata = {
     siteName: 'Alex Unnippillil Personal Portfolio',
     images: [
       {
-        url: '/images/logos/logo_1200.png',
+        url: '/api/og?title=Alex%20Unnippillil',
         width: 1200,
         height: 630,
         alt: 'Alex Unnippillil logo',
@@ -39,7 +39,7 @@ export const baseMetadata: Metadata = {
     description: 'Alex Unnippillil Personal Portfolio Website',
     site: '@alexunnippillil',
     creator: '@unnippillil',
-    images: ['/images/logos/logo_1024.png'],
+    images: ['/api/og?title=Alex%20Unnippillil'],
   },
   alternates: {
     canonical: 'https://unnippillil.com/',

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import Meta from '@/seo/Meta';
 
 
 let SpeedInsights = () => null;
@@ -226,6 +227,7 @@ function MyApp(props) {
 
   return (
     <>
+      <Meta />
       <Head>
         {locales?.map((l) => {
           const href = l === defaultLocale ? path : `/${l}${path === '/' ? '' : path}`;

--- a/pages/api/og.ts
+++ b/pages/api/og.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import sharp from 'sharp';
+import path from 'path';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { title = 'Alex Unnippillil' } = req.query;
+    const baseImage = path.join(process.cwd(), 'public/images/logos/logo_1200.png');
+
+    const svg = `<svg width="1200" height="630">
+      <style>
+      .title { fill: #fff; font-size: 64px; font-family: sans-serif; font-weight: bold; }
+      </style>
+      <rect x="0" y="0" width="1200" height="630" fill="rgba(0,0,0,0.5)" />
+      <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" class="title">${String(title).slice(0,80)}</text>
+    </svg>`;
+
+    const image = await sharp(baseImage)
+      .composite([{ input: Buffer.from(svg), gravity: 'center' }])
+      .png()
+      .toBuffer();
+
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.send(image);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to generate image' });
+  }
+}

--- a/seo/Meta.js
+++ b/seo/Meta.js
@@ -1,0 +1,80 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { baseMetadata } from '@/lib/metadata';
+
+const siteUrl = baseMetadata.metadataBase?.toString().replace(/\/$/, '') || '';
+
+export default function Meta({ title, description, image, canonical, robots = 'index,follow' }) {
+  const router = useRouter();
+  const pageTitle = title || baseMetadata.title;
+  const pageDescription = description || baseMetadata.description;
+  const url = (canonical || `${siteUrl}${router.asPath}`).replace(/\/$/, '') || siteUrl;
+  const ogImage = image || `/api/og?title=${encodeURIComponent(pageTitle)}`;
+
+  const websiteLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    url: siteUrl,
+    name: baseMetadata.title,
+  };
+
+  const personLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: baseMetadata.authors?.[0]?.name || '',
+    url: siteUrl,
+  };
+
+  const organizationLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: baseMetadata.authors?.[0]?.name || '',
+    url: siteUrl,
+    logo: `${siteUrl}/images/logos/logo_1200.png`,
+  };
+
+  const pathSegments = router.asPath.split('?')[0].split('/').filter(Boolean);
+  let breadcrumbLd;
+  if (pathSegments.length > 1) {
+    const itemListElement = pathSegments.map((segment, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: decodeURIComponent(segment),
+      item: `${siteUrl}/${pathSegments.slice(0, index + 1).join('/')}`,
+    }));
+    breadcrumbLd = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement,
+    };
+  }
+
+  const jsonLd = [websiteLd, personLd, organizationLd, breadcrumbLd].filter(Boolean);
+
+  return (
+    <Head>
+      <title>{pageTitle}</title>
+      <meta name="description" content={pageDescription} />
+      <meta name="robots" content={robots} />
+      <link rel="canonical" href={url} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={pageDescription} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={ogImage} />
+      {baseMetadata.twitter?.card && <meta name="twitter:card" content={baseMetadata.twitter.card} />}
+      {baseMetadata.twitter?.site && <meta name="twitter:site" content={baseMetadata.twitter.site} />}
+      {baseMetadata.twitter?.creator && <meta name="twitter:creator" content={baseMetadata.twitter.creator} />}
+      <meta name="twitter:title" content={pageTitle} />
+      <meta name="twitter:description" content={pageDescription} />
+      <meta name="twitter:image" content={ogImage} />
+      {jsonLd.map((data, idx) => (
+        <script
+          key={idx}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        />
+      ))}
+    </Head>
+  );
+}

--- a/seo/plan.md
+++ b/seo/plan.md
@@ -1,0 +1,52 @@
+# SEO Plan
+
+## JSON-LD Samples
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Alex Unnippillil's Portfolio",
+  "url": "https://unnippillil.com"
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Alex Unnippillil",
+  "url": "https://unnippillil.com"
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Alex Unnippillil",
+  "url": "https://unnippillil.com",
+  "logo": "https://unnippillil.com/images/logos/logo_1200.png"
+}
+```
+
+For deep routes, breadcrumbs are emitted like:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "apps", "item": "https://unnippillil.com/apps" },
+    { "@type": "ListItem", "position": 2, "name": "metasploit", "item": "https://unnippillil.com/apps/metasploit" }
+  ]
+}
+```
+
+## Validation Steps
+
+1. `yarn dev` to start the development server.
+2. Visit any page and view source to confirm presence of canonical, meta robots and Open Graph tags.
+3. Generate an OG image by visiting `/api/og?title=Hello` and confirm an image is returned.
+4. Use Google's [Rich Results Test](https://search.google.com/test/rich-results) and paste the page URL or HTML snippet to validate the WebSite, Person, Organization and BreadcrumbList JSON‑LD.
+5. Inspect Open Graph tags using the [Open Graph Debugger](https://developers.facebook.com/tools/debug/).


### PR DESCRIPTION
## Summary
- add SEO/Meta component with canonical tags, robots, and JSON-LD for site, person, org and breadcrumbs
- expose /api/og endpoint that renders dynamic Open Graph images
- document SEO approach and validation steps

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Unable to find role="alert", Missing remotePatterns, and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be42761c8c832896baca7bd3acfb3d