### PR TITLE
feat(ui): add spacing tokens and align layout

### DIFF
--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1,0 +1,27 @@
+# Design Guidelines
+
+## Spacing Tokens
+
+Use the `space-*` scale to maintain an 8px rhythm across breakpoints. The tokens are available in Tailwind as margin, padding, gap and positional utilities (`p-space-2`, `mt-space-1`, etc.).
+
+| Token | Value |
+|-------|-------|
+| `space-0` | 0px |
+| `space-1` | 8px |
+| `space-2` | 16px |
+| `space-3` | 24px |
+| `space-4` | 32px |
+| `space-5` | 40px |
+| `space-6` | 48px |
+| `space-7` | 56px |
+| `space-8` | 64px |
+
+Example:
+
+```html
+<section class="p-space-2 md:p-space-3">
+  <!-- content -->
+</section>
+```
+
+These tokens ensure that layouts snap to the 8px grid at all breakpoints.

--- a/pages/apps/settings/date-time.tsx
+++ b/pages/apps/settings/date-time.tsx
@@ -55,9 +55,9 @@ export default function DateTimeSettings() {
   };
 
   return (
-    <div className="p-4 text-ubt-grey">
-      <h1 className="text-xl mb-4">Date &amp; Time</h1>
-      <div className="flex items-center gap-2 mb-4">
+    <div className="p-space-2 text-ubt-grey">
+      <h1 className="text-xl mb-space-2">Date &amp; Time</h1>
+      <div className="flex items-center gap-space-1 mb-space-2">
         <label htmlFor="timezone" className="w-36">
           Time zone
         </label>
@@ -65,7 +65,7 @@ export default function DateTimeSettings() {
           id="timezone"
           value={timezone}
           onChange={handleTimezone}
-          className="flex-1 bg-ub-cool-grey text-ubt-grey p-1 rounded"
+          className="flex-1 bg-ub-cool-grey text-ubt-grey p-space-1 rounded"
         >
           {tzList.map((tz) => (
             <option key={tz} value={tz}>
@@ -74,7 +74,7 @@ export default function DateTimeSettings() {
           ))}
         </select>
       </div>
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-center gap-space-1 mb-space-2">
         <span className="w-36">24-hour time</span>
         <ToggleSwitch
           checked={twentyFourHour}
@@ -82,7 +82,7 @@ export default function DateTimeSettings() {
           ariaLabel="toggle-24-hour"
         />
       </div>
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-center gap-space-1 mb-space-2">
         <span className="w-36">Show seconds</span>
         <ToggleSwitch
           checked={showSeconds}
@@ -90,7 +90,7 @@ export default function DateTimeSettings() {
           ariaLabel="toggle-seconds"
         />
       </div>
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-center gap-space-1 mb-space-2">
         <label htmlFor="first-day" className="w-36">
           First day of week
         </label>
@@ -98,7 +98,7 @@ export default function DateTimeSettings() {
           id="first-day"
           value={firstDay}
           onChange={handleFirstDay}
-          className="flex-1 bg-ub-cool-grey text-ubt-grey p-1 rounded"
+          className="flex-1 bg-ub-cool-grey text-ubt-grey p-space-1 rounded"
         >
           {days.map((d, i) => (
             <option key={d} value={i}>
@@ -107,7 +107,7 @@ export default function DateTimeSettings() {
           ))}
         </select>
       </div>
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-center gap-space-1 mb-space-2">
         <span>Use network time (NTP)</span>
         <ToggleSwitch
           checked={networkTime}
@@ -116,7 +116,7 @@ export default function DateTimeSettings() {
         />
         <span className="cursor-help" title={tooltip} aria-label="NTP info">ℹ️</span>
       </div>
-      <div className="space-y-2" aria-label="NTP commands">
+      <div className="space-y-space-1" aria-label="NTP commands">
         <CommandChip command="sudo apt install chrony" />
         <CommandChip command="sudo systemctl enable --now chrony" />
       </div>

--- a/pages/apps/settings/removable-media.tsx
+++ b/pages/apps/settings/removable-media.tsx
@@ -46,7 +46,7 @@ export default function RemovableMediaPage() {
   };
 
   return (
-    <div className="p-4 text-white space-y-4">
+    <div className="p-space-2 text-white space-y-space-2">
       <div className="flex items-center justify-between">
         <span>Mount removable drives when hot-plugged</span>
         <ToggleSwitch
@@ -80,7 +80,7 @@ export default function RemovableMediaPage() {
         />
       </div>
       <div>
-        <label htmlFor="camera-import" className="block mb-1">
+        <label htmlFor="camera-import" className="block mb-space-1">
           Camera import command
         </label>
         <input
@@ -88,20 +88,20 @@ export default function RemovableMediaPage() {
           type="text"
           value={settings.cameraImportCommand}
           onChange={(e) => update({ cameraImportCommand: e.target.value })}
-          className="w-full border rounded p-1"
+          className="w-full border rounded p-space-1"
           aria-label="Camera import command"
         />
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-space-1">
         <button
           onClick={insertDevice}
-          className="px-4 py-2 rounded bg-ub-orange text-white"
+          className="px-space-2 py-space-1 rounded bg-ub-orange text-white"
         >
           Insert mock device
         </button>
         <button
           onClick={ejectDevice}
-          className="px-4 py-2 rounded bg-ubt-cool-grey text-white"
+          className="px-space-2 py-space-1 rounded bg-ubt-cool-grey text-white"
         >
           Eject device
         </button>

--- a/pages/daily-quote.tsx
+++ b/pages/daily-quote.tsx
@@ -56,34 +56,34 @@ export default function DailyQuote() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-ub-cool-grey text-white p-space-2">
       <div
         ref={cardRef}
-        className="group relative p-6 rounded text-center bg-gradient-to-br from-[var(--color-primary)]/30 to-[var(--color-secondary)]/30 text-white"
+        className="group relative p-space-3 rounded text-center bg-gradient-to-br from-[var(--color-primary)]/30 to-[var(--color-secondary)]/30 text-white"
       >
         {quote ? (
           <div key={quote.content} className="animate-quote">
             <span
-              className="absolute -top-4 left-4 text-[64px] text-white/20 select-none"
+              className="absolute -top-space-2 left-space-2 text-[64px] text-white/20 select-none"
               aria-hidden="true"
             >
               &ldquo;
             </span>
-            <p className="mb-4 text-[18px] leading-[24px] sm:text-[20px] sm:leading-[26px] tracking-[6px]">
+            <p className="mb-space-2 text-[18px] leading-[24px] sm:text-[20px] sm:leading-[26px] tracking-[6px]">
               {quote.content}
             </p>
             <p className="text-sm text-white/80">— {quote.author}</p>
-            <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition">
+            <div className="absolute top-space-1 right-space-1 flex gap-space-1 opacity-0 group-hover:opacity-100 transition">
               <button
                 onClick={copyQuote}
-                className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                className="p-space-1 bg-black/30 hover:bg-black/50 rounded"
                 aria-label="Copy quote"
               >
                 <CopyIcon className="w-6 h-6" />
               </button>
               <button
                 onClick={tweetQuote}
-                className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                className="p-space-1 bg-black/30 hover:bg-black/50 rounded"
                 aria-label="Tweet quote"
               >
                 <TwitterIcon className="w-6 h-6" />
@@ -94,9 +94,9 @@ export default function DailyQuote() {
           <p>Loading...</p>
         )}
       </div>
-      <div className="flex gap-2 mt-4">
+      <div className="flex gap-space-1 mt-space-2">
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-space-2 py-space-1 bg-gray-700 hover:bg-gray-600 rounded"
           onClick={exportCard}
           disabled={!quote}
         >
@@ -104,7 +104,7 @@ export default function DailyQuote() {
         </button>
         {canShare() && (
           <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+            className="px-space-2 py-space-1 bg-gray-700 hover:bg-gray-600 rounded"
             onClick={shareQuote}
             disabled={!quote}
           >

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -169,33 +169,33 @@ const InputHub = () => {
   };
 
   return (
-    <div className="p-4 text-black max-w-md mx-auto">
-      <div className="mb-4">
+    <div className="p-space-2 text-black max-w-md mx-auto">
+      <div className="mb-space-2">
         <span
-          className={`px-2 py-1 text-sm rounded ${
+          className={`px-space-1 py-space-1 text-sm rounded ${
             emailjsReady ? 'bg-green-600 text-white' : 'bg-red-600 text-white'
           }`}
         >
           {emailjsReady ? 'EmailJS: Online' : 'EmailJS: Offline'}
         </span>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-space-1">
         <input
-          className="p-1 border"
+          className="p-space-1 border"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
         />
         <input
-          className="p-1 border"
+          className="p-space-1 border"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
         />
         <select
-          className="p-1 border"
+          className="p-space-1 border"
           value={subject}
           onChange={(e) => setSubject(e.target.value)}
         >
@@ -206,14 +206,14 @@ const InputHub = () => {
           ))}
         </select>
         <textarea
-          className="p-1 border"
+          className="p-space-1 border"
           placeholder="Message"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           required
         />
         {process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY && (
-          <label className="flex items-center gap-2">
+          <label className="flex items-center gap-space-1">
             <input
               type="checkbox"
               checked={useCaptcha}
@@ -222,12 +222,12 @@ const InputHub = () => {
             <span>Use reCAPTCHA</span>
           </label>
         )}
-        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+        <button type="submit" className="bg-blue-500 text-white px-space-1 py-space-1">
           Send
         </button>
       </form>
       {status && (
-        <div role="status" aria-live="polite" className="mt-2 text-sm">
+        <div role="status" aria-live="polite" className="mt-space-1 text-sm">
           {status}
         </div>
       )}

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -102,29 +102,29 @@ const ModuleWorkspace: React.FC = () => {
   }, [selected, optionValues]);
 
   return (
-    <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
-      <section className="space-y-2">
+    <div className="p-space-2 space-y-space-2 bg-ub-cool-grey text-white min-h-screen">
+      <section className="space-y-space-1">
         <h1 className="text-xl font-semibold">Workspaces</h1>
-        <div className="flex gap-2">
+        <div className="flex gap-space-1">
           <input
             value={newWorkspace}
             onChange={(e) => setNewWorkspace(e.target.value)}
             placeholder="New workspace"
-            className="p-1 rounded text-black"
+            className="p-space-1 rounded text-black"
           />
           <button
             onClick={addWorkspace}
-            className="px-2 py-1 bg-ub-orange rounded text-black"
+            className="px-space-1 py-space-1 bg-ub-orange rounded text-black"
           >
             Create
           </button>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-space-1">
           {workspaces.map((ws) => (
             <button
               key={ws}
               onClick={() => setCurrentWorkspace(ws)}
-              className={`px-2 py-1 rounded ${
+              className={`px-space-1 py-space-1 rounded ${
                 currentWorkspace === ws ? 'bg-blue-600' : 'bg-gray-700'
               }`}
             >
@@ -135,10 +135,10 @@ const ModuleWorkspace: React.FC = () => {
       </section>
       {currentWorkspace && (
         <>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-space-1">
             <button
               onClick={() => setFilter('')}
-              className={`px-2 py-1 text-sm rounded ${
+              className={`px-space-1 py-space-1 text-sm rounded ${
                 filter === '' ? 'bg-blue-600' : 'bg-gray-700'
               }`}
             >
@@ -148,7 +148,7 @@ const ModuleWorkspace: React.FC = () => {
               <button
                 key={t}
                 onClick={() => setFilter(t)}
-                className={`px-2 py-1 text-sm rounded ${
+                className={`px-space-1 py-space-1 text-sm rounded ${
                   filter === t ? 'bg-blue-600' : 'bg-gray-700'
                 }`}
               >
@@ -156,12 +156,12 @@ const ModuleWorkspace: React.FC = () => {
               </button>
             ))}
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-space-2 sm:grid-cols-2 lg:grid-cols-3">
             {filteredModules.map((m) => (
               <button
                 key={m.id}
                 onClick={() => selectModule(m)}
-                className="p-3 text-left bg-ub-grey rounded border border-gray-700"
+                className="p-space-3 text-left bg-ub-grey rounded border border-gray-700"
               >
                 <h3 className="font-semibold">{m.name}</h3>
                 <p className="text-sm text-gray-300">{m.description}</p>
@@ -169,7 +169,7 @@ const ModuleWorkspace: React.FC = () => {
             ))}
           </div>
           {selected && (
-            <div className="space-y-2">
+            <div className="space-y-space-1">
               <h2 className="font-semibold">Command Composer</h2>
               {selected.options.map((opt) => (
                 <div key={opt.name}>
@@ -183,21 +183,21 @@ const ModuleWorkspace: React.FC = () => {
                           [opt.name]: e.target.value,
                         })
                       }
-                      className="mt-1 w-full p-1 rounded text-black"
+                      className="mt-space-1 w-full p-space-1 rounded text-black"
                     />
                   </label>
                 </div>
               ))}
               <button
                 onClick={runCommand}
-                className="px-2 py-1 bg-green-600 rounded text-black"
+                className="px-space-1 py-space-1 bg-green-600 rounded text-black"
               >
                 Run
               </button>
               {result && (
-                <div className="flex items-start gap-2">
+                <div className="flex items-start gap-space-1">
                   <pre
-                    className="flex-1 bg-black text-green-400 p-2 overflow-auto font-mono"
+                    className="flex-1 bg-black text-green-400 p-space-1 overflow-auto font-mono"
                     role="log"
                   >
                     {result}
@@ -206,7 +206,7 @@ const ModuleWorkspace: React.FC = () => {
                     onClick={() =>
                       navigator.clipboard?.writeText(result)
                     }
-                    className="px-2 py-1 text-sm rounded bg-gray-700"
+                    className="px-space-1 py-space-1 text-sm rounded bg-gray-700"
                   >
                     Copy
                   </button>

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -134,16 +134,16 @@ const NessusReport: React.FC = () => {
   }, [counts, findings.length]);
 
   return (
-    <div className="p-4 bg-gray-900 text-white min-h-screen">
-      <h1 className="text-2xl mb-4">Sample Nessus Report</h1>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+    <div className="p-space-2 bg-gray-900 text-white min-h-screen">
+      <h1 className="text-2xl mb-space-2">Sample Nessus Report</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-space-1 mb-space-2">
         {['Critical', 'High', 'Medium', 'Low'].map((sev) => (
           <div
             key={sev}
-            className="bg-gray-800 p-2 rounded flex items-center justify-between"
+            className="bg-gray-800 p-space-1 rounded flex items-center justify-between"
           >
             <span
-              className="px-2 py-0.5 rounded-full text-xs text-white"
+              className="px-space-1 py-space-1 rounded-full text-xs text-white"
               style={{ backgroundColor: severityColors[sev] }}
             >
               {sev}
@@ -153,7 +153,7 @@ const NessusReport: React.FC = () => {
         ))}
 
       </div>
-      <div className="flex items-center space-x-2 mb-4 flex-wrap">
+      <div className="flex items-center space-x-space-1 mb-space-2 flex-wrap">
         <label htmlFor="report-file" className="text-sm">
           Import report
         </label>
@@ -161,7 +161,7 @@ const NessusReport: React.FC = () => {
           id="report-file"
           type="file"
           accept=".json"
-          className="text-black p-1 rounded"
+          className="text-black p-space-1 rounded"
           onChange={handleFile}
         />
         <label htmlFor="severity-filter" className="text-sm">
@@ -169,7 +169,7 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="severity-filter"
-          className="text-black p-1 rounded"
+          className="text-black p-space-1 rounded"
           value={severity}
           onChange={(e) => setSeverity(e.target.value)}
         >
@@ -184,7 +184,7 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="host-filter"
-          className="text-black p-1 rounded"
+          className="text-black p-space-1 rounded"
           value={host}
           onChange={(e) => setHost(e.target.value)}
         >
@@ -199,7 +199,7 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="family-filter"
-          className="text-black p-1 rounded"
+          className="text-black p-space-1 rounded"
           value={family}
           onChange={(e) => setFamily(e.target.value)}
         >
@@ -212,7 +212,7 @@ const NessusReport: React.FC = () => {
         <button
           type="button"
           onClick={exportCSV}
-          className="p-2 bg-blue-600 rounded"
+          className="p-space-1 bg-blue-600 rounded"
           aria-label="Export CSV"
         >
           <svg
@@ -230,26 +230,26 @@ const NessusReport: React.FC = () => {
           </svg>
         </button>
       </div>
-      <p className="text-xs text-gray-400 mb-2">
+      <p className="text-xs text-gray-400 mb-space-1">
         Only the bundled sample-report.json is supported. Files are processed locally and never uploaded.
       </p>
       <svg
         width={(radius + 20) * 2}
         height={(radius + 20) * 2}
         aria-label="CVSS severity distribution"
-        className="mx-auto mb-4"
+        className="mx-auto mb-space-2"
       >
         {segments}
       </svg>
-      <table className="w-full mb-4 text-sm">
+      <table className="w-full mb-space-2 text-sm">
         <thead>
           <tr className="text-left border-b border-gray-700 h-9">
-            <th className="px-2" scope="col">ID</th>
-            <th className="px-2" scope="col">Finding</th>
-            <th className="px-2" scope="col">CVSS</th>
-            <th className="px-2" scope="col">Severity</th>
-            <th className="px-2" scope="col">Host</th>
-            <th className="px-2" scope="col">Plugin Family</th>
+            <th className="px-space-1" scope="col">ID</th>
+            <th className="px-space-1" scope="col">Finding</th>
+            <th className="px-space-1" scope="col">CVSS</th>
+            <th className="px-space-1" scope="col">Severity</th>
+            <th className="px-space-1" scope="col">Host</th>
+            <th className="px-space-1" scope="col">Plugin Family</th>
           </tr>
         </thead>
         <tbody>
@@ -261,19 +261,19 @@ const NessusReport: React.FC = () => {
 
               onClick={() => setSelected(f)}
             >
-              <td className="px-2">{f.id}</td>
-              <td className="px-2">{f.name}</td>
-              <td className="px-2">{f.cvss}</td>
-              <td className="px-2">
+              <td className="px-space-1">{f.id}</td>
+              <td className="px-space-1">{f.name}</td>
+              <td className="px-space-1">{f.cvss}</td>
+              <td className="px-space-1">
                 <span
-                  className="px-2 py-0.5 rounded-full text-xs text-white"
+                  className="px-space-1 py-space-1 rounded-full text-xs text-white"
                   style={{ backgroundColor: severityColors[f.severity] }}
                 >
                   {f.severity}
                 </span>
               </td>
-              <td className="px-2">{f.host}</td>
-              <td className="px-2">{f.pluginFamily}</td>
+              <td className="px-space-1">{f.host}</td>
+              <td className="px-space-1">{f.pluginFamily}</td>
             </tr>
           ))}
         </tbody>
@@ -281,20 +281,20 @@ const NessusReport: React.FC = () => {
       {selected && (
         <div
           role="dialog"
-          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
+          className="fixed top-space-0 right-space-0 h-full w-80 bg-gray-800 p-space-2 overflow-auto shadow-lg"
         >
           <button
             type="button"
             onClick={() => setSelected(null)}
-            className="mb-2 text-sm bg-red-600 px-2 py-1 rounded"
+            className="mb-space-1 text-sm bg-red-600 px-space-1 py-space-1 rounded"
           >
             Close
           </button>
-          <h2 className="text-xl mb-2">{selected.name}</h2>
-          <p className="text-sm mb-2">
+          <h2 className="text-xl mb-space-1">{selected.name}</h2>
+          <p className="text-sm mb-space-1">
             CVSS {selected.cvss} ({selected.severity})
           </p>
-          <p className="mb-4 text-sm whitespace-pre-wrap">
+          <p className="mb-space-2 text-sm whitespace-pre-wrap">
             {selected.description}
           </p>
           <p className="text-xs text-gray-400">

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -36,7 +36,7 @@ export default function PostExploitation() {
 
   return (
     <>
-      <main className="mx-auto grid gap-4 p-4 md:grid-cols-2">
+      <main className="mx-auto grid gap-space-2 p-space-2 md:grid-cols-2">
         <section className="prose">
           <h1>Metasploit Post-Exploitation Modules</h1>
           <p>
@@ -56,11 +56,11 @@ export default function PostExploitation() {
             placeholder="Search modules..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="mb-4 w-full rounded border p-2"
+            className="mb-space-2 w-full rounded border p-space-1"
           />
-          <div className="mb-4 flex flex-wrap gap-2">
+          <div className="mb-space-2 flex flex-wrap gap-space-1">
             {allTags.map((tag) => (
-              <label key={tag} className="flex items-center space-x-1">
+              <label key={tag} className="flex items-center space-x-space-1">
                 <input
                   type="checkbox"
                   checked={selectedTags.includes(tag)}
@@ -80,7 +80,7 @@ export default function PostExploitation() {
               itemHeight={120}
               itemKey="name"
               component="ul"
-              className="grid gap-4 list-none p-0"
+              className="grid gap-space-2 list-none p-space-0"
             >
               {(m: ModuleMetadata) => (
                 <li key={m.name}>
@@ -114,13 +114,13 @@ export default function PostExploitation() {
             <p>Select a module to view details.</p>
           )}
           <h3>Example Transcript</h3>
-          <div className="flex items-start gap-2">
-            <pre className="flex-1 overflow-x-auto rounded bg-black p-3 text-green-400 font-mono">
+          <div className="flex items-start gap-space-1">
+            <pre className="flex-1 overflow-x-auto rounded bg-black p-space-3 text-green-400 font-mono">
               {transcript}
             </pre>
             <button
               onClick={copyTranscript}
-              className="px-2 py-1 text-sm rounded bg-gray-700"
+              className="px-space-1 py-space-1 text-sm rounded bg-gray-700"
             >
               Copy
             </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,6 +59,17 @@ module.exports = {
           h2: ['clamp(1.5rem, 1.25rem + 0.5vw, 1.875rem)', { lineHeight: '1.3' }],
           h3: ['clamp(1.25rem, 1rem + 0.5vw, 1.5rem)', { lineHeight: '1.4' }],
         },
+      spacing: {
+        'space-0': '0px',
+        'space-1': '8px',
+        'space-2': '16px',
+        'space-3': '24px',
+        'space-4': '32px',
+        'space-5': '40px',
+        'space-6': '48px',
+        'space-7': '56px',
+        'space-8': '64px',
+      },
       minWidth: {
         '0': '0',
         '1/4': '25%',


### PR DESCRIPTION
## Summary
- define space-0..space-8 spacing scale for 8px rhythm
- refactor pages to use spacing tokens so sections snap to grid
- document spacing tokens in new design guidelines

## Testing
- `yarn test` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be50cd09608328819ba7a2c592c20b