### PR TITLE
feat: add dismissible promo banner

### DIFF
--- a/__tests__/promo-banner.test.tsx
+++ b/__tests__/promo-banner.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PromoBanner from '../components/screen/PromoBanner';
+import { contrastRatio } from '../components/apps/Games/common/theme';
+
+describe('Promo banner', () => {
+  beforeAll(() => {
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --color-ub-grey: #0f1317;
+        --color-ubt-grey: #F6F6F5;
+      }
+      html[data-theme='kali-light'] {
+        --color-ub-grey: #0f1317;
+        --color-ubt-grey: #F6F6F5;
+      }
+      html[data-theme='kali-dark'] {
+        --color-ub-grey: #0f1317;
+        --color-ubt-grey: #F6F6F5;
+      }
+    `;
+    document.head.appendChild(style);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('has minimum height class', () => {
+    const { container } = render(<PromoBanner messages={['hi']} />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toMatch(/h-10/);
+  });
+
+  ['kali-dark', 'kali-light'].forEach((theme) => {
+    test(`meets contrast requirements in ${theme} theme`, () => {
+      document.documentElement.setAttribute('data-theme', theme);
+      render(<PromoBanner messages={['hello']} />);
+      const rootStyles = getComputedStyle(document.documentElement);
+      const fg = rootStyles.getPropertyValue('--color-ub-grey').trim();
+      const bg = rootStyles.getPropertyValue('--color-ubt-grey').trim();
+      expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+});
+

--- a/components/screen/PromoBanner.tsx
+++ b/components/screen/PromoBanner.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface PromoBannerProps {
+  messages: string[];
+  rotateInterval?: number; // ms
+  onDismiss?: () => void;
+}
+
+export default function PromoBanner({
+  messages,
+  rotateInterval = 5000,
+  onDismiss,
+}: PromoBannerProps) {
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (messages.length <= 1) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % messages.length);
+    }, rotateInterval);
+    return () => clearInterval(id);
+  }, [messages, rotateInterval]);
+
+  if (!visible || messages.length === 0) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    onDismiss?.();
+  };
+
+  return (
+    <div
+      className="promo-banner absolute top-0 w-screen flex items-center justify-center bg-ubt-grey text-ub-grey text-sm h-10 z-50"
+      role="region"
+      aria-label="Promotional banner"
+    >
+      <span className="px-4 text-center flex-1">{messages[index]}</span>
+      <button
+        aria-label="Dismiss promotional banner"
+        onClick={dismiss}
+        className="px-4"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -7,6 +7,7 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import HelpMenu from '../menu/HelpMenu';
 import { getTheme, setTheme } from '../../utils/theme';
+import PromoBanner from './PromoBanner';
 
 export default class Navbar extends Component {
   constructor() {
@@ -15,6 +16,7 @@ export default class Navbar extends Component {
       status_card: false,
       undercover: getTheme() === 'undercover',
       showTip: false,
+      bannerDismissed: false,
     };
   }
 
@@ -25,8 +27,20 @@ export default class Navbar extends Component {
       this.setState({ undercover: !this.state.undercover });
     };
 
+    const messages = this.props.promoMessages || [];
+    const bannerVisible = messages.length > 0 && !this.state.bannerDismissed;
+
     return (
-      <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <>
+        {bannerVisible && (
+          <PromoBanner
+            messages={messages}
+            onDismiss={() => this.setState({ bannerDismissed: true })}
+          />
+        )}
+        <div
+          className={`main-navbar-vp absolute right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50 ${bannerVisible ? 'top-10' : 'top-0'}`}
+        >
         <div className="pl-3 pr-1">
           <Image
             src={
@@ -87,7 +101,8 @@ export default class Navbar extends Component {
             logOut={this.props.logOut}
           />
         </button>
-      </div>
+        </div>
+      </>
     );
   }
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -161,7 +161,11 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-                                <Navbar lockScreen={this.lockScreen} logOut={this.logOut} />
+                                <Navbar
+                                        lockScreen={this.lockScreen}
+                                        logOut={this.logOut}
+                                        promoMessages={this.props.promoMessages || []}
+                                />
                                 <Desktop
                                         ref={this.desktopRef}
                                         bg_image_name={this.state.bg_image_name}


### PR DESCRIPTION
## Summary
- add rotating, dismissible promo banner
- integrate banner above navbar with offset
- expose promoMessages prop on Ubuntu component

## Testing
- `yarn eslint components/screen/navbar.js components/screen/PromoBanner.tsx components/ubuntu.js __tests__/promo-banner.test.tsx __tests__/navbar-contrast.test.tsx`
- `yarn test __tests__/promo-banner.test.tsx __tests__/navbar-contrast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be510bbee88328979083f6014eb3aa