### PR TITLE
feat: add accessible pagination component

### DIFF
--- a/components/kali/BlogFeed.tsx
+++ b/components/kali/BlogFeed.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import { useState, useRef, KeyboardEvent } from 'react';
 import posts from '../../data/kali-blog.json';
+import Pagination from '../ui/Pagination';
 
 interface Post {
   title: string;
@@ -7,32 +8,78 @@ interface Post {
   date: string;
 }
 
+const PAGE_SIZE = 6;
+
 const BlogFeed: React.FC = () => {
+  const [page, setPage] = useState(0);
+  const itemRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+
+  const pageCount = Math.ceil(posts.length / PAGE_SIZE);
+  const pagePosts = posts.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = itemRefs.current.findIndex(
+      (el) => el === document.activeElement,
+    );
+    if (currentIndex === -1) return;
+    let nextIndex = currentIndex;
+    switch (e.key) {
+      case 'ArrowRight':
+        nextIndex = Math.min(currentIndex + 1, pagePosts.length - 1);
+        break;
+      case 'ArrowLeft':
+        nextIndex = Math.max(currentIndex - 1, 0);
+        break;
+      case 'ArrowDown':
+        nextIndex = Math.min(currentIndex + 2, pagePosts.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIndex = Math.max(currentIndex - 2, 0);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    itemRefs.current[nextIndex]?.focus();
+  };
+
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
-      {posts.slice(0, 6).map((post: Post) => (
-        <div
-          key={post.link}
-          className="flex flex-col p-4 rounded bg-gray-800 text-white"
-        >
-          <h3 className="text-lg font-semibold">{post.title}</h3>
-          <p className="text-sm text-gray-400">
-            {new Date(post.date).toLocaleDateString(undefined, {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            })}
-          </p>
-          <a
-            href={post.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-auto text-sm text-blue-400 hover:underline"
+    <div>
+      <div className="grid gap-4 sm:grid-cols-2" onKeyDown={handleKeyDown}>
+        {pagePosts.map((post: Post, i: number) => (
+          <div
+            key={post.link}
+            className="flex flex-col p-4 rounded bg-gray-800 text-white"
           >
-            Read on kali.org ↗
-          </a>
-        </div>
-      ))}
+            <h3 className="text-lg font-semibold">{post.title}</h3>
+            <p className="text-sm text-gray-400">
+              {new Date(post.date).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </p>
+            <a
+              href={post.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-auto text-sm text-blue-400 hover:underline"
+              ref={(el) => {
+                itemRefs.current[i] = el;
+              }}
+            >
+              Read on kali.org ↗
+            </a>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex justify-center">
+        <Pagination
+          currentPage={page}
+          totalPages={pageCount}
+          onPageChange={setPage}
+        />
+      </div>
     </div>
   );
 };

--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -1,0 +1,115 @@
+import { useRef, KeyboardEvent } from "react";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  const btnRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  btnRefs.current = [];
+  let refIndex = 0;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
+    const currentIndex = btnRefs.current.findIndex(
+      (el) => el === document.activeElement,
+    );
+    if (currentIndex === -1) return;
+    let nextIndex = currentIndex;
+    switch (e.key) {
+      case "ArrowRight":
+        nextIndex = Math.min(currentIndex + 1, btnRefs.current.length - 1);
+        break;
+      case "ArrowLeft":
+        nextIndex = Math.max(currentIndex - 1, 0);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    btnRefs.current[nextIndex]?.focus();
+  };
+
+  return (
+    <nav aria-label="Pagination">
+      <ul className="flex items-center gap-2" onKeyDown={handleKeyDown}>
+        <li>
+          <button
+            ref={(el) => {
+              btnRefs.current[refIndex++] = el;
+            }}
+            onClick={() => onPageChange(0)}
+            disabled={currentPage === 0}
+            aria-label="First page"
+            className="rounded border px-3 py-1 disabled:opacity-50"
+          >
+            First
+          </button>
+        </li>
+        <li>
+          <button
+            ref={(el) => {
+              btnRefs.current[refIndex++] = el;
+            }}
+            onClick={() => onPageChange(Math.max(currentPage - 1, 0))}
+            disabled={currentPage === 0}
+            aria-label="Previous page"
+            className="rounded border px-3 py-1 disabled:opacity-50"
+          >
+            Prev
+          </button>
+        </li>
+        {Array.from({ length: totalPages }, (_, i) => (
+          <li key={i}>
+            <button
+              ref={(el) => {
+                btnRefs.current[refIndex++] = el;
+              }}
+              onClick={() => onPageChange(i)}
+              aria-label={`Page ${i + 1}`}
+              aria-current={currentPage === i ? "page" : undefined}
+              className={`rounded border px-3 py-1 ${
+                currentPage === i ? "bg-gray-200 dark:bg-gray-700" : ""
+              }`}
+            >
+              {i + 1}
+            </button>
+          </li>
+        ))}
+        <li>
+          <button
+            ref={(el) => {
+              btnRefs.current[refIndex++] = el;
+            }}
+            onClick={() =>
+              onPageChange(Math.min(currentPage + 1, totalPages - 1))
+            }
+            disabled={currentPage === totalPages - 1}
+            aria-label="Next page"
+            className="rounded border px-3 py-1 disabled:opacity-50"
+          >
+            Next
+          </button>
+        </li>
+        <li>
+          <button
+            ref={(el) => {
+              btnRefs.current[refIndex++] = el;
+            }}
+            onClick={() => onPageChange(totalPages - 1)}
+            disabled={currentPage === totalPages - 1}
+            aria-label="Last page"
+            className="rounded border px-3 py-1 disabled:opacity-50"
+          >
+            Last
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, KeyboardEvent } from 'react';
 import tools from '../../data/kali-tools.json';
+import Pagination from '../../components/ui/Pagination';
 
 const PAGE_SIZE = 30;
 const COLUMNS = 3; // used for keyboard navigation
@@ -54,7 +55,9 @@ export default function ToolsPage() {
             <a
               href={`https://www.kali.org/tools/${tool.id}/`}
               className="block rounded border p-4 focus:outline-none focus:ring"
-              ref={(el) => (itemRefs.current[i] = el)}
+              ref={(el) => {
+                itemRefs.current[i] = el;
+              }}
             >
               <h3 className="font-semibold">{tool.name}</h3>
               <div className="mt-2 flex flex-wrap gap-2">
@@ -80,24 +83,12 @@ export default function ToolsPage() {
           </li>
         ))}
       </ul>
-      <div className="mt-4 flex items-center justify-between">
-        <button
-          onClick={() => setPage((p) => Math.max(p - 1, 0))}
-          disabled={page === 0}
-          className="rounded border px-3 py-1 disabled:opacity-50"
-        >
-          Previous
-        </button>
-        <span>
-          Page {page + 1} of {pageCount}
-        </span>
-        <button
-          onClick={() => setPage((p) => Math.min(p + 1, pageCount - 1))}
-          disabled={page === pageCount - 1}
-          className="rounded border px-3 py-1 disabled:opacity-50"
-        >
-          Next
-        </button>
+      <div className="mt-4 flex justify-center">
+        <Pagination
+          currentPage={page}
+          totalPages={pageCount}
+          onPageChange={setPage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable Pagination component with numeric and first/prev/next/last controls
- integrate Pagination with tools page and blog feed
- enable keyboard navigation and ARIA attributes for better accessibility

## Testing
- `npx eslint components/ui/Pagination.tsx components/kali/BlogFeed.tsx pages/tools/index.tsx`
- `npx jest __tests__/pager.test.tsx`
- `npx tsc --noEmit components/ui/Pagination.tsx components/kali/BlogFeed.tsx pages/tools/index.tsx` *(fails: Cannot find module '../../data/kali-blog.json')*

------
https://chatgpt.com/codex/tasks/task_e_68be512317bc8328bafc4040fbb54a50