### PR TITLE
feat: add rtl demo and styles

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -36,7 +36,7 @@ export default function VsCode() {
         </aside>
         <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
           <div
-            className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
+            className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20 rtl:justify-start"
             style={{ backgroundColor: kaliTheme.background }}
           >
             <button aria-label="Minimize">

--- a/components/filemanager/Sidebar.tsx
+++ b/components/filemanager/Sidebar.tsx
@@ -15,7 +15,7 @@ interface SidebarProps {
 
 export default function Sidebar({ devices, onEject }: SidebarProps) {
   return (
-    <aside className="p-2 w-48 bg-gray-100" aria-label="device sidebar">
+    <aside className="p-2 w-48 bg-gray-100 rtl:text-right" aria-label="device sidebar">
       <ul>
         {devices.map((device) => (
           <li key={device.id} className="mb-1 flex items-center justify-between">

--- a/components/layout/DocMegaMenu.tsx
+++ b/components/layout/DocMegaMenu.tsx
@@ -23,7 +23,7 @@ export default function DocMegaMenu({ onClose }: DocMegaMenuProps) {
   return (
     <div
       ref={ref}
-      className="fixed left-0 top-12 z-50 w-full bg-white shadow-lg p-4"
+      className="fixed left-0 top-12 z-50 w-full bg-white shadow-lg p-4 rtl:left-auto rtl:right-0"
     >
       <ul className="grid gap-2 sm:grid-cols-2">
         <li>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -8,8 +8,8 @@ export default function Header() {
   const closeDocs = () => setDocsOpen(false);
 
   return (
-    <header className="relative bg-gray-900 text-white">
-      <nav className="flex gap-4 p-4">
+    <header className="relative bg-gray-900 text-white rtl:text-right">
+      <nav className="flex gap-4 p-4 rtl:flex-row-reverse">
         <a href="/" className="hover:underline">
           Home
         </a>

--- a/pages/rtl-demo.tsx
+++ b/pages/rtl-demo.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import Header from '../components/layout/Header';
+import Sidebar from '../components/filemanager/Sidebar';
+import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../components/ToolbarIcons';
+
+export default function RtlDemo() {
+  const [rtl, setRtl] = useState(false);
+
+  const devices = [
+    { id: '1', name: 'usb', label: 'USB Drive' },
+    { id: '2', name: 'sd', label: 'SD Card' },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col" dir={rtl ? 'rtl' : 'ltr'}>
+      <Header />
+      <div className="p-4">
+        <button
+          type="button"
+          className="px-2 py-1 border rounded"
+          onClick={() => setRtl((v) => !v)}
+        >
+          Toggle RTL
+        </button>
+      </div>
+      <div className="flex flex-1 rtl:flex-row-reverse">
+        <Sidebar devices={devices} />
+        <div className="flex-1 p-4 space-y-4">
+          <div className="flex items-center justify-end gap-2 rtl:justify-start">
+            <button aria-label="Minimize"><MinimizeIcon /></button>
+            <button aria-label="Maximize"><MaximizeIcon /></button>
+            <button aria-label="Close"><CloseIcon /></button>
+          </div>
+          <article className="prose rtl:prose-rtl">
+            <h1>Typography Demo</h1>
+            <p>
+              This text demonstrates how content flips when using right-to-left direction.
+            </p>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add rtl-aware navigation and mega menu
- support rtl sidebar text and window buttons
- add demo page to toggle rtl and verify typography

## Testing
- `yarn test vscode.test.tsx`
- `yarn test fileManagerStatusBar`


------
https://chatgpt.com/codex/tasks/task_e_68be514648c08328ba6e3f32fc17246c