### PR TITLE
feat: display latest blog posts

### DIFF
--- a/components/kali/BlogFeed.tsx
+++ b/components/kali/BlogFeed.tsx
@@ -9,29 +9,33 @@ interface Post {
 
 const BlogFeed: React.FC = () => {
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
-      {posts.slice(0, 6).map((post: Post) => (
-        <div
+    <div className="grid gap-4 sm:grid-cols-3" aria-label="Latest blog posts">
+      {posts.slice(0, 3).map((post: Post) => (
+        <article
           key={post.link}
-          className="flex flex-col p-4 rounded bg-gray-800 text-white"
+          className="flex flex-col rounded border border-gray-700 bg-gray-800 p-4 text-white"
         >
-          <h3 className="text-lg font-semibold">{post.title}</h3>
-          <p className="text-sm text-gray-400">
+          <h3 className="text-base font-semibold leading-snug">
+            <a
+              href={post.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              {post.title}
+            </a>
+          </h3>
+          <time
+            dateTime={post.date}
+            className="mt-2 text-sm text-gray-400"
+          >
             {new Date(post.date).toLocaleDateString(undefined, {
               year: 'numeric',
               month: 'short',
               day: 'numeric',
             })}
-          </p>
-          <a
-            href={post.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-auto text-sm text-blue-400 hover:underline"
-          >
-            Read on kali.org ↗
-          </a>
-        </div>
+          </time>
+        </article>
       ))}
     </div>
   );

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import { decode } from "blurhash";
 import { PNG } from "pngjs";
 import desktopsData from "../content/desktops.json";
 import { baseMetadata } from "../lib/metadata";
+import BlogFeed from "../components/kali/BlogFeed";
 
 export const metadata = baseMetadata;
 
@@ -27,24 +28,32 @@ export async function getStaticProps() {
  */
 export default function Home({ desktops }) {
   return (
-    <main className="p-4">
-      <h1 className="text-xl font-bold mb-4">Choose the desktop you prefer</h1>
-      <div className="grid gap-4 sm:grid-cols-3">
-        {desktops.map((d) => (
-          <div key={d.name} className="text-center">
-            <Image
-              src={d.image}
-              alt={d.name}
-              width={320}
-              height={200}
-              placeholder="blur"
-              blurDataURL={d.blurDataURL}
-              className="rounded"
-            />
-            <p className="mt-2">{d.name}</p>
-          </div>
-        ))}
-      </div>
+    <main className="p-4 space-y-8">
+      <section>
+        <h1 className="mb-4 text-xl font-bold">Choose the desktop you prefer</h1>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {desktops.map((d) => (
+            <div key={d.name} className="text-center">
+              <Image
+                src={d.image}
+                alt={d.name}
+                width={320}
+                height={200}
+                placeholder="blur"
+                blurDataURL={d.blurDataURL}
+                className="rounded"
+              />
+              <p className="mt-2">{d.name}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section aria-labelledby="latest-posts">
+        <h2 id="latest-posts" className="mb-4 text-xl font-bold">
+          Latest from the blog
+        </h2>
+        <BlogFeed />
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show latest 3 blog posts in card layout with dates and links
- render blog feed on home page

## Testing
- `npx eslint components/kali/BlogFeed.tsx`
- `yarn test` *(fails: SessionNotCreatedError: cannot find Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68be5117a86c8328a3dcba375a7038e3