### PR TITLE
feat: refine responsive layout

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -28,8 +28,8 @@ export async function getStaticProps() {
 export default function Home({ desktops }) {
   return (
     <main className="p-4">
-      <h1 className="text-xl font-bold mb-4">Choose the desktop you prefer</h1>
-      <div className="grid gap-4 sm:grid-cols-3">
+      <h1 className="mb-4 text-2xl font-bold sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">Choose the desktop you prefer</h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
         {desktops.map((d) => (
           <div key={d.name} className="text-center">
             <Image
@@ -41,7 +41,7 @@ export default function Home({ desktops }) {
               blurDataURL={d.blurDataURL}
               className="rounded"
             />
-            <p className="mt-2">{d.name}</p>
+            <p className="mt-2 text-sm sm:text-base md:text-lg">{d.name}</p>
           </div>
         ))}
       </div>

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -46,7 +46,7 @@ export default function ToolsPage() {
   return (
     <div className="p-4">
       <ul
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
         onKeyDown={handleKeyDown}
       >
         {pageTools.map((tool, i) => (
@@ -56,7 +56,7 @@ export default function ToolsPage() {
               className="block rounded border p-4 focus:outline-none focus:ring"
               ref={(el) => (itemRefs.current[i] = el)}
             >
-              <h3 className="font-semibold">{tool.name}</h3>
+              <h3 className="font-semibold text-base sm:text-lg md:text-xl">{tool.name}</h3>
               <div className="mt-2 flex flex-wrap gap-2">
                 <a
                   href={`https://gitlab.com/kalilinux/packages/${tool.id}`}

--- a/styles/index.css
+++ b/styles/index.css
@@ -18,9 +18,39 @@
 }
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: calc(14px * var(--font-multiplier));
     scrollbar-width: thin;
     scrollbar-color: var(--color-border) transparent;
+}
+
+@media (min-width: 640px) {
+    html {
+        font-size: calc(16px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 768px) {
+    html {
+        font-size: calc(18px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1024px) {
+    html {
+        font-size: calc(20px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1280px) {
+    html {
+        font-size: calc(22px * var(--font-multiplier));
+    }
+}
+
+@media (min-width: 1536px) {
+    html {
+        font-size: calc(24px * var(--font-multiplier));
+    }
 }
 
 body{


### PR DESCRIPTION
## Summary
- enhance hero section with responsive typography and grid scaling
- expand tools list grid and heading sizes for smoother device breakpoints
- add media queries to scale base font size across viewport widths

## Testing
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*
- `timeout 30 yarn lint` *(terminated without output)*
- `timeout 30 yarn test` *(terminated without output)*

------
https://chatgpt.com/codex/tasks/task_e_68be514492ac83288d8588fb4fa60ee0