### PR TITLE
docs: add interaction state examples and transition token

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -28,7 +28,7 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
+          className={`px-4 py-2 focus:outline-none motion-reduce:transition-none ${
             active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
           }`}
         >

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -34,7 +34,7 @@ export default function Button({
   const variantStyle = variantStyles[variant];
   return (
     <button
-      className={`btn ${className}`}
+      className={`btn motion-reduce:transition-none ${className}`}
       style={{ ...variantStyle, ...style }}
       {...props}
     />

--- a/components/ui/CommandChip.tsx
+++ b/components/ui/CommandChip.tsx
@@ -30,7 +30,7 @@ export default function CommandChip({ command, className = '', ...props }: Comma
     <button
       type="button"
       onClick={copy}
-      className={`inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm ${className}`}
+      className={`command-chip inline-flex items-center gap-1 rounded-full border border-gray-600 bg-black px-2 py-1 font-mono text-green-400 text-sm motion-reduce:transition-none ${className}`}
       aria-label={`Copy ${command}`}
       title="Copy command"
       {...props}

--- a/docs/design/states.mdx
+++ b/docs/design/states.mdx
@@ -1,0 +1,64 @@
+import Button from '../../components/ui/Button';
+import CommandChip from '../../components/ui/CommandChip';
+
+<style>
+.state-hover { filter: brightness(1.1); }
+.state-active { transform: scale(0.98); }
+.state-focus { outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color); outline-offset: 2px; }
+.state-disabled { opacity: 0.5; pointer-events: none; }
+.state-loading { opacity: 0.7; cursor: progress; }
+</style>
+
+# Interaction States
+
+Examples of interactive component states. Transitions use the shared token and respect `prefers-reduced-motion`.
+
+## Buttons
+<div className="flex flex-wrap gap-2">
+  <Button>Default</Button>
+  <Button className="state-hover">Hover</Button>
+  <Button className="state-focus">Focus</Button>
+  <Button className="state-active">Active</Button>
+  <Button disabled>Disabled</Button>
+  <Button aria-busy="true" className="state-loading">Loading</Button>
+</div>
+
+## Links
+<div className="flex flex-wrap gap-2">
+  <a href="#">Default</a>
+  <a href="#" className="state-hover">Hover</a>
+  <a href="#" className="state-focus">Focus</a>
+  <a href="#" className="state-active">Active</a>
+  <a aria-disabled="true" className="state-disabled">Disabled</a>
+  <a aria-busy="true" className="state-loading">Loading</a>
+</div>
+
+## Inputs
+<div className="flex flex-wrap gap-2">
+  <input placeholder="Default" />
+  <input placeholder="Hover" className="state-hover" />
+  <input placeholder="Focus" className="state-focus" />
+  <input placeholder="Active" className="state-active" />
+  <input placeholder="Disabled" disabled />
+  <input placeholder="Loading" aria-busy="true" className="state-loading" />
+</div>
+
+## Chips
+<div className="flex flex-wrap gap-2">
+  <CommandChip command="whoami" />
+  <CommandChip command="whoami" className="state-hover" />
+  <CommandChip command="whoami" className="state-focus" />
+  <CommandChip command="whoami" className="state-active" />
+  <CommandChip command="whoami" disabled />
+  <CommandChip command="whoami" aria-busy="true" className="state-loading" />
+</div>
+
+## Tabs
+<div className="flex flex-wrap gap-2">
+  <button role="tab" className="px-4 py-2">Default</button>
+  <button role="tab" className="px-4 py-2 state-hover">Hover</button>
+  <button role="tab" className="px-4 py-2 state-focus">Focus</button>
+  <button role="tab" className="px-4 py-2 state-active">Active</button>
+  <button role="tab" className="px-4 py-2 state-disabled" disabled>Disabled</button>
+  <button role="tab" className="px-4 py-2 state-loading" aria-busy="true">Loading</button>
+</div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -129,7 +129,7 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
     justify-content: center;
     font-weight: 500;
     cursor: pointer;
-    transition: background-color var(--motion-fast), transform var(--motion-fast);
+    transition: var(--transition-base);
 }
 
 .btn:hover {
@@ -155,6 +155,28 @@ select:focus-visible,
 [tabindex]:not([tabindex="-1"]):focus-visible {
     outline: var(--focus-outline-width) var(--focus-outline-style) var(--focus-outline-color) !important;
     outline-offset: 2px;
+}
+
+a,
+button,
+input,
+textarea,
+select,
+[role="button"],
+[role="tab"],
+.command-chip {
+    transition: var(--transition-base);
+}
+
+:disabled,
+[aria-disabled="true"] {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+[aria-busy="true"] {
+    cursor: progress;
+    opacity: 0.7;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -50,6 +50,8 @@
   --motion-fast: 150ms;
   --motion-medium: 300ms;
   --motion-slow: 500ms;
+  /* Shared transition */
+  --transition-base: background-color var(--motion-fast), color var(--motion-fast), border-color var(--motion-fast), transform var(--motion-fast);
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
@@ -106,6 +108,7 @@
   --motion-fast: 0ms;
   --motion-medium: 0ms;
   --motion-slow: 0ms;
+  --transition-base: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -113,6 +116,7 @@
     --motion-fast: 0ms;
     --motion-medium: 0ms;
     --motion-slow: 0ms;
+    --transition-base: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- document hover, focus, active, disabled and loading states for common UI elements
- add shared transition token and disable on reduced motion
- ensure buttons, chips and tabs use unified transitions

## Testing
- `yarn lint components/Tabs.tsx components/ui/Button.tsx components/ui/CommandChip.tsx styles/index.css styles/tokens.css docs/design/states.mdx` (fails: A control must be associated with a text label)
- `npx eslint components/Tabs.tsx components/ui/Button.tsx components/ui/CommandChip.tsx styles/index.css styles/tokens.css docs/design/states.mdx`
- `yarn test __tests__/reducedMotion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68be601f631c8328805918c9a9a5edca