### PR TITLE
Add responsive download tile grid

### DIFF
--- a/components/platforms/DownloadCard.tsx
+++ b/components/platforms/DownloadCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface DownloadCardProps {
+  title: string;
+  href: string;
+  caption: string;
+}
+
+export default function DownloadCard({ title, href, caption }: DownloadCardProps) {
+  return (
+    <div className="flex flex-col rounded border p-4">
+      <h2 className="mb-2 text-xl font-semibold">{title}</h2>
+      <p className="mb-4">{caption}</p>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-auto text-blue-500 hover:underline"
+      >
+        Learn more
+      </a>
+    </div>
+  );
+}

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,54 +1,67 @@
 import React from 'react';
 import Link from 'next/link';
+import DownloadCard from '../../components/platforms/DownloadCard';
+
+const tiles = [
+  {
+    title: 'ARM',
+    caption: 'Run Kali on ARM devices like Raspberry Pi and Pinebook.',
+    href: 'https://www.kali.org/get-kali/#kali-arm',
+  },
+  {
+    title: 'Cloud',
+    caption: 'Deploy Kali on AWS, Azure and other cloud providers.',
+    href: 'https://www.kali.org/get-kali/#kali-cloud',
+  },
+  {
+    title: 'Containers',
+    caption: 'Pull Kali Docker and LXC images for portable use.',
+    href: 'https://www.kali.org/get-kali/#kali-containers',
+  },
+  {
+    title: 'Mobile',
+    caption: 'Install Kali NetHunter on supported Android devices.',
+    href: 'https://www.kali.org/get-kali/#kali-mobile',
+  },
+  {
+    title: 'VMs',
+    caption: 'Run Kali in VMware or VirtualBox with pre-built images.',
+    href: 'https://www.kali.org/get-kali/#kali-virtual-machines',
+  },
+  {
+    title: 'WSL',
+    caption: 'Use Kali within Windows Subsystem for Linux.',
+    href: 'https://www.kali.org/get-kali/#kali-wsl',
+  },
+  {
+    title: 'Live',
+    caption: 'Boot from a USB drive for a fully-featured live session.',
+    href: 'https://www.kali.org/get-kali/#kali-live',
+  },
+  {
+    title: 'Installer',
+    caption: 'Install Kali to your system using our installer images.',
+    href: 'https://www.kali.org/get-kali/#kali-installer-images',
+  },
+];
 
 const GetKali: React.FC = () => (
   <main className="p-4">
     <div className="mb-6 flex items-center justify-between rounded bg-purple-600 p-4 text-white">
       <span className="text-lg">New to Kali Linux? Learn how to get started.</span>
-      <Link href="/install-options" className="rounded bg-white px-4 py-2 font-semibold text-purple-700 hover:bg-purple-50">
+      <Link
+        href="/install-options"
+        className="rounded bg-white px-4 py-2 font-semibold text-purple-700 hover:bg-purple-50"
+      >
         Learn More
       </Link>
     </div>
-    <div className="grid gap-4 md:grid-cols-3">
-      <div className="flex flex-col rounded border p-4">
-        <h2 className="mb-2 text-xl font-semibold">VMware</h2>
-        <p className="mb-4">Run Kali in a VMware virtual machine and use snapshots to save and revert your setup anytime.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-virtual-machines"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-auto text-blue-500 hover:underline"
-        >
-          Learn more
-        </a>
-      </div>
-      <div className="flex flex-col rounded border p-4">
-        <h2 className="mb-2 text-xl font-semibold">USB Live</h2>
-        <p className="mb-4">Boot from a portable USB drive and run Kali without touching your system&apos;s disk.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-live"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-auto text-blue-500 hover:underline"
-        >
-          Learn more
-        </a>
-      </div>
-      <div className="flex flex-col rounded border p-4">
-        <h2 className="mb-2 text-xl font-semibold">Cloud</h2>
-        <p className="mb-4">Deploy Kali on popular cloud providers for on-demand access from anywhere.</p>
-        <a
-          href="https://www.kali.org/get-kali/#kali-cloud"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-auto text-blue-500 hover:underline"
-        >
-          Learn more
-        </a>
-      </div>
+    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {tiles.map((tile) => (
+        <DownloadCard key={tile.title} {...tile} />
+      ))}
     </div>
   </main>
 );
 
 export default GetKali;
-


### PR DESCRIPTION
## Summary
- create reusable DownloadCard component
- add responsive tile grid for ARM, Cloud, Containers, Mobile, VMs, WSL, Live, Installer on Get Kali page

## Testing
- `yarn test` *(fails: missing allowlist entries and Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be511608d48328811621414e2a6c64