### PR TITLE
feat: add custom K logo and wordmark

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import DocMegaMenu from './DocMegaMenu';
 
 export default function Header() {
@@ -9,7 +10,20 @@ export default function Header() {
 
   return (
     <header className="relative bg-gray-900 text-white">
-      <nav className="flex gap-4 p-4">
+      <nav className="flex items-center gap-4 p-4">
+        <a href="/" className="flex items-center gap-2">
+          <Image
+            src="/k-logo.svg"
+            alt="Kali Portfolio logo"
+            width={32}
+            height={32}
+            className="h-8 w-auto sm:h-10"
+            priority
+          />
+          <span className="text-xl font-semibold sm:text-2xl">
+            Kali Portfolio
+          </span>
+        </a>
         <a href="/" className="hover:underline">
           Home
         </a>

--- a/public/k-logo.svg
+++ b/public/k-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0A0A23"/>
+  <path d="M9 7v18h4v-7l7 7h4l-8-8 8-10h-4l-6 7-1.5-1.5V7z" fill="#00E0FF"/>
+</svg>


### PR DESCRIPTION
## Summary
- add original "K" glyph asset
- use custom logo and wordmark in header with responsive sizing and alt text

## Testing
- `yarn lint components/layout/Header.tsx` *(fails: Cannot read config file)*
- `yarn test components/layout/Header.tsx` *(fails: No tests found, exiting with code 1)*


------
https://chatgpt.com/codex/tasks/task_e_68be50caba208328a8b370bb11fc68b4