### PR TITLE
feat: add analytics consent

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -9,6 +9,8 @@ describe('analytics utilities', () => {
   const mockEvent = ReactGA.event as jest.Mock;
 
   beforeEach(() => {
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'true';
+    window.localStorage.setItem('analytics-enabled', 'true');
     mockEvent.mockReset();
   });
 

--- a/__tests__/reportWebVitals.test.ts
+++ b/__tests__/reportWebVitals.test.ts
@@ -23,6 +23,8 @@ describe('reportWebVitals', () => {
     logSpy.mockClear();
     mockTrack.mockReset();
     process.env = { ...originalEnv };
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'true';
+    window.localStorage.setItem('analytics-enabled', 'true');
   });
 
   afterAll(() => {

--- a/__tests__/useReportWebVitals.test.ts
+++ b/__tests__/useReportWebVitals.test.ts
@@ -17,6 +17,10 @@ jest.mock('@/utils/reportWebVitals', () => ({
 }));
 
 describe('useReportWebVitals', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'true';
+    window.localStorage.setItem('analytics-enabled', 'true');
+  });
   it('forwards metrics to analytics services', () => {
     const metric = { id: '1', name: 'LCP', value: 123 } as any;
     (nextUseReportWebVitals as jest.Mock).mockImplementation((cb: any) => cb(metric));

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -6,7 +6,7 @@ import { isBrowser } from '../../utils/env';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, symbolicTrayIcons, setSymbolicTrayIcons } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, symbolicTrayIcons, setSymbolicTrayIcons, analytics, setAnalytics } = useSettings();
     const [panelBehavior, setPanelBehavior] = usePersistentState('xfce.panel.autohideBehavior', 'never');
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
@@ -184,6 +184,19 @@ export function Settings() {
                     Allow Network Requests
                 </label>
             </div>
+            {process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true' && (
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={analytics}
+                        onChange={(e) => setAnalytics(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Enable Analytics
+                </label>
+            </div>
+            )}
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input

--- a/hooks/useReportWebVitals.ts
+++ b/hooks/useReportWebVitals.ts
@@ -6,6 +6,8 @@ const vitals = new Set(['LCP', 'CLS', 'INP']);
 
 export default function useReportWebVitals(): void {
   useNextReportWebVitals((metric) => {
+    if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
+    if (typeof window !== 'undefined' && window.localStorage.getItem('analytics-enabled') !== 'true') return;
     const { id, name, value } = metric;
     if (vitals.has(name)) {
       track(name, { id, value });

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,8 @@ import {
   setNetworkTime as saveNetworkTime,
   getSymbolicTrayIcons as loadSymbolicTrayIcons,
   setSymbolicTrayIcons as saveSymbolicTrayIcons,
+  getAnalytics as loadAnalytics,
+  setAnalytics as saveAnalytics,
   defaults,
 } from '../utils/settingsStore';
 import { THEME_KEY, getTheme as getStoredTheme, setTheme as applyTheme } from '../utils/theme';
@@ -67,6 +69,7 @@ interface SettingsContextValue {
   networkTime: boolean;
   theme: string;
   symbolicTrayIcons: boolean;
+  analytics: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -80,6 +83,7 @@ interface SettingsContextValue {
   setNetworkTime: (value: boolean) => void;
   setTheme: (value: string) => void;
   setSymbolicTrayIcons: (value: boolean) => void;
+  setAnalytics: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -96,6 +100,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   networkTime: defaults.networkTime,
   theme: 'default',
   symbolicTrayIcons: defaults.symbolicTrayIcons,
+  analytics: defaults.analytics,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -109,6 +114,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setNetworkTime: () => {},
   setTheme: () => {},
   setSymbolicTrayIcons: () => {},
+  setAnalytics: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -137,6 +143,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [networkTime, setNetworkTime] = useState<boolean>(defaults.networkTime);
   const [symbolicTrayIcons, setSymbolicTrayIcons] = useState<boolean>(defaults.symbolicTrayIcons);
+  const [analytics, setAnalytics] = useState<boolean>(defaults.analytics);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   const [rotationMode] = usePersistentState<'off' | 'daily' | 'login'>(
@@ -173,6 +180,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHaptics(await loadHaptics());
       setNetworkTime(await loadNetworkTime());
       setSymbolicTrayIcons(await loadSymbolicTrayIcons());
+      setAnalytics(await loadAnalytics());
     })();
   }, []);
 
@@ -212,7 +220,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setWallpaper(base);
       setRotationIndex((index + 1) % rotationSet.length);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rotationMode, rotationSet]);
 
   useEffect(() => {
@@ -303,6 +310,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveSymbolicTrayIcons(symbolicTrayIcons);
   }, [symbolicTrayIcons]);
 
+  useEffect(() => {
+    saveAnalytics(analytics);
+  }, [analytics]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -318,6 +329,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         haptics,
         networkTime,
         symbolicTrayIcons,
+        analytics,
         theme,
         setAccent,
         setWallpaper,
@@ -332,6 +344,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setNetworkTime,
         setTheme,
         setSymbolicTrayIcons,
+        setAnalytics,
       }}
     >
       {children}

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -10,9 +10,10 @@ export function trackEvent(
   name: EventName,
   props?: Record<string, string | number | boolean>,
 ) {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
+  if (typeof window !== 'undefined' && window.localStorage.getItem('analytics-enabled') !== 'true') return;
   try {
     // Dynamically require to avoid ESM issues in test environment
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     const { track } = require('@vercel/analytics');
     track(name, props);
   } catch {

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -1,13 +1,13 @@
 export default async function trackServerEvent(
   event: string,
   properties?: Record<string, any>,
-  options?: Record<string, any>
+  options?: Record<string, any>,
 ): Promise<void> {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
   try {
     const mod = await import('@vercel/analytics/server');
     await mod.track(event, properties, options);
   } catch {
     // ignore analytics errors
-
   }
 }

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -3,6 +3,8 @@ import ReactGA from 'react-ga4';
 type EventInput = Parameters<typeof ReactGA.event>[0];
 
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
+  if (typeof window !== 'undefined' && window.localStorage.getItem('analytics-enabled') !== 'true') return;
   try {
     const eventFn = ReactGA.event;
     if (typeof eventFn === 'function') {

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -17,6 +17,8 @@ const thresholds: Record<string, number> = {
 const vitalNames = new Set(['TTFB', 'LCP', 'INP', 'CLS', 'TTI']);
 
 export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
+  if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS !== 'true') return;
+  if (typeof window !== 'undefined' && window.localStorage.getItem('analytics-enabled') !== 'true') return;
   if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview') return;
   if (!vitalNames.has(name)) return;
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS = {
   haptics: true,
   networkTime: false,
   symbolicTrayIcons: false,
+  analytics: false,
 };
 
 export async function getAccent() {
@@ -148,6 +149,16 @@ export async function setSymbolicTrayIcons(value) {
   window.localStorage.setItem('symbolic-tray-icons', value ? 'true' : 'false');
 }
 
+export async function getAnalytics() {
+  if (!isBrowser()) return DEFAULT_SETTINGS.analytics;
+  return window.localStorage.getItem('analytics-enabled') === 'true';
+}
+
+export async function setAnalytics(value) {
+  if (!isBrowser()) return;
+  window.localStorage.setItem('analytics-enabled', value ? 'true' : 'false');
+}
+
 export async function resetSettings() {
   if (!isBrowser()) return;
   window.localStorage.removeItem('accent');
@@ -162,6 +173,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('network-time');
   window.localStorage.removeItem('symbolic-tray-icons');
+  window.localStorage.removeItem('analytics-enabled');
 }
 
 export async function exportSettings() {
@@ -178,6 +190,7 @@ export async function exportSettings() {
     haptics,
     networkTime,
     symbolicTrayIcons,
+    analytics,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -191,6 +204,7 @@ export async function exportSettings() {
     getHaptics(),
     getNetworkTime(),
     getSymbolicTrayIcons(),
+    getAnalytics(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -206,6 +220,7 @@ export async function exportSettings() {
     haptics,
     networkTime,
     symbolicTrayIcons,
+    analytics,
     theme,
   });
 }
@@ -232,6 +247,7 @@ export async function importSettings(json) {
     haptics,
     networkTime,
     symbolicTrayIcons,
+    analytics,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -246,6 +262,7 @@ export async function importSettings(json) {
   if (haptics !== undefined) await setHaptics(haptics);
   if (networkTime !== undefined) await setNetworkTime(networkTime);
   if (symbolicTrayIcons !== undefined) await setSymbolicTrayIcons(symbolicTrayIcons);
+  if (analytics !== undefined) await setAnalytics(analytics);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- gate analytics with NEXT_PUBLIC_ENABLE_ANALYTICS and user consent
- expose analytics toggle in settings and persist preference
- load analytics scripts and web vitals only when consented

## Testing
- `npx eslint __tests__/analytics.test.ts __tests__/reportWebVitals.test.ts __tests__/useReportWebVitals.test.ts components/apps/settings.js hooks/useReportWebVitals.ts hooks/useSettings.tsx lib/analytics-client.ts lib/analytics-server.ts pages/_app.jsx utils/analytics.ts utils/reportWebVitals.ts utils/settingsStore.js`
- `yarn test __tests__/analytics.test.ts __tests__/useReportWebVitals.test.ts __tests__/reportWebVitals.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be4215c3e083288f6dd572a1a0ec14