### PR TITLE
Add copy icon and tooltip to command chips

### DIFF
--- a/components/CommandChip.tsx
+++ b/components/CommandChip.tsx
@@ -1,25 +1,3 @@
-import React from 'react';
+'use client';
 
-interface CommandChipProps {
-  command: string;
-}
-
-export default function CommandChip({ command }: CommandChipProps) {
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-    } catch {
-      // ignore clipboard errors
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={copy}
-      className="px-2 py-0.5 rounded border text-xs font-mono bg-ub-cool-grey text-white hover:bg-ub-orange focus:outline-none focus:ring"
-    >
-      {command}
-    </button>
-  );
-}
+export { default } from './ui/CommandChip';

--- a/components/ui/CommandChip.tsx
+++ b/components/ui/CommandChip.tsx
@@ -6,6 +6,13 @@ interface CommandChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement>
   command: string;
 }
 
+const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1z" />
+    <path d="M20 5H8a2 2 0 0 0-2 2v16h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 18H8V7h12v16z" />
+  </svg>
+);
+
 export default function CommandChip({ command, className = '', ...props }: CommandChipProps) {
   const [copied, setCopied] = useState(false);
 
@@ -23,12 +30,14 @@ export default function CommandChip({ command, className = '', ...props }: Comma
     <button
       type="button"
       onClick={copy}
-      className={`inline-flex items-center rounded bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
+      className={`inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
       aria-label={`Copy ${command}`}
+      title="Copy command"
       {...props}
     >
       <span className="select-all">$ {command}</span>
-      {copied && <span className="ml-2 text-xs text-gray-400">Copied</span>}
+      <CopyIcon className="h-4 w-4" />
+      {copied && <span className="ml-1 text-xs text-gray-400">Copied</span>}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- style command chips with rounded borders and embedded copy icon
- add "Copy command" tooltip for better clarity
- reuse unified component across docs and tool pages

## Testing
- `npx eslint components/CommandChip.tsx components/ui/CommandChip.tsx && echo "eslint: no problems"`
- `yarn test --passWithNoTests components/ui/CommandChip.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be51216b188328a1c004ec6fd07ccb