### PR TITLE
Improve fenced code block styling and copy interactions

### DIFF
--- a/components/ui/CodeBlock.tsx
+++ b/components/ui/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import copyToClipboard from "../../utils/clipboard";
 
 interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
   children: React.ReactNode;
@@ -9,9 +10,26 @@ export default function CodeBlock({
   className = "",
   ...props
 }: CodeBlockProps) {
+  const ref = React.useRef<HTMLPreElement>(null);
+
+  const copy = () => {
+    const text = ref.current?.innerText || "";
+    if (text) copyToClipboard(text);
+  };
+
   return (
-    <pre className={className} {...props}>
-      <code>{children}</code>
-    </pre>
+    <div className="relative group">
+      <pre ref={ref} className={className} {...props}>
+        <code>{children}</code>
+      </pre>
+      <button
+        type="button"
+        aria-label="Copy code"
+        onClick={copy}
+        className="absolute top-2 right-2 rounded bg-[var(--color-muted)] text-[var(--color-text)] px-1.5 py-1 text-xs opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-[var(--color-accent)] hover:text-[var(--color-inverse)] focus-visible:opacity-100 focus-visible:bg-[var(--color-accent)] focus-visible:text-[var(--color-inverse)]"
+      >
+        📋
+      </button>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,6 +29,15 @@
   --kali-panel: var(--color-surface);
   --icon-spacing: var(--space-2);
   --background-image: url(/wallpapers/wall-2.webp);
+  /* Code block tokens */
+  --code-token-comment: #6e7681;
+  --code-token-string: #a5d6ff;
+  --code-token-keyword: #ff7b72;
+  --code-token-function: #d2a8ff;
+  --code-token-number: #ffa657;
+  --code-gutter-bg: var(--color-secondary);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: var(--color-muted);
 }
 
 /* Dark theme */
@@ -89,6 +98,15 @@ html[data-theme='kali-light'] {
   --color-border: var(--color-ubt-cool-grey);
   --color-terminal: #00ff00;
   --color-dark: var(--color-ubt-gedit-dark);
+  /* Code block tokens */
+  --code-token-comment: #6a737d;
+  --code-token-string: #22863a;
+  --code-token-keyword: #d73a49;
+  --code-token-function: #6f42c1;
+  --code-token-number: #005cc5;
+  --code-gutter-bg: var(--color-muted);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: var(--color-ubt-cool-grey);
 }
 
 /* Undercover theme */
@@ -109,6 +127,15 @@ html[data-theme='undercover'] {
   --color-ub-cool-grey: #e5e5e5;
   --color-ub-orange: #0078d7;
   --color-ub-window-title: #0078d7;
+  /* Code block tokens */
+  --code-token-comment: #6a737d;
+  --code-token-string: #22863a;
+  --code-token-keyword: #d73a49;
+  --code-token-function: #6f42c1;
+  --code-token-number: #005cc5;
+  --code-gutter-bg: var(--color-muted);
+  --code-gutter-border: var(--color-border);
+  --code-gutter-text: #666666;
 }
 
 html[data-theme='undercover'] .main-navbar-vp {

--- a/styles/index.css
+++ b/styles/index.css
@@ -631,12 +631,42 @@ code,
 kbd,
 pre {
     font-family: var(--font-family-mono, monospace);
-}
-
-pre {
     line-height: 1.2;
     padding: var(--space-2);
     overflow-x: auto;
+    position: relative;
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+}
+
+pre code {
+    display: block;
+    counter-reset: line;
+}
+
+pre code .token.comment { color: var(--code-token-comment); }
+pre code .token.string { color: var(--code-token-string); }
+pre code .token.keyword { color: var(--code-token-keyword); }
+pre code .token.function { color: var(--code-token-function); }
+pre code .token.number { color: var(--code-token-number); }
+
+pre code .line {
+    display: block;
+    padding-left: calc(var(--space-4) + 2.5rem);
+    position: relative;
+}
+
+pre code .line::before {
+    counter-increment: line;
+    content: counter(line);
+    position: absolute;
+    left: 0;
+    width: 2.5rem;
+    padding-right: var(--space-2);
+    text-align: right;
+    color: var(--code-gutter-text);
+    background: var(--code-gutter-bg);
+    border-right: 1px solid var(--code-gutter-border);
 }
 
 /* Visible focus rings for copy buttons and text areas */


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button for fenced code blocks
- introduce theme-aware token color and gutter CSS variables
- style code tokens and line-number gutter

## Testing
- `yarn test __tests__/csp.test.ts` *(fails: Missing allowlist entries)*
- `yarn lint` *(fails: Cannot read config file: eslint-config-next)*

------
https://chatgpt.com/codex/tasks/task_e_68be50cbddf483289989666ccbbc623d