### PR TITLE
feat: add high contrast theme toggle

### DIFF
--- a/components/common/HighContrastToggle.tsx
+++ b/components/common/HighContrastToggle.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSettings } from '@/hooks/useSettings';
+
+export default function HighContrastToggle() {
+  const { highContrast, setHighContrast } = useSettings();
+  return (
+    <button
+      type="button"
+      onClick={() => setHighContrast(!highContrast)}
+      className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:right-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+    >
+      {highContrast ? 'Disable high contrast' : 'Enable high contrast'}
+    </button>
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -23,6 +23,7 @@ import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 import useReportWebVitals from '../hooks/useReportWebVitals';
 import NotificationCenter from '../components/common/NotificationCenter';
+import HighContrastToggle from '../components/common/HighContrastToggle';
 
 
 let SpeedInsights = () => null;
@@ -245,6 +246,7 @@ function MyApp(props) {
             Skip to app grid
           </a>
           <SettingsProvider>
+            <HighContrastToggle />
             <TrayProvider>
               <PipPortalProvider>
                 <NotificationCenter>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -144,7 +144,7 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
   outline-offset: 2px;
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -109,7 +109,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 .btn:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
     outline-offset: 2px;
 }
 
@@ -120,7 +120,7 @@ textarea:focus-visible,
 select:focus-visible,
 [role="button"]:focus-visible,
 [tabindex]:not([tabindex="-1"]):focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
+    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color) !important;
     outline-offset: 2px;
 }
 
@@ -642,7 +642,7 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color);
     outline-offset: 2px;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -59,12 +59,22 @@
   /* Focus outline */
   --focus-outline-color: var(--color-accent);
   --focus-outline-width: 2px;
+  --focus-outline-style: solid;
 }
 
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;
   --color-text: #ffffff;
+  --color-primary: #ffff00;
+  --color-secondary: #000000;
+  --color-accent: #ffff00;
+  --color-muted: #000000;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #ffff00;
+  --color-info: #00ffff;
+  --color-success: #00ff00;
   --color-ub-grey: #000000;
   --color-ub-cool-grey: #000000;
   --color-ubt-grey: #ffffff;
@@ -73,6 +83,8 @@
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
   --focus-outline-color: #ffff00;
+  --focus-outline-width: 3px;
+  --focus-outline-style: solid;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;


### PR DESCRIPTION
## Summary
- define high-contrast color variables and outline styles
- add keyboard-accessible toggle to switch high contrast globally
- apply outline style variable across global styles

## Testing
- `yarn test` *(fails: SessionNotCreatedError: cannot find Chrome binary; a11y.cli test failed)*
- `npx eslint pages/_app.jsx components/common/HighContrastToggle.tsx styles/globals.css styles/index.css styles/tokens.css`

------
https://chatgpt.com/codex/tasks/task_e_68be5146b370832883ed6d092d6dbc8c