### PR TITLE
Refine tools index badges and spacing

### DIFF
--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -2,6 +2,9 @@ import Head from 'next/head';
 import { useState } from 'react';
 import tools from '../../../data/kali-tools.json';
 
+const badgeClass =
+  'inline-block rounded bg-gray-200 px-2 py-0.5 text-xs font-semibold leading-tight text-gray-800 transition-colors hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600';
+
 const KaliToolsPage = () => {
   const [query, setQuery] = useState('');
   const filteredTools = tools.filter((tool) =>
@@ -46,9 +49,20 @@ const KaliToolsPage = () => {
               href={`https://www.kali.org/tools/${tool.id}/`}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+              className="flex flex-col items-center rounded border p-4 text-center leading-tight hover:bg-gray-50 focus:outline-none focus:ring dark:hover:bg-gray-800"
             >
-              <span>{tool.name}</span>
+              <span className="font-semibold leading-tight">{tool.name}</span>
+              <div className="mt-2 flex flex-wrap justify-center gap-2">
+                <a
+                  href={`https://www.kali.org/tools/${tool.id}/`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={badgeClass}
+                >
+                  Package
+                </a>
+                <span className={badgeClass}>{`$ apt install ${tool.id}`}</span>
+              </div>
             </a>
           ))}
         </div>

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -5,7 +5,7 @@ const PAGE_SIZE = 30;
 const COLUMNS = 3; // used for keyboard navigation
 
 const badgeClass =
-  'inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-800 dark:bg-gray-700 dark:text-gray-100';
+  'inline-block rounded bg-gray-200 px-2 py-0.5 text-xs font-semibold leading-tight text-gray-800 transition-colors hover:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600';
 
 export default function ToolsPage() {
   const [page, setPage] = useState(0);
@@ -53,10 +53,10 @@ export default function ToolsPage() {
           <li key={tool.id}>
             <a
               href={`https://www.kali.org/tools/${tool.id}/`}
-              className="block rounded border p-4 focus:outline-none focus:ring"
+              className="block rounded border p-4 leading-tight hover:bg-gray-50 focus:outline-none focus:ring dark:hover:bg-gray-800"
               ref={(el) => (itemRefs.current[i] = el)}
             >
-              <h3 className="font-semibold">{tool.name}</h3>
+              <h3 className="font-semibold leading-tight">{tool.name}</h3>
               <div className="mt-2 flex flex-wrap gap-2">
                 <a
                   href={`https://gitlab.com/kalilinux/packages/${tool.id}`}


### PR DESCRIPTION
## Summary
- Tighten line height and add consistent badge styling across tool listings
- Introduce command and package badges with hover/focus feedback

## Testing
- `yarn lint pages/tools/index.tsx pages/apps/kali-tools/index.jsx` *(fails: repository lint errors)*
- `npx eslint pages/tools/index.tsx pages/apps/kali-tools/index.jsx` *(warning: file ignored due to missing config)*
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `yarn test pages/tools/index.tsx pages/apps/kali-tools/index.jsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be511f57808328b6faaceb0c4b46e0