### PR TITLE
feat: add breadcrumbs and edit links to mdx pages

### DIFF
--- a/components/ui/MDXPageHeader.tsx
+++ b/components/ui/MDXPageHeader.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Link from 'next/link';
+
+interface Crumb {
+  label: string;
+  href?: string;
+}
+
+interface Props {
+  breadcrumbs: Crumb[];
+  filePath: string;
+}
+
+const REPO_URL = 'https://github.com/unnippillil/kali-linux-portfolio';
+
+const MDXPageHeader: React.FC<Props> = ({ breadcrumbs, filePath }) => {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
+      <nav aria-label="Breadcrumb" className="text-sm">
+        <ol className="flex flex-wrap items-center gap-1 text-blue-600">
+          {breadcrumbs.map((crumb, idx) => (
+            <li key={idx} className="flex items-center">
+              {crumb.href ? (
+                <Link href={crumb.href} className="hover:underline">
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span>{crumb.label}</span>
+              )}
+              {idx < breadcrumbs.length - 1 && <span className="mx-1">/</span>}
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <a
+        href={`${REPO_URL}/edit/main/${filePath}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-gray-600 hover:text-gray-900 mt-2 sm:mt-0"
+      >
+        Edit this page
+      </a>
+    </div>
+  );
+};
+
+export default MDXPageHeader;

--- a/content/get-kali/arm.mdx
+++ b/content/get-kali/arm.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'ARM' }]}
+  filePath="content/get-kali/arm.mdx"
+/>
+
 export const title = 'ARM';
 export const summary = 'Images for ARM-based single-board computers.';
 export const badges = ['arm', 'arm64'];

--- a/content/get-kali/cloud.mdx
+++ b/content/get-kali/cloud.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Cloud' }]}
+  filePath="content/get-kali/cloud.mdx"
+/>
+
 export const title = 'Cloud';
 export const summary = 'Images for AWS, Azure, and other cloud providers.';
 export const badges = ['aws', 'azure', 'gcp'];

--- a/content/get-kali/containers.mdx
+++ b/content/get-kali/containers.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Containers' }]}
+  filePath="content/get-kali/containers.mdx"
+/>
+
 export const title = 'Containers';
 export const summary = 'Docker and LXC/LXD container images.';
 export const badges = ['docker', 'lxc'];

--- a/content/get-kali/installer.mdx
+++ b/content/get-kali/installer.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Installer' }]}
+  filePath="content/get-kali/installer.mdx"
+/>
+
 export const title = 'Installer';
 export const summary = 'Full-featured ISO for bare-metal installation.';
 export const badges = ['amd64', 'arm64'];

--- a/content/get-kali/live.mdx
+++ b/content/get-kali/live.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Live' }]}
+  filePath="content/get-kali/live.mdx"
+/>
+
 export const title = 'Live';
 export const summary = 'Bootable live system with optional persistence.';
 export const badges = ['usb'];

--- a/content/get-kali/mobile.mdx
+++ b/content/get-kali/mobile.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Mobile (NetHunter)' }]}
+  filePath="content/get-kali/mobile.mdx"
+/>
+
 export const title = 'Mobile (NetHunter)';
 export const summary = 'Kali NetHunter for Android devices.';
 export const badges = ['android'];

--- a/content/get-kali/purple.mdx
+++ b/content/get-kali/purple.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Kali Purple' }]}
+  filePath="content/get-kali/purple.mdx"
+/>
+
 export const title = 'Kali Purple';
 export const summary = 'Security operations-focused Kali variant.';
 export const badges = ['soc'];

--- a/content/get-kali/vms.mdx
+++ b/content/get-kali/vms.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'Virtual Machines' }]}
+  filePath="content/get-kali/vms.mdx"
+/>
+
 export const title = 'Virtual Machines';
 export const summary = 'Pre-built images for VMware and VirtualBox.';
 export const badges = ['vmware', 'virtualbox'];

--- a/content/get-kali/wsl.mdx
+++ b/content/get-kali/wsl.mdx
@@ -1,3 +1,10 @@
+import MDXPageHeader from '../../components/ui/MDXPageHeader';
+
+<MDXPageHeader
+  breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Kali', href: '/get-kali' }, { label: 'WSL' }]}
+  filePath="content/get-kali/wsl.mdx"
+/>
+
 export const title = 'WSL';
 export const summary = 'Kali Linux for Windows Subsystem for Linux.';
 export const badges = ['wsl'];


### PR DESCRIPTION
## Summary
- add `MDXPageHeader` component showing breadcrumbs and an edit-on-GitHub link
- include the header at the top of each `content/get-kali` MDX entry

## Testing
- `yarn test` *(fails: Missing allowlist entries for CSP and TypeError in terminal tests)*
- `yarn lint` *(fails: TypeError: Cannot set properties of undefined (setting 'theme'))*

------
https://chatgpt.com/codex/tasks/task_e_68be5130f3648328a3b2a96ae5481491