### PR TITLE
style: add kbd styling for docs and help

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -178,3 +178,16 @@ html[data-theme='matrix'] {
 @keyframes fadeOut {
   to { opacity: 0; }
 }
+
+kbd,
+.prose kbd {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  box-shadow: 0 2px 0 var(--color-border);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- style `kbd` elements to resemble physical keys across docs and help content

## Testing
- `yarn test` *(fails: cannot find Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68be513cc30c8328aae4dd4baaae0009