### PR TITLE
feat: add accessible docs mega menu

### DIFF
--- a/components/layout/DocMegaMenu.tsx
+++ b/components/layout/DocMegaMenu.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import {
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 
 interface DocMegaMenuProps {
   onClose: () => void;
@@ -8,44 +12,98 @@ interface DocMegaMenuProps {
 
 export default function DocMegaMenu({ onClose }: DocMegaMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+  const items = [
+    { href: '/docs', label: 'Docs' },
+    { href: '/tools', label: 'Tools Docs' },
+    { href: '/legal', label: 'Policy' },
+  ];
+  const COLUMNS = 2;
 
   useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    itemRefs.current[0]?.focus();
+
     const handleClick = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         onClose();
       }
     };
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus();
+    };
   }, [onClose]);
+
+  const handleListKeyDown = (e: ReactKeyboardEvent<HTMLUListElement>) => {
+    const currentIndex = itemRefs.current.findIndex(
+      (el) => el === document.activeElement,
+    );
+
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const dir = e.shiftKey ? -1 : 1;
+      const nextIndex =
+        (currentIndex + dir + items.length) % items.length;
+      itemRefs.current[nextIndex]?.focus();
+      return;
+    }
+
+    let nextIndex = currentIndex;
+    switch (e.key) {
+      case 'ArrowRight':
+        nextIndex = Math.min(currentIndex + 1, items.length - 1);
+        break;
+      case 'ArrowLeft':
+        nextIndex = Math.max(currentIndex - 1, 0);
+        break;
+      case 'ArrowDown':
+        nextIndex = Math.min(currentIndex + COLUMNS, items.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIndex = Math.max(currentIndex - COLUMNS, 0);
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    itemRefs.current[nextIndex]?.focus();
+  };
 
   return (
     <div
       ref={ref}
-      className="fixed left-0 top-12 z-50 w-full bg-white shadow-lg p-4"
+      className="fixed left-0 top-12 z-50 w-full bg-white p-4 shadow-lg"
     >
-      <ul className="grid gap-2 sm:grid-cols-2">
-        <li>
-          <a href="/docs" className="block hover:underline">
-            Docs pages
-          </a>
-        </li>
-        <li>
-          <a href="/tools" className="block hover:underline">
-            Tools docs
-          </a>
-        </li>
-        <li>
-          <a href="/faq" className="block hover:underline">
-            FAQ
-          </a>
-        </li>
-        <li>
-          <a href="/known-issues" className="block hover:underline">
-            Known Issues
-          </a>
-        </li>
+      <ul
+        className="grid grid-cols-2 gap-4"
+        onKeyDown={handleListKeyDown}
+        role="menu"
+      >
+        {items.map((item, i) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className="block rounded border p-4 hover:bg-gray-50 focus:outline-none focus:ring"
+              ref={(el) => (itemRefs.current[i] = el)}
+              role="menuitem"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -16,11 +16,14 @@ export default function Header() {
         <div
           className="relative"
           onMouseEnter={() => setDocsOpen(true)}
+          onMouseLeave={closeDocs}
         >
           <button
             type="button"
             onClick={() => setDocsOpen((v) => !v)}
             className="hover:underline"
+            aria-haspopup="true"
+            aria-expanded={docsOpen}
           >
             Documentation
           </button>


### PR DESCRIPTION
## Summary
- add two-column docs mega menu with Docs, Tools Docs and Policy links
- trap focus and enable arrow/Tab navigation for accessibility
- hook menu into header with hover/click activation and ARIA attributes

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be5110edfc8328b5028909a66846c4