### PR TITLE
Add heading typography variables and apply to prose

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,6 +29,13 @@
   --kali-panel: var(--color-surface);
   --icon-spacing: var(--space-2);
   --background-image: url(/wallpapers/wall-2.webp);
+  /* Heading typography */
+  --h1-size: clamp(1.875rem, 1.5rem + 1vw, 2.25rem);
+  --h1-tracking: -0.02em;
+  --h1-line-height: 1.2;
+  --h2-size: clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem);
+  --h2-tracking: -0.01em;
+  --h2-line-height: 1.3;
 }
 
 /* Dark theme */

--- a/styles/index.css
+++ b/styles/index.css
@@ -66,11 +66,15 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-    font-size: clamp(1.875rem, 1.5rem + 1vw, 2.25rem);
+    font-size: var(--h1-size);
+    letter-spacing: var(--h1-tracking);
+    line-height: var(--h1-line-height);
 }
 
 h2 {
-    font-size: clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem);
+    font-size: var(--h2-size);
+    letter-spacing: var(--h2-tracking);
+    line-height: var(--h2-line-height);
 }
 
 h3 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,10 +55,26 @@ module.exports = {
         },
         fontSize: {
           base: ['1rem', { lineHeight: '1.5' }],
-          h1: ['clamp(1.875rem, 1.5rem + 1vw, 2.25rem)', { lineHeight: '1.2' }],
-          h2: ['clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem)', { lineHeight: '1.3' }],
+          h1: ['var(--h1-size)', { lineHeight: 'var(--h1-line-height)', letterSpacing: 'var(--h1-tracking)' }],
+          h2: ['var(--h2-size)', { lineHeight: 'var(--h2-line-height)', letterSpacing: 'var(--h2-tracking)' }],
           h3: ['clamp(1.25rem, 1rem + 0.5vw, 1.5rem)', { lineHeight: '1.4' }],
         },
+        typography: (theme) => ({
+          DEFAULT: {
+            css: {
+              h1: {
+                fontSize: 'var(--h1-size)',
+                letterSpacing: 'var(--h1-tracking)',
+                lineHeight: 'var(--h1-line-height)',
+              },
+              h2: {
+                fontSize: 'var(--h2-size)',
+                letterSpacing: 'var(--h2-tracking)',
+                lineHeight: 'var(--h2-line-height)',
+              },
+            },
+          },
+        }),
       minWidth: {
         '0': '0',
         '1/4': '25%',


### PR DESCRIPTION
## Summary
- define CSS variables for H1/H2 sizing, tracking and line-height
- wire variables into global headings and Tailwind typography plugin
- document pages missing primary headings during audit

## Testing
- `yarn lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `yarn test` *(fails: TypeError: Cannot set properties of undefined (setting 'theme'))*
- `rg '<h1' -c pages | awk -F: '$2>1'`
- `rg --files-without-match -e '<h1' pages | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68be50cb640483288a791d8b302be874