### PR TITLE
Standardize status indicator modules and add theme tests

### DIFF
--- a/__tests__/StatusIndicators.test.tsx
+++ b/__tests__/StatusIndicators.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Status from '../components/util-components/status';
+import { useSettings } from '../hooks/useSettings';
+import { useTray } from '../hooks/useTray';
+
+jest.mock('../hooks/useSettings');
+jest.mock('../hooks/useTray');
+
+type SettingsReturn = {
+  allowNetwork: boolean;
+  theme: string;
+  symbolicTrayIcons: boolean;
+};
+
+const mockUseSettings = useSettings as jest.MockedFunction<typeof useSettings>;
+const mockUseTray = useTray as jest.MockedFunction<typeof useTray>;
+
+const setupMocks = (theme: string) => {
+  mockUseSettings.mockReturnValue({
+    allowNetwork: true,
+    theme,
+    symbolicTrayIcons: false,
+  } as SettingsReturn);
+
+  mockUseTray.mockReturnValue({
+    icons: [
+      { id: 'network', tooltip: 'Network', legacy: '/n.svg' },
+      { id: 'volume', tooltip: 'Volume', legacy: '/v.svg' },
+      { id: 'battery', tooltip: 'Battery', legacy: '/b.svg' },
+    ],
+    register: jest.fn(),
+    unregister: jest.fn(),
+  });
+};
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe('Status indicators', () => {
+  test('render 20px modules in dark theme', () => {
+    setupMocks('kali-dark');
+    render(<Status />);
+    const icons = screen.getAllByRole('img');
+    icons.forEach((icon) => {
+      expect(icon).toHaveClass('w-5');
+      expect(icon).toHaveClass('h-5');
+    });
+  });
+
+  test('render 20px modules in light theme', () => {
+    setupMocks('kali-light');
+    render(<Status />);
+    const icons = screen.getAllByRole('img');
+    icons.forEach((icon) => {
+      expect(icon).toHaveClass('w-5');
+      expect(icon).toHaveClass('h-5');
+    });
+  });
+});

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -71,28 +71,32 @@ export default function Status() {
   }, [register, unregister, theme]);
 
   return (
-    <div className="flex justify-center items-center" role="group" aria-label="System tray">
+    <div className="flex items-center gap-2" role="group" aria-label="System tray">
       {icons.map((icon) => (
-        <span key={icon.id} className="mx-1.5 relative" title={icon.tooltip}>
+        <span
+          key={icon.id}
+          className="relative flex items-center justify-center w-5 h-5"
+          title={icon.tooltip}
+        >
           <Image
-            width={16}
-            height={16}
+            width={20}
+            height={20}
             src={
               symbolicTrayIcons
                 ? icon.sni || icon.legacy
                 : icon.legacy || icon.sni
             }
             alt={icon.tooltip || icon.id}
-            className="inline status-symbol w-4 h-4"
-            sizes="16px"
+            className="status-symbol w-5 h-5"
+            sizes="20px"
           />
           {icon.id === 'network' && !allowNetwork && (
             <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
           )}
         </span>
       ))}
-      <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+      <span className="flex items-center justify-center w-5 h-5">
+        <SmallArrow angle="down" className="status-symbol" />
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- enforce consistent 20px modules for system tray indicators
- cover indicator sizing across dark and light themes

## Testing
- `yarn test __tests__/StatusIndicators.test.tsx`
- `yarn test` *(fails: missing Playwright browsers and axe CLI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be513d3c8083289a19f4d885f3a072