### PR TITLE
feat: add reusable empty-state for search

### DIFF
--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -4,6 +4,7 @@ import CommandBuilder from '../../CommandBuilder';
 import FixturesLoader from '../../FixturesLoader';
 import ResultViewer from '../../ResultViewer';
 import ExplainerPane from '../../ExplainerPane';
+import EmptyState from '../../ui/EmptyState';
 
 const tabs = [
   { id: 'repeater', label: 'Repeater' },
@@ -189,7 +190,13 @@ export default function SecurityTools() {
               <div>Sample text contains &quot;{query}&quot;</div>
             </div>
           )}
-            {!hasResults && <div>No results found.</div>}
+            {!hasResults && (
+              <EmptyState
+                icon={<span>🔍</span>}
+                headline="No results"
+                helperText="Try refining your query"
+              />
+            )}
           </div>
         ) : (
           <>

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import apps from '../../apps.config';
+import EmptyState from '../ui/EmptyState';
 
 // Load the actual VSCode app lazily so no editor dependencies are required
 const VsCode = dynamic(
@@ -93,7 +94,13 @@ export default function VsCodeWrapper({ openApp }) {
                 </li>
               ))}
               {items.length === 0 && (
-                <li className="px-2 py-1 text-sm text-gray-400">No results</li>
+                <li className="py-8">
+                  <EmptyState
+                    icon={<span>🔍</span>}
+                    headline="No results"
+                    helperText="Try another search"
+                  />
+                </li>
               )}
             </ul>
           </div>

--- a/components/panel/WeatherPopover.tsx
+++ b/components/panel/WeatherPopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import EmptyState from "../ui/EmptyState";
 
 interface Props {
   location: string;
@@ -63,7 +64,13 @@ export default function WeatherPopover({
               </li>
             ))}
             {filtered.length === 0 && (
-              <li className="px-2 py-1 text-sm text-gray-300">No results</li>
+              <li className="p-4">
+                <EmptyState
+                  icon={<span>📍</span>}
+                  headline="No results"
+                  helperText="Try another location"
+                />
+              </li>
             )}
           </ul>
         )}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  headline: string;
+  helperText?: string;
+  className?: string;
+}
+
+export default function EmptyState({
+  icon,
+  headline,
+  helperText,
+  className = '',
+}: EmptyStateProps) {
+  return (
+    <div className={`flex flex-col items-center text-center ${className}`.trim()}>
+      {icon && (
+        <div className="text-4xl mb-2 text-muted" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <h3 className="font-semibold text-text">{headline}</h3>
+      {helperText && <p className="mt-1 text-sm text-muted">{helperText}</p>}
+    </div>
+  );
+}

--- a/components/ui/SearchOverlay.tsx
+++ b/components/ui/SearchOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
+import EmptyState from './EmptyState';
 
 interface SearchOverlayProps {
   open: boolean;
@@ -80,7 +81,13 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
             </li>
           ))}
           {query && results.length === 0 && (
-            <li className="px-2 py-1 text-gray-300">No results</li>
+            <li className="py-8">
+              <EmptyState
+                icon={<span>🔍</span>}
+                headline="No results"
+                helperText="Try a different search term"
+              />
+            </li>
           )}
         </ul>
       </div>

--- a/src/plugins/Dictionary.tsx
+++ b/src/plugins/Dictionary.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Modal from "../../components/base/Modal";
+import EmptyState from "../../components/ui/EmptyState";
 import {
   Definition,
   fetchDefinitions,
@@ -80,7 +81,13 @@ export default function Dictionary() {
               </button>
             </form>
             {loading && <p>Loading...</p>}
-            {error && <p>{error}</p>}
+            {error && (
+              <EmptyState
+                icon={<span>📖</span>}
+                headline={error}
+                helperText="Try another word"
+              />
+            )}
             {!loading && !error && results.length > 0 && (
               <ul className="list-disc pl-5 max-h-64 overflow-auto">
                 {results.map((r, i) => (


### PR DESCRIPTION
## Summary
- add reusable `EmptyState` component with icon, headline and helper text
- use empty state when searches return no results across UI components

## Testing
- `yarn lint` *(fails: command hung without output)*
- `yarn test` *(fails: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68be5122771c8328b44eaa3bce04e90f