### PR TITLE
feat: add download verification note

### DIFF
--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface CalloutProps {
-  variant: 'defaultCredentials' | 'readDocs';
+  variant: 'defaultCredentials' | 'readDocs' | 'verifyDownload';
   children: React.ReactNode;
 }
 
@@ -29,6 +29,25 @@ const BookOpenIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const ShieldCheckIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 3L3 5.25v6.75c0 5.523 3.807 10.74 9 12 5.193-1.26 9-6.477 9-12V5.25L12 3z"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9 12l2 2 4-4"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const variants = {
   defaultCredentials: {
     icon: KeyIcon,
@@ -39,6 +58,11 @@ const variants = {
     icon: BookOpenIcon,
     border: 'border-blue-400',
     label: 'Read the docs',
+  },
+  verifyDownload: {
+    icon: ShieldCheckIcon,
+    border: 'border-green-400',
+    label: 'Verify downloads',
   },
 };
 

--- a/pages/get-kali/index.tsx
+++ b/pages/get-kali/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Callout from '../../components/ui/Callout';
 
 const GetKali: React.FC = () => (
   <main className="p-4">
@@ -46,6 +47,22 @@ const GetKali: React.FC = () => (
           Learn more
         </a>
       </div>
+    </div>
+    <div className="mt-6">
+      <Callout variant="verifyDownload">
+        <p>
+          Verify downloads using signatures or hashes.{' '}
+          <a
+            href="https://www.kali.org/docs/introduction/download-validation/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Verification instructions
+          </a>
+          .
+        </p>
+      </Callout>
     </div>
   </main>
 );

--- a/pages/platforms/cloud.tsx
+++ b/pages/platforms/cloud.tsx
@@ -19,6 +19,20 @@ const CloudPage: React.FC = () => (
         {' '}to get started.
       </p>
     </Callout>
+    <Callout variant="verifyDownload">
+      <p>
+        Verify the image after downloading using signatures or hashes.{' '}
+        <a
+          href="https://www.kali.org/docs/introduction/download-validation/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          Verification instructions
+        </a>
+        .
+      </p>
+    </Callout>
   </main>
 );
 

--- a/pages/platforms/usb-live.tsx
+++ b/pages/platforms/usb-live.tsx
@@ -19,6 +19,20 @@ const USBLivePage: React.FC = () => (
         .
       </p>
     </Callout>
+    <Callout variant="verifyDownload">
+      <p>
+        Verify the image after downloading using signatures or hashes.{' '}
+        <a
+          href="https://www.kali.org/docs/introduction/download-validation/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          Verification instructions
+        </a>
+        .
+      </p>
+    </Callout>
   </main>
 );
 

--- a/pages/platforms/vmware.tsx
+++ b/pages/platforms/vmware.tsx
@@ -24,6 +24,20 @@ const VMwarePage: React.FC = () => (
         The default login for VMware images is <code>kali/kali</code>.
       </p>
     </Callout>
+    <Callout variant="verifyDownload">
+      <p>
+        Verify the image after downloading using signatures or hashes.{' '}
+        <a
+          href="https://www.kali.org/docs/introduction/download-validation/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          Verification instructions
+        </a>
+        .
+      </p>
+    </Callout>
   </main>
 );
 


### PR DESCRIPTION
## Summary
- add verification callout variant
- encourage verifying downloads on platform pages

## Testing
- `npx eslint components/ui/Callout.tsx pages/platforms/vmware.tsx pages/platforms/usb-live.tsx pages/platforms/cloud.tsx pages/get-kali/index.tsx`
- `yarn test components/ui/Callout.tsx pages/platforms/vmware.tsx pages/platforms/usb-live.tsx pages/platforms/cloud.tsx pages/get-kali/index.tsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be511ba0948328a543e22d1c8e3072