### PR TITLE
feat: add color-coded category badges

### DIFF
--- a/components/CategoryBadge.tsx
+++ b/components/CategoryBadge.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const categoryClasses: Record<string, string> = {
+  'information-gathering':
+    'bg-category-information-gathering text-gray-800 dark:bg-category-information-gathering-dark dark:text-white',
+  'password-attacks':
+    'bg-category-password-attacks text-gray-800 dark:bg-category-password-attacks-dark dark:text-white',
+  'web-applications':
+    'bg-category-web-applications text-gray-800 dark:bg-category-web-applications-dark dark:text-white',
+};
+
+export default function CategoryBadge({ category }: { category: string }) {
+  const slug = category.toLowerCase().replace(/\s+/g, '-');
+  const base = 'inline-block rounded px-2 py-1 text-xs font-semibold';
+  const color = categoryClasses[slug] ||
+    'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100';
+  return <span className={`${base} ${color}`}>{category}</span>;
+}

--- a/data/tool-details.json
+++ b/data/tool-details.json
@@ -2,6 +2,7 @@
   "nmap": {
     "name": "Nmap",
     "description": "Network exploration tool and security/port scanner.",
+    "categories": ["Information Gathering"],
     "commands": [
       "nmap -sV 192.168.0.1",
       "nmap -A 192.168.0.1"
@@ -14,6 +15,7 @@
   "hydra": {
     "name": "Hydra",
     "description": "Parallelized login cracker which supports numerous protocols.",
+    "categories": ["Password Attacks"],
     "commands": [
       "hydra -l user -P passlist.txt ftp://192.168.0.1",
       "hydra -L users.txt -P passlist.txt ssh://192.168.0.1"

--- a/data/tools.json
+++ b/data/tools.json
@@ -1,8 +1,39 @@
 [
   {
+    "id": "nmap",
+    "name": "Nmap",
+    "summary": "Network exploration tool and security/port scanner.",
+    "categories": ["Information Gathering"],
+    "packages": [
+      { "name": "nmap" }
+    ],
+    "commands": [
+      { "label": "Install", "cmd": "apt install nmap" },
+      { "label": "Run", "cmd": "nmap -sV 192.168.0.1" }
+    ],
+    "upstream": "https://nmap.org/",
+    "related": ["hydra"]
+  },
+  {
+    "id": "hydra",
+    "name": "Hydra",
+    "summary": "Parallelized login cracker which supports numerous protocols.",
+    "categories": ["Password Attacks"],
+    "packages": [
+      { "name": "hydra" }
+    ],
+    "commands": [
+      { "label": "Install", "cmd": "apt install hydra" },
+      { "label": "Run", "cmd": "hydra -l user -P passlist.txt ftp://192.168.0.1" }
+    ],
+    "upstream": "https://github.com/vanhauser-thc/thc-hydra",
+    "related": ["nmap"]
+  },
+  {
     "id": "dirbuster",
     "name": "DirBuster",
     "summary": "DirBuster is a multi threaded java application designed to brute force directories and files names on web/application servers.",
+    "categories": ["Web Applications"],
     "packages": [
       { "name": "dirbuster", "version": "1.0-RC1" }
     ],
@@ -17,6 +48,7 @@
     "id": "gobuster",
     "name": "GoBuster",
     "summary": "Directory/file & DNS busting tool written in Go.",
+    "categories": ["Web Applications", "Information Gathering"],
     "packages": [
       { "name": "gobuster", "version": "3.5.0" }
     ],
@@ -31,6 +63,7 @@
     "id": "feroxbuster",
     "name": "Feroxbuster",
     "summary": "A simple, fast, recursive content discovery tool written in Rust.",
+    "categories": ["Web Applications"],
     "packages": [
       { "name": "feroxbuster", "version": "2.10.4" }
     ],

--- a/pages/tools/[slug].tsx
+++ b/pages/tools/[slug].tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import tools from '../../data/tools.json';
 import copyToClipboard from '../../utils/clipboard';
+import CategoryBadge from '../../components/CategoryBadge';
 
 interface ToolCommand {
   label?: string;
@@ -17,6 +18,7 @@ interface Tool {
   id: string;
   name: string;
   summary: string;
+  categories?: string[];
   packages: ToolPackage[];
   commands: ToolCommand[];
   upstream: string;
@@ -34,7 +36,14 @@ export default function ToolPage({ tool }: Props) {
 
   return (
     <div className="p-4 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">{tool.name}</h1>
+      <h1 className="text-2xl font-bold mb-2">{tool.name}</h1>
+      {tool.categories && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {tool.categories.map((cat) => (
+            <CategoryBadge key={cat} category={cat} />
+          ))}
+        </div>
+      )}
       <p className="mb-6">{tool.summary}</p>
 
       {tool.packages?.length > 0 && (

--- a/pages/tools/[tool].tsx
+++ b/pages/tools/[tool].tsx
@@ -1,4 +1,5 @@
 import CommandChip from '@/components/CommandChip';
+import CategoryBadge from '@/components/CategoryBadge';
 import toolData from '@/data/tool-details.json';
 import { GetStaticPaths, GetStaticProps } from 'next';
 
@@ -12,6 +13,7 @@ interface ToolInfo {
   description: string;
   commands: string[];
   links: LinkInfo[];
+  categories?: string[];
 }
 
 interface ToolPageProps {
@@ -22,6 +24,13 @@ export default function ToolPage({ tool }: ToolPageProps) {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">{tool.name}</h1>
+      {tool.categories && (
+        <div className="flex flex-wrap gap-2">
+          {tool.categories.map((cat) => (
+            <CategoryBadge key={cat} category={cat} />
+          ))}
+        </div>
+      )}
       <p>{tool.description}</p>
       {tool.commands.length > 0 && (
         <section>

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, KeyboardEvent } from 'react';
-import tools from '../../data/kali-tools.json';
+import tools from '../../data/tools.json';
+import CategoryBadge from '../../components/CategoryBadge';
 
 const PAGE_SIZE = 30;
 const COLUMNS = 3; // used for keyboard navigation
@@ -58,6 +59,9 @@ export default function ToolsPage() {
             >
               <h3 className="font-semibold">{tool.name}</h3>
               <div className="mt-2 flex flex-wrap gap-2">
+                {tool.categories?.map((cat: string) => (
+                  <CategoryBadge key={cat} category={cat} />
+                ))}
                 <a
                   href={`https://gitlab.com/kalilinux/packages/${tool.id}`}
                   target="_blank"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,20 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        category: {
+          'information-gathering': {
+            DEFAULT: '#DBEAFE',
+            dark: '#1E3A8A',
+          },
+          'password-attacks': {
+            DEFAULT: '#FEE2E2',
+            dark: '#991B1B',
+          },
+          'web-applications': {
+            DEFAULT: '#FEF3C7',
+            dark: '#92400E',
+          },
+        },
       },
         fontFamily: {
           ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- map tool categories to themed colors in Tailwind config
- show category badges in tool list and detail pages
- define categories for sample tools

## Testing
- `npm test __tests__/csp.test.ts` *(fails: Missing allowlist entries)*

------
https://chatgpt.com/codex/tasks/task_e_68be512099548328903b28ba12283071