### PR TITLE
feat(docs): add sticky toc sidebar

### DIFF
--- a/pages/docs/[topic].tsx
+++ b/pages/docs/[topic].tsx
@@ -4,7 +4,7 @@ import path from 'path';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { marked } from 'marked';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface TocItem {
   id: string;
@@ -26,6 +26,39 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
       el?.scrollIntoView();
     }
   }, []);
+
+  interface TocSection {
+    id: string;
+    text: string;
+    children: TocItem[];
+  }
+
+  const sections: TocSection[] = toc.reduce((acc: TocSection[], item) => {
+    if (item.depth === 2) {
+      acc.push({ id: item.id, text: item.text, children: [] });
+    } else if (item.depth === 3 && acc.length > 0) {
+      acc[acc.length - 1].children.push(item);
+    }
+    return acc;
+  }, []);
+
+  const [openSections, setOpenSections] = useState<string[]>([]);
+  const [showToc, setShowToc] = useState(false);
+
+  useEffect(() => {
+    if (!isBrowser()) return;
+    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+    if (isDesktop) {
+      setOpenSections(sections.map((s) => s.id));
+      setShowToc(true);
+    }
+  }, [sections]);
+
+  const toggleSection = (id: string) => {
+    setOpenSections((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
+    );
+  };
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://example.com';
 
@@ -68,16 +101,43 @@ export default function DocPage({ html, toc, title, topic }: DocProps) {
         />
       </Head>
       <div className="flex flex-col md:flex-row p-4">
-      <nav className="md:w-1/4 md:pr-4">
-        <ul>
-          {toc.map(({ id, text, depth }) => (
-            <li key={id} className={depth === 3 ? 'ml-4' : ''}>
-              <a href={`#${id}`}>{text}</a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
+        <nav className="md:w-1/4 md:pr-4 md:sticky md:top-0">
+          <button
+            className="md:hidden mb-2 flex items-center"
+            onClick={() => setShowToc((v) => !v)}
+            aria-label="Toggle table of contents"
+          >
+            Table of Contents {showToc ? '▲' : '▼'}
+          </button>
+          <div className={`${showToc ? '' : 'hidden'} md:block`}> 
+            {sections.map((section) => (
+              <div key={section.id} className="mb-2">
+                <div className="flex items-center text-sm font-medium">
+                  <button
+                    onClick={() => toggleSection(section.id)}
+                    className="mr-1"
+                    aria-label={`Toggle ${section.text}`}
+                  >
+                    {openSections.includes(section.id) ? '▼' : '▶'}
+                  </button>
+                  <a href={`#${section.id}`}>{section.text}</a>
+                </div>
+                {section.children.length > 0 && openSections.includes(section.id) && (
+                  <ul className="ml-4 mt-1 space-y-1">
+                    {section.children.map((child) => (
+                      <li key={child.id}>
+                        <a href={`#${child.id}`} className="text-sm">
+                          {child.text}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </nav>
+        <article className="prose flex-1" dangerouslySetInnerHTML={{ __html: html }} />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- make docs navigation sidebar sticky on desktop
- add collapsible sections with chevron toggles and mobile toggle button

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx eslint pages/docs/[topic].tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be512ca59083288925b7929620da17