### PR TITLE
style: add responsive zebra-striped tables

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -178,3 +178,33 @@ html[data-theme='matrix'] {
 @keyframes fadeOut {
   to { opacity: 0; }
 }
+
+/* Global table styling */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.25rem 0.5rem;
+}
+
+tbody tr:nth-child(even) {
+  background-color: color-mix(in srgb, var(--color-muted), transparent 80%);
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-surface);
+}
+
+@media (max-width: 600px) {
+  table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
## Summary
- add global table styling with zebra stripes, sticky headers, and responsive overflow

## Testing
- `npx eslint styles/globals.css`
- `yarn test __tests__/blackjack.test.ts`
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68be5131829c8328ba63e7a739ef1ba1