### PR TITLE
Honor reduced-motion preference for animations

### DIFF
--- a/__tests__/reducedMotion.test.tsx
+++ b/__tests__/reducedMotion.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
+import { SettingsProvider } from '../hooks/useSettings';
+
+describe('prefers-reduced-motion handling', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  test('detects system preference via media query', async () => {
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: query.includes('reduced-motion'),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+    const { result } = renderHook(() => usePrefersReducedMotion(), {
+      wrapper: SettingsProvider,
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+});

--- a/styles/index.css
+++ b/styles/index.css
@@ -126,17 +126,15 @@ select:focus-visible,
 
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
+        animation: none !important;
+        transition: none !important;
         scroll-behavior: auto !important;
     }
 }
 
 .reduced-motion *, .reduced-motion *::before, .reduced-motion *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
 }
 


### PR DESCRIPTION
## Summary
- disable animations and transitions when `prefers-reduced-motion` is set
- test reduced motion detection through `usePrefersReducedMotion`

## Testing
- `yarn test reducedMotion.test.tsx phaserMatter.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be51503820832896000e08451818ef