### PR TITLE
feat: add neutral auth screen

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -2,57 +2,78 @@ import React, { useState, useRef, useEffect } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 
-export default function LockScreen(props) {
+/**
+ * Authentication screen used for both login and lock flows.
+ * Shows the current time, a generic avatar and a password field.
+ */
+export default function AuthScreen({
+  isLocked = false,
+  mode = 'lock',
+  username = 'user',
+  onSubmit,
+}) {
+  const { wallpaper } = useSettings();
+  const [password, setPassword] = useState('');
+  const inputRef = useRef(null);
 
-    const { wallpaper } = useSettings();
-    const [password, setPassword] = useState('');
-    const inputRef = useRef(null);
+  const visible = mode === 'login' || isLocked;
 
-    useEffect(() => {
-        if (props.isLocked) {
-            inputRef.current?.focus();
-        }
-    }, [props.isLocked]);
+  useEffect(() => {
+    if (visible) {
+      inputRef.current?.focus();
+    }
+  }, [visible]);
 
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        setPassword('');
-        props.unLockScreen();
-    };
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit?.(password);
+    setPassword('');
+  };
 
-    return (
-        <div
-            id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-md' : 'blur-none'}`}
-            />
-            <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
-                <div className="absolute top-10 text-center">
-                    <div className="text-7xl">
-                        <Clock onlyTime={true} />
-                    </div>
-                    <div className="mt-2 text-xl font-medium">
-                        <Clock onlyDay={true} />
-                    </div>
-                </div>
-                <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
-                    <img src="/images/logos/bitmoji.png" alt="avatar" className="w-24 h-24 rounded-full mb-4 border-2 border-white" />
-                    <div className="text-2xl mb-4">kali</div>
-                    <input
-                        ref={inputRef}
-                        type="password"
-                        className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
-                        placeholder="Password"
-                        aria-label="Password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                    />
-                </form>
-            </div>
+  return (
+    <div
+      id="auth-screen"
+      style={{ zIndex: '100', contentVisibility: 'auto' }}
+      className={`${visible ? 'visible translate-y-0' : 'invisible -translate-y-full'} absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen`}
+    >
+      <img
+        src={`/wallpapers/${wallpaper}.webp`}
+        alt=""
+        className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${visible ? 'blur-md' : 'blur-none'}`}
+      />
+      <div className="w-full h-full z-50 relative flex flex-col items-center justify-center text-white">
+        <div className="absolute top-10 text-center">
+          <div className="text-7xl">
+            <Clock onlyTime={true} />
+          </div>
+          <div className="mt-2 text-xl font-medium">
+            <Clock onlyDay={true} />
+          </div>
         </div>
-    )
+        <form onSubmit={handleSubmit} className="bg-black bg-opacity-50 p-8 rounded flex flex-col items-center">
+          <div className="w-24 h-24 rounded-full mb-4 border-2 border-white bg-gray-600 flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-16 h-16 text-white"
+            >
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-3.866 0-7 3.134-7 7h14c0-3.866-3.134-7-7-7z" />
+            </svg>
+          </div>
+          <div className="text-2xl mb-4">{username}</div>
+          <input
+            ref={inputRef}
+            type="password"
+            className="px-4 py-2 rounded bg-gray-800 focus:outline-none"
+            placeholder="Password"
+            aria-label="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </form>
+      </div>
+    </div>
+  );
 }
+

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -151,11 +151,11 @@ export default class Ubuntu extends Component {
 	render() {
 		return (
 			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
+                                <LockScreen
+                                        mode="lock"
+                                        isLocked={this.state.screen_locked}
+                                        onSubmit={this.unLockScreen}
+                                />
 				<BootingScreen
 					visible={this.state.booting_screen}
 					isShutDown={this.state.shutDownScreen}

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -1,0 +1,8 @@
+import LockScreen from '../../components/screen/lock_screen';
+
+export default function LoginPage() {
+  const handleLogin = () => {};
+
+  return <LockScreen mode="login" onSubmit={handleLogin} />;
+}
+


### PR DESCRIPTION
## Summary
- add generic authentication screen with time, avatar and password field
- wire auth screen into lock flow and expose login page

## Testing
- `yarn test` *(fails: Cannot set properties of undefined (setting 'theme'); Missing remotePatterns, ascii-art module, etc.)*
- `pnpm -w typecheck` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68be5143d440832892051522ae87f529