### PR TITLE
Add A–Z navigation rail for Kali tools page

### DIFF
--- a/pages/apps/kali-tools/index.jsx
+++ b/pages/apps/kali-tools/index.jsx
@@ -1,18 +1,39 @@
 import Head from 'next/head';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import tools from '../../../data/kali-tools.json';
+
+const letters = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode(65 + i),
+);
 
 const KaliToolsPage = () => {
   const [query, setQuery] = useState('');
-  const filteredTools = tools.filter((tool) =>
-    tool.name.toLowerCase().includes(query.toLowerCase()),
+  const filteredTools = useMemo(
+    () =>
+      tools.filter((tool) =>
+        tool.name.toLowerCase().includes(query.toLowerCase()),
+      ),
+    [query],
   );
+
+  const grouped = useMemo(() => {
+    return filteredTools.reduce((acc, tool) => {
+      const letter = tool.name[0].toUpperCase();
+      (acc[letter] ||= []).push(tool);
+      return acc;
+    }, {});
+  }, [filteredTools]);
 
   const softwareLd = filteredTools.map((tool) => ({
     '@type': 'SoftwareApplication',
     name: tool.name,
     url: `https://www.kali.org/tools/${tool.id}/`,
   }));
+
+  const handleScroll = (letter) => {
+    const el = document.getElementById(`section-${letter}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth' });
+  };
 
   return (
     <>
@@ -27,7 +48,7 @@ const KaliToolsPage = () => {
           }}
         />
       </Head>
-      <div className="p-4">
+      <div className="relative p-4">
         <label htmlFor="tool-search" className="sr-only">
           Search tools
         </label>
@@ -39,19 +60,54 @@ const KaliToolsPage = () => {
           placeholder="Search tools"
           className="mb-4 w-full rounded border p-2"
         />
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {filteredTools.map((tool) => (
-            <a
-              key={tool.id}
-              href={`https://www.kali.org/tools/${tool.id}/`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-            >
-              <span>{tool.name}</span>
-            </a>
-          ))}
-        </div>
+        {letters.map((letter) =>
+          grouped[letter] ? (
+            <section key={letter} id={`section-${letter}`} className="mb-8">
+              <h2 className="mb-2 text-xl font-bold">{letter}</h2>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                {grouped[letter].map((tool) => (
+                  <a
+                    key={tool.id}
+                    href={`https://www.kali.org/tools/${tool.id}/`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+                  >
+                    <span>{tool.name}</span>
+                  </a>
+                ))}
+              </div>
+            </section>
+          ) : null,
+        )}
+        <nav
+          aria-label="Alphabet navigation"
+          className="fixed right-2 top-1/2 -translate-y-1/2"
+        >
+          <ul className="flex flex-col items-center space-y-1">
+            {letters.map((letter) => {
+              const disabled = !grouped[letter];
+              return (
+                <li key={letter}>
+                  <button
+                    type="button"
+                    aria-label={`Jump to ${letter} section`}
+                    aria-disabled={disabled}
+                    disabled={disabled}
+                    onClick={() => !disabled && handleScroll(letter)}
+                    className={`h-6 w-6 text-xs ${
+                      disabled
+                        ? 'cursor-default text-gray-400'
+                        : 'text-blue-600 hover:underline'
+                    }`}
+                  >
+                    {letter}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- group Kali tools by initial letter
- add vertical A–Z navigation rail with smooth scrolling
- improve accessibility with ARIA labels

## Testing
- `yarn test` *(fails: cannot find Chrome binary; axe CLI failure)*


------
https://chatgpt.com/codex/tasks/task_e_68be51200c008328b6bebf3e4f7b91a3