### PR TITLE
feat: add platform hero component

### DIFF
--- a/__tests__/Hero.test.tsx
+++ b/__tests__/Hero.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Hero from '../components/ui/Hero';
+
+test('renders hero content', () => {
+  render(
+    <Hero
+      title="My Title"
+      summary={['First', 'Second']}
+      meta={[{ label: 'Info', value: 'Details' }]}
+    />
+  );
+
+  expect(screen.getByRole('heading', { name: 'My Title' })).toBeInTheDocument();
+  expect(screen.getByText('First')).toBeInTheDocument();
+  expect(screen.getByText('Details')).toBeInTheDocument();
+});
+

--- a/components/ui/Hero.tsx
+++ b/components/ui/Hero.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface MetaItem {
+  label: string;
+  value: React.ReactNode;
+}
+
+interface HeroProps {
+  title: string;
+  summary: string[];
+  meta?: MetaItem[];
+}
+
+export default function Hero({ title, summary, meta }: HeroProps) {
+  return (
+    <section className="flex flex-col gap-6 md:flex-row">
+      <div className="flex-1 space-y-4">
+        <h1 className="text-3xl font-bold">{title}</h1>
+        <ul className="list-disc list-inside space-y-2">
+          {summary.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+      {meta && meta.length > 0 && (
+        <aside className="md:w-64 border rounded p-4 space-y-2">
+          {meta.map((item) => (
+            <div key={item.label} className="flex justify-between gap-2 text-sm">
+              <span className="font-medium">{item.label}</span>
+              <span className="text-right">{item.value}</span>
+            </div>
+          ))}
+        </aside>
+      )}
+    </section>
+  );
+}
+

--- a/data/platforms.tsx
+++ b/data/platforms.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+export interface PlatformInfo {
+  slug: string;
+  title: string;
+  bullets: string[];
+  meta: { label: string; value: React.ReactNode }[];
+}
+
+export const platforms: PlatformInfo[] = [
+  {
+    slug: 'vmware',
+    title: 'VMware',
+    bullets: [
+      'Run Kali in a VMware virtual machine',
+      'Use snapshots to save and revert your setup anytime',
+    ],
+    meta: [
+      {
+        label: 'Docs',
+        value: (
+          <a
+            href="https://www.kali.org/docs/virtualization/install-vmware/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Installation Guide
+          </a>
+        ),
+      },
+      { label: 'Default login', value: <code>kali/kali</code> },
+    ],
+  },
+  {
+    slug: 'cloud',
+    title: 'Cloud',
+    bullets: [
+      'Deploy Kali on popular cloud providers for on-demand access.',
+      'Access your environment from anywhere.',
+    ],
+    meta: [
+      {
+        label: 'Docs',
+        value: (
+          <a
+            href="https://www.kali.org/docs/cloud/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Cloud Docs
+          </a>
+        ),
+      },
+    ],
+  },
+  {
+    slug: 'usb-live',
+    title: 'USB Live',
+    bullets: [
+      'Boot from a portable USB drive without touching your disk.',
+      'Enable persistence for a customizable environment.',
+    ],
+    meta: [
+      {
+        label: 'Docs',
+        value: (
+          <a
+            href="https://www.kali.org/docs/usb/usb-persistence/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Persistence Guide
+          </a>
+        ),
+      },
+    ],
+  },
+];
+
+export function getPlatformSlugs() {
+  return platforms.map((p) => p.slug);
+}
+
+export function getPlatformBySlug(slug: string) {
+  return platforms.find((p) => p.slug === slug);
+}
+

--- a/pages/platform/[slug].tsx
+++ b/pages/platform/[slug].tsx
@@ -1,0 +1,36 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import Hero from '../../components/ui/Hero';
+import { getPlatformSlugs, getPlatformBySlug, PlatformInfo } from '../../data/platforms';
+
+interface PlatformPageProps {
+  platform: PlatformInfo;
+}
+
+export default function PlatformPage({ platform }: PlatformPageProps) {
+  return (
+    <main className="p-4">
+      <Hero title={platform.title} summary={platform.bullets} meta={platform.meta} />
+    </main>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const slugs = getPlatformSlugs();
+  return {
+    paths: slugs.map((slug) => ({ params: { slug } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<PlatformPageProps> = async ({ params }) => {
+  const platform = getPlatformBySlug(params!.slug as string);
+  if (!platform) {
+    return { notFound: true };
+  }
+  return {
+    props: {
+      platform,
+    },
+  };
+};
+


### PR DESCRIPTION
## Summary
- add reusable Hero UI with bullet summary and optional meta panel
- define platform data and dynamic /platform/[slug] page using Hero
- test hero rendering

## Testing
- `npx eslint components/ui/Hero.tsx pages/platform/[slug].tsx data/platforms.tsx __tests__/Hero.test.tsx`
- `yarn lint components/ui/Hero.tsx "pages/platform/[slug].tsx" data/platforms.tsx __tests__/Hero.test.tsx` *(fails: A control must be associated with a text label)*
- `yarn typecheck` *(fails: TS2538: Type 'undefined' cannot be used as an index type)*
- `yarn test __tests__/Hero.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be5119116c8328bca67efcd09025d8