### PR TITLE
Add scroll-aware header blur with transitions

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,14 +1,28 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DocMegaMenu from './DocMegaMenu';
 
 export default function Header() {
   const [docsOpen, setDocsOpen] = useState(false);
   const closeDocs = () => setDocsOpen(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled(window.scrollY > 64);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
-    <header className="relative bg-gray-900 text-white">
+    <header
+      className={`sticky top-0 z-50 transition-all duration-300 bg-white text-gray-900 dark:bg-gray-900 dark:text-white ${
+        scrolled ? 'shadow-md backdrop-blur-md' : ''
+      }`}
+    >
       <nav className="flex gap-4 p-4">
         <a href="/" className="hover:underline">
           Home


### PR DESCRIPTION
## Summary
- add scroll listener to layout header to apply shadow and backdrop blur after 64px
- ensure header supports smooth light/dark transitions

## Testing
- `yarn test` *(fails: Missing allowlist entries and other test failures)*
- `npx playwright test` *(fails: duplicate test title)*
- `npx playwright test --viewport=375,667` *(fails: unknown option '--viewport=375,667')*


------
https://chatgpt.com/codex/tasks/task_e_68be511348388328a1e766561ebdc7a2