### PR TITLE
feat(content): refine mdx list and code styling

### DIFF
--- a/content/mdx.css
+++ b/content/mdx.css
@@ -1,0 +1,64 @@
+ul,
+ol {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+  line-height: 1.6;
+}
+
+li {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+li ul,
+li ol {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+code {
+  font-size: 0.875em;
+  line-height: 1.5;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.25rem;
+}
+
+pre {
+  line-height: 1.5;
+  background-color: var(--color-surface);
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 0.25rem;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  border: 0;
+}
+
+.admonition {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border-left: 4px solid;
+  border-radius: 0.25rem;
+  line-height: 1.6;
+}
+
+.admonition-note {
+  border-color: var(--color-info);
+  background: color-mix(in srgb, var(--color-info), transparent 85%);
+}
+
+.admonition-warning {
+  border-color: #f59e0b;
+  background: color-mix(in srgb, #f59e0b, transparent 85%);
+}
+
+.admonition-danger {
+  border-color: #ef4444;
+  background: color-mix(in srgb, #ef4444, transparent 85%);
+}

--- a/content/sample.mdx
+++ b/content/sample.mdx
@@ -1,0 +1,34 @@
+import './mdx.css';
+
+export const title = 'MDX Sample';
+export const summary = 'Demonstrates list, code, and admonition styling.';
+
+# MDX Sample
+
+Here is a list:
+
+- Item one
+- Item two
+  - Nested item a
+  - Nested item b
+
+1. First ordered
+2. Second ordered
+
+Inline `code` example.
+
+```bash
+echo "Hello Kali"
+```
+
+<div className="admonition admonition-note">
+  <p>This is a note admonition.</p>
+</div>
+
+<div className="admonition admonition-warning">
+  <p>This is a warning admonition.</p>
+</div>
+
+<div className="admonition admonition-danger">
+  <p>This is a danger admonition.</p>
+</div>


### PR DESCRIPTION
## Summary
- add content-level CSS for list, nested list, code, and admonition spacing
- include sample MDX showing updated styles for verification

## Testing
- `node -e "const fs=require('fs');const {marked}=require('marked');const md=fs.readFileSync('content/sample.mdx','utf8').replace(/^import.*\n/,'');console.log(marked.parse(md));" | head -n 40`
- `yarn test` *(fails: Cannot set properties of undefined (setting 'theme'))*

------
https://chatgpt.com/codex/tasks/task_e_68be50cb862083288dc6cbb427c05c09