### PR TITLE
feat: add notifications popover

### DIFF
--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -19,8 +19,10 @@ interface LogEntry extends AppNotification {
 
 interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
+  log: LogEntry[];
   pushNotification: (appId: string, message: string) => void;
   clearNotifications: (appId?: string) => void;
+  clearLog: () => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(
@@ -36,7 +38,10 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
   const [notifications, setNotifications] = useState<
     Record<string, AppNotification[]>
   >({});
-  const [log, setLog] = useState<LogEntry[]>([]);
+  const [log, setLog] = usePersistentState<LogEntry[]>(
+    'notification-log',
+    [],
+  );
   const [activeTab, setActiveTab] = useState<Tab>('general');
   const [doNotDisturb, setDoNotDisturb] = usePersistentState<boolean>(
     'notifications-dnd',
@@ -128,6 +133,10 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
     });
   }, []);
 
+  const clearLog = useCallback(() => {
+    setLog([]);
+  }, [setLog]);
+
   const totalCount = Object.values(notifications).reduce(
     (sum, list) => sum + list.length,
     0
@@ -214,7 +223,7 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+      value={{ notifications, log, pushNotification, clearNotifications, clearLog }}
     >
       {children}
       <div className={`notification-center ${position}`}>

--- a/components/panel/items.ts
+++ b/components/panel/items.ts
@@ -1,6 +1,8 @@
 import Separator from "./plugins/Separator";
+import Notifications from "./plugins/Notifications";
 
 export const panelItems = [
+  { id: "notifications", component: Notifications },
   { id: "separator", component: Separator },
 ];
 

--- a/components/panel/plugins/Notifications.tsx
+++ b/components/panel/plugins/Notifications.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import useNotifications from "@/hooks/useNotifications";
+
+export default function Notifications() {
+  const { log, clearNotifications, clearLog } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  useEffect(() => {
+    if (open && ref.current) {
+      ref.current.focus();
+    }
+  }, [open]);
+
+  const handleClear = () => {
+    clearNotifications();
+    clearLog();
+    setOpen(false);
+  };
+
+  const recent = log.slice(-5).reverse();
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Show notifications"
+        className="relative px-2 py-1 text-white hover:bg-gray-700 rounded"
+        onClick={() => setOpen(o => !o)}
+      >
+        🔔
+        {log.length > 0 && (
+          <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-600 text-xs rounded-full flex items-center justify-center" aria-label={"" + log.length}>
+            {log.length}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div
+          ref={ref}
+          tabIndex={-1}
+          role="dialog"
+          aria-label="Notifications"
+          onKeyDown={e => e.key === "Escape" && setOpen(false)}
+          className="absolute right-0 mt-2 w-64 bg-gray-800 text-white rounded shadow-lg z-10 p-2"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="font-semibold text-sm">Notifications</h2>
+            {log.length > 0 && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="text-xs underline"
+                aria-label="Clear all notifications"
+              >
+                Clear All
+              </button>
+            )}
+          </div>
+          <ul role="list" className="max-h-60 overflow-auto">
+            {recent.length === 0 && (
+              <li className="text-sm text-gray-300">No notifications</li>
+            )}
+            {recent.map(n => (
+              <li
+                key={n.id}
+                className="text-sm border-b border-gray-700 last:border-b-0 py-1"
+              >
+                {n.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 
 let SpeedInsights = () => null;
@@ -245,23 +246,25 @@ function MyApp(props) {
           <SettingsProvider>
             <TrayProvider>
               <PipPortalProvider>
-                <div aria-live="polite" id="live-region" />
-                <Component {...pageProps} />
-                <ShortcutOverlay />
-                {process.env.VERCEL_ANALYTICS_ID && (
-                  <>
-                    <Analytics
-                      beforeSend={(e) => {
-                        if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                        const evt = e;
-                        if (evt.metadata?.email) delete evt.metadata.email;
-                        return e;
-                      }}
-                    />
+                <NotificationCenter>
+                  <div aria-live="polite" id="live-region" />
+                  <Component {...pageProps} />
+                  <ShortcutOverlay />
+                  {process.env.VERCEL_ANALYTICS_ID && (
+                    <>
+                      <Analytics
+                        beforeSend={(e) => {
+                          if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                          const evt = e;
+                          if (evt.metadata?.email) delete evt.metadata.email;
+                          return e;
+                        }}
+                      />
 
-                    <SpeedInsights />
-                  </>
-                )}
+                      <SpeedInsights />
+                    </>
+                  )}
+                </NotificationCenter>
               </PipPortalProvider>
             </TrayProvider>
           </SettingsProvider>


### PR DESCRIPTION
## Summary
- add panel plugin to view and clear recent notifications
- persist notification log to avoid reappearing after reload
- wire NotificationCenter provider into app layout

## Testing
- `yarn test` (fails: Unable to find role="alert" in nmapNse.test.tsx)
- `yarn lint components/common/NotificationCenter.tsx components/panel/items.ts components/panel/plugins/Notifications.tsx pages/_app.jsx` (fails: A control must be associated with a text label)


------
https://chatgpt.com/codex/tasks/task_e_68be420628188328ae2de478f3efee7b