### PR TITLE
feat: add window snap previews with reduced motion support

### DIFF
--- a/__tests__/desktop-window.snap.test.tsx
+++ b/__tests__/desktop-window.snap.test.tsx
@@ -1,0 +1,35 @@
+import React, { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import Window from '../components/desktop/Window';
+
+describe('Desktop Window snapping', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+  });
+
+  it('disables transitions when reduced motion is preferred', async () => {
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    render(
+      <Window title="Motion">
+        <div>content</div>
+      </Window>
+    );
+
+    await act(async () => {});
+
+    const winEl = screen.getByText('Motion').parentElement?.parentElement as HTMLElement;
+    expect(winEl.style.transition).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- show snap region overlay when dragging desktop windows near edges
- snap window on release and respect reduced motion preference
- test reduced motion disables transitions

## Testing
- `npm test __tests__/desktop-window.snap.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be513f573083289ba1db6ef22b19c7