### PR TITLE
feat: add undercover toggle

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -144,7 +144,6 @@ export default function Settings() {
               <option value="default">Default</option>
               <option value="kali-dark">Kali Dark</option>
               <option value="kali-light">Kali Light</option>
-              <option value="undercover">Undercover</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -84,7 +84,6 @@ export function Settings() {
                     <option value="default">Default</option>
                     <option value="kali-dark">Kali Dark</option>
                     <option value="kali-light">Kali Light</option>
-                    <option value="undercover">Undercover</option>
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -6,23 +6,27 @@ import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import HelpMenu from '../menu/HelpMenu';
-import { getTheme, setTheme } from '../../utils/theme';
+import { getUndercover, setUndercover } from '../../utils/theme';
 
 export default class Navbar extends Component {
   constructor() {
     super();
     this.state = {
       status_card: false,
-      undercover: getTheme() === 'undercover',
+      undercover: getUndercover(),
       showTip: false,
     };
   }
 
+  componentDidMount() {
+    setUndercover(this.state.undercover);
+  }
+
   render() {
     const toggleUndercover = () => {
-      const next = this.state.undercover ? 'default' : 'undercover';
-      setTheme(next);
-      this.setState({ undercover: !this.state.undercover });
+      const next = !this.state.undercover;
+      setUndercover(next);
+      this.setState({ undercover: next });
     };
 
     return (
@@ -61,7 +65,7 @@ export default class Navbar extends Component {
               role="tooltip"
               className="absolute right-0 mt-1 w-48 p-2 text-xs text-white bg-black rounded shadow-lg"
             >
-              Windows-like theme.{' '}
+              Undercover mode – Windows-like theme.{' '}
               <Link href="/undercover" className="underline text-blue-300">
                 Read disclaimer
               </Link>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -8,6 +8,14 @@ export default function Status() {
   const { allowNetwork, theme, symbolicTrayIcons } = useSettings();
   const { icons, register, unregister } = useTray();
   const [online, setOnline] = useState(true);
+  const [undercover, setUndercover] = useState(false);
+
+  useEffect(() => {
+    setUndercover(document.documentElement.dataset.undercover === 'true');
+    const handler = (e) => setUndercover(e.detail.value);
+    document.addEventListener('undercover-change', handler);
+    return () => document.removeEventListener('undercover-change', handler);
+  }, []);
 
   useEffect(() => {
     const pingServer = async () => {
@@ -40,19 +48,21 @@ export default function Status() {
 
   useEffect(() => {
     const id = 'network';
-    const themeDir = theme === 'kali-light' ? 'Yaru' : 'Yaru';
+    const themeDir = undercover ? 'Undercover' : 'Yaru';
+    const connected = undercover
+      ? '/themes/Undercover/status/network.svg'
+      : `/themes/${themeDir}/status/network-wireless-signal-good-symbolic.svg`;
+    const disconnected = undercover
+      ? '/themes/Undercover/status/network.svg'
+      : `/themes/${themeDir}/status/network-wireless-signal-none-symbolic.svg`;
     register({
       id,
       tooltip: online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline',
-      sni: online
-        ? `/themes/${themeDir}/status/network-wireless-signal-good-symbolic.svg`
-        : `/themes/${themeDir}/status/network-wireless-signal-none-symbolic.svg`,
-      legacy: online
-        ? `/themes/${themeDir}/status/network-wireless-signal-good-symbolic.svg`
-        : `/themes/${themeDir}/status/network-wireless-signal-none-symbolic.svg`,
+      sni: online ? connected : disconnected,
+      legacy: online ? connected : disconnected,
     });
     return () => unregister(id);
-  }, [online, allowNetwork, register, unregister, theme]);
+  }, [online, allowNetwork, register, unregister, undercover]);
 
   useEffect(() => {
     const id = 'volume';

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -85,7 +85,6 @@ export default function ThemeSettings() {
           <option value="default">Default</option>
           <option value="kali-dark">Kali Dark</option>
           <option value="kali-light">Kali Light</option>
-          <option value="undercover">Undercover</option>
           <option value="dark">Dark</option>
           <option value="neon">Neon</option>
           <option value="matrix">Matrix</option>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -91,8 +91,8 @@ html[data-theme='kali-light'] {
   --color-dark: var(--color-ubt-gedit-dark);
 }
 
-/* Undercover theme */
-html[data-theme='undercover'] {
+/* Undercover mode */
+html[data-undercover='true'] {
   --color-bg: #f0f0f0;
   --color-text: #000000;
   --color-primary: #0078d7;
@@ -111,12 +111,12 @@ html[data-theme='undercover'] {
   --color-ub-window-title: #0078d7;
 }
 
-html[data-theme='undercover'] .main-navbar-vp {
+html[data-undercover='true'] .main-navbar-vp {
   background: #e5e5e5;
   color: #000;
 }
 
-html[data-theme='undercover'] .window-titlebar {
+html[data-undercover='true'] .window-titlebar {
   background: #ffffff;
   color: #000;
   border-bottom: 1px solid #c0c0c0;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -6,7 +6,6 @@ export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
   'kali-light': 0,
   'kali-dark': 0,
-  undercover: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,
@@ -21,7 +20,7 @@ export const getTheme = (): string => {
   if (!isBrowser()) return 'default';
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
-    if (stored) return stored;
+    if (stored && stored !== 'undercover') return stored;
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
     ).matches;
@@ -37,6 +36,34 @@ export const setTheme = (theme: string): void => {
     window.localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+export const UNDERCOVER_KEY = 'app:undercover';
+
+export const getUndercover = (): boolean => {
+  if (!isBrowser()) return false;
+  try {
+    return window.localStorage.getItem(UNDERCOVER_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const setUndercover = (on: boolean): void => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(UNDERCOVER_KEY, on ? 'true' : 'false');
+    if (on) {
+      document.documentElement.setAttribute('data-undercover', 'true');
+    } else {
+      document.documentElement.removeAttribute('data-undercover');
+    }
+    document.dispatchEvent(
+      new CustomEvent('undercover-change', { detail: { value: on } }),
+    );
   } catch {
     /* ignore storage errors */
   }


### PR DESCRIPTION
## Summary
- add dedicated Undercover mode toggle and style
- scope Windows-like styling to OS layer
- remove Undercover from theme settings

## Testing
- `npx eslint components/screen/navbar.js`
- `npx playwright test tests/ui/undercover-tooltip.spec.tsx` *(fails: missing system dependencies)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be5143484c832891a9fe7a72954856