### PR TITLE
feat: add theme-aware focus ring utility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,7 +16,6 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   /* Toast bubble theme variables */
@@ -144,8 +143,7 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: var(--focus-outline-width) solid var(--focus-outline-color);
-  outline-offset: 2px;
+  @apply focus-ring;
 }
 
 .notification-center {

--- a/styles/index.css
+++ b/styles/index.css
@@ -109,8 +109,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 .btn:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
+    @apply focus-ring;
 }
 
 a:focus-visible,
@@ -120,8 +119,8 @@ textarea:focus-visible,
 select:focus-visible,
 [role="button"]:focus-visible,
 [tabindex]:not([tabindex="-1"]):focus-visible {
+    @apply focus-ring;
     outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -642,8 +641,7 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
+    @apply focus-ring;
 }
 
 /* Enable scroll snapping for gallery containers */

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,6 +9,10 @@
   .transition-active {
     @apply transition ease-out duration-100;
   }
+  .focus-ring {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 2px;
+  }
 }
 
 @layer base {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,8 +57,17 @@
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
-  --focus-outline-color: var(--color-accent);
+  --color-focus-ring-dark: var(--color-accent);
+  --color-focus-ring-light: var(--color-ubt-blue);
+  --color-focus-ring: var(--color-focus-ring-dark);
+  --focus-outline-color: var(--color-focus-ring);
   --focus-outline-width: 2px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-focus-ring: var(--color-focus-ring-light);
+  }
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add focus ring color variables for light and dark modes
- create global `.focus-ring` utility and apply to interactive elements
- ensure universal focus visibility across themes

## Testing
- `npm run lint`
- `npm test __tests__/panel_keyboard_navigation.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be50ceedc883289b4692998660d99d