### PR TITLE
Add desktop environment selection to homepage

### DIFF
--- a/components/home/DesktopEnvs.tsx
+++ b/components/home/DesktopEnvs.tsx
@@ -14,18 +14,29 @@ const desktopEnvs: DesktopEnv[] = [
 export default function DesktopEnvs() {
   return (
     <div className="grid gap-4 sm:grid-cols-3">
-      {desktopEnvs.map((env) => (
-        <div key={env.name} className="Surface rounded p-4 text-center">
-          <Image
-            src={env.image}
-            alt={env.name}
-            width={128}
-            height={128}
-            className="mx-auto mb-2 h-24 w-24 object-contain"
-          />
-          <h3 className="text-lg font-semibold">{env.name}</h3>
-        </div>
-      ))}
+      {desktopEnvs.map((env) => {
+        const isDefault = env.name === "Xfce";
+        return (
+          <div
+            key={env.name}
+            className={`flex flex-col items-center p-4 border rounded text-center bg-white ${
+              isDefault ? "ring-2 ring-blue-500" : ""
+            }`}
+          >
+            <Image
+              src={env.image}
+              alt={env.name}
+              width={128}
+              height={128}
+              className="mx-auto mb-2 h-24 w-24 object-contain"
+            />
+            <h3 className="text-lg font-semibold">
+              {env.name}
+              {isDefault && <span className="ml-1 text-sm text-blue-600">(Default)</span>}
+            </h3>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,50 +1,21 @@
-import Image from "next/image";
-import { decode } from "blurhash";
-import { PNG } from "pngjs";
-import desktopsData from "../content/desktops.json";
+import DesktopEnvs from "../components/home/DesktopEnvs";
+import KaliEverywhere from "../components/home/KaliEverywhere";
 import { baseMetadata } from "../lib/metadata";
 
 export const metadata = baseMetadata;
 
-function blurHashToDataURL(blurhash) {
-  const pixels = decode(blurhash, 32, 32);
-  const png = new PNG({ width: 32, height: 32 });
-  png.data = Buffer.from(pixels);
-  return `data:image/png;base64,${PNG.sync.write(png).toString("base64")}`;
-}
-
-export async function getStaticProps() {
-  const desktops = desktopsData.map((d) => ({
-    ...d,
-    blurDataURL: blurHashToDataURL(d.blurhash),
-  }));
-  return { props: { desktops } };
-}
-
-/**
- * @param {{ desktops: { name: string; image: string; blurDataURL: string }[] }} props
- * @returns {JSX.Element}
- */
-export default function Home({ desktops }) {
+export default function Home() {
   return (
-    <main className="p-4">
-      <h1 className="text-xl font-bold mb-4">Choose the desktop you prefer</h1>
-      <div className="grid gap-4 sm:grid-cols-3">
-        {desktops.map((d) => (
-          <div key={d.name} className="text-center">
-            <Image
-              src={d.image}
-              alt={d.name}
-              width={320}
-              height={200}
-              placeholder="blur"
-              blurDataURL={d.blurDataURL}
-              className="rounded"
-            />
-            <p className="mt-2">{d.name}</p>
-          </div>
-        ))}
-      </div>
+    <main className="p-4 space-y-8">
+      <section>
+        <h1 className="text-xl font-bold mb-4">Kali Everywhere</h1>
+        <KaliEverywhere />
+      </section>
+      <section>
+        <h2 className="text-xl font-bold mb-4">Desktop Environments</h2>
+        <DesktopEnvs />
+      </section>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- Show desktop environment choices on homepage alongside Kali platforms
- Emphasize Xfce as the default desktop

## Testing
- `npm test` *(fails: session not created for Chrome; missing browsers and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be5116f20c8328a6c270846d0a6c4a