### PR TITLE
Add synchronized footer theme toggle

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useTheme } from "../hooks/useTheme";
 
 interface SocialLink {
   href: string;
@@ -45,29 +46,44 @@ const links: SocialLink[] = [
 ];
 
 export default function Footer() {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
+
   return (
-    <footer
-      className="flex items-center justify-center gap-4 p-4"
-      aria-label="social links"
-    >
-      {links.map((link) => (
-        <a
-          key={link.label}
-          href={link.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="p-1 rounded focus:outline-none focus:ring hover:opacity-80"
-        >
-          <Image
-            src={link.icon}
-            alt=""
-            width={24}
-            height={24}
-            aria-hidden="true"
-          />
-          <span className="sr-only">{link.label}</span>
-        </a>
-      ))}
-    </footer>
+    <div className="flex flex-col items-center">
+      <button
+        type="button"
+        onClick={toggleTheme}
+        aria-label="Toggle theme"
+        aria-pressed={isDark}
+        className="mb-4 rounded p-2 focus:outline-none focus:ring"
+      >
+        {isDark ? "Light mode" : "Dark mode"}
+      </button>
+      <footer
+        className="flex items-center justify-center gap-4 p-4"
+        aria-label="social links"
+      >
+        {links.map((link) => (
+          <a
+            key={link.label}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-1 rounded focus:outline-none focus:ring hover:opacity-80"
+          >
+            <Image
+              src={link.icon}
+              alt=""
+              width={24}
+              height={24}
+              aria-hidden="true"
+            />
+            <span className="sr-only">{link.label}</span>
+          </a>
+        ))}
+      </footer>
+    </div>
   );
 }

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useTheme } from '../../hooks/useTheme';
 
 interface Props {
   open: boolean;
@@ -10,7 +11,8 @@ interface Props {
 }
 
 const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === 'dark';
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState(
@@ -18,15 +20,10 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
     false,
   );
 
-  const toggleTheme = () =>
-    setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+  const toggleTheme = () => setTheme(isDark ? 'light' : 'dark');
   const toggleSound = () => setSound((s) => !s);
   const toggleOnline = () => setOnline((o) => !o);
   const toggleReduceMotion = () => setReduceMotion((r) => !r);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
@@ -44,7 +41,7 @@ const QuickSettings = ({ open, lockScreen, logOut }: Props) => {
           onClick={toggleTheme}
         >
           <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span>{isDark ? 'Dark' : 'Light'}</span>
         </button>
       </div>
       <div className="px-4 pb-2 flex justify-between">


### PR DESCRIPTION
## Summary
- add accessible theme toggle above footer
- synchronize header quick settings and footer theme state via useTheme

## Testing
- `yarn eslint components/Footer.tsx components/ui/QuickSettings.tsx --max-warnings=0`
- `yarn test components/ui/QuickSettings.tsx --passWithNoTests`
- `yarn a11y components/Footer.tsx` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be512f5d348328b106f8d3729dff81