### PR TITLE
feat(ui): improve window chrome

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -812,13 +812,22 @@ export class Window extends Component {
                         tabIndex={this.props.isFocused ? 0 : -1}
                         onKeyDown={this.handleKeyDown}
                     >
-                        {this.props.resizable !== false && <WindowYBorder resize={this.debouncedHandleHorizontalResize} />}
-                        {this.props.resizable !== false && <WindowXBorder resize={this.debouncedHandleVerticleResize} />}
+                        {this.props.resizable !== false && (
+                            <>
+                                <WindowYBorder resize={this.debouncedHandleHorizontalResize} />
+                                <WindowXBorder resize={this.debouncedHandleVerticleResize} />
+                                <div className={`${styles.windowCorner} ${styles.nw}`}></div>
+                                <div className={`${styles.windowCorner} ${styles.ne}`}></div>
+                                <div className={`${styles.windowCorner} ${styles.sw}`}></div>
+                                <div className={`${styles.windowCorner} ${styles.se}`}></div>
+                            </>
+                        )}
                         <WindowTopBar
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
+                            isFocused={this.props.isFocused}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -844,11 +853,11 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, isFocused }) {
     return (
         <button
             type="button"
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={`relative window-titlebar ${isFocused ? 'window-titlebar-active' : 'window-titlebar-inactive'} border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11`}
             tabIndex={0}
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
@@ -904,7 +913,11 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = isBrowser() && !!window.documentPictureInPicture;
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
+        <div
+            className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]"
+            role="group"
+            aria-label="Window controls"
+        >
             {pipSupported && props.pip && (
                 <button
                     type="button"
@@ -914,11 +927,12 @@ export function WindowEditButtons(props) {
                 >
                     <NextImage
                         src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
+                        alt=""
                         className="h-4 w-4 inline"
                         width={16}
                         height={16}
                         sizes="16px"
+                        aria-hidden="true"
                     />
                 </button>
             )}
@@ -930,11 +944,12 @@ export function WindowEditButtons(props) {
             >
                 <NextImage
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
+                    alt=""
                     className="h-4 w-4 inline"
                     width={16}
                     height={16}
                     sizes="16px"
+                    aria-hidden="true"
                 />
             </button>
             {props.allowMaximize && (
@@ -948,11 +963,12 @@ export function WindowEditButtons(props) {
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
+                                alt=""
                                 className="h-4 w-4 inline"
                                 width={16}
                                 height={16}
                                 sizes="16px"
+                                aria-hidden="true"
                             />
                         </button>
                     ) : (
@@ -964,11 +980,12 @@ export function WindowEditButtons(props) {
                         >
                             <NextImage
                                 src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
+                                alt=""
                                 className="h-4 w-4 inline"
                                 width={16}
                                 height={16}
                                 sizes="16px"
+                                aria-hidden="true"
                             />
                         </button>
                     )
@@ -982,11 +999,12 @@ export function WindowEditButtons(props) {
             >
                 <NextImage
                     src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
+                    alt=""
                     className="h-4 w-4 inline"
                     width={16}
                     height={16}
                     sizes="16px"
+                    aria-hidden="true"
                 />
             </button>
         </div>

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,94 @@
 .windowYBorder {
   height: calc(100% - 10px);
   width: calc(100% + 10px);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.windowYBorder::before,
+.windowYBorder::after {
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  width: 8px;
+  background: var(--color-border);
+  opacity: 0.5;
+  pointer-events: auto;
+}
+
+.windowYBorder::before {
+  left: -4px;
+  cursor: ew-resize;
+}
+
+.windowYBorder::after {
+  right: -4px;
+  cursor: ew-resize;
 }
 
 .windowXBorder {
   height: calc(100% + 10px);
   width: calc(100% - 10px);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.windowXBorder::before,
+.windowXBorder::after {
+  content: '';
+  position: absolute;
+  left: -5px;
+  right: -5px;
+  height: 8px;
+  background: var(--color-border);
+  opacity: 0.5;
+  pointer-events: auto;
+}
+
+.windowXBorder::before {
+  top: -4px;
+  cursor: ns-resize;
+}
+
+.windowXBorder::after {
+  bottom: -4px;
+  cursor: ns-resize;
+}
+
+.windowCorner {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: var(--color-border);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.windowCorner.nw {
+  top: -5px;
+  left: -5px;
+  cursor: nwse-resize;
+}
+
+.windowCorner.ne {
+  top: -5px;
+  right: -5px;
+  cursor: nesw-resize;
+}
+
+.windowCorner.sw {
+  bottom: -5px;
+  left: -5px;
+  cursor: nesw-resize;
+}
+
+.windowCorner.se {
+  bottom: -5px;
+  right: -5px;
+  cursor: nwse-resize;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -116,8 +116,14 @@ html[data-theme='undercover'] .main-navbar-vp {
   color: #000;
 }
 
-html[data-theme='undercover'] .window-titlebar {
-  background: #ffffff;
+html[data-theme='undercover'] .window-titlebar-active {
+  background: linear-gradient(to bottom, #ffffff, #e5e5e5);
+  color: #000;
+  border-bottom: 1px solid #c0c0c0;
+}
+
+html[data-theme='undercover'] .window-titlebar-inactive {
+  background: linear-gradient(to bottom, #f7f7f7, #e0e0e0);
   color: #000;
   border-bottom: 1px solid #c0c0c0;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -213,6 +213,26 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     filter: brightness(90%);
 }
 
+.window-titlebar {
+    color: var(--color-inverse);
+}
+
+.window-titlebar-active {
+    background: linear-gradient(
+        to bottom,
+        color-mix(in srgb, var(--color-ub-window-title), white 10%),
+        color-mix(in srgb, var(--color-ub-window-title), black 10%)
+    );
+}
+
+.window-titlebar-inactive {
+    background: linear-gradient(
+        to bottom,
+        color-mix(in srgb, var(--color-ub-window-title), white 30%),
+        color-mix(in srgb, var(--color-ub-window-title), black 5%)
+    );
+}
+
 .root,
 #root,
 #docs-root {


### PR DESCRIPTION
## Summary
- add active/inactive titlebar gradients
- expose resize handles and corners
- improve accessibility of window controls

## Testing
- `npm test` *(fails: appImport.test.ts, terminal.test.tsx, middleware-csp.test.ts, calculator.formulas.test.ts, a11y.cli.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68be513eb60c832897cc9ddaa2469b13