### PR TITLE
Add color contrast styleguide

### DIFF
--- a/components/ui/ColorSwatch.tsx
+++ b/components/ui/ColorSwatch.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { contrastRatio } from '../apps/Games/common/theme';
+
+interface ColorSwatchProps {
+  fg: string;
+  bg: string;
+  label?: string;
+}
+
+export default function ColorSwatch({ fg, bg, label }: ColorSwatchProps) {
+  const ratio = contrastRatio(fg, bg);
+  const level = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'Fail';
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className="w-32 h-16 flex items-center justify-center rounded"
+        style={{ backgroundColor: bg, color: fg }}
+      >
+        {label || `${fg} / ${bg}`}
+      </div>
+      <span className="mt-2 text-sm">
+        {`Contrast ${ratio.toFixed(2)}:1 ${level}`}
+      </span>
+    </div>
+  );
+}

--- a/docs/whisker-theme.md
+++ b/docs/whisker-theme.md
@@ -9,3 +9,5 @@ Adjusting these values updates the appearance of the interface without modifying
 - `--menu-opacity`: Overall opacity for menu and sidebar backgrounds. Defaults to `0.9`.
 
 Override these variables in a global stylesheet or within the `:root` selector to customize themes.
+
+For examples of accessible color combinations, see the [color contrast swatches](/styleguide) page.

--- a/pages/styleguide/index.tsx
+++ b/pages/styleguide/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ColorSwatch from '../../components/ui/ColorSwatch';
+
+const pairs = [
+  { fg: '#000000', bg: '#ffffff', label: 'Black on White' },
+  { fg: '#333333', bg: '#ffffff', label: 'Dark Gray on White' },
+  { fg: '#555555', bg: '#ffffff', label: 'Gray on White' },
+  { fg: '#ffffff', bg: '#1E3A8A', label: 'White on Indigo' },
+];
+
+export default function Styleguide() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Color Contrast Swatches</h1>
+      <p className="mb-6">Examples of color pairs with their WCAG contrast levels.</p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {pairs.map((p) => (
+          <ColorSwatch key={p.label} {...p} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ColorSwatch` component to show contrast ratio and WCAG level
- create `/styleguide` page with accessible color pair examples
- document link from theme guide to color swatches

## Testing
- `yarn lint components/ui/ColorSwatch.tsx pages/styleguide/index.tsx docs/whisker-theme.md` *(fails: existing repository lint errors)*
- `yarn test __tests__/tokens-contrast.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68be50d00b148328be4532a645f901ae